### PR TITLE
ci: fix release workflow and allow manual tag releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.2.3)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,10 +17,15 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: pip
@@ -26,15 +37,17 @@ jobs:
           import tomllib
           from pathlib import Path
 
-          tag = os.environ["GITHUB_REF_NAME"]
+          tag = os.environ["RELEASE_TAG"]
           if not tag.startswith("v"):
             raise SystemExit("tag must start with v")
 
           want = tag[1:]
           data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
           have = data["project"]["version"]
+
           if have != want:
             raise SystemExit(f"version mismatch: tag={want} pyproject={have}")
+
           print("ok: tag matches version:", have)
           PY
 
@@ -42,10 +55,11 @@ jobs:
         run: |
           python -m pip install build twine
           python -m build
-          twine check dist/*
+          python -m twine check dist/*
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true
           files: dist/*


### PR DESCRIPTION
## Summary

What does this change do?

Why
Why is this change needed?

How
Key implementation notes (high level).

Checklist
 bash scripts/check.sh all passes locally

 Tests added/updated

 Docs updated if needed
