### PR TITLE
ci: fix release workflow (tag + manual dispatch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,26 +21,36 @@ jobs:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Validate workflow_dispatch tag exists
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git ls-remote --exit-code --tags "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${RELEASE_TAG}" >/dev/null \
+            || {
+              echo "::error::workflow_dispatch tag '${RELEASE_TAG}' was not found in ${GITHUB_REPOSITORY}. Push the tag before running this workflow."
+              exit 1
+            }
+
+      - name: Checkout release ref
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Build dist
         run: |
-          python -m pip install build
+          python -m pip install --upgrade pip build
           python -m build
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_TAG }}
-          target_commitish: ${{ github.sha }}
           generate_release_notes: true
           files: |
             dist/*


### PR DESCRIPTION
### Motivation
- Make the GitHub Release workflow robust for both tag pushes (tags like `v*`) and manual `workflow_dispatch` runs that accept a `tag` input.
- Ensure the workflow builds and uploads distributables from the exact release tag ref and fails with a clear message when a manual dispatch references a non-existent tag.
- Keep workflow permissions minimal while using stable action versions and reliable artifact publishing via `dist/*`.

### Description
- Compute `RELEASE_TAG` from `github.ref_name` for tag pushes or from `github.event.inputs.tag` for `workflow_dispatch` and use that value throughout the job via `env.RELEASE_TAG` in the job.
- Add a validation step that runs only on `workflow_dispatch` and fails with a clear error if the requested tag is not found in the remote repository using `git ls-remote`.
- Update checkout to `actions/checkout@v4` and configure it to `fetch-depth: 0`, `fetch-tags: true`, and `ref: ${{ env.RELEASE_TAG }}` so the job builds from the intended tag; use `actions/setup-python@v5` and install `pip` + `build` before running `python -m build`.
- Publish a GitHub Release with `softprops/action-gh-release@v2` using `tag_name: ${{ env.RELEASE_TAG }}` and uploading `dist/*` as artifacts so the release corresponds to the checked-out tag.

### Testing
- Ran `./.venv/bin/pre-commit run -a`, which could not be executed because the local `.venv` environment is not present in this execution environment (failed).
- Ran `bash scripts/check.sh all`, which executed but failed `mypy` checks due to missing `httpx` types/imports in this environment (failed).
- Ran `./.venv/bin/python -m pytest -q`, which could not be executed because the local `.venv` Python is not present in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6987c17adaf48323a4c0e4dcf107fc0d)