### PR TITLE
Fix CI failures: cassette entrypoint, security redaction, and patch symlink checks

### DIFF
--- a/src/sdetkit/__main__.py
+++ b/src/sdetkit/__main__.py
@@ -48,11 +48,9 @@ def _cassette_get(argv: list[str]) -> int:
 
     if ns.replay:
         try:
-                Path.cwd(), ns.replay, allow_absolute=True
-            )
+            replay_path = safe_path(Path.cwd(), ns.replay, allow_absolute=True)
             cass = Cassette.load(replay_path)
         except (SecurityError, ValueError, OSError) as exc:
-
             print(str(exc), file=sys.stderr)
             return 2
         transport = CassetteReplayTransport(cass)
@@ -68,8 +66,8 @@ def _cassette_get(argv: list[str]) -> int:
     if ns.record:
         try:
             record_path = safe_path(
+                Path.cwd(), ns.record, allow_absolute=bool(ns.allow_absolute_path)
             )
-                print("refusing to overwrite existing cassette (use --force)", file=sys.stderr)
             if record_path.exists() and not ns.force:
                 print("refusing to overwrite existing cassette (use --force)", file=sys.stderr)
                 return 2

--- a/src/sdetkit/patch.py
+++ b/src/sdetkit/patch.py
@@ -632,6 +632,7 @@ def _normalize_rel_path(raw_path: str) -> str:
 
 def _resolve_target(root: Path, rel_path: str) -> Path:
     root_real = root.resolve(strict=True)
+    raw_target = root_real / rel_path
     try:
         target = safe_path(root_real, rel_path)
     except SecurityError as exc:
@@ -643,7 +644,7 @@ def _resolve_target(root: Path, rel_path: str) -> Path:
         if cursor.exists() and cursor.is_symlink():
             raise PatchSpecError(f"symlink parent rejected: {rel_path}")
 
-    if target.exists() and target.is_symlink():
+    if raw_target.exists() and raw_target.is_symlink():
         raise PatchSpecError(f"symlink target rejected: {rel_path}")
 
     resolved = target.resolve(strict=False)

--- a/src/sdetkit/security.py
+++ b/src/sdetkit/security.py
@@ -55,8 +55,8 @@ def redact_json(value: object, *, enabled: bool, keys: set[str]) -> object:
         return value
     if isinstance(value, dict):
         out: dict[object, object] = {}
-            v = value[k]
         for k in sorted(value.keys(), key=str):
+            v = value[k]
             if isinstance(k, str) and is_sensitive_key(k, keys):
                 out[k] = "<redacted>"
             else:
@@ -85,7 +85,6 @@ def redact_url(url: str, *, enabled: bool, keys: set[str]) -> str:
     return urlunsplit(
         (split.scheme, split.netloc, split.path, urlencode(q, doseq=True), split.fragment)
     )
-    return urlunsplit((split.scheme, split.netloc, split.path, urlencode(q, doseq=True), split.fragment))
 
 
 def ensure_allowed_scheme(url: str, *, allowed: set[str]) -> None:


### PR DESCRIPTION
### Motivation
- Resolve CI/runtime failures and linter errors that were breaking the test pipeline for `cassette-get`, JSON redaction, and patch path handling.
- Ensure entrypoint behavior matches tests that rely on absolute cassette paths and safe-path checks.
- Prevent unsafe patch operations that follow symlinks and could escape the intended root.

### Description
- Restored and corrected `cassette-get` path resolution and guards in `src/sdetkit/__main__.py` by assigning `replay_path = safe_path(...)` for replay mode and using `safe_path(...)` for record mode while preserving the `--allow-absolute-path` semantics and the overwrite (`--force`) check. 
- Fixed JSON redaction in `src/sdetkit/security.py` by correcting the dict traversal to recurse values properly in `redact_json()` and removed an unreachable duplicate `return` in `redact_url()`. 
- Hardened patch path resolution in `src/sdetkit/patch.py` by checking the raw (unresolved) target for symlink status before resolving, preserving the intended symlink-target rejection in `_resolve_target()`.

### Testing
- Ran pre-commit hooks with `PYENV_VERSION=3.12.12 pre-commit run -a` which completed successfully. 
- Ran the full quality and test suite with `PYENV_VERSION=3.12.12 bash quality.sh cov`, resulting in all tests passing (244 passed) and the coverage gate satisfied (coverage >= 70%).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698c062e5dd08323a68f7870b7a73fa7)