### PR TITLE
feat(repo): add deterministic `sdetkit repo audit` and rebrand to DevS69-sdetkit

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@ blank_issues_enabled: true
 contact_links:
 
 name: Questions / discussion
-url: https://github.com/sherif69-sa/sdet_bootcamp/discussions
+url: https://github.com/sherif69-sa/DevS69-sdetkit/discussions
 about: Please ask and answer questions here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Thanks for helping improve **sdetkit**.
 ## 1) Local development setup
 
 ```bash
-cd ~/sdet_bootcamp
+cd ~/DevS69-sdetkit
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install -U pip

--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@
   </p>
 
   <p>
-    <a href="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/ci.yml"><img src="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
-    <a href="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/quality.yml"><img src="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/quality.yml/badge.svg?branch=main" alt="Quality"></a>
-    <a href="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/mutation-tests.yml"><img src="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/mutation-tests.yml/badge.svg?branch=main" alt="Mutation Tests"></a>
-    <a href="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/security.yml"><img src="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/security.yml/badge.svg?branch=main" alt="Security"></a>
-    <a href="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/pages.yml"><img src="https://github.com/sherif69-sa/sdet_bootcamp/actions/workflows/pages.yml/badge.svg?branch=main" alt="Pages"></a>
+    <a href="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml"><img src="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+    <a href="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/quality.yml"><img src="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/quality.yml/badge.svg?branch=main" alt="Quality"></a>
+    <a href="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/mutation-tests.yml"><img src="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/mutation-tests.yml/badge.svg?branch=main" alt="Mutation Tests"></a>
+    <a href="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/security.yml"><img src="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/security.yml/badge.svg?branch=main" alt="Security"></a>
+    <a href="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/pages.yml"><img src="https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/pages.yml/badge.svg?branch=main" alt="Pages"></a>
   </p>
 
   <p>
-    <a href="https://github.com/sherif69-sa/sdet_bootcamp/releases"><img src="https://img.shields.io/github/v/release/sherif69-sa/sdet_bootcamp?sort=semver" alt="Latest Release"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/github/license/sherif69-sa/sdet_bootcamp" alt="License"></a>
+    <a href="https://github.com/sherif69-sa/DevS69-sdetkit/releases"><img src="https://img.shields.io/github/v/release/sherif69-sa/DevS69-sdetkit?sort=semver" alt="Latest Release"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/github/license/sherif69-sa/DevS69-sdetkit" alt="License"></a>
     <img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python">
-    <a href="https://github.com/sherif69-sa/sdet_bootcamp/security/code-scanning"><img src="https://img.shields.io/badge/security-code%20scanning-success" alt="Code Scanning"></a>
-    <a href="https://github.com/sherif69-sa/sdet_bootcamp/security/dependabot"><img src="https://img.shields.io/badge/dependencies-auto%20update-success" alt="Dependabot"></a>
+    <a href="https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning"><img src="https://img.shields.io/badge/security-code%20scanning-success" alt="Code Scanning"></a>
+    <a href="https://github.com/sherif69-sa/DevS69-sdetkit/security/dependabot"><img src="https://img.shields.io/badge/dependencies-auto%20update-success" alt="Dependabot"></a>
   </p>
 </div>
 
@@ -111,6 +111,7 @@ tools/                    # extra developer tooling + patch harness wrapper
 ./.venv/bin/sdetkit --help
 ./.venv/bin/sdetkit doctor --all
 ./.venv/bin/sdetkit apiget https://example.com/api --expect dict
+./.venv/bin/sdetkit repo audit --format text
 ./.venv/bin/sdetkit repo check . --profile enterprise --format json
 ./.venv/bin/python tools/patch_harness.py spec.json --check
 ```
@@ -135,7 +136,7 @@ bash scripts/shell.sh
 - [docs/project-structure.md](docs/project-structure.md) — architecture + file/folder map
 - [docs/cli.md](docs/cli.md) — CLI command guide
 - [docs/doctor.md](docs/doctor.md) — repository health diagnostics
-- [docs/repo-audit.md](docs/repo-audit.md) — repo audit and safe fixes
+- [docs/repo-audit.md](docs/repo-audit.md) — repo audit and repository hardening
 - [docs/patch-harness.md](docs/patch-harness.md) — spec-driven patch harness usage
 - [docs/security.md](docs/security.md) — security policies and notes
 - [docs/releasing.md](docs/releasing.md) — release process

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,6 +79,12 @@ Tool-specific notes:
 
 ## `repo`
 
+- `sdetkit repo audit [PATH] [--format text|json] [--out PATH] [--force]`
 - `sdetkit repo check [PATH] [--format text|json|md] [--out PATH] [--fail-on LEVEL] [--min-score N]`
 - `sdetkit repo fix [PATH] [--check|--dry-run] [--diff] [--eol lf|crlf]`
 - Security-first defaults: safe paths, deterministic sorted outputs, and atomic writes.
+
+Audit examples:
+
+- `sdetkit repo audit`
+- `sdetkit repo audit --format json --out repo-audit.json --force`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 <div class="hero-panel" markdown>
 
-# SDET Bootcamp (sdetkit)
+# DevS69 sdetkit
 
 A practical, production-ready toolkit for SDET workflows — with clean CLI ergonomics, diagnostics, API automation, and repository safety checks.
 

--- a/docs/repo-tour.md
+++ b/docs/repo-tour.md
@@ -30,7 +30,7 @@ Readme -> Setup -> CLI usage -> Diagnostics -> Safe repo checks -> Contribution/
 1. Read [project structure](project-structure.md) to map modules quickly.
 2. Review [design principles](design.md) to understand trade-offs.
 3. Check [doctor](doctor.md) + [repo audit](repo-audit.md) for real quality mechanics.
-4. Scan [ROADMAP](https://github.com/sherif69-sa/sdet_bootcamp/blob/main/ROADMAP.md) for direction and maturity indicators.
+4. Scan [ROADMAP](https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/ROADMAP.md) for direction and maturity indicators.
 
 ## Contributor path
 
@@ -70,4 +70,4 @@ Readme -> Setup -> CLI usage -> Diagnostics -> Safe repo checks -> Contribution/
 
 ---
 
-Need a top-level jump list? Return to [docs home](index.md) or [README](https://github.com/sherif69-sa/sdet_bootcamp/blob/main/README.md).
+Need a top-level jump list? Return to [docs home](index.md) or [README](https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/README.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -50,5 +50,5 @@ The repository includes always-on security maintenance so it behaves like an aut
 
 Use the GitHub Security tab to review alerts:
 
-- Code scanning: `https://github.com/sherif69-sa/sdet_bootcamp/security/code-scanning`
-- Dependabot alerts: `https://github.com/sherif69-sa/sdet_bootcamp/security/dependabot`
+- Code scanning: `https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning`
+- Dependabot alerts: `https://github.com/sherif69-sa/DevS69-sdetkit/security/dependabot`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: SDET Bootcamp (sdetkit)
+site_name: DevS69 sdetkit
 site_description: Professional SDET toolkit docs for CLI workflows, diagnostics, API integrations, and repository automation.
-repo_url: https://github.com/sherif69-sa/sdet_bootcamp
-repo_name: sherif69-sa/sdet_bootcamp
+repo_url: https://github.com/sherif69-sa/DevS69-sdetkit
+repo_name: sherif69-sa/DevS69-sdetkit
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 description = "Developer productivity and QA automation toolkit: CLI utilities, quality gates, and testable modules."
 license = "MIT"
 keywords = ["sdet", "testing", "qa", "automation", "cli", "devtools", "quality-gates"]
-authors = [{ name = "SDET Bootcamp contributors" }]
-maintainers = [{ name = "SDET Bootcamp maintainers" }]
+authors = [{ name = "DevS69 contributors" }]
+maintainers = [{ name = "DevS69 maintainers" }]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
@@ -32,11 +32,11 @@ license-files = ["LICENSE"]
 
 
 [project.urls]
-Homepage = "https://github.com/sherif69-sa/sdet_bootcamp"
-Repository = "https://github.com/sherif69-sa/sdet_bootcamp"
-Documentation = "https://github.com/sherif69-sa/sdet_bootcamp/tree/main/docs"
-Issues = "https://github.com/sherif69-sa/sdet_bootcamp/issues"
-Changelog = "https://github.com/sherif69-sa/sdet_bootcamp/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/sherif69-sa/DevS69-sdetkit"
+Repository = "https://github.com/sherif69-sa/DevS69-sdetkit"
+Documentation = "https://github.com/sherif69-sa/DevS69-sdetkit/tree/main/docs"
+Issues = "https://github.com/sherif69-sa/DevS69-sdetkit/issues"
+Changelog = "https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_repo_audit_cli.py
+++ b/tests/test_repo_audit_cli.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+
+
+def _seed_min_repo(root: Path) -> None:
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    (root / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    (root / "CONTRIBUTING.md").write_text("guide\n", encoding="utf-8")
+    (root / "CODE_OF_CONDUCT.md").write_text("code\n", encoding="utf-8")
+    (root / "SECURITY.md").write_text("security\n", encoding="utf-8")
+    (root / "CHANGELOG.md").write_text("changes\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    (root / "noxfile.py").write_text("\n", encoding="utf-8")
+    (root / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (root / "requirements-test.txt").write_text("pytest\n", encoding="utf-8")
+    (root / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (root / "tests").mkdir()
+    (root / "docs").mkdir()
+    wf = root / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+    (wf / "security.yml").write_text("name: security\n", encoding="utf-8")
+
+
+def test_repo_audit_text_and_json_are_deterministic(tmp_path: Path, capsys) -> None:
+    _seed_min_repo(tmp_path)
+
+    rc = cli.main(["repo", "audit", str(tmp_path), "--allow-absolute-path"])
+    assert rc == 0
+    text = capsys.readouterr().out
+    assert "Result: PASS" in text
+    assert "OSS readiness files" in text
+
+    rc2 = cli.main(["repo", "audit", str(tmp_path), "--allow-absolute-path", "--format", "json"])
+    assert rc2 == 0
+    j1 = json.loads(capsys.readouterr().out)
+
+    rc3 = cli.main(["repo", "audit", str(tmp_path), "--allow-absolute-path", "--format", "json"])
+    assert rc3 == 0
+    j2 = json.loads(capsys.readouterr().out)
+    assert j1 == j2
+    assert j1["summary"]["ok"] is True
+
+
+def test_repo_audit_fails_when_license_and_workflow_missing(tmp_path: Path, capsys) -> None:
+    _seed_min_repo(tmp_path)
+    (tmp_path / "LICENSE").unlink()
+    (tmp_path / ".github" / "workflows" / "security.yml").unlink()
+
+    rc = cli.main(["repo", "audit", str(tmp_path), "--allow-absolute-path", "--format", "json"])
+    assert rc == 1
+    report = json.loads(capsys.readouterr().out)
+    failed = {item["key"] for item in report["checks"] if item["status"] == "fail"}
+    assert "oss_readiness" in failed
+    assert "ci_security_workflows" in failed
+
+
+def test_repo_audit_out_respects_force(tmp_path: Path) -> None:
+    _seed_min_repo(tmp_path)
+    report = tmp_path / "audit.json"
+    report.write_text("old", encoding="utf-8")
+
+    rc = cli.main(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--format",
+            "json",
+            "--out",
+            "audit.json",
+        ]
+    )
+    assert rc == 2
+
+    rc2 = cli.main(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--format",
+            "json",
+            "--out",
+            "audit.json",
+            "--force",
+        ]
+    )
+    assert rc2 == 0
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["summary"]["ok"] is True


### PR DESCRIPTION
### Motivation

- Provide a production-minded, deterministic repository readiness/audit command that teams can run in CI or locally without network access. 
- Surface high-impact, file-system-only checks (governance files, CI/security workflows, Python tooling, basic hygiene) in a single extensible command. 
- Make the project look and behave like a company-grade toolkit by updating user-facing references and documentation to `DevS69-sdetkit`.

### Description

- Added a new `repo audit` subcommand implemented in `src/sdetkit/repo.py` with a `RepoAuditCheck` dataclass and a `run_repo_audit` orchestration function. 
- Implemented four independent, extendable audit checks: `_audit_oss_readiness`, `_audit_ci_security_workflows`, `_audit_python_tooling`, and `_audit_repo_hygiene`, plus `_render_repo_audit` with `text` and `json` outputs and safe `--out`/`--force` behavior. 
- Integrated the new `audit` parser into the existing `sdetkit repo` CLI and wired exit codes: `0` pass, `1` failing checks, `2` usage/path/runtime errors. 
- Added a pytest file `tests/test_repo_audit_cli.py` covering deterministic output, fail scenarios, and `--out`/`--force` behavior. 
- Updated documentation and user-facing metadata: `docs/repo-audit.md`, `docs/cli.md`, `README.md`, `mkdocs.yml`, `pyproject.toml`, `.github/ISSUE_TEMPLATE/config.yml`, and related docs to rebrand `sdet_bootcamp` → `DevS69-sdetkit` and include audit examples.

### Testing

- Ran the full quality and test suite via `bash quality.sh all` and all checks passed. 
- Ran `pytest` (full suite) and observed: `266 passed`. 
- Ran `pytest` targeted on new tests and repo-audit tests; the new `tests/test_repo_audit_cli.py` passed. 
- Built docs with `mkdocs build --strict` successfully and performed a smoke check of `mkdocs serve` (server started successfully; run was timed out to allow non-blocking verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698cebc73c488323b5e6d396b5d186b4)