### PR TITLE
repo audit: add policy config and deterministic baseline workflows (Phase 4)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,7 +79,9 @@ Tool-specific notes:
 
 ## `repo`
 
-- `sdetkit repo audit [PATH] [--profile default|enterprise] [--format text|json|sarif] [--output PATH] [--fail-on none|warn|error] [--force]`
+- `sdetkit repo audit [PATH] [--profile default|enterprise] [--format text|json|sarif] [--output PATH] [--config PATH] [--baseline PATH] [--update-baseline] [--exclude GLOB ...] [--disable-rule RULE_ID ...] [--fail-on none|warn|error] [--force]`
+- `sdetkit repo baseline create [PATH] [--output BASELINE.json] [--profile default|enterprise] [--exclude GLOB ...]`
+- `sdetkit repo baseline check [PATH] [--baseline BASELINE.json] [--fail-on none|warn|error] [--update] [--diff]`
 - `sdetkit repo check [PATH] [--format text|json|md] [--out PATH] [--fail-on LEVEL] [--min-score N]`
 - `sdetkit repo fix [PATH] [--check|--dry-run] [--diff] [--eol lf|crlf]`
 - `sdetkit repo init [PATH] [--profile default|enterprise] [--dry-run] [--apply] [--force] [--diff]`
@@ -89,6 +91,8 @@ Audit examples:
 
 - `sdetkit repo audit`
 - `sdetkit repo audit --format json --out repo-audit.json --force`
+- `sdetkit repo baseline create .`
+- `sdetkit repo baseline check . --diff`
 
 Init examples:
 

--- a/docs/policy-and-baselines.md
+++ b/docs/policy-and-baselines.md
@@ -1,0 +1,83 @@
+# Policy and baselines (`sdetkit repo audit`)
+
+Phase 4 adds company-grade policy and baseline controls to keep `repo audit` signal high while staying deterministic and offline.
+
+## Configuration location
+
+`sdetkit` reads policy from `pyproject.toml` at:
+
+```toml
+[tool.sdetkit.repo_audit]
+profile = "enterprise"
+fail_on = "warn"
+baseline_path = ".sdetkit/audit-baseline.json"
+exclude_paths = ["docs/**", ".venv/**", "dist/**"]
+disable_rules = ["repo_audit/missing_repo_hygiene_item"]
+severity_overrides = { "repo_audit/large_tracked_file" = "error" }
+allowlist = [
+  { rule_id = "repo_audit/missing_repo_hygiene_item", path = "examples/**" },
+  { rule_id = "repo_audit/missing_codeql", path = "legacy/**", contains = "accepted for legacy" }
+]
+```
+
+## Precedence (deterministic)
+
+1. CLI flags
+2. `pyproject.toml` policy
+3. profile defaults
+
+No network calls are used for policy/baseline resolution.
+
+## Baseline workflow
+
+Create baseline:
+
+```bash
+sdetkit repo baseline create .
+```
+
+Check drift (NEW/RESOLVED/UNCHANGED):
+
+```bash
+sdetkit repo baseline check . --diff
+```
+
+Update baseline in-place:
+
+```bash
+sdetkit repo baseline check . --update --fail-on none
+```
+
+Baseline JSON format:
+
+- `schema_version`
+- optional metadata (`created_at`, `tool_version`)
+- `entries`: `rule_id`, `path`, `fingerprint`, `severity`, `message_key`
+
+Fingerprints are deterministic hashes of rule id + normalized path + stable message key.
+
+## `repo audit` integration
+
+`repo audit` supports:
+
+- `--config PATH`
+- `--baseline PATH`
+- `--update-baseline`
+- `--exclude GLOB` (repeatable)
+- `--disable-rule RULE_ID` (repeatable)
+
+When baseline is present and `--update-baseline` is not used, baseline-matching findings are suppressed from actionable output and fail gating.
+
+Text output includes:
+
+- total findings
+- suppressed by baseline
+- suppressed by policy (`exclude_paths`, `disable_rules`, `allowlist`)
+- actionable findings
+
+JSON output includes suppression records and aggregate suppression counters.
+SARIF output includes actionable findings only.
+
+## CI + GitHub Action guidance
+
+Use baseline-aware `repo audit` in CI for stable gates while keeping trend visibility through baseline check output and optional JSON artifacts/step summary from the Phase 3 GitHub Action workflow.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - CLI: cli.md
       - Doctor: doctor.md
       - Repo audit: repo-audit.md
+      - Policy & baselines: policy-and-baselines.md
       - Repo init: repo-init.md
       - Patch harness: patch-harness.md
   - Integrations:

--- a/tests/test_repo_audit_cli.py
+++ b/tests/test_repo_audit_cli.py
@@ -56,7 +56,14 @@ def test_repo_audit_json_schema_and_stable_keys(tmp_path: Path) -> None:
 
     payload = json.loads(result.stdout)
     assert payload["schema_version"] == "1.0.0"
-    assert list(payload.keys()) == ["checks", "findings", "root", "schema_version", "summary"]
+    assert list(payload.keys()) == [
+        "checks",
+        "findings",
+        "root",
+        "schema_version",
+        "summary",
+        "suppressed",
+    ]
 
 
 def test_repo_audit_sarif_has_required_fields(tmp_path: Path) -> None:

--- a/tests/test_repo_audit_policy_baseline.py
+++ b/tests/test_repo_audit_policy_baseline.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+
+from sdetkit import cli
+
+
+@dataclass
+class Result:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class CliRunner:
+    def invoke(self, args: list[str]) -> Result:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = cli.main(args)
+        return Result(exit_code=exit_code, stdout=stdout.getvalue(), stderr=stderr.getvalue())
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    (root / "CONTRIBUTING.md").write_text("guide\n", encoding="utf-8")
+    (root / "CODE_OF_CONDUCT.md").write_text("code\n", encoding="utf-8")
+    (root / "SECURITY.md").write_text("security\n", encoding="utf-8")
+    (root / "CHANGELOG.md").write_text("changes\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    (root / "noxfile.py").write_text("\n", encoding="utf-8")
+    (root / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (root / "requirements-test.txt").write_text("pytest\n", encoding="utf-8")
+    (root / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (root / "tests").mkdir()
+    (root / "docs").mkdir()
+    wf = root / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+
+
+def _audit_json(runner: CliRunner, root: Path, *extra: str) -> Result:
+    return runner.invoke(
+        ["repo", "audit", str(root), "--allow-absolute-path", "--format", "json", *extra]
+    )
+
+
+def test_config_precedence_cli_over_config_over_profile(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+[tool.sdetkit.repo_audit]
+profile = "default"
+fail_on = "none"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    result_config = _audit_json(runner, tmp_path)
+    assert result_config.exit_code == 0
+
+    result_cli = _audit_json(runner, tmp_path, "--fail-on", "warn")
+    assert result_cli.exit_code == 1
+
+
+def test_exclude_patterns_disable_rules_and_allowlist_suppress(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "docs" / "huge.bin").write_bytes(b"x" * (6 * 1024 * 1024))
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+[tool.sdetkit.repo_audit]
+exclude_paths = ["docs/**"]
+disable_rules = ["repo_audit/missing_repo_hygiene_item"]
+allowlist = [
+  { rule_id = "repo_audit/missing_repo_hygiene_item", path = ".github/**", contains = "required repository hygiene item" }
+]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = _audit_json(runner, tmp_path)
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["policy"]["suppressed_by_policy"] >= 1
+    assert all(item["code"] != "large_tracked_file" for item in payload["findings"])
+
+
+def test_severity_overrides_apply_for_gating(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "LICENSE").unlink(missing_ok=True)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+[tool.sdetkit.repo_audit]
+severity_overrides = { "repo_audit/missing_required_file" = "info" }
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = _audit_json(runner, tmp_path, "--fail-on", "warn")
+    payload = json.loads(result.stdout)
+    overridden = [item for item in payload["findings"] if item["code"] == "missing_required_file"]
+    assert overridden
+    assert {item["severity"] for item in overridden} == {"info"}
+    assert result.exit_code == 1
+
+
+def test_baseline_create_stable_schema_and_order(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    runner = CliRunner()
+    baseline = tmp_path / ".sdetkit" / "audit-baseline.json"
+
+    first = runner.invoke(["repo", "baseline", "create", str(tmp_path), "--allow-absolute-path"])
+    assert first.exit_code == 0
+    doc1 = json.loads(baseline.read_text(encoding="utf-8"))
+
+    second = runner.invoke(["repo", "baseline", "create", str(tmp_path), "--allow-absolute-path"])
+    assert second.exit_code == 0
+    doc2 = json.loads(baseline.read_text(encoding="utf-8"))
+
+    assert doc1["schema_version"] == "1.0"
+    assert doc1 == doc2
+    assert doc1["entries"] == sorted(
+        doc1["entries"], key=lambda x: (x["path"], x["rule_id"], x["fingerprint"])
+    )
+
+
+def test_baseline_check_new_resolved_unchanged_and_update(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    runner = CliRunner()
+
+    create = runner.invoke(["repo", "baseline", "create", str(tmp_path), "--allow-absolute-path"])
+    assert create.exit_code == 0
+
+    (tmp_path / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    (tmp_path / "docs" / "huge.bin").write_bytes(b"x" * (6 * 1024 * 1024))
+
+    check = runner.invoke(
+        [
+            "repo",
+            "baseline",
+            "check",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--fail-on",
+            "warn",
+            "--diff",
+        ]
+    )
+    assert check.exit_code == 1
+    assert "NEW:" in check.stdout and "RESOLVED:" in check.stdout and "UNCHANGED:" in check.stdout
+
+    update = runner.invoke(
+        [
+            "repo",
+            "baseline",
+            "check",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--fail-on",
+            "none",
+            "--update",
+        ]
+    )
+    assert update.exit_code == 0
+
+
+def test_repo_audit_baseline_suppression_hides_gating_noise(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    runner = CliRunner()
+    create = runner.invoke(["repo", "baseline", "create", str(tmp_path), "--allow-absolute-path"])
+    assert create.exit_code == 0
+
+    result = _audit_json(runner, tmp_path)
+    payload = json.loads(result.stdout)
+    assert result.exit_code == 0
+    assert payload["summary"]["policy"]["suppressed_by_baseline"] >= 1
+    assert payload["summary"]["policy"]["actionable"] == 0
+
+
+def test_update_baseline_is_idempotent(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    runner = CliRunner()
+    baseline = tmp_path / ".sdetkit" / "audit-baseline.json"
+    runner.invoke(["repo", "baseline", "create", str(tmp_path), "--allow-absolute-path"])
+
+    first = _audit_json(runner, tmp_path, "--update-baseline")
+    assert first.exit_code == 0
+    snapshot1 = baseline.read_text(encoding="utf-8")
+
+    second = _audit_json(runner, tmp_path, "--update-baseline")
+    assert second.exit_code == 0
+    snapshot2 = baseline.read_text(encoding="utf-8")
+
+    assert snapshot1 == snapshot2
+    assert first.stdout == second.stdout


### PR DESCRIPTION
### Motivation

- Enable enterprise-grade, deterministic policy and baseline workflows for `sdetkit repo audit` so teams can enforce gates without noise and track drift over time. 
- Keep everything offline-friendly, deterministic across machines, and tightly integrated into the existing CLI and outputs (JSON/SARIF/text). 

### Description

- Add config support via `pyproject.toml` under `[tool.sdetkit.repo_audit]` with fields `profile`, `fail_on`, `baseline_path`, `exclude_paths`, `disable_rules`, `severity_overrides`, and `allowlist`, and implement precedence `CLI > config > profile defaults`. 
- Implement deterministic finding fingerprinting and policy model (new `RepoAuditPolicy`, `AllowlistRule`, config validation) and apply policy rules (excludes, disabled rules, severity overrides, allowlist) to produce actionable vs suppressed findings with suppression reasons and stable ordering. 
- Add baseline JSON handling and helpers: deterministic baseline entries schema (`schema_version`, `tool_version`, `entries`), stable ordering, concise diff generation, and read/write helpers. 
- Add new CLI subcommands and flags: `sdetkit repo baseline create` and `sdetkit repo baseline check` (with `--update`/`--diff`/`--fail-on`), and extend `sdetkit repo audit` with `--config`, `--baseline`, `--update-baseline`, `--exclude`, and `--disable-rule`; baseline suppression is applied to gating and outputs. 
- Integrate suppression metadata into outputs: text rendering now prints a suppression summary, JSON includes `suppressed` records and `summary.policy` counters, and SARIF continues to emit actionable findings only. 
- Add docs page `docs/policy-and-baselines.md`, update `docs/cli.md` and `mkdocs.yml`, and add extensive end-to-end pytest coverage for policy and baseline behaviors (`tests/test_repo_audit_policy_baseline.py`) while adjusting existing tests as needed. Changes are concentrated in `src/sdetkit/repo.py` with small CLI wiring and docs/tests added. 

### Testing

- Ran targeted tests for the new feature: `python -m pytest -q tests/test_repo_audit_policy_baseline.py tests/test_repo_audit_cli.py` and they passed. 
- Ran the full test suite: `python -m pytest -q` with all tests passing (`281 passed`). 
- Ran quality tooling: `bash quality.sh all` and resolved lint/type issues until `quality.sh` reported success.

------