### PR TITLE
Fix Ruff format check failure in plugins.py

### DIFF
--- a/src/sdetkit/plugins.py
+++ b/src/sdetkit/plugins.py
@@ -72,9 +72,7 @@ class Fixer(Protocol):
     @property
     def rule_id(self) -> str: ...
 
-    def fix(
-        self, repo_root: Path, findings: list[Finding], context: dict[str, Any]
-    ) -> list[Fix]:
+    def fix(self, repo_root: Path, findings: list[Finding], context: dict[str, Any]) -> list[Fix]:
         pass
 
 


### PR DESCRIPTION
### Motivation
- CI formatting reported `src/sdetkit/plugins.py` would be reformatted by `ruff`, causing the repo check to fail due to a wrapped function signature.

### Description
- Applied `python -m ruff format` to `src/sdetkit/plugins.py` to normalize formatting and collapse the `Fixer.fix` function signature onto a single line.

### Testing
- Ran `python -m ruff format --check .` and `python -m ruff check .`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698d1759cd3083239a995b8820d3dcd1)