### PR TITLE
Potential fix for code scanning alert no. 32: Statement has no effect

### DIFF
--- a/src/sdetkit/plugins.py
+++ b/src/sdetkit/plugins.py
@@ -70,7 +70,8 @@ class AuditRule(Protocol):
 
 class Fixer(Protocol):
     @property
-    def rule_id(self) -> str: ...
+    def rule_id(self) -> str:
+        pass
 
     def fix(self, repo_root: Path, findings: list[Finding], context: dict[str, Any]) -> list[Fix]:
         pass


### PR DESCRIPTION
Potential fix for [https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/32](https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/32)

In general, to fix a “statement has no effect” issue caused by a bare `...`, either remove the statement or replace it with a construct that clearly expresses the intent (such as `pass` for an empty body, or a real implementation / exception). For protocol or interface-like definitions in Python, `pass` is idiomatic when the body is intentionally empty.

Here, `AuditRule.meta` uses `raise NotImplementedError`, and the `run` and `fix` methods use `pass`. To be consistent and avoid a no-effect expression, we should change the `rule_id` property in `Fixer` from `...` to `pass`. This keeps it as an unimplemented placeholder, matches the existing style in this file, and removes the no-effect statement. Concretely, in `src/sdetkit/plugins.py`, adjust the `rule_id` property of `Fixer` so its body is `pass` instead of `...`. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
