### PR TITLE
Potential fix for code scanning alert no. 33: Variable defined multiple times

### DIFF
--- a/src/sdetkit/report.py
+++ b/src/sdetkit/report.py
@@ -338,10 +338,6 @@ def build_dashboard(history_dir: Path, output: Path, fmt: str, since: int | None
 
     totals = [
         int(item.get("aggregates", {}).get("counts_by_severity", {}).get("error", 0))
-        for item in runs
-    ]
-    totals = [
-        int(item.get("aggregates", {}).get("counts_by_severity", {}).get("error", 0))
         + int(item.get("aggregates", {}).get("counts_by_severity", {}).get("warn", 0))
         for item in runs
     ]


### PR DESCRIPTION
Potential fix for [https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/33](https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/33)

In general, when a variable is assigned multiple times without any intervening reads, and the first assignment has no side effects, the first assignment should be removed. This eliminates dead code and clarifies the intended value of the variable.

Here, in `build_dashboard` in `src/sdetkit/report.py`, `totals` is assigned twice in a row:

- First, to a list of error counts (lines 339–342).
- Immediately after, to a list of error + warn counts (lines 343–347).

Since only the second assignment can ever be used, we should delete the first `totals = [...]` block on lines 339–342 and leave the second one (lines 343–347) intact. No imports or additional definitions are required, and this does not change functionality because the overwritten value was never observed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
