### PR TITLE
feat(repo): add monorepo project discovery and aggregate audit/fix flows

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,10 +79,10 @@ Tool-specific notes:
 
 ## `repo`
 
-- `sdetkit repo audit [PATH] [--profile default|enterprise] [--pack PACKS] [--format text|json|sarif] [--json-schema legacy|v1] [--output PATH] [--emit-run-record PATH] [--diff-against RUN.json] [--step-summary] [--config PATH] [--baseline PATH] [--update-baseline] [--exclude GLOB ...] [--disable-rule RULE_ID ...] [--fail-on none|warn|error] [--force]`
+- `sdetkit repo audit [PATH] [--profile default|enterprise] [--pack PACKS] [--format text|json|sarif] [--json-schema legacy|v1] [--output PATH] [--emit-run-record PATH] [--diff-against RUN.json] [--step-summary] [--config PATH] [--baseline PATH] [--update-baseline] [--exclude GLOB ...] [--disable-rule RULE_ID ...] [--fail-on none|warn|error] [--all-projects] [--fail-strategy overall|per-project] [--sort] [--force]`
 - `sdetkit repo baseline create [PATH] [--output BASELINE.json] [--profile default|enterprise] [--exclude GLOB ...]`
 - `sdetkit repo rules list [--profile default|enterprise] [--pack PACKS] [--json]`
-- `sdetkit repo fix-audit [PATH] [--profile ...] [--pack PACKS] [--dry-run|--apply] [--diff] [--patch OUT.patch] [--force]`
+- `sdetkit repo fix-audit [PATH] [--profile ...] [--pack PACKS] [--project NAME|--all-projects] [--dry-run|--apply] [--diff] [--patch OUT.patch] [--sort] [--force]`
 - `sdetkit repo baseline check [PATH] [--baseline BASELINE.json] [--fail-on none|warn|error] [--update] [--diff]`
 - `sdetkit repo check [PATH] [--format text|json|md] [--out PATH] [--fail-on LEVEL] [--min-score N]`
 - `sdetkit repo fix [PATH] [--check|--dry-run] [--diff] [--eol lf|crlf]`
@@ -117,3 +117,5 @@ GitHub Action integration:
 - `sdetkit report build [--history-dir .sdetkit/audit-history] [--output report.html] [--format html|md] [--since N]`
 
 See: reporting-and-trends.md
+
+- `sdetkit repo projects list [PATH] [--json] [--sort]`

--- a/docs/monorepo-projects.md
+++ b/docs/monorepo-projects.md
@@ -1,0 +1,57 @@
+# Monorepo + multi-project support
+
+`sdetkit` supports deterministic multi-project audits from a single repository root.
+
+## Manifest formats
+
+Preferred file: `.sdetkit/projects.toml`.
+Fallback: `pyproject.toml` with `[tool.sdetkit.projects]`.
+
+```toml
+[[project]]
+name = "api"
+root = "services/api"
+config = "services/api/pyproject.toml"
+profile = "enterprise"
+packs = ["core", "security"]
+baseline = "services/api/.sdetkit/audit-baseline.json"
+exclude = ["docs/*", "generated/*"]
+
+[[project]]
+name = "core"
+root = "libs/core"
+packs = "core,security"
+```
+
+## Commands
+
+- List discovered projects:
+  - `sdetkit repo projects list .`
+  - `sdetkit repo projects list . --json`
+- Aggregate audit:
+  - `sdetkit repo audit . --all-projects`
+  - `sdetkit repo audit . --all-projects --format json`
+  - `sdetkit repo audit . --all-projects --format sarif`
+- Fix-audit targeting:
+  - `sdetkit repo fix-audit . --project api --apply`
+  - `sdetkit repo fix-audit . --all-projects --dry-run`
+
+## Aggregation behavior
+
+- Project discovery is deterministic (manifest order).
+- `--sort` switches to alphabetical project ordering.
+- JSON aggregate schema: `sdetkit.audit.aggregate.v1`.
+- SARIF output emits one SARIF file with separate `runs` per project.
+- Baseline default per project root is `.sdetkit/audit-baseline.json`.
+
+## Precedence
+
+- Defaults < manifest values < project config < CLI flags.
+- Project config is loaded from each project root (or manifest `config` path).
+- CLI flags always win for profile, fail-on, packs, excludes, and baseline.
+
+## Safety and determinism
+
+- No network calls are used.
+- Paths in findings and SARIF are normalized to relative POSIX style.
+- `fix-audit` writes only under each selected project root.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Repo audit: repo-audit.md
       - Policy & baselines: policy-and-baselines.md
       - Plugins & fix-audit: plugins-and-fix.md
+      - Monorepo projects: monorepo-projects.md
       - Reporting & trends: reporting-and-trends.md
       - Repo init: repo-init.md
       - Patch harness: patch-harness.md

--- a/src/sdetkit/projects.py
+++ b/src/sdetkit/projects.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+try:
+    import tomllib as _tomllib
+except Exception:  # pragma: no cover
+    import tomli as _tomllib  # type: ignore
+
+
+class ProjectsConfigError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class RepoProject:
+    name: str
+    root: str
+    config_path: str | None
+    profile: str | None
+    packs: tuple[str, ...]
+    baseline_path: str | None
+    exclude_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedRepoProject:
+    name: str
+    root: Path
+    root_rel: str
+    config_path: Path | None
+    config_rel: str | None
+    profile: str | None
+    packs: tuple[str, ...]
+    baseline_path: str | None
+    baseline_rel: str
+    exclude_paths: tuple[str, ...]
+
+
+def _as_str(value: Any, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ProjectsConfigError(f"projects field '{field}' must be a string")
+    text = value.strip()
+    return text or None
+
+
+def _as_str_list_or_csv(value: Any, *, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return tuple(part.strip() for part in value.split(",") if part.strip())
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return tuple(item.strip() for item in value if item.strip())
+    raise ProjectsConfigError(f"projects field '{field}' must be a list of strings or csv string")
+
+
+def _normalize_rel(path_text: str, *, field: str) -> str:
+    raw = path_text.replace("\\", "/").strip()
+    while raw.startswith("./"):
+        raw = raw[2:]
+    if not raw:
+        return "."
+    if raw.startswith("/"):
+        raise ProjectsConfigError(f"projects field '{field}' must be relative")
+    parts = [part for part in raw.split("/") if part]
+    if any(part == ".." for part in parts):
+        raise ProjectsConfigError(f"projects field '{field}' cannot contain traversal")
+    return "/".join(parts) or "."
+
+
+def _load_manifest_doc(repo_root: Path) -> tuple[dict[str, Any], str] | None:
+    preferred = repo_root / ".sdetkit" / "projects.toml"
+    if preferred.exists():
+        data = cast(Any, _tomllib).loads(preferred.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ProjectsConfigError("projects manifest must be a TOML table")
+        return data, ".sdetkit/projects.toml"
+
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    data = cast(Any, _tomllib).loads(pyproject.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        return None
+    tool = data.get("tool")
+    if not isinstance(tool, dict):
+        return None
+    sdetkit = tool.get("sdetkit")
+    if not isinstance(sdetkit, dict):
+        return None
+    projects = sdetkit.get("projects")
+    if projects is None:
+        return None
+    if not isinstance(projects, dict):
+        raise ProjectsConfigError("[tool.sdetkit.projects] must be a table")
+    return projects, "pyproject.toml"
+
+
+def discover_projects(
+    repo_root: Path, *, sort: bool = False
+) -> tuple[str | None, list[RepoProject]]:
+    loaded = _load_manifest_doc(repo_root)
+    if loaded is None:
+        return None, []
+    data, source = loaded
+
+    raw_items = data.get("project")
+    if raw_items is None:
+        return source, []
+    if not isinstance(raw_items, list) or any(not isinstance(item, dict) for item in raw_items):
+        raise ProjectsConfigError("projects manifest must define [[project]] entries")
+
+    projects: list[RepoProject] = []
+    seen: set[str] = set()
+    for item in raw_items:
+        entry = cast(dict[str, Any], item)
+        name = _as_str(entry.get("name"), field="name")
+        root = _as_str(entry.get("root"), field="root")
+        if not name or not root:
+            raise ProjectsConfigError("project entries require 'name' and 'root'")
+        if name in seen:
+            raise ProjectsConfigError(f"duplicate project name: {name}")
+        seen.add(name)
+        projects.append(
+            RepoProject(
+                name=name,
+                root=_normalize_rel(root, field="root"),
+                config_path=(
+                    _normalize_rel(cfg, field="config")
+                    if (cfg := _as_str(entry.get("config"), field="config"))
+                    else None
+                ),
+                profile=_as_str(entry.get("profile"), field="profile"),
+                packs=_as_str_list_or_csv(entry.get("packs"), field="packs"),
+                baseline_path=(
+                    _normalize_rel(base, field="baseline")
+                    if (base := _as_str(entry.get("baseline"), field="baseline"))
+                    else None
+                ),
+                exclude_paths=_as_str_list_or_csv(entry.get("exclude"), field="exclude"),
+            )
+        )
+
+    if sort:
+        projects.sort(key=lambda p: p.name)
+    return source, projects
+
+
+def resolve_project(repo_root: Path, project: RepoProject) -> ResolvedRepoProject:
+    root_rel = _normalize_rel(project.root, field="root")
+    root = (repo_root / root_rel).resolve(strict=False)
+    baseline_rel = project.baseline_path or f"{root_rel}/.sdetkit/audit-baseline.json"
+    return ResolvedRepoProject(
+        name=project.name,
+        root=root,
+        root_rel=root_rel,
+        config_path=(repo_root / project.config_path).resolve(strict=False)
+        if project.config_path
+        else None,
+        config_rel=project.config_path,
+        profile=project.profile,
+        packs=project.packs,
+        baseline_path=project.baseline_path,
+        baseline_rel=_normalize_rel(baseline_rel, field="baseline"),
+        exclude_paths=project.exclude_paths,
+    )

--- a/tests/test_repo_monorepo_projects.py
+++ b/tests/test_repo_monorepo_projects.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+
+from sdetkit import cli
+
+
+@dataclass
+class Result:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class CliRunner:
+    def invoke(self, args: list[str]) -> Result:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = cli.main(args)
+        return Result(exit_code=exit_code, stdout=stdout.getvalue(), stderr=stderr.getvalue())
+
+
+def _seed_project(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    (root / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    (root / "CONTRIBUTING.md").write_text("guide\n", encoding="utf-8")
+    (root / "CODE_OF_CONDUCT.md").write_text("code\n", encoding="utf-8")
+    (root / "SECURITY.md").write_text("security\n", encoding="utf-8")
+    (root / "CHANGELOG.md").write_text("changes\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    (root / "noxfile.py").write_text("\n", encoding="utf-8")
+    (root / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (root / "requirements-test.txt").write_text("pytest\n", encoding="utf-8")
+    (root / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (root / "tests").mkdir(exist_ok=True)
+    (root / "docs").mkdir(exist_ok=True)
+    wf = root / ".github" / "workflows"
+    wf.mkdir(parents=True, exist_ok=True)
+    (wf / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+    (wf / "security.yml").write_text("name: security\n", encoding="utf-8")
+
+
+def _seed_monorepo(root: Path) -> None:
+    _seed_project(root / "services" / "api")
+    _seed_project(root / "libs" / "core")
+    (root / ".sdetkit").mkdir(parents=True)
+    (root / ".sdetkit" / "projects.toml").write_text(
+        """
+[[project]]
+name = "api"
+root = "services/api"
+exclude = ["docs/*"]
+
+[[project]]
+name = "core"
+root = "libs/core"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_projects_list_json_is_deterministic(tmp_path: Path) -> None:
+    _seed_monorepo(tmp_path)
+    runner = CliRunner()
+    first = runner.invoke(
+        ["repo", "projects", "list", str(tmp_path), "--allow-absolute-path", "--json"]
+    )
+    second = runner.invoke(
+        ["repo", "projects", "list", str(tmp_path), "--allow-absolute-path", "--json"]
+    )
+    assert first.exit_code == 0
+    assert first.stdout == second.stdout
+    payload = json.loads(first.stdout)
+    assert [item["name"] for item in payload["projects"]] == ["api", "core"]
+
+
+def test_audit_all_projects_json_and_sarif_runs(tmp_path: Path) -> None:
+    _seed_monorepo(tmp_path)
+    (tmp_path / "services" / "api" / "CONTRIBUTING.md").unlink()
+
+    runner = CliRunner()
+    out_json = runner.invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--all-projects",
+            "--format",
+            "json",
+        ]
+    )
+    assert out_json.exit_code == 1
+    payload = json.loads(out_json.stdout)
+    assert payload["schema_version"] == "sdetkit.audit.aggregate.v1"
+    assert len(payload["projects"]) == 2
+
+    out_sarif = runner.invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--all-projects",
+            "--format",
+            "sarif",
+        ]
+    )
+    sarif = json.loads(out_sarif.stdout)
+    assert len(sarif["runs"]) == 2
+
+
+def test_fix_audit_project_scoped_only(tmp_path: Path) -> None:
+    _seed_monorepo(tmp_path)
+    (tmp_path / "services" / "api" / "SECURITY.md").unlink()
+    (tmp_path / "libs" / "core" / "SECURITY.md").unlink()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        [
+            "repo",
+            "fix-audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--project",
+            "api",
+            "--apply",
+            "--force",
+        ]
+    )
+    assert result.exit_code == 0
+    assert (tmp_path / "services" / "api" / "SECURITY.md").exists()
+    assert not (tmp_path / "libs" / "core" / "SECURITY.md").exists()
+
+
+def test_all_projects_audit_idempotent_json(tmp_path: Path) -> None:
+    _seed_monorepo(tmp_path)
+    runner = CliRunner()
+    first = runner.invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--all-projects",
+            "--format",
+            "json",
+        ]
+    )
+    second = runner.invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--all-projects",
+            "--format",
+            "json",
+        ]
+    )
+    assert first.stdout == second.stdout


### PR DESCRIPTION
### Motivation

- Many repositories are monorepos with multiple services that need per-project policy, baselines, and scoped fixes, so the audit/fix pipeline must discover and operate per-project while producing aggregated results.
- Outputs (text/json/sarif) and CI gates must be deterministic and offline-friendly to ensure stable automation and reporting across teams.

### Description

- Add a new project model and manifest discovery in `src/sdetkit/projects.py` supporting `.sdetkit/projects.toml` (preferred) and `[tool.sdetkit.projects]` in `pyproject.toml`, with strict validation, deterministic ordering, and `--sort` for stable alphabetical ordering.
- Extend the `sdetkit repo` CLI (`src/sdetkit/repo.py`) with `projects list`, `audit --all-projects`, and `fix-audit --project|--all-projects` options and related flags (`--sort`, `--fail-strategy`, etc.) to run audits per resolved project using per-project config/packs/baselines and aggregate results.
- Implement aggregate rendering for text/json/sarif: JSON schema `sdetkit.audit.aggregate.v1` and SARIF emits one `run` per project; per-project run records are preserved and totals/deltas are computed.
- Ensure `fix-audit` is project-scoped (writes only under each project root) and respects config precedence (defaults < manifest < project config < CLI flags) and baseline defaults (`.sdetkit/audit-baseline.json` under project root).
- Add docs `docs/monorepo-projects.md`, update `docs/cli.md`, and add navigation entry in `mkdocs.yml`.
- Add tests `tests/test_repo_monorepo_projects.py` covering discovery, deterministic listing, aggregate JSON/SARIF, project-scoped fixes, and idempotency.

### Testing

- Ran unit test suite: `python -m pytest -q` and observed `296 passed` with full test run completing successfully.
- Ran quality and formatting checks: `bash quality.sh all` and auto-fixes (`ruff --fix`) were applied where needed and the quality checks passed.
- Ran targeted tests during development: `python -m pytest -q tests/test_repo_monorepo_projects.py` (all tests passed) and `python -m pytest -q tests/test_repo_audit_cli.py tests/test_repo_plugins_fix_audit.py` as part of integration validation (all passed as part of the full run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698d2102b5408323ae58ccda3d67d2d4)