### PR TITLE
feat(repo-audit): governed allowlists, org policy packs, and policy lint/export

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,11 +79,13 @@ Tool-specific notes:
 
 ## `repo`
 
-- `sdetkit repo audit [PATH] [--profile default|enterprise] [--pack PACKS] [--format text|json|sarif] [--json-schema legacy|v1] [--output PATH] [--emit-run-record PATH] [--diff-against RUN.json] [--step-summary] [--config PATH] [--baseline PATH] [--update-baseline] [--exclude GLOB ...] [--disable-rule RULE_ID ...] [--fail-on none|warn|error] [--all-projects] [--fail-strategy overall|per-project] [--sort] [--force]`
+- `sdetkit repo audit [PATH] [--profile default|enterprise] [--pack PACKS] [--org-pack PACK ...] [--format text|json|sarif] [--json-schema legacy|v1] [--output PATH] [--emit-run-record PATH] [--diff-against RUN.json] [--step-summary] [--config PATH] [--baseline PATH] [--update-baseline] [--exclude GLOB ...] [--disable-rule RULE_ID ...] [--fail-on none|warn|error] [--all-projects] [--fail-strategy overall|per-project] [--sort] [--force]`
 - `sdetkit repo baseline create [PATH] [--output BASELINE.json] [--profile default|enterprise] [--exclude GLOB ...]`
-- `sdetkit repo rules list [--profile default|enterprise] [--pack PACKS] [--json]`
-- `sdetkit repo fix-audit [PATH] [--profile ...] [--pack PACKS] [--project NAME|--all-projects] [--dry-run|--apply] [--diff] [--patch OUT.patch] [--sort] [--force]`
+- `sdetkit repo rules list [--profile default|enterprise] [--pack PACKS] [--org-pack PACK ...] [--json]`
+- `sdetkit repo fix-audit [PATH] [--profile ...] [--pack PACKS] [--org-pack PACK ...] [--project NAME|--all-projects] [--dry-run|--apply] [--diff] [--patch OUT.patch] [--sort] [--force]`
 - `sdetkit repo baseline check [PATH] [--baseline BASELINE.json] [--fail-on none|warn|error] [--update] [--diff]`
+- `sdetkit repo policy lint [PATH] [--config PATH] [--format text|json] [--fail-on none|warn|error]`
+- `sdetkit repo policy export [PATH] [--config PATH] [--output FILE.json] [--include-expired]`
 - `sdetkit repo check [PATH] [--format text|json|md] [--out PATH] [--fail-on LEVEL] [--min-score N]`
 - `sdetkit repo fix [PATH] [--check|--dry-run] [--diff] [--eol lf|crlf]`
 - `sdetkit repo init [PATH] [--profile default|enterprise] [--dry-run] [--apply] [--force] [--diff]`

--- a/docs/governance-and-org-packs.md
+++ b/docs/governance-and-org-packs.md
@@ -1,0 +1,98 @@
+# Governance and org packs
+
+`sdetkit repo audit` supports governed allowlist exceptions and organization policy packs.
+
+## Governed allowlist entries
+
+Use TOML tables for deterministic, reviewable exceptions:
+
+```toml
+[[tool.sdetkit.repo_audit.allowlist]]
+rule_id = "CORE_MISSING_SECURITY_MD"
+path = "SECURITY.md"
+contains = "missing required file"
+owner = "security@acme.example"
+justification = "Temporary exception while template is being migrated"
+created = "2026-01-01"
+expires = "2026-06-30"
+ticket = "SEC-1234"
+```
+
+Fields:
+
+- `owner` (required by lint)
+- `justification` (required by lint, non-empty)
+- `created` (optional ISO date)
+- `expires` (optional ISO date)
+- `ticket` (optional)
+- `rule_id`, `path`, `contains` (match scope)
+
+## Expiration and determinism
+
+Current date source:
+
+1. `SDETKIT_TODAY=YYYY-MM-DD` if set (recommended for CI/tests)
+2. Local date otherwise
+
+Behavior:
+
+- `expires < today` → entry is `expired`
+- Expired entries do **not** suppress findings
+- Expired matches are reported in audit summaries via `suppressed_expired`
+
+## Policy lint (CI-friendly)
+
+```bash
+sdetkit repo policy lint . --format json --fail-on warn
+```
+
+Checks include:
+
+- missing `owner` / `justification` (errors)
+- expired exceptions (warning)
+- exceptions too far in future (warning, default threshold 365 days via `lint_expiry_max_days`)
+- duplicate allowlist scope tuples
+- unknown rule IDs in `disable_rules` and `severity_overrides`
+- unknown selected org packs
+
+## Policy export artifact
+
+```bash
+sdetkit repo policy export . --output policy-artifact.json --include-expired
+```
+
+Export format:
+
+- `schema_version: "sdetkit.policy.v1"`
+- normalized allowlist entries
+- computed `status` (`active` / `expired`)
+- deterministic ordering and stable JSON keys
+
+Use this artifact in CI for human approval workflows.
+
+## Org packs
+
+Select org packs from CLI or config:
+
+```toml
+[tool.sdetkit.repo_audit]
+org_packs = ["org-acme", "org-platform"]
+```
+
+```bash
+sdetkit repo audit . --org-pack org-acme --org-pack org-platform
+```
+
+Entry point group for pack plugins:
+
+- `sdetkit.repo_audit_packs`
+
+Plugin contract:
+
+- `pack_name: str`
+- `rule_ids: list[str] | tuple[str, ...]`
+- optional `defaults`:
+  - `fail_on`
+  - `severity_overrides`
+
+Org packs add rule selection and can provide defaults, while core rule IDs remain explicit and auditable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Policy & baselines: policy-and-baselines.md
       - Plugins & fix-audit: plugins-and-fix.md
       - Monorepo projects: monorepo-projects.md
+      - Governance & org packs: governance-and-org-packs.md
       - Reporting & trends: reporting-and-trends.md
       - Repo init: repo-init.md
       - Patch harness: patch-harness.md

--- a/tests/test_repo_audit_cli.py
+++ b/tests/test_repo_audit_cli.py
@@ -67,6 +67,7 @@ def test_repo_audit_json_schema_and_stable_keys(tmp_path: Path) -> None:
         "schema_version",
         "summary",
         "suppressed",
+        "suppressed_expired",
     ]
 
 

--- a/tests/test_repo_policy_governance.py
+++ b/tests/test_repo_policy_governance.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+
+from sdetkit import cli
+
+
+@dataclass
+class Result:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class CliRunner:
+    def invoke(self, args: list[str]) -> Result:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = cli.main(args)
+        return Result(exit_code=exit_code, stdout=stdout.getvalue(), stderr=stderr.getvalue())
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+
+
+def test_policy_lint_requires_owner_and_justification(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SDETKIT_TODAY", "2026-01-02")
+    _seed_repo(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+[tool.sdetkit.repo_audit]
+allowlist = [{ rule_id = "CORE_MISSING_SECURITY_MD", path = "SECURITY.md" }]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        [
+            "repo",
+            "policy",
+            "lint",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--format",
+            "json",
+            "--fail-on",
+            "error",
+        ]
+    )
+    payload = json.loads(result.stdout)
+    assert result.exit_code == 1
+    assert payload["counts"]["errors"] == 2
+    assert {item["code"] for item in payload["errors"]} == {
+        "missing_owner",
+        "missing_justification",
+    }
+
+
+def test_expired_allowlist_is_actionable_and_counted(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SDETKIT_TODAY", "2026-02-01")
+    _seed_repo(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+[tool.sdetkit.repo_audit]
+fail_on = "none"
+[[tool.sdetkit.repo_audit.allowlist]]
+rule_id = "CORE_MISSING_SECURITY_MD"
+path = "SECURITY.md"
+owner = "sec@acme"
+justification = "temp"
+expires = "2026-01-31"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        ["repo", "audit", str(tmp_path), "--allow-absolute-path", "--format", "json"]
+    )
+    payload = json.loads(result.stdout)
+    assert result.exit_code == 0
+    assert any(item["rule_id"] == "CORE_MISSING_SECURITY_MD" for item in payload["findings"])
+    assert payload["summary"]["policy"]["suppressed_active"] == 0
+    assert payload["summary"]["policy"]["suppressed_expired"] >= 1
+
+
+def test_today_env_controls_expiration_deterministically(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+[tool.sdetkit.repo_audit]
+[[tool.sdetkit.repo_audit.allowlist]]
+rule_id = "CORE_MISSING_SECURITY_MD"
+path = "SECURITY.md"
+owner = "sec@acme"
+justification = "temp"
+expires = "2026-01-31"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    monkeypatch.setenv("SDETKIT_TODAY", "2026-01-30")
+    active = runner.invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--format",
+            "json",
+            "--fail-on",
+            "none",
+        ]
+    )
+    active_payload = json.loads(active.stdout)
+    assert all(item["rule_id"] != "CORE_MISSING_SECURITY_MD" for item in active_payload["findings"])
+
+    monkeypatch.setenv("SDETKIT_TODAY", "2026-02-01")
+    expired = runner.invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--format",
+            "json",
+            "--fail-on",
+            "none",
+        ]
+    )
+    expired_payload = json.loads(expired.stdout)
+    assert any(
+        item["rule_id"] == "CORE_MISSING_SECURITY_MD" for item in expired_payload["findings"]
+    )
+
+
+def test_policy_export_is_deterministic_and_sorted(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SDETKIT_TODAY", "2026-01-01")
+    _seed_repo(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+[tool.sdetkit.repo_audit]
+[[tool.sdetkit.repo_audit.allowlist]]
+rule_id = "CORE_MISSING_SECURITY_MD"
+path = "SECURITY.md"
+owner = "sec@acme"
+justification = "waiver"
+created = "2025-12-01"
+expires = "2026-12-31"
+ticket = "SEC-123"
+[[tool.sdetkit.repo_audit.allowlist]]
+rule_id = "CORE_MISSING_CODE_OF_CONDUCT_MD"
+path = "CODE_OF_CONDUCT.md"
+owner = "eng@acme"
+justification = "migration"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    first = runner.invoke(["repo", "policy", "export", str(tmp_path), "--allow-absolute-path"])
+    second = runner.invoke(["repo", "policy", "export", str(tmp_path), "--allow-absolute-path"])
+    assert first.exit_code == 0
+    assert first.stdout == second.stdout
+    payload = json.loads(first.stdout)
+    assert payload["schema_version"] == "sdetkit.policy.v1"
+    assert payload["allowlist"] == sorted(
+        payload["allowlist"],
+        key=lambda item: (item["rule_id"], item["path"], item.get("contains") or ""),
+    )
+
+
+def test_org_pack_entrypoint_discovery_affects_audit_selection(tmp_path: Path, monkeypatch) -> None:
+    from sdetkit import plugins
+
+    class FakePack:
+        pack_name = "org-acme"
+        rule_ids = ("CORE_MISSING_SECURITY_MD",)
+        defaults = {"fail_on": "error"}
+
+    class FakeEP:
+        name = "acme-pack"
+
+        def load(self):
+            return FakePack
+
+    class EPs:
+        def select(self, *, group: str):
+            if group == "sdetkit.repo_audit_packs":
+                return [FakeEP()]
+            return []
+
+    monkeypatch.setattr(plugins.importlib_metadata, "entry_points", lambda: EPs())
+    _seed_repo(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+[tool.sdetkit.repo_audit]
+fail_on = "none"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--format",
+            "json",
+            "--org-pack",
+            "org-acme",
+        ]
+    )
+    assert result.exit_code == 1
+
+
+def test_unknown_ids_warn_deterministically(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SDETKIT_TODAY", "2026-01-01")
+    _seed_repo(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+[tool.sdetkit.repo_audit]
+disable_rules = ["NOT_REAL"]
+severity_overrides = { "ALSO_UNKNOWN" = "warn" }
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        [
+            "repo",
+            "policy",
+            "lint",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--format",
+            "json",
+            "--fail-on",
+            "none",
+        ]
+    )
+    payload = json.loads(result.stdout)
+    assert result.exit_code == 0
+    assert [item["code"] for item in payload["warnings"]] == [
+        "unknown_disable_rule",
+        "unknown_severity_override",
+    ]


### PR DESCRIPTION
### Motivation

- Make allowlist/suppressions governable and auditable with owners, justifications, and expirations so exceptions require review and can lapse deterministically.
- Enable organization-specific policy packs delivered via plugins and selectable from CLI/config without silently changing core rules.
- Provide CI-friendly policy validation and artifact export to support human approval workflows and deterministic testing.

### Description

- Extended allowlist model to include governance fields: `owner`, `justification`, `created`, `expires`, and `ticket`, and validate/parse ISO dates. (`src/sdetkit/repo.py`) 
- Added deterministic date source using `SDETKIT_TODAY` (override) and expiration semantics where expired allowlist entries do not suppress findings but are reported as expired matches; active/expired counts are exposed as `suppressed_active` / `suppressed_expired`. (audit pipeline integration and reporting changes)
- Implemented `sdetkit repo policy lint` and `sdetkit repo policy export` subcommands with deterministic JSON/text output, checks (missing owner/justification, expired, long expiry, duplicates, unknown rule IDs, unknown org packs) and an exported artifact schema `sdetkit.policy.v1`. (CLI wiring in `repo.py`)
- Added org pack support via new plugin entrypoint group `sdetkit.repo_audit_packs` and helpers to discover packs, merge selections, and apply pack defaults (`fail_on`, `severity_overrides`); CLI supports `--org-pack` and config `org_packs`. (`src/sdetkit/plugins.py`, `src/sdetkit/repo.py`)
- Integrated expiry-aware suppressions into the audit and fix-audit flows so expired suppressions are actionable; SARIF and run-record outputs include suppression context (`suppression_status`, `suppression_reason`, and `suppressed_expired` metadata).
- Documentation added: `docs/governance-and-org-packs.md`, updated `docs/cli.md` and `mkdocs.yml` navigation.
- Tests: new and updated pytest coverage for governance behavior, deterministic `SDETKIT_TODAY`, policy lint/export, org-pack discovery, and updated JSON expectations.

### Testing

- Ran unit test suite: `python -m pytest -q` and observed all tests pass (`302 passed`).
- Ran local quality gates: `bash quality.sh all` (format/lint/ruff/quality checks) and confirmed success.
- Executed targeted tests during development: `pytest tests/test_repo_policy_governance.py` and `pytest tests/test_repo_audit_policy_baseline.py tests/test_repo_plugins_fix_audit.py`, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698d23b62bcc8323b52044ea7f281fce)