### PR TITLE
Potential fix for code scanning alert no. 34: Empty except

### DIFF
--- a/src/sdetkit/repo.py
+++ b/src/sdetkit/repo.py
@@ -1878,6 +1878,8 @@ def collect_git_changed_files(
     try:
         changed.update(_git_name_only(root, ["diff", "--name-only", f"{since_ref}...HEAD"]))
     except ValueError:
+        # Ignore failures when diffing from since_ref (e.g., invalid ref or no common base);
+        # we still return files changed in the working tree, staged area, and untracked files.
         pass
     if include_untracked:
         changed.update(_git_name_only(root, ["ls-files", "--others", "--exclude-standard"]))


### PR DESCRIPTION
Potential fix for [https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/34](https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/34)

General approach: either handle the exception meaningfully (e.g., log a warning) or, if the intent is genuinely to ignore it, add an explanatory comment and, ideally, narrow the circumstances or content of the suppression to make that intent explicit.

Best minimal fix without changing functionality: keep ignoring the `ValueError` so behavior is unchanged, but add a clear comment explaining why it is safe to ignore failures when diffing from `since_ref`. Optionally, also bind the exception to a variable so the comment can mention that details are intentionally discarded. This satisfies CodeQL’s requirement (the `except` no longer “does nothing but pass and there is an explanatory comment”) and improves code readability.

Concrete change (in `src/sdetkit/repo.py` lines 1878–1881): modify the `except ValueError:` block to include a short explanatory comment stating that failures in computing the diff from `since_ref` are non-fatal and intentionally ignored, because other change sources (working tree, staged, untracked) are still used.

No new imports or helpers are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
