### PR TITLE
Add dev UX: pre-commit installer, IDE diagnostics, and dev wrappers

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -80,6 +80,7 @@ Tool-specific notes:
 ## `repo`
 
 - `sdetkit repo audit [PATH] [--profile default|enterprise] [--pack PACKS] [--org-pack PACK ...] [--format text|json|sarif] [--json-schema legacy|v1] [--output PATH] [--emit-run-record PATH] [--diff-against RUN.json] [--step-summary] [--config PATH] [--baseline PATH] [--update-baseline] [--exclude GLOB ...] [--disable-rule RULE_ID ...] [--fail-on none|warn|error] [--all-projects] [--fail-strategy overall|per-project] [--sort] [--changed-only] [--since-ref REF] [--include-untracked|--no-include-untracked] [--include-staged|--no-include-staged] [--require-git] [--cache-dir PATH] [--no-cache] [--cache-stats] [--jobs N] [--force]`
+- `sdetkit repo audit ... [--ide vscode|generic] [--ide-output PATH] [--include-suppressed]`
 - `sdetkit repo baseline create [PATH] [--output BASELINE.json] [--profile default|enterprise] [--exclude GLOB ...]`
 - `sdetkit repo rules list [--profile default|enterprise] [--pack PACKS] [--org-pack PACK ...] [--json]`
 - `sdetkit repo fix-audit [PATH] [--profile ...] [--pack PACKS] [--org-pack PACK ...] [--project NAME|--all-projects] [--dry-run|--apply] [--diff] [--patch OUT.patch] [--sort] [--changed-only] [--since-ref REF] [--include-untracked|--no-include-untracked] [--include-staged|--no-include-staged] [--require-git] [--cache-dir PATH] [--no-cache] [--cache-stats] [--jobs N] [--force]`
@@ -126,3 +127,11 @@ GitHub Action integration:
 See: reporting-and-trends.md
 
 - `sdetkit repo projects list [PATH] [--json] [--sort]`
+
+## `dev`
+
+- `sdetkit dev audit [PATH] [--mode changed-only|full] [--pack PACKS] [--profile default|enterprise]`
+- `sdetkit dev fix [PATH] [--mode changed-only|full] [--pack PACKS] [--profile default|enterprise] [--diff] [--apply]`
+- `sdetkit dev precommit install [PATH] [--profile ...] [--pack ...] [--mode changed-only|full] [--apply] [--dry-run] [--force] [--diff]`
+
+See: ide-and-precommit.md

--- a/docs/ide-and-precommit.md
+++ b/docs/ide-and-precommit.md
@@ -1,0 +1,71 @@
+# IDE + pre-commit integration
+
+## Install pre-commit hook
+
+Use the developer helper to plan first, then apply:
+
+- Dry-run plan: `sdetkit dev precommit install . --dry-run --diff`
+- Write file: `sdetkit dev precommit install . --apply`
+
+Default hook command is optimized for local speed:
+
+- `sdetkit repo audit --pack core --changed-only --fail-on error`
+
+You can customize profile/pack/mode:
+
+- `sdetkit dev precommit install . --profile enterprise --pack core,security --mode full --apply`
+
+## Recommended hook modes
+
+- `changed-only` (default): fast feedback on staged/changed files.
+- `full`: slower but catches full-repo issues before commit.
+
+In monorepos, keep pre-commit on `changed-only` and run a full scheduled/CI audit.
+
+## IDE diagnostics output
+
+`repo audit` can write deterministic IDE JSON diagnostics:
+
+- `sdetkit repo audit --ide generic --ide-output .sdetkit/diag.json`
+- `sdetkit repo audit --ide vscode --ide-output .sdetkit/diag.json`
+
+Output schema:
+
+```json
+{
+  "schema_version": "sdetkit.ide.diagnostics.v1",
+  "diagnostics": [
+    {
+      "path": "src/pkg/file.py",
+      "line": 12,
+      "col": 4,
+      "severity": "error",
+      "code": "missing_repo_hygiene_item",
+      "message": "required repository hygiene item is missing: LICENSE",
+      "fixable": false
+    }
+  ]
+}
+```
+
+By default, suppressed findings are not emitted. Use `--include-suppressed` to inspect everything in IDE tooling.
+
+SARIF remains available for compatible IDEs:
+
+- `sdetkit repo audit --format sarif --output .sdetkit/repo-audit.sarif --force`
+
+## VS Code task example
+
+```json
+{
+  "label": "sdetkit: audit changed",
+  "type": "shell",
+  "command": "sdetkit repo audit --pack core --changed-only --ide vscode --ide-output .sdetkit/diag.json"
+}
+```
+
+## Monorepo tips
+
+- For project-level audits, pair `--all-projects` with `--ide-output` for aggregated diagnostics.
+- Keep baseline and policy files per project where practical.
+- Use `sdetkit dev audit` for day-to-day local checks and `sdetkit dev fix` for quick fix previews.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Plugins & fix-audit: plugins-and-fix.md
       - Security suite: security-suite.md
       - PR automation: pr-automation.md
+      - IDE & pre-commit: ide-and-precommit.md
       - Monorepo projects: monorepo-projects.md
       - Governance & org packs: governance-and-org-packs.md
       - Reporting & trends: reporting-and-trends.md

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -45,6 +45,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "repo":
         return repo.main(list(argv[1:]))
 
+    if argv and argv[0] == "dev":
+        return repo.main(["dev", *list(argv[1:])])
+
     if argv and argv[0] == "report":
         return report.main(list(argv[1:]))
 
@@ -69,6 +72,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     rp = sub.add_parser("repo")
     rp.add_argument("args", nargs=argparse.REMAINDER)
 
+    dv = sub.add_parser("dev")
+    dv.add_argument("args", nargs=argparse.REMAINDER)
+
     rpt = sub.add_parser("report")
     rpt.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -82,6 +88,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "repo":
         return repo.main(ns.args)
+
+    if ns.cmd == "dev":
+        return repo.main(["dev", *ns.args])
 
     if ns.cmd == "report":
         return report.main(ns.args)

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-def test_help_lists_doctor_patch_cassette_get_repo_and_report() -> None:
+def test_help_lists_doctor_patch_cassette_get_repo_dev_and_report() -> None:
     r = subprocess.run(
         [sys.executable, "-m", "sdetkit", "--help"],
         text=True,
@@ -18,5 +18,6 @@ def test_help_lists_doctor_patch_cassette_get_repo_and_report() -> None:
     assert "patch" in out
     assert "cassette-get" in out
     assert "repo" in out
+    assert "dev" in out
 
     assert "report" in out

--- a/tests/test_repo_dev_ide_precommit.py
+++ b/tests/test_repo_dev_ide_precommit.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from sdetkit import cli, repo
+
+
+def _seed_min_repo(root: Path) -> None:
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    (root / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    (root / "CONTRIBUTING.md").write_text("guide\n", encoding="utf-8")
+    (root / "CODE_OF_CONDUCT.md").write_text("code\n", encoding="utf-8")
+    (root / "SECURITY.md").write_text("security\n", encoding="utf-8")
+    (root / "CHANGELOG.md").write_text("changes\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    (root / "noxfile.py").write_text("\n", encoding="utf-8")
+    (root / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (root / "requirements-test.txt").write_text("pytest\n", encoding="utf-8")
+    (root / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (root / "tests").mkdir()
+    (root / "docs").mkdir()
+    wf = root / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+    issue = root / ".github" / "ISSUE_TEMPLATE"
+    issue.mkdir(parents=True, exist_ok=True)
+    (issue / "config.yml").write_text("blank_issues_enabled: false\n", encoding="utf-8")
+    (root / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+    (wf / "security.yml").write_text("name: security\n", encoding="utf-8")
+
+
+def _invoke(args: list[str]) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        code = cli.main(args)
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def test_precommit_install_dry_run_does_not_write(tmp_path: Path) -> None:
+    code, out, err = _invoke(
+        ["dev", "precommit", "install", str(tmp_path), "--dry-run", "--allow-absolute-path"]
+    )
+    assert code == 0
+    assert err == ""
+    assert "dry-run" in out
+    assert not (tmp_path / ".pre-commit-config.yaml").exists()
+
+
+def test_precommit_install_apply_and_idempotent(tmp_path: Path) -> None:
+    code, _, _ = _invoke(
+        [
+            "dev",
+            "precommit",
+            "install",
+            str(tmp_path),
+            "--apply",
+            "--mode",
+            "changed-only",
+            "--allow-absolute-path",
+        ]
+    )
+    assert code == 0
+    target = tmp_path / ".pre-commit-config.yaml"
+    content = target.read_text(encoding="utf-8")
+    assert "id: sdetkit-repo-audit" in content
+    assert "--changed-only" in content
+
+    code2, out2, _ = _invoke(
+        ["dev", "precommit", "install", str(tmp_path), "--dry-run", "--allow-absolute-path"]
+    )
+    assert code2 == 0
+    assert "already up to date" in out2
+    assert target.read_text(encoding="utf-8") == content
+
+
+def test_precommit_install_refuses_incompatible_without_force(tmp_path: Path) -> None:
+    target = tmp_path / ".pre-commit-config.yaml"
+    target.write_text("minimum_pre_commit_version: '3.0.0'\n", encoding="utf-8")
+    code, _, err = _invoke(
+        ["dev", "precommit", "install", str(tmp_path), "--apply", "--allow-absolute-path"]
+    )
+    assert code == 2
+    assert "unable to merge" in err
+
+
+def test_precommit_install_diff_is_deterministic(tmp_path: Path) -> None:
+    target = tmp_path / ".pre-commit-config.yaml"
+    target.write_text("repos:\n  - repo: local\n    hooks: []\n", encoding="utf-8")
+    args = [
+        "dev",
+        "precommit",
+        "install",
+        str(tmp_path),
+        "--dry-run",
+        "--diff",
+        "--allow-absolute-path",
+    ]
+    code1, out1, _ = _invoke(args)
+    code2, out2, _ = _invoke(args)
+    assert code1 == 0
+    assert code2 == 0
+    assert out1 == out2
+
+
+def test_ide_diagnostics_schema_and_ordering(tmp_path: Path) -> None:
+    _seed_min_repo(tmp_path)
+    (tmp_path / "CONTRIBUTING.md").unlink()
+    (tmp_path / "LICENSE").unlink()
+    ide_out = tmp_path / "diag.json"
+
+    code, _, _ = _invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--ide",
+            "generic",
+            "--ide-output",
+            str(ide_out),
+        ]
+    )
+    assert code == 1
+    payload = json.loads(ide_out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.ide.diagnostics.v1"
+    assert payload["diagnostics"] == sorted(
+        payload["diagnostics"],
+        key=lambda x: (x["path"], x["line"], x.get("col", 0), x["code"], x["message"]),
+    )
+    assert all(item["severity"] in {"info", "warn", "error"} for item in payload["diagnostics"])
+    assert all(item["code"] for item in payload["diagnostics"])
+
+
+def test_ide_diagnostics_include_suppressed_toggle(tmp_path: Path) -> None:
+    _seed_min_repo(tmp_path)
+    (tmp_path / "CONTRIBUTING.md").unlink()
+
+    code, out, _ = _invoke(
+        ["repo", "audit", str(tmp_path), "--allow-absolute-path", "--format", "json"]
+    )
+    assert code == 1
+    audit = json.loads(out)
+    entries = repo._baseline_entries_from_findings(audit["findings"])
+    baseline = tmp_path / ".sdetkit" / "repo-audit-baseline.json"
+    baseline.parent.mkdir(parents=True, exist_ok=True)
+    baseline.write_text(
+        json.dumps(
+            {"schema_version": "1.0", "entries": entries}, ensure_ascii=True, sort_keys=True
+        ),
+        encoding="utf-8",
+    )
+
+    ide_default = tmp_path / "default.json"
+    rc_default, _, _ = _invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--ide-output",
+            str(ide_default),
+            "--fail-on",
+            "none",
+            "--baseline",
+            str(baseline),
+        ]
+    )
+    assert rc_default == 0
+    default_doc = json.loads(ide_default.read_text(encoding="utf-8"))
+    assert default_doc["diagnostics"] == []
+
+    ide_all = tmp_path / "all.json"
+    rc_all, _, _ = _invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--ide-output",
+            str(ide_all),
+            "--include-suppressed",
+            "--fail-on",
+            "none",
+            "--baseline",
+            str(baseline),
+        ]
+    )
+    assert rc_all == 0
+    all_doc = json.loads(ide_all.read_text(encoding="utf-8"))
+    assert len(all_doc["diagnostics"]) >= 1
+
+
+def test_dev_wrappers_match_core_commands(tmp_path: Path) -> None:
+    _seed_min_repo(tmp_path)
+    (tmp_path / "CONTRIBUTING.md").unlink()
+
+    rc_repo, out_repo, _ = _invoke(
+        [
+            "repo",
+            "audit",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--pack",
+            "core",
+            "--changed-only",
+            "--fail-on",
+            "error",
+        ]
+    )
+    rc_dev, out_dev, _ = _invoke(["dev", "audit", str(tmp_path), "--allow-absolute-path"])
+    assert rc_dev == rc_repo
+    assert out_dev == out_repo
+
+    rc_fix, out_fix, _ = _invoke(["dev", "fix", str(tmp_path), "--allow-absolute-path"])
+    assert rc_fix == 0
+    assert "repo fix-audit (dry-run)" in out_fix


### PR DESCRIPTION
### Motivation

- Make sdetkit easy to adopt for developers by providing safe, deterministic pre-commit hook generation and an install flow.  
- Produce IDE-friendly diagnostics (deterministic JSON schema) so editors/CI can consume findings reliably.  
- Improve day-to-day DX with thin `dev` wrappers for fast, changed-only audits and quick fix previews.

### Description

- Add top-level `sdetkit dev` routing and a `repo dev` command group with `dev audit`, `dev fix`, and `dev precommit install` that reuse the core `repo` pipeline and expose safe defaults.  
- Implement deterministic pre-commit template generation and safe install/update logic: `_build_precommit_entry`, `_precommit_hook_item`, `_default_precommit_config`, `_update_precommit_yaml`, and `_precommit_diff`; `dev precommit install` supports `--dry-run`, `--apply`, `--force`, `--diff`, and refuses unsafe merges.  
- Add IDE diagnostics support to `repo audit` with flags `--ide vscode|generic`, `--ide-output PATH`, and `--include-suppressed`, producing stable JSON of schema `sdetkit.ide.diagnostics.v1` via `_to_ide_diagnostics` and path normalization `_to_posix_relpath`.  
- Add docs page `docs/ide-and-precommit.md`, update `docs/cli.md` and `mkdocs.yml`, and include comprehensive unit tests covering pre-commit install behavior, IDE output schema/order/suppression, dev wrappers parity, and CLI help.

### Testing

- Ran unit tests: `python -m pytest -q` which completed successfully (324 passed).  
- Ran quality checks: `bash quality.sh all` which reported "All checks passed!" and no issues after static checks.  
- Added targeted pytest cases for pre-commit install, IDE diagnostics ordering/schema, suppression toggle, and dev wrapper behavior; all new tests pass as part of the suite.

------