### PR TITLE
Potential fix for code scanning alert no. 35: Module is imported with 'import' and 'import from'

### DIFF
--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import importlib
 import json
 import os
 import shutil


### PR DESCRIPTION
Potential fix for [https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/35](https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/35)

To fix this issue in general, avoid importing the same module both with `import module` and `from module import name` in the same file. Either (a) keep the `from module import name` form and remove the unused `import module`, or (b) keep `import module` and reference the attribute via `module.name`, possibly adding an alias variable if desired. The goal is to have a single, clear import style per module per file.

In this specific file (`src/sdetkit/doctor.py`), the cleanest, least invasive fix is to remove the unused `import importlib` on line 4 and keep `from importlib import metadata` on line 11, because `_package_info` currently calls `metadata.version(name)` and does not use `importlib` directly. Removing the redundant top-level import will not change functionality but will resolve the CodeQL warning and reduce confusion. No additional imports, variables, or method changes are required.

The only needed change is in `src/sdetkit/doctor.py`:
- Delete the line `import importlib` (line 4 in the provided snippet).
No new methods, definitions, or external libraries are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
