### PR TITLE
Fix Dependabot auto-merge by passing PR number

### DIFF
--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash
+          pull-request-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Motivation
- Dependabot auto-merge failed because `gh pr merge` was invoked with an empty PR target, causing the action to attempt branch inference and fail with `not a git repository` in the action workspace.

### Description
- Add `pull-request-number: ${{ github.event.pull_request.number }}` to the `peter-evans/enable-pull-request-automerge@v3` step in `.github/workflows/dependency-auto-merge.yml` so the action receives an explicit PR target.

### Testing
- Validated the workflow YAML parses successfully with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/dependency-auto-merge.yml')"`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698d690c284c8323b97475693490eff7)