### PR TITLE
Include changed-only flags in repo audit run-cache key

### DIFF
--- a/src/sdetkit/repo.py
+++ b/src/sdetkit/repo.py
@@ -396,6 +396,8 @@ def _run_cache_key(
     repo_fingerprint: str,
     changed_only: bool,
     since_ref: str,
+    include_untracked: bool,
+    include_staged: bool,
 ) -> str:
     material = {
         "profile": profile,
@@ -404,6 +406,8 @@ def _run_cache_key(
         "ruleset_version": REPO_AUDIT_RULESET_VERSION,
         "changed_only": changed_only,
         "since_ref": since_ref,
+        "include_untracked": include_untracked,
+        "include_staged": include_staged,
     }
     payload = json.dumps(material, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
@@ -2102,6 +2106,8 @@ def run_repo_audit(
         repo_fingerprint=repo_fingerprint,
         changed_only=changed_only,
         since_ref=since_ref,
+        include_untracked=include_untracked,
+        include_staged=include_staged,
     )
     if cache_enabled:
         cached_run = _load_run_cache(cache_root, run_cache_key)


### PR DESCRIPTION
### Motivation

- Different `--changed-only` behaviors (`--include-untracked` / `--include-staged`) should produce distinct run-cache entries so incremental caching does not incorrectly reuse results from a run with different semantics.

### Description

- Extended `_run_cache_key` signature to accept `include_untracked` and `include_staged` and added both fields to the key material JSON used for hashing.
- Updated the call site in `run_repo_audit` to pass the effective `include_untracked` and `include_staged` values into `_run_cache_key`.
- Added a regression test `test_incremental_run_cache_key_includes_changed_only_flags` in `tests/test_repo_audit_incremental_cache.py` that runs changed-only audits with different `include-untracked` flags and asserts separate run-cache files are created.
- Tests and helpers keep output deterministic (the test harness sets `PYTHONHASHSEED` and `SOURCE_DATE_EPOCH`) and avoid timestamp-dependent assertions.

### Testing

- Ran `pytest -q tests/test_repo_audit_incremental_cache.py`, which executed the two tests in the file and both passed (`2 passed`).

------