### PR TITLE
maintenance: support allow-network deps check and deterministic gener…

### DIFF
--- a/src/sdetkit/maintenance/checks/deps_check.py
+++ b/src/sdetkit/maintenance/checks/deps_check.py
@@ -1,48 +1,60 @@
 from __future__ import annotations
 
-from ..types import CheckAction, CheckResult, MaintenanceContext
-from ..utils import run_cmd
+from sdetkit.maintenance.types import CheckAction, CheckResult, MaintenanceContext
+from sdetkit.maintenance.utils import run_cmd
 
-CHECK_NAME = "deps_check"
+CHECK_NAME = "deps"
+CHECK_MODES = {"quick", "full"}
 
 
 def run(ctx: MaintenanceContext) -> CheckResult:
     pip_check = run_cmd([ctx.python_exe, "-m", "pip", "check"], cwd=ctx.repo_root)
-    outdated = run_cmd(
-        [ctx.python_exe, "-m", "pip", "list", "--outdated", "--format=json"], cwd=ctx.repo_root
-    )
-    outdated_info: dict[str, object]
-    if outdated.returncode == 0:
-        outdated_info = {"ok": True, "data": outdated.stdout}
-    else:
-        outdated_info = {
-            "ok": False,
-            "error": outdated.stderr or outdated.stdout,
-            "note": "outdated package listing is informational",
+    pip_check_ok = pip_check.returncode == 0
+
+    allow_network = ctx.env.get("SDETKIT_ALLOW_NETWORK") == "1"
+    pip_outdated_info: dict[str, object] = {
+        "ok": True,
+        "skipped": True,
+        "note": "Skipped by default. Use --allow-network to run pip list --outdated.",
+    }
+
+    if allow_network:
+        pip_outdated = run_cmd(
+            [ctx.python_exe, "-m", "pip", "list", "--outdated"], cwd=ctx.repo_root
+        )
+        pip_outdated_info = {
+            "ok": pip_outdated.returncode == 0,
+            "rc": pip_outdated.returncode,
+            "out": pip_outdated.stdout.strip(),
+            "err": pip_outdated.stderr.strip(),
         }
-    ok = pip_check.returncode == 0
-    return CheckResult(
-        ok=ok,
-        summary="pip dependency graph is consistent"
-        if ok
-        else "pip check found dependency conflicts",
-        details={
-            "pip_check": {
-                "returncode": pip_check.returncode,
-                "stdout": pip_check.stdout,
-                "stderr": pip_check.stderr,
-            },
-            "outdated": outdated_info,
+
+    details = {
+        "pip_check": {
+            "ok": pip_check_ok,
+            "rc": pip_check.returncode,
+            "out": pip_check.stdout.strip(),
+            "err": pip_check.stderr.strip(),
         },
+        "pip_outdated": pip_outdated_info,
+    }
+
+    pip_outdated = details.get("pip_outdated")
+
+    if isinstance(pip_outdated, dict):
+        pip_outdated.setdefault("skipped", False)
+
+    return CheckResult(
+        ok=pip_check_ok,
+        summary="pip dependency graph is consistent"
+        if pip_check_ok
+        else "pip dependency graph has issues",
+        details=details,
         actions=[
             CheckAction(
                 id="pip-check",
-                title="Run pip check",
-                applied=False,
-                notes="Resolve dependency conflicts" if not ok else "",
-            )
+                title="Run pip check and resolve dependency conflicts",
+                notes="Try: python -m pip check (and reconcile version constraints).",
+            ),
         ],
     )
-
-
-CHECK_MODES = {"quick", "full"}

--- a/tests/test_maintenance_offline_flags.py
+++ b/tests/test_maintenance_offline_flags.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+
+from sdetkit.maintenance.checks import deps_check
+from sdetkit.maintenance.types import MaintenanceContext
+
+
+def _ctx(tmp_path, env: dict[str, str]) -> MaintenanceContext:
+    return MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe=sys.executable,
+        mode="quick",
+        fix=False,
+        env=env,
+        logger=SimpleNamespace(info=lambda *_: None),
+    )
+
+
+def test_deps_check_skips_outdated_by_default(monkeypatch, tmp_path):
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], *, cwd):
+        calls.append(list(cmd))
+        if cmd[-1] == "check":
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr(deps_check, "run_cmd", fake_run_cmd)
+
+    result = deps_check.run(_ctx(tmp_path, env={}))
+    assert result.ok is True
+    assert any(cmd[-1] == "check" for cmd in calls)
+    assert not any("--outdated" in cmd for cmd in calls)
+    assert result.details["pip_outdated"]["skipped"] is True
+
+
+def test_deps_check_runs_outdated_when_allowed(monkeypatch, tmp_path):
+    calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], *, cwd):
+        calls.append(list(cmd))
+        if cmd[-1] == "check":
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "--outdated" in cmd:
+            return SimpleNamespace(returncode=0, stdout="pkg 1.0 2.0\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr(deps_check, "run_cmd", fake_run_cmd)
+
+    result = deps_check.run(_ctx(tmp_path, env={"SDETKIT_ALLOW_NETWORK": "1"}))
+    assert result.ok is True
+    assert any("--outdated" in cmd for cmd in calls)
+    assert result.details["pip_outdated"]["skipped"] is False
+
+
+def test_maintenance_generated_at_can_be_forced(tmp_path):
+    import sys
+    from datetime import datetime
+
+    out = tmp_path / "report.json"
+    env = os.environ.copy()
+    env["SDETKIT_NOW"] = "2000-01-02T03:04:05Z"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit.maintenance",
+            "--format",
+            "json",
+            "--mode",
+            "quick",
+            "--out",
+            str(out),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode in {0, 1}
+    assert out.exists()
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    got = payload["meta"]["generated_at"]
+
+    def _parse(s: str) -> datetime:
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        return datetime.fromisoformat(s)
+
+    assert _parse(got) == _parse("2000-01-02T03:04:05+00:00")


### PR DESCRIPTION
### Summary

* Make maintenance deps check output schema stable by always including `pip_outdated.skipped`.
* Make maintenance JSON report timestamp deterministic in tests via `SDETKIT_NOW`, without requiring success exit code.

### Why

* Tests and downstream tooling should not crash on missing keys when `pip_outdated` actually runs.
* Maintenance CLI can legitimately exit non-zero due to other failing checks (e.g., clean tree, lint), but `--out` JSON must still be written and deterministic.

### How

* In `deps_check`, ensure `details["pip_outdated"]["skipped"]` defaults to `False` whenever the structure exists.
* In the maintenance CLI test, use `subprocess.run` and accept `{0,1}` return codes, then validate the written JSON’s `meta.generated_at` matches the forced timestamp.

### Tests added/updated

* `tests/test_maintenance_offline_flags.py`

  * validates offline default behavior
  * validates `SDETKIT_ALLOW_NETWORK=1` triggers outdated
  * validates `SDETKIT_NOW` forces `generated_at` in JSON output

### Checklist

* [x] `python3 -m compileall -q src tools`
* [x] `pytest -q` (360 passed)
* [ ] `ruff format` / `ruff check` clean (run and confirm)
* [ ] `git status -sb` clean except intended changes