### PR TITLE
tests: lock report ingest/diff/build contracts

### DIFF
--- a/tests/test_report_cli_contracts.py
+++ b/tests/test_report_cli_contracts.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+
+from sdetkit import cli
+
+
+@dataclass
+class Result:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class CliRunner:
+    def invoke(self, args: list[str]) -> Result:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            code = cli.main(args)
+        return Result(exit_code=code, stdout=stdout.getvalue(), stderr=stderr.getvalue())
+
+
+def _write_run(path: Path, *, captured_at: str | None, findings: list[dict]) -> None:
+    run = {
+        "schema_version": "sdetkit.audit.run.v1",
+        "tool_version": "0",
+        "profile": "default",
+        "packs": ["core"],
+        "fail_on": "none",
+        "findings": findings,
+        "aggregates": {
+            "counts_by_severity": {"error": 0, "info": 0, "warn": 0},
+            "counts_fixable": 0,
+            "counts_suppressed": 0,
+        },
+        "execution": {"incremental_used": False, "changed_file_count": 0},
+    }
+    if captured_at is not None:
+        run["source"] = {"captured_at": captured_at}
+    path.write_text(
+        json.dumps(run, ensure_ascii=True, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def test_report_ingest_is_deterministic_and_dedup(tmp_path: Path) -> None:
+    runner = CliRunner()
+    history = tmp_path / "history"
+    r1 = tmp_path / "run1.json"
+    r2 = tmp_path / "run2.json"
+
+    _write_run(
+        r1,
+        captured_at="2020-01-01T00:00:00Z",
+        findings=[
+            {
+                "fingerprint": "a",
+                "rule_id": "r1",
+                "severity": "warn",
+                "message": "m",
+                "path": "a.py",
+            },
+        ],
+    )
+    _write_run(
+        r2,
+        captured_at="2020-01-02T00:00:00Z",
+        findings=[
+            {
+                "fingerprint": "b",
+                "rule_id": "r2",
+                "severity": "error",
+                "message": "m",
+                "path": "b.py",
+            },
+        ],
+    )
+
+    one = runner.invoke(
+        ["report", "ingest", str(r1), "--history-dir", str(history), "--label", "first"]
+    )
+    assert one.exit_code == 0
+
+    two = runner.invoke(
+        ["report", "ingest", str(r2), "--history-dir", str(history), "--label", "second"]
+    )
+    assert two.exit_code == 0
+
+    again = runner.invoke(
+        ["report", "ingest", str(r1), "--history-dir", str(history), "--label", "first-again"]
+    )
+    assert again.exit_code == 0
+
+    index_path = history / "index.json"
+    assert index_path.exists()
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    assert index["schema_version"] == "sdetkit.audit.history.v1"
+    runs = index["runs"]
+    assert len(runs) == 2
+
+    assert runs[0]["captured_at"] == "2020-01-01T00:00:00Z"
+    assert runs[1]["captured_at"] == "2020-01-02T00:00:00Z"
+
+    for row in runs:
+        sha = row["sha256"]
+        file = row["file"]
+        assert isinstance(sha, str) and len(sha) == 64
+        assert file == f"{sha}.json"
+        assert (history / file).exists()
+
+
+def test_report_diff_text_and_json_match_and_exit_codes(tmp_path: Path) -> None:
+    runner = CliRunner()
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+
+    _write_run(
+        a,
+        captured_at="2020-01-01T00:00:00Z",
+        findings=[
+            {
+                "fingerprint": "x",
+                "rule_id": "r1",
+                "severity": "warn",
+                "message": "m",
+                "path": "a.py",
+            },
+        ],
+    )
+    _write_run(
+        b,
+        captured_at="2020-01-02T00:00:00Z",
+        findings=[
+            {
+                "fingerprint": "x",
+                "rule_id": "r1",
+                "severity": "warn",
+                "message": "m",
+                "path": "a.py",
+            },
+            {
+                "fingerprint": "y",
+                "rule_id": "r2",
+                "severity": "error",
+                "message": "m",
+                "path": "b.py",
+            },
+        ],
+    )
+
+    text = runner.invoke(
+        [
+            "report",
+            "diff",
+            "--from",
+            str(a),
+            "--to",
+            str(b),
+            "--format",
+            "text",
+            "--fail-on",
+            "none",
+        ]
+    )
+    assert text.exit_code == 0
+    assert "NEW: 1" in text.stdout
+    assert "RESOLVED: 0" in text.stdout
+
+    warn = runner.invoke(
+        [
+            "report",
+            "diff",
+            "--from",
+            str(a),
+            "--to",
+            str(b),
+            "--format",
+            "text",
+            "--fail-on",
+            "warn",
+        ]
+    )
+    assert warn.exit_code == 1
+
+    js = runner.invoke(
+        [
+            "report",
+            "diff",
+            "--from",
+            str(a),
+            "--to",
+            str(b),
+            "--format",
+            "json",
+            "--fail-on",
+            "none",
+        ]
+    )
+    assert js.exit_code == 0
+    payload = json.loads(js.stdout)
+    assert payload["counts"]["new"] == 1
+    assert payload["counts"]["resolved"] == 0
+    assert payload["counts"]["unchanged"] == 1
+
+
+def test_report_build_md_and_html_are_stable(tmp_path: Path, monkeypatch) -> None:
+    runner = CliRunner()
+    history = tmp_path / "history"
+    history.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1577836800")
+    run1 = tmp_path / "run1.json"
+    _write_run(
+        run1,
+        captured_at="2020-01-01T00:00:00Z",
+        findings=[
+            {
+                "fingerprint": "a",
+                "rule_id": "r1",
+                "severity": "warn",
+                "message": "m",
+                "path": "a.py",
+            },
+        ],
+    )
+    assert (
+        runner.invoke(["report", "ingest", str(run1), "--history-dir", str(history)]).exit_code == 0
+    )
+
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1577923200")
+    run2 = tmp_path / "run2.json"
+    _write_run(
+        run2,
+        captured_at="2020-01-02T00:00:00Z",
+        findings=[
+            {
+                "fingerprint": "b",
+                "rule_id": "r2",
+                "severity": "error",
+                "message": "m",
+                "path": "b.py",
+            },
+        ],
+    )
+    assert (
+        runner.invoke(["report", "ingest", str(run2), "--history-dir", str(history)]).exit_code == 0
+    )
+
+    out_md = tmp_path / "report.md"
+    out_html = tmp_path / "report.html"
+
+    first_md = runner.invoke(
+        [
+            "report",
+            "build",
+            "--history-dir",
+            str(history),
+            "--format",
+            "md",
+            "--output",
+            str(out_md),
+        ]
+    )
+    assert first_md.exit_code == 0
+    md1 = out_md.read_text(encoding="utf-8")
+    assert "# sdetkit audit trends" in md1
+    assert "- runs: 2" in md1
+    assert "## Top recurring rules" in md1
+    assert "## Top paths" in md1
+
+    second_md = runner.invoke(
+        [
+            "report",
+            "build",
+            "--history-dir",
+            str(history),
+            "--format",
+            "md",
+            "--output",
+            str(out_md),
+        ]
+    )
+    assert second_md.exit_code == 0
+    md2 = out_md.read_text(encoding="utf-8")
+    assert md1 == md2
+
+    first_html = runner.invoke(
+        [
+            "report",
+            "build",
+            "--history-dir",
+            str(history),
+            "--format",
+            "html",
+            "--output",
+            str(out_html),
+        ]
+    )
+    assert first_html.exit_code == 0
+    html1 = out_html.read_text(encoding="utf-8")
+    assert "<h1>sdetkit audit trends</h1>" in html1
+    assert "Runs: 2" in html1
+    assert "<svg " in html1
+
+    second_html = runner.invoke(
+        [
+            "report",
+            "build",
+            "--history-dir",
+            str(history),
+            "--format",
+            "html",
+            "--output",
+            str(out_html),
+        ]
+    )
+    assert second_html.exit_code == 0
+    html2 = out_html.read_text(encoding="utf-8")
+    assert html1 == html2


### PR DESCRIPTION
### Summary

Add deterministic contract tests for `sdetkit report ingest`, `report diff`, and `report build` (md/html).

### Why

Reporting is the long-term stability surface for caching/incremental runs, monorepo aggregation, CI artifacts, and new exporters. These tests prevent subtle nondeterminism and regressions.

### How

* Use tiny synthetic run records with fixed `captured_at`
* Assert deterministic history storage (`<sha256>.json`, stable `index.json`)
* Assert diff counts and exit codes are consistent across text/json
* Assert build outputs are stable across repeated invocations

### Tests

* `tests/test_report_cli_contracts.py`

### Checklist

* [ ] `python3 -m compileall -q src tools`
* [ ] `pytest -q`
* [ ] Clean `git status -sb` except intended changes

---