### PR TITLE
Codex-generated pull request

### DIFF
--- a/tests/test_collect_git_changed_files_flags.py
+++ b/tests/test_collect_git_changed_files_flags.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from sdetkit.repo import collect_git_changed_files
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def test_collect_git_changed_files_respects_staged_and_untracked_flags(tmp_path: Path) -> None:
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+
+    (repo / "tracked.txt").write_text("v1\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-m", "c1")
+
+    (repo / "tracked.txt").write_text("v2\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-m", "c2")
+
+    (repo / "staged.txt").write_text("stage\n", encoding="utf-8")
+    _git(repo, "add", "staged.txt")
+
+    (repo / "untracked.txt").write_text("u\n", encoding="utf-8")
+
+    all_changed = collect_git_changed_files(
+        repo,
+        since_ref="HEAD~1",
+        include_untracked=True,
+        include_staged=True,
+    )
+    assert "tracked.txt" in all_changed
+    assert "staged.txt" in all_changed
+    assert "untracked.txt" in all_changed
+
+    no_untracked = collect_git_changed_files(
+        repo,
+        since_ref="HEAD~1",
+        include_untracked=False,
+        include_staged=True,
+    )
+    assert "tracked.txt" in no_untracked
+    assert "staged.txt" in no_untracked
+    assert "untracked.txt" not in no_untracked
+
+    no_staged = collect_git_changed_files(
+        repo,
+        since_ref="HEAD~1",
+        include_untracked=True,
+        include_staged=False,
+    )
+    assert "tracked.txt" in no_staged
+    assert "staged.txt" not in no_staged
+    assert "untracked.txt" in no_staged
+
+    neither = collect_git_changed_files(
+        repo,
+        since_ref="HEAD~1",
+        include_untracked=False,
+        include_staged=False,
+    )
+    assert "tracked.txt" in neither
+    assert "staged.txt" not in neither
+    assert "untracked.txt" not in neither

--- a/tests/test_file_inventory_cache.py
+++ b/tests/test_file_inventory_cache.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.repo import _FileInventoryCache
+
+
+def _write(p: Path, s: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(s, encoding="utf-8", newline="\n")
+
+
+def test_file_inventory_cache_hit_and_invalidation(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    _write(repo / "a.py", "print('a')\n")
+    _write(repo / "pkg" / "b.py", "x = 1\n")
+
+    cache_root = tmp_path / "cache"
+    c = _FileInventoryCache(cache_root)
+
+    inv1 = c.get_inventory(repo)
+    s1 = c.stats()
+    assert s1 == {"hits": 0, "misses": 1, "writes": 1, "invalidations": 0}
+
+    inv1d = [f.to_dict() for f in inv1]
+    paths1 = [d["path"] for d in inv1d]
+    assert paths1 == sorted(paths1)
+
+    cache_files = sorted(cache_root.rglob("*.json"))
+    assert cache_files
+    raw = json.loads(cache_files[0].read_text(encoding="utf-8"))
+    assert raw["schema_version"] == 1
+    assert isinstance(raw["dirs"], list)
+    assert isinstance(raw["files"], list)
+
+    inv2 = c.get_inventory(repo)
+    assert _inv_paths(inv2) == _inv_paths(inv1)
+    s2 = c.stats()
+    assert s2 == {"hits": 1, "misses": 1, "writes": 1, "invalidations": 0}
+
+    _write(repo / "pkg" / "b.py", "x = 2\n")
+    inv3 = c.get_inventory(repo)
+    s3 = c.stats()
+    assert s3["invalidations"] >= 1
+    assert s3["writes"] >= 2
+    assert any(d["path"] == "pkg/b.py" for d in [f.to_dict() for f in inv3])
+
+    _write(repo / "pkg" / "c.py", "y = 3\n")
+    inv4 = c.get_inventory(repo)
+    s4 = c.stats()
+    assert s4["invalidations"] >= 2
+    assert s4["writes"] >= 3
+    paths4 = [d["path"] for d in [f.to_dict() for f in inv4]]
+    assert "pkg/c.py" in paths4
+
+
+def _inv_paths(inv: list[object]) -> list[str]:
+    out: list[str] = []
+    for fi in inv:
+        out.append(str(getattr(fi, "path", getattr(fi, "rel_path", ""))))
+    return sorted(out)
+
+
+def _stats_dict(cache: object) -> dict[str, int]:
+    if hasattr(cache, "stats"):
+        try:
+            st = cache.stats()
+            if isinstance(st, dict):
+                return {str(k): int(v) for k, v in st.items()}
+        except TypeError:
+            pass
+    st2 = getattr(cache, "_stats", None)
+    if isinstance(st2, dict):
+        return {str(k): int(v) for k, v in st2.items()}
+    raise AssertionError("cache has no stats dict")
+
+
+def test_file_inventory_cache_corrupt_cache_treated_as_miss(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write(repo / "a.py", "print('a')\n")
+    _write(repo / "pkg" / "b.py", "x = 1\n")
+
+    cache_root = tmp_path / "cache"
+    c = _FileInventoryCache(cache_root)
+
+    inv1 = c.get_inventory(repo)
+    before = _stats_dict(c)
+
+    cache_path = c._path_for_root(repo)
+    cache_path.write_text("{not valid json", encoding="utf-8")
+
+    c.get_inventory(repo)
+    after = _stats_dict(c)
+
+    assert _inv_paths(c.get_inventory(repo)) == _inv_paths(inv1)
+    assert after.get("misses", 0) >= before.get("misses", 0) + 1
+
+
+def test_file_inventory_cache_add_file_invalidates_and_updates(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write(repo / "a.py", "print('a')\n")
+    _write(repo / "pkg" / "b.py", "x = 1\n")
+
+    cache_root = tmp_path / "cache"
+    c = _FileInventoryCache(cache_root)
+
+    inv1 = c.get_inventory(repo)
+    st1 = _stats_dict(c)
+
+    assert _inv_paths(c.get_inventory(repo)) == _inv_paths(inv1)
+    st2 = _stats_dict(c)
+    assert _inv_paths(c.get_inventory(repo)) == _inv_paths(inv1)
+    assert st2.get("hits", 0) >= st1.get("hits", 0) + 1
+
+    _write(repo / "pkg" / "c.py", "y = 2\n")
+    inv3 = c.get_inventory(repo)
+    st3 = _stats_dict(c)
+
+    assert "pkg/c.py" in _inv_paths(inv3)
+    assert st3.get("invalidations", 0) >= st2.get("invalidations", 0) + 1
+
+    inv4 = c.get_inventory(repo)
+    st4 = _stats_dict(c)
+    assert _inv_paths(inv4) == _inv_paths(inv3)
+    assert st4.get("hits", 0) >= st3.get("hits", 0) + 1
+
+
+def test_file_inventory_cache_remove_file_invalidates_and_updates(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write(repo / "a.py", "print('a')\n")
+    _write(repo / "pkg" / "b.py", "x = 1\n")
+
+    cache_root = tmp_path / "cache"
+    c = _FileInventoryCache(cache_root)
+
+    inv1 = c.get_inventory(repo)
+    st1 = _stats_dict(c)
+    assert "pkg/b.py" in _inv_paths(inv1)
+
+    c.get_inventory(repo)
+    st2 = _stats_dict(c)
+    assert st2.get("hits", 0) >= st1.get("hits", 0) + 1
+
+    (repo / "pkg" / "b.py").unlink()
+    inv3 = c.get_inventory(repo)
+    st3 = _stats_dict(c)
+
+    assert "pkg/b.py" not in _inv_paths(inv3)
+    assert st3.get("invalidations", 0) >= st2.get("invalidations", 0) + 1

--- a/tests/test_no_hidden_unicode.py
+++ b/tests/test_no_hidden_unicode.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import unicodedata as ud
+from pathlib import Path
+
+BIDI = {
+    0x200E,
+    0x200F,
+    0x061C,
+    0x202A,
+    0x202B,
+    0x202C,
+    0x202D,
+    0x202E,
+    0x2066,
+    0x2067,
+    0x2068,
+    0x2069,
+}
+
+
+def _is_bad(ch: str) -> bool:
+    o = ord(ch)
+    if o in BIDI:
+        return True
+    cat = ud.category(ch)
+    if cat == "Cf" and ch not in ("\n", "\r", "\t"):
+        return True
+    return False
+
+
+def test_repo_has_no_bidi_or_invisible_unicode_in_py_sources() -> None:
+    targets: list[Path] = []
+    for root in ("src", "tests", "tools"):
+        p = Path(root)
+        if p.exists():
+            targets.extend(sorted(p.rglob("*.py")))
+
+    bad: list[tuple[str, int, int, str, str]] = []
+    for path in targets:
+        s = path.read_text(encoding="utf-8", errors="strict")
+        for i, ch in enumerate(s):
+            if _is_bad(ch):
+                line = s.count("\n", 0, i) + 1
+                col = i - s.rfind("\n", 0, i)
+                name = ud.name(ch, "UNKNOWN")
+                bad.append((str(path), line, col, f"U+{ord(ch):04X}", name))
+
+    if bad:
+        msg = "\n".join(f"{p}:{ln}:{col} {cp} {name}" for p, ln, col, cp, name in bad[:200])
+        raise AssertionError(msg)


### PR DESCRIPTION
## Summary

* Hardened `_FileInventoryCache` to be stable + resilient (atomic writes, digest support, safer load/validation paths).
* Added/expanded tests for cache hit/invalidation behavior and `changed-only` git-collection flags.

## Why

* Repo audit caching is a core performance feature, but it needs to be correct under real-world conditions (cache hits, invalidations, and corrupted cache files) without breaking CLI stability.
* `changed-only` behavior depends on git-state flags; we want to lock in correct behavior and prevent regressions.

## How

* Implemented a stronger `FileInfo` contract (path/rel_path + `to_dict`/`from_dict`) used consistently across inventory + cache serialization.
* Improved `_FileInventoryCache`:

  * deterministic cache paths via hashing
  * atomic cache writer to avoid partial/corrupt JSON writes
  * robust cache loading (treat bad cache as miss + invalidate)
  * `digest_for()` support for per-file digests used by dependency manifest
  * `save()` compatibility (`save()` no-op + `save(repo_root, inventory)` supported)
* Added tests:

  * inventory cache hit + invalidation + corruption treated as miss
  * git changed-only collection flags coverage to ensure correct file selection

## Checklist

* [x] Tests added/updated
* [ ] `bash ci.sh` passes
* [ ] `bash quality.sh` passes
* [x] Docs updated (if needed)
* [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`