### PR TITLE
fix(triage): handle missing pytest log path gracefully

### DIFF
--- a/tests/test_triage_tool.py
+++ b/tests/test_triage_tool.py
@@ -84,3 +84,12 @@ def test_parse_pytest_log_prints_useful_commands(tmp_path: Path) -> None:
     assert "pytest -q tests/test_x.py::test_a" in out
     assert "nl -ba" in out
     assert "sed -n" in out
+
+
+def test_parse_pytest_log_missing_file_reports_message(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.log"
+    triage = _load_triage()
+    rc, out = _run(triage, ["--parse-pytest-log", str(missing), "--radius", "3"], tmp_path)
+    assert rc == 2
+    assert "log file not found" in out
+    assert "pytest -q" in out

--- a/tools/triage.py
+++ b/tools/triage.py
@@ -207,7 +207,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.parse_pytest_log:
         logp = Path(args.parse_pytest_log)
-        text = logp.read_text(encoding="utf-8", errors="replace")
+        try:
+            text = logp.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            print(f"triage: log file not found: {logp}")
+            print("suggested command:")
+            print(f"  pytest -q 2>&1 | tee {logp}")
+            return 2
         nodeids, files = _parse_pytest_log(text)
         return _print_pytest_suggestions(nodeids, files, radius)
 
@@ -215,6 +221,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.mode in {"compile", "both"}:
         rc_compile, _ = _compile_check(root, targets, bool(args.fix_nul), radius)
+        if rc_compile == 0:
+            print("triage: compile ok")
         rc = max(rc, rc_compile)
 
     if args.mode in {"pytest", "both"}:


### PR DESCRIPTION
## Summary

* Make `tools/triage.py --parse-pytest-log <path>` handle missing/unreadable log paths gracefully.
* Print a deterministic “how to generate the log” command instead of crashing.
* Print `triage: compile ok` when compile scan finds no issues.

## Why

* A triage tool should reduce friction during failures, not introduce new failure modes.
* Missing `/tmp/pytest.log` is common; we want an immediate next step.

## How

* Wrap log reads in `try/except OSError` and return exit code `2` with a suggested command.
* Add unit test ensuring deterministic output and no crash.

## Checklist

* [x] Tests added/updated
* [x] `pytest -q` passes
* [x] Hooks pass on commit