### PR TITLE
Add top-level --version support to sdetkit CLI

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 import argparse
 import os
 from collections.abc import Sequence
+from importlib import metadata
 
 from . import apiget, kvcli, patch, repo, report
 from .maintenance import main as maintenance_main
+
+
+def _tool_version() -> str:
+    try:
+        return metadata.version("sdetkit")
+    except metadata.PackageNotFoundError:
+        return "0+unknown"
 
 
 def _add_apiget_args(p: argparse.ArgumentParser) -> None:
@@ -56,6 +64,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return maintenance_main(list(argv[1:]))
 
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
+    p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
 
     kv = sub.add_parser("kv")


### PR DESCRIPTION
### Motivation
- Provide a standard, top-level `--version` CLI flag so `sdetkit --version` and `python -m sdetkit --version` work without requiring a subcommand.
- Ensure version resolution is deterministic and safe when package metadata is unavailable.

### Description
- Added a `_tool_version()` helper in `src/sdetkit/cli.py` that returns `importlib.metadata.version("sdetkit")` and falls back to the fixed string `0+unknown` on `PackageNotFoundError`.
- Wired `--version` into the root `ArgumentParser` using `p.add_argument("--version", action="version", version=_tool_version())` so argparse handles printing and exit behavior.
- Added focused tests in `tests/test_cli_sdetkit.py` validating the module entrypoint, exact printed output and exit code for `--version`, and the fallback behavior when metadata lookup fails, and imported `pytest` where needed.

### Testing
- Ran `pytest -q tests/test_cli_sdetkit.py` which passed (`9 passed`).
- Ran `python3 -m compileall -q src tools` and then the full test suite with `pytest -q`, which passed (`377 passed`).
- All automated checks (compile and tests) completed successfully.

------