### PR TITLE
Add opt-in pyproject autodiscovery with configurable roots for monorepos

### DIFF
--- a/docs/monorepo-projects.md
+++ b/docs/monorepo-projects.md
@@ -7,6 +7,17 @@
 Preferred file: `.sdetkit/projects.toml`.
 Fallback: `pyproject.toml` with `[tool.sdetkit.projects]`.
 
+If you prefer not to maintain explicit `[[project]]` entries, you can enable autodiscovery
+from `pyproject.toml`:
+
+```toml
+[tool.sdetkit.projects]
+autodiscover = true
+autodiscover_roots = ["services", "libs"]
+```
+
+`autodiscover_roots` accepts a string list or comma-separated string.
+
 ```toml
 [[project]]
 name = "api"

--- a/tests/test_projects_autodiscover.py
+++ b/tests/test_projects_autodiscover.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from sdetkit.projects import discover_projects, resolve_project
 
 
@@ -31,3 +33,54 @@ def test_autodiscover_packages_ignores_node_modules(tmp_path: Path) -> None:
     resolved = [resolve_project(repo, p) for p in projects]
     assert [r.root_rel for r in resolved] == ["packages/a", "packages/b"]
     assert resolved[0].baseline_rel == "packages/a/.sdetkit/audit-baseline.json"
+
+
+def test_pyproject_autodiscover_with_custom_roots_and_stable_order(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_pyproject(repo / "services" / "api", "svc-api")
+    _write_pyproject(repo / "libs" / "core", "lib-core")
+    (repo / "pyproject.toml").write_text(
+        """
+[tool.sdetkit.projects]
+autodiscover = true
+autodiscover_roots = ["services", "libs", "services"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    source, projects = discover_projects(repo, sort=True)
+    assert source == "pyproject.toml (autodiscover)"
+    assert [(p.name, p.root) for p in projects] == [
+        ("lib-core", "libs/core"),
+        ("svc-api", "services/api"),
+    ]
+
+
+def test_pyproject_autodiscover_validates_boolean_and_roots_type(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    (repo / "pyproject.toml").write_text(
+        """
+[tool.sdetkit.projects]
+autodiscover = "yes"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="autodiscover must be a boolean"):
+        discover_projects(repo)
+
+    (repo / "pyproject.toml").write_text(
+        """
+[tool.sdetkit.projects]
+autodiscover = true
+autodiscover_roots = 12
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="autodiscover_roots"):
+        discover_projects(repo)


### PR DESCRIPTION
### Motivation
- Provide an opt-in way for pyproject-managed repos to discover projects automatically so monorepos (e.g., `services/*`, `libs/*`) need not maintain `[[project]]` manifests. 
- Keep discovery deterministic and safe by validating, normalizing, and deduplicating configured roots before filesystem traversal. 

### Description
- Added `_autodiscover_roots(...)` to parse `autodiscover_roots` (CSV or list), normalize paths, deduplicate entries, and validate types. 
- Extended autodiscovery internals with `_autodiscover_projects(..., base_roots=...)` so base roots are configurable and traversal order is deterministic. 
- Updated `discover_projects(...)` to honor an opt-in `autodiscover` boolean from `[tool.sdetkit.projects]` and to use `autodiscover_roots` when present, returning a clear source label (e.g., `pyproject.toml (autodiscover)`). 
- Added behavior tests in `tests/test_projects_autodiscover.py` covering custom roots, stable ordering, and invalid configuration types, and documented the new option in `docs/monorepo-projects.md`. 

### Testing
- Ran targeted tests: `pytest -q tests/test_projects_autodiscover.py tests/test_repo_monorepo_projects.py`, which completed successfully (`7 passed`). 
- Ran full validation: `python3 -m compileall -q src tools` and `pytest -q`, which completed successfully (`393 passed`). 
- All new and existing tests that exercise project discovery, validation, and CLI behaviors passed after the change.

------