### PR TITLE
Harden report history loading and inventory cache invalidation

### DIFF
--- a/src/sdetkit/repo.py
+++ b/src/sdetkit/repo.py
@@ -421,6 +421,7 @@ class _FileInventoryCache:
         return True
 
     def _validate_files(self, repo_root: Path, files: list[FileInfo]) -> bool:
+        expected_paths = {f.path for f in files}
         for f in files:
             p = repo_root / f.path
             try:
@@ -431,6 +432,10 @@ class _FileInventoryCache:
                 return False
             if st.st_size != f.size:
                 return False
+
+        current_paths = {fp.relative_to(repo_root).as_posix() for fp in _iter_files(repo_root)}
+        if current_paths != expected_paths:
+            return False
         return True
 
     def _dirs_for_inventory(self, inventory: list[FileInfo]) -> list[str]:

--- a/src/sdetkit/report.py
+++ b/src/sdetkit/report.py
@@ -414,7 +414,14 @@ def _load_history_run_records(history_dir: Path) -> list[dict[str, Any]]:
         if not run_path.exists():
             continue
 
-        loaded = load_run_record(run_path)
+        try:
+            loaded = load_run_record(run_path)
+        except (OSError, ValueError) as exc:
+            print(
+                f"warning: skipping unreadable history run {file_name}: {exc}",
+                file=sys.stderr,
+            )
+            continue
         run: dict[str, Any] | None = None
         if isinstance(loaded, dict) and isinstance(loaded.get("run_record"), dict):
             rr = loaded["run_record"]


### PR DESCRIPTION
### Motivation
- `report build` / `report recommend` could abort if a single historical run file was unreadable or corrupt, making trend data unavailable. 
- The file-inventory cache could incorrectly return stale results when files are added but directory mtimes are unchanged on some filesystems, causing missing findings.

### Description
- Make `_load_history_run_records` robust by wrapping `load_run_record` per-file in a `try/except (OSError, ValueError)` that emits a deterministic warning to `stderr` and continues rather than aborting. (changed `src/sdetkit/report.py`).
- Harden `_FileInventoryCache._validate_files` to verify the set of current file paths discovered by `_iter_files` matches the cached paths, forcing invalidation when new/removed files exist even if mtimes appear unchanged. (changed `src/sdetkit/repo.py`).
- Add regression tests that exercise both behaviors: a corrupt history run is skipped with a warning while valid runs are still used, and a newly added file is detected even when directory mtime is restored. (changed `tests/test_report_cli_contracts.py` and `tests/test_file_inventory_cache.py`).

### Testing
- Ran targeted report tests with `pytest -q tests/test_report_cli_contracts.py -k "skip_unreadable_history_runs or recommend_supports_auto_detection_and_override"`, which passed (`2 passed`).
- Ran targeted inventory + report tests with `pytest -q tests/test_file_inventory_cache.py tests/test_report_cli_contracts.py -k "unreadable_history_runs or unchanged or add_file_invalidates_and_updates or remove_file_invalidates_and_updates"`, which passed (`4 passed`).
- Ran the full test suite with `pytest -q` after changes and observed all tests passed (`398 passed`).

------