### PR TITLE
Potential fix for code scanning alert no. 38: Empty except

### DIFF
--- a/tools/triage.py
+++ b/tools/triage.py
@@ -236,8 +236,9 @@ def _run_pytest(args: argparse.Namespace, root: Path) -> tuple[int, str]:
     if args.tee:
         try:
             Path(args.tee).write_text(out, encoding="utf-8")
-        except OSError:
-            pass
+        except OSError as exc:
+            # Best-effort: failing to tee output should not be fatal, but log for visibility.
+            print(f"triage: failed to write tee output to {args.tee!r}: {exc}", file=sys.stderr)
     return int(proc.returncode), out
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/38](https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/38)

In general, to fix an empty `except` block, either remove it (letting the exception propagate), narrow the exception type and handle it specifically, or at least log and document why it is being ignored. Here, we should preserve the current behavior that tee failures are non-fatal but make them visible and self-documented.

The best minimal-impact fix is to keep catching `OSError` but log a brief warning to `sys.stderr` and add a comment clarifying that tee failures are non-fatal. We already import `sys` at the top of `tools/triage.py`, so we can use `print(..., file=sys.stderr)` without adding dependencies. The change will be confined to the `try/except` inside `_run_pytest` around lines 236–240. Specifically, replace the `except OSError: pass` with:

- An explanatory comment like `# Best-effort: failing to tee output should not be fatal, but log for visibility.`
- A `print` to `stderr` including the path and the exception message.

No new imports or functions are required; we only adjust the body of the `except` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
