### PR TITLE
feat(projects): merge manifest project entries with autodiscovery

### DIFF
--- a/docs/monorepo-projects.md
+++ b/docs/monorepo-projects.md
@@ -21,6 +21,9 @@ autodiscover_roots = ["services", "libs"]
 ```
 
 `autodiscover_roots` accepts a string list or comma-separated string.
+When `autodiscover = true` is combined with explicit `[[project]]` entries,
+manifest projects are kept first and autodiscovered projects are appended.
+Duplicate names/roots are deduplicated in favor of the explicit manifest entry.
 
 ```toml
 [[project]]


### PR DESCRIPTION
### Motivation
- Allow hybrid monorepo manifests where explicit `[[tool.sdetkit.projects.project]]` entries coexist with `autodiscover = true` so curated projects and autodiscovered projects can be used together.
- Prevent ambiguous duplicate projects introduced by path normalization (e.g. `services/api` vs `./services/api`).
- Preserve deterministic ordering and behavior so discovery remains stable for CI and consumers.

### Description
- Update `discover_projects` in `src/sdetkit/projects.py` to track `seen_names` and `seen_roots`, normalize manifest roots early, and raise on duplicate normalized manifest roots.
- When `autodiscover = true` and explicit `[[project]]` entries exist, append autodiscovered projects while skipping any names or roots already present, preserving manifest order first and autodiscovered entries afterwards.
- Add focused tests in `tests/test_projects_autodiscover.py` to exercise merge behavior, manifest override of autodiscovered duplicates, and duplicate-normalized-root rejection.
- Update documentation `docs/monorepo-projects.md` to describe the hybrid manifest+autodiscovery semantics and determinism guarantees.

### Testing
- Added tests: `tests/test_projects_autodiscover.py` now includes hybrid merge assertions and duplicate-root rejection assertions which run as part of the suite.
- Ran targeted tests: `pytest -q tests/test_projects_autodiscover.py` — all tests passed (`12 passed`).
- Ran full project validation: `python3 -m compileall -q src tools` then `pytest -q` — full suite passed (`409 passed`).
- No network or external resources were used in tests; behavior is deterministic (manifest-order retained, autodiscovered roots appended in stable order).
