### PR TITLE
chore: repo-wide AgentOS polish — CLI UX, deterministic outputs, docs, and safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,50 @@
 3. Use [docs/cli.md](docs/cli.md) + [docs/doctor.md](docs/doctor.md) for daily operations.
 4. Follow [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
 
+
+## AgentOS overview
+
+AgentOS is the deterministic orchestration layer behind `sdetkit agent`.
+
+```text
+User/CI
+  |
+  v
+sdetkit agent CLI
+  |
+  +--> Manager (plan)
+  +--> Workers (actions: repo/report/fs/shell)
+  +--> Reviewer (accept/reject)
+  |
+  +--> Safety gates (approval, allowlists, restricted shell)
+  +--> Stable artifacts (history, conversations, dashboards, exports)
+```
+
+Core docs: [AgentOS foundation](docs/agentos-foundation.md), [Omnichannel + MCP bridge](docs/omnichannel-mcp-bridge.md), [Automation templates engine](docs/automation-templates-engine.md).
+
+## Quickstart (clean checkout, provider=none)
+
+```bash
+python3 -m venv .venv
+./.venv/bin/python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .
+./.venv/bin/sdetkit agent init
+./.venv/bin/sdetkit agent run 'action repo.audit {"profile":"default"}' --approve
+./.venv/bin/sdetkit agent dashboard build --format html
+./.venv/bin/sdetkit report build --history-dir .sdetkit/audit-history --output report.html
+```
+
+This path is offline-friendly and deterministic when `provider.type=none` and inputs are unchanged.
+
+## Production and enterprise notes
+
+- Safety gates are explicit: dangerous writes/shell actions require approval and allowlists.
+- Run records provide durable evidence for what executed and why.
+- Exports are deterministic by default (sorted keys/lists + canonical JSON).
+- Data ownership remains local to your repository workspace unless you explicitly route data elsewhere.
+- MCP/tool bridge is disabled by default and must be explicitly allowlisted.
+
+Additional references: [AgentOS cookbook](docs/agentos-cookbook.md), [Determinism contract](docs/determinism-contract.md), [Security model](docs/security-model.md).
+
 ## 🧩 Why this repository exists
 
 This project is designed for fast onboarding and high-confidence delivery:

--- a/docs/agentos-cookbook.md
+++ b/docs/agentos-cookbook.md
@@ -1,0 +1,158 @@
+# AgentOS cookbook
+
+This page provides practical, deterministic recipes for `provider.type=none` workflows.
+
+## Recipe 1: bootstrap AgentOS workspace
+
+Command:
+
+```bash
+sdetkit agent init
+```
+
+Expected output:
+
+- JSON with `created` entries.
+- `.sdetkit/agent/config.yaml` and standard folders.
+
+Artifacts:
+
+- `.sdetkit/agent/config.yaml`
+- `.sdetkit/agent/history/`
+- `.sdetkit/agent/workdir/`
+- `.sdetkit/agent/cache/`
+
+## Recipe 2: run deterministic task
+
+Command:
+
+```bash
+sdetkit agent run "action repo.audit {\"profile\":\"default\"}" --approve
+```
+
+Expected output:
+
+- JSON record containing `status`, `steps`, `actions`, and stable `hash`.
+
+Artifacts:
+
+- `.sdetkit/agent/history/<hash>.json`
+
+## Recipe 3: run automation template with overrides
+
+Command:
+
+```bash
+sdetkit agent templates run report-dashboard --set profile=default --output-dir .sdetkit/agent/template-runs/report-dashboard
+```
+
+Expected output:
+
+- JSON run record with `status=ok` and `artifacts` list.
+
+Artifacts:
+
+- `.sdetkit/agent/template-runs/report-dashboard/run-record.json`
+- Any template-declared outputs.
+
+## Recipe 4: build dashboard and markdown summary
+
+Command:
+
+```bash
+sdetkit agent dashboard build --history-dir .sdetkit/agent/history --format html --output .sdetkit/agent/workdir/agent-dashboard.html --summary-output .sdetkit/agent/workdir/agent-summary.md
+```
+
+Expected output:
+
+- JSON with `status=ok`, `output`, and run counts.
+
+Artifacts:
+
+- `.sdetkit/agent/workdir/agent-dashboard.html`
+- `.sdetkit/agent/workdir/agent-summary.md`
+
+## Recipe 5: export history summary CSV
+
+Command:
+
+```bash
+sdetkit agent history export --history-dir .sdetkit/agent/history --format csv --output .sdetkit/agent/workdir/history-summary.csv
+```
+
+Expected output:
+
+- JSON with `count` and `output`.
+
+Artifacts:
+
+- `.sdetkit/agent/workdir/history-summary.csv`
+
+## Recipe 6: webhook ingest simulation (generic)
+
+Command:
+
+```bash
+sdetkit agent serve --host 127.0.0.1 --port 8787
+curl -sS -X POST http://127.0.0.1:8787/webhook/generic -H 'content-type: application/json' -d '{"channel":"slack","user_id":"u1","text":"audit status"}'
+```
+
+Expected output:
+
+- HTTP 200 response with `status=ok` or `rate_limited`.
+
+Artifacts:
+
+- `.sdetkit/agent/conversations/slack/u1.jsonl`
+- `.sdetkit/agent/rate_limits/slack/u1.json`
+
+## Recipe 7: inspect cache behavior
+
+Command:
+
+```bash
+sdetkit agent run "health-check" --cache-dir .sdetkit/agent/cache
+sdetkit agent run "health-check" --cache-dir .sdetkit/agent/cache
+```
+
+Expected output:
+
+- Same deterministic plan and same run hash in `provider=none` mode.
+
+Artifacts:
+
+- `.sdetkit/agent/cache/*.json`
+
+## Recipe 8: approval gates in CI/non-interactive mode
+
+Command:
+
+```bash
+sdetkit agent run 'action shell.run {"cmd":"python -V"}'
+```
+
+Expected output:
+
+- Action denied with reason containing `approval required (non-interactive)`.
+
+Artifacts:
+
+- Denied action captured in history run record.
+
+## Common mistakes and fixes
+
+- Wrong config path:
+  - Symptom: `agent error: [Errno 2] ... config.yaml`
+  - Fix: pass `--config .sdetkit/agent/config.yaml` or run `sdetkit agent init` first.
+- Unsafe write blocked:
+  - Symptom: `write denied by allowlist`
+  - Fix: write under `.sdetkit/agent/workdir` or update config allowlist intentionally.
+- Missing history:
+  - Symptom: empty dashboard/history results.
+  - Fix: run `sdetkit agent run ...` at least once before dashboard/export.
+- Invalid template schema:
+  - Symptom: `agent error: ... metadata must be a mapping` (or similar).
+  - Fix: validate template keys (`metadata`, `inputs`, `workflow`) and indentation.
+- Server port in use:
+  - Symptom: bind failure on `agent serve`.
+  - Fix: switch to another port with `--port 8788`.

--- a/docs/agentos-foundation.md
+++ b/docs/agentos-foundation.md
@@ -86,8 +86,7 @@ provider:
 safety:
   write_allowlist:
     - .sdetkit/agent/workdir
-  shell_allowlist:
-    - python
+  shell_allowlist: []
 ```
 
 Provider modes:
@@ -99,3 +98,5 @@ Provider modes:
 ## Productization blueprint
 
 See `docs/enterprise-productization-blueprint.md` for deployment modes, governance controls, adoption plans, and packaging deliverables.
+
+See also: [AgentOS cookbook](agentos-cookbook.md), [Determinism contract](determinism-contract.md), and [Security model](security-model.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -123,7 +123,7 @@ GitHub Action integration:
 ## `report`
 
 - `sdetkit report ingest RUN.json [--history-dir .sdetkit/audit-history] [--label LABEL]`
-- `sdetkit report diff --from RUN.json --to RUN.json [--format text|json] [--fail-on none|warn|error]`
+- `sdetkit report diff --from RUN.json --to RUN.json [--format text|json|md] [--fail-on none|warn|error] [--limit-new N]`
 - `sdetkit report build [--history-dir .sdetkit/audit-history] [--output report.html] [--format html|md] [--since N]`
 
 See: reporting-and-trends.md
@@ -151,3 +151,10 @@ See: ide-and-precommit.md
 - `sdetkit agent templates pack [--output FILE.tar]`
 
 See: agentos-foundation.md, omnichannel-mcp-bridge.md, and automation-templates-engine.md
+
+
+## CLI consistency notes
+
+- Agent/report commands use shared option names where applicable: `--history-dir`, `--output`, `--format`, `--config`, `--cache-dir`, `--no-cache`, `--approve`, `--output-dir`, and `--set`.
+- `--help` output includes default values for faster operator onboarding.
+- Normal user errors are emitted as single-line messages (`agent error: ...`, `report error: ...`) without stack traces.

--- a/docs/determinism-contract.md
+++ b/docs/determinism-contract.md
@@ -1,0 +1,24 @@
+# Determinism contract
+
+This project guarantees deterministic output structures for offline (`provider=none`) workflows.
+
+## Guaranteed deterministic
+
+- Canonical JSON serialization for run/history records (`ensure_ascii`, sorted keys).
+- Stable list ordering for findings, top-N summaries, recurring rules/paths, and history indexes.
+- Deterministic tar packaging for template bundles (sorted paths, fixed uid/gid/mtime).
+- Atomic writes for generated artifacts to avoid partial outputs.
+- HTML escaping for user-supplied text rendered in dashboards.
+
+## Not guaranteed deterministic
+
+- Wall-clock timestamps when `SOURCE_DATE_EPOCH` is not set.
+- External command output from `shell.run` actions.
+- Any provider-generated text when `provider.type=local` is used.
+
+## Best-practice reproducible runs
+
+1. Use `provider.type=none`.
+2. Set `SOURCE_DATE_EPOCH` for stable timestamps.
+3. Keep input files stable and run from a clean tree.
+4. Use explicit output paths (`--output`, `--output-dir`, `--history-dir`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🧭 Repo tour](repo-tour.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+[⚡ Fast start](#fast-start) · [🧭 Repo tour](repo-tour.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
 
 </div>
 
@@ -91,3 +91,22 @@ bash scripts/check.sh all
 ## License
 
 Free for personal/educational noncommercial use. Commercial use requires a paid license; see [license page](license.md).
+
+
+### AgentOS operations
+
+<div class="grid cards" markdown>
+
+- [**AgentOS foundation**](agentos-foundation.md)
+  Deterministic orchestrator, safety gates, and provider modes.
+
+- [**AgentOS cookbook**](agentos-cookbook.md)
+  End-to-end recipes with commands, expected outputs, and artifact paths.
+
+- [**Determinism contract**](determinism-contract.md)
+  What is guaranteed stable and what is intentionally variable.
+
+- [**Security model**](security-model.md)
+  Approval gates, allowlists, shell restrictions, and MCP bridge defaults.
+
+</div>

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,31 @@
+# AgentOS security model
+
+AgentOS applies deny-by-default controls for sensitive actions.
+
+## Safety gates
+
+- File writes:
+  - Denied unless target is inside repository root and matches write allowlist.
+  - Default allowlist is `.sdetkit/agent/workdir`.
+- Shell actions:
+  - Always approval-gated.
+  - Command allowlist is explicit in config; default is empty.
+- MCP/tool bridge:
+  - Disabled by default.
+  - Requires explicit `--tool-bridge-enabled` and `--tool-bridge-allow` entries.
+
+## Operational controls
+
+- Every run emits a structured run record with approvals/denials.
+- Omnichannel traffic records append to conversation history and rate-limit state.
+- Deterministic report exports support audit evidence and change tracking.
+
+## Verification
+
+Use:
+
+```bash
+python -m sdetkit doctor --ascii
+```
+
+and verify security-oriented checks remain green.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,9 @@ nav:
       - Repo init: repo-init.md
       - Patch harness: patch-harness.md
       - AgentOS foundation: agentos-foundation.md
+      - AgentOS cookbook: agentos-cookbook.md
+      - Determinism contract: determinism-contract.md
+      - Security model: security-model.md
       - Omnichannel + MCP bridge: omnichannel-mcp-bridge.md
       - Automation templates engine: automation-templates-engine.md
       - CI Contract: ci-contract.md

--- a/src/sdetkit/agent/actions.py
+++ b/src/sdetkit/agent/actions.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from sdetkit import repo
+from sdetkit.atomicio import atomic_write_text
 from sdetkit.report import build_dashboard
 
 
@@ -89,8 +90,7 @@ class ActionRegistry:
             )
         try:
             path = self._safe_rel(rel)
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(content, encoding="utf-8")
+            atomic_write_text(path, content)
         except (OSError, ValueError) as exc:
             return ActionResult("fs.write", False, {"error": str(exc), "path": rel})
         return ActionResult("fs.write", True, {"path": rel, "bytes": len(content.encode("utf-8"))})

--- a/src/sdetkit/agent/cli.py
+++ b/src/sdetkit/agent/cli.py
@@ -20,160 +20,336 @@ from .templates import (
 )
 
 
-def main(argv: list[str]) -> int:
-    parser = argparse.ArgumentParser(prog="sdetkit agent")
-    sub = parser.add_subparsers(dest="agent_cmd", required=True)
+def _json_out(payload: object) -> None:
+    sys.stdout.write(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n")
 
-    init_p = sub.add_parser("init")
-    init_p.add_argument("--config", default=".sdetkit/agent/config.yaml")
 
-    run_p = sub.add_parser("run")
-    run_p.add_argument("task")
-    run_p.add_argument("--config", default=".sdetkit/agent/config.yaml")
+def _fail(message: str) -> int:
+    print(message.replace("\n", " "), file=sys.stderr)
+    return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit agent",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=(
+            "AgentOS workflows for deterministic orchestration: init, run, templates, "
+            "serve, history, and dashboard."
+        ),
+        epilog=(
+            "Workflows: `sdetkit agent init` to bootstrap, `run` for orchestration, "
+            "`templates` for reusable automation, `serve` for omnichannel ingestion, "
+            "`history` for run records, and `dashboard build` for exports."
+        ),
+    )
+    sub = parser.add_subparsers(
+        dest="agent_cmd", required=True, parser_class=argparse.ArgumentParser
+    )
+
+    init_p = sub.add_parser(
+        "init",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Create AgentOS config and working directories.",
+    )
+    init_p.add_argument(
+        "--config", default=".sdetkit/agent/config.yaml", help="Path to agent config file."
+    )
+
+    run_p = sub.add_parser(
+        "run",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Execute one deterministic orchestration run.",
+    )
+    run_p.add_argument("task", help="Task description or explicit action payload.")
+    run_p.add_argument(
+        "--config", default=".sdetkit/agent/config.yaml", help="Path to agent config file."
+    )
     run_p.add_argument("--approve", action="store_true", help="Auto-approve dangerous actions.")
-    run_p.add_argument("--cache-dir", default=".sdetkit/agent/cache")
-    run_p.add_argument("--no-cache", action="store_true")
+    run_p.add_argument(
+        "--cache-dir", default=".sdetkit/agent/cache", help="Provider cache directory."
+    )
+    run_p.add_argument(
+        "--no-cache", action="store_true", help="Disable provider cache reads and writes."
+    )
 
-    doctor_p = sub.add_parser("doctor")
-    doctor_p.add_argument("--config", default=".sdetkit/agent/config.yaml")
+    doctor_p = sub.add_parser(
+        "doctor",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Validate AgentOS config and safety posture.",
+    )
+    doctor_p.add_argument(
+        "--config", default=".sdetkit/agent/config.yaml", help="Path to agent config file."
+    )
 
-    hist_p = sub.add_parser("history")
-    hist_p.add_argument("--limit", type=int, default=10)
-    hist_sub = hist_p.add_subparsers(dest="history_cmd")
+    hist_p = sub.add_parser(
+        "history",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="List or export run history artifacts.",
+    )
+    hist_p.add_argument(
+        "--limit", type=int, default=10, help="Maximum number of records returned for list mode."
+    )
+    hist_sub = hist_p.add_subparsers(dest="history_cmd", parser_class=argparse.ArgumentParser)
     hist_sub.required = False
 
-    hist_list = hist_sub.add_parser("list")
-    hist_list.add_argument("--limit", type=int, default=10)
+    hist_list = hist_sub.add_parser(
+        "list",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="List run history records.",
+    )
+    hist_list.add_argument(
+        "--limit", type=int, default=10, help="Maximum number of records returned."
+    )
 
-    hist_export = hist_sub.add_parser("export")
-    hist_export.add_argument("--format", choices=["csv"], default="csv")
-    hist_export.add_argument("--output", default=".sdetkit/agent/workdir/history-summary.csv")
+    hist_export = hist_sub.add_parser(
+        "export",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Export run history summary.",
+    )
+    hist_export.add_argument(
+        "--history-dir",
+        default=".sdetkit/agent/history",
+        help="Directory containing run history JSON files.",
+    )
+    hist_export.add_argument("--format", choices=["csv"], default="csv", help="Export format.")
+    hist_export.add_argument(
+        "--output",
+        default=".sdetkit/agent/workdir/history-summary.csv",
+        help="Path for exported history summary.",
+    )
 
-    dash_p = sub.add_parser("dashboard")
-    dash_sub = dash_p.add_subparsers(dest="dashboard_cmd", required=True)
-    dash_build = dash_sub.add_parser("build")
-    dash_build.add_argument("--history-dir", default=".sdetkit/agent/history")
-    dash_build.add_argument("--output", default=".sdetkit/agent/workdir/agent-dashboard.html")
-    dash_build.add_argument("--summary-output", default=".sdetkit/agent/workdir/agent-summary.md")
-    dash_build.add_argument("--format", choices=["json", "md", "html", "csv"], default="html")
+    dash_p = sub.add_parser(
+        "dashboard",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Build dashboard artifacts from run history.",
+    )
+    dash_sub = dash_p.add_subparsers(
+        dest="dashboard_cmd", required=True, parser_class=argparse.ArgumentParser
+    )
+    dash_build = dash_sub.add_parser(
+        "build",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Build dashboard outputs (html/md/json/csv).",
+    )
+    dash_build.add_argument(
+        "--history-dir",
+        default=".sdetkit/agent/history",
+        help="Directory containing run history JSON files.",
+    )
+    dash_build.add_argument(
+        "--output",
+        default=".sdetkit/agent/workdir/agent-dashboard.html",
+        help="Main output file path.",
+    )
+    dash_build.add_argument(
+        "--summary-output",
+        default=".sdetkit/agent/workdir/agent-summary.md",
+        help="Markdown summary output path used in html mode.",
+    )
+    dash_build.add_argument(
+        "--format",
+        choices=["json", "md", "html", "csv"],
+        default="html",
+        help="Dashboard output format.",
+    )
 
-    demo_p = sub.add_parser("demo")
-    demo_p.add_argument("--scenario", choices=["repo-enterprise-audit"], required=True)
+    demo_p = sub.add_parser(
+        "demo",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Run deterministic end-to-end demo workflow.",
+    )
+    demo_p.add_argument(
+        "--scenario",
+        choices=["repo-enterprise-audit"],
+        required=True,
+        help="Demo scenario identifier.",
+    )
 
-    serve_p = sub.add_parser("serve")
-    serve_p.add_argument("--config", default=".sdetkit/agent/config.yaml")
-    serve_p.add_argument("--host", default="127.0.0.1")
-    serve_p.add_argument("--port", type=int, default=8787)
-    serve_p.add_argument("--telegram-simulation-mode", action="store_true")
-    serve_p.add_argument("--telegram-enable-outgoing", action="store_true")
-    serve_p.add_argument("--rate-limit-max-tokens", type=int, default=5)
-    serve_p.add_argument("--rate-limit-refill-per-second", type=float, default=1.0)
-    serve_p.add_argument("--tool-bridge-enabled", action="store_true")
-    serve_p.add_argument("--tool-bridge-allow", action="append", default=[])
-    serve_p.add_argument("--tool-bridge-command", action="append", default=[])
+    serve_p = sub.add_parser(
+        "serve",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Start omnichannel webhook server.",
+    )
+    serve_p.add_argument(
+        "--config", default=".sdetkit/agent/config.yaml", help="Path to agent config file."
+    )
+    serve_p.add_argument("--host", default="127.0.0.1", help="Bind host for the HTTP server.")
+    serve_p.add_argument("--port", type=int, default=8787, help="Bind port for the HTTP server.")
+    serve_p.add_argument(
+        "--telegram-simulation-mode",
+        action="store_true",
+        help="Annotate telegram events as simulation mode.",
+    )
+    serve_p.add_argument(
+        "--telegram-enable-outgoing", action="store_true", help="Enable outgoing telegram replies."
+    )
+    serve_p.add_argument(
+        "--rate-limit-max-tokens",
+        type=int,
+        default=5,
+        help="Token bucket capacity per channel/user key.",
+    )
+    serve_p.add_argument(
+        "--rate-limit-refill-per-second",
+        type=float,
+        default=1.0,
+        help="Token refill rate per second.",
+    )
+    serve_p.add_argument(
+        "--tool-bridge-enabled", action="store_true", help="Enable MCP/tool bridge invocation."
+    )
+    serve_p.add_argument(
+        "--tool-bridge-allow",
+        action="append",
+        default=[],
+        help="Allowlisted tool name (repeatable).",
+    )
+    serve_p.add_argument(
+        "--tool-bridge-command",
+        action="append",
+        default=[],
+        help="Bridge command token (repeatable, build full command in order).",
+    )
 
-    tpl = sub.add_parser("templates")
-    tpl_sub = tpl.add_subparsers(dest="templates_cmd", required=True)
+    tpl = sub.add_parser(
+        "templates",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Discover, inspect, run, and package templates.",
+    )
+    tpl_sub = tpl.add_subparsers(
+        dest="templates_cmd", required=True, parser_class=argparse.ArgumentParser
+    )
 
-    tpl_sub.add_parser("list")
+    tpl_sub.add_parser(
+        "list",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="List available template metadata.",
+    )
 
-    tpl_show = tpl_sub.add_parser("show")
-    tpl_show.add_argument("id")
+    tpl_show = tpl_sub.add_parser(
+        "show",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Show template details.",
+    )
+    tpl_show.add_argument("id", help="Template identifier.")
 
-    tpl_run = tpl_sub.add_parser("run")
-    tpl_run.add_argument("id")
-    tpl_run.add_argument("--set", dest="set_values", action="append", default=[])
-    tpl_run.add_argument("--output-dir", default=".sdetkit/agent/template-runs")
+    tpl_run = tpl_sub.add_parser(
+        "run",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Run template with optional input overrides.",
+    )
+    tpl_run.add_argument("id", help="Template identifier.")
+    tpl_run.add_argument(
+        "--set",
+        dest="set_values",
+        action="append",
+        default=[],
+        help="Set template input as key=value (repeatable).",
+    )
+    tpl_run.add_argument(
+        "--output-dir",
+        default=".sdetkit/agent/template-runs",
+        help="Directory for template run artifacts.",
+    )
 
-    tpl_pack = tpl_sub.add_parser("pack")
-    tpl_pack.add_argument("--output", default=".sdetkit/agent/templates/automation-templates.tar")
+    tpl_pack = tpl_sub.add_parser(
+        "pack",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        help="Create deterministic template tar package.",
+    )
+    tpl_pack.add_argument(
+        "--output",
+        default=".sdetkit/agent/templates/automation-templates.tar",
+        help="Output tar path.",
+    )
 
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = _build_parser()
     ns = parser.parse_args(argv)
     root = Path.cwd()
 
-    if ns.agent_cmd == "init":
-        created = init_agent(root, root / ns.config)
-        sys.stdout.write(json.dumps({"created": created}, ensure_ascii=True, sort_keys=True) + "\n")
-        return 0
+    try:
+        if ns.agent_cmd == "init":
+            created = init_agent(root, root / ns.config)
+            _json_out({"created": created})
+            return 0
 
-    if ns.agent_cmd == "run":
-        record = run_agent(
-            root,
-            config_path=root / ns.config,
-            task=ns.task,
-            auto_approve=bool(ns.approve),
-            cache_dir=root / ns.cache_dir,
-            no_cache=bool(ns.no_cache),
-        )
-        sys.stdout.write(json.dumps(record, ensure_ascii=True, sort_keys=True) + "\n")
-        return 0 if record.get("status") == "ok" else 1
+        if ns.agent_cmd == "run":
+            record = run_agent(
+                root,
+                config_path=root / ns.config,
+                task=ns.task,
+                auto_approve=bool(ns.approve),
+                cache_dir=root / ns.cache_dir,
+                no_cache=bool(ns.no_cache),
+            )
+            _json_out(record)
+            return 0 if record.get("status") == "ok" else 1
 
-    if ns.agent_cmd == "doctor":
-        doctor_payload = doctor_agent(root, config_path=root / ns.config)
-        sys.stdout.write(json.dumps(doctor_payload, ensure_ascii=True, sort_keys=True) + "\n")
-        return 0 if doctor_payload.get("ok") else 1
+        if ns.agent_cmd == "doctor":
+            doctor_payload = doctor_agent(root, config_path=root / ns.config)
+            _json_out(doctor_payload)
+            return 0 if doctor_payload.get("ok") else 1
 
-    if ns.agent_cmd == "history":
-        history_cmd = ns.history_cmd or "list"
-        if history_cmd == "export":
-            export_payload = export_history_summary(
-                history_dir=root / ".sdetkit" / "agent" / "history",
+        if ns.agent_cmd == "history":
+            history_cmd = ns.history_cmd or "list"
+            if history_cmd == "export":
+                export_payload = export_history_summary(
+                    history_dir=root / ns.history_dir,
+                    output=root / ns.output,
+                    fmt=ns.format,
+                )
+                _json_out(export_payload)
+                return 0
+            history_payload = history_agent(root, limit=ns.limit)
+            _json_out(history_payload)
+            return 0
+
+        if ns.agent_cmd == "dashboard":
+            dashboard_payload = build_agent_dashboard(
+                history_dir=root / ns.history_dir,
                 output=root / ns.output,
                 fmt=ns.format,
+                summary_output=root / ns.summary_output,
             )
-            sys.stdout.write(json.dumps(export_payload, ensure_ascii=True, sort_keys=True) + "\n")
+            _json_out(dashboard_payload)
             return 0
-        history_payload = history_agent(root, limit=ns.limit)
-        sys.stdout.write(json.dumps(history_payload, ensure_ascii=True, sort_keys=True) + "\n")
-        return 0
 
-    if ns.agent_cmd == "dashboard":
-        dashboard_payload = build_agent_dashboard(
-            history_dir=root / ns.history_dir,
-            output=root / ns.output,
-            fmt=ns.format,
-            summary_output=root / ns.summary_output,
-        )
-        sys.stdout.write(json.dumps(dashboard_payload, ensure_ascii=True, sort_keys=True) + "\n")
-        return 0
+        if ns.agent_cmd == "demo":
+            demo_payload = run_demo(root=root, scenario=ns.scenario)
+            _json_out(demo_payload)
+            return 0
 
-    if ns.agent_cmd == "demo":
-        demo_payload = run_demo(root=root, scenario=ns.scenario)
-        sys.stdout.write(json.dumps(demo_payload, ensure_ascii=True, sort_keys=True) + "\n")
-        return 0
-
-    if ns.agent_cmd == "serve":
-        app = AgentServeApp(
-            root=root,
-            config_path=root / ns.config,
-            host=ns.host,
-            port=ns.port,
-            telegram_simulation_mode=bool(ns.telegram_simulation_mode),
-            telegram_enable_outgoing=bool(ns.telegram_enable_outgoing),
-            capacity=int(ns.rate_limit_max_tokens),
-            refill_per_second=float(ns.rate_limit_refill_per_second),
-            tool_bridge_enabled=bool(ns.tool_bridge_enabled),
-            tool_bridge_allowlist=tuple(str(x) for x in ns.tool_bridge_allow),
-            tool_bridge_command=[str(x) for x in ns.tool_bridge_command],
-        )
-        sys.stdout.write(
-            json.dumps(
+        if ns.agent_cmd == "serve":
+            app = AgentServeApp(
+                root=root,
+                config_path=root / ns.config,
+                host=ns.host,
+                port=ns.port,
+                telegram_simulation_mode=bool(ns.telegram_simulation_mode),
+                telegram_enable_outgoing=bool(ns.telegram_enable_outgoing),
+                capacity=int(ns.rate_limit_max_tokens),
+                refill_per_second=float(ns.rate_limit_refill_per_second),
+                tool_bridge_enabled=bool(ns.tool_bridge_enabled),
+                tool_bridge_allowlist=tuple(str(x) for x in ns.tool_bridge_allow),
+                tool_bridge_command=[str(x) for x in ns.tool_bridge_command],
+            )
+            _json_out(
                 {
                     "status": "serving",
                     "host": ns.host,
                     "port": ns.port,
                     "tool_bridge_enabled": bool(ns.tool_bridge_enabled),
-                },
-                ensure_ascii=True,
-                sort_keys=True,
+                }
             )
-            + "\n"
-        )
-        app.serve_forever()
-        return 0
+            app.serve_forever()
+            return 0
 
-    if ns.agent_cmd == "templates":
-        try:
+        if ns.agent_cmd == "templates":
             if ns.templates_cmd == "list":
                 list_payload = [
                     {
@@ -184,10 +360,7 @@ def main(argv: list[str]) -> int:
                     }
                     for item in discover_templates(root)
                 ]
-                sys.stdout.write(
-                    json.dumps({"templates": list_payload}, ensure_ascii=True, sort_keys=True)
-                    + "\n"
-                )
+                _json_out({"templates": list_payload})
                 return 0
 
             if ns.templates_cmd == "show":
@@ -204,7 +377,7 @@ def main(argv: list[str]) -> int:
                     ],
                     "source": item.source.relative_to(root).as_posix(),
                 }
-                sys.stdout.write(json.dumps(show_payload, ensure_ascii=True, sort_keys=True) + "\n")
+                _json_out(show_payload)
                 return 0
 
             if ns.templates_cmd == "run":
@@ -219,17 +392,14 @@ def main(argv: list[str]) -> int:
                     set_values=parsed_set_values,
                     output_dir=root / output_dir,
                 )
-                sys.stdout.write(json.dumps(record, ensure_ascii=True, sort_keys=True) + "\n")
+                _json_out(record)
                 return 0 if record.get("status") == "ok" else 1
 
             if ns.templates_cmd == "pack":
                 pack_payload = pack_templates(root, output=root / ns.output)
-                sys.stdout.write(json.dumps(pack_payload, ensure_ascii=True, sort_keys=True) + "\n")
+                _json_out(pack_payload)
                 return 0
-        except TemplateValidationError as exc:
-            sys.stdout.write(
-                json.dumps({"error": str(exc)}, ensure_ascii=True, sort_keys=True) + "\n"
-            )
-            return 1
+    except (TemplateValidationError, ValueError, OSError) as exc:
+        return _fail(f"agent error: {exc}")
 
     return 2

--- a/src/sdetkit/atomicio.py
+++ b/src/sdetkit/atomicio.py
@@ -1,7 +1,9 @@
+import json
 import os
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 
 def atomic_write_text(
@@ -76,3 +78,13 @@ def atomic_write_bytes(
                 tmp_path.unlink()
         except Exception:
             pass
+
+
+def canonical_json_dumps(payload: Any, *, indent: int | None = 2) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=indent) + "\n"
+
+
+def canonical_json_bytes(payload: Any) -> bytes:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )

--- a/tests/test_agent_cli_ux.py
+++ b/tests/test_agent_cli_ux.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def test_agent_help_lists_major_workflows() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "agent", "--help"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    out = proc.stdout
+    for phrase in ["init", "run", "templates", "serve", "history", "dashboard"]:
+        assert phrase in out
+
+
+def test_agent_run_help_shows_consistent_option_defaults() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "agent", "run", "--help"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    out = proc.stdout
+    assert "--config" in out
+    assert ".sdetkit/agent/config.yaml" in out
+    assert "--cache-dir" in out
+    assert ".sdetkit/agent/cache" in out
+
+
+def test_agent_user_error_is_single_line() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "agent", "templates", "show", "missing-template"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+    assert "agent error:" in proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert "\n" in proc.stderr
+    assert len([x for x in proc.stderr.splitlines() if x.strip()]) == 1
+
+
+def test_history_export_honors_history_dir_option(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    hist = tmp_path / "custom-history"
+    hist.mkdir()
+    record = {
+        "captured_at": "2024-01-01T00:00:00Z",
+        "hash": "abc",
+        "status": "ok",
+        "task": "demo",
+        "actions": [],
+    }
+    (hist / "abc.json").write_text(json.dumps(record), encoding="utf-8")
+
+    out_csv = tmp_path / "history.csv"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "agent",
+            "history",
+            "export",
+            "--history-dir",
+            str(hist),
+            "--output",
+            str(out_csv),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert out_csv.exists()

--- a/tests/test_agent_dashboard_escaping.py
+++ b/tests/test_agent_dashboard_escaping.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.agent.dashboard import build_dashboard
+
+
+def test_dashboard_html_escapes_user_content(tmp_path: Path) -> None:
+    history = tmp_path / ".sdetkit/agent/history"
+    history.mkdir(parents=True)
+    (history / "run.json").write_text(
+        json.dumps(
+            {
+                "captured_at": "2024-01-01T00:00:00Z",
+                "hash": "h1",
+                "status": "error",
+                "task": "<script>alert(1)</script>",
+                "actions": [{"action": "<b>bad</b>"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "dashboard.html"
+    build_dashboard(history_dir=history, output=out, fmt="html")
+    html = out.read_text(encoding="utf-8")
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html


### PR DESCRIPTION
### Motivation
- Make the AgentOS surface feel enterprise-ready by harmonizing CLI UX, tightening determinism for generated artifacts, and hardening safety defaults. 
- Reduce operator friction by surfacing defaults in `--help` and converting noisy errors into single-line, user-friendly messages. 
- Ensure artifacts are stable and auditable (canonical JSON, atomic writes, deterministic packaging) for CI and production workflows. 
- Provide premium-quality documentation and cookbook recipes so operators can verify and reproduce workflows in `provider=none` mode. 

### Description
- CLI UX: replaced and unified `sdetkit agent` help and subparsers with `ArgumentDefaultsHelpFormatter`, added consistent option names and defaults (e.g. `--config`, `--cache-dir`, `--no-cache`, `--history-dir`, `--output`, `--format`, `--approve`, `--output-dir`, `--set`), and made agent errors print as single-line messages (`agent error: ...`).
- Determinism & atomic writes: introduced `canonical_json_dumps`/`canonical_json_bytes` helpers in `atomicio.py` and switched run history, report ingest/diff/recommend outputs, template run records, conversation and rate-limit state, and tar packaging to atomic write patterns to avoid partial writes and ensure canonical sorting. 
- Safety defaults: updated default AgentOS config to keep `shell_allowlist` empty and documented deny-by-default write/shell gates and explicit MCP/tool-bridge enablement requirements. 
- Templates & packaging: made tar packaging deterministic (sorted paths, fixed uid/gid/mtime) and written via an atomic-temp-then-replace helper to produce stable bundles. 
- Docs & cookbook: updated `README.md`, `docs/cli.md`, added `docs/agentos-cookbook.md`, `docs/determinism-contract.md`, and `docs/security-model.md`, and updated `mkdocs.yml` nav to include AgentOS operational pages and cookbook. 
- Tests & small refactors: added focused tests for CLI UX (`tests/test_agent_cli_ux.py`) and HTML escaping in dashboards (`tests/test_agent_dashboard_escaping.py`), refactored small helpers across `agent/*`, `report.py`, and `templates.py` to use canonical JSON and `atomic_write_text` without behavior changes. 

### Testing
- Ran `python -m pytest` with full suite: all tests passed (`437 passed`).
- Ran quality checks: `bash quality.sh` completed with no issues (lint/format/static checks passed).
- Ran CI script: `bash ci.sh` completed and the suite passed (`437 passed`).
- Ran runtime doctor: `python -m sdetkit doctor --ascii` returned score `100%` and all requested checks OK.
- Added tests executed and validated: `tests/test_agent_cli_ux.py` and `tests/test_agent_dashboard_escaping.py` both passed as part of the suite.

------
