### PR TITLE
Potential fix for code scanning alert no. 42: Empty except

### DIFF
--- a/src/sdetkit/atomicio.py
+++ b/src/sdetkit/atomicio.py
@@ -4,6 +4,7 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+import logging
 
 
 def atomic_write_text(
@@ -39,8 +40,9 @@ def atomic_write_text(
         try:
             if tmp_path.exists():
                 tmp_path.unlink()
-        except Exception:
-            pass
+        except Exception as exc:
+            # Best-effort cleanup: failure to remove temporary file is non-fatal.
+            logging.debug("Failed to remove temporary file %s: %s", tmp_path, exc)
 
 
 def atomic_write_bytes(
@@ -76,8 +78,9 @@ def atomic_write_bytes(
         try:
             if tmp_path.exists():
                 tmp_path.unlink()
-        except Exception:
-            pass
+        except Exception as exc:
+            # Best-effort cleanup: failure to remove temporary file is non-fatal.
+            logging.debug("Failed to remove temporary file %s: %s", tmp_path, exc)
 
 
 def canonical_json_dumps(payload: Any, *, indent: int | None = 2) -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/42](https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/42)

To fix this, we should stop having a truly “empty” `except` block and make the intent explicit. The safest change that does not alter existing functionality is:

- Catch `Exception` as a variable (e.g., `as exc`).
- Add an explanatory comment that unlink failures are non-fatal best-effort cleanup.
- Optionally log the exception at a low level (e.g., `logging.debug`) so it remains non-fatal but is visible during debugging.

Because we must not change outward behavior, we should log only at `DEBUG` level and not re-raise; that keeps the operation succeeding exactly as before while satisfying the static analysis requirement and improving debuggability.

Concretely, in `src/sdetkit/atomicio.py`:

- Add an `import logging` alongside the other imports at the top of the file.
- In both `atomic_write_text` and `atomic_write_bytes` `finally` blocks, replace:

```python
        except Exception:
            pass
```

with:

```python
        except Exception as exc:
            # Best-effort cleanup: failure to remove temporary file is non-fatal.
            logging.debug("Failed to remove temporary file %s: %s", tmp_path, exc)
```

This keeps functional behavior the same (no exception is propagated) while documenting intent and avoiding an empty `except`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
