### PR TITLE
Add sdetkit security gate: deterministic repo scanner with baseline, SARIF, and CI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,22 @@ This path is offline-friendly and deterministic when `provider.type=none` and in
 
 Additional references: [AgentOS cookbook](docs/agentos-cookbook.md), [Determinism contract](docs/determinism-contract.md), [Security model](docs/security-model.md).
 
+
+## 🔐 Security Gate
+
+Run the top-level security gate locally and in CI:
+
+```bash
+python -m sdetkit security check --baseline tools/security.baseline.json --format text
+python -m sdetkit security check --baseline tools/security.baseline.json --format sarif --output build/security.sarif
+python -m sdetkit security fix
+```
+
+More details:
+
+- [Security gate guide](docs/security-gate.md)
+- [Security model](docs/security-model.md)
+
 ## 🧩 Why this repository exists
 
 This project is designed for fast onboarding and high-confidence delivery:

--- a/ci.sh
+++ b/ci.sh
@@ -12,6 +12,7 @@ mode=${1:-quick}
 case "$mode" in
   quick)
     python -m pytest -q
+    bash security.sh
     ;;
   docker)
     docker build -t sdet-bootcamp:ci .
@@ -19,6 +20,7 @@ case "$mode" in
     ;;
   all)
     python -m pytest -q
+    bash security.sh
     docker build -t sdet-bootcamp:ci .
     docker run --rm sdet-bootcamp:ci
     ;;

--- a/docs/security-gate.md
+++ b/docs/security-gate.md
@@ -1,0 +1,84 @@
+# Security Gate
+
+The `sdetkit security` command provides an offline, deterministic repository security scanner and CI gate.
+
+## Commands
+
+- `python -m sdetkit security scan`
+  - scans repository and returns findings based on `--fail-on` threshold.
+- `python -m sdetkit security check --baseline tools/security.baseline.json`
+  - compares findings against a baseline and fails only on regressions.
+- `python -m sdetkit security baseline --output tools/security.baseline.json`
+  - writes a baseline snapshot.
+- `python -m sdetkit security fix`
+  - applies conservative autofixes for safe cases only.
+
+## Output formats
+
+Use `--format text|json|sarif` and optional `--output <path>`.
+
+- `text`: concise developer summary (counts + top findings)
+- `json`: machine-readable findings for tooling
+- `sarif`: GitHub code-scanning compatible output
+
+Example SARIF export:
+
+```bash
+python -m sdetkit security check \
+  --baseline tools/security.baseline.json \
+  --format sarif \
+  --output build/security.sarif
+```
+
+## Regression baseline behavior
+
+Baseline matching uses stable fingerprint attributes:
+
+- `rule_id`
+- `path`
+- `line`
+- `fingerprint` (`rule_id|path|line|normalized_message` hash)
+
+Behavior:
+
+- baseline present: fail only for **new** findings at/above threshold
+- baseline missing: fail for all findings at/above threshold
+
+## What is detected
+
+Minimum red-flag coverage:
+
+- dangerous execution (`eval`, `exec`, `compile`, `os.system`, `subprocess shell=True`)
+- insecure deserialization (`pickle`, `dill`)
+- unsafe YAML (`yaml.load` without safe loader)
+- weak hashes (`md5`, `sha1`)
+- obvious path traversal / unsafe writes
+- secret patterns + high-entropy strings
+- network calls without timeout (`requests`, `urllib`)
+- `print(...)` debug leakage in `src/`
+
+## Allowlists
+
+Two allowlist mechanisms are supported:
+
+1. inline allowlist comment:
+
+```python
+# sdetkit: allow-security SEC_WEAK_HASH
+```
+
+2. repository allowlist file: `tools/security_allowlist.json`
+
+Use allowlists only for intentionally accepted risk and include rationale in code review.
+
+## Auto-fix behavior
+
+`python -m sdetkit security fix` only performs conservative transformations:
+
+- `yaml.load(...)` → `yaml.safe_load(...)` when confidently matched
+- adds `timeout=<N>` to simple one-line `requests.*(...)` calls missing timeout
+- optionally runs `ruff --fix` when available (`--run-ruff`)
+
+Not auto-fixed:
+
+- `subprocess(..., shell=True)` is reported with a recommendation, not rewritten automatically.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,31 +1,57 @@
-# AgentOS security model
+# Security model
 
-AgentOS applies deny-by-default controls for sensitive actions.
+This repository uses a layered security posture:
 
-## Safety gates
+1. runtime safety controls (AgentOS)
+2. repository security gate (`sdetkit security`)
+3. CI regression baseline checks
+
+## Threat model assumptions
+
+- The repository may contain untrusted code changes from contributors and automation.
+- CI and local execution should remain offline-capable for core checks.
+- Preventing accidental secret leakage and high-risk patterns is prioritized over broad heuristic noise.
+- Security checks must be deterministic to support reliable baselines and diffing.
+
+## Default blocked/guarded behavior
+
+AgentOS deny-by-default controls:
 
 - File writes:
   - Denied unless target is inside repository root and matches write allowlist.
   - Default allowlist is `.sdetkit/agent/workdir`.
 - Shell actions:
-  - Always approval-gated.
-  - Command allowlist is explicit in config; default is empty.
+  - Approval-gated with explicit command allowlists.
 - MCP/tool bridge:
   - Disabled by default.
   - Requires explicit `--tool-bridge-enabled` and `--tool-bridge-allow` entries.
 
-## Operational controls
+## Security gate policy behavior
 
-- Every run emits a structured run record with approvals/denials.
-- Omnichannel traffic records append to conversation history and rate-limit state.
-- Deterministic report exports support audit evidence and change tracking.
+`python -m sdetkit security` enforces red-flag policy for:
+
+- dangerous execution APIs
+- insecure deserialization and YAML loading
+- weak hashes
+- obvious path traversal / unsafe writes
+- secret leakage patterns
+- network calls without timeouts
+- debug prints in `src/`
+
+Allowlists:
+
+- inline: `# sdetkit: allow-security <RULE_ID>`
+- repo file: `tools/security_allowlist.json`
+
+Baseline regression gate:
+
+- baseline file: `tools/security.baseline.json`
+- checks fail only on new findings when baseline exists
+- checks fail on all violations when baseline is missing
 
 ## Verification
 
-Use:
-
 ```bash
+python -m sdetkit security check --baseline tools/security.baseline.json --format text
 python -m sdetkit doctor --ascii
 ```
-
-and verify security-oriented checks remain green.

--- a/security.sh
+++ b/security.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -f .venv/bin/activate ]; then
+  # shellcheck disable=SC1091
+  . .venv/bin/activate
+fi
+
+mkdir -p build
+python -m sdetkit security check --baseline tools/security.baseline.json --format text
+python -m sdetkit security check --baseline tools/security.baseline.json --format sarif --output build/security.sarif

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -8,6 +8,7 @@ from importlib import metadata
 from . import apiget, kvcli, patch, repo, report
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
+from .security_gate import main as security_main
 
 
 def _tool_version() -> str:
@@ -67,6 +68,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "agent":
         return agent_main(list(argv[1:]))
 
+    if argv and argv[0] == "security":
+        return security_main(list(argv[1:]))
+
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -101,6 +105,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     agt = sub.add_parser("agent")
     agt.add_argument("args", nargs=argparse.REMAINDER)
 
+    sec = sub.add_parser("security")
+    sec.add_argument("args", nargs=argparse.REMAINDER)
+
     ns = p.parse_args(argv)
 
     if ns.cmd == "kv":
@@ -123,6 +130,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "agent":
         return agent_main(ns.args)
+
+    if ns.cmd == "security":
+        return security_main(ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)

--- a/src/sdetkit/security_gate.py
+++ b/src/sdetkit/security_gate.py
@@ -1,0 +1,788 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import math
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SEVERITY_RANK = {"info": 1, "warn": 2, "error": 3}
+DEFAULT_ALLOWLIST_PATH = Path("tools/security_allowlist.json")
+DEFAULT_BASELINE_PATH = Path("tools/security.baseline.json")
+INLINE_ALLOW_PREFIX = "# sdetkit: allow-security"
+
+SKIP_DIRS = {
+    ".git",
+    ".venv",
+    "node_modules",
+    "dist",
+    "build",
+    "site",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".sdetkit",
+}
+TEXT_EXTENSIONS = {
+    ".py",
+    ".md",
+    ".txt",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".env",
+    ".sh",
+}
+SUSPICIOUS_INPUT_NAMES = {"user_input", "input_path", "filename", "filepath", "path", "name"}
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule_id: str
+    severity: str
+    path: str
+    line: int
+    column: int
+    message: str
+    suggestion: str = ""
+    fingerprint: str = ""
+
+
+@dataclass(frozen=True)
+class RuleMeta:
+    rule_id: str
+    severity: str
+    title: str
+    description: str
+
+
+RULES: dict[str, RuleMeta] = {
+    "SEC_DANGEROUS_EVAL": RuleMeta(
+        "SEC_DANGEROUS_EVAL", "error", "Dangerous code execution", "Use of eval/exec/compile."
+    ),
+    "SEC_SUBPROCESS_SHELL_TRUE": RuleMeta(
+        "SEC_SUBPROCESS_SHELL_TRUE",
+        "error",
+        "subprocess shell=True",
+        "Avoid shell=True in subprocess calls.",
+    ),
+    "SEC_OS_SYSTEM": RuleMeta(
+        "SEC_OS_SYSTEM",
+        "error",
+        "os.system invocation",
+        "Avoid os.system; use subprocess with argument lists.",
+    ),
+    "SEC_INSECURE_DESERIALIZATION": RuleMeta(
+        "SEC_INSECURE_DESERIALIZATION",
+        "error",
+        "Insecure deserialization",
+        "Avoid pickle/dill for untrusted input.",
+    ),
+    "SEC_YAML_UNSAFE_LOAD": RuleMeta(
+        "SEC_YAML_UNSAFE_LOAD",
+        "error",
+        "Unsafe YAML load",
+        "Use yaml.safe_load instead of yaml.load.",
+    ),
+    "SEC_WEAK_HASH": RuleMeta(
+        "SEC_WEAK_HASH",
+        "warn",
+        "Weak hash usage",
+        "Avoid md5/sha1 for security-sensitive workflows.",
+    ),
+    "SEC_POTENTIAL_PATH_TRAVERSAL": RuleMeta(
+        "SEC_POTENTIAL_PATH_TRAVERSAL",
+        "warn",
+        "Potential path traversal",
+        "Use safe_path-style guard for user-controlled path segments.",
+    ),
+    "SEC_POTENTIAL_UNSAFE_WRITE": RuleMeta(
+        "SEC_POTENTIAL_UNSAFE_WRITE",
+        "warn",
+        "Potential unsafe write",
+        "Avoid absolute writes outside workspace allowlist.",
+    ),
+    "SEC_SECRET_PATTERN": RuleMeta(
+        "SEC_SECRET_PATTERN",
+        "error",
+        "Secret-like pattern",
+        "Potential credential or private key material detected.",
+    ),
+    "SEC_HIGH_ENTROPY_STRING": RuleMeta(
+        "SEC_HIGH_ENTROPY_STRING",
+        "warn",
+        "High entropy string",
+        "Potential token-like hardcoded value detected.",
+    ),
+    "SEC_NETWORK_TIMEOUT": RuleMeta(
+        "SEC_NETWORK_TIMEOUT",
+        "warn",
+        "Network call missing timeout",
+        "Set explicit timeout for requests/urllib calls.",
+    ),
+    "SEC_DEBUG_PRINT": RuleMeta(
+        "SEC_DEBUG_PRINT", "info", "Debug print in src", "Avoid print() in src/ modules."
+    ),
+}
+
+SECRET_PATTERNS: list[tuple[str, re.Pattern[str], str]] = [
+    ("SEC_SECRET_PATTERN", re.compile(r"AKIA[0-9A-Z]{16}"), "Potential AWS access key"),
+    ("SEC_SECRET_PATTERN", re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"), "Potential GitHub token"),
+    (
+        "SEC_SECRET_PATTERN",
+        re.compile(r"(?i)api[_-]?key\s*[:=]\s*['\"]?[A-Za-z0-9_\-]{8,}"),
+        "Potential hardcoded API key",
+    ),
+    (
+        "SEC_SECRET_PATTERN",
+        re.compile(r"(?i)(token|secret|password)\s*[:=]\s*['\"]?[A-Za-z0-9_\-]{8,}"),
+        "Potential hardcoded credential",
+    ),
+    (
+        "SEC_SECRET_PATTERN",
+        re.compile(r"-----BEGIN (?:RSA|EC|OPENSSH|DSA|PRIVATE) KEY-----"),
+        "Potential PEM private key",
+    ),
+]
+
+
+class SecurityScanError(ValueError):
+    pass
+
+
+class _RuleVisitor(ast.NodeVisitor):
+    def __init__(self, rel_path: str, lines: list[str]) -> None:
+        self.rel_path = rel_path
+        self.lines = lines
+        self.findings: list[Finding] = []
+
+    def _add(self, rule_id: str, node: ast.AST, message: str, suggestion: str = "") -> None:
+        self.findings.append(
+            Finding(
+                rule_id=rule_id,
+                severity=RULES[rule_id].severity,
+                path=self.rel_path,
+                line=getattr(node, "lineno", 1),
+                column=getattr(node, "col_offset", 0),
+                message=message,
+                suggestion=suggestion,
+            )
+        )
+
+    def visit_Call(self, node: ast.Call) -> Any:
+        name = _call_name(node)
+        if name in {"eval", "exec", "compile"}:
+            self._add(
+                "SEC_DANGEROUS_EVAL", node, f"Avoid {name}(); dynamic execution is dangerous."
+            )
+        if name == "os.system":
+            self._add(
+                "SEC_OS_SYSTEM", node, "os.system detected; use subprocess with argument list."
+            )
+        if name and name.startswith("subprocess.") and _kw_bool(node, "shell", True):
+            self._add(
+                "SEC_SUBPROCESS_SHELL_TRUE",
+                node,
+                "subprocess call uses shell=True.",
+                suggestion="Set shell=False and pass command as a list.",
+            )
+        if name in {"pickle.load", "pickle.loads"} or name.startswith("dill"):
+            self._add(
+                "SEC_INSECURE_DESERIALIZATION",
+                node,
+                f"Insecure deserialization via {name}.",
+            )
+        if name == "yaml.load" and not _is_safe_yaml_loader(node):
+            self._add(
+                "SEC_YAML_UNSAFE_LOAD",
+                node,
+                "yaml.load used without SafeLoader/safe_load.",
+                suggestion="Replace with yaml.safe_load(...).",
+            )
+        if name in {"hashlib.md5", "hashlib.sha1", "md5", "sha1"}:
+            self._add("SEC_WEAK_HASH", node, f"Weak hash usage: {name}.")
+        if (
+            name
+            and name.startswith("requests.")
+            and name.split(".")[-1]
+            in {
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete",
+                "head",
+                "request",
+            }
+        ):
+            if not _has_kw(node, "timeout"):
+                self._add(
+                    "SEC_NETWORK_TIMEOUT",
+                    node,
+                    f"{name} without timeout.",
+                    suggestion="Add timeout=<seconds> argument.",
+                )
+        if name in {"urllib.request.urlopen", "urlopen"} and not _has_kw(node, "timeout"):
+            self._add(
+                "SEC_NETWORK_TIMEOUT",
+                node,
+                "urllib.request.urlopen without timeout.",
+                suggestion="Add timeout=<seconds> argument.",
+            )
+        if name in {
+            "os.path.join",
+            "pathlib.Path",
+            "Path",
+            "pathlib.Path.joinpath",
+            "Path.joinpath",
+        }:
+            if _looks_untrusted_path_args(node):
+                self._add(
+                    "SEC_POTENTIAL_PATH_TRAVERSAL",
+                    node,
+                    "Path join with potentially user-controlled segment.",
+                    suggestion="Validate with safe_path before filesystem access.",
+                )
+        if name == "open" and _is_write_mode_open(node):
+            if _is_absolute_literal(node):
+                self._add(
+                    "SEC_POTENTIAL_UNSAFE_WRITE",
+                    node,
+                    "Write to absolute path detected.",
+                    suggestion="Restrict writes to workspace or explicit allowlist.",
+                )
+        if self.rel_path.startswith("src/") and name == "print":
+            self._add("SEC_DEBUG_PRINT", node, "print(...) found in src/.")
+        self.generic_visit(node)
+
+
+def _call_name(node: ast.Call) -> str:
+    fn = node.func
+    if isinstance(fn, ast.Name):
+        return fn.id
+    if isinstance(fn, ast.Attribute):
+        parts = [fn.attr]
+        value = fn.value
+        while isinstance(value, ast.Attribute):
+            parts.append(value.attr)
+            value = value.value
+        if isinstance(value, ast.Name):
+            parts.append(value.id)
+        return ".".join(reversed(parts))
+    return ""
+
+
+def _kw_bool(node: ast.Call, key: str, expected: bool) -> bool:
+    for kw in node.keywords:
+        if (
+            kw.arg == key
+            and isinstance(kw.value, ast.Constant)
+            and isinstance(kw.value.value, bool)
+        ):
+            return kw.value.value is expected
+    return False
+
+
+def _has_kw(node: ast.Call, key: str) -> bool:
+    return any(kw.arg == key for kw in node.keywords)
+
+
+def _looks_untrusted_path_args(node: ast.Call) -> bool:
+    for arg in node.args:
+        if isinstance(arg, ast.Name) and arg.id.lower() in SUSPICIOUS_INPUT_NAMES:
+            return True
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str) and ".." in arg.value:
+            return True
+    return False
+
+
+def _is_write_mode_open(node: ast.Call) -> bool:
+    if (
+        len(node.args) >= 2
+        and isinstance(node.args[1], ast.Constant)
+        and isinstance(node.args[1].value, str)
+    ):
+        mode = node.args[1].value
+        return any(ch in mode for ch in ("w", "a", "x"))
+    for kw in node.keywords:
+        if (
+            kw.arg == "mode"
+            and isinstance(kw.value, ast.Constant)
+            and isinstance(kw.value.value, str)
+        ):
+            return any(ch in kw.value.value for ch in ("w", "a", "x"))
+    return False
+
+
+def _is_absolute_literal(node: ast.Call) -> bool:
+    if not node.args:
+        return False
+    first = node.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value.startswith("/")
+    return False
+
+
+def _is_safe_yaml_loader(node: ast.Call) -> bool:
+    for kw in node.keywords:
+        if kw.arg != "Loader":
+            continue
+        if isinstance(kw.value, ast.Attribute) and kw.value.attr in {"SafeLoader", "CSafeLoader"}:
+            return True
+        if isinstance(kw.value, ast.Name) and kw.value.id in {"SafeLoader", "CSafeLoader"}:
+            return True
+    return False
+
+
+def _should_scan_file(path: Path) -> bool:
+    if path.suffix.lower() in TEXT_EXTENSIONS:
+        return True
+    return path.name in {".env", ".env.local", ".env.production"}
+
+
+def _iter_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        if any(part in SKIP_DIRS for part in p.parts):
+            continue
+        if not _should_scan_file(p):
+            continue
+        try:
+            if p.stat().st_size > 1_000_000:
+                continue
+        except OSError:
+            continue
+        files.append(p)
+    files.sort(key=lambda x: x.as_posix())
+    return files
+
+
+def _normalized_message(message: str) -> str:
+    return re.sub(r"\s+", " ", message.strip()).lower()
+
+
+def _fingerprint(rule_id: str, path: str, line: int, message: str) -> str:
+    raw = f"{rule_id}|{path}|{line}|{_normalized_message(message)}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def _load_repo_allowlist(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SecurityScanError(f"invalid allowlist JSON: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("entries", []), list):
+        raise SecurityScanError("allowlist file must be object with 'entries' list")
+    entries = [item for item in payload["entries"] if isinstance(item, dict)]
+    entries.sort(
+        key=lambda x: (
+            str(x.get("rule_id", "")),
+            str(x.get("path", "")),
+            int(x.get("line", 0) or 0),
+        )
+    )
+    return entries
+
+
+def _inline_allowed(lines: list[str], finding: Finding) -> bool:
+    line_no = finding.line
+    for idx in (line_no - 1, line_no - 2):
+        if idx < 0 or idx >= len(lines):
+            continue
+        txt = lines[idx]
+        if INLINE_ALLOW_PREFIX in txt:
+            allow_rule = txt.split(INLINE_ALLOW_PREFIX, 1)[1].strip()
+            if allow_rule == finding.rule_id:
+                return True
+    return False
+
+
+def _repo_allowed(entries: list[dict[str, Any]], finding: Finding) -> bool:
+    for item in entries:
+        if str(item.get("rule_id", "")) != finding.rule_id:
+            continue
+        if str(item.get("path", "")) != finding.path:
+            continue
+        line = item.get("line")
+        if isinstance(line, int) and line != finding.line:
+            continue
+        fp = item.get("fingerprint")
+        if isinstance(fp, str) and fp and fp != finding.fingerprint:
+            continue
+        return True
+    return False
+
+
+def _scan_text_patterns(rel_path: str, text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    lines = text.splitlines()
+    for i, line in enumerate(lines, start=1):
+        for rule_id, pattern, msg in SECRET_PATTERNS:
+            if pattern.search(line):
+                findings.append(
+                    Finding(
+                        rule_id=rule_id,
+                        severity=RULES[rule_id].severity,
+                        path=rel_path,
+                        line=i,
+                        column=0,
+                        message=msg,
+                    )
+                )
+        # quoted token-like strings
+        for match in re.finditer(r"['\"]([A-Za-z0-9+/=_\-]{20,})['\"]", line):
+            token = match.group(1)
+            if _entropy(token) >= 4.0 and not token.isdigit():
+                findings.append(
+                    Finding(
+                        rule_id="SEC_HIGH_ENTROPY_STRING",
+                        severity=RULES["SEC_HIGH_ENTROPY_STRING"].severity,
+                        path=rel_path,
+                        line=i,
+                        column=match.start(1),
+                        message="High-entropy string literal detected.",
+                    )
+                )
+    return findings
+
+
+def _entropy(text: str) -> float:
+    if not text:
+        return 0.0
+    counts: dict[str, int] = {}
+    for ch in text:
+        counts[ch] = counts.get(ch, 0) + 1
+    total = len(text)
+    return -sum((v / total) * math.log2(v / total) for v in counts.values())
+
+
+def scan_repo(root: Path, *, allowlist_path: Path | None = None) -> list[Finding]:
+    allow_entries = _load_repo_allowlist(allowlist_path or DEFAULT_ALLOWLIST_PATH)
+    findings: list[Finding] = []
+    for file_path in _iter_files(root):
+        rel = file_path.relative_to(root).as_posix()
+        try:
+            text = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        lines = text.splitlines()
+        file_findings: list[Finding] = []
+        if file_path.suffix == ".py":
+            try:
+                tree = ast.parse(text)
+            except SyntaxError:
+                tree = None
+            if tree is not None:
+                visitor = _RuleVisitor(rel, lines)
+                visitor.visit(tree)
+                file_findings.extend(visitor.findings)
+        file_findings.extend(_scan_text_patterns(rel, text))
+
+        for finding in file_findings:
+            with_fp = Finding(
+                **{
+                    **asdict(finding),
+                    "fingerprint": _fingerprint(
+                        finding.rule_id, finding.path, finding.line, finding.message
+                    ),
+                }
+            )
+            if _inline_allowed(lines, with_fp):
+                continue
+            if _repo_allowed(allow_entries, with_fp):
+                continue
+            file_line = lines[with_fp.line - 1] if 0 < with_fp.line <= len(lines) else ""
+            if with_fp.rule_id == "SEC_WEAK_HASH" and INLINE_ALLOW_PREFIX in file_line:
+                continue
+            findings.append(with_fp)
+
+    findings.sort(key=lambda x: (x.path, x.line, x.column, x.rule_id, x.message))
+    return findings
+
+
+def _to_json_payload(
+    findings: list[Finding], *, new_only: list[Finding] | None = None
+) -> dict[str, Any]:
+    counts = {"info": 0, "warn": 0, "error": 0}
+    for f in findings:
+        counts[f.severity] += 1
+    return {
+        "version": 1,
+        "counts": counts,
+        "findings": [asdict(x) for x in findings],
+        "new_findings": [asdict(x) for x in (new_only or findings)],
+    }
+
+
+def _to_text(findings: list[Finding]) -> str:
+    counts = {"info": 0, "warn": 0, "error": 0}
+    for f in findings:
+        counts[f.severity] += 1
+    lines = [
+        f"security scan: total={len(findings)} error={counts['error']} warn={counts['warn']} info={counts['info']}",
+        "top findings:",
+    ]
+    for item in findings[:15]:
+        lines.append(f"- [{item.severity}] {item.rule_id} {item.path}:{item.line} {item.message}")
+    if not findings:
+        lines.append("- none")
+    return "\n".join(lines) + "\n"
+
+
+def _to_sarif(findings: list[Finding]) -> dict[str, Any]:
+    rules = []
+    for rid in sorted({f.rule_id for f in findings}):
+        meta = RULES[rid]
+        rules.append(
+            {
+                "id": rid,
+                "name": meta.title,
+                "shortDescription": {"text": meta.title},
+                "fullDescription": {"text": meta.description},
+                "help": {"text": meta.description},
+                "defaultConfiguration": {
+                    "level": {"info": "note", "warn": "warning", "error": "error"}[meta.severity]
+                },
+            }
+        )
+    results = []
+    for f in findings:
+        results.append(
+            {
+                "ruleId": f.rule_id,
+                "level": {"info": "note", "warn": "warning", "error": "error"}[f.severity],
+                "message": {"text": f.message},
+                "fingerprints": {"primaryLocationLineHash": f.fingerprint},
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": f.path},
+                            "region": {"startLine": f.line, "startColumn": max(f.column, 1)},
+                        }
+                    }
+                ],
+            }
+        )
+    return {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {"driver": {"name": "sdetkit-security-gate", "rules": rules}},
+                "results": results,
+            }
+        ],
+    }
+
+
+def _write_output(text: str, output: str | None) -> None:
+    if output:
+        path = Path(output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+
+
+def _severity_trips(findings: list[Finding], threshold: str) -> bool:
+    if threshold == "none":
+        return False
+    gate = SEVERITY_RANK[threshold]
+    return any(SEVERITY_RANK[f.severity] >= gate for f in findings)
+
+
+def _load_baseline(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("entries"), list):
+        raise SecurityScanError("baseline must be JSON object containing entries[]")
+    entries = [x for x in data["entries"] if isinstance(x, dict)]
+    entries.sort(
+        key=lambda x: (
+            str(x.get("path", "")),
+            str(x.get("rule_id", "")),
+            str(x.get("fingerprint", "")),
+        )
+    )
+    return entries
+
+
+def _make_baseline_entries(findings: list[Finding]) -> list[dict[str, Any]]:
+    entries = [
+        {
+            "rule_id": f.rule_id,
+            "severity": f.severity,
+            "path": f.path,
+            "line": f.line,
+            "fingerprint": f.fingerprint,
+            "message": _normalized_message(f.message)[:120],
+        }
+        for f in findings
+    ]
+    entries.sort(key=lambda x: (x["path"], x["rule_id"], x["line"], x["fingerprint"]))
+    return entries
+
+
+def _filter_new(findings: list[Finding], baseline_entries: list[dict[str, Any]]) -> list[Finding]:
+    known = {
+        (
+            str(x.get("rule_id", "")),
+            str(x.get("path", "")),
+            int(x.get("line", 0) or 0),
+            str(x.get("fingerprint", "")),
+        )
+        for x in baseline_entries
+    }
+    return [f for f in findings if (f.rule_id, f.path, f.line, f.fingerprint) not in known]
+
+
+def _render(findings: list[Finding], fmt: str, *, new_only: list[Finding] | None = None) -> str:
+    if fmt == "text":
+        return _to_text(findings if new_only is None else new_only)
+    if fmt == "json":
+        return (
+            json.dumps(
+                _to_json_payload(findings, new_only=new_only),
+                ensure_ascii=True,
+                sort_keys=True,
+                indent=2,
+            )
+            + "\n"
+        )
+    if fmt == "sarif":
+        target = findings if new_only is None else new_only
+        return json.dumps(_to_sarif(target), ensure_ascii=True, sort_keys=True, indent=2) + "\n"
+    raise SecurityScanError(f"unsupported format: {fmt}")
+
+
+def _fix_yaml_safe_load(path: Path) -> bool:
+    text = path.read_text(encoding="utf-8")
+    out = re.sub(r"\byaml\.load\s*\(", "yaml.safe_load(", text)
+    if out != text:
+        path.write_text(out, encoding="utf-8")
+        return True
+    return False
+
+
+def _fix_requests_timeout(path: Path, timeout: int) -> bool:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    changed = False
+    for idx, line in enumerate(lines):
+        if "requests." not in line or "timeout=" in line:
+            continue
+        m = re.search(r"requests\.(get|post|put|patch|delete|head|request)\((.*)\)", line)
+        if not m:
+            continue
+        lines[idx] = line[:-1] + f", timeout={timeout})"
+        changed = True
+    if changed:
+        path.write_text("\n".join(lines) + ("\n" if text.endswith("\n") else ""), encoding="utf-8")
+    return changed
+
+
+def _run_ruff_fix(root: Path) -> tuple[bool, str]:
+    if not shutil.which("ruff"):
+        return False, "ruff not available; skipped"
+    proc = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", str(root), "--fix"], capture_output=True, text=True
+    )
+    return proc.returncode == 0, (proc.stdout + proc.stderr).strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="sdetkit security")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--root", default=".")
+    common.add_argument("--allowlist", default=str(DEFAULT_ALLOWLIST_PATH))
+    common.add_argument("--format", choices=["text", "json", "sarif"], default="text")
+    common.add_argument("--output", default=None)
+    common.add_argument("--fail-on", choices=["none", "warn", "error"], default="error")
+
+    sub.add_parser("scan", parents=[common])
+
+    chk = sub.add_parser("check", parents=[common])
+    chk.add_argument("--baseline", default=str(DEFAULT_BASELINE_PATH))
+
+    sub.add_parser("baseline", parents=[common])
+
+    fixp = sub.add_parser("fix")
+    fixp.add_argument("--root", default=".")
+    fixp.add_argument("--allowlist", default=str(DEFAULT_ALLOWLIST_PATH))
+    fixp.add_argument("--timeout", type=int, default=10)
+    fixp.add_argument("--run-ruff", action="store_true")
+
+    ns = parser.parse_args(argv)
+    try:
+        root = Path(ns.root).resolve()
+        allowlist = Path(ns.allowlist)
+        findings = scan_repo(root, allowlist_path=allowlist)
+
+        if ns.cmd == "baseline":
+            entries = _make_baseline_entries(findings)
+            baseline_payload = {"version": 1, "entries": entries}
+            if not ns.output:
+                raise SecurityScanError("baseline requires --output <path>")
+            output = Path(ns.output)
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(
+                json.dumps(baseline_payload, ensure_ascii=True, sort_keys=True, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            sys.stdout.write(f"baseline written: {output.as_posix()} ({len(entries)} entries)\n")
+            return 0
+
+        if ns.cmd == "fix":
+            changed = 0
+            for py_file in [p for p in _iter_files(root) if p.suffix == ".py"]:
+                did_change = _fix_yaml_safe_load(py_file)
+                did_change = _fix_requests_timeout(py_file, ns.timeout) or did_change
+                if did_change:
+                    changed += 1
+            if ns.run_ruff:
+                ok, msg = _run_ruff_fix(root)
+                status = "ruff-fix applied" if ok else "ruff-fix had issues"
+                sys.stdout.write(f"{status}: {msg}\n")
+            sys.stdout.write(f"security fix complete; files changed: {changed}\n")
+            return 0
+
+        if ns.cmd == "check":
+            baseline_path = Path(ns.baseline)
+            if baseline_path.exists():
+                baseline_entries = _load_baseline(baseline_path)
+                new_findings = _filter_new(findings, baseline_entries)
+            else:
+                new_findings = findings
+            rendered = _render(findings, ns.format, new_only=new_findings)
+            _write_output(rendered, ns.output)
+            return 1 if _severity_trips(new_findings, ns.fail_on) else 0
+
+        rendered = _render(findings, ns.format)
+        _write_output(rendered, ns.output)
+        return 1 if _severity_trips(findings, ns.fail_on) else 0
+    except SecurityScanError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return 2
+    except OSError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_security_gate_cli.py
+++ b/tests/test_security_gate_cli.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+
+
+def _run(args: list[str]) -> int:
+    return cli.main(["security", *args])
+
+
+def test_security_scan_detects_multiple_rules(tmp_path: Path, capsys) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.py").write_text(
+        """
+import hashlib
+import os
+import pickle
+import requests
+import yaml
+
+print('debug')
+os.system('echo bad')
+value = eval('1+1')
+obj = pickle.loads(data)
+cfg = yaml.load(doc)
+h = hashlib.md5(b'x').hexdigest()
+resp = requests.get('https://example.com')
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rc = _run(["scan", "--root", str(tmp_path), "--format", "json", "--fail-on", "none"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    rules = {item["rule_id"] for item in payload["findings"]}
+    assert {
+        "SEC_DEBUG_PRINT",
+        "SEC_OS_SYSTEM",
+        "SEC_DANGEROUS_EVAL",
+        "SEC_INSECURE_DESERIALIZATION",
+        "SEC_YAML_UNSAFE_LOAD",
+        "SEC_WEAK_HASH",
+        "SEC_NETWORK_TIMEOUT",
+    }.issubset(rules)
+
+
+def test_security_baseline_regression_only(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    file = src / "mod.py"
+    file.write_text("import os\nos.system('echo x')\n", encoding="utf-8")
+
+    baseline = tmp_path / "baseline.json"
+    assert _run(["baseline", "--root", str(tmp_path), "--output", str(baseline)]) == 0
+
+    # Existing finding should not fail with baseline
+    assert (
+        _run(["check", "--root", str(tmp_path), "--baseline", str(baseline), "--format", "json"])
+        == 0
+    )
+
+    # New finding should fail regression gate
+    file.write_text(
+        "import os\nimport requests\nos.system('echo x')\nrequests.get('https://example.com')\n",
+        encoding="utf-8",
+    )
+    assert (
+        _run(["check", "--root", str(tmp_path), "--baseline", str(baseline), "--format", "json"])
+        == 1
+    )
+
+
+def test_security_scan_output_is_deterministic(tmp_path: Path, capsys) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "z.py").write_text("import os\nos.system('z')\n", encoding="utf-8")
+    (src / "a.py").write_text("import os\nos.system('a')\n", encoding="utf-8")
+
+    assert _run(["scan", "--root", str(tmp_path), "--format", "json", "--fail-on", "none"]) == 0
+    first = capsys.readouterr().out
+    assert _run(["scan", "--root", str(tmp_path), "--format", "json", "--fail-on", "none"]) == 0
+    second = capsys.readouterr().out
+    assert first == second
+
+
+def test_security_sarif_shape(tmp_path: Path, capsys) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.py").write_text("import os\nos.system('x')\n", encoding="utf-8")
+
+    rc = _run(["scan", "--root", str(tmp_path), "--format", "sarif", "--fail-on", "none"])
+    assert rc == 0
+    sarif = json.loads(capsys.readouterr().out)
+    assert sarif["version"] == "2.1.0"
+    run = sarif["runs"][0]
+    assert run["tool"]["driver"]["name"] == "sdetkit-security-gate"
+    assert run["tool"]["driver"]["rules"]
+    assert run["results"][0]["ruleId"]
+    assert run["results"][0]["locations"]

--- a/tools/security.baseline.json
+++ b/tools/security.baseline.json
@@ -1,0 +1,1109 @@
+{
+  "entries": [
+    {
+      "fingerprint": "d67abd7a274b05b78fc5b5b2",
+      "line": 19,
+      "message": "high-entropy string literal detected.",
+      "path": "docs/policy-and-baselines.md",
+      "rule_id": "SEC_HIGH_ENTROPY_STRING",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "5ed3b31699d1f21bea844498",
+      "line": 38,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/__main__.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "bba07426566942158daa6262",
+      "line": 41,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/__main__.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "a6ac9c560d2286ad52ac3c82",
+      "line": 54,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/__main__.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "4009a581a92bd61ba747e993",
+      "line": 72,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/__main__.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "b7833b382141e8dc91ad595a",
+      "line": 75,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/__main__.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "ee14285044ba1c81cc2099ea",
+      "line": 101,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/__main__.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "2b0d2a8c386aed47be32657d",
+      "line": 28,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/agent/cli.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "ffe6974007927ea5cde2cf79",
+      "line": 266,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/apiget.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "6734a93f6789d2bdf671c528",
+      "line": 289,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/apiget.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "035bae7ec19cfdc7659d066e",
+      "line": 12,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/atomicio.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "432516dc91eed0298afbe8e4",
+      "line": 49,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/atomicio.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "8f82c4e64c8472501d8dccbd",
+      "line": 54,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/cassette.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "29de1c3e131d754a605d1088",
+      "line": 63,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/cassette.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "cd44e471fa3e3cb9a41a2528",
+      "line": 165,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/cassette.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "d9caca05cda857a8b9eb264e",
+      "line": 246,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/cassette.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "87e1aca567c952fc8cda7a7b",
+      "line": 268,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/cassette.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "207ec413b71211f932fc69e0",
+      "line": 45,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/cli.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "1f20726d0b85bf1aadbbb1ef",
+      "line": 524,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/doctor.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "3d687214eae53c2dd15719ed",
+      "line": 702,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/doctor.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "c742b5849a7353fe38442fc7",
+      "line": 713,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/doctor.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "d9fc09d7cb4a440ae1ef81f2",
+      "line": 20,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/maintenance/cli.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "012fa72348541a2b46216299",
+      "line": 121,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/maintenance/cli.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "77c098ac6cc26514ebfc5d4a",
+      "line": 123,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/maintenance/cli.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "21457288b0d2a8d983d51c36",
+      "line": 156,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/maintenance/cli.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "70a6952e8dab088c9871a099",
+      "line": 158,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/maintenance/cli.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "b57b143c3355882adc35f70b",
+      "line": 165,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/maintenance/cli.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "a2f38a0cb56bf86cf49d84a3",
+      "line": 71,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/maintenance/cli.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "9a166263e60c7cdc70a2059e",
+      "line": 940,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/patch.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "c2095932e4a8ea49be7e542a",
+      "line": 945,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/patch.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "cec65a5eab9166a6327a88e6",
+      "line": 62,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/patch.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "301189438109adbc57fe9961",
+      "line": 682,
+      "message": "high-entropy string literal detected.",
+      "path": "src/sdetkit/plugins.py",
+      "rule_id": "SEC_HIGH_ENTROPY_STRING",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "cc1d23ff263ae400ea1e2a56",
+      "line": 716,
+      "message": "high-entropy string literal detected.",
+      "path": "src/sdetkit/plugins.py",
+      "rule_id": "SEC_HIGH_ENTROPY_STRING",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "91be506786e1c8edcea267b1",
+      "line": 1426,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "8c3cc8c758fc1c7f24a6aa57",
+      "line": 1429,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "502efdaeba4b6b5fdadc75d0",
+      "line": 1432,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "51d1fc50292c0e97f37cb993",
+      "line": 1452,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "7ad4c464b13574b3102deeac",
+      "line": 1456,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "e466af52137ac84a028b0e0f",
+      "line": 1466,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "0fedce7d09cf263fbe509e8c",
+      "line": 1571,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "4ff87eb987fae8853fdadb15",
+      "line": 1575,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "203642c8cd8dd4a37e6172dd",
+      "line": 1576,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "91eaf2e00b7f4299ba0aa121",
+      "line": 1632,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "0f36d2f50fff8763f276ec86",
+      "line": 1646,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "9858a269c6a27e09502ee30a",
+      "line": 1657,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "ea7e0de86fe44ce87f38f96e",
+      "line": 3506,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "11575552f7070d0d0181c5d0",
+      "line": 3516,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "538308bdd17971b508cdce69",
+      "line": 3541,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "081064e341375fa8ee4b1cad",
+      "line": 3543,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "53a58628264bc23d3f54020c",
+      "line": 3550,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "056c99da13f04ba866276af7",
+      "line": 3558,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "fc862cb4d44cec06f7f662bd",
+      "line": 3597,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "630269108e3d44e5ba40ba46",
+      "line": 3607,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "08b21c59892fd72480e5c06a",
+      "line": 3614,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "aef1b026331157d43cad0957",
+      "line": 3618,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "52443a3c08c130f78718959d",
+      "line": 3630,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "8b04f0915c2de21df1ac920f",
+      "line": 3646,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "611cfa70b0567ffa0f462f20",
+      "line": 3658,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "c01f87c24d8aafc3a7b12dd1",
+      "line": 3670,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "b98023b4374baa1cc75e1198",
+      "line": 3674,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "e13a4154bc91ca4b77c049b0",
+      "line": 3683,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "03db1b4483fb8e6fff9e629d",
+      "line": 3685,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "21bc3c9cc7c8bfb6e2032c49",
+      "line": 3703,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "0432f7bbe0a78d0ed11295fb",
+      "line": 3717,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "c33c426da22504290de4bb1f",
+      "line": 3738,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "23ec6f2975466322a60bdebe",
+      "line": 3742,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "d998fb9714a3a8e54ab29f26",
+      "line": 3755,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "2290ca5d44dad4607a89eceb",
+      "line": 3759,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "e10c111de742948a76d7e42f",
+      "line": 3805,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "fb2a4e53c8fa622f0ded200a",
+      "line": 3825,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "26dd328ab7d98258e9208889",
+      "line": 3835,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "0769a302c5f235b7e08aa03e",
+      "line": 3836,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "79e3f7de874521d02c4b3e80",
+      "line": 3840,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "5f6eccf75e6faa3d11c7f776",
+      "line": 3843,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "48230563c4a83344867151b9",
+      "line": 3846,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "d8398a2469117c167b7bcfa0",
+      "line": 3854,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "978ecd9c7935acfc82c676e3",
+      "line": 3873,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "a057889e75fd5752d970448f",
+      "line": 3984,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "dda62062a75e9ece42109fd0",
+      "line": 3996,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "fe5f8acc34446fff426561c0",
+      "line": 4010,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "7e7c9a662c03d531ce7b4bea",
+      "line": 4024,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "1be4bc4310052f0bf781e6e7",
+      "line": 4049,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "b8d4adafa80235a7f0e1c127",
+      "line": 4099,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "3421069f3ccbf115eb948c19",
+      "line": 4105,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "78a3b8870252239f7a5d96e7",
+      "line": 4114,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "bf4a08e7b6020049176d62ad",
+      "line": 4121,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "bc85f25fe8c3eccbd16d6251",
+      "line": 4156,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "d91d27e5a4bfb5bfb586c094",
+      "line": 4166,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "96bd36b782076dea928b2340",
+      "line": 4182,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "13758c2c7575d71d82f4d0c8",
+      "line": 4188,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "ad2b3c957909a73c195c1c80",
+      "line": 4192,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "64e87c2fd56c1452c385533e",
+      "line": 4200,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "0ae7d8a0210b096cf69cf080",
+      "line": 4203,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "9d1c1217a168467d738f54e7",
+      "line": 4209,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "c4639928ec13e4bb8cacc947",
+      "line": 4215,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "d26e98566613edb325fad5bd",
+      "line": 4232,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "0d205cb5829850a09328afeb",
+      "line": 4270,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "2f2f2669c00c1a42f3c1f8be",
+      "line": 4284,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "e90614a34887c8931f627d5b",
+      "line": 4311,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "c9cdfbe974885c938292a17d",
+      "line": 4314,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "5ef3cbaacbe2fbdca48b9676",
+      "line": 4317,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "9c0b45b6141946d1e225c4dc",
+      "line": 4320,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "42c316b8a7ee61cdca3d7268",
+      "line": 4328,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "f9bde2df1183c2fae35bc82a",
+      "line": 4334,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "fac3555cde28bca47b221c80",
+      "line": 4350,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "551e147c4b2dae20ef3c2361",
+      "line": 4377,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "b603a264aff7b4b73a180de1",
+      "line": 4406,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "2247c591657021bbfbe91b39",
+      "line": 4420,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "f5b888c824c289b90a9427bd",
+      "line": 4442,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "ccf42fb2c9255035a9dd4cfe",
+      "line": 4475,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "77745e39c1f8c7b0564d8157",
+      "line": 4481,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "75e17a245269c0b3b03ef0a9",
+      "line": 4487,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "86d608697ae4ea632859d8ce",
+      "line": 4492,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "3715c651111ef2bbe170eda7",
+      "line": 4496,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "91a8ddfde0ec02f900e49d2e",
+      "line": 4501,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "e9e5e2d3930b4fb001a065be",
+      "line": 4505,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "4972f77a8fc400cb0eca28e5",
+      "line": 4515,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "091cd5ab3e8c8707ba59662b",
+      "line": 4523,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "ab7e3c46fc35045f12f4e83b",
+      "line": 4540,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "d3133b4e20a7c8d278c881d1",
+      "line": 4544,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "9707674337571dc37b4006b2",
+      "line": 4549,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "841b15117222f24ae54bcea7",
+      "line": 4553,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "99a101ca5eaef6dae742f381",
+      "line": 4557,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "2d4c97abaeaafb58b8727421",
+      "line": 4586,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "b9b359fdea05acd30b8cce7d",
+      "line": 4589,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "998f9c1ee96b1e585e511235",
+      "line": 4611,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "9080c2f3d15f3c70eecb0493",
+      "line": 4625,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "e9f363f79fceedc31dee9587",
+      "line": 4636,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "67aa386c206ac18557a9bc24",
+      "line": 606,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "161c3bfb82c861e77d1e22e7",
+      "line": 611,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "03933352b33bad52111a0138",
+      "line": 2976,
+      "message": "path join with potentially user-controlled segment.",
+      "path": "src/sdetkit/repo.py",
+      "rule_id": "SEC_POTENTIAL_PATH_TRAVERSAL",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "fe0af88c257a0589911afd30",
+      "line": 454,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/report.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "ed67b51f5df3b79f25c47454",
+      "line": 561,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/report.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "0c7239fa96286515a278a35c",
+      "line": 900,
+      "message": "print(...) found in src/.",
+      "path": "src/sdetkit/report.py",
+      "rule_id": "SEC_DEBUG_PRINT",
+      "severity": "info"
+    },
+    {
+      "fingerprint": "4efa5eb7482926ffda22b69d",
+      "line": 42,
+      "message": "potential hardcoded api key",
+      "path": "tests/test_apiget_verbose_debug.py",
+      "rule_id": "SEC_SECRET_PATTERN",
+      "severity": "error"
+    },
+    {
+      "fingerprint": "e5e754844d5f3704db19b356",
+      "line": 58,
+      "message": "high-entropy string literal detected.",
+      "path": "tests/test_repo_plugins_fix_audit.py",
+      "rule_id": "SEC_HIGH_ENTROPY_STRING",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "714ed57a5246f1a07b51ae12",
+      "line": 61,
+      "message": "high-entropy string literal detected.",
+      "path": "tests/test_textutil.py",
+      "rule_id": "SEC_HIGH_ENTROPY_STRING",
+      "severity": "warn"
+    },
+    {
+      "fingerprint": "15f97bd1159da37636b5d318",
+      "line": 73,
+      "message": "avoid compile(); dynamic execution is dangerous.",
+      "path": "tools/triage.py",
+      "rule_id": "SEC_DANGEROUS_EVAL",
+      "severity": "error"
+    }
+  ],
+  "version": 1
+}

--- a/tools/security_allowlist.json
+++ b/tools/security_allowlist.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": []
+}


### PR DESCRIPTION
### Motivation

- Provide a top-level, repo-native security gate that auto-detects high-risk patterns, supports deterministic baselines, and prevents security regressions in CI.
- Produce machine-readable outputs (JSON + SARIF) so findings integrate with tooling and GitHub code scanning while remaining offline-friendly and developer-friendly.
- Offer a conservative auto-fix path for safe cases and allow explicit allowlisting to reduce false positives.

### Description

- Added a new deterministic security scanner implementation in `src/sdetkit/security_gate.py` that uses AST-based rules and pattern scanning to detect red flags (eval/exec/compile, `subprocess(..., shell=True)`, `os.system`, `pickle`/`dill`, unsafe `yaml.load`, weak hashes, path traversal/unsafe writes, secret/PEM patterns, high-entropy literals, network calls without timeout, and `print` leakage in `src/`).
- Exposed CLI entrypoints wired into the main CLI as `python -m sdetkit security` with subcommands: `scan`, `check`, `baseline`, and `fix`, plus flags `--format text|json|sarif`, `--output <path>`, `--fail-on none|warn|error`, and baseline handling.
- Implemented a stable fingerprint and baseline model (fingerprint includes `rule_id|path|line|normalized_message`) so `check` fails only on new findings when a baseline exists; also added repo allowlist (`tools/security_allowlist.json`) and inline allow comments (`# sdetkit: allow-security <RULE_ID>`).
- Added conservative autofix behavior in `security fix` (safe `yaml.load` → `yaml.safe_load`, simple `requests.*(...)` timeout injection, optional `ruff --fix` run) and ensured unsafe patterns (e.g. `shell=True`) are only reported with suggestions.
- Added SARIF export (`--format sarif`) compatible with GitHub scanning and a short human `text` summary with deterministic ordering; created `security.sh` runner and integrated it into `ci.sh` to produce `build/security.sarif` in CI.
- Documentation and onboarding: added `docs/security-gate.md`, updated `docs/security-model.md`, and added a README Security Gate section linking to docs and commands.
- Tests: added `tests/test_security_gate_cli.py` exercising multiple rules, baseline regression behavior, deterministic output, and SARIF shape sanity; included a committed baseline `tools/security.baseline.json` to enable regression-only CI gating.

### Testing

- Ran the new security unit tests: `python -m pytest tests/test_security_gate_cli.py` (4 tests) — passed.
- Ran full test suite: `python -m pytest` (all tests) — 441 passed; total test run succeeded.
- Ran repo quality checks: `bash quality.sh` — passed (ruff/mypy/pytest checks green).
- Ran CI runner: `bash ci.sh` (quick mode) — executed tests and `security.sh`; all tests passed and security scan output produced SARIF; security checks reported no new failures after baseline.
- Exercised scanner baseline and SARIF flows manually: `python -m sdetkit security baseline --output tools/security.baseline.json`, `python -m sdetkit security check --baseline tools/security.baseline.json --format text`, and `python -m sdetkit security check --baseline tools/security.baseline.json --format sarif --output build/security.sarif` — all completed successfully.

------