### PR TITLE
Potential fix for code scanning alert no. 39: Statement has no effect

### DIFF
--- a/src/sdetkit/agent/providers.py
+++ b/src/sdetkit/agent/providers.py
@@ -9,7 +9,8 @@ from typing import Protocol, cast
 
 
 class Provider(Protocol):
-    def complete(self, *, role: str, task: str, context: dict[str, object]) -> str: ...
+    def complete(self, *, role: str, task: str, context: dict[str, object]) -> str:
+        raise NotImplementedError
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Potential fix for [https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/39](https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/39)

In general, to fix a “statement has no effect” issue for a protocol or abstract method, replace a bare expression like `...` with a statement that clearly expresses the intention: either `pass` (if it should do nothing) or raising `NotImplementedError` (if it must be overridden). This ensures that, if the base method is ever called, the behavior is explicit.

For this specific code, the best fix is to change the body of `Provider.complete` from the ellipsis expression to raising `NotImplementedError`. That keeps the interface abstract: any attempt to call `Provider.complete` directly will fail loudly instead of returning `Ellipsis`. It also removes the no-effect statement that CodeQL is flagging.

Concretely, in `src/sdetkit/agent/providers.py`, at the `Provider` protocol definition (around lines 11–13), replace:

```py
class Provider(Protocol):
    def complete(self, *, role: str, task: str, context: dict[str, object]) -> str: ...
```

with:

```py
class Provider(Protocol):
    def complete(self, *, role: str, task: str, context: dict[str, object]) -> str:
        raise NotImplementedError
```

No new imports are needed because `NotImplementedError` is a built-in exception.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
