### PR TITLE
security: harden shell action parsing and document code-scanning follow-ups

### DIFF
--- a/docs/security-code-scanning-followups.md
+++ b/docs/security-code-scanning-followups.md
@@ -1,0 +1,25 @@
+# Security code scanning follow-ups
+
+Date: 2026-02-16
+
+## GitHub Code Scanning API access limitation
+
+`gh` CLI is not available in the execution environment, so GitHub Code Scanning alerts could not be fetched directly from:
+
+- `/repos/sherif69-sa/DevS69-sdetkit/code-scanning/alerts`
+- `/repos/sherif69-sa/DevS69-sdetkit/code-scanning/alerts/<N>/instances`
+
+## Locally triaged findings to track
+
+The local workflow run (`bash ci.sh`, `bash security.sh`) reported warning-class findings that need repository-owner triage in GitHub Code Scanning / issues:
+
+1. `SEC_POTENTIAL_PATH_TRAVERSAL` in `src/sdetkit/apiget.py` (at-file support reads user-provided paths intentionally).
+2. `SEC_POTENTIAL_PATH_TRAVERSAL` in `src/sdetkit/cassette.py` (CLI-configured cassette path handling).
+3. `SEC_HIGH_ENTROPY_STRING` in docs/tests (likely false positives for documentation/test fixtures).
+
+## Next actions for maintainers
+
+1. Install/authenticate `gh` and fetch live alerts from GitHub.
+2. Map each open alert to code location and severity.
+3. For true positives that cannot be fixed quickly, create GitHub issues labeled `security` with alert links.
+4. Close false positives with documented justification in alert dismissal comments.


### PR DESCRIPTION
### Motivation
- GitHub Code Scanning alerts could not be fetched in this environment (`gh` not available), so local security tooling was used to triage and guide focused fixes. 
- The agent `shell.run` action previously performed naive string splitting and raw-prefix allowlist checks which are error-prone with quoted/complex arguments and increase risk of unexpected command execution.

### Description
- Hardened `ActionRegistry._shell_run` to parse commands with `shlex.split`, return a clear error for malformed command syntax, and enforce allowlist checks by comparing tokenized prefix sequences instead of raw string prefixes (file: `src/sdetkit/agent/actions.py`).
- Replaced `cmd.split()`-based execution with `subprocess.run(argv, ...)` using the parsed `argv` to preserve quoted argument boundaries and avoid ambiguous splitting.
- Added two regression tests in `tests/test_agent_foundation.py` that assert quoted-argument handling and malformed-command rejection for the `shell.run` action.
- Added `docs/security-code-scanning-followups.md` to record locally triaged findings and next steps for maintainers because live GitHub alerts could not be fetched here.

### Testing
- Ran `pytest -q tests/test_agent_foundation.py` and observed `10 passed` for the modified tests.
- Ran the full test suite with `pytest -q` and observed `463 passed` (no regressions introduced).
- Ran repository quality and CI scripts (`bash quality.sh` and `bash ci.sh`) and observed successful completion of checks and the local security scan output, with follow-up items documented in `docs/security-code-scanning-followups.md`.
- Compiled sources with `python3 -m compileall -q src tools` and executed `python3 -m sdetkit doctor --ascii` as part of validation, all completing successfully.

------