### PR TITLE
Add --deterministic option to maintenance CLI to freeze volatile meta fields

### DIFF
--- a/src/sdetkit/maintenance/cli.py
+++ b/src/sdetkit/maintenance/cli.py
@@ -13,6 +13,7 @@ from .registry import checks_for_mode
 from .types import CheckResult, MaintenanceContext
 
 SCHEMA_VERSION = "1.0"
+DETERMINISTIC_GENERATED_AT = "1970-01-01T00:00:00+00:00"
 
 
 class StderrLogger:
@@ -26,6 +27,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--out", default=None)
     parser.add_argument("--mode", choices=["quick", "full"], default="quick")
     parser.add_argument("--fix", action="store_true")
+    parser.add_argument("--deterministic", action="store_true")
     parser.add_argument("--quiet", action="store_true")
     return parser
 
@@ -73,7 +75,17 @@ def _write_output(path: str | None, content: str) -> None:
     out_path.write_text(content, encoding="utf-8")
 
 
-def _build_report(ctx: MaintenanceContext) -> dict[str, Any]:
+def _deterministic_generated_at(env: dict[str, str]) -> str:
+    epoch = env.get("SOURCE_DATE_EPOCH")
+    if epoch is None:
+        return DETERMINISTIC_GENERATED_AT
+    try:
+        return datetime.fromtimestamp(int(epoch), UTC).isoformat()
+    except (TypeError, ValueError, OSError, OverflowError):
+        return DETERMINISTIC_GENERATED_AT
+
+
+def _build_report(ctx: MaintenanceContext, *, deterministic: bool = False) -> dict[str, Any]:
     started = time.monotonic()
     checks: dict[str, dict[str, Any]] = {}
     crashes = False
@@ -104,11 +116,13 @@ def _build_report(ctx: MaintenanceContext) -> dict[str, Any]:
         "recommendations": recommendations,
         "meta": {
             "schema_version": SCHEMA_VERSION,
-            "generated_at": datetime.now(UTC).isoformat(),
+            "generated_at": _deterministic_generated_at(ctx.env)
+            if deterministic
+            else datetime.now(UTC).isoformat(),
             "mode": ctx.mode,
             "fix": ctx.fix,
             "python": ctx.python_exe,
-            "duration_seconds": round(time.monotonic() - started, 3),
+            "duration_seconds": 0.0 if deterministic else round(time.monotonic() - started, 3),
             "had_crash": crashes,
         },
     }
@@ -145,7 +159,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     try:
-        report = _build_report(ctx)
+        report = _build_report(ctx, deterministic=bool(ns.deterministic))
         rendered = {
             "json": json.dumps(report, sort_keys=True),
             "text": _render_text(report),


### PR DESCRIPTION
### Motivation
- Ensure maintenance JSON output can be made reproducible for CI and caching by freezing volatile metadata fields.
- Preserve existing behavior by making deterministic output opt-in so defaults remain unchanged.

### Description
- Add a `--deterministic` CLI switch in `_build_parser()` to opt into deterministic reporting via `ns.deterministic`.
- Introduce `DETERMINISTIC_GENERATED_AT` sentinel and `_deterministic_generated_at()` helper to resolve `meta.generated_at` from `SOURCE_DATE_EPOCH` or fall back to a fixed timestamp.
- Change `_build_report()` signature to accept `deterministic: bool` and, when enabled, set `meta.generated_at` deterministically and `meta.duration_seconds` to `0.0` while leaving other fields intact.
- Wire `main()` to pass the deterministic flag into `_build_report()` and keep JSON/text/MD rendering logic unchanged.
- Extend tests in `tests/test_maintenance_cli.py` to assert required `meta` keys remain present and add `test_deterministic_mode_is_byte_identical_across_runs()` which runs the maintenance command twice with `--deterministic` and asserts byte-identical stdout.

### Testing
- Ran `pytest -q tests/test_maintenance_cli.py` and all tests passed, with `5 passed` reported.
- The new deterministic contract test succeeded and confirms byte-identical JSON output across repeated runs in deterministic mode.
- Existing schema and behavior tests continue to pass, confirming backward compatibility.

------
