### PR TITLE
Refactor Shannon entropy to single-pass counting and add tests

### DIFF
--- a/src/sdetkit/repo.py
+++ b/src/sdetkit/repo.py
@@ -126,12 +126,14 @@ REPO_PRESETS: frozenset[str] = frozenset({"enterprise_python"})
 def _shannon_entropy(s: str) -> float:
     if not s:
         return 0.0
-    counts = {ch: s.count(ch) for ch in set(s)}
+    counts: dict[str, int] = {}
+    for ch in s:
+        counts[ch] = counts.get(ch, 0) + 1
     n = float(len(s))
     entropy = 0.0
     for count in counts.values():
         p = count / n
-        entropy -= p * (0 if p == 0 else math.log2(p))
+        entropy -= p * math.log2(p)
     return entropy
 
 

--- a/tests/test_repo_entropy.py
+++ b/tests/test_repo_entropy.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import math
+
+from sdetkit.repo import _shannon_entropy
+
+
+def test_shannon_entropy_known_strings() -> None:
+    assert _shannon_entropy("aaaa") == 0.0
+    assert math.isclose(_shannon_entropy("ab"), 1.0, rel_tol=1e-12)
+
+    mixed = _shannon_entropy("aab")
+    assert 0.9 < mixed < 0.92
+
+    uniform = _shannon_entropy("abcd")
+    assert math.isclose(uniform, 2.0, rel_tol=1e-12)
+
+
+def test_shannon_entropy_empty_string_regression() -> None:
+    assert _shannon_entropy("") == 0.0
+
+
+def test_shannon_entropy_handles_long_strings() -> None:
+    token = "abc123XYZ_-/+="
+    long_s = token * 20_000
+
+    entropy = _shannon_entropy(long_s)
+
+    assert entropy >= 0.0
+    assert entropy <= math.log2(len(set(token))) + 1e-12


### PR DESCRIPTION
### Motivation
- `_shannon_entropy` built a frequency map by calling `s.count(ch)` for each unique character, causing repeated scans of the input; this refactor removes that inefficiency. 
- Add focused tests to guard correctness, the empty-string regression, and to ensure the implementation handles long inputs without pathological behavior.

### Description
- Replaced the `counts = {ch: s.count(ch) for ch in set(s)}` approach with a single-pass incremental frequency map using a plain `dict` and per-character `counts[ch] = counts.get(ch, 0) + 1` in `src/sdetkit/repo.py`. 
- Preserved the exact entropy math and return type by computing `p = count / n` and `entropy -= p * math.log2(p)` for each count. 
- Added `tests/test_repo_entropy.py` containing three tests: known-value/range accuracy cases, a regression test asserting `"" -> 0.0`, and a long-string guard test to validate behavior on large inputs while allowing a tiny floating-point tolerance.

### Testing
- Ran `pytest -q tests/test_repo_entropy.py` and initially observed a failure due to a strict floating-point upper-bound in the long-string guard test. 
- Updated the test to allow a minimal tolerance for floating-point rounding and re-ran `pytest -q tests/test_repo_entropy.py`, which completed successfully with `3 passed`.
- No other automated tests in the repository were modified or executed as part of this change.

------
