### PR TITLE
fix(security): keep security scan enumeration inside repo root

### DIFF
--- a/src/sdetkit/security_gate.py
+++ b/src/sdetkit/security_gate.py
@@ -379,9 +379,16 @@ def _should_scan_file(path: Path) -> bool:
 
 
 def _iter_files(root: Path) -> list[Path]:
+    resolved_root = root.resolve(strict=True)
     files: list[Path] = []
     for p in root.rglob("*"):
         if not p.is_file():
+            continue
+        try:
+            resolved = p.resolve(strict=False)
+        except OSError:
+            continue
+        if resolved != resolved_root and resolved_root not in resolved.parents:
             continue
         if any(part in SKIP_DIRS for part in p.parts):
             continue


### PR DESCRIPTION
### Motivation
- Prevent `security scan` from following symlinks under the scan `--root` whose resolved targets live outside the requested root, which can leak host files into findings and introduce nondeterminism. 
- Make file discovery deterministic and safe by bounding enumeration to the resolved scan root and handling resolution errors gracefully.

### Description
- Update `_iter_files` in `src/sdetkit/security_gate.py` to resolve the provided `root` once and skip any candidate whose `Path.resolve()` is not contained under that resolved root. 
- Continue gracefully on `OSError` during candidate resolution or `stat()` checks so broken symlinks do not make the scan fail. 
- Preserve existing deterministic ordering by still sorting `files` before returning. 
- Add two regression tests to `tests/test_security_gate_cli.py` asserting that an out-of-root symlink is ignored and a broken symlink is skipped without failing.

### Testing
- Ran `pytest -q tests/test_security_gate_cli.py` which passed (`8 passed`), covering the new symlink and broken-link cases. 
- Ran the full test/validation pipeline (`python3 -m compileall -q src tools && pytest -q && bash quality.sh && bash ci.sh && python3 -m sdetkit doctor --ascii`) and observed all automated checks succeeding (`486 passed` across the suite and quality/ci/doctor checks succeeded). 
- Verified `sdetkit security scan --help` and related CLI help commands to ensure no regressions in CLI contracts.

------