### PR TITLE
Make project autodiscovery deterministic and improve duplicate-name diagnostics

### DIFF
--- a/tests/test_projects_autodiscover.py
+++ b/tests/test_projects_autodiscover.py
@@ -333,3 +333,19 @@ version = "0.1.0"
         ("github.com/acme/edge", "apps/edge"),
         ("py-name", "packages/hybrid"),
     ]
+
+
+def test_autodiscover_duplicate_name_error_includes_both_roots_in_stable_order(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    _write_pyproject(repo / "packages" / "zeta", "shared-name")
+    _write_pyproject(repo / "packages" / "alpha", "shared-name")
+
+    with pytest.raises(
+        ValueError,
+        match=r"duplicate project name: shared-name \(roots: packages/alpha and packages/zeta\)",
+    ):
+        discover_projects(repo)


### PR DESCRIPTION
### Motivation
- Autodiscovery could produce nondeterministic project lists due to filesystem iteration order, making CI and user-facing errors unstable.
- Duplicate autodiscovered project names produced low-context errors that slowed diagnosis and remediation.

### Description
- Sort `dirnames` before descending in `_autodiscover_projects` to make traversal deterministic (`src/sdetkit/projects.py`).
- Change duplicate tracking from a `set` to a `dict` mapping `name -> first_root` and raise `ProjectsConfigError` that includes both conflicting roots for actionable diagnostics (`src/sdetkit/projects.py`).
- Add a regression test `test_autodiscover_duplicate_name_error_includes_both_roots_in_stable_order` to assert stable ordering and enriched error text (`tests/test_projects_autodiscover.py`).

### Testing
- Ran the focused module tests with `pytest -q tests/test_projects_autodiscover.py` and they passed (13 passed for the module after the change). 
- Ran `pytest -q tests/test_repo_monorepo_projects.py tests/test_projects_autodiscover.py` and those module tests passed (17 passed combined).
- Ran the full test suite with `python3 -m compileall -q src tools && pytest -q` and all tests succeeded (487 passed).
- Commands executed during validation: `cd /workspace/DevS69-sdetkit && pytest -q tests/test_projects_autodiscover.py`, `cd /workspace/DevS69-sdetkit && pytest -q tests/test_repo_monorepo_projects.py tests/test_projects_autodiscover.py`, and `cd /workspace/DevS69-sdetkit && python3 -m compileall -q src tools && pytest -q`.

------