### PR TITLE
Harden user-controlled filesystem paths in apiget, cassette, and maintenance CLI

### DIFF
--- a/src/sdetkit/apiget.py
+++ b/src/sdetkit/apiget.py
@@ -263,8 +263,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         if path == "":
             raise _AtFileError("apiget: cannot read file: <empty path>")
         try:
-            return Path(path).read_text(encoding="utf-8")
-        except FileNotFoundError:
+            safe_file = safe_path(Path.cwd(), path, allow_absolute=True)
+            return safe_file.read_text(encoding="utf-8")
+        except (SecurityError, FileNotFoundError):
             raise _AtFileError("apiget: file not found: " + path) from None
         except (OSError, UnicodeError):
             raise _AtFileError("apiget: cannot read file: " + path) from None
@@ -286,8 +287,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         if path == "":
             raise _AtFileError("apiget: cannot read file: <empty path>")
         try:
-            return Path(path).read_bytes()
-        except FileNotFoundError:
+            safe_file = safe_path(Path.cwd(), path, allow_absolute=True)
+            return safe_file.read_bytes()
+        except (SecurityError, FileNotFoundError):
             raise _AtFileError("apiget: file not found: " + path) from None
         except OSError:
             raise _AtFileError("apiget: cannot read file: " + path) from None

--- a/src/sdetkit/maintenance/cli.py
+++ b/src/sdetkit/maintenance/cli.py
@@ -9,6 +9,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from sdetkit.security import safe_path
+
 from .registry import checks_for_mode
 from .types import CheckResult, MaintenanceContext
 
@@ -83,7 +85,7 @@ def _render_markdown(report: dict[str, Any]) -> str:
 def _write_output(path: str | None, content: str) -> None:
     if not path:
         return
-    out_path = Path(path)
+    out_path = safe_path(Path.cwd(), path, allow_absolute=True)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(content, encoding="utf-8")
 

--- a/tests/test_apiget_at_file.py
+++ b/tests/test_apiget_at_file.py
@@ -69,3 +69,35 @@ def test_apiget_at_file_missing_is_clean_error(capsys):
     assert out.out.strip() == ""
     assert "file not found" in out.err
     assert "Traceback" not in out.err
+
+
+def test_apiget_at_file_blocks_traversal(monkeypatch, capsys, tmp_path: Path):
+    from sdetkit import apiget, cli
+
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("request should not run")
+
+    monkeypatch.setattr(apiget.httpx, "Client", _client_factory(handler))
+
+    rc = cli.main(
+        [
+            "apiget",
+            "https://example.test/x",
+            "--method",
+            "POST",
+            "--data",
+            "@../outside.txt",
+            "--expect",
+            "dict",
+        ]
+    )
+    out = capsys.readouterr()
+    assert rc == 1
+    assert out.out.strip() == ""
+    assert "file not found" in out.err

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -13,6 +13,7 @@ from sdetkit.cassette import (
     CassetteReplayTransport,
 )
 from sdetkit.netclient import SdetAsyncHttpClient, SdetHttpClient
+from sdetkit.security import SecurityError
 
 
 def test_cassette_record_then_replay_sync(tmp_path: Path) -> None:
@@ -122,3 +123,18 @@ async def test_cassette_record_then_replay_async(tmp_path: Path) -> None:
         c3 = SdetAsyncHttpClient(raw3)
         with pytest.raises(RuntimeError):
             await c3.get_json_dict("https://example.test/other")
+
+
+def test_cassette_save_and_load_block_traversal(tmp_path: Path, monkeypatch) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    cassette = Cassette()
+    with pytest.raises(SecurityError):
+        cassette.save("../escape.json")
+
+    escaped = tmp_path / "escape.json"
+    escaped.write_text('{"version": 1, "interactions": []}', encoding="utf-8")
+    with pytest.raises(SecurityError):
+        Cassette.load("../escape.json")


### PR DESCRIPTION
### Motivation
- GitHub code-scanning flagged potential path traversal issues where user-supplied paths were passed directly to filesystem APIs (notably in `apiget`, cassette persistence, and maintenance CLI output writing). 
- The intent is to validate and canonicalize user-controlled paths before any read/write to prevent escapes from the intended root. 

### Description
- Validate `@file` handling in `apiget` by resolving the requested path with `safe_path(Path.cwd(), path, allow_absolute=True)` before reading text/bytes and map `SecurityError` to the existing clean `_AtFileError` flow. 
- Harden cassette persistence by importing `safe_path` and using it for `Cassette.save`, `Cassette.load`, record/async-record transport `path` handling, and in `open_transport` path resolution. 
- Harden maintenance CLI output by importing `safe_path` and using it in `_write_output` to validate `--out` before creating directories and writing. 
- Add regression tests asserting traversal attempts are rejected for `apiget` (`tests/test_apiget_at_file.py`), cassette `save/load` (`tests/test_cassette.py`), and maintenance `_write_output` (`tests/test_maintenance_cli.py`). 

### Testing
- Ran the targeted unit tests with `pytest -q tests/test_apiget_at_file.py tests/test_cassette.py tests/test_maintenance_cli.py` which passed (`16 passed`). 
- Ran the full CI test run via `bash ci.sh` earlier which passed (`488 passed`). 
- Ran the repository security check `bash security.sh` after changes which shows no warnings for the previously reported path-traversal findings (`security scan: total=33 error=0 warn=0 info=33`).

------
