### PR TITLE
Unify `python -m sdetkit` with the multi-command CLI via a central registry

### DIFF
--- a/src/sdetkit/__main__.py
+++ b/src/sdetkit/__main__.py
@@ -93,17 +93,10 @@ def _cassette_get(argv: list[str]) -> int:
 
 
 def main() -> int:
-    argv = sys.argv[1:]
-    if argv and argv[0] == "cassette-get":
-        try:
-            return _cassette_get(argv[1:])
-        except Exception as e:
-            print(str(e), file=sys.stderr)
-            return 2
-
     from .cli import main as cli_main
 
-    return int(cli_main() or 0)
+    argv = sys.argv[1:]
+    return int(cli_main(argv, cassette_compat_fallback=True) or 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_sdetkit.py
+++ b/tests/test_cli_sdetkit.py
@@ -100,10 +100,8 @@ def test_python_m_sdetkit_version():
 def test_sdetkit_version_flag_prints_resolved_version(monkeypatch, capsys):
     monkeypatch.setattr(cli, "_tool_version", lambda: "9.9.9")
 
-    with pytest.raises(SystemExit) as excinfo:
-        cli.main(["--version"])
-
-    assert excinfo.value.code == 0
+    rc = cli.main(["--version"])
+    assert rc == 0
     out = capsys.readouterr().out
     assert out == "9.9.9\n"
 

--- a/tests/test_cli_unified_entrypoint.py
+++ b/tests/test_cli_unified_entrypoint.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from sdetkit import cli
+
+
+def test_python_m_sdetkit_help_lists_unified_commands() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "--help"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    out = proc.stdout
+    for token in ("doctor", "patch", "repo", "cassette-get", "agent", "maintenance"):
+        assert token in out
+
+
+def test_sdetkit_entrypoint_help_lists_unified_commands(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cli.main(["--help"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    for token in ("doctor", "patch", "repo", "cassette-get", "agent", "maintenance"):
+        assert token in out
+
+
+def test_representative_subcommand_smoke() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "kv", "--text", "a=1"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == '{"a": "1"}'

--- a/tests/test_main_cassette_get_extra.py
+++ b/tests/test_main_cassette_get_extra.py
@@ -94,5 +94,25 @@ def test_main_cassette_get_exception_path(monkeypatch: pytest.MonkeyPatch, capsy
         sys.argv = old_argv
 
     err = capsys.readouterr().err
-    assert rc == 2
-    assert "boom" in err
+    assert rc == 1
+    assert "runtime error: boom" in err
+
+
+def test_main_legacy_cassette_get_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def _fake(argv: list[str]) -> int:
+        seen["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(mainmod, "_cassette_get", _fake)
+
+    old_argv = sys.argv[:]
+    try:
+        sys.argv = ["sdetkit", "https://example.invalid", "--timeout", "1"]
+        rc = mainmod.main()
+    finally:
+        sys.argv = old_argv
+
+    assert rc == 0
+    assert seen["argv"] == ["https://example.invalid", "--timeout", "1"]


### PR DESCRIPTION
### Motivation
- Replace ad-hoc `argparse.REMAINDER` forwarding and many module-level entry wrappers with a single, consistent dispatch so the module and console entrypoints behave identically.
- Preserve backwards compatibility for existing cassette-get usage where `python -m sdetkit <url/flags>` was treated as a cassette-get call.
- Make top-level parse vs runtime error semantics explicit and consistent across subcommands.
- Add fast deterministic tests that exercise the unified entrypoint and the cassette-get compatibility path.

### Description
- Implemented a central command registry and top-level subparser dispatcher in `src/sdetkit/cli.py` and replaced the previous per-module REMAINDER-style re-parsing with a registry-driven dispatch (`_command_registry`, `_build_parser`, `main`).
- Added a dedicated `apiget` handler that preserves the cassette environment behavior by stripping cassette flags before invoking `apiget.main` (`_run_apiget`), and added a `cassette-get` handler to keep the legacy command path (`_run_cassette_get`).
- Introduced a robust parse/error model: custom `_CliParser` that returns exit code `2` for parse errors, returns subcommand handler exit codes, and prints `runtime error: ...` with return `1` for unhandled exceptions.
- Unified module runner by changing `src/sdetkit/__main__.py` to call `cli.main(argv, cassette_compat_fallback=True)` so `python -m sdetkit ...` uses the same dispatcher while still supporting the legacy cassette-get fallback when argv does not start with a known subcommand.
- Added/updated tests: new `tests/test_cli_unified_entrypoint.py` (help and representative `kv` smoke), extended `tests/test_main_cassette_get_extra.py` to cover the legacy cassette-get fallback and updated exception expectations, and adjusted `tests/test_cli_sdetkit.py` to align with return-code handling.

### Testing
- Ran `pytest -q tests/test_cli_unified_entrypoint.py tests/test_main_cassette_get_extra.py tests/test_cli_help_lists_subcommands.py tests/test_cli_cassette_get.py tests/test_entrypoints_cassette_get.py tests/test_cli_sdetkit.py` and all tests passed (`21 passed`).
- Ran `pytest -q tests/test_entrypoints_smoke.py tests/test_cli_smoke_coverage.py` and all tests passed (`8 passed`).
- The added/modified tests are deterministic and fast and validated both `python -m sdetkit --help` and the `kv` smoke path as well as legacy cassette-get fallback behavior.

------