### PR TITLE
feat(report): add weighted recommendation hotspots and window controls

### DIFF
--- a/tests/test_report_cli_contracts.py
+++ b/tests/test_report_cli_contracts.py
@@ -803,7 +803,10 @@ def test_report_recommend_supports_since_window_and_weighted_hotspots(tmp_path: 
     )
 
     for path in (run1, run2, run3):
-        assert runner.invoke(["report", "ingest", str(path), "--history-dir", str(history)]).exit_code == 0
+        assert (
+            runner.invoke(["report", "ingest", str(path), "--history-dir", str(history)]).exit_code
+            == 0
+        )
 
     result = runner.invoke(
         [


### PR DESCRIPTION
### Motivation
- Recommendations from long-run histories were noisy and lacked signal-weighting, making it hard to prioritize recent high-severity recurrences.
- It should be possible to focus recommendations on a recent window of runs and suppress low-signal items to make CI/automation outputs actionable and deterministic.

### Description
- Added severity-weighted hotspot scoring with `_severity_weight`, `_top_risk_hotspots`, and `_trend_direction` and exposed severity-weighted hotspot lists for both rules and paths in the recommendation payload (`risk_hotspots`).
- Extended `suggest_optimizations` to accept `since` and `min_occurrences` arguments, compute an `actionable_series` and `trend` direction, and include `run_window` metadata reflecting the requested window and effective runs analyzed.
- Wired new CLI flags `--since` and `--min-occurrences` into `report recommend` and updated text/markdown renderers to surface `trend` and weighted hotspot sections while preserving deterministic ordering.
- Added tests and assertions in `tests/test_report_cli_contracts.py` to lock the JSON contract and markdown output for the new hotspot, windowing, and trend behavior.

### Testing
- Compiled sources with `python -m compileall -q src tools` successfully under the test interpreter.
- Installed test dependencies via `python -m pip install -r requirements-test.txt` and ran focused tests with `PYENV_VERSION=3.11.14 PYTHONPATH=src pytest -q tests/test_report_cli_contracts.py tests/test_report_build_determinism.py tests/test_report_trends.py`, which passed (`20 passed`).
- Verified the new behavior with added assertions that check `risk_hotspots`, `run_window`, and `trend` in JSON output and new markdown sections in `report recommend` outputs.

------