### PR TITLE
feat(apiget/netclient): add envelope-mode pagination (items/next)

### DIFF
--- a/tests/test_apiget_envelope_pagination.py
+++ b/tests/test_apiget_envelope_pagination.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+import sdetkit.apiget as apiget
+from sdetkit import cli
+from sdetkit.netclient import RetryPolicy, SdetHttpClient
+
+_REAL_HTTPX_CLIENT = httpx.Client
+
+
+def _client_factory(transport: httpx.BaseTransport):
+    def _make_client(*args, **kwargs):
+        if kwargs.get("transport") is not None:
+            return _REAL_HTTPX_CLIENT(*args, **kwargs)
+        return _REAL_HTTPX_CLIENT(transport=transport)
+
+    return _make_client
+
+
+def test_apiget_paginate_envelope_mode_accumulates_items(monkeypatch, capsys):
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        if request.url.path == "/items" and request.url.query == b"page=2":
+            return httpx.Response(200, json={"items": [{"id": 2}], "next": None})
+        if request.url.path == "/items" and request.url.query == b"":
+            return httpx.Response(
+                200,
+                json={"items": [{"id": 1}], "next": "?page=2"},
+            )
+        raise AssertionError(f"unexpected request url: {request.url}")
+
+    monkeypatch.setattr(apiget.httpx, "Client", _client_factory(httpx.MockTransport(handler)))
+
+    rc = cli.main(
+        [
+            "apiget",
+            "https://example.test/items",
+            "--paginate",
+            "--paginate-mode",
+            "envelope",
+            "--expect",
+            "list",
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr()
+    assert json.loads(out.out) == [{"id": 1}, {"id": 2}]
+    assert out.err == ""
+    assert calls == ["https://example.test/items", "https://example.test/items?page=2"]
+
+
+def test_apiget_paginate_envelope_mode_validates_keys(monkeypatch, capsys):
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={"ok": True}))
+    monkeypatch.setattr(apiget.httpx, "Client", _client_factory(transport))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(
+            [
+                "apiget",
+                "https://example.test/items",
+                "--paginate",
+                "--paginate-mode",
+                "envelope",
+                "--paginate-items-key",
+                "",
+            ]
+        )
+
+    assert exc.value.code == 2
+    out = capsys.readouterr()
+    assert out.out == ""
+    assert "paginate-items-key must not be empty" in out.err
+
+
+def test_netclient_envelope_pagination_cycle_and_shape_errors():
+    responses = {
+        "https://example.test/items": {"items": [1], "next": "?page=2"},
+        "https://example.test/items?page=2": {"items": [2], "next": "/items"},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = responses.get(str(request.url))
+        if payload is None:
+            raise AssertionError(f"unexpected url: {request.url}")
+        return httpx.Response(200, json=payload)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as raw:
+        client = SdetHttpClient(raw, retry=RetryPolicy(retries=1))
+        with pytest.raises(RuntimeError, match="pagination cycle"):
+            client.get_json_list_paginated_envelope("https://example.test/items", max_pages=4)
+
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json={"items": "bad"}))
+    ) as raw:
+        client = SdetHttpClient(raw, retry=RetryPolicy(retries=1))
+        with pytest.raises(ValueError, match="expected json array at key 'items'"):
+            client.get_json_list_paginated_envelope("https://example.test/items")


### PR DESCRIPTION
### Motivation
- Many production APIs paginate using JSON envelopes (e.g. `{ "items": [...], "next": "..." }`) and `apiget` previously only supported RFC5988 Link headers, forcing callers to write custom glue.

### Description
- Add a new pagination strategy flag to `apiget`: `--paginate-mode` with options `link` (default) and `envelope`, plus `--paginate-items-key` and `--paginate-next-key` to configure envelope keys.
- Implement `SdetHttpClient.get_json_list_paginated_envelope(...)` to aggregate page `items`, resolve relative `next` URLs with `urljoin`, validate envelope shapes, detect cycles, and enforce `max_pages` limits.
- Wire CLI `apiget --paginate --paginate-mode envelope` to the new client method while preserving the existing Link-header pagination behavior as the default.
- Add behavior-focused tests `tests/test_apiget_envelope_pagination.py` that verify accumulation across pages, CLI key validation, cycle detection, and invalid-shape errors.

### Testing
- Ran focused tests `pytest -q tests/test_apiget_envelope_pagination.py` which passed, and included the existing `tests/test_apiget_auth_dump_headers.py::test_apiget_paginate_with_header_still_paginates` which passed as well.
- Ran formatter/linter checks with `ruff format` and `ruff check` and fixed import/format issues reported by ruff.
- Compiled package sources with `python3 -m compileall -q src tools` and executed the full test suite with `pytest -q`, resulting in all tests passing (497 passed).

------