### PR TITLE
Potential fix for code scanning alert no. 234: Uncontrolled data used in path expression

### DIFF
--- a/src/sdetkit/security.py
+++ b/src/sdetkit/security.py
@@ -136,7 +136,8 @@ def safe_path(root: Path, user_path: str, *, allow_absolute: bool = False) -> Pa
     base = p if p.is_absolute() else (root / p)
     resolved_target = base.resolve(strict=False)
     if not p.is_absolute() or not allow_absolute:
-        resolved_root = root.resolve(strict=True)
+        # Use non-strict resolution for root to avoid filesystem access on tainted input
+        resolved_root = root.resolve(strict=False)
         if resolved_target != resolved_root and resolved_root not in resolved_target.parents:
             raise SecurityError("unsafe path rejected: escapes root")
     return resolved_target


### PR DESCRIPTION
Potential fix for [https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/234](https://github.com/sherif69-sa/DevS69-sdetkit/security/code-scanning/234)

General approach: When constructing file system paths from any combination of untrusted and trusted input, normalize the paths first and ensure that the resolved target is contained within a trusted root directory. Avoid making security checks depend on filesystem state in ways that involve tainted values (for example, calling `Path.resolve(strict=True)` on a tainted `root`), and keep checks consistent regardless of whether the target exists.

Concrete fix here: In `safe_path` in `src/sdetkit/security.py`, we currently do:

```py
resolved_target = base.resolve(strict=False)
if not p.is_absolute() or not allow_absolute:
    resolved_root = root.resolve(strict=True)
    if resolved_target != resolved_root and resolved_root not in resolved_target.parents:
        raise SecurityError("unsafe path rejected: escapes root")
```

CodeQL highlights `root` at `root.resolve(strict=True)` as depending on tainted data. We can avoid that by normalizing `root` using `strict=False` as well, and then performing the same containment check. This keeps the security properties intact: we still ensure that `resolved_target` is within `root`, but we no longer rely on the directory existing nor call a filesystem operation with `strict=True` on a tainted path. Behavior change is minimal: previously, if `root` didn’t exist, `safe_path` would raise `FileNotFoundError` from `resolve(strict=True)`; after the change, `safe_path` will instead allow computing a normalized `resolved_root` even if the directory doesn’t exist and still enforce “must stay under this root” via pure path semantics. In current usages (`_history_root(history_dir)` and `_resolve_workflow_path`), the root should exist anyway, so this is not a breaking change.

Steps/regions to change:

- File: `src/sdetkit/security.py`
  - In `safe_path` (lines ~126–142), change the computation of `resolved_root` from `root.resolve(strict=True)` to `root.resolve(strict=False)`.
  - Optionally add a brief comment to clarify that a non-strict resolve is intentional for security checking on potentially tainted roots, but this is not strictly necessary.

No other files need modification because `safe_path` already validates `user_path` and all callers of `safe_path` in `ops.py` benefit from the centralized fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
