### PR TITLE
feat(day7): add weekly-review command and Day 7 reporting artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,30 @@ python -m pytest -q tests/test_docs_qa.py tests/test_cli_help_lists_subcommands.
 python scripts/check_day6_conversion_contract.py
 ```
 
+
+## 📊 Day 7 ultra: weekly review #1
+
+Day 7 closes week one with an objective review of what shipped, KPI movement, and next-week priorities.
+
+```bash
+python -m sdetkit weekly-review --format text
+```
+
+Export a markdown artifact for stakeholder handoff:
+
+```bash
+python -m sdetkit weekly-review --format markdown --output docs/artifacts/day7-weekly-review-sample.md
+```
+
+See implementation details: [Day 7 ultra upgrade report](docs/day-7-ultra-upgrade-report.md).
+
+Day 7 closeout checks:
+
+```bash
+python -m pytest -q tests/test_weekly_review.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day7_weekly_review_contract.py
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day7-weekly-review-sample.md
+++ b/docs/artifacts/day7-weekly-review-sample.md
@@ -1,0 +1,24 @@
+# Day 7 Weekly Review #1
+
+## What shipped (Day 1-6)
+
+| Day | Upgrade | Report | Artifact | Status |
+| --- | --- | --- | --- | --- |
+| 1 | Core positioning + role onboarding | `docs/day-1-ultra-upgrade-report.md` | `docs/artifacts/day1-onboarding-sample.md` | shipped ✅ |
+| 2 | 60-second demo workflow | `docs/day-2-ultra-upgrade-report.md` | `docs/artifacts/day2-demo-sample.md` | shipped ✅ |
+| 3 | Proof pack with runnable checks | `docs/day-3-ultra-upgrade-report.md` | `docs/artifacts/day3-proof-sample.md` | shipped ✅ |
+| 4 | Template/skill expansion run-all | `docs/day-4-ultra-upgrade-report.md` | `docs/artifacts/day4-skills-sample.md` | shipped ✅ |
+| 5 | Cross-platform onboarding snippets | `docs/day-5-ultra-upgrade-report.md` | `docs/artifacts/day5-platform-onboarding-sample.md` | shipped ✅ |
+| 6 | Docs conversion QA gate | `docs/day-6-ultra-upgrade-report.md` | `docs/artifacts/day6-conversion-qa-sample.md` | shipped ✅ |
+
+## KPI movement
+
+- Completion rate: **6/6 (100%)**
+- Runnable command paths delivered: **6**
+- Artifact coverage: **6/6**
+
+## Next-week focus
+
+- Day 8: publish 10 curated good-first-issue tasks with clear acceptance criteria.
+- Day 9: tighten issue/PR templates to reduce triage response time.
+- Day 10: add first-contribution checklist from clone to first merged PR.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,6 +95,21 @@ Useful flags: `--root`, `--format`, `--output`.
 See: day-6-ultra-upgrade-report.md
 
 
+
+## weekly-review
+
+Builds Day 7 weekly review #1 output with shipped upgrades, KPI movement, and next-week focus.
+
+Examples:
+
+- `sdetkit weekly-review --format text`
+- `sdetkit weekly-review --format json`
+- `sdetkit weekly-review --format markdown --output docs/artifacts/day7-weekly-review-sample.md`
+
+Useful flags: `--root`, `--format`, `--output`.
+
+See: day-7-ultra-upgrade-report.md
+
 ## patch
 
 Deterministic, spec-driven file edits (official CLI command).

--- a/docs/day-7-ultra-upgrade-report.md
+++ b/docs/day-7-ultra-upgrade-report.md
@@ -1,0 +1,56 @@
+# Day 7 Ultra Upgrade Report — Weekly Review #1
+
+## Upgrade title
+
+**Day 7 big upgrade: runnable weekly review command for shipped scope, KPI movement, and next-week focus**
+
+## Problem statement
+
+Phase-1 work had six daily upgrades shipped, but no deterministic way to produce a weekly closeout summary from the repository itself.
+
+This made weekly reporting manual and increased drift risk between what was delivered and what was communicated.
+
+## Implementation scope
+
+### Files changed
+
+- `src/sdetkit/weekly_review.py`
+  - Added a Day 7 weekly review engine that evaluates Day 1–6 report/artifact coverage.
+  - Computes KPI snapshot (`days_completed`, `completion_rate_percent`, `runnable_commands`, `artifact_coverage`).
+  - Emits text/json/markdown output and supports writing artifacts through `--output`.
+- `src/sdetkit/cli.py`
+  - Added top-level `weekly-review` command wiring: `python -m sdetkit weekly-review ...`.
+- `tests/test_weekly_review.py`
+  - Added positive KPI coverage for repository-level review generation.
+  - Added failure-path coverage for incomplete temporary fixture repositories.
+- `tests/test_cli_help_lists_subcommands.py`
+  - Extended CLI help contract to include `weekly-review` in `sdetkit --help` output.
+- `README.md`
+  - Added Day 7 weekly review section with runnable command flow and closeout checks.
+- `docs/index.md`
+  - Added Day 7 report link and execution bullets.
+- `docs/cli.md`
+  - Added `weekly-review` command reference and usage examples.
+- `scripts/check_day7_weekly_review_contract.py`
+  - Added Day 7 contract checker for README/docs/report/script wiring and artifact presence.
+- `docs/artifacts/day7-weekly-review-sample.md`
+  - Added generated Day 7 weekly review artifact sample.
+
+## Validation checklist
+
+- `python -m sdetkit weekly-review --format text`
+- `python -m sdetkit weekly-review --format markdown --output docs/artifacts/day7-weekly-review-sample.md`
+- `python -m pytest -q tests/test_weekly_review.py tests/test_cli_help_lists_subcommands.py`
+- `python scripts/check_day7_weekly_review_contract.py`
+
+## Artifact
+
+This document is the Day 7 artifact report for Weekly review #1 closeout and KPI checkpointing.
+
+## Rollback plan
+
+1. Remove `weekly-review` command wiring from `src/sdetkit/cli.py`.
+2. Remove `src/sdetkit/weekly_review.py` and related tests.
+3. Revert Day 7 docs/report updates and remove Day 7 artifact/checker script.
+
+Rollback risk is low because this is an additive reporting command and does not alter existing workflows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
 
 </div>
 
@@ -102,6 +102,14 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 - Run `sdetkit docs-qa --format text` to validate README/docs internal links and heading anchors.
 - Export markdown QA report for PR handoff: `sdetkit docs-qa --format markdown --output docs/artifacts/day6-conversion-qa-sample.md`.
 - Review the generated artifact: [day6 conversion QA sample](artifacts/day6-conversion-qa-sample.md).
+
+
+## Day 7 ultra upgrades (weekly review + KPI checkpoint)
+
+- Read the implementation report: [Day 7 ultra upgrade report](day-7-ultra-upgrade-report.md).
+- Run `sdetkit weekly-review --format text` to summarize shipped days, KPI movement, and next-week focus.
+- Export markdown review artifact: `sdetkit weekly-review --format markdown --output docs/artifacts/day7-weekly-review-sample.md`.
+- Review the generated artifact: [day7 weekly review sample](artifacts/day7-weekly-review-sample.md).
 
 ## Fast start
 

--- a/scripts/check_day7_weekly_review_contract.py
+++ b/scripts/check_day7_weekly_review_contract.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+README = Path('README.md')
+DOCS_INDEX = Path('docs/index.md')
+DAY7_REPORT = Path('docs/day-7-ultra-upgrade-report.md')
+DAY7_ARTIFACT = Path('docs/artifacts/day7-weekly-review-sample.md')
+WEEKLY_MODULE = Path('src/sdetkit/weekly_review.py')
+
+REQUIRED_README_SNIPPETS = [
+    '## 📊 Day 7 ultra: weekly review #1',
+    'python -m sdetkit weekly-review --format text',
+    'python -m sdetkit weekly-review --format markdown --output docs/artifacts/day7-weekly-review-sample.md',
+    'docs/day-7-ultra-upgrade-report.md',
+]
+
+REQUIRED_INDEX_SNIPPETS = [
+    'Day 7 ultra upgrade report',
+    'sdetkit weekly-review --format text',
+]
+
+REQUIRED_REPORT_SNIPPETS = [
+    'Day 7 big upgrade',
+    'src/sdetkit/weekly_review.py',
+    'tests/test_weekly_review.py',
+    'python scripts/check_day7_weekly_review_contract.py',
+]
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        return ''
+    return path.read_text(encoding='utf-8')
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    readme = _read(README)
+    docs_index = _read(DOCS_INDEX)
+    report = _read(DAY7_REPORT)
+
+    for s in REQUIRED_README_SNIPPETS:
+        if s not in readme:
+            errors.append(f'missing README snippet: {s}')
+
+    for s in REQUIRED_INDEX_SNIPPETS:
+        if s not in docs_index:
+            errors.append(f'missing docs/index snippet: {s}')
+
+    for s in REQUIRED_REPORT_SNIPPETS:
+        if s not in report:
+            errors.append(f'missing Day 7 report snippet: {s}')
+
+    for p in [DAY7_REPORT, DAY7_ARTIFACT, WEEKLY_MODULE]:
+        if not p.exists():
+            errors.append(f'missing required file: {p}')
+
+    if errors:
+        print('day7-weekly-review-contract check failed:', file=sys.stderr)
+        for e in errors:
+            print(f'- {e}', file=sys.stderr)
+        return 1
+
+    print('day7-weekly-review-contract check passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Sequence
 from importlib import metadata
 
-from . import apiget, demo, docs_qa, evidence, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report
+from . import apiget, demo, docs_qa, evidence, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, weekly_review
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
 from .security_gate import main as security_main
@@ -95,6 +95,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "docs-qa":
         return docs_qa.main(list(argv[1:]))
 
+    if argv and argv[0] == "weekly-review":
+        return weekly_review.main(list(argv[1:]))
+
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -156,6 +159,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     dqa = sub.add_parser("docs-qa")
     dqa.add_argument("args", nargs=argparse.REMAINDER)
 
+    wrv = sub.add_parser("weekly-review")
+    wrv.add_argument("args", nargs=argparse.REMAINDER)
+
     ns = p.parse_args(argv)
 
     if ns.cmd == "kv":
@@ -205,6 +211,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "docs-qa":
         return docs_qa.main(ns.args)
+
+    if ns.cmd == "weekly-review":
+        return weekly_review.main(ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)

--- a/src/sdetkit/weekly_review.py
+++ b/src/sdetkit/weekly_review.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DayShipped:
+    day: int
+    title: str
+    report_path: str
+    artifact_path: str
+    command: str
+
+
+DAY1_TO_6: tuple[DayShipped, ...] = (
+    DayShipped(1, "Core positioning + role onboarding", "docs/day-1-ultra-upgrade-report.md", "docs/artifacts/day1-onboarding-sample.md", "python -m sdetkit onboarding --format text"),
+    DayShipped(2, "60-second demo workflow", "docs/day-2-ultra-upgrade-report.md", "docs/artifacts/day2-demo-sample.md", "python -m sdetkit demo --execute --format text"),
+    DayShipped(3, "Proof pack with runnable checks", "docs/day-3-ultra-upgrade-report.md", "docs/artifacts/day3-proof-sample.md", "python -m sdetkit proof --execute --strict --format text"),
+    DayShipped(4, "Template/skill expansion run-all", "docs/day-4-ultra-upgrade-report.md", "docs/artifacts/day4-skills-sample.md", "python -m sdetkit agent templates run-all --output-dir .sdetkit/agent/template-runs"),
+    DayShipped(5, "Cross-platform onboarding snippets", "docs/day-5-ultra-upgrade-report.md", "docs/artifacts/day5-platform-onboarding-sample.md", "python -m sdetkit onboarding --format text --platform all"),
+    DayShipped(6, "Docs conversion QA gate", "docs/day-6-ultra-upgrade-report.md", "docs/artifacts/day6-conversion-qa-sample.md", "python -m sdetkit docs-qa --format text"),
+)
+
+
+@dataclass(frozen=True)
+class WeeklyReview:
+    week: int
+    shipped: tuple[dict[str, object], ...]
+    kpis: dict[str, int]
+    next_week_focus: tuple[str, ...]
+
+
+def build_weekly_review(repo_root: Path) -> WeeklyReview:
+    shipped: list[dict[str, object]] = []
+    for day in DAY1_TO_6:
+        report_exists = (repo_root / day.report_path).exists()
+        artifact_exists = (repo_root / day.artifact_path).exists()
+        shipped.append(
+            {
+                "day": day.day,
+                "title": day.title,
+                "report": day.report_path,
+                "artifact": day.artifact_path,
+                "command": day.command,
+                "report_exists": report_exists,
+                "artifact_exists": artifact_exists,
+                "status": "shipped" if report_exists and artifact_exists else "incomplete",
+            }
+        )
+
+    shipped_count = sum(1 for item in shipped if item["status"] == "shipped")
+    kpis = {
+        "days_completed": shipped_count,
+        "days_planned": len(DAY1_TO_6),
+        "completion_rate_percent": int((shipped_count / len(DAY1_TO_6)) * 100),
+        "runnable_commands": len(DAY1_TO_6),
+        "artifact_coverage": sum(1 for item in shipped if item["artifact_exists"]),
+    }
+
+    next_week_focus = (
+        "Day 8: publish 10 curated good-first-issue tasks with clear acceptance criteria.",
+        "Day 9: tighten issue/PR templates to reduce triage response time.",
+        "Day 10: add first-contribution checklist from clone to first merged PR.",
+    )
+
+    return WeeklyReview(week=1, shipped=tuple(shipped), kpis=kpis, next_week_focus=next_week_focus)
+
+
+def _render_text(review: WeeklyReview) -> str:
+    lines = [
+        "Day 7 weekly review #1",
+        "",
+        "What shipped (Day 1-6):",
+    ]
+    for item in review.shipped:
+        mark = "✅" if item["status"] == "shipped" else "⚠️"
+        lines.append(
+            f"- {mark} Day {item['day']}: {item['title']} | report={item['report_exists']} artifact={item['artifact_exists']}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "KPI movement:",
+            f"- Completion: {review.kpis['days_completed']}/{review.kpis['days_planned']} ({review.kpis['completion_rate_percent']}%)",
+            f"- Runnable command paths: {review.kpis['runnable_commands']}",
+            f"- Artifact coverage: {review.kpis['artifact_coverage']}/{review.kpis['days_planned']}",
+            "",
+            "Next-week focus:",
+        ]
+    )
+    lines.extend(f"- {item}" for item in review.next_week_focus)
+    return "\n".join(lines) + "\n"
+
+
+def _render_markdown(review: WeeklyReview) -> str:
+    lines = [
+        "# Day 7 Weekly Review #1",
+        "",
+        "## What shipped (Day 1-6)",
+        "",
+        "| Day | Upgrade | Report | Artifact | Status |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+
+    for item in review.shipped:
+        status = "shipped ✅" if item["status"] == "shipped" else "incomplete ⚠️"
+        lines.append(
+            f"| {item['day']} | {item['title']} | `{item['report']}` | `{item['artifact']}` | {status} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## KPI movement",
+            "",
+            f"- Completion rate: **{review.kpis['days_completed']}/{review.kpis['days_planned']} ({review.kpis['completion_rate_percent']}%)**",
+            f"- Runnable command paths delivered: **{review.kpis['runnable_commands']}**",
+            f"- Artifact coverage: **{review.kpis['artifact_coverage']}/{review.kpis['days_planned']}**",
+            "",
+            "## Next-week focus",
+            "",
+        ]
+    )
+    lines.extend(f"- {item}" for item in review.next_week_focus)
+    return "\n".join(lines) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="sdetkit weekly-review", description="Generate Day 7 weekly review summary.")
+    p.add_argument("--root", default=".", help="Repository root path.")
+    p.add_argument("--format", choices=["text", "json", "markdown"], default="text")
+    p.add_argument("--output", default=None, help="Optional output path for the report.")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    review = build_weekly_review(Path(args.root).resolve())
+
+    if args.format == "json":
+        rendered = json.dumps(
+            {
+                "week": review.week,
+                "shipped": list(review.shipped),
+                "kpis": review.kpis,
+                "next_week_focus": list(review.next_week_focus),
+            },
+            indent=2,
+        ) + "\n"
+    elif args.format == "markdown":
+        rendered = _render_markdown(review)
+    else:
+        rendered = _render_text(review)
+
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_and_docs_qa() -> None:
+def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_and_weekly_review() -> None:
     r = subprocess.run(
         [sys.executable, "-m", "sdetkit", "--help"],
         text=True,
@@ -25,3 +25,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "agent" in out
     assert "proof" in out
     assert "docs-qa" in out
+    assert "weekly-review" in out

--- a/tests/test_weekly_review.py
+++ b/tests/test_weekly_review.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit import weekly_review
+
+
+def test_weekly_review_repo_passes_core_kpis() -> None:
+    review = weekly_review.build_weekly_review(Path('.').resolve())
+    assert review.kpis['days_planned'] == 6
+    assert review.kpis['days_completed'] >= 6
+    assert review.kpis['completion_rate_percent'] == 100
+
+
+def test_weekly_review_flags_missing_files(tmp_path: Path) -> None:
+    (tmp_path / 'README.md').write_text('# temp\n', encoding='utf-8')
+    (tmp_path / 'docs').mkdir()
+    (tmp_path / 'docs' / 'day-1-ultra-upgrade-report.md').write_text('ok\n', encoding='utf-8')
+
+    review = weekly_review.build_weekly_review(tmp_path)
+    assert review.kpis['days_completed'] < review.kpis['days_planned']
+    assert any(item['status'] == 'incomplete' for item in review.shipped)


### PR DESCRIPTION
### Motivation

- Provide a deterministic, runnable Day 7 weekly closeout that summarizes what shipped, KPI movement, and next-week focus. 
- Make weekly reporting reproducible from the repo and enable artifact export for stakeholder handoffs.

### Description

- Added a new reporting engine at `src/sdetkit/weekly_review.py` that computes Day 1–6 coverage, KPIs, and renders text/json/markdown outputs with optional `--output` support. 
- Wired the new command into the top-level CLI in `src/sdetkit/cli.py` as `sdetkit weekly-review` and added a subparser for discoverability. 
- Added tests: `tests/test_weekly_review.py` for KPI and incomplete-repo behavior and updated `tests/test_cli_help_lists_subcommands.py` to assert `weekly-review` appears in `--help`. 
- Updated documentation and artifacts including `README.md`, `docs/index.md`, `docs/cli.md`, `docs/day-7-ultra-upgrade-report.md`, and a generated sample `docs/artifacts/day7-weekly-review-sample.md`, plus a contract checker script `scripts/check_day7_weekly_review_contract.py`.

### Testing

- Ran `python -m pytest -q tests/test_weekly_review.py tests/test_cli_help_lists_subcommands.py tests/test_docs_qa.py` and all tests passed (`7 passed`).
- Generated the markdown artifact with `python -m sdetkit weekly-review --format markdown --output docs/artifacts/day7-weekly-review-sample.md` which produced the expected sample file. 
- Executed the contract checker `python scripts/check_day7_weekly_review_contract.py` which returned a passing status. 
- Verified CLI text output with `python -m sdetkit weekly-review --format text` and inspected the first lines for expected summary content.

------