### PR TITLE
feat(day10): harden first-contribution workflow with recovery mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,29 @@ Thanks for helping improve **sdetkit**.
 
 ---
 
+## 0) Day 10 first-contribution checklist
+
+Use this guided path from local clone to first merged PR:
+
+- [ ] Fork the repository and clone your fork locally.
+- [ ] Create and activate a virtual environment.
+- [ ] Install editable dependencies for dev/test/docs.
+- [ ] Create a branch named `feat/<topic>` or `fix/<topic>`.
+- [ ] Run focused tests for changed modules before committing.
+- [ ] Run full quality gates (`pre-commit`, `quality.sh`, docs build) before opening a PR.
+- [ ] Open a PR using the repository template and include test evidence.
+
+Recommended shell sequence:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .[dev,test,docs]
+pre-commit run -a
+bash quality.sh cov
+mkdocs build
+```
+
 ## Contribution flow
 
 1. Fork and create a focused branch.

--- a/README.md
+++ b/README.md
@@ -547,6 +547,31 @@ python scripts/check_day9_contribution_templates_contract.py
 python -m sdetkit triage-templates --format json --strict
 ```
 
+## ✅ Day 10 ultra: first-contribution checklist
+
+Day 10 adds a guided first-contribution checklist so new contributors can move from fork/clone to PR with deterministic quality gates.
+
+```bash
+python -m sdetkit first-contribution --format text --strict
+python -m sdetkit first-contribution --write-defaults --format json --strict
+```
+
+Export a markdown artifact for mentor/reviewer handoff:
+
+```bash
+python -m sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md
+```
+
+See implementation details: [Day 10 ultra upgrade report](docs/day-10-ultra-upgrade-report.md).
+
+Day 10 closeout checks:
+
+```bash
+python -m pytest -q tests/test_first_contribution.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day10_first_contribution_contract.py
+python -m sdetkit first-contribution --format json --strict
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day10-first-contribution-checklist-sample.md
+++ b/docs/artifacts/day10-first-contribution-checklist-sample.md
@@ -1,0 +1,36 @@
+# Day 10 first-contribution checklist
+
+- Score: **100.0** (14/14)
+- Guide file: `CONTRIBUTING.md`
+
+## Checklist
+
+- [ ] Fork the repository and clone your fork locally.
+- [ ] Create and activate a virtual environment.
+- [ ] Install editable dependencies for dev/test/docs.
+- [ ] Create a branch named `feat/<topic>` or `fix/<topic>`.
+- [ ] Run focused tests for changed modules before committing.
+- [ ] Run full quality gates (`pre-commit`, `quality.sh`, docs build) before opening a PR.
+- [ ] Open a PR using the repository template and include test evidence.
+
+## Required command sequence
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .[dev,test,docs]
+pre-commit run -a
+bash quality.sh cov
+mkdocs build
+```
+
+## Missing guide content
+
+- none
+
+## Actions
+
+- `docs/contributing.md`
+- `sdetkit first-contribution --format json --strict`
+- `sdetkit first-contribution --write-defaults --strict`
+- `sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -147,6 +147,25 @@ Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`.
 
 See: day-9-ultra-upgrade-report.md
 
+## first-contribution
+
+Builds Day 10 first-contribution checklist output and validates that `CONTRIBUTING.md` contains the guided path from fork to PR.
+
+Examples:
+
+- `sdetkit first-contribution --format text --strict`
+- `sdetkit first-contribution --format json`
+- `sdetkit first-contribution --write-defaults --format json --strict`
+- `sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md`
+
+Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`.
+
+`--strict` returns non-zero if required Day 10 checklist content or required command snippets are missing from `CONTRIBUTING.md`.
+
+`--write-defaults` writes a default Day 10 checklist block to `CONTRIBUTING.md` if missing, then re-validates in the same run.
+
+See: day-10-ultra-upgrade-report.md
+
 ## patch
 
 Deterministic, spec-driven file edits (official CLI command).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,16 @@
 
 Use the repository root guide (`CONTRIBUTING.md`) for the full contributor workflow.
 
+## Day 10 first-contribution checklist
+
+Generate a guided checklist from clone to PR:
+
+```bash
+sdetkit first-contribution --format text --strict
+sdetkit first-contribution --write-defaults --format json --strict
+sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md
+```
+
 Quick start:
 
 ```bash

--- a/docs/day-10-ultra-upgrade-report.md
+++ b/docs/day-10-ultra-upgrade-report.md
@@ -1,0 +1,58 @@
+# Day 10 Ultra Upgrade Report — First-Contribution Checklist
+
+## Snapshot
+
+**Day 10 big upgrade: shipped a runnable first-contribution checklist command plus docs contract checks so new contributors can move from clone to first PR with clear quality gates.**
+
+## Problem statement
+
+The repository had contribution guidance, but first-time contributors still had to infer the exact path from fork/clone to PR. Missing checklist structure can increase onboarding time and create avoidable review loops.
+
+## What shipped
+
+### Product code
+
+- `src/sdetkit/first_contribution.py`
+  - Added Day 10 checklist engine with text/markdown/json output, now validating checklist items plus required command snippets.
+  - Added `--root` support for validating arbitrary repository targets.
+  - Added `--strict` contract mode to fail when required checklist content or shell command snippets are missing from `CONTRIBUTING.md`.
+  - Added `--write-defaults` recovery mode to write Day 10 baseline checklist content when missing, then re-validate.
+- `src/sdetkit/cli.py`
+  - Added top-level command wiring: `python -m sdetkit first-contribution ...`.
+
+### Docs and contribution surface
+
+- `CONTRIBUTING.md`
+  - Added `## 0) Day 10 first-contribution checklist` section with fork→env→branch→test→quality→PR flow.
+- `docs/contributing.md`
+  - Added Day 10 quick commands for checklist generation/validation.
+- `README.md`, `docs/index.md`, `docs/cli.md`
+  - Added Day 10 command docs, report links, and artifact references.
+
+### Tests and checks
+
+- `tests/test_first_contribution.py`
+  - Added command rendering, strict-pass, strict-fail, and CLI-dispatch tests.
+- `tests/test_cli_help_lists_subcommands.py`
+  - Added `first-contribution` CLI help contract assertion.
+- `scripts/check_day10_first_contribution_contract.py`
+  - Added Day 10 contract checker for README/docs/report/artifact wiring.
+
+## Validation checklist
+
+- `python -m pytest -q tests/test_first_contribution.py tests/test_cli_help_lists_subcommands.py`
+- `python scripts/check_day10_first_contribution_contract.py`
+- `python -m sdetkit first-contribution --format json --strict`
+- `python -m sdetkit first-contribution --write-defaults --format json --strict`
+
+## Artifacts
+
+- `docs/artifacts/day10-first-contribution-checklist-sample.md`
+
+## Rollback plan
+
+1. Revert `src/sdetkit/first_contribution.py` and remove the `first-contribution` command wiring from `src/sdetkit/cli.py`.
+2. Revert Day 10 sections in `CONTRIBUTING.md`, `README.md`, and docs files.
+3. Remove Day 10 contract checker and tests if rolling back the feature entirely.
+
+This document is the Day 10 artifact report for first-contribution onboarding hardening.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
 
 </div>
 
@@ -127,6 +127,14 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 - Auto-write hardened defaults when bootstrapping: `sdetkit triage-templates --write-defaults --format json --strict`.
 - Export markdown template-health artifact: `sdetkit triage-templates --format markdown --output docs/artifacts/day9-triage-templates-sample.md`.
 - Review the generated artifact: [day9 triage templates sample](artifacts/day9-triage-templates-sample.md).
+
+## Day 10 ultra upgrades (first-contribution checklist)
+
+- Read the implementation report: [Day 10 ultra upgrade report](day-10-ultra-upgrade-report.md).
+- Run `sdetkit first-contribution --format text --strict` to print and validate the guided first-contribution path.
+- Auto-recover missing checklist content: `sdetkit first-contribution --write-defaults --format json --strict`.
+- Export markdown checklist artifact: `sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md`.
+- Review the generated artifact: [day10 first contribution checklist sample](artifacts/day10-first-contribution-checklist-sample.md).
 
 ## Fast start
 

--- a/scripts/check_day10_first_contribution_contract.py
+++ b/scripts/check_day10_first_contribution_contract.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+README = Path('README.md')
+CONTRIBUTING = Path('CONTRIBUTING.md')
+DOCS_INDEX = Path('docs/index.md')
+DOCS_CLI = Path('docs/cli.md')
+DOCS_CONTRIBUTING = Path('docs/contributing.md')
+DAY10_REPORT = Path('docs/day-10-ultra-upgrade-report.md')
+DAY10_ARTIFACT = Path('docs/artifacts/day10-first-contribution-checklist-sample.md')
+
+README_EXPECTED = [
+    '## ✅ Day 10 ultra: first-contribution checklist',
+    'python -m sdetkit first-contribution --format text --strict',
+    'python -m sdetkit first-contribution --write-defaults --format json --strict',
+    'python scripts/check_day10_first_contribution_contract.py',
+    'docs/day-10-ultra-upgrade-report.md',
+]
+
+CONTRIBUTING_EXPECTED = [
+    '## 0) Day 10 first-contribution checklist',
+    'Fork the repository and clone your fork locally.',
+    'Create a branch named `feat/<topic>` or `fix/<topic>`.',
+    'Run full quality gates (`pre-commit`, `quality.sh`, docs build) before opening a PR.',
+]
+
+DOCS_INDEX_EXPECTED = [
+    '## Day 10 ultra upgrades (first-contribution checklist)',
+    'sdetkit first-contribution --format text --strict',
+    'sdetkit first-contribution --write-defaults --format json --strict',
+    'artifacts/day10-first-contribution-checklist-sample.md',
+]
+
+DOCS_CLI_EXPECTED = [
+    '## first-contribution',
+    'sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md',
+    '--strict',
+    '--write-defaults',
+]
+
+DOCS_CONTRIBUTING_EXPECTED = [
+    '## Day 10 first-contribution checklist',
+    'sdetkit first-contribution --format text --strict',
+    'sdetkit first-contribution --write-defaults --format json --strict',
+]
+
+REPORT_EXPECTED = [
+    'Day 10 big upgrade',
+    'python -m sdetkit first-contribution --format json --strict',
+    'python -m sdetkit first-contribution --write-defaults --format json --strict',
+    'scripts/check_day10_first_contribution_contract.py',
+]
+
+ARTIFACT_EXPECTED = [
+    '# Day 10 first-contribution checklist',
+    '- Score: **100.0** (14/14)',
+]
+
+
+def _missing(path: Path, expected: list[str]) -> list[str]:
+    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    return [item for item in expected if item not in text]
+
+
+def main() -> int:
+    errors: list[str] = []
+    required = [README, CONTRIBUTING, DOCS_INDEX, DOCS_CLI, DOCS_CONTRIBUTING, DAY10_REPORT, DAY10_ARTIFACT]
+    for path in required:
+        if not path.exists():
+            errors.append(f'missing required file: {path}')
+
+    if not errors:
+        errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
+        errors.extend(f'{CONTRIBUTING}: missing "{m}"' for m in _missing(CONTRIBUTING, CONTRIBUTING_EXPECTED))
+        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
+        errors.extend(
+            f'{DOCS_CONTRIBUTING}: missing "{m}"' for m in _missing(DOCS_CONTRIBUTING, DOCS_CONTRIBUTING_EXPECTED)
+        )
+        errors.extend(f'{DAY10_REPORT}: missing "{m}"' for m in _missing(DAY10_REPORT, REPORT_EXPECTED))
+        errors.extend(f'{DAY10_ARTIFACT}: missing "{m}"' for m in _missing(DAY10_ARTIFACT, ARTIFACT_EXPECTED))
+
+    if errors:
+        print('day10-first-contribution-contract check failed:', file=sys.stderr)
+        for error in errors:
+            print(f' - {error}', file=sys.stderr)
+        return 1
+
+    print('day10-first-contribution-contract check passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Sequence
 from importlib import metadata
 
-from . import apiget, contributor_funnel, demo, docs_qa, evidence, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, triage_templates, weekly_review
+from . import apiget, contributor_funnel, demo, docs_qa, evidence, first_contribution, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, triage_templates, weekly_review
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
 from .security_gate import main as security_main
@@ -86,6 +86,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "onboarding":
         return onboarding.main(list(argv[1:]))
 
+    if argv and argv[0] == "first-contribution":
+        return first_contribution.main(list(argv[1:]))
+
     if argv and argv[0] == "demo":
         return demo.main(list(argv[1:]))
 
@@ -159,6 +162,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     dmo = sub.add_parser("demo")
     dmo.add_argument("args", nargs=argparse.REMAINDER)
 
+    fct = sub.add_parser("first-contribution")
+    fct.add_argument("args", nargs=argparse.REMAINDER)
+
     ctf = sub.add_parser("contributor-funnel")
     ctf.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -217,6 +223,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "demo":
         return demo.main(ns.args)
+
+    if ns.cmd == "first-contribution":
+        return first_contribution.main(ns.args)
 
     if ns.cmd == "contributor-funnel":
         return contributor_funnel.main(ns.args)

--- a/src/sdetkit/first_contribution.py
+++ b/src/sdetkit/first_contribution.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+_CHECKLIST_SECTION_HEADER = "## 0) Day 10 first-contribution checklist"
+
+_CHECKLIST_ITEMS = [
+    "Fork the repository and clone your fork locally.",
+    "Create and activate a virtual environment.",
+    "Install editable dependencies for dev/test/docs.",
+    "Create a branch named `feat/<topic>` or `fix/<topic>`.",
+    "Run focused tests for changed modules before committing.",
+    "Run full quality gates (`pre-commit`, `quality.sh`, docs build) before opening a PR.",
+    "Open a PR using the repository template and include test evidence.",
+]
+
+_COMMAND_BLOCKS = [
+    "python3 -m venv .venv",
+    "source .venv/bin/activate",
+    "python -m pip install -e .[dev,test,docs]",
+    "pre-commit run -a",
+    "bash quality.sh cov",
+    "mkdocs build",
+]
+
+_DAY10_DEFAULT_BLOCK = """## 0) Day 10 first-contribution checklist
+
+Use this guided path from local clone to first merged PR:
+
+- [ ] Fork the repository and clone your fork locally.
+- [ ] Create and activate a virtual environment.
+- [ ] Install editable dependencies for dev/test/docs.
+- [ ] Create a branch named `feat/<topic>` or `fix/<topic>`.
+- [ ] Run focused tests for changed modules before committing.
+- [ ] Run full quality gates (`pre-commit`, `quality.sh`, docs build) before opening a PR.
+- [ ] Open a PR using the repository template and include test evidence.
+
+Recommended shell sequence:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .[dev,test,docs]
+pre-commit run -a
+bash quality.sh cov
+mkdocs build
+```
+
+"""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sdetkit first-contribution",
+        description="Render and validate the Day 10 first-contribution checklist.",
+    )
+    p.add_argument("--format", choices=["text", "markdown", "json"], default="text")
+    p.add_argument("--root", default=".", help="Repository root where CONTRIBUTING.md lives.")
+    p.add_argument("--output", default="", help="Optional output file path.")
+    p.add_argument("--strict", action="store_true", help="Return non-zero if required checklist content is missing.")
+    p.add_argument(
+        "--write-defaults",
+        action="store_true",
+        help="Write Day 10 checklist block into CONTRIBUTING.md if missing, then validate again.",
+    )
+    return p
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _missing_checks(guide_text: str) -> list[str]:
+    checks = [_CHECKLIST_SECTION_HEADER, *_CHECKLIST_ITEMS, *_COMMAND_BLOCKS]
+    return [item for item in checks if item not in guide_text]
+
+
+def _write_defaults(base: Path) -> list[str]:
+    guide = base / "CONTRIBUTING.md"
+    current = _read(guide)
+    if _CHECKLIST_SECTION_HEADER in current:
+        return []
+
+    if current:
+        updated = current.rstrip() + "\n\n" + _DAY10_DEFAULT_BLOCK
+    else:
+        updated = "# Contributing\n\n" + _DAY10_DEFAULT_BLOCK
+
+    guide.write_text(updated, encoding="utf-8")
+    return ["CONTRIBUTING.md"]
+
+
+def build_first_contribution_status(root: str = ".") -> dict[str, object]:
+    base = Path(root)
+    guide = base / "CONTRIBUTING.md"
+    guide_text = _read(guide)
+    missing = _missing_checks(guide_text)
+
+    total_checks = len([_CHECKLIST_SECTION_HEADER, *_CHECKLIST_ITEMS, *_COMMAND_BLOCKS])
+    passed_checks = total_checks - len(missing)
+    score = round((passed_checks / total_checks) * 100, 1) if total_checks else 0.0
+
+    return {
+        "name": "day10-first-contribution-checklist",
+        "score": score,
+        "total_checks": total_checks,
+        "passed_checks": passed_checks,
+        "checklist": list(_CHECKLIST_ITEMS),
+        "required_commands": list(_COMMAND_BLOCKS),
+        "guide": str(guide),
+        "missing": missing,
+        "actions": {
+            "open_guide": "docs/contributing.md",
+            "validate": "sdetkit first-contribution --format json --strict",
+            "write_defaults": "sdetkit first-contribution --write-defaults --strict",
+            "artifact": "sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md",
+        },
+    }
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [
+        "Day 10 first-contribution checklist",
+        f"score: {payload['score']} ({payload['passed_checks']}/{payload['total_checks']})",
+        "",
+        "checklist:",
+    ]
+    for idx, item in enumerate(payload["checklist"], start=1):
+        lines.append(f"{idx}. {item}")
+    lines.extend(["", "required commands:"])
+    for cmd in payload["required_commands"]:
+        lines.append(f"- {cmd}")
+    lines.extend(["", f"guide: {payload['guide']}"])
+    if payload["missing"]:
+        lines.append("missing guide content:")
+        for item in payload["missing"]:
+            lines.append(f"- {item}")
+    else:
+        lines.append("missing guide content: none")
+    lines.extend(["", "actions:"])
+    lines.append(f"- open guide: {payload['actions']['open_guide']}")
+    lines.append(f"- validate: {payload['actions']['validate']}")
+    lines.append(f"- write defaults: {payload['actions']['write_defaults']}")
+    lines.append(f"- export artifact: {payload['actions']['artifact']}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# Day 10 first-contribution checklist",
+        "",
+        f"- Score: **{payload['score']}** ({payload['passed_checks']}/{payload['total_checks']})",
+        f"- Guide file: `{payload['guide']}`",
+        "",
+        "## Checklist",
+        "",
+    ]
+    for item in payload["checklist"]:
+        lines.append(f"- [ ] {item}")
+    lines.extend(["", "## Required command sequence", "", "```bash"])
+    lines.extend(payload["required_commands"])
+    lines.extend(["```", "", "## Missing guide content", ""])
+    if payload["missing"]:
+        for item in payload["missing"]:
+            lines.append(f"- `{item}`")
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Actions", ""])
+    lines.append(f"- `{payload['actions']['open_guide']}`")
+    lines.append(f"- `{payload['actions']['validate']}`")
+    lines.append(f"- `{payload['actions']['write_defaults']}`")
+    lines.append(f"- `{payload['actions']['artifact']}`")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+
+    touched: list[str] = []
+    if args.write_defaults:
+        touched = _write_defaults(Path(args.root))
+
+    payload = build_first_contribution_status(args.root)
+    payload["touched_files"] = touched
+
+    if args.format == "json":
+        rendered = json.dumps(payload, indent=2) + "\n"
+    elif args.format == "markdown":
+        rendered = _render_markdown(payload)
+    else:
+        rendered = _render_text(payload)
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, encoding="utf-8")
+
+    print(rendered, end="")
+
+    if args.strict and payload["passed_checks"] != payload["total_checks"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_and_weekly_review_and_contributor_funnel_and_triage_templates() -> None:
+def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_and_weekly_review_and_first_contribution_and_contributor_funnel_and_triage_templates() -> None:
     r = subprocess.run(
         [sys.executable, "-m", "sdetkit", "--help"],
         text=True,
@@ -26,5 +26,6 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "proof" in out
     assert "docs-qa" in out
     assert "weekly-review" in out
+    assert "first-contribution" in out
     assert "contributor-funnel" in out
     assert "triage-templates" in out

--- a/tests/test_first_contribution.py
+++ b/tests/test_first_contribution.py
@@ -1,0 +1,45 @@
+import json
+
+from sdetkit import cli, first_contribution
+
+
+def test_first_contribution_default_text(capsys):
+    rc = first_contribution.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Day 10 first-contribution checklist" in out
+    assert "Create and activate a virtual environment" in out
+    assert "required commands:" in out
+
+
+def test_first_contribution_json_and_strict_success(capsys):
+    rc = first_contribution.main(["--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["name"] == "day10-first-contribution-checklist"
+    assert data["passed_checks"] == data["total_checks"]
+    assert "mkdocs build" in data["required_commands"]
+
+
+def test_first_contribution_strict_fails_when_content_missing(tmp_path, capsys):
+    (tmp_path / "CONTRIBUTING.md").write_text("# Contributing\n", encoding="utf-8")
+    rc = first_contribution.main(["--root", str(tmp_path), "--strict"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "missing guide content:" in out
+
+
+def test_first_contribution_write_defaults_recovers_missing_file(tmp_path, capsys):
+    rc = first_contribution.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["passed_checks"] == data["total_checks"]
+    assert data["touched_files"] == ["CONTRIBUTING.md"]
+    assert (tmp_path / "CONTRIBUTING.md").exists()
+
+
+def test_main_cli_dispatches_first_contribution(capsys):
+    rc = cli.main(["first-contribution", "--format", "text"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Day 10 first-contribution checklist" in out


### PR DESCRIPTION
### Motivation
- Tighten Day 10 onboarding by providing a deterministic, verifiable first-contribution checklist and ensure the repo contains both checklist text and the required shell command snippets. 
- Provide a safe recovery path so missing contributor guidance can be bootstrapped automatically and re-validated in one command.

### Description
- Added `src/sdetkit/first_contribution.py`, a checklist engine that validates checklist items and required command snippets, emits `text|markdown|json`, and exposes `build_first_contribution_status` with `required_commands`, `touched_files`, and `actions` in the payload. 
- Added `--write-defaults` to the command to auto-insert a Day 10 checklist block into `CONTRIBUTING.md` when missing and re-run validation in the same invocation. 
- Wired the command into the CLI in `src/sdetkit/cli.py` as `first-contribution` and added tests in `tests/test_first_contribution.py` and updated `tests/test_cli_help_lists_subcommands.py`. 
- Updated docs, README, an artifact sample, and a contract checker `scripts/check_day10_first_contribution_contract.py` to reflect the recovery flow and updated expectations (score/requirements updated to 14/14).

### Testing
- Ran unit/CLI tests with `python -m pytest -q tests/test_first_contribution.py tests/test_cli_help_lists_subcommands.py` which passed (`6 passed`).
- Ran the Day 10 contract checker with `python scripts/check_day10_first_contribution_contract.py` which printed `day10-first-contribution-contract check passed` (exit 0).
- Executed the CLI end-to-end with `python -m sdetkit first-contribution --format json --strict` which returned a 100% score JSON payload, and with `--write-defaults` against a temporary root to verify recovery which also returned success and created `CONTRIBUTING.md`.

------