### PR TITLE
Harden Day 11 docs-nav recovery and closeout checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,32 @@ python scripts/check_day10_first_contribution_contract.py
 python -m sdetkit first-contribution --format json --strict
 ```
 
+
+## 🧭 Day 11 ultra: docs navigation tune-up
+
+Day 11 makes top user journeys one-click from docs home so users can jump straight to fast start, core CLI guidance, and contribution paths.
+
+```bash
+python -m sdetkit docs-nav --format text --strict
+python -m sdetkit docs-nav --write-defaults --format json --strict
+```
+
+Export a markdown artifact for docs handoff:
+
+```bash
+python -m sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md
+```
+
+See implementation details: [Day 11 ultra upgrade report](docs/day-11-ultra-upgrade-report.md).
+
+Day 11 closeout checks:
+
+```bash
+python -m pytest -q tests/test_docs_navigation.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day11_docs_navigation_contract.py
+python -m sdetkit docs-nav --format json --strict
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day11-docs-navigation-sample.md
+++ b/docs/artifacts/day11-docs-navigation-sample.md
@@ -1,0 +1,30 @@
+# Day 11 docs navigation tune-up
+
+- Score: **100.0** (12/12)
+- Docs home: `docs/index.md`
+
+## Top journeys
+
+- [ ] Run first command in under 60 seconds
+- [ ] Validate docs links and anchors before publishing
+- [ ] Ship a first contribution with deterministic quality gates
+
+## Required one-click links
+
+- `[⚡ Fast start](#fast-start)`
+- `[🛠 CLI commands](cli.md)`
+- `[🩺 Doctor checks](doctor.md)`
+- `[🤝 Contribute](contributing.md)`
+- `[✅ Day 10 ultra report](day-10-ultra-upgrade-report.md)`
+- `[🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md)`
+
+## Missing docs navigation content
+
+- none
+
+## Actions
+
+- `docs/index.md`
+- `sdetkit docs-nav --format json --strict`
+- `sdetkit docs-nav --write-defaults --format json --strict`
+- `sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -166,6 +166,25 @@ Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`.
 
 See: day-10-ultra-upgrade-report.md
 
+## docs-nav
+
+Builds Day 11 docs-navigation status and validates one-click journey links from `docs/index.md`.
+
+Examples:
+
+- `sdetkit docs-nav --format text --strict`
+- `sdetkit docs-nav --format json`
+- `sdetkit docs-nav --write-defaults --format json --strict`
+- `sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md`
+
+Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`.
+
+`--strict` returns non-zero if required Day 11 journey links/content are missing from `docs/index.md`.
+
+`--write-defaults` repairs the quick-jump nav block, restores the Day 11 top-journey section when missing, and then validates again.
+
+See: day-11-ultra-upgrade-report.md
+
 ## patch
 
 Deterministic, spec-driven file edits (official CLI command).

--- a/docs/day-11-ultra-upgrade-report.md
+++ b/docs/day-11-ultra-upgrade-report.md
@@ -1,0 +1,59 @@
+# Day 11 Ultra Upgrade Report — Docs Navigation Tune-Up
+
+## Snapshot
+
+**Day 11 big upgrade: shipped a runnable docs-navigation command plus contract checks so top user journeys are one-click from docs home.**
+
+## Problem statement
+
+The docs home page had many valuable links, but maintainers lacked an executable guard proving that the highest-value journeys stayed visible and one-click after edits.
+
+## What shipped
+
+### Product code
+
+- `src/sdetkit/docs_navigation.py`
+  - Added Day 11 docs-navigation engine with text/markdown/json output and strict validation.
+  - Added `--root` support for validating arbitrary repository targets.
+  - Added `--strict` mode to fail when required one-click links or journey content is missing from `docs/index.md`.
+  - Added `--write-defaults` mode to repair quick-jump defaults, restore the Day 11 section header + top-journey block, and bootstrap `docs/index.md` when missing.
+- `src/sdetkit/cli.py`
+  - Added top-level command wiring: `python -m sdetkit docs-nav ...`.
+
+### Docs surface
+
+- `README.md`
+  - Added Day 11 section, runnable commands, artifact export flow, and closeout checks.
+- `docs/index.md`
+  - Added Day 11 report link in quick-jump and Day 11 top-journey section.
+- `docs/cli.md`
+  - Added `docs-nav` command reference and strict/recovery flag guidance.
+
+### Tests and checks
+
+- `tests/test_docs_navigation.py`
+  - Added rendering, strict-pass, strict-fail, write-defaults recovery, docs-index bootstrap, and CLI-dispatch coverage.
+- `tests/test_cli_help_lists_subcommands.py`
+  - Added `docs-nav` subcommand contract assertion.
+- `scripts/check_day11_docs_navigation_contract.py`
+  - Added Day 11 contract checker for README/docs/report/artifact wiring.
+
+## Validation checklist
+
+- `python -m pytest -q tests/test_docs_navigation.py tests/test_cli_help_lists_subcommands.py`
+- `python scripts/check_day11_docs_navigation_contract.py`
+- `python -m sdetkit docs-nav --format json --strict`
+- `python -m sdetkit docs-nav --write-defaults --format json --strict`
+- `python -m sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md`
+
+## Artifacts
+
+- `docs/artifacts/day11-docs-navigation-sample.md`
+
+## Rollback plan
+
+1. Revert `src/sdetkit/docs_navigation.py` and remove `docs-nav` wiring from `src/sdetkit/cli.py`.
+2. Revert Day 11 sections in `README.md`, `docs/index.md`, and `docs/cli.md`.
+3. Remove Day 11 tests/checker/report/artifact if rolling back this feature.
+
+This document is the Day 11 artifact report for docs-home navigation hardening.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
 
 </div>
 
@@ -135,6 +135,21 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 - Auto-recover missing checklist content: `sdetkit first-contribution --write-defaults --format json --strict`.
 - Export markdown checklist artifact: `sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md`.
 - Review the generated artifact: [day10 first contribution checklist sample](artifacts/day10-first-contribution-checklist-sample.md).
+
+
+## Day 11 ultra upgrades (docs navigation tune-up)
+
+- Read the implementation report: [Day 11 ultra upgrade report](day-11-ultra-upgrade-report.md).
+- Run `sdetkit docs-nav --format text --strict` to validate one-click docs journeys from docs home.
+- Auto-recover the quick-jump nav block: `sdetkit docs-nav --write-defaults --format json --strict`.
+- Export markdown docs-nav artifact: `sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md`.
+- Review the generated artifact: [day11 docs navigation sample](artifacts/day11-docs-navigation-sample.md).
+
+### Day 11 top journeys
+
+- Run first command in under 60 seconds
+- Validate docs links and anchors before publishing
+- Ship a first contribution with deterministic quality gates
 
 ## Fast start
 

--- a/scripts/check_day11_docs_navigation_contract.py
+++ b/scripts/check_day11_docs_navigation_contract.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+README = Path('README.md')
+DOCS_INDEX = Path('docs/index.md')
+DOCS_CLI = Path('docs/cli.md')
+DAY11_REPORT = Path('docs/day-11-ultra-upgrade-report.md')
+DAY11_ARTIFACT = Path('docs/artifacts/day11-docs-navigation-sample.md')
+
+README_EXPECTED = [
+    '## 🧭 Day 11 ultra: docs navigation tune-up',
+    'python -m sdetkit docs-nav --format text --strict',
+    'python -m sdetkit docs-nav --write-defaults --format json --strict',
+    'python scripts/check_day11_docs_navigation_contract.py',
+    'docs/day-11-ultra-upgrade-report.md',
+]
+
+DOCS_INDEX_EXPECTED = [
+    '[🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md)',
+    '## Day 11 ultra upgrades (docs navigation tune-up)',
+    'sdetkit docs-nav --format text --strict',
+    'sdetkit docs-nav --write-defaults --format json --strict',
+    'Run first command in under 60 seconds',
+    'Validate docs links and anchors before publishing',
+    'Ship a first contribution with deterministic quality gates',
+]
+
+DOCS_CLI_EXPECTED = [
+    '## docs-nav',
+    'sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md',
+    '--strict',
+    '--write-defaults',
+]
+
+REPORT_EXPECTED = [
+    'Day 11 big upgrade',
+    'python -m sdetkit docs-nav --format json --strict',
+    'python -m sdetkit docs-nav --write-defaults --format json --strict',
+    'scripts/check_day11_docs_navigation_contract.py',
+]
+
+ARTIFACT_EXPECTED = [
+    '# Day 11 docs navigation tune-up',
+    '- Score: **100.0** (12/12)',
+]
+
+
+def _missing(path: Path, expected: list[str]) -> list[str]:
+    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    return [item for item in expected if item not in text]
+
+
+def main() -> int:
+    errors: list[str] = []
+    required = [README, DOCS_INDEX, DOCS_CLI, DAY11_REPORT, DAY11_ARTIFACT]
+    for path in required:
+        if not path.exists():
+            errors.append(f'missing required file: {path}')
+
+    if not errors:
+        errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
+        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
+        errors.extend(f'{DAY11_REPORT}: missing "{m}"' for m in _missing(DAY11_REPORT, REPORT_EXPECTED))
+        errors.extend(f'{DAY11_ARTIFACT}: missing "{m}"' for m in _missing(DAY11_ARTIFACT, ARTIFACT_EXPECTED))
+
+    if errors:
+        print('day11-docs-navigation-contract check failed:', file=sys.stderr)
+        for error in errors:
+            print(f' - {error}', file=sys.stderr)
+        return 1
+
+    print('day11-docs-navigation-contract check passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Sequence
 from importlib import metadata
 
-from . import apiget, contributor_funnel, demo, docs_qa, evidence, first_contribution, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, triage_templates, weekly_review
+from . import apiget, contributor_funnel, demo, docs_navigation, docs_qa, evidence, first_contribution, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, triage_templates, weekly_review
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
 from .security_gate import main as security_main
@@ -107,6 +107,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "weekly-review":
         return weekly_review.main(list(argv[1:]))
 
+    if argv and argv[0] == "docs-nav":
+        return docs_navigation.main(list(argv[1:]))
+
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -180,6 +183,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     wrv = sub.add_parser("weekly-review")
     wrv.add_argument("args", nargs=argparse.REMAINDER)
 
+    dnv = sub.add_parser("docs-nav")
+    dnv.add_argument("args", nargs=argparse.REMAINDER)
+
     ns = p.parse_args(argv)
 
     if ns.cmd == "kv":
@@ -241,6 +247,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "weekly-review":
         return weekly_review.main(ns.args)
+
+    if ns.cmd == "docs-nav":
+        return docs_navigation.main(ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)

--- a/src/sdetkit/docs_navigation.py
+++ b/src/sdetkit/docs_navigation.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+_QUICK_JUMP_START = '<div class="quick-jump" markdown>'
+_QUICK_JUMP_END = '</div>'
+
+_REQUIRED_LINKS = [
+    '[⚡ Fast start](#fast-start)',
+    '[🛠 CLI commands](cli.md)',
+    '[🩺 Doctor checks](doctor.md)',
+    '[🤝 Contribute](contributing.md)',
+    '[✅ Day 10 ultra report](day-10-ultra-upgrade-report.md)',
+    '[🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md)',
+]
+
+_DAY11_SECTION_HEADER = '## Day 11 ultra upgrades (docs navigation tune-up)'
+_DAY11_JOURNEYS_HEADER = '### Day 11 top journeys'
+
+_TOP_JOURNEYS = [
+    'Run first command in under 60 seconds',
+    'Validate docs links and anchors before publishing',
+    'Ship a first contribution with deterministic quality gates',
+]
+
+_DAY11_QUICK_JUMP_BLOCK = """<div class=\"quick-jump\" markdown>
+
+[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+
+</div>
+"""
+
+_DAY11_JOURNEYS_BLOCK = """### Day 11 top journeys
+
+- Run first command in under 60 seconds
+- Validate docs links and anchors before publishing
+- Ship a first contribution with deterministic quality gates
+"""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog='sdetkit docs-nav',
+        description='Render and validate Day 11 docs navigation one-click journeys from docs home.',
+    )
+    p.add_argument('--format', choices=['text', 'markdown', 'json'], default='text')
+    p.add_argument('--root', default='.', help='Repository root where docs/index.md lives.')
+    p.add_argument('--output', default='', help='Optional output file path.')
+    p.add_argument('--strict', action='store_true', help='Return non-zero when required docs navigation entries are missing.')
+    p.add_argument(
+        '--write-defaults',
+        action='store_true',
+        help='Repair Day 11 quick-jump + top-journey baseline content in docs/index.md, then validate again.',
+    )
+    return p
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        return ''
+    return path.read_text(encoding='utf-8')
+
+
+def _extract_quick_jump(text: str) -> str:
+    start = text.find(_QUICK_JUMP_START)
+    if start < 0:
+        return ''
+    end = text.find(_QUICK_JUMP_END, start)
+    if end < 0:
+        return ''
+    return text[start : end + len(_QUICK_JUMP_END)]
+
+
+def _replace_or_append_block(text: str, start_marker: str, end_marker: str, block: str) -> tuple[str, bool]:
+    start = text.find(start_marker)
+    end = text.find(end_marker, start) if start >= 0 else -1
+    if start >= 0 and end >= 0:
+        updated = text[:start] + block + text[end + len(end_marker) :]
+        return updated, updated != text
+    updated = text.rstrip() + ('\n\n' if text.strip() else '') + block
+    return updated, updated != text
+
+
+def _ensure_day11_section_header(text: str) -> tuple[str, bool]:
+    if _DAY11_SECTION_HEADER in text:
+        return text, False
+    updated = text.rstrip() + '\n\n' + _DAY11_SECTION_HEADER + '\n'
+    return updated, updated != text
+
+
+def _ensure_journey_block(text: str) -> tuple[str, bool]:
+    if _DAY11_JOURNEYS_HEADER in text and all(f'- {journey}' in text for journey in _TOP_JOURNEYS):
+        return text, False
+
+    updated = text.rstrip() + '\n\n' + _DAY11_JOURNEYS_BLOCK + '\n'
+    return updated, updated != text
+
+
+def _check_results(index_text: str) -> list[dict[str, object]]:
+    quick_jump = _extract_quick_jump(index_text)
+    checks: list[tuple[str, str, str]] = [
+        ('quick-jump-wrapper', _QUICK_JUMP_START, 'quick_jump'),
+        ('day11-upgrade-section', _DAY11_SECTION_HEADER, 'index'),
+        ('day11-top-journeys-header', _DAY11_JOURNEYS_HEADER, 'index'),
+    ]
+    checks.extend((f'quick-jump-link:{link}', link, 'quick_jump') for link in _REQUIRED_LINKS)
+    checks.extend((f'top-journey:{journey}', f'- {journey}', 'index') for journey in _TOP_JOURNEYS)
+
+    results: list[dict[str, object]] = []
+    for check_id, needle, scope in checks:
+        target = quick_jump if scope == 'quick_jump' else index_text
+        results.append(
+            {
+                'id': check_id,
+                'scope': scope,
+                'needle': needle,
+                'present': needle in target,
+            }
+        )
+    return results
+
+
+def _write_defaults(base: Path) -> list[str]:
+    path = base / 'docs/index.md'
+    current = _read(path)
+    if not current:
+        current = '# Documentation Home\n\n'
+
+    updated, changed_quick_jump = _replace_or_append_block(current, _QUICK_JUMP_START, _QUICK_JUMP_END, _DAY11_QUICK_JUMP_BLOCK)
+    updated, changed_section = _ensure_day11_section_header(updated)
+    updated, changed_journeys = _ensure_journey_block(updated)
+
+    if not (changed_quick_jump or changed_section or changed_journeys or not path.exists()):
+        return []
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(updated, encoding='utf-8')
+    return ['docs/index.md']
+
+
+def build_docs_navigation_status(root: str = '.') -> dict[str, object]:
+    base = Path(root)
+    docs_index = base / 'docs/index.md'
+    index_text = _read(docs_index)
+    checks = _check_results(index_text)
+    missing = [str(check['needle']) for check in checks if not check['present']]
+
+    total_checks = len(checks)
+    passed_checks = sum(1 for check in checks if check['present'])
+    score = round((passed_checks / total_checks) * 100, 1) if total_checks else 0.0
+
+    return {
+        'name': 'day11-docs-navigation',
+        'score': score,
+        'total_checks': total_checks,
+        'passed_checks': passed_checks,
+        'journeys': list(_TOP_JOURNEYS),
+        'required_links': list(_REQUIRED_LINKS),
+        'docs_index': str(docs_index),
+        'missing': missing,
+        'checks': checks,
+        'actions': {
+            'open_docs_home': 'docs/index.md',
+            'validate': 'sdetkit docs-nav --format json --strict',
+            'write_defaults': 'sdetkit docs-nav --write-defaults --format json --strict',
+            'artifact': 'sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md',
+        },
+    }
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [
+        'Day 11 docs navigation tune-up',
+        f"score: {payload['score']} ({payload['passed_checks']}/{payload['total_checks']})",
+        '',
+        'top journeys:',
+    ]
+    for idx, item in enumerate(payload['journeys'], start=1):
+        lines.append(f'{idx}. {item}')
+    lines.extend(['', 'required links:'])
+    for link in payload['required_links']:
+        lines.append(f'- {link}')
+    lines.extend(['', f"docs home: {payload['docs_index']}"])
+    if payload['missing']:
+        lines.append('missing docs navigation content:')
+        for item in payload['missing']:
+            lines.append(f'- {item}')
+    else:
+        lines.append('missing docs navigation content: none')
+    lines.extend(['', 'actions:'])
+    lines.append(f"- open docs home: {payload['actions']['open_docs_home']}")
+    lines.append(f"- validate: {payload['actions']['validate']}")
+    lines.append(f"- write defaults: {payload['actions']['write_defaults']}")
+    lines.append(f"- export artifact: {payload['actions']['artifact']}")
+    return '\n'.join(lines) + '\n'
+
+
+def _render_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        '# Day 11 docs navigation tune-up',
+        '',
+        f"- Score: **{payload['score']}** ({payload['passed_checks']}/{payload['total_checks']})",
+        f"- Docs home: `{payload['docs_index']}`",
+        '',
+        '## Top journeys',
+        '',
+    ]
+    for item in payload['journeys']:
+        lines.append(f'- [ ] {item}')
+    lines.extend(['', '## Required one-click links', ''])
+    for item in payload['required_links']:
+        lines.append(f'- `{item}`')
+    lines.extend(['', '## Missing docs navigation content', ''])
+    if payload['missing']:
+        for item in payload['missing']:
+            lines.append(f'- `{item}`')
+    else:
+        lines.append('- none')
+    lines.extend(['', '## Actions', ''])
+    lines.append(f"- `{payload['actions']['open_docs_home']}`")
+    lines.append(f"- `{payload['actions']['validate']}`")
+    lines.append(f"- `{payload['actions']['write_defaults']}`")
+    lines.append(f"- `{payload['actions']['artifact']}`")
+    return '\n'.join(lines) + '\n'
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+
+    touched: list[str] = []
+    if args.write_defaults:
+        touched = _write_defaults(Path(args.root))
+
+    payload = build_docs_navigation_status(args.root)
+    payload['touched_files'] = touched
+
+    if args.format == 'json':
+        rendered = json.dumps(payload, indent=2) + '\n'
+    elif args.format == 'markdown':
+        rendered = _render_markdown(payload)
+    else:
+        rendered = _render_text(payload)
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, encoding='utf-8')
+
+    print(rendered, end='')
+
+    if args.strict and payload['passed_checks'] != payload['total_checks']:
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_and_weekly_review_and_first_contribution_and_contributor_funnel_and_triage_templates() -> None:
+def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_weekly_review_first_contribution_contributor_funnel_triage_templates_and_docs_nav() -> None:
     r = subprocess.run(
         [sys.executable, "-m", "sdetkit", "--help"],
         text=True,
@@ -29,3 +29,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "first-contribution" in out
     assert "contributor-funnel" in out
     assert "triage-templates" in out
+    assert "docs-nav" in out

--- a/tests/test_docs_navigation.py
+++ b/tests/test_docs_navigation.py
@@ -1,0 +1,62 @@
+import json
+
+from sdetkit import cli, docs_navigation
+
+
+def test_docs_navigation_default_text(capsys):
+    rc = docs_navigation.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Day 11 docs navigation tune-up" in out
+    assert "top journeys:" in out
+
+
+def test_docs_navigation_json_and_strict_success(capsys):
+    rc = docs_navigation.main(["--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["name"] == "day11-docs-navigation"
+    assert data["passed_checks"] == data["total_checks"]
+    assert data["total_checks"] == 12
+    assert any(check["id"] == "day11-top-journeys-header" for check in data["checks"])
+
+
+def test_docs_navigation_strict_fails_when_content_missing(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/index.md").write_text("# Docs\n", encoding="utf-8")
+    rc = docs_navigation.main(["--root", str(tmp_path), "--strict"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "missing docs navigation content:" in out
+
+
+def test_docs_navigation_write_defaults_recovers_missing_quick_jump(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/index.md").write_text(
+        "## Day 11 ultra upgrades (docs navigation tune-up)\n\n<div class=\"quick-jump\" markdown>\nold\n</div>\n",
+        encoding="utf-8",
+    )
+    rc = docs_navigation.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["touched_files"] == ["docs/index.md"]
+    assert data["passed_checks"] == data["total_checks"]
+    repaired = (tmp_path / "docs/index.md").read_text(encoding="utf-8")
+    assert "[🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md)" in repaired
+    assert "### Day 11 top journeys" in repaired
+
+
+def test_docs_navigation_write_defaults_bootstraps_missing_docs_index(tmp_path, capsys):
+    rc = docs_navigation.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["touched_files"] == ["docs/index.md"]
+    assert data["passed_checks"] == data["total_checks"]
+    assert (tmp_path / "docs/index.md").exists()
+
+
+def test_main_cli_dispatches_docs_navigation(capsys):
+    rc = cli.main(["docs-nav", "--format", "text"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Day 11 docs navigation tune-up" in out


### PR DESCRIPTION
### Motivation

- Make Day 11 docs navigation validation deterministic by exposing explicit per-check results and scopes so strict mode reliably reports failures. 
- Provide a true recovery path that can repair the quick-jump block, restore Day 11 section and top-journeys, and bootstrap `docs/index.md` when missing. 
- Align tests, contract checker, artifacts, and docs with the strengthened 12-check baseline for Day 11 closeout.

### Description

- Reworked `src/sdetkit/docs_navigation.py` to emit scoped per-check results (`quick_jump` vs `index`), added a check inventory, and improved rendering (`text|markdown|json`).
- Expanded `--write-defaults` to repair/replace the quick-jump block, ensure the Day 11 section header, restore the Day 11 top-journeys block, and bootstrap `docs/index.md` when absent. 
- Wired the command into the CLI (`src/sdetkit/cli.py`) and added/updated Day 11 docs, the generated artifact (`docs/artifacts/day11-docs-navigation-sample.md`), the upgrade report, and the `scripts/check_day11_docs_navigation_contract.py` contract. 
- Strengthened tests in `tests/test_docs_navigation.py` and updated `tests/test_cli_help_lists_subcommands.py` to include `docs-nav` in help output.

### Testing

- Ran `python -m pytest -q tests/test_docs_navigation.py tests/test_cli_help_lists_subcommands.py`, which completed successfully (`7 passed`).
- Ran the Day 11 contract check `python scripts/check_day11_docs_navigation_contract.py`, which passed.
- Executed end-to-end validations: `python -m sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md` and `python -m sdetkit docs-nav --format json --strict`, both of which succeeded.

------