### PR TITLE
feat(day12): close out startup workflow with operating pack and CI guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,32 @@ python scripts/check_day11_docs_navigation_contract.py
 python -m sdetkit docs-nav --format json --strict
 ```
 
+## 🚀 Day 12 ultra: startup/small-team use-case page
+
+Day 12 ships a dedicated startup/small-team workflow landing page with a runnable 10-minute path, weekly operating rhythm, and quality guardrails.
+
+```bash
+python -m sdetkit startup-use-case --format text --strict
+python -m sdetkit startup-use-case --write-defaults --format json --strict
+python -m sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict
+```
+
+Export a markdown artifact for adoption handoff:
+
+```bash
+python -m sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md
+```
+
+See implementation details: [Day 12 ultra upgrade report](docs/day-12-ultra-upgrade-report.md).
+
+Day 12 closeout checks:
+
+```bash
+python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day12_startup_use_case_contract.py
+python -m sdetkit startup-use-case --format json --strict
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day12-startup-pack/startup-day12-checklist.md
+++ b/docs/artifacts/day12-startup-pack/startup-day12-checklist.md
@@ -1,0 +1,6 @@
+# Day 12 startup operating checklist
+
+- [ ] Validate landing page contract in strict mode.
+- [ ] Regenerate startup artifact markdown for handoff.
+- [ ] Run startup fast-lane tests for command integrity.
+- [ ] Publish weekly startup report evidence.

--- a/docs/artifacts/day12-startup-pack/startup-day12-ci.yml
+++ b/docs/artifacts/day12-startup-pack/startup-day12-ci.yml
@@ -1,0 +1,16 @@
+name: startup-quality-fast-lane
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  startup-fast-lane:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m sdetkit startup-use-case --format json --strict
+      - run: python scripts/check_day12_startup_use_case_contract.py

--- a/docs/artifacts/day12-startup-pack/startup-day12-risk-register.md
+++ b/docs/artifacts/day12-startup-pack/startup-day12-risk-register.md
@@ -1,0 +1,7 @@
+# Day 12 startup risk register
+
+| Risk | Trigger | Mitigation |
+| --- | --- | --- |
+| Docs drift | Required sections are removed | Run `startup-use-case --strict` in CI |
+| Broken command examples | CLI flags change | Keep Day 12 tests in startup fast-lane |
+| Missing artifacts | Report generation skipped | Require artifact publish in weekly cadence |

--- a/docs/artifacts/day12-startup-use-case-sample.md
+++ b/docs/artifacts/day12-startup-use-case-sample.md
@@ -1,0 +1,42 @@
+# Day 12 startup use-case page
+
+- Score: **100.0** (14/14)
+- Page: `docs/use-cases-startup-small-team.md`
+
+## Required sections
+
+- `## Who this is for`
+- `## 10-minute startup path`
+- `## Weekly operating rhythm`
+- `## Guardrails that prevent regressions`
+- `## CI fast-lane recipe`
+- `## KPI snapshot for lean teams`
+- `## Exit criteria to graduate to enterprise workflow`
+
+## Required commands
+
+```bash
+python -m sdetkit doctor --format text
+python -m sdetkit repo audit --json
+python -m sdetkit security --strict
+python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py
+python -m sdetkit report --out reports/startup-weekly.json
+```
+
+## Emitted pack files
+
+- `docs/artifacts/day12-startup-pack/startup-day12-checklist.md`
+- `docs/artifacts/day12-startup-pack/startup-day12-ci.yml`
+- `docs/artifacts/day12-startup-pack/startup-day12-risk-register.md`
+
+## Missing use-case content
+
+- none
+
+## Actions
+
+- `docs/use-cases-startup-small-team.md`
+- `sdetkit startup-use-case --format json --strict`
+- `sdetkit startup-use-case --write-defaults --format json --strict`
+- `sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md`
+- `sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -139,7 +139,7 @@ Examples:
 - `sdetkit triage-templates --write-defaults --format json --strict`
 - `sdetkit triage-templates --format markdown --output docs/artifacts/day9-triage-templates-sample.md`
 
-Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`.
+Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`, `--emit-pack-dir`.
 
 `--strict` returns non-zero if required Day 9 triage checks are missing from bug/feature/PR templates or `.github/ISSUE_TEMPLATE/config.yml`.
 
@@ -158,7 +158,7 @@ Examples:
 - `sdetkit first-contribution --write-defaults --format json --strict`
 - `sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md`
 
-Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`.
+Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`, `--emit-pack-dir`.
 
 `--strict` returns non-zero if required Day 10 checklist content or required command snippets are missing from `CONTRIBUTING.md`.
 
@@ -177,13 +177,35 @@ Examples:
 - `sdetkit docs-nav --write-defaults --format json --strict`
 - `sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md`
 
-Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`.
+Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`, `--emit-pack-dir`.
 
 `--strict` returns non-zero if required Day 11 journey links/content are missing from `docs/index.md`.
 
 `--write-defaults` repairs the quick-jump nav block, restores the Day 11 top-journey section when missing, and then validates again.
 
 See: day-11-ultra-upgrade-report.md
+
+## startup-use-case
+
+Builds Day 12 startup/small-team landing-page status and validates required workflow sections and runnable command sequence.
+
+Examples:
+
+- `sdetkit startup-use-case --format text --strict`
+- `sdetkit startup-use-case --format json`
+- `sdetkit startup-use-case --write-defaults --format json --strict`
+- `sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md`
+- `sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict`
+
+Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`, `--emit-pack-dir`.
+
+`--strict` returns non-zero if required Day 12 use-case sections or command snippets are missing from `docs/use-cases-startup-small-team.md`.
+
+`--write-defaults` writes a hardened Day 12 startup workflow page if missing/incomplete, then validates again.
+
+`--emit-pack-dir` writes a startup operating-pack bundle containing checklist, CI fast-lane recipe, and risk register files.
+
+See: day-12-ultra-upgrade-report.md
 
 ## patch
 

--- a/docs/day-12-ultra-upgrade-report.md
+++ b/docs/day-12-ultra-upgrade-report.md
@@ -1,0 +1,65 @@
+# Day 12 Ultra Upgrade Report — Startup/Small-Team Use-Case Page
+
+## Snapshot
+
+**Day 12 big upgrade: upgraded the startup/small-team landing page with CI fast-lane and operating-pack generation (checklist + CI recipe + risk register) plus strict validation + recovery commands.**
+
+## Problem statement
+
+Startups and small teams need a focused workflow page that converts repository capabilities into a fast operating path, and they need enforceable guardrails that keep docs and commands from drifting.
+
+## What shipped
+
+### Product code
+
+- `src/sdetkit/startup_use_case.py`
+  - Added stricter Day 12 validation for expanded workflow sections, CI fast-lane snippet, and runnable command sequence.
+  - Added `--emit-pack-dir` to generate a startup operating pack:
+    - `startup-day12-checklist.md`
+    - `startup-day12-ci.yml`
+    - `startup-day12-risk-register.md`
+  - Kept `--write-defaults` recovery path and multi-format rendering (text/markdown/json).
+- `src/sdetkit/cli.py`
+  - Preserved top-level command wiring for `python -m sdetkit startup-use-case ...`.
+
+### Docs surface
+
+- `docs/use-cases-startup-small-team.md`
+  - Expanded startup path with Day 12 fast-lane test command and CI fast-lane recipe section.
+- `docs/index.md`
+  - Added Day 12 operating-pack command in the docs-home Day 12 section.
+- `docs/cli.md`
+  - Added `--emit-pack-dir` usage + examples.
+- `README.md`
+  - Added Day 12 operating-pack command in the execution block.
+
+### Tests and checks
+
+- `tests/test_startup_use_case.py`
+  - Added coverage for pack emission and updated strict check count assertions.
+- `scripts/check_day12_startup_use_case_contract.py`
+  - Hardened Day 12 contract checks for pack generation, CI snippet coverage, and docs wiring.
+
+## Validation checklist
+
+- `python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py`
+- `python -m sdetkit startup-use-case --format json --strict`
+- `python -m sdetkit startup-use-case --write-defaults --format json --strict`
+- `python -m sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict`
+- `python -m sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md`
+- `python scripts/check_day12_startup_use_case_contract.py`
+
+## Artifacts
+
+- `docs/artifacts/day12-startup-use-case-sample.md`
+- `docs/artifacts/day12-startup-pack/startup-day12-checklist.md`
+- `docs/artifacts/day12-startup-pack/startup-day12-ci.yml`
+- `docs/artifacts/day12-startup-pack/startup-day12-risk-register.md`
+
+## Rollback plan
+
+1. Revert `src/sdetkit/startup_use_case.py` enhancements if Day 12 operating-pack output is no longer required.
+2. Revert Day 12 docs updates in `README.md`, `docs/index.md`, `docs/cli.md`, and `docs/use-cases-startup-small-team.md`.
+3. Remove Day 12 pack artifacts + contract checks if rolling back this feature.
+
+This document is the Day 12 closeout report for startup/small-team workflow hardening.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧪 Day 12 ultra report](day-12-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
 
 </div>
 
@@ -150,6 +150,16 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 - Run first command in under 60 seconds
 - Validate docs links and anchors before publishing
 - Ship a first contribution with deterministic quality gates
+
+## Day 12 ultra upgrades (startup/small-team use-case page)
+
+- Read the implementation report: [Day 12 ultra upgrade report](day-12-ultra-upgrade-report.md).
+- Open the landing page: [startup + small-team workflow](use-cases-startup-small-team.md).
+- Run `sdetkit startup-use-case --format text --strict` to validate required sections and command sequence.
+- Auto-recover missing/incomplete landing-page content: `sdetkit startup-use-case --write-defaults --format json --strict`.
+- Export markdown use-case artifact: `sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md`.
+- Emit startup operating pack (checklist + CI + risk register): `sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict`.
+- Review the generated artifact: [day12 startup use-case sample](artifacts/day12-startup-use-case-sample.md).
 
 ## Fast start
 

--- a/docs/use-cases-startup-small-team.md
+++ b/docs/use-cases-startup-small-team.md
@@ -1,0 +1,73 @@
+# Startup + small-team workflow
+
+A practical landing page for lean engineering teams that need reliable quality gates without heavy process overhead.
+
+## Who this is for
+
+- Teams with 2-20 engineers shipping quickly.
+- Founders or EMs who need confidence before each release.
+- QA/SDET owners establishing a repeatable baseline in one sprint.
+
+## 10-minute startup path
+
+Use this sequence to move from clone to reliable checks quickly:
+
+```bash
+python -m sdetkit doctor --format text
+python -m sdetkit repo audit --json
+python -m sdetkit security --strict
+python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py
+python -m sdetkit report --out reports/startup-weekly.json
+```
+
+## Weekly operating rhythm
+
+1. Run `doctor` and `repo audit` at sprint start to catch drift early.
+2. Run `security --strict` before release candidate tagging.
+3. Publish `report` artifacts to preserve a quality trail.
+
+## Guardrails that prevent regressions
+
+- **Deterministic checks:** lock expected commands in CI and pre-merge workflows.
+- **Single source of evidence:** save generated report artifacts under `reports/`.
+- **Fast rollback:** revert to last known-good baseline when score drops.
+
+## CI fast-lane recipe
+
+Use this minimal workflow to enforce the Day 12 page contract in PRs:
+
+```yaml
+name: startup-quality-fast-lane
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  startup-fast-lane:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m sdetkit startup-use-case --format json --strict
+      - run: python scripts/check_day12_startup_use_case_contract.py
+```
+
+## KPI snapshot for lean teams
+
+Track these signals every week:
+
+- Mean time from PR open to merge.
+- Failed quality gates per sprint.
+- Security findings closed within SLA.
+- New contributor first-PR success rate.
+
+## Exit criteria to graduate to enterprise workflow
+
+Move to the enterprise/regulated path once you need:
+
+- Separation of duties and approval workflows.
+- Extended audit retention and compliance mapping.
+- Multi-repository governance at org level.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - Omnichannel + MCP bridge: omnichannel-mcp-bridge.md
       - Automation templates engine: automation-templates-engine.md
       - CI Contract: ci-contract.md
+      - Startup + small-team workflow: use-cases-startup-small-team.md
   - Integrations:
       - GitHub Action: github-action.md
       - n8n integration: n8n.md

--- a/scripts/check_day12_startup_use_case_contract.py
+++ b/scripts/check_day12_startup_use_case_contract.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+README = Path('README.md')
+DOCS_INDEX = Path('docs/index.md')
+DOCS_CLI = Path('docs/cli.md')
+USE_CASE_PAGE = Path('docs/use-cases-startup-small-team.md')
+DAY12_REPORT = Path('docs/day-12-ultra-upgrade-report.md')
+DAY12_ARTIFACT = Path('docs/artifacts/day12-startup-use-case-sample.md')
+DAY12_PACK_CI = Path('docs/artifacts/day12-startup-pack/startup-day12-ci.yml')
+
+README_EXPECTED = [
+    '## 🚀 Day 12 ultra: startup/small-team use-case page',
+    'python -m sdetkit startup-use-case --format text --strict',
+    'python -m sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
+    'python scripts/check_day12_startup_use_case_contract.py',
+    'docs/day-12-ultra-upgrade-report.md',
+]
+
+DOCS_INDEX_EXPECTED = [
+    '## Day 12 ultra upgrades (startup/small-team use-case page)',
+    'startup + small-team workflow',
+    'sdetkit startup-use-case --format text --strict',
+    'sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
+    'artifacts/day12-startup-use-case-sample.md',
+]
+
+DOCS_CLI_EXPECTED = [
+    '## startup-use-case',
+    'sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md',
+    'sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
+    '--write-defaults',
+]
+
+USE_CASE_EXPECTED = [
+    '# Startup + small-team workflow',
+    '## 10-minute startup path',
+    'python -m sdetkit doctor --format text',
+    'python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py',
+    '## CI fast-lane recipe',
+    'name: startup-quality-fast-lane',
+    '## Exit criteria to graduate to enterprise workflow',
+]
+
+REPORT_EXPECTED = [
+    'Day 12 big upgrade',
+    'python -m sdetkit startup-use-case --format json --strict',
+    'python -m sdetkit startup-use-case --write-defaults --format json --strict',
+    'python -m sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
+    'scripts/check_day12_startup_use_case_contract.py',
+]
+
+ARTIFACT_EXPECTED = [
+    '# Day 12 startup use-case page',
+    '- Score: **100.0** (14/14)',
+    'sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
+]
+
+PACK_CI_EXPECTED = [
+    'name: startup-quality-fast-lane',
+    'python -m sdetkit startup-use-case --format json --strict',
+]
+
+
+def _missing(path: Path, expected: list[str]) -> list[str]:
+    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    return [item for item in expected if item not in text]
+
+
+def main() -> int:
+    errors: list[str] = []
+    required = [README, DOCS_INDEX, DOCS_CLI, USE_CASE_PAGE, DAY12_REPORT, DAY12_ARTIFACT, DAY12_PACK_CI]
+    for path in required:
+        if not path.exists():
+            errors.append(f'missing required file: {path}')
+
+    if not errors:
+        errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
+        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
+        errors.extend(f'{USE_CASE_PAGE}: missing "{m}"' for m in _missing(USE_CASE_PAGE, USE_CASE_EXPECTED))
+        errors.extend(f'{DAY12_REPORT}: missing "{m}"' for m in _missing(DAY12_REPORT, REPORT_EXPECTED))
+        errors.extend(f'{DAY12_ARTIFACT}: missing "{m}"' for m in _missing(DAY12_ARTIFACT, ARTIFACT_EXPECTED))
+        errors.extend(f'{DAY12_PACK_CI}: missing "{m}"' for m in _missing(DAY12_PACK_CI, PACK_CI_EXPECTED))
+
+    if errors:
+        print('day12-startup-use-case-contract check failed:', file=sys.stderr)
+        for error in errors:
+            print(f' - {error}', file=sys.stderr)
+        return 1
+
+    print('day12-startup-use-case-contract check passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Sequence
 from importlib import metadata
 
-from . import apiget, contributor_funnel, demo, docs_navigation, docs_qa, evidence, first_contribution, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, triage_templates, weekly_review
+from . import apiget, contributor_funnel, demo, docs_navigation, docs_qa, evidence, first_contribution, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, startup_use_case, triage_templates, weekly_review
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
 from .security_gate import main as security_main
@@ -110,6 +110,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "docs-nav":
         return docs_navigation.main(list(argv[1:]))
 
+    if argv and argv[0] == "startup-use-case":
+        return startup_use_case.main(list(argv[1:]))
+
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -186,6 +189,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     dnv = sub.add_parser("docs-nav")
     dnv.add_argument("args", nargs=argparse.REMAINDER)
 
+    suc = sub.add_parser("startup-use-case")
+    suc.add_argument("args", nargs=argparse.REMAINDER)
+
     ns = p.parse_args(argv)
 
     if ns.cmd == "kv":
@@ -250,6 +256,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "docs-nav":
         return docs_navigation.main(ns.args)
+
+    if ns.cmd == "startup-use-case":
+        return startup_use_case.main(ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)

--- a/src/sdetkit/startup_use_case.py
+++ b/src/sdetkit/startup_use_case.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+_PAGE_PATH = "docs/use-cases-startup-small-team.md"
+
+_SECTION_HEADER = "# Startup + small-team workflow"
+_REQUIRED_SECTIONS = [
+    "## Who this is for",
+    "## 10-minute startup path",
+    "## Weekly operating rhythm",
+    "## Guardrails that prevent regressions",
+    "## CI fast-lane recipe",
+    "## KPI snapshot for lean teams",
+    "## Exit criteria to graduate to enterprise workflow",
+]
+
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit doctor --format text",
+    "python -m sdetkit repo audit --json",
+    "python -m sdetkit security --strict",
+    "python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py",
+    "python -m sdetkit report --out reports/startup-weekly.json",
+]
+
+_CI_FAST_LANE = """name: startup-quality-fast-lane
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  startup-fast-lane:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m sdetkit startup-use-case --format json --strict
+      - run: python scripts/check_day12_startup_use_case_contract.py
+"""
+
+_DAY12_DEFAULT_PAGE = f"""# Startup + small-team workflow
+
+A practical landing page for lean engineering teams that need reliable quality gates without heavy process overhead.
+
+## Who this is for
+
+- Teams with 2-20 engineers shipping quickly.
+- Founders or EMs who need confidence before each release.
+- QA/SDET owners establishing a repeatable baseline in one sprint.
+
+## 10-minute startup path
+
+Use this sequence to move from clone to reliable checks quickly:
+
+```bash
+python -m sdetkit doctor --format text
+python -m sdetkit repo audit --json
+python -m sdetkit security --strict
+python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py
+python -m sdetkit report --out reports/startup-weekly.json
+```
+
+## Weekly operating rhythm
+
+1. Run `doctor` and `repo audit` at sprint start to catch drift early.
+2. Run `security --strict` before release candidate tagging.
+3. Publish `report` artifacts to preserve a quality trail.
+
+## Guardrails that prevent regressions
+
+- **Deterministic checks:** lock expected commands in CI and pre-merge workflows.
+- **Single source of evidence:** save generated report artifacts under `reports/`.
+- **Fast rollback:** revert to last known-good baseline when score drops.
+
+## CI fast-lane recipe
+
+Use this minimal workflow to enforce the Day 12 page contract in PRs:
+
+```yaml
+{_CI_FAST_LANE.rstrip()}
+```
+
+## KPI snapshot for lean teams
+
+Track these signals every week:
+
+- Mean time from PR open to merge.
+- Failed quality gates per sprint.
+- Security findings closed within SLA.
+- New contributor first-PR success rate.
+
+## Exit criteria to graduate to enterprise workflow
+
+Move to the enterprise/regulated path once you need:
+
+- Separation of duties and approval workflows.
+- Extended audit retention and compliance mapping.
+- Multi-repository governance at org level.
+"""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit startup-use-case",
+        description="Render and validate the Day 12 startup/small-team use-case landing page.",
+    )
+    parser.add_argument("--format", choices=["text", "markdown", "json"], default="text")
+    parser.add_argument("--root", default=".", help="Repository root where docs live.")
+    parser.add_argument("--output", default="", help="Optional output file path.")
+    parser.add_argument("--strict", action="store_true", help="Return non-zero when required use-case content is missing.")
+    parser.add_argument(
+        "--write-defaults",
+        action="store_true",
+        help="Write or repair the Day 12 startup use-case page before validation.",
+    )
+    parser.add_argument(
+        "--emit-pack-dir",
+        default="",
+        help="Optional path to emit a Day 12 startup operating pack (checklist, CI recipe, risk register).",
+    )
+    return parser
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _missing_checks(page_text: str) -> list[str]:
+    checks = [_SECTION_HEADER, *_REQUIRED_SECTIONS, *_REQUIRED_COMMANDS, "name: startup-quality-fast-lane"]
+    return [item for item in checks if item not in page_text]
+
+
+def _write_defaults(base: Path) -> list[str]:
+    page = base / _PAGE_PATH
+    current = _read(page)
+
+    if current and not _missing_checks(current):
+        return []
+
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(_DAY12_DEFAULT_PAGE, encoding="utf-8")
+    return [_PAGE_PATH]
+
+
+def _emit_pack(base: Path, out_dir: str) -> list[str]:
+    root = base / out_dir
+    root.mkdir(parents=True, exist_ok=True)
+
+    checklist = root / "startup-day12-checklist.md"
+    checklist.write_text(
+        "\n".join(
+            [
+                "# Day 12 startup operating checklist",
+                "",
+                "- [ ] Validate landing page contract in strict mode.",
+                "- [ ] Regenerate startup artifact markdown for handoff.",
+                "- [ ] Run startup fast-lane tests for command integrity.",
+                "- [ ] Publish weekly startup report evidence.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    ci_recipe = root / "startup-day12-ci.yml"
+    ci_recipe.write_text(_CI_FAST_LANE, encoding="utf-8")
+
+    risk_register = root / "startup-day12-risk-register.md"
+    risk_register.write_text(
+        "\n".join(
+            [
+                "# Day 12 startup risk register",
+                "",
+                "| Risk | Trigger | Mitigation |",
+                "| --- | --- | --- |",
+                "| Docs drift | Required sections are removed | Run `startup-use-case --strict` in CI |",
+                "| Broken command examples | CLI flags change | Keep Day 12 tests in startup fast-lane |",
+                "| Missing artifacts | Report generation skipped | Require artifact publish in weekly cadence |",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return [str(path.relative_to(base)) for path in [checklist, ci_recipe, risk_register]]
+
+
+def build_startup_use_case_status(root: str = ".") -> dict[str, object]:
+    base = Path(root)
+    page = base / _PAGE_PATH
+    page_text = _read(page)
+    missing = _missing_checks(page_text)
+
+    total_checks = len([_SECTION_HEADER, *_REQUIRED_SECTIONS, *_REQUIRED_COMMANDS, "name: startup-quality-fast-lane"])
+    passed_checks = total_checks - len(missing)
+    score = round((passed_checks / total_checks) * 100, 1) if total_checks else 0.0
+
+    return {
+        "name": "day12-startup-use-case",
+        "score": score,
+        "total_checks": total_checks,
+        "passed_checks": passed_checks,
+        "page": str(page),
+        "required_sections": list(_REQUIRED_SECTIONS),
+        "required_commands": list(_REQUIRED_COMMANDS),
+        "missing": missing,
+        "actions": {
+            "open_page": _PAGE_PATH,
+            "validate": "sdetkit startup-use-case --format json --strict",
+            "write_defaults": "sdetkit startup-use-case --write-defaults --format json --strict",
+            "artifact": "sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md",
+            "emit_pack": "sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict",
+        },
+    }
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [
+        "Day 12 startup use-case page",
+        f"score: {payload['score']} ({payload['passed_checks']}/{payload['total_checks']})",
+        "",
+        f"page: {payload['page']}",
+        "",
+        "required sections:",
+    ]
+    for idx, item in enumerate(payload["required_sections"], start=1):
+        lines.append(f"{idx}. {item}")
+    lines.extend(["", "required commands:"])
+    for cmd in payload["required_commands"]:
+        lines.append(f"- {cmd}")
+    if payload.get("pack_files"):
+        lines.extend(["", "emitted pack files:"])
+        for item in payload["pack_files"]:
+            lines.append(f"- {item}")
+    if payload["missing"]:
+        lines.append("")
+        lines.append("missing use-case content:")
+        for item in payload["missing"]:
+            lines.append(f"- {item}")
+    else:
+        lines.extend(["", "missing use-case content: none"])
+    return "\n".join(lines) + "\n"
+
+
+def _render_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# Day 12 startup use-case page",
+        "",
+        f"- Score: **{payload['score']}** ({payload['passed_checks']}/{payload['total_checks']})",
+        f"- Page: `{payload['page']}`",
+        "",
+        "## Required sections",
+        "",
+    ]
+    for item in payload["required_sections"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Required commands", "", "```bash"])
+    lines.extend(payload["required_commands"])
+    lines.extend(["```"])
+    if payload.get("pack_files"):
+        lines.extend(["", "## Emitted pack files", ""])
+        for item in payload["pack_files"]:
+            lines.append(f"- `{item}`")
+    lines.extend(["", "## Missing use-case content", ""])
+    if payload["missing"]:
+        for item in payload["missing"]:
+            lines.append(f"- `{item}`")
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Actions", ""])
+    lines.append(f"- `{payload['actions']['open_page']}`")
+    lines.append(f"- `{payload['actions']['validate']}`")
+    lines.append(f"- `{payload['actions']['write_defaults']}`")
+    lines.append(f"- `{payload['actions']['artifact']}`")
+    lines.append(f"- `{payload['actions']['emit_pack']}`")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+
+    touched: list[str] = []
+    if args.write_defaults:
+        touched = _write_defaults(Path(args.root))
+
+    payload = build_startup_use_case_status(args.root)
+    payload["touched_files"] = touched
+
+    if args.emit_pack_dir:
+        payload["pack_files"] = _emit_pack(Path(args.root), args.emit_pack_dir)
+
+    if args.format == "json":
+        rendered = json.dumps(payload, indent=2) + "\n"
+    elif args.format == "markdown":
+        rendered = _render_markdown(payload)
+    else:
+        rendered = _render_text(payload)
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, encoding="utf-8")
+
+    print(rendered, end="")
+
+    if args.strict and payload["passed_checks"] != payload["total_checks"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_weekly_review_first_contribution_contributor_funnel_triage_templates_and_docs_nav() -> None:
+def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_weekly_review_first_contribution_contributor_funnel_triage_templates_and_docs_nav_and_startup_use_case() -> None:
     r = subprocess.run(
         [sys.executable, "-m", "sdetkit", "--help"],
         text=True,
@@ -30,3 +30,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "contributor-funnel" in out
     assert "triage-templates" in out
     assert "docs-nav" in out
+    assert "startup-use-case" in out

--- a/tests/test_startup_use_case.py
+++ b/tests/test_startup_use_case.py
@@ -1,0 +1,66 @@
+import json
+
+from sdetkit import cli, startup_use_case
+
+
+def test_startup_use_case_default_text(capsys):
+    rc = startup_use_case.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Day 12 startup use-case page" in out
+    assert "required sections:" in out
+
+
+def test_startup_use_case_json_and_strict_success(capsys):
+    rc = startup_use_case.main(["--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["name"] == "day12-startup-use-case"
+    assert data["passed_checks"] == data["total_checks"]
+    assert data["total_checks"] == 14
+
+
+def test_startup_use_case_strict_fails_when_content_missing(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/use-cases-startup-small-team.md").write_text("# Placeholder\n", encoding="utf-8")
+    rc = startup_use_case.main(["--root", str(tmp_path), "--strict"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "missing use-case content:" in out
+
+
+def test_startup_use_case_write_defaults_recovers_missing_file(tmp_path, capsys):
+    rc = startup_use_case.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["passed_checks"] == data["total_checks"]
+    assert data["touched_files"] == ["docs/use-cases-startup-small-team.md"]
+    assert (tmp_path / "docs/use-cases-startup-small-team.md").exists()
+
+
+def test_startup_use_case_emit_pack(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/use-cases-startup-small-team.md").write_text("# Startup + small-team workflow\n", encoding="utf-8")
+    rc = startup_use_case.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--write-defaults",
+            "--emit-pack-dir",
+            "docs/artifacts/day12-startup-pack",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert len(data["pack_files"]) == 3
+    assert "docs/artifacts/day12-startup-pack/startup-day12-ci.yml" in data["pack_files"]
+
+
+def test_main_cli_dispatches_startup_use_case(capsys):
+    rc = cli.main(["startup-use-case", "--format", "text"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Day 12 startup use-case page" in out


### PR DESCRIPTION
### Motivation

- Close out Day 12 by providing a focused, runnable startup/small-team landing page and enforceable guardrails so docs and commands can’t drift. 
- Ensure Day 12 is CI-ready by adding a minimal PR fast-lane and an emit-able operating pack for repeatable handoff. 
- Provide recovery and validation paths so the landing page remains production-ready and exportable as an artifact.

### Description

- Added `src/sdetkit/startup_use_case.py` which validates the Day 12 landing page, supports `--write-defaults`, `--emit-pack-dir`, and renders text/markdown/json status. 
- Wired the command into the dispatcher in `src/sdetkit/cli.py` and extended CLI docs and examples in `docs/cli.md`, `README.md`, and `docs/index.md`. 
- Added contract checker `scripts/check_day12_startup_use_case_contract.py`, Day 12 docs `docs/use-cases-startup-small-team.md`, closeout report `docs/day-12-ultra-upgrade-report.md`, and MkDocs nav entry. 
- Added tests `tests/test_startup_use_case.py` and updated `tests/test_cli_help_lists_subcommands.py`, and generated artifacts and an operating pack under `docs/artifacts/day12-startup-pack/` (`checklist`, `CI yaml`, `risk register`).

### Testing

- Ran unit tests: `python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py` — all tests passed (`7 passed`).
- Ran the Day 12 contract checker: `python scripts/check_day12_startup_use_case_contract.py` — check passed. 
- Exercised CLI and artifact flows: `python -m sdetkit startup-use-case --format json --strict` and `python -m sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format markdown --output docs/artifacts/day12-startup-use-case-sample.md --strict` — commands succeeded and artifacts were generated under `docs/artifacts/day12-startup-pack/`.

------
