### PR TITLE
Day 14 closeout hardening: growth signals, strict gates, and operating pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,36 @@ python -m sdetkit enterprise-use-case --format json --strict
 python -m sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict
 ```
 
+## 📈 Day 14 ultra: weekly review #2
+
+Day 14 closes week two with deterministic reporting for Day 8-13 shipment status, KPI movement, growth signals (traffic/stars/discussions), and blocker-fix closeout tracking.
+
+```bash
+python -m sdetkit weekly-review --week 2 --format text --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json
+```
+
+Export a markdown artifact for stakeholder handoff:
+
+```bash
+python -m sdetkit weekly-review --week 2 --format markdown --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --output docs/artifacts/day14-weekly-review-sample.md
+```
+
+Emit a Day 14 closeout pack (checklist, KPI scorecard, blocker action plan):
+
+```bash
+python -m sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --format json --strict
+```
+
+See implementation details: [Day 14 ultra upgrade report](docs/day-14-ultra-upgrade-report.md).
+
+Day 14 closeout checks:
+
+```bash
+python -m pytest -q tests/test_weekly_review.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day14_weekly_review_contract.py
+python -m sdetkit weekly-review --week 2 --format json --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --strict
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day14-growth-signals.json
+++ b/docs/artifacts/day14-growth-signals.json
@@ -1,0 +1,6 @@
+{
+  "traffic": 1800,
+  "stars": 90,
+  "discussions": 24,
+  "blocker_fixes": 7
+}

--- a/docs/artifacts/day14-weekly-pack/day14-blocker-action-plan.md
+++ b/docs/artifacts/day14-weekly-pack/day14-blocker-action-plan.md
@@ -1,0 +1,7 @@
+# Day 14 blocker action plan
+
+| Blocker | Owner | Target date | Mitigation |
+| --- | --- | --- | --- |
+| Missing contributor responses | Maintainer on-call | +2 days | tighten template auto-labeling and triage SLA reminders |
+| Slow docs feedback turnaround | Docs owner | +3 days | schedule twice-weekly docs office-hours review |
+| CI flake investigation backlog | QE lead | +5 days | split flaky jobs, add retry visibility and quarantine workflow |

--- a/docs/artifacts/day14-weekly-pack/day14-closeout-checklist.md
+++ b/docs/artifacts/day14-weekly-pack/day14-closeout-checklist.md
@@ -1,0 +1,6 @@
+# Day 14 closeout checklist
+
+- [ ] Run `sdetkit weekly-review --week 2 --format text` and verify all Day 8-13 items are shipped.
+- [ ] Refresh markdown artifact and attach it to the status update.
+- [ ] Update growth signals JSON (traffic, stars, discussions, blocker_fixes).
+- [ ] Review blocker-fix owners and confirm SLA commitments for next sprint.

--- a/docs/artifacts/day14-weekly-pack/day14-kpi-scorecard.json
+++ b/docs/artifacts/day14-weekly-pack/day14-kpi-scorecard.json
@@ -1,0 +1,22 @@
+{
+  "week": 2,
+  "kpis": {
+    "days_completed": 6,
+    "days_planned": 6,
+    "completion_rate_percent": 100,
+    "runnable_commands": 6,
+    "artifact_coverage": 6
+  },
+  "growth_signals": {
+    "traffic": 1800,
+    "stars": 90,
+    "discussions": 24,
+    "blocker_fixes": 7
+  },
+  "growth_deltas": {
+    "traffic": 600,
+    "stars": 13,
+    "discussions": 6,
+    "blocker_fixes": 2
+  }
+}

--- a/docs/artifacts/day14-weekly-review-sample.md
+++ b/docs/artifacts/day14-weekly-review-sample.md
@@ -1,0 +1,38 @@
+# Day 14 Weekly Review #2
+
+## What shipped (Day 8-13)
+
+| Day | Upgrade | Report | Artifact | Status |
+| --- | --- | --- | --- | --- |
+| 8 | Good-first-issue accelerator pack | `docs/day-8-ultra-upgrade-report.md` | `docs/artifacts/day8-good-first-issues-sample.md` | shipped ✅ |
+| 9 | Triage-ready issue + PR templates | `docs/day-9-ultra-upgrade-report.md` | `docs/artifacts/day9-triage-templates-sample.md` | shipped ✅ |
+| 10 | First-contribution checklist | `docs/day-10-ultra-upgrade-report.md` | `docs/artifacts/day10-first-contribution-checklist-sample.md` | shipped ✅ |
+| 11 | Docs navigation tune-up | `docs/day-11-ultra-upgrade-report.md` | `docs/artifacts/day11-docs-navigation-sample.md` | shipped ✅ |
+| 12 | Startup/small-team workflow | `docs/day-12-ultra-upgrade-report.md` | `docs/artifacts/day12-startup-use-case-sample.md` | shipped ✅ |
+| 13 | Enterprise/regulated workflow | `docs/day-13-ultra-upgrade-report.md` | `docs/artifacts/day13-enterprise-use-case-sample.md` | shipped ✅ |
+
+## KPI movement
+
+- Completion rate: **6/6 (100%)**
+- Runnable command paths delivered: **6**
+- Artifact coverage: **6/6**
+
+## Week-two growth signals
+
+- Traffic: **1800**
+- Stars: **90**
+- Discussions: **24**
+- Blocker fixes: **7**
+
+## Week-over-week deltas
+
+- Traffic: **+600**
+- Stars: **+13**
+- Discussions: **+6**
+- Blocker fixes: **+2**
+
+## Next-week focus
+
+- Day 15: refine multi-channel distribution loop for documentation and demos.
+- Day 16: publish adoption-ready workflow templates with copy/paste CI variants.
+- Day 17: capture week-over-week quality + contribution deltas in one evidence pack.

--- a/docs/artifacts/day7-growth-signals.json
+++ b/docs/artifacts/day7-growth-signals.json
@@ -1,0 +1,6 @@
+{
+  "traffic": 1200,
+  "stars": 77,
+  "discussions": 18,
+  "blocker_fixes": 5
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,7 +90,7 @@ Examples:
 - `sdetkit docs-qa --format json`
 - `sdetkit docs-qa --format markdown --output docs/artifacts/day6-conversion-qa-sample.md`
 
-Useful flags: `--root`, `--format`, `--output`.
+Useful flags: `--root`, `--week`, `--signals-file`, `--previous-signals-file`, `--emit-pack-dir`, `--strict`, `--format`, `--output`.
 
 See: day-6-ultra-upgrade-report.md
 
@@ -98,15 +98,17 @@ See: day-6-ultra-upgrade-report.md
 
 ## weekly-review
 
-Builds Day 7 weekly review #1 output with shipped upgrades, KPI movement, and next-week focus.
+Builds weekly review output (Day 7/week 1 and Day 14/week 2) with shipped upgrades, KPI movement, growth signals, and blocker-fix closeout data.
 
 Examples:
 
-- `sdetkit weekly-review --format text`
-- `sdetkit weekly-review --format json`
-- `sdetkit weekly-review --format markdown --output docs/artifacts/day7-weekly-review-sample.md`
+- `sdetkit weekly-review --week 1 --format text`
+- `sdetkit weekly-review --week 2 --format json --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json`
+- `sdetkit weekly-review --week 1 --format markdown --output docs/artifacts/day7-weekly-review-sample.md`
+- `sdetkit weekly-review --week 2 --format markdown --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --output docs/artifacts/day14-weekly-review-sample.md`
+- `sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --format json --strict`
 
-Useful flags: `--root`, `--format`, `--output`.
+Useful flags: `--root`, `--week`, `--signals-file`, `--previous-signals-file`, `--emit-pack-dir`, `--strict`, `--format`, `--output`.
 
 See: day-7-ultra-upgrade-report.md
 

--- a/docs/day-14-ultra-upgrade-report.md
+++ b/docs/day-14-ultra-upgrade-report.md
@@ -1,0 +1,55 @@
+# Day 14 Ultra Upgrade Report — Weekly Review #2
+
+## Upgrade title
+
+**Day 14 big upgrade: week-two closeout engine with growth signals, week-over-week deltas, strict policy mode, and emitted blocker-remediation operating pack.**
+
+## Problem statement
+
+Week-two delivery (Days 8-13) was shippable, but maintainers still needed manual reporting for growth and blocker outcomes.
+
+The previous Day 14 implementation only mirrored week-one coverage and did not enforce growth-signal completeness or produce structured closeout artifacts for handoff.
+
+## Implementation scope
+
+### Files changed
+
+- `src/sdetkit/weekly_review.py`
+  - Expanded Day 14 mode to accept growth signals (`traffic`, `stars`, `discussions`, `blocker_fixes`).
+  - Added optional previous-week signal loading and automatic week-over-week delta computation.
+  - Added strict mode gate (`--strict`) to fail when shipped scope is incomplete or week-two signals are missing.
+  - Added emitted closeout pack support (`--emit-pack-dir`) for checklist, KPI scorecard JSON, and blocker action plan.
+- `tests/test_weekly_review.py`
+  - Added growth signal + delta contract coverage for week-two report generation.
+- `docs/cli.md`
+  - Updated `weekly-review` command examples and flags with Day 14 growth-signal and pack workflows.
+- `README.md`
+  - Upgraded Day 14 section with signal files, strict closeout run, and pack-generation command.
+- `docs/index.md`
+  - Added Day 14 signal-driven command examples and links to closeout artifacts.
+- `scripts/check_day14_weekly_review_contract.py`
+  - Hardened Day 14 contract checks to include growth-signal and pack-file expectations.
+- `docs/artifacts/day14-growth-signals.json`
+  - Added sample week-two growth signals.
+- `docs/artifacts/day7-growth-signals.json`
+  - Added baseline week-one growth signals for delta calculations.
+- `docs/artifacts/day14-weekly-pack/*`
+  - Added emitted Day 14 closeout operating pack files.
+
+## Validation checklist
+
+- `python -m sdetkit weekly-review --week 2 --format text --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json`
+- `python -m sdetkit weekly-review --week 2 --format markdown --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --output docs/artifacts/day14-weekly-review-sample.md`
+- `python -m sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --format json --strict`
+- `python -m pytest -q tests/test_weekly_review.py tests/test_cli_help_lists_subcommands.py`
+- `python scripts/check_day14_weekly_review_contract.py`
+
+## Artifact
+
+This document is the Day 14 closeout report for weekly review #2 with growth deltas and blocker-remediation pack outputs.
+
+## Rollback plan
+
+1. Revert signal and pack options in `src/sdetkit/weekly_review.py`.
+2. Remove Day 14 pack artifacts and growth signal sample JSON files.
+3. Revert Day 14 docs and contract checker updates.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧪 Day 12 ultra report](day-12-ultra-upgrade-report.md) · [🏢 Day 13 ultra report](day-13-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧪 Day 12 ultra report](day-12-ultra-upgrade-report.md) · [🏢 Day 13 ultra report](day-13-ultra-upgrade-report.md) · [📈 Day 14 ultra report](day-14-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
 
 </div>
 
@@ -171,6 +171,14 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 - Emit enterprise operating pack (checklist + CI + controls register): `sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict`.
 - Execute full enterprise command sequence and write evidence bundle: `sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict`.
 - Review the generated artifact: [day13 enterprise use-case sample](artifacts/day13-enterprise-use-case-sample.md).
+
+## Day 14 ultra upgrades (weekly review #2 + KPI checkpoint)
+
+- Read the implementation report: [Day 14 ultra upgrade report](day-14-ultra-upgrade-report.md).
+- Run `sdetkit weekly-review --week 2 --format text --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json` to summarize Day 8-13 shipped scope, KPI movement, growth signals, and week-over-week deltas.
+- Export markdown review artifact: `sdetkit weekly-review --week 2 --format markdown --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --output docs/artifacts/day14-weekly-review-sample.md`.
+- Emit Day 14 closeout pack: `sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --format json --strict`.
+- Review generated artifacts: [day14 weekly review sample](artifacts/day14-weekly-review-sample.md), [day14 growth signals](artifacts/day14-growth-signals.json), and [day14 closeout checklist](artifacts/day14-weekly-pack/day14-closeout-checklist.md).
 
 ## Fast start
 

--- a/scripts/check_day14_weekly_review_contract.py
+++ b/scripts/check_day14_weekly_review_contract.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+README = Path('README.md')
+DOCS_INDEX = Path('docs/index.md')
+DOCS_CLI = Path('docs/cli.md')
+DAY14_REPORT = Path('docs/day-14-ultra-upgrade-report.md')
+DAY14_ARTIFACT = Path('docs/artifacts/day14-weekly-review-sample.md')
+DAY14_SIGNALS = Path('docs/artifacts/day14-growth-signals.json')
+DAY7_SIGNALS = Path('docs/artifacts/day7-growth-signals.json')
+DAY14_PACK_CHECKLIST = Path('docs/artifacts/day14-weekly-pack/day14-closeout-checklist.md')
+DAY14_PACK_SCORECARD = Path('docs/artifacts/day14-weekly-pack/day14-kpi-scorecard.json')
+DAY14_PACK_PLAN = Path('docs/artifacts/day14-weekly-pack/day14-blocker-action-plan.md')
+WEEKLY_MODULE = Path('src/sdetkit/weekly_review.py')
+
+README_EXPECTED = [
+    '## 📈 Day 14 ultra: weekly review #2',
+    'python -m sdetkit weekly-review --week 2 --format text --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json',
+    'python -m sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --format json --strict',
+    'python scripts/check_day14_weekly_review_contract.py',
+    'docs/day-14-ultra-upgrade-report.md',
+]
+
+INDEX_EXPECTED = [
+    'Day 14 ultra upgrades (weekly review #2 + KPI checkpoint)',
+    'sdetkit weekly-review --week 2 --format text --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json',
+    'artifacts/day14-weekly-review-sample.md',
+    'artifacts/day14-weekly-pack/day14-closeout-checklist.md',
+]
+
+CLI_EXPECTED = [
+    'sdetkit weekly-review --week 2 --format json --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json',
+    'sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --format json --strict',
+    'Useful flags: `--root`, `--week`, `--signals-file`, `--previous-signals-file`, `--emit-pack-dir`, `--strict`, `--format`, `--output`.',
+]
+
+REPORT_EXPECTED = [
+    'Day 14 big upgrade',
+    'src/sdetkit/weekly_review.py',
+    'tests/test_weekly_review.py',
+    'docs/artifacts/day14-weekly-pack/*',
+    'python scripts/check_day14_weekly_review_contract.py',
+]
+
+ARTIFACT_EXPECTED = [
+    '# Day 14 Weekly Review #2',
+    '## What shipped (Day 8-13)',
+    '## Week-two growth signals',
+    '## Week-over-week deltas',
+]
+
+
+def _missing(path: Path, expected: list[str]) -> list[str]:
+    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    return [item for item in expected if item not in text]
+
+
+def main() -> int:
+    errors: list[str] = []
+    required = [
+        README,
+        DOCS_INDEX,
+        DOCS_CLI,
+        DAY14_REPORT,
+        DAY14_ARTIFACT,
+        DAY14_SIGNALS,
+        DAY7_SIGNALS,
+        DAY14_PACK_CHECKLIST,
+        DAY14_PACK_SCORECARD,
+        DAY14_PACK_PLAN,
+        WEEKLY_MODULE,
+    ]
+    for path in required:
+        if not path.exists():
+            errors.append(f'missing required file: {path}')
+
+    if not errors:
+        errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
+        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
+        errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, CLI_EXPECTED))
+        errors.extend(f'{DAY14_REPORT}: missing "{m}"' for m in _missing(DAY14_REPORT, REPORT_EXPECTED))
+        errors.extend(f'{DAY14_ARTIFACT}: missing "{m}"' for m in _missing(DAY14_ARTIFACT, ARTIFACT_EXPECTED))
+
+    if errors:
+        print('day14-weekly-review-contract check failed:', file=sys.stderr)
+        for error in errors:
+            print(f' - {error}', file=sys.stderr)
+        return 1
+
+    print('day14-weekly-review-contract check passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/sdetkit/weekly_review.py
+++ b/src/sdetkit/weekly_review.py
@@ -24,6 +24,17 @@ DAY1_TO_6: tuple[DayShipped, ...] = (
     DayShipped(6, "Docs conversion QA gate", "docs/day-6-ultra-upgrade-report.md", "docs/artifacts/day6-conversion-qa-sample.md", "python -m sdetkit docs-qa --format text"),
 )
 
+DAY8_TO_13: tuple[DayShipped, ...] = (
+    DayShipped(8, "Good-first-issue accelerator pack", "docs/day-8-ultra-upgrade-report.md", "docs/artifacts/day8-good-first-issues-sample.md", "python -m sdetkit contributor-funnel --format markdown --output docs/artifacts/day8-good-first-issues-sample.md --strict"),
+    DayShipped(9, "Triage-ready issue + PR templates", "docs/day-9-ultra-upgrade-report.md", "docs/artifacts/day9-triage-templates-sample.md", "python -m sdetkit triage-templates --format markdown --output docs/artifacts/day9-triage-templates-sample.md --strict"),
+    DayShipped(10, "First-contribution checklist", "docs/day-10-ultra-upgrade-report.md", "docs/artifacts/day10-first-contribution-checklist-sample.md", "python -m sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md --strict"),
+    DayShipped(11, "Docs navigation tune-up", "docs/day-11-ultra-upgrade-report.md", "docs/artifacts/day11-docs-navigation-sample.md", "python -m sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md --strict"),
+    DayShipped(12, "Startup/small-team workflow", "docs/day-12-ultra-upgrade-report.md", "docs/artifacts/day12-startup-use-case-sample.md", "python -m sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md --strict"),
+    DayShipped(13, "Enterprise/regulated workflow", "docs/day-13-ultra-upgrade-report.md", "docs/artifacts/day13-enterprise-use-case-sample.md", "python -m sdetkit enterprise-use-case --format markdown --output docs/artifacts/day13-enterprise-use-case-sample.md --strict"),
+)
+
+_GROWTH_KEYS = ("traffic", "stars", "discussions", "blocker_fixes")
+
 
 @dataclass(frozen=True)
 class WeeklyReview:
@@ -31,11 +42,52 @@ class WeeklyReview:
     shipped: tuple[dict[str, object], ...]
     kpis: dict[str, int]
     next_week_focus: tuple[str, ...]
+    growth_signals: dict[str, int] | None
+    growth_deltas: dict[str, int] | None
 
 
-def build_weekly_review(repo_root: Path) -> WeeklyReview:
+def _validate_signals(signals: dict[str, int] | None) -> dict[str, int] | None:
+    if signals is None:
+        return None
+    validated: dict[str, int] = {}
+    for key in _GROWTH_KEYS:
+        value = signals.get(key)
+        if not isinstance(value, int):
+            raise ValueError(f"signals.{key} must be an integer")
+        validated[key] = value
+    return validated
+
+
+def _load_signals(path: str) -> dict[str, int]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("signals file must contain a JSON object")
+    return _validate_signals(payload) or {}
+
+
+def build_weekly_review(
+    repo_root: Path,
+    week: int = 1,
+    signals: dict[str, int] | None = None,
+    previous_signals: dict[str, int] | None = None,
+) -> WeeklyReview:
+    if week == 2:
+        shipped_days = DAY8_TO_13
+        next_week_focus = (
+            "Day 15: refine multi-channel distribution loop for documentation and demos.",
+            "Day 16: publish adoption-ready workflow templates with copy/paste CI variants.",
+            "Day 17: capture week-over-week quality + contribution deltas in one evidence pack.",
+        )
+    else:
+        shipped_days = DAY1_TO_6
+        next_week_focus = (
+            "Day 8: publish 10 curated good-first-issue tasks with clear acceptance criteria.",
+            "Day 9: tighten issue/PR templates to reduce triage response time.",
+            "Day 10: add first-contribution checklist from clone to first merged PR.",
+        )
+
     shipped: list[dict[str, object]] = []
-    for day in DAY1_TO_6:
+    for day in shipped_days:
         report_exists = (repo_root / day.report_path).exists()
         artifact_exists = (repo_root / day.artifact_path).exists()
         shipped.append(
@@ -54,26 +106,33 @@ def build_weekly_review(repo_root: Path) -> WeeklyReview:
     shipped_count = sum(1 for item in shipped if item["status"] == "shipped")
     kpis = {
         "days_completed": shipped_count,
-        "days_planned": len(DAY1_TO_6),
-        "completion_rate_percent": int((shipped_count / len(DAY1_TO_6)) * 100),
-        "runnable_commands": len(DAY1_TO_6),
+        "days_planned": len(shipped_days),
+        "completion_rate_percent": int((shipped_count / len(shipped_days)) * 100),
+        "runnable_commands": len(shipped_days),
         "artifact_coverage": sum(1 for item in shipped if item["artifact_exists"]),
     }
 
-    next_week_focus = (
-        "Day 8: publish 10 curated good-first-issue tasks with clear acceptance criteria.",
-        "Day 9: tighten issue/PR templates to reduce triage response time.",
-        "Day 10: add first-contribution checklist from clone to first merged PR.",
-    )
+    current = _validate_signals(signals)
+    previous = _validate_signals(previous_signals)
+    deltas = None
+    if current and previous:
+        deltas = {key: current[key] - previous[key] for key in _GROWTH_KEYS}
 
-    return WeeklyReview(week=1, shipped=tuple(shipped), kpis=kpis, next_week_focus=next_week_focus)
+    return WeeklyReview(
+        week=week,
+        shipped=tuple(shipped),
+        kpis=kpis,
+        next_week_focus=next_week_focus,
+        growth_signals=current,
+        growth_deltas=deltas,
+    )
 
 
 def _render_text(review: WeeklyReview) -> str:
     lines = [
-        "Day 7 weekly review #1",
+        f"Day {7 if review.week == 1 else 14} weekly review #{review.week}",
         "",
-        "What shipped (Day 1-6):",
+        f"What shipped ({'Day 1-6' if review.week == 1 else 'Day 8-13'}):",
     ]
     for item in review.shipped:
         mark = "✅" if item["status"] == "shipped" else "⚠️"
@@ -88,19 +147,42 @@ def _render_text(review: WeeklyReview) -> str:
             f"- Completion: {review.kpis['days_completed']}/{review.kpis['days_planned']} ({review.kpis['completion_rate_percent']}%)",
             f"- Runnable command paths: {review.kpis['runnable_commands']}",
             f"- Artifact coverage: {review.kpis['artifact_coverage']}/{review.kpis['days_planned']}",
-            "",
-            "Next-week focus:",
         ]
     )
+
+    if review.growth_signals:
+        lines.extend(
+            [
+                "",
+                "Week-two growth signals:",
+                f"- Traffic: {review.growth_signals['traffic']}",
+                f"- Stars: {review.growth_signals['stars']}",
+                f"- Discussions: {review.growth_signals['discussions']}",
+                f"- Blocker fixes: {review.growth_signals['blocker_fixes']}",
+            ]
+        )
+    if review.growth_deltas:
+        lines.extend(
+            [
+                "",
+                "Week-over-week deltas:",
+                f"- Traffic: {review.growth_deltas['traffic']:+d}",
+                f"- Stars: {review.growth_deltas['stars']:+d}",
+                f"- Discussions: {review.growth_deltas['discussions']:+d}",
+                f"- Blocker fixes: {review.growth_deltas['blocker_fixes']:+d}",
+            ]
+        )
+
+    lines.extend(["", "Next-week focus:"])
     lines.extend(f"- {item}" for item in review.next_week_focus)
     return "\n".join(lines) + "\n"
 
 
 def _render_markdown(review: WeeklyReview) -> str:
     lines = [
-        "# Day 7 Weekly Review #1",
+        f"# Day {7 if review.week == 1 else 14} Weekly Review #{review.week}",
         "",
-        "## What shipped (Day 1-6)",
+        f"## What shipped ({'Day 1-6' if review.week == 1 else 'Day 8-13'})",
         "",
         "| Day | Upgrade | Report | Artifact | Status |",
         "| --- | --- | --- | --- | --- |",
@@ -120,18 +202,103 @@ def _render_markdown(review: WeeklyReview) -> str:
             f"- Completion rate: **{review.kpis['days_completed']}/{review.kpis['days_planned']} ({review.kpis['completion_rate_percent']}%)**",
             f"- Runnable command paths delivered: **{review.kpis['runnable_commands']}**",
             f"- Artifact coverage: **{review.kpis['artifact_coverage']}/{review.kpis['days_planned']}**",
-            "",
-            "## Next-week focus",
-            "",
         ]
     )
+
+    if review.growth_signals:
+        lines.extend(
+            [
+                "",
+                "## Week-two growth signals",
+                "",
+                f"- Traffic: **{review.growth_signals['traffic']}**",
+                f"- Stars: **{review.growth_signals['stars']}**",
+                f"- Discussions: **{review.growth_signals['discussions']}**",
+                f"- Blocker fixes: **{review.growth_signals['blocker_fixes']}**",
+            ]
+        )
+
+    if review.growth_deltas:
+        lines.extend(
+            [
+                "",
+                "## Week-over-week deltas",
+                "",
+                f"- Traffic: **{review.growth_deltas['traffic']:+d}**",
+                f"- Stars: **{review.growth_deltas['stars']:+d}**",
+                f"- Discussions: **{review.growth_deltas['discussions']:+d}**",
+                f"- Blocker fixes: **{review.growth_deltas['blocker_fixes']:+d}**",
+            ]
+        )
+
+    lines.extend(["", "## Next-week focus", ""])
     lines.extend(f"- {item}" for item in review.next_week_focus)
     return "\n".join(lines) + "\n"
 
 
+def _emit_week2_pack(base: Path, out_dir: str, review: WeeklyReview) -> list[str]:
+    root = base / out_dir
+    root.mkdir(parents=True, exist_ok=True)
+
+    checklist = root / "day14-closeout-checklist.md"
+    checklist.write_text(
+        "\n".join(
+            [
+                "# Day 14 closeout checklist",
+                "",
+                "- [ ] Run `sdetkit weekly-review --week 2 --format text` and verify all Day 8-13 items are shipped.",
+                "- [ ] Refresh markdown artifact and attach it to the status update.",
+                "- [ ] Update growth signals JSON (traffic, stars, discussions, blocker_fixes).",
+                "- [ ] Review blocker-fix owners and confirm SLA commitments for next sprint.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    scorecard = root / "day14-kpi-scorecard.json"
+    scorecard.write_text(
+        json.dumps(
+            {
+                "week": review.week,
+                "kpis": review.kpis,
+                "growth_signals": review.growth_signals,
+                "growth_deltas": review.growth_deltas,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    action_plan = root / "day14-blocker-action-plan.md"
+    action_plan.write_text(
+        "\n".join(
+            [
+                "# Day 14 blocker action plan",
+                "",
+                "| Blocker | Owner | Target date | Mitigation |",
+                "| --- | --- | --- | --- |",
+                "| Missing contributor responses | Maintainer on-call | +2 days | tighten template auto-labeling and triage SLA reminders |",
+                "| Slow docs feedback turnaround | Docs owner | +3 days | schedule twice-weekly docs office-hours review |",
+                "| CI flake investigation backlog | QE lead | +5 days | split flaky jobs, add retry visibility and quarantine workflow |",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return [str(path.relative_to(base)) for path in (checklist, scorecard, action_plan)]
+
+
 def _build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="sdetkit weekly-review", description="Generate Day 7 weekly review summary.")
+    p = argparse.ArgumentParser(prog="sdetkit weekly-review", description="Generate day-based weekly review summaries.")
     p.add_argument("--root", default=".", help="Repository root path.")
+    p.add_argument("--week", type=int, choices=[1, 2], default=1, help="Weekly review window (1=Day 1-6, 2=Day 8-13).")
+    p.add_argument("--signals-file", default="", help="Optional JSON file with week growth signals: traffic, stars, discussions, blocker_fixes.")
+    p.add_argument("--previous-signals-file", default="", help="Optional previous-week JSON signal file to compute week-over-week deltas.")
+    p.add_argument("--emit-pack-dir", default="", help="Optional output directory to emit Day 14 closeout pack files.")
+    p.add_argument("--strict", action="store_true", help="Return non-zero if shipped coverage is incomplete (or week-2 growth signals are missing).")
     p.add_argument("--format", choices=["text", "json", "markdown"], default="text")
     p.add_argument("--output", default=None, help="Optional output path for the report.")
     return p
@@ -139,18 +306,34 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
-    review = build_weekly_review(Path(args.root).resolve())
+
+    signals = _load_signals(args.signals_file) if args.signals_file else None
+    previous_signals = _load_signals(args.previous_signals_file) if args.previous_signals_file else None
+
+    review = build_weekly_review(
+        Path(args.root).resolve(),
+        week=args.week,
+        signals=signals,
+        previous_signals=previous_signals,
+    )
+
+    payload: dict[str, object] = {
+        "week": review.week,
+        "shipped": list(review.shipped),
+        "kpis": review.kpis,
+        "next_week_focus": list(review.next_week_focus),
+    }
+
+    if review.growth_signals:
+        payload["growth_signals"] = review.growth_signals
+    if review.growth_deltas:
+        payload["growth_deltas"] = review.growth_deltas
+
+    if args.emit_pack_dir:
+        payload["pack_files"] = _emit_week2_pack(Path(args.root).resolve(), args.emit_pack_dir, review)
 
     if args.format == "json":
-        rendered = json.dumps(
-            {
-                "week": review.week,
-                "shipped": list(review.shipped),
-                "kpis": review.kpis,
-                "next_week_focus": list(review.next_week_focus),
-            },
-            indent=2,
-        ) + "\n"
+        rendered = json.dumps(payload, indent=2) + "\n"
     elif args.format == "markdown":
         rendered = _render_markdown(review)
     else:
@@ -160,6 +343,12 @@ def main(argv: list[str] | None = None) -> int:
         Path(args.output).write_text(rendered, encoding="utf-8")
     else:
         print(rendered, end="")
+
+    if args.strict:
+        has_incomplete = any(item["status"] != "shipped" for item in review.shipped)
+        missing_signals = args.week == 2 and review.growth_signals is None
+        if has_incomplete or missing_signals:
+            return 1
 
     return 0
 

--- a/tests/test_weekly_review.py
+++ b/tests/test_weekly_review.py
@@ -12,6 +12,25 @@ def test_weekly_review_repo_passes_core_kpis() -> None:
     assert review.kpis['completion_rate_percent'] == 100
 
 
+def test_week2_review_repo_passes_core_kpis() -> None:
+    review = weekly_review.build_weekly_review(Path('.').resolve(), week=2)
+    assert review.week == 2
+    assert review.kpis['days_planned'] == 6
+    assert review.kpis['days_completed'] >= 6
+    assert review.kpis['completion_rate_percent'] == 100
+
+
+def test_week2_review_adds_growth_signals_and_deltas() -> None:
+    review = weekly_review.build_weekly_review(
+        Path('.').resolve(),
+        week=2,
+        signals={'traffic': 1800, 'stars': 90, 'discussions': 24, 'blocker_fixes': 7},
+        previous_signals={'traffic': 1200, 'stars': 77, 'discussions': 18, 'blocker_fixes': 5},
+    )
+    assert review.growth_signals == {'traffic': 1800, 'stars': 90, 'discussions': 24, 'blocker_fixes': 7}
+    assert review.growth_deltas == {'traffic': 600, 'stars': 13, 'discussions': 6, 'blocker_fixes': 2}
+
+
 def test_weekly_review_flags_missing_files(tmp_path: Path) -> None:
     (tmp_path / 'README.md').write_text('# temp\n', encoding='utf-8')
     (tmp_path / 'docs').mkdir()


### PR DESCRIPTION
### Motivation

- Close out Day 14 with richer, deterministic reporting by adding growth signal ingestion (traffic/stars/discussions/blocker_fixes) and week-over-week deltas.
- Enforce a strict closeout policy so maintainers can fail the CI gate if shipment coverage or required signals are missing. 
- Produce a structured Day 14 operating pack (checklist, KPI scorecard, blocker action plan) for handoff and remediation tracking.

### Description

- Extended `src/sdetkit/weekly_review.py` to accept `--signals-file` and `--previous-signals-file`, validate integer growth keys, compute deltas, and expose `growth_signals` and `growth_deltas` on the `WeeklyReview` return value. 
- Added `--week`, `--emit-pack-dir`, and `--strict` CLI flags and implemented `_emit_week2_pack` to write `day14-closeout-checklist.md`, `day14-kpi-scorecard.json`, and `day14-blocker-action-plan.md`. 
- Added tests in `tests/test_weekly_review.py` for week-2 behavior, growth signal ingestion, and delta math, and added a contract checker `scripts/check_day14_weekly_review_contract.py`. 
- Updated documentation and artifacts (`README.md`, `docs/cli.md`, `docs/index.md`, `docs/day-14-ultra-upgrade-report.md`, and `docs/artifacts/*`) with sample signal files and a generated Day 14 markdown sample.

### Testing

- Ran unit tests with `python -m pytest -q tests/test_weekly_review.py tests/test_cli_help_lists_subcommands.py` and all tests passed (`5 passed`).
- Ran the contract checker `python scripts/check_day14_weekly_review_contract.py` which returned a passing result. 
- Exercised the CLI end-to-end with `python -m sdetkit weekly-review --week 2 --format json --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --strict` and with `--emit-pack-dir` to generate the operating pack, both of which produced the expected JSON output and pack files.

------