### PR TITLE
feat(day15): close Day 15 with workflow variants, execution, and evidence pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,35 @@ python scripts/check_day14_weekly_review_contract.py
 python -m sdetkit weekly-review --week 2 --format json --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --strict
 ```
 
+## 🔁 Day 15 ultra: GitHub Actions quickstart
+
+Day 15 closes with a **production-ready integration recipe**: minimal + strict + nightly GitHub Actions workflows, execution evidence capture, and distribution-loop guidance.
+
+```bash
+python -m sdetkit github-actions-quickstart --format text --strict
+python -m sdetkit github-actions-quickstart --format json --variant strict --strict
+python -m sdetkit github-actions-quickstart --write-defaults --format json --strict
+python -m sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict
+python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
+```
+
+Export a markdown artifact for handoff:
+
+```bash
+python -m sdetkit github-actions-quickstart --format markdown --variant strict --output docs/artifacts/day15-github-actions-quickstart-sample.md
+```
+
+See implementation details: [Day 15 ultra upgrade report](docs/day-15-ultra-upgrade-report.md).
+
+Day 15 closeout checks:
+
+```bash
+python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day15_github_actions_quickstart_contract.py
+python -m sdetkit github-actions-quickstart --format json --strict
+python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day15-github-actions-quickstart-sample.md
+++ b/docs/artifacts/day15-github-actions-quickstart-sample.md
@@ -1,0 +1,15 @@
+# Day 15 GitHub Actions quickstart
+
+- Page: `docs/integrations-github-actions-quickstart.md`
+- Variant: `strict`
+- Score: **100.0** (18/18)
+- Missing: none ✅
+
+## Commands
+
+```bash
+sdetkit github-actions-quickstart --format text --strict
+sdetkit github-actions-quickstart --format json --variant strict --strict
+sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict
+sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
+```

--- a/docs/artifacts/day15-github-pack/day15-distribution-plan.md
+++ b/docs/artifacts/day15-github-pack/day15-distribution-plan.md
@@ -1,0 +1,7 @@
+# Day 15 distribution plan
+
+| Channel | Artifact | Owner | Cadence |
+| --- | --- | --- | --- |
+| Engineering Slack | quickstart workflow + execution summary | QE lead | weekly |
+| Docs portal | Day 15 integration page | Docs owner | weekly |
+| Sprint retro | evidence logs and failure themes | Team lead | bi-weekly |

--- a/docs/artifacts/day15-github-pack/day15-github-checklist.md
+++ b/docs/artifacts/day15-github-pack/day15-github-checklist.md
@@ -1,0 +1,7 @@
+# Day 15 GitHub Actions rollout checklist
+
+- [ ] Validate quickstart page in strict mode.
+- [ ] Commit workflow files under .github/workflows/.
+- [ ] Verify PR run passes doctor, repo audit, and tests.
+- [ ] Generate evidence bundle from --execute mode.
+- [ ] Share workflow + evidence links in onboarding docs.

--- a/docs/artifacts/day15-github-pack/day15-sdetkit-nightly.yml
+++ b/docs/artifacts/day15-github-pack/day15-sdetkit-nightly.yml
@@ -1,0 +1,18 @@
+name: sdetkit-github-nightly
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m sdetkit doctor --format text
+      - run: python -m sdetkit repo audit --format json
+      - run: python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict

--- a/docs/artifacts/day15-github-pack/day15-sdetkit-quickstart.yml
+++ b/docs/artifacts/day15-github-pack/day15-sdetkit-quickstart.yml
@@ -1,0 +1,16 @@
+name: sdetkit-github-quickstart
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  quality-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m sdetkit github-actions-quickstart --format json --strict
+      - run: python -m pytest -q tests/test_cli_sdetkit.py tests/test_github_actions_quickstart.py

--- a/docs/artifacts/day15-github-pack/day15-sdetkit-strict.yml
+++ b/docs/artifacts/day15-github-pack/day15-sdetkit-strict.yml
@@ -1,0 +1,17 @@
+name: sdetkit-github-strict
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  strict-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m pytest -q tests/test_cli_sdetkit.py tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py
+      - run: python -m sdetkit github-actions-quickstart --format json --strict
+      - run: python scripts/check_day15_github_actions_quickstart_contract.py

--- a/docs/artifacts/day15-github-pack/day15-validation-commands.md
+++ b/docs/artifacts/day15-github-pack/day15-validation-commands.md
@@ -1,0 +1,10 @@
+# Day 15 validation commands
+
+```bash
+python -m sdetkit doctor --format text
+python -m sdetkit repo audit --format json
+python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day15_github_actions_quickstart_contract.py
+python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
+```
+

--- a/docs/artifacts/day15-github-pack/evidence/command-01.log
+++ b/docs/artifacts/day15-github-pack/evidence/command-01.log
@@ -1,0 +1,17 @@
+command: python -m sdetkit doctor --format text
+returncode: 0
+ok: True
+--- stdout ---
+doctor score: 100%
+[OK] ascii: ASCII scan not requested
+[OK] ci_workflows: CI workflow check not requested
+[OK] clean_tree: clean tree check not requested
+[OK] deps: dependency consistency check not requested
+[OK] pre_commit: pre-commit check not requested
+[OK] security_files: security governance file check not requested
+[OK] stdlib_shadowing: no stdlib shadowing detected
+recommendations:
+- No immediate blockers detected. Keep CI, docs, and tests green for premium delivery quality.
+
+--- stderr ---
+

--- a/docs/artifacts/day15-github-pack/evidence/command-02.log
+++ b/docs/artifacts/day15-github-pack/evidence/command-02.log
@@ -1,0 +1,93 @@
+command: python -m sdetkit repo audit --format json
+returncode: 0
+ok: True
+--- stdout ---
+{
+  "checks": [
+    {
+      "details": [
+        "Repository should define contributor conduct expectations."
+      ],
+      "key": "CORE_MISSING_CODE_OF_CONDUCT_MD",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "CODE_OF_CONDUCT.md exists"
+    },
+    {
+      "details": [
+        "Repository should explain how to contribute."
+      ],
+      "key": "CORE_MISSING_CONTRIBUTING_MD",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "CONTRIBUTING.md exists"
+    },
+    {
+      "details": [
+        "Repository should define issue template defaults."
+      ],
+      "key": "CORE_MISSING_ISSUE_TEMPLATE_CONFIG",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "Issue template config exists"
+    },
+    {
+      "details": [
+        "Repository should provide a pull request template."
+      ],
+      "key": "CORE_MISSING_PR_TEMPLATE",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "PR template exists"
+    },
+    {
+      "details": [
+        "Repository should publish a security reporting policy."
+      ],
+      "key": "CORE_MISSING_SECURITY_MD",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "SECURITY.md exists"
+    }
+  ],
+  "findings": [],
+  "root": "/workspace/DevS69-sdetkit",
+  "schema_version": "1.1.0",
+  "summary": {
+    "checks": 5,
+    "counts": {
+      "error": 0,
+      "info": 0,
+      "warn": 0
+    },
+    "failed": 0,
+    "findings": 0,
+    "incremental": {
+      "changed_files": 0,
+      "used": false
+    },
+    "ok": true,
+    "packs": [
+      "core"
+    ],
+    "passed": 5,
+    "policy": {
+      "actionable": 0,
+      "suppressed_active": 0,
+      "suppressed_by_baseline": 0,
+      "suppressed_by_policy": 0,
+      "suppressed_expired": 0,
+      "total_findings": 0
+    }
+  },
+  "suppressed": [],
+  "suppressed_expired": []
+}
+
+--- stderr ---
+

--- a/docs/artifacts/day15-github-pack/evidence/command-03.log
+++ b/docs/artifacts/day15-github-pack/evidence/command-03.log
@@ -1,0 +1,9 @@
+command: python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py
+returncode: 0
+ok: True
+--- stdout ---
+..........                                                               [100%]
+10 passed in 0.96s
+
+--- stderr ---
+

--- a/docs/artifacts/day15-github-pack/evidence/command-04.log
+++ b/docs/artifacts/day15-github-pack/evidence/command-04.log
@@ -1,0 +1,18 @@
+command: python -m sdetkit github-actions-quickstart --format json --strict
+returncode: 0
+ok: True
+--- stdout ---
+{
+  "name": "day15-github-actions-quickstart",
+  "page": "docs/integrations-github-actions-quickstart.md",
+  "variant": "minimal",
+  "selected_workflow": "name: sdetkit-github-quickstart\non:\n  pull_request:\n  workflow_dispatch:\n\njobs:\n  quality-gate:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - uses: actions/setup-python@v5\n        with:\n          python-version: '3.11'\n      - run: python -m pip install -r requirements-test.txt -e .\n      - run: python -m sdetkit github-actions-quickstart --format json --strict\n      - run: python -m pytest -q tests/test_cli_sdetkit.py tests/test_github_actions_quickstart.py\n",
+  "passed_checks": 18,
+  "total_checks": 18,
+  "score": 100.0,
+  "missing": [],
+  "touched_files": []
+}
+
+--- stderr ---
+

--- a/docs/artifacts/day15-github-pack/evidence/day15-execution-summary.json
+++ b/docs/artifacts/day15-github-pack/evidence/day15-execution-summary.json
@@ -1,0 +1,40 @@
+{
+  "name": "day15-github-actions-execution",
+  "total_commands": 4,
+  "passed_commands": 4,
+  "failed_commands": 0,
+  "results": [
+    {
+      "index": 1,
+      "command": "python -m sdetkit doctor --format text",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "doctor score: 100%\n[OK] ascii: ASCII scan not requested\n[OK] ci_workflows: CI workflow check not requested\n[OK] clean_tree: clean tree check not requested\n[OK] deps: dependency consistency check not requested\n[OK] pre_commit: pre-commit check not requested\n[OK] security_files: security governance file check not requested\n[OK] stdlib_shadowing: no stdlib shadowing detected\nrecommendations:\n- No immediate blockers detected. Keep CI, docs, and tests green for premium delivery quality.\n",
+      "stderr": ""
+    },
+    {
+      "index": 2,
+      "command": "python -m sdetkit repo audit --format json",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "{\n  \"checks\": [\n    {\n      \"details\": [\n        \"Repository should define contributor conduct expectations.\"\n      ],\n      \"key\": \"CORE_MISSING_CODE_OF_CONDUCT_MD\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"CODE_OF_CONDUCT.md exists\"\n    },\n    {\n      \"details\": [\n        \"Repository should explain how to contribute.\"\n      ],\n      \"key\": \"CORE_MISSING_CONTRIBUTING_MD\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"CONTRIBUTING.md exists\"\n    },\n    {\n      \"details\": [\n        \"Repository should define issue template defaults.\"\n      ],\n      \"key\": \"CORE_MISSING_ISSUE_TEMPLATE_CONFIG\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"Issue template config exists\"\n    },\n    {\n      \"details\": [\n        \"Repository should provide a pull request template.\"\n      ],\n      \"key\": \"CORE_MISSING_PR_TEMPLATE\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"PR template exists\"\n    },\n    {\n      \"details\": [\n        \"Repository should publish a security reporting policy.\"\n      ],\n      \"key\": \"CORE_MISSING_SECURITY_MD\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"SECURITY.md exists\"\n    }\n  ],\n  \"findings\": [],\n  \"root\": \"/workspace/DevS69-sdetkit\",\n  \"schema_version\": \"1.1.0\",\n  \"summary\": {\n    \"checks\": 5,\n    \"counts\": {\n      \"error\": 0,\n      \"info\": 0,\n      \"warn\": 0\n    },\n    \"failed\": 0,\n    \"findings\": 0,\n    \"incremental\": {\n      \"changed_files\": 0,\n      \"used\": false\n    },\n    \"ok\": true,\n    \"packs\": [\n      \"core\"\n    ],\n    \"passed\": 5,\n    \"policy\": {\n      \"actionable\": 0,\n      \"suppressed_active\": 0,\n      \"suppressed_by_baseline\": 0,\n      \"suppressed_by_policy\": 0,\n      \"suppressed_expired\": 0,\n      \"total_findings\": 0\n    }\n  },\n  \"suppressed\": [],\n  \"suppressed_expired\": []\n}\n",
+      "stderr": ""
+    },
+    {
+      "index": 3,
+      "command": "python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "..........                                                               [100%]\n10 passed in 0.96s\n",
+      "stderr": ""
+    },
+    {
+      "index": 4,
+      "command": "python -m sdetkit github-actions-quickstart --format json --strict",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "{\n  \"name\": \"day15-github-actions-quickstart\",\n  \"page\": \"docs/integrations-github-actions-quickstart.md\",\n  \"variant\": \"minimal\",\n  \"selected_workflow\": \"name: sdetkit-github-quickstart\\non:\\n  pull_request:\\n  workflow_dispatch:\\n\\njobs:\\n  quality-gate:\\n    runs-on: ubuntu-latest\\n    steps:\\n      - uses: actions/checkout@v4\\n      - uses: actions/setup-python@v5\\n        with:\\n          python-version: '3.11'\\n      - run: python -m pip install -r requirements-test.txt -e .\\n      - run: python -m sdetkit github-actions-quickstart --format json --strict\\n      - run: python -m pytest -q tests/test_cli_sdetkit.py tests/test_github_actions_quickstart.py\\n\",\n  \"passed_checks\": 18,\n  \"total_checks\": 18,\n  \"score\": 100.0,\n  \"missing\": [],\n  \"touched_files\": []\n}\n",
+      "stderr": ""
+    }
+  ]
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -236,6 +236,33 @@ Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`, 
 
 See: day-13-ultra-upgrade-report.md
 
+## github-actions-quickstart
+
+Builds Day 15 GitHub Actions quickstart status and validates required integration sections, workflow variants, and execution evidence workflow.
+
+Examples:
+
+- `sdetkit github-actions-quickstart --format text --strict`
+- `sdetkit github-actions-quickstart --format json --variant strict --strict`
+- `sdetkit github-actions-quickstart --write-defaults --format json --strict`
+- `sdetkit github-actions-quickstart --format markdown --variant strict --output docs/artifacts/day15-github-actions-quickstart-sample.md`
+- `sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict`
+- `sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict`
+
+Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`, `--emit-pack-dir`, `--variant`, `--execute`, `--evidence-dir`, `--timeout-sec`.
+
+`--strict` returns non-zero if required Day 15 quickstart sections or command snippets are missing from `docs/integrations-github-actions-quickstart.md`.
+
+`--write-defaults` writes a hardened Day 15 quickstart page if missing/incomplete, then validates again.
+
+`--emit-pack-dir` writes a Day 15 integration pack containing checklist, minimal/strict/nightly workflows, distribution plan, and validation commands.
+
+`--execute` runs Day 15 command chain and captures pass/fail output.
+
+`--evidence-dir` writes `day15-execution-summary.json` plus per-command log files for CI incident triage and closeout handoff.
+
+See: day-15-ultra-upgrade-report.md
+
 ## patch
 
 Deterministic, spec-driven file edits (official CLI command).

--- a/docs/day-15-ultra-upgrade-report.md
+++ b/docs/day-15-ultra-upgrade-report.md
@@ -1,0 +1,49 @@
+# Day 15 ultra upgrade report
+
+## Day 15 big upgrade
+
+Day 15 now ships a **full GitHub Actions integration operating loop**:
+
+- quickstart + strict + nightly workflow variants,
+- contract-backed docs validation,
+- pack generation for rollout/distribution,
+- and execution evidence capture (`day15-execution-summary.json` + command logs).
+
+## What changed
+
+- Upgraded `sdetkit github-actions-quickstart` with:
+  - `--variant` (`minimal`, `strict`, `nightly`)
+  - `--execute` with command-run status capture
+  - `--evidence-dir` + command log exports
+  - enhanced strict checks for expanded Day 15 content
+- Expanded Day 15 integration docs with:
+  - strict and nightly workflow snippets,
+  - multi-channel distribution loop,
+  - failure recovery playbook.
+- Expanded emitted pack artifacts with strict/nightly workflows and distribution plan.
+- Strengthened tests for execute/evidence behavior and strict failure paths.
+- Hardened contract check script to enforce Day 15 closeout assets.
+
+## Validation commands
+
+```bash
+python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py
+python -m sdetkit github-actions-quickstart --format json --strict
+python -m sdetkit github-actions-quickstart --format json --variant strict --strict
+python -m sdetkit github-actions-quickstart --write-defaults --format json --strict
+python -m sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict
+python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
+python scripts/check_day15_github_actions_quickstart_contract.py
+```
+
+## Artifacts
+
+- `docs/integrations-github-actions-quickstart.md`
+- `docs/artifacts/day15-github-actions-quickstart-sample.md`
+- `docs/artifacts/day15-github-pack/day15-github-checklist.md`
+- `docs/artifacts/day15-github-pack/day15-sdetkit-quickstart.yml`
+- `docs/artifacts/day15-github-pack/day15-sdetkit-strict.yml`
+- `docs/artifacts/day15-github-pack/day15-sdetkit-nightly.yml`
+- `docs/artifacts/day15-github-pack/day15-distribution-plan.md`
+- `docs/artifacts/day15-github-pack/day15-validation-commands.md`
+- `docs/artifacts/day15-github-pack/evidence/day15-execution-summary.json`

--- a/docs/index.md
+++ b/docs/index.md
@@ -266,3 +266,16 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
   Approval gates, allowlists, shell restrictions, and MCP bridge defaults.
 
 </div>
+
+
+## Day 15 ultra upgrades (GitHub Actions quickstart)
+
+- Read the implementation report: [Day 15 ultra upgrade report](day-15-ultra-upgrade-report.md).
+- Run `sdetkit github-actions-quickstart --format text --strict` to validate required integration recipe sections and workflow variants.
+- Validate strict variant output: `sdetkit github-actions-quickstart --format json --variant strict --strict`.
+- Auto-recover missing quickstart content: `sdetkit github-actions-quickstart --write-defaults --format json --strict`.
+- Export markdown quickstart artifact: `sdetkit github-actions-quickstart --format markdown --variant strict --output docs/artifacts/day15-github-actions-quickstart-sample.md`.
+- Emit Day 15 rollout pack: `sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict`.
+- Capture deterministic execution evidence: `sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict`.
+- Review generated artifacts: [day15 quickstart sample](artifacts/day15-github-actions-quickstart-sample.md), [day15 strict workflow](artifacts/day15-github-pack/day15-sdetkit-strict.yml), [day15 evidence summary](artifacts/day15-github-pack/evidence/day15-execution-summary.json).
+

--- a/docs/integrations-github-actions-quickstart.md
+++ b/docs/integrations-github-actions-quickstart.md
@@ -1,0 +1,113 @@
+# GitHub Actions quickstart (Day 15)
+
+A production-ready integration recipe to run `sdetkit` quality checks in GitHub Actions with quickstart, strict, and nightly variants.
+
+## Who this recipe is for
+
+- Maintainers who need CI guardrails in less than 5 minutes.
+- Teams moving from local-only checks to PR gate automation.
+- Contributors who want deterministic quality signals in pull requests.
+
+## 5-minute setup
+
+1. Add `.github/workflows/sdetkit-quickstart.yml` with the minimal workflow below.
+2. Push a branch and open a pull request.
+3. Confirm the quality-gate job passes before merge.
+
+## Minimal workflow
+
+```yaml
+name: sdetkit-github-quickstart
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  quality-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m sdetkit github-actions-quickstart --format json --strict
+      - run: python -m pytest -q tests/test_cli_sdetkit.py tests/test_github_actions_quickstart.py
+```
+
+## Strict workflow variant
+
+```yaml
+name: sdetkit-github-strict
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  strict-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m pytest -q tests/test_cli_sdetkit.py tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py
+      - run: python -m sdetkit github-actions-quickstart --format json --strict
+      - run: python scripts/check_day15_github_actions_quickstart_contract.py
+```
+
+## Nightly reliability variant
+
+```yaml
+name: sdetkit-github-nightly
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m sdetkit doctor --format text
+      - run: python -m sdetkit repo audit --format json
+      - run: python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
+```
+
+## Fast verification commands
+
+Run these locally before opening PRs:
+
+```bash
+python -m sdetkit doctor --format text
+python -m sdetkit repo audit --format json
+python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day15_github_actions_quickstart_contract.py
+python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
+```
+
+## Multi-channel distribution loop
+
+1. Post merged workflow update in engineering chat with before/after CI timing.
+2. Publish docs update in `docs/index.md` weekly rollout section.
+3. Share one artifact (`day15-execution-summary.json`) in team retro for adoption tracking.
+
+## Failure recovery playbook
+
+- If checks fail from missing docs content, run `--write-defaults` and rerun strict validation.
+- If tests fail, keep quickstart lane blocking and move nightly lane to diagnostics-only until stable.
+- If flaky behavior appears, attach evidence logs from `--execute --evidence-dir` to the incident thread.
+
+## Rollout checklist
+
+- [ ] Workflow is enabled on `pull_request` and `workflow_dispatch`.
+- [ ] CI installs from `requirements-test.txt` and editable package source.
+- [ ] Day 15 contract check is part of docs validation.
+- [ ] Execution evidence bundle is generated weekly.
+- [ ] Team channel has a pinned link to this quickstart page.

--- a/scripts/check_day15_github_actions_quickstart_contract.py
+++ b/scripts/check_day15_github_actions_quickstart_contract.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+README = Path('README.md')
+DOCS_INDEX = Path('docs/index.md')
+DOCS_CLI = Path('docs/cli.md')
+QUICKSTART_PAGE = Path('docs/integrations-github-actions-quickstart.md')
+DAY15_REPORT = Path('docs/day-15-ultra-upgrade-report.md')
+DAY15_ARTIFACT = Path('docs/artifacts/day15-github-actions-quickstart-sample.md')
+DAY15_PACK_STRICT = Path('docs/artifacts/day15-github-pack/day15-sdetkit-strict.yml')
+DAY15_PACK_NIGHTLY = Path('docs/artifacts/day15-github-pack/day15-sdetkit-nightly.yml')
+DAY15_EVIDENCE = Path('docs/artifacts/day15-github-pack/evidence/day15-execution-summary.json')
+
+README_EXPECTED = [
+    '## 🔁 Day 15 ultra: GitHub Actions quickstart',
+    'python -m sdetkit github-actions-quickstart --format text --strict',
+    'python -m sdetkit github-actions-quickstart --format json --variant strict --strict',
+    'python -m sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict',
+    'python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+    'python scripts/check_day15_github_actions_quickstart_contract.py',
+    'docs/day-15-ultra-upgrade-report.md',
+]
+
+DOCS_INDEX_EXPECTED = [
+    '## Day 15 ultra upgrades (GitHub Actions quickstart)',
+    'sdetkit github-actions-quickstart --format text --strict',
+    'sdetkit github-actions-quickstart --format json --variant strict --strict',
+    'sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict',
+    'sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+    'artifacts/day15-github-actions-quickstart-sample.md',
+]
+
+DOCS_CLI_EXPECTED = [
+    '## github-actions-quickstart',
+    'sdetkit github-actions-quickstart --format markdown --variant strict --output docs/artifacts/day15-github-actions-quickstart-sample.md',
+    'sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict',
+    'sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+    '--write-defaults',
+    '--variant',
+    '--evidence-dir',
+]
+
+QUICKSTART_EXPECTED = [
+    '# GitHub Actions quickstart (Day 15)',
+    '## Strict workflow variant',
+    '## Nightly reliability variant',
+    '## Multi-channel distribution loop',
+    '## Failure recovery playbook',
+    'name: sdetkit-github-quickstart',
+    'name: sdetkit-github-strict',
+    'name: sdetkit-github-nightly',
+    'python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+]
+
+REPORT_EXPECTED = [
+    'Day 15 big upgrade',
+    'python -m sdetkit github-actions-quickstart --format json --variant strict --strict',
+    'python -m sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict',
+    'python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+    'scripts/check_day15_github_actions_quickstart_contract.py',
+]
+
+ARTIFACT_EXPECTED = [
+    '# Day 15 GitHub Actions quickstart',
+    '- Variant: `strict`',
+    '- Score: **100.0** (18/18)',
+    'sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+]
+
+PACK_STRICT_EXPECTED = [
+    'name: sdetkit-github-strict',
+    'python -m sdetkit github-actions-quickstart --format json --strict',
+]
+
+PACK_NIGHTLY_EXPECTED = [
+    'name: sdetkit-github-nightly',
+    'python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+]
+
+EVIDENCE_EXPECTED = [
+    '"name": "day15-github-actions-execution"',
+    '"total_commands": 4',
+]
+
+
+def _missing(path: Path, expected: list[str]) -> list[str]:
+    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    return [item for item in expected if item not in text]
+
+
+def main() -> int:
+    errors: list[str] = []
+    required = [README, DOCS_INDEX, DOCS_CLI, QUICKSTART_PAGE, DAY15_REPORT, DAY15_ARTIFACT, DAY15_PACK_STRICT, DAY15_PACK_NIGHTLY, DAY15_EVIDENCE]
+    for path in required:
+        if not path.exists():
+            errors.append(f'missing required file: {path}')
+
+    if not errors:
+        errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
+        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
+        errors.extend(f'{QUICKSTART_PAGE}: missing "{m}"' for m in _missing(QUICKSTART_PAGE, QUICKSTART_EXPECTED))
+        errors.extend(f'{DAY15_REPORT}: missing "{m}"' for m in _missing(DAY15_REPORT, REPORT_EXPECTED))
+        errors.extend(f'{DAY15_ARTIFACT}: missing "{m}"' for m in _missing(DAY15_ARTIFACT, ARTIFACT_EXPECTED))
+        errors.extend(f'{DAY15_PACK_STRICT}: missing "{m}"' for m in _missing(DAY15_PACK_STRICT, PACK_STRICT_EXPECTED))
+        errors.extend(f'{DAY15_PACK_NIGHTLY}: missing "{m}"' for m in _missing(DAY15_PACK_NIGHTLY, PACK_NIGHTLY_EXPECTED))
+        errors.extend(f'{DAY15_EVIDENCE}: missing "{m}"' for m in _missing(DAY15_EVIDENCE, EVIDENCE_EXPECTED))
+
+    if errors:
+        print('day15-github-actions-quickstart-contract check failed:', file=sys.stderr)
+        for error in errors:
+            print(f' - {error}', file=sys.stderr)
+        return 1
+
+    print('day15-github-actions-quickstart-contract check passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Sequence
 from importlib import metadata
 
-from . import apiget, contributor_funnel, demo, docs_navigation, docs_qa, enterprise_use_case, evidence, first_contribution, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, startup_use_case, triage_templates, weekly_review
+from . import apiget, contributor_funnel, demo, docs_navigation, docs_qa, enterprise_use_case, evidence, first_contribution, github_actions_quickstart, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, startup_use_case, triage_templates, weekly_review
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
 from .security_gate import main as security_main
@@ -116,6 +116,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "enterprise-use-case":
         return enterprise_use_case.main(list(argv[1:]))
 
+    if argv and argv[0] == "github-actions-quickstart":
+        return github_actions_quickstart.main(list(argv[1:]))
+
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -198,6 +201,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     euc = sub.add_parser("enterprise-use-case")
     euc.add_argument("args", nargs=argparse.REMAINDER)
 
+    gha = sub.add_parser("github-actions-quickstart")
+    gha.add_argument("args", nargs=argparse.REMAINDER)
+
     ns = p.parse_args(argv)
 
     if ns.cmd == "kv":
@@ -268,6 +274,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "enterprise-use-case":
         return enterprise_use_case.main(ns.args)
+
+    if ns.cmd == "github-actions-quickstart":
+        return github_actions_quickstart.main(ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)

--- a/src/sdetkit/github_actions_quickstart.py
+++ b/src/sdetkit/github_actions_quickstart.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+_PAGE_PATH = "docs/integrations-github-actions-quickstart.md"
+
+_SECTION_HEADER = "# GitHub Actions quickstart (Day 15)"
+_REQUIRED_SECTIONS = [
+    "## Who this recipe is for",
+    "## 5-minute setup",
+    "## Minimal workflow",
+    "## Strict workflow variant",
+    "## Nightly reliability variant",
+    "## Fast verification commands",
+    "## Multi-channel distribution loop",
+    "## Failure recovery playbook",
+    "## Rollout checklist",
+]
+
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit doctor --format text",
+    "python -m sdetkit repo audit --format json",
+    "python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py",
+    "python scripts/check_day15_github_actions_quickstart_contract.py",
+    "python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict",
+]
+
+
+def _workflow_content(variant: str) -> str:
+    if variant == "strict":
+        return """name: sdetkit-github-strict
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  strict-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m pytest -q tests/test_cli_sdetkit.py tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py
+      - run: python -m sdetkit github-actions-quickstart --format json --strict
+      - run: python scripts/check_day15_github_actions_quickstart_contract.py
+"""
+
+    if variant == "nightly":
+        return """name: sdetkit-github-nightly
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m sdetkit doctor --format text
+      - run: python -m sdetkit repo audit --format json
+      - run: python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
+"""
+
+    return """name: sdetkit-github-quickstart
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  quality-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r requirements-test.txt -e .
+      - run: python -m sdetkit github-actions-quickstart --format json --strict
+      - run: python -m pytest -q tests/test_cli_sdetkit.py tests/test_github_actions_quickstart.py
+"""
+
+
+_DAY15_DEFAULT_PAGE = f"""# GitHub Actions quickstart (Day 15)
+
+A production-ready integration recipe to run `sdetkit` quality checks in GitHub Actions with quickstart, strict, and nightly variants.
+
+## Who this recipe is for
+
+- Maintainers who need CI guardrails in less than 5 minutes.
+- Teams moving from local-only checks to PR gate automation.
+- Contributors who want deterministic quality signals in pull requests.
+
+## 5-minute setup
+
+1. Add `.github/workflows/sdetkit-quickstart.yml` with the minimal workflow below.
+2. Push a branch and open a pull request.
+3. Confirm the quality-gate job passes before merge.
+
+## Minimal workflow
+
+```yaml
+{_workflow_content('minimal').rstrip()}
+```
+
+## Strict workflow variant
+
+```yaml
+{_workflow_content('strict').rstrip()}
+```
+
+## Nightly reliability variant
+
+```yaml
+{_workflow_content('nightly').rstrip()}
+```
+
+## Fast verification commands
+
+Run these locally before opening PRs:
+
+```bash
+python -m sdetkit doctor --format text
+python -m sdetkit repo audit --format json
+python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day15_github_actions_quickstart_contract.py
+python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
+```
+
+## Multi-channel distribution loop
+
+1. Post merged workflow update in engineering chat with before/after CI timing.
+2. Publish docs update in `docs/index.md` weekly rollout section.
+3. Share one artifact (`day15-execution-summary.json`) in team retro for adoption tracking.
+
+## Failure recovery playbook
+
+- If checks fail from missing docs content, run `--write-defaults` and rerun strict validation.
+- If tests fail, keep quickstart lane blocking and move nightly lane to diagnostics-only until stable.
+- If flaky behavior appears, attach evidence logs from `--execute --evidence-dir` to the incident thread.
+
+## Rollout checklist
+
+- [ ] Workflow is enabled on `pull_request` and `workflow_dispatch`.
+- [ ] CI installs from `requirements-test.txt` and editable package source.
+- [ ] Day 15 contract check is part of docs validation.
+- [ ] Execution evidence bundle is generated weekly.
+- [ ] Team channel has a pinned link to this quickstart page.
+"""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit github-actions-quickstart",
+        description="Render and validate the Day 15 GitHub Actions quickstart integration recipe.",
+    )
+    parser.add_argument("--format", choices=["text", "markdown", "json"], default="text")
+    parser.add_argument("--root", default=".", help="Repository root where docs live.")
+    parser.add_argument("--output", default="", help="Optional output file path.")
+    parser.add_argument("--strict", action="store_true", help="Return non-zero when required quickstart content is missing.")
+    parser.add_argument("--write-defaults", action="store_true", help="Write or repair the Day 15 quickstart page before validation.")
+    parser.add_argument("--emit-pack-dir", default="", help="Optional path to emit a Day 15 quickstart pack.")
+    parser.add_argument("--variant", choices=["minimal", "strict", "nightly"], default="minimal", help="Workflow variant for markdown/text snippets.")
+    parser.add_argument("--execute", action="store_true", help="Run Day 15 command sequence and capture pass/fail details.")
+    parser.add_argument("--evidence-dir", default="", help="Optional output directory for execution summary JSON and command logs.")
+    parser.add_argument("--timeout-sec", type=int, default=300, help="Per-command timeout in seconds for --execute mode.")
+    return parser
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _missing_checks(page_text: str) -> list[str]:
+    checks = [_SECTION_HEADER, *_REQUIRED_SECTIONS, *_REQUIRED_COMMANDS, "name: sdetkit-github-quickstart", "name: sdetkit-github-strict", "name: sdetkit-github-nightly"]
+    return [item for item in checks if item not in page_text]
+
+
+def _write_defaults(base: Path) -> list[str]:
+    page = base / _PAGE_PATH
+    current = _read(page)
+    if current and not _missing_checks(current):
+        return []
+
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(_DAY15_DEFAULT_PAGE, encoding="utf-8")
+    return [_PAGE_PATH]
+
+
+def _emit_pack(base: Path, out_dir: str) -> list[str]:
+    root = base / out_dir
+    root.mkdir(parents=True, exist_ok=True)
+
+    checklist = root / "day15-github-checklist.md"
+    checklist.write_text(
+        "\n".join(
+            [
+                "# Day 15 GitHub Actions rollout checklist",
+                "",
+                "- [ ] Validate quickstart page in strict mode.",
+                "- [ ] Commit workflow files under .github/workflows/.",
+                "- [ ] Verify PR run passes doctor, repo audit, and tests.",
+                "- [ ] Generate evidence bundle from --execute mode.",
+                "- [ ] Share workflow + evidence links in onboarding docs.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    minimal_workflow = root / "day15-sdetkit-quickstart.yml"
+    minimal_workflow.write_text(_workflow_content("minimal"), encoding="utf-8")
+
+    strict_workflow = root / "day15-sdetkit-strict.yml"
+    strict_workflow.write_text(_workflow_content("strict"), encoding="utf-8")
+
+    nightly_workflow = root / "day15-sdetkit-nightly.yml"
+    nightly_workflow.write_text(_workflow_content("nightly"), encoding="utf-8")
+
+    distribution_plan = root / "day15-distribution-plan.md"
+    distribution_plan.write_text(
+        "\n".join(
+            [
+                "# Day 15 distribution plan",
+                "",
+                "| Channel | Artifact | Owner | Cadence |",
+                "| --- | --- | --- | --- |",
+                "| Engineering Slack | quickstart workflow + execution summary | QE lead | weekly |",
+                "| Docs portal | Day 15 integration page | Docs owner | weekly |",
+                "| Sprint retro | evidence logs and failure themes | Team lead | bi-weekly |",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    validation = root / "day15-validation-commands.md"
+    validation.write_text(
+        "\n".join(["# Day 15 validation commands", "", "```bash", *_REQUIRED_COMMANDS, "```", ""]) + "\n",
+        encoding="utf-8",
+    )
+
+    return [
+        str(path.relative_to(base))
+        for path in (checklist, minimal_workflow, strict_workflow, nightly_workflow, distribution_plan, validation)
+    ]
+
+
+def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    for idx, command in enumerate(commands, start=1):
+        try:
+            proc = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout_sec, check=False)
+            results.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": proc.returncode,
+                    "ok": proc.returncode == 0,
+                    "stdout": proc.stdout,
+                    "stderr": proc.stderr,
+                }
+            )
+        except subprocess.TimeoutExpired as exc:
+            results.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": 124,
+                    "ok": False,
+                    "stdout": (exc.stdout or "") if isinstance(exc.stdout, str) else "",
+                    "stderr": (exc.stderr or "") if isinstance(exc.stderr, str) else "",
+                    "error": f"timed out after {timeout_sec}s",
+                }
+            )
+    return results
+
+
+def _write_execution_evidence(base: Path, out_dir: str, results: list[dict[str, object]]) -> list[str]:
+    root = base / out_dir
+    root.mkdir(parents=True, exist_ok=True)
+
+    summary = root / "day15-execution-summary.json"
+    payload = {
+        "name": "day15-github-actions-execution",
+        "total_commands": len(results),
+        "passed_commands": len([r for r in results if r.get("ok")]),
+        "failed_commands": len([r for r in results if not r.get("ok")]),
+        "results": results,
+    }
+    summary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    emitted = [summary]
+    for row in results:
+        log_file = root / f"command-{row['index']:02d}.log"
+        log_file.write_text(
+            "\n".join(
+                [
+                    f"command: {row['command']}",
+                    f"returncode: {row['returncode']}",
+                    f"ok: {row['ok']}",
+                    "--- stdout ---",
+                    str(row.get("stdout", "")),
+                    "--- stderr ---",
+                    str(row.get("stderr", "")),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        emitted.append(log_file)
+
+    return [str(path.relative_to(base)) for path in emitted]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    base = Path(args.root).resolve()
+
+    touched = _write_defaults(base) if args.write_defaults else []
+    page = base / _PAGE_PATH
+    text = _read(page)
+
+    missing = _missing_checks(text)
+    total = len([_SECTION_HEADER, *_REQUIRED_SECTIONS, *_REQUIRED_COMMANDS, "name: sdetkit-github-quickstart", "name: sdetkit-github-strict", "name: sdetkit-github-nightly"])
+    passed = total - len(missing)
+    score = round((passed / total) * 100, 1)
+
+    payload: dict[str, object] = {
+        "name": "day15-github-actions-quickstart",
+        "page": _PAGE_PATH,
+        "variant": args.variant,
+        "selected_workflow": _workflow_content(args.variant),
+        "passed_checks": passed,
+        "total_checks": total,
+        "score": score,
+        "missing": missing,
+        "touched_files": touched,
+    }
+
+    if args.emit_pack_dir:
+        payload["pack_files"] = _emit_pack(base, args.emit_pack_dir)
+
+    execution_failed = False
+    if args.execute:
+        commands = [
+            "python -m sdetkit doctor --format text",
+            "python -m sdetkit repo audit --format json",
+            "python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py",
+            "python -m sdetkit github-actions-quickstart --format json --strict",
+        ]
+        results = _execute_commands(commands, timeout_sec=args.timeout_sec)
+        execution = {
+            "total_commands": len(results),
+            "passed_commands": len([r for r in results if r.get("ok")]),
+            "failed_commands": len([r for r in results if not r.get("ok")]),
+            "results": results,
+        }
+        payload["execution"] = execution
+        execution_failed = execution["failed_commands"] > 0
+
+        evidence_dir = args.evidence_dir or "docs/artifacts/day15-github-pack/evidence"
+        payload["evidence_files"] = _write_execution_evidence(base, evidence_dir, results)
+
+    if args.format == "json":
+        rendered = json.dumps(payload, indent=2) + "\n"
+    elif args.format == "markdown":
+        lines = [
+            "# Day 15 GitHub Actions quickstart",
+            "",
+            f"- Page: `{_PAGE_PATH}`",
+            f"- Variant: `{args.variant}`",
+            f"- Score: **{score}** ({passed}/{total})",
+        ]
+        if missing:
+            lines.append("- Missing:")
+            lines.extend(f"  - `{item}`" for item in missing)
+        else:
+            lines.append("- Missing: none ✅")
+
+        lines.extend(
+            [
+                "",
+                "## Commands",
+                "",
+                "```bash",
+                "sdetkit github-actions-quickstart --format text --strict",
+                "sdetkit github-actions-quickstart --format json --variant strict --strict",
+                "sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict",
+                "sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict",
+                "```",
+            ]
+        )
+        rendered = "\n".join(lines) + "\n"
+    else:
+        rendered = (
+            "Day 15 GitHub Actions quickstart\n"
+            f"page: {_PAGE_PATH}\n"
+            f"variant: {args.variant}\n"
+            f"score: {score} ({passed}/{total})\n"
+            f"missing checks: {len(missing)}\n"
+        )
+
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if args.strict and (missing or execution_failed):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_weekly_review_first_contribution_contributor_funnel_triage_templates_and_docs_nav_and_startup_and_enterprise_use_case() -> None:
+def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_weekly_review_first_contribution_contributor_funnel_triage_templates_and_docs_nav_and_startup_and_enterprise_and_github_actions_quickstart_use_case() -> None:
     r = subprocess.run(
         [sys.executable, "-m", "sdetkit", "--help"],
         text=True,
@@ -32,3 +32,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "docs-nav" in out
     assert "startup-use-case" in out
     assert "enterprise-use-case" in out
+    assert "github-actions-quickstart" in out

--- a/tests/test_github_actions_quickstart.py
+++ b/tests/test_github_actions_quickstart.py
@@ -1,0 +1,124 @@
+import json
+
+from sdetkit import cli, github_actions_quickstart
+
+
+def test_day15_quickstart_default_text(capsys):
+    rc = github_actions_quickstart.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Day 15 GitHub Actions quickstart" in out
+
+
+def test_day15_quickstart_json_and_strict_success(capsys):
+    rc = github_actions_quickstart.main(["--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["name"] == "day15-github-actions-quickstart"
+    assert data["passed_checks"] == data["total_checks"]
+    assert data["total_checks"] == 18
+
+
+def test_day15_quickstart_variant_switches_workflow(capsys):
+    rc = github_actions_quickstart.main(["--format", "json", "--variant", "strict", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["variant"] == "strict"
+    assert "name: sdetkit-github-strict" in data["selected_workflow"]
+
+
+def test_day15_quickstart_strict_fails_when_content_missing(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/integrations-github-actions-quickstart.md").write_text("# Placeholder\n", encoding="utf-8")
+    rc = github_actions_quickstart.main(["--root", str(tmp_path), "--strict"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "missing checks:" in out
+
+
+def test_day15_quickstart_write_defaults_recovers_missing_file(tmp_path, capsys):
+    rc = github_actions_quickstart.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["passed_checks"] == data["total_checks"]
+    assert data["touched_files"] == ["docs/integrations-github-actions-quickstart.md"]
+
+
+def test_day15_quickstart_emit_pack(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/integrations-github-actions-quickstart.md").write_text(
+        github_actions_quickstart._DAY15_DEFAULT_PAGE, encoding="utf-8"
+    )
+    rc = github_actions_quickstart.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "docs/artifacts/day15-github-pack",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert len(data["pack_files"]) == 6
+    assert "docs/artifacts/day15-github-pack/day15-sdetkit-strict.yml" in data["pack_files"]
+
+
+def test_day15_quickstart_execute_writes_evidence(monkeypatch, tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/integrations-github-actions-quickstart.md").write_text(
+        github_actions_quickstart._DAY15_DEFAULT_PAGE, encoding="utf-8"
+    )
+
+    class _Proc:
+        def __init__(self):
+            self.returncode = 0
+            self.stdout = "ok"
+            self.stderr = ""
+
+    monkeypatch.setattr(github_actions_quickstart.subprocess, "run", lambda *a, **k: _Proc())
+
+    rc = github_actions_quickstart.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--execute",
+            "--evidence-dir",
+            "docs/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["execution"]["failed_commands"] == 0
+    assert (tmp_path / "docs/evidence/day15-execution-summary.json").exists()
+
+
+def test_day15_quickstart_execute_strict_fails_on_command_error(monkeypatch, tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/integrations-github-actions-quickstart.md").write_text(
+        github_actions_quickstart._DAY15_DEFAULT_PAGE, encoding="utf-8"
+    )
+
+    class _Proc:
+        def __init__(self):
+            self.returncode = 1
+            self.stdout = ""
+            self.stderr = "boom"
+
+    monkeypatch.setattr(github_actions_quickstart.subprocess, "run", lambda *a, **k: _Proc())
+
+    rc = github_actions_quickstart.main(["--root", str(tmp_path), "--execute", "--format", "json", "--strict"])
+    assert rc == 1
+    data = json.loads(capsys.readouterr().out)
+    assert data["execution"]["failed_commands"] == 4
+
+
+def test_main_cli_dispatches_day15_quickstart(capsys):
+    rc = cli.main(["github-actions-quickstart", "--format", "text"])
+    assert rc == 0
+    assert "Day 15 GitHub Actions quickstart" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation

- Close out Day 15 by expanding the initial quickstart into a production-ready GitHub Actions integration with minimal, strict, and nightly variants.
- Provide deterministic execution/evidence capture so teams can publish reproducible pass/fail artifacts for audits and incident triage.
- Harden docs and contract checks so the quickstart can auto-recover missing content and be validated in CI and handoff flows.

### Description

- Add a new CLI module `sdetkit.github_actions_quickstart` that renders and validates the Day 15 quickstart and supports `--variant` (`minimal|strict|nightly`), `--write-defaults`, `--emit-pack-dir`, `--execute`, `--evidence-dir`, `--timeout-sec`, `--strict`, and `--format` output.
- Emit a Day 15 rollout pack with checklist, minimal/strict/nightly workflows, distribution plan, and validation commands via `--emit-pack-dir` and generate execution evidence (`day15-execution-summary.json` + per-command logs) when run with `--execute` and `--evidence-dir`.
- Wire the command into the top-level CLI by updating `src/sdetkit/cli.py` and expand docs and sample artifacts under `docs/` and `docs/artifacts/` to include the strict/nightly variants, distribution loop, failure playbook, and a Day 15 report.
- Add tests and a contract-check script: `tests/test_github_actions_quickstart.py`, update `tests/test_cli_help_lists_subcommands.py`, and add `scripts/check_day15_github_actions_quickstart_contract.py` to validate README/docs/pack/evidence expectations.

### Testing

- Ran unit tests with `python -m pytest -q tests/test_github_actions_quickstart.py tests/test_cli_help_lists_subcommands.py`, which completed successfully (`10 passed`).
- Executed the contract script `python scripts/check_day15_github_actions_quickstart_contract.py`, which reported the contract check as passed. 
- Validated the CLI output with `python -m sdetkit github-actions-quickstart --format json --strict`, which returned a 100.0 score and no missing checks. 
- Exercised full execution/evidence flow with `python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict`, which ran the command chain and produced the `day15-execution-summary.json` and per-command logs with successful results.

------