### PR TITLE
Upgrade Day 16 closeout with GitLab pipeline bootstrap + stricter gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,37 @@ python -m sdetkit github-actions-quickstart --format json --strict
 python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict
 ```
 
+## 🦊 Day 16 ultra: GitLab CI quickstart
+
+Day 16 ships a **production-ready GitLab CI integration recipe** with minimal + strict + nightly pipelines, evidence capture, and distribution-loop guidance.
+
+```bash
+python -m sdetkit gitlab-ci-quickstart --format text --strict
+python -m sdetkit gitlab-ci-quickstart --format json --variant strict --strict
+python -m sdetkit gitlab-ci-quickstart --write-defaults --format json --strict
+python -m sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict
+python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict
+python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+```
+
+Export a markdown artifact for handoff:
+
+```bash
+python -m sdetkit gitlab-ci-quickstart --format markdown --variant strict --output docs/artifacts/day16-gitlab-ci-quickstart-sample.md
+```
+
+See implementation details: [Day 16 ultra upgrade report](docs/day-16-ultra-upgrade-report.md).
+
+Day 16 closeout checks:
+
+```bash
+python -m pytest -q tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day16_gitlab_ci_quickstart_contract.py
+python -m sdetkit gitlab-ci-quickstart --format json --strict
+python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict
+python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day16-gitlab-ci-quickstart-sample.md
+++ b/docs/artifacts/day16-gitlab-ci-quickstart-sample.md
@@ -1,0 +1,16 @@
+# Day 16 GitLab CI quickstart
+
+- Page: `docs/integrations-gitlab-ci-quickstart.md`
+- Variant: `strict`
+- Score: **100.0** (19/19)
+- Missing: none ✅
+
+## Commands
+
+```bash
+sdetkit gitlab-ci-quickstart --format text --strict
+sdetkit gitlab-ci-quickstart --format json --variant strict --strict
+sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict
+sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict
+sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+```

--- a/docs/artifacts/day16-gitlab-pack/day16-distribution-plan.md
+++ b/docs/artifacts/day16-gitlab-pack/day16-distribution-plan.md
@@ -1,0 +1,7 @@
+# Day 16 distribution plan
+
+| Channel | Artifact | Owner | Cadence |
+| --- | --- | --- | --- |
+| Engineering Slack | `.gitlab-ci.yml` quickstart + evidence summary | QE lead | weekly |
+| Docs portal | Day 16 integration page | Docs owner | weekly |
+| Sprint retro | evidence logs and failure themes | Team lead | bi-weekly |

--- a/docs/artifacts/day16-gitlab-pack/day16-gitlab-checklist.md
+++ b/docs/artifacts/day16-gitlab-pack/day16-gitlab-checklist.md
@@ -1,0 +1,7 @@
+# Day 16 GitLab CI rollout checklist
+
+- [ ] Validate quickstart page in strict mode.
+- [ ] Commit `.gitlab-ci.yml` updates with staged variants.
+- [ ] Verify merge request pipeline passes doctor, repo audit, and tests.
+- [ ] Generate evidence bundle from --execute mode.
+- [ ] Share pipeline + evidence links in onboarding docs.

--- a/docs/artifacts/day16-gitlab-pack/day16-sdetkit-nightly.yml
+++ b/docs/artifacts/day16-gitlab-pack/day16-sdetkit-nightly.yml
@@ -1,0 +1,17 @@
+stages:
+  - nightly
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+nightly-audit:
+  stage: nightly
+  image: python:3.11
+  script:
+    - python -m pip install -r requirements-test.txt -e .
+    - python -m sdetkit doctor --format text
+    - python -m sdetkit repo audit --format json
+    - python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "web"

--- a/docs/artifacts/day16-gitlab-pack/day16-sdetkit-quickstart.yml
+++ b/docs/artifacts/day16-gitlab-pack/day16-sdetkit-quickstart.yml
@@ -1,0 +1,16 @@
+stages:
+  - quality
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+quickstart-gate:
+  stage: quality
+  image: python:3.11
+  script:
+    - python -m pip install -r requirements-test.txt -e .
+    - python -m sdetkit gitlab-ci-quickstart --format json --strict
+    - python -m pytest -q tests/test_cli_sdetkit.py tests/test_gitlab_ci_quickstart.py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "web"

--- a/docs/artifacts/day16-gitlab-pack/day16-sdetkit-strict.yml
+++ b/docs/artifacts/day16-gitlab-pack/day16-sdetkit-strict.yml
@@ -1,0 +1,17 @@
+stages:
+  - quality
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+strict-gate:
+  stage: quality
+  image: python:3.11
+  script:
+    - python -m pip install -r requirements-test.txt -e .
+    - python -m pytest -q tests/test_cli_sdetkit.py tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py
+    - python -m sdetkit gitlab-ci-quickstart --format json --strict
+    - python scripts/check_day16_gitlab_ci_quickstart_contract.py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "web"

--- a/docs/artifacts/day16-gitlab-pack/day16-validation-commands.md
+++ b/docs/artifacts/day16-gitlab-pack/day16-validation-commands.md
@@ -1,0 +1,11 @@
+# Day 16 validation commands
+
+```bash
+python -m sdetkit doctor --format text
+python -m sdetkit repo audit --format json
+python -m pytest -q tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day16_gitlab_ci_quickstart_contract.py
+python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict
+python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+```
+

--- a/docs/artifacts/day16-gitlab-pack/evidence/command-01.log
+++ b/docs/artifacts/day16-gitlab-pack/evidence/command-01.log
@@ -1,0 +1,17 @@
+command: python -m sdetkit doctor --format text
+returncode: 0
+ok: True
+--- stdout ---
+doctor score: 100%
+[OK] ascii: ASCII scan not requested
+[OK] ci_workflows: CI workflow check not requested
+[OK] clean_tree: clean tree check not requested
+[OK] deps: dependency consistency check not requested
+[OK] pre_commit: pre-commit check not requested
+[OK] security_files: security governance file check not requested
+[OK] stdlib_shadowing: no stdlib shadowing detected
+recommendations:
+- No immediate blockers detected. Keep CI, docs, and tests green for premium delivery quality.
+
+--- stderr ---
+

--- a/docs/artifacts/day16-gitlab-pack/evidence/command-02.log
+++ b/docs/artifacts/day16-gitlab-pack/evidence/command-02.log
@@ -1,0 +1,93 @@
+command: python -m sdetkit repo audit --format json
+returncode: 0
+ok: True
+--- stdout ---
+{
+  "checks": [
+    {
+      "details": [
+        "Repository should define contributor conduct expectations."
+      ],
+      "key": "CORE_MISSING_CODE_OF_CONDUCT_MD",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "CODE_OF_CONDUCT.md exists"
+    },
+    {
+      "details": [
+        "Repository should explain how to contribute."
+      ],
+      "key": "CORE_MISSING_CONTRIBUTING_MD",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "CONTRIBUTING.md exists"
+    },
+    {
+      "details": [
+        "Repository should define issue template defaults."
+      ],
+      "key": "CORE_MISSING_ISSUE_TEMPLATE_CONFIG",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "Issue template config exists"
+    },
+    {
+      "details": [
+        "Repository should provide a pull request template."
+      ],
+      "key": "CORE_MISSING_PR_TEMPLATE",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "PR template exists"
+    },
+    {
+      "details": [
+        "Repository should publish a security reporting policy."
+      ],
+      "key": "CORE_MISSING_SECURITY_MD",
+      "pack": "core",
+      "status": "pass",
+      "supports_fix": true,
+      "title": "SECURITY.md exists"
+    }
+  ],
+  "findings": [],
+  "root": "/workspace/DevS69-sdetkit",
+  "schema_version": "1.1.0",
+  "summary": {
+    "checks": 5,
+    "counts": {
+      "error": 0,
+      "info": 0,
+      "warn": 0
+    },
+    "failed": 0,
+    "findings": 0,
+    "incremental": {
+      "changed_files": 0,
+      "used": false
+    },
+    "ok": true,
+    "packs": [
+      "core"
+    ],
+    "passed": 5,
+    "policy": {
+      "actionable": 0,
+      "suppressed_active": 0,
+      "suppressed_by_baseline": 0,
+      "suppressed_by_policy": 0,
+      "suppressed_expired": 0,
+      "total_findings": 0
+    }
+  },
+  "suppressed": [],
+  "suppressed_expired": []
+}
+
+--- stderr ---
+

--- a/docs/artifacts/day16-gitlab-pack/evidence/command-03.log
+++ b/docs/artifacts/day16-gitlab-pack/evidence/command-03.log
@@ -1,0 +1,9 @@
+command: python -m pytest -q tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py
+returncode: 0
+ok: True
+--- stdout ---
+...........                                                              [100%]
+11 passed in 1.38s
+
+--- stderr ---
+

--- a/docs/artifacts/day16-gitlab-pack/evidence/command-04.log
+++ b/docs/artifacts/day16-gitlab-pack/evidence/command-04.log
@@ -1,0 +1,18 @@
+command: python -m sdetkit gitlab-ci-quickstart --format json --strict
+returncode: 0
+ok: True
+--- stdout ---
+{
+  "name": "day16-gitlab-ci-quickstart",
+  "page": "docs/integrations-gitlab-ci-quickstart.md",
+  "variant": "minimal",
+  "selected_pipeline": "stages:\n  - quality\n\nvariables:\n  PIP_DISABLE_PIP_VERSION_CHECK: \"1\"\n\nquickstart-gate:\n  stage: quality\n  image: python:3.11\n  script:\n    - python -m pip install -r requirements-test.txt -e .\n    - python -m sdetkit gitlab-ci-quickstart --format json --strict\n    - python -m pytest -q tests/test_cli_sdetkit.py tests/test_gitlab_ci_quickstart.py\n  rules:\n    - if: $CI_PIPELINE_SOURCE == \"merge_request_event\"\n    - if: $CI_PIPELINE_SOURCE == \"web\"\n",
+  "passed_checks": 19,
+  "total_checks": 19,
+  "score": 100.0,
+  "missing": [],
+  "touched_files": []
+}
+
+--- stderr ---
+

--- a/docs/artifacts/day16-gitlab-pack/evidence/day16-execution-summary.json
+++ b/docs/artifacts/day16-gitlab-pack/evidence/day16-execution-summary.json
@@ -1,0 +1,40 @@
+{
+  "name": "day16-gitlab-ci-execution",
+  "total_commands": 4,
+  "passed_commands": 4,
+  "failed_commands": 0,
+  "results": [
+    {
+      "index": 1,
+      "command": "python -m sdetkit doctor --format text",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "doctor score: 100%\n[OK] ascii: ASCII scan not requested\n[OK] ci_workflows: CI workflow check not requested\n[OK] clean_tree: clean tree check not requested\n[OK] deps: dependency consistency check not requested\n[OK] pre_commit: pre-commit check not requested\n[OK] security_files: security governance file check not requested\n[OK] stdlib_shadowing: no stdlib shadowing detected\nrecommendations:\n- No immediate blockers detected. Keep CI, docs, and tests green for premium delivery quality.\n",
+      "stderr": ""
+    },
+    {
+      "index": 2,
+      "command": "python -m sdetkit repo audit --format json",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "{\n  \"checks\": [\n    {\n      \"details\": [\n        \"Repository should define contributor conduct expectations.\"\n      ],\n      \"key\": \"CORE_MISSING_CODE_OF_CONDUCT_MD\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"CODE_OF_CONDUCT.md exists\"\n    },\n    {\n      \"details\": [\n        \"Repository should explain how to contribute.\"\n      ],\n      \"key\": \"CORE_MISSING_CONTRIBUTING_MD\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"CONTRIBUTING.md exists\"\n    },\n    {\n      \"details\": [\n        \"Repository should define issue template defaults.\"\n      ],\n      \"key\": \"CORE_MISSING_ISSUE_TEMPLATE_CONFIG\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"Issue template config exists\"\n    },\n    {\n      \"details\": [\n        \"Repository should provide a pull request template.\"\n      ],\n      \"key\": \"CORE_MISSING_PR_TEMPLATE\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"PR template exists\"\n    },\n    {\n      \"details\": [\n        \"Repository should publish a security reporting policy.\"\n      ],\n      \"key\": \"CORE_MISSING_SECURITY_MD\",\n      \"pack\": \"core\",\n      \"status\": \"pass\",\n      \"supports_fix\": true,\n      \"title\": \"SECURITY.md exists\"\n    }\n  ],\n  \"findings\": [],\n  \"root\": \"/workspace/DevS69-sdetkit\",\n  \"schema_version\": \"1.1.0\",\n  \"summary\": {\n    \"checks\": 5,\n    \"counts\": {\n      \"error\": 0,\n      \"info\": 0,\n      \"warn\": 0\n    },\n    \"failed\": 0,\n    \"findings\": 0,\n    \"incremental\": {\n      \"changed_files\": 0,\n      \"used\": false\n    },\n    \"ok\": true,\n    \"packs\": [\n      \"core\"\n    ],\n    \"passed\": 5,\n    \"policy\": {\n      \"actionable\": 0,\n      \"suppressed_active\": 0,\n      \"suppressed_by_baseline\": 0,\n      \"suppressed_by_policy\": 0,\n      \"suppressed_expired\": 0,\n      \"total_findings\": 0\n    }\n  },\n  \"suppressed\": [],\n  \"suppressed_expired\": []\n}\n",
+      "stderr": ""
+    },
+    {
+      "index": 3,
+      "command": "python -m pytest -q tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "...........                                                              [100%]\n11 passed in 1.38s\n",
+      "stderr": ""
+    },
+    {
+      "index": 4,
+      "command": "python -m sdetkit gitlab-ci-quickstart --format json --strict",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "{\n  \"name\": \"day16-gitlab-ci-quickstart\",\n  \"page\": \"docs/integrations-gitlab-ci-quickstart.md\",\n  \"variant\": \"minimal\",\n  \"selected_pipeline\": \"stages:\\n  - quality\\n\\nvariables:\\n  PIP_DISABLE_PIP_VERSION_CHECK: \\\"1\\\"\\n\\nquickstart-gate:\\n  stage: quality\\n  image: python:3.11\\n  script:\\n    - python -m pip install -r requirements-test.txt -e .\\n    - python -m sdetkit gitlab-ci-quickstart --format json --strict\\n    - python -m pytest -q tests/test_cli_sdetkit.py tests/test_gitlab_ci_quickstart.py\\n  rules:\\n    - if: $CI_PIPELINE_SOURCE == \\\"merge_request_event\\\"\\n    - if: $CI_PIPELINE_SOURCE == \\\"web\\\"\\n\",\n  \"passed_checks\": 19,\n  \"total_checks\": 19,\n  \"score\": 100.0,\n  \"missing\": [],\n  \"touched_files\": []\n}\n",
+      "stderr": ""
+    }
+  ]
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -263,6 +263,37 @@ Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`, 
 
 See: day-15-ultra-upgrade-report.md
 
+
+## gitlab-ci-quickstart
+
+Builds Day 16 GitLab CI quickstart status and validates required integration sections, pipeline variants, and execution evidence workflow.
+
+Examples:
+
+- `sdetkit gitlab-ci-quickstart --format text --strict`
+- `sdetkit gitlab-ci-quickstart --format json --variant strict --strict`
+- `sdetkit gitlab-ci-quickstart --write-defaults --format json --strict`
+- `sdetkit gitlab-ci-quickstart --format markdown --variant strict --output docs/artifacts/day16-gitlab-ci-quickstart-sample.md`
+- `sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict`
+- `sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict`
+- `sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict`
+
+Useful flags: `--root`, `--format`, `--output`, `--strict`, `--write-defaults`, `--emit-pack-dir`, `--variant`, `--bootstrap-pipeline`, `--pipeline-path`, `--execute`, `--evidence-dir`, `--timeout-sec`.
+
+`--strict` returns non-zero if required Day 16 quickstart sections or command snippets are missing from `docs/integrations-gitlab-ci-quickstart.md`.
+
+`--write-defaults` writes a hardened Day 16 quickstart page if missing/incomplete, then validates again.
+
+`--emit-pack-dir` writes a Day 16 integration pack containing checklist, minimal/strict/nightly pipelines, distribution plan, and validation commands.
+
+`--bootstrap-pipeline` writes the selected pipeline variant directly to `--pipeline-path` for copy/paste-free adoption.
+
+`--execute` runs Day 16 command chain and captures pass/fail output.
+
+`--evidence-dir` writes `day16-execution-summary.json` plus per-command log files for CI incident triage and closeout handoff.
+
+See: day-16-ultra-upgrade-report.md
+
 ## patch
 
 Deterministic, spec-driven file edits (official CLI command).

--- a/docs/day-16-ultra-upgrade-report.md
+++ b/docs/day-16-ultra-upgrade-report.md
@@ -1,0 +1,27 @@
+# Day 16 ultra upgrade report
+
+## Day 16 big upgrade
+
+Day 16 adds a full **GitLab CI quickstart integration operating loop** with minimal, strict, and nightly pipeline templates plus deterministic validation and execution evidence capture.
+
+## What shipped
+
+- New CLI command: `sdetkit gitlab-ci-quickstart` with `--strict`, `--write-defaults`, `--variant`, `--emit-pack-dir`, `--bootstrap-pipeline`, and `--execute` support.
+- New integration docs page: `docs/integrations-gitlab-ci-quickstart.md`.
+- New Day 16 artifacts: sample markdown output, rollout pack templates, and execution evidence summary/logs.
+- New contract checker: `scripts/check_day16_gitlab_ci_quickstart_contract.py`.
+- CLI dispatcher and help coverage updated to include `gitlab-ci-quickstart`.
+
+## Validation commands
+
+```bash
+python -m sdetkit gitlab-ci-quickstart --format json --variant strict --strict
+python -m sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict
+python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict
+python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+python scripts/check_day16_gitlab_ci_quickstart_contract.py
+```
+
+## Closeout
+
+Day 16 now provides adoption-ready, copy/paste GitLab CI templates and deterministic checks aligned with the integration roadmap.

--- a/docs/index.md
+++ b/docs/index.md
@@ -279,3 +279,17 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Capture deterministic execution evidence: `sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict`.
 - Review generated artifacts: [day15 quickstart sample](artifacts/day15-github-actions-quickstart-sample.md), [day15 strict workflow](artifacts/day15-github-pack/day15-sdetkit-strict.yml), [day15 evidence summary](artifacts/day15-github-pack/evidence/day15-execution-summary.json).
 
+
+
+## Day 16 ultra upgrades (GitLab CI quickstart)
+
+- Read the implementation report: [Day 16 ultra upgrade report](day-16-ultra-upgrade-report.md).
+- Run `sdetkit gitlab-ci-quickstart --format text --strict` to validate required integration recipe sections and pipeline variants.
+- Validate strict variant output: `sdetkit gitlab-ci-quickstart --format json --variant strict --strict`.
+- Auto-recover missing quickstart content: `sdetkit gitlab-ci-quickstart --write-defaults --format json --strict`.
+- Export markdown quickstart artifact: `sdetkit gitlab-ci-quickstart --format markdown --variant strict --output docs/artifacts/day16-gitlab-ci-quickstart-sample.md`.
+- Emit Day 16 rollout pack: `sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict`.
+- Bootstrap `.gitlab-ci.yml` from strict variant: `sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict`.
+- Capture deterministic execution evidence: `sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict`.
+- Review generated artifacts: [day16 quickstart sample](artifacts/day16-gitlab-ci-quickstart-sample.md), [day16 strict pipeline](artifacts/day16-gitlab-pack/day16-sdetkit-strict.yml), [day16 evidence summary](artifacts/day16-gitlab-pack/evidence/day16-execution-summary.json).
+

--- a/docs/integrations-gitlab-ci-quickstart.md
+++ b/docs/integrations-gitlab-ci-quickstart.md
@@ -1,0 +1,113 @@
+# GitLab CI quickstart (Day 16)
+
+A production-ready integration recipe to run `sdetkit` quality checks in GitLab CI with quickstart, strict, and nightly variants.
+
+## Who this recipe is for
+
+- Maintainers who need CI guardrails in less than 5 minutes.
+- Teams migrating from ad-hoc local checks into merge request quality gates.
+- Contributors who want deterministic quality signals in merge request pipelines.
+
+## 5-minute setup
+
+1. Add `.gitlab-ci.yml` using the minimal pipeline below.
+2. Open a merge request to trigger the quality gate.
+3. Confirm the quickstart-gate job passes before merge.
+
+## Minimal pipeline
+
+```yaml
+stages:
+  - quality
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+quickstart-gate:
+  stage: quality
+  image: python:3.11
+  script:
+    - python -m pip install -r requirements-test.txt -e .
+    - python -m sdetkit gitlab-ci-quickstart --format json --strict
+    - python -m pytest -q tests/test_cli_sdetkit.py tests/test_gitlab_ci_quickstart.py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "web"
+```
+
+## Strict pipeline variant
+
+```yaml
+stages:
+  - quality
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+strict-gate:
+  stage: quality
+  image: python:3.11
+  script:
+    - python -m pip install -r requirements-test.txt -e .
+    - python -m pytest -q tests/test_cli_sdetkit.py tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py
+    - python -m sdetkit gitlab-ci-quickstart --format json --strict
+    - python scripts/check_day16_gitlab_ci_quickstart_contract.py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "web"
+```
+
+## Nightly reliability variant
+
+```yaml
+stages:
+  - nightly
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+nightly-audit:
+  stage: nightly
+  image: python:3.11
+  script:
+    - python -m pip install -r requirements-test.txt -e .
+    - python -m sdetkit doctor --format text
+    - python -m sdetkit repo audit --format json
+    - python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "web"
+```
+
+## Fast verification commands
+
+Run these locally before opening merge requests:
+
+```bash
+python -m sdetkit doctor --format text
+python -m sdetkit repo audit --format json
+python -m pytest -q tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day16_gitlab_ci_quickstart_contract.py
+python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict
+python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+```
+
+## Multi-channel distribution loop
+
+1. Share merged `.gitlab-ci.yml` updates in engineering chat with before/after timing.
+2. Publish docs updates in `docs/index.md` weekly rollout section.
+3. Attach one artifact (`day16-execution-summary.json`) in retro for adoption tracking.
+
+## Failure recovery playbook
+
+- If checks fail because docs content drifted, run `--write-defaults` then rerun strict mode.
+- If tests fail, keep strict gate required and move nightly lane to diagnostics-only until stable.
+- If flaky behavior appears, attach evidence logs from `--execute --evidence-dir` to incident notes.
+
+## Rollout checklist
+
+- [ ] Pipeline runs for merge requests and manual dispatches.
+- [ ] CI installs from `requirements-test.txt` and editable package source.
+- [ ] Day 16 contract check is part of docs validation.
+- [ ] Execution evidence bundle is generated weekly.
+- [ ] Team channel has a pinned link to this quickstart page.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -35,6 +35,8 @@ case "$mode" in
     python scripts/check_onboarding_contract.py
     python scripts/check_day3_proof_contract.py
     python scripts/check_day4_skills_contract.py
+    python scripts/check_day15_github_actions_quickstart_contract.py
+    python scripts/check_day16_gitlab_ci_quickstart_contract.py
     ;;
   onboarding)
     python scripts/check_onboarding_contract.py
@@ -44,6 +46,12 @@ case "$mode" in
     ;;
   day4)
     python scripts/check_day4_skills_contract.py
+    ;;
+  day15)
+    python scripts/check_day15_github_actions_quickstart_contract.py
+    ;;
+  day16)
+    python scripts/check_day16_gitlab_ci_quickstart_contract.py
     ;;
   all)
     ruff format --check .
@@ -55,9 +63,11 @@ case "$mode" in
     python scripts/check_onboarding_contract.py
     python scripts/check_day3_proof_contract.py
     python scripts/check_day4_skills_contract.py
+    python scripts/check_day15_github_actions_quickstart_contract.py
+    python scripts/check_day16_gitlab_ci_quickstart_contract.py
     ;;
   *)
-    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|day3|day4|all}" >&2
+    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|day3|day4|day15|day16|all}" >&2
     exit 2
     ;;
 esac

--- a/scripts/check_day16_gitlab_ci_quickstart_contract.py
+++ b/scripts/check_day16_gitlab_ci_quickstart_contract.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+README = Path('README.md')
+DOCS_INDEX = Path('docs/index.md')
+DOCS_CLI = Path('docs/cli.md')
+QUICKSTART_PAGE = Path('docs/integrations-gitlab-ci-quickstart.md')
+DAY16_REPORT = Path('docs/day-16-ultra-upgrade-report.md')
+DAY16_ARTIFACT = Path('docs/artifacts/day16-gitlab-ci-quickstart-sample.md')
+DAY16_PACK_STRICT = Path('docs/artifacts/day16-gitlab-pack/day16-sdetkit-strict.yml')
+DAY16_PACK_NIGHTLY = Path('docs/artifacts/day16-gitlab-pack/day16-sdetkit-nightly.yml')
+DAY16_EVIDENCE = Path('docs/artifacts/day16-gitlab-pack/evidence/day16-execution-summary.json')
+
+README_EXPECTED = [
+    '## 🦊 Day 16 ultra: GitLab CI quickstart',
+    'python -m sdetkit gitlab-ci-quickstart --format text --strict',
+    'python -m sdetkit gitlab-ci-quickstart --format json --variant strict --strict',
+    'python -m sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict',
+    'python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict',
+    'python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+    'python scripts/check_day16_gitlab_ci_quickstart_contract.py',
+    'docs/day-16-ultra-upgrade-report.md',
+]
+
+DOCS_INDEX_EXPECTED = [
+    '## Day 16 ultra upgrades (GitLab CI quickstart)',
+    'sdetkit gitlab-ci-quickstart --format text --strict',
+    'sdetkit gitlab-ci-quickstart --format json --variant strict --strict',
+    'sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict',
+    'sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict',
+    'sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+    'artifacts/day16-gitlab-ci-quickstart-sample.md',
+]
+
+DOCS_CLI_EXPECTED = [
+    '## gitlab-ci-quickstart',
+    'sdetkit gitlab-ci-quickstart --format markdown --variant strict --output docs/artifacts/day16-gitlab-ci-quickstart-sample.md',
+    'sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict',
+    'sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict',
+    'sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+    '--write-defaults',
+    '--variant',
+    '--bootstrap-pipeline',
+    '--pipeline-path',
+    '--evidence-dir',
+]
+
+QUICKSTART_EXPECTED = [
+    '# GitLab CI quickstart (Day 16)',
+    '## Strict pipeline variant',
+    '## Nightly reliability variant',
+    '## Multi-channel distribution loop',
+    '## Failure recovery playbook',
+    'quickstart-gate:',
+    'strict-gate:',
+    'nightly-audit:',
+    'python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+]
+
+REPORT_EXPECTED = [
+    'Day 16 big upgrade',
+    'python -m sdetkit gitlab-ci-quickstart --format json --variant strict --strict',
+    'python -m sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict',
+    'python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict',
+    'python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+    'scripts/check_day16_gitlab_ci_quickstart_contract.py',
+]
+
+ARTIFACT_EXPECTED = [
+    '# Day 16 GitLab CI quickstart',
+    '- Variant: `strict`',
+    '- Score: **100.0** (19/19)',
+    'sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+]
+
+PACK_STRICT_EXPECTED = [
+    'strict-gate:',
+    'python -m sdetkit gitlab-ci-quickstart --format json --strict',
+]
+
+PACK_NIGHTLY_EXPECTED = [
+    'nightly-audit:',
+    'python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+]
+
+EVIDENCE_EXPECTED = [
+    '"name": "day16-gitlab-ci-execution"',
+    '"total_commands": 4',
+]
+
+
+def _missing(path: Path, expected: list[str]) -> list[str]:
+    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    return [item for item in expected if item not in text]
+
+
+def main() -> int:
+    errors: list[str] = []
+    required = [README, DOCS_INDEX, DOCS_CLI, QUICKSTART_PAGE, DAY16_REPORT, DAY16_ARTIFACT, DAY16_PACK_STRICT, DAY16_PACK_NIGHTLY, DAY16_EVIDENCE]
+    for path in required:
+        if not path.exists():
+            errors.append(f'missing required file: {path}')
+
+    if not errors:
+        errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
+        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
+        errors.extend(f'{QUICKSTART_PAGE}: missing "{m}"' for m in _missing(QUICKSTART_PAGE, QUICKSTART_EXPECTED))
+        errors.extend(f'{DAY16_REPORT}: missing "{m}"' for m in _missing(DAY16_REPORT, REPORT_EXPECTED))
+        errors.extend(f'{DAY16_ARTIFACT}: missing "{m}"' for m in _missing(DAY16_ARTIFACT, ARTIFACT_EXPECTED))
+        errors.extend(f'{DAY16_PACK_STRICT}: missing "{m}"' for m in _missing(DAY16_PACK_STRICT, PACK_STRICT_EXPECTED))
+        errors.extend(f'{DAY16_PACK_NIGHTLY}: missing "{m}"' for m in _missing(DAY16_PACK_NIGHTLY, PACK_NIGHTLY_EXPECTED))
+        errors.extend(f'{DAY16_EVIDENCE}: missing "{m}"' for m in _missing(DAY16_EVIDENCE, EVIDENCE_EXPECTED))
+
+    if errors:
+        print('day16-gitlab-ci-quickstart-contract check failed:', file=sys.stderr)
+        for error in errors:
+            print(f' - {error}', file=sys.stderr)
+        return 1
+
+    print('day16-gitlab-ci-quickstart-contract check passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import Sequence
 from importlib import metadata
 
-from . import apiget, contributor_funnel, demo, docs_navigation, docs_qa, enterprise_use_case, evidence, first_contribution, github_actions_quickstart, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, startup_use_case, triage_templates, weekly_review
+from . import apiget, contributor_funnel, demo, docs_navigation, docs_qa, enterprise_use_case, evidence, first_contribution, github_actions_quickstart, gitlab_ci_quickstart, kvcli, notify, onboarding, ops, patch, policy, proof, repo, report, startup_use_case, triage_templates, weekly_review
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
 from .security_gate import main as security_main
@@ -119,6 +119,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "github-actions-quickstart":
         return github_actions_quickstart.main(list(argv[1:]))
 
+    if argv and argv[0] == "gitlab-ci-quickstart":
+        return gitlab_ci_quickstart.main(list(argv[1:]))
+
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -204,6 +207,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     gha = sub.add_parser("github-actions-quickstart")
     gha.add_argument("args", nargs=argparse.REMAINDER)
 
+    glc = sub.add_parser("gitlab-ci-quickstart")
+    glc.add_argument("args", nargs=argparse.REMAINDER)
+
     ns = p.parse_args(argv)
 
     if ns.cmd == "kv":
@@ -277,6 +283,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "github-actions-quickstart":
         return github_actions_quickstart.main(ns.args)
+
+    if ns.cmd == "gitlab-ci-quickstart":
+        return gitlab_ci_quickstart.main(ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)

--- a/src/sdetkit/gitlab_ci_quickstart.py
+++ b/src/sdetkit/gitlab_ci_quickstart.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+_PAGE_PATH = "docs/integrations-gitlab-ci-quickstart.md"
+
+_SECTION_HEADER = "# GitLab CI quickstart (Day 16)"
+_REQUIRED_SECTIONS = [
+    "## Who this recipe is for",
+    "## 5-minute setup",
+    "## Minimal pipeline",
+    "## Strict pipeline variant",
+    "## Nightly reliability variant",
+    "## Fast verification commands",
+    "## Multi-channel distribution loop",
+    "## Failure recovery playbook",
+    "## Rollout checklist",
+]
+
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit doctor --format text",
+    "python -m sdetkit repo audit --format json",
+    "python -m pytest -q tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py",
+    "python scripts/check_day16_gitlab_ci_quickstart_contract.py",
+    "python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict",
+    "python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict",
+]
+
+
+def _pipeline_content(variant: str) -> str:
+    if variant == "strict":
+        return """stages:
+  - quality
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+strict-gate:
+  stage: quality
+  image: python:3.11
+  script:
+    - python -m pip install -r requirements-test.txt -e .
+    - python -m pytest -q tests/test_cli_sdetkit.py tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py
+    - python -m sdetkit gitlab-ci-quickstart --format json --strict
+    - python scripts/check_day16_gitlab_ci_quickstart_contract.py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "web"
+"""
+
+    if variant == "nightly":
+        return """stages:
+  - nightly
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+nightly-audit:
+  stage: nightly
+  image: python:3.11
+  script:
+    - python -m pip install -r requirements-test.txt -e .
+    - python -m sdetkit doctor --format text
+    - python -m sdetkit repo audit --format json
+    - python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "web"
+"""
+
+    return """stages:
+  - quality
+
+variables:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+quickstart-gate:
+  stage: quality
+  image: python:3.11
+  script:
+    - python -m pip install -r requirements-test.txt -e .
+    - python -m sdetkit gitlab-ci-quickstart --format json --strict
+    - python -m pytest -q tests/test_cli_sdetkit.py tests/test_gitlab_ci_quickstart.py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "web"
+"""
+
+
+_DAY16_DEFAULT_PAGE = f"""# GitLab CI quickstart (Day 16)
+
+A production-ready integration recipe to run `sdetkit` quality checks in GitLab CI with quickstart, strict, and nightly variants.
+
+## Who this recipe is for
+
+- Maintainers who need CI guardrails in less than 5 minutes.
+- Teams migrating from ad-hoc local checks into merge request quality gates.
+- Contributors who want deterministic quality signals in merge request pipelines.
+
+## 5-minute setup
+
+1. Add `.gitlab-ci.yml` using the minimal pipeline below.
+2. Open a merge request to trigger the quality gate.
+3. Confirm the quickstart-gate job passes before merge.
+
+## Minimal pipeline
+
+```yaml
+{_pipeline_content('minimal').rstrip()}
+```
+
+## Strict pipeline variant
+
+```yaml
+{_pipeline_content('strict').rstrip()}
+```
+
+## Nightly reliability variant
+
+```yaml
+{_pipeline_content('nightly').rstrip()}
+```
+
+## Fast verification commands
+
+Run these locally before opening merge requests:
+
+```bash
+python -m sdetkit doctor --format text
+python -m sdetkit repo audit --format json
+python -m pytest -q tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day16_gitlab_ci_quickstart_contract.py
+python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict
+python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict
+```
+
+## Multi-channel distribution loop
+
+1. Share merged `.gitlab-ci.yml` updates in engineering chat with before/after timing.
+2. Publish docs updates in `docs/index.md` weekly rollout section.
+3. Attach one artifact (`day16-execution-summary.json`) in retro for adoption tracking.
+
+## Failure recovery playbook
+
+- If checks fail because docs content drifted, run `--write-defaults` then rerun strict mode.
+- If tests fail, keep strict gate required and move nightly lane to diagnostics-only until stable.
+- If flaky behavior appears, attach evidence logs from `--execute --evidence-dir` to incident notes.
+
+## Rollout checklist
+
+- [ ] Pipeline runs for merge requests and manual dispatches.
+- [ ] CI installs from `requirements-test.txt` and editable package source.
+- [ ] Day 16 contract check is part of docs validation.
+- [ ] Execution evidence bundle is generated weekly.
+- [ ] Team channel has a pinned link to this quickstart page.
+"""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit gitlab-ci-quickstart",
+        description="Render and validate the Day 16 GitLab CI quickstart integration recipe.",
+    )
+    parser.add_argument("--format", choices=["text", "markdown", "json"], default="text")
+    parser.add_argument("--root", default=".", help="Repository root where docs live.")
+    parser.add_argument("--output", default="", help="Optional output file path.")
+    parser.add_argument("--strict", action="store_true", help="Return non-zero when required quickstart content is missing.")
+    parser.add_argument("--write-defaults", action="store_true", help="Write or repair the Day 16 quickstart page before validation.")
+    parser.add_argument("--emit-pack-dir", default="", help="Optional path to emit a Day 16 quickstart pack.")
+    parser.add_argument("--variant", choices=["minimal", "strict", "nightly"], default="minimal", help="Pipeline variant for markdown/text snippets.")
+    parser.add_argument("--execute", action="store_true", help="Run Day 16 command sequence and capture pass/fail details.")
+    parser.add_argument("--bootstrap-pipeline", action="store_true", help="Write selected pipeline variant to --pipeline-path.")
+    parser.add_argument("--pipeline-path", default=".gitlab-ci.yml", help="Pipeline file path used with --bootstrap-pipeline.")
+    parser.add_argument("--evidence-dir", default="", help="Optional output directory for execution summary JSON and command logs.")
+    parser.add_argument("--timeout-sec", type=int, default=300, help="Per-command timeout in seconds for --execute mode.")
+    return parser
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _missing_checks(page_text: str) -> list[str]:
+    checks = [
+        _SECTION_HEADER,
+        *_REQUIRED_SECTIONS,
+        *_REQUIRED_COMMANDS,
+        "quickstart-gate:",
+        "strict-gate:",
+        "nightly-audit:",
+    ]
+    return [item for item in checks if item not in page_text]
+
+
+def _write_defaults(base: Path) -> list[str]:
+    page = base / _PAGE_PATH
+    current = _read(page)
+    if current and not _missing_checks(current):
+        return []
+
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(_DAY16_DEFAULT_PAGE, encoding="utf-8")
+    return [_PAGE_PATH]
+
+
+def _emit_pack(base: Path, out_dir: str) -> list[str]:
+    root = base / out_dir
+    root.mkdir(parents=True, exist_ok=True)
+
+    checklist = root / "day16-gitlab-checklist.md"
+    checklist.write_text(
+        "\n".join(
+            [
+                "# Day 16 GitLab CI rollout checklist",
+                "",
+                "- [ ] Validate quickstart page in strict mode.",
+                "- [ ] Commit `.gitlab-ci.yml` updates with staged variants.",
+                "- [ ] Verify merge request pipeline passes doctor, repo audit, and tests.",
+                "- [ ] Generate evidence bundle from --execute mode.",
+                "- [ ] Share pipeline + evidence links in onboarding docs.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    minimal_pipeline = root / "day16-sdetkit-quickstart.yml"
+    minimal_pipeline.write_text(_pipeline_content("minimal"), encoding="utf-8")
+
+    strict_pipeline = root / "day16-sdetkit-strict.yml"
+    strict_pipeline.write_text(_pipeline_content("strict"), encoding="utf-8")
+
+    nightly_pipeline = root / "day16-sdetkit-nightly.yml"
+    nightly_pipeline.write_text(_pipeline_content("nightly"), encoding="utf-8")
+
+    distribution_plan = root / "day16-distribution-plan.md"
+    distribution_plan.write_text(
+        "\n".join(
+            [
+                "# Day 16 distribution plan",
+                "",
+                "| Channel | Artifact | Owner | Cadence |",
+                "| --- | --- | --- | --- |",
+                "| Engineering Slack | `.gitlab-ci.yml` quickstart + evidence summary | QE lead | weekly |",
+                "| Docs portal | Day 16 integration page | Docs owner | weekly |",
+                "| Sprint retro | evidence logs and failure themes | Team lead | bi-weekly |",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    validation = root / "day16-validation-commands.md"
+    validation.write_text(
+        "\n".join(["# Day 16 validation commands", "", "```bash", *_REQUIRED_COMMANDS, "```", ""]) + "\n",
+        encoding="utf-8",
+    )
+
+    return [
+        str(path.relative_to(base))
+        for path in (checklist, minimal_pipeline, strict_pipeline, nightly_pipeline, distribution_plan, validation)
+    ]
+
+
+def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    for idx, command in enumerate(commands, start=1):
+        try:
+            proc = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout_sec, check=False)
+            results.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": proc.returncode,
+                    "ok": proc.returncode == 0,
+                    "stdout": proc.stdout,
+                    "stderr": proc.stderr,
+                }
+            )
+        except subprocess.TimeoutExpired as exc:
+            results.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": 124,
+                    "ok": False,
+                    "stdout": (exc.stdout or "") if isinstance(exc.stdout, str) else "",
+                    "stderr": (exc.stderr or "") if isinstance(exc.stderr, str) else "",
+                    "error": f"timed out after {timeout_sec}s",
+                }
+            )
+    return results
+
+
+def _write_execution_evidence(base: Path, out_dir: str, results: list[dict[str, object]]) -> list[str]:
+    root = base / out_dir
+    root.mkdir(parents=True, exist_ok=True)
+
+    summary = root / "day16-execution-summary.json"
+    payload = {
+        "name": "day16-gitlab-ci-execution",
+        "total_commands": len(results),
+        "passed_commands": len([r for r in results if r.get("ok")]),
+        "failed_commands": len([r for r in results if not r.get("ok")]),
+        "results": results,
+    }
+    summary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    emitted = [summary]
+    for row in results:
+        log_file = root / f"command-{row['index']:02d}.log"
+        log_file.write_text(
+            "\n".join(
+                [
+                    f"command: {row['command']}",
+                    f"returncode: {row['returncode']}",
+                    f"ok: {row['ok']}",
+                    "--- stdout ---",
+                    str(row.get("stdout", "")),
+                    "--- stderr ---",
+                    str(row.get("stderr", "")),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        emitted.append(log_file)
+
+    return [str(path.relative_to(base)) for path in emitted]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    base = Path(args.root).resolve()
+
+    touched = _write_defaults(base) if args.write_defaults else []
+    text = _read(base / _PAGE_PATH)
+
+    checks = [_SECTION_HEADER, *_REQUIRED_SECTIONS, *_REQUIRED_COMMANDS, "quickstart-gate:", "strict-gate:", "nightly-audit:"]
+    missing = _missing_checks(text)
+    total = len(checks)
+    passed = total - len(missing)
+    score = round((passed / total) * 100, 1)
+
+    payload: dict[str, object] = {
+        "name": "day16-gitlab-ci-quickstart",
+        "page": _PAGE_PATH,
+        "variant": args.variant,
+        "selected_pipeline": _pipeline_content(args.variant),
+        "passed_checks": passed,
+        "total_checks": total,
+        "score": score,
+        "missing": missing,
+        "touched_files": touched,
+    }
+
+    if args.emit_pack_dir:
+        payload["pack_files"] = _emit_pack(base, args.emit_pack_dir)
+
+    if args.bootstrap_pipeline:
+        pipeline_target = (base / args.pipeline_path).resolve()
+        pipeline_target.parent.mkdir(parents=True, exist_ok=True)
+        pipeline_target.write_text(_pipeline_content(args.variant), encoding="utf-8")
+        rel = str(pipeline_target.relative_to(base)) if pipeline_target.is_relative_to(base) else str(pipeline_target)
+        touched.append(rel)
+        payload["bootstrapped_pipeline"] = rel
+
+    execution_failed = False
+    if args.execute:
+        commands = [
+            "python -m sdetkit doctor --format text",
+            "python -m sdetkit repo audit --format json",
+            "python -m pytest -q tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py",
+            "python -m sdetkit gitlab-ci-quickstart --format json --strict",
+        ]
+        results = _execute_commands(commands, timeout_sec=args.timeout_sec)
+        execution = {
+            "total_commands": len(results),
+            "passed_commands": len([r for r in results if r.get("ok")]),
+            "failed_commands": len([r for r in results if not r.get("ok")]),
+            "results": results,
+        }
+        payload["execution"] = execution
+        execution_failed = execution["failed_commands"] > 0
+
+        evidence_dir = args.evidence_dir or "docs/artifacts/day16-gitlab-pack/evidence"
+        payload["evidence_files"] = _write_execution_evidence(base, evidence_dir, results)
+
+    if args.format == "json":
+        rendered = json.dumps(payload, indent=2) + "\n"
+    elif args.format == "markdown":
+        lines = [
+            "# Day 16 GitLab CI quickstart",
+            "",
+            f"- Page: `{_PAGE_PATH}`",
+            f"- Variant: `{args.variant}`",
+            f"- Score: **{score}** ({passed}/{total})",
+        ]
+        if missing:
+            lines.append("- Missing:")
+            lines.extend(f"  - `{item}`" for item in missing)
+        else:
+            lines.append("- Missing: none ✅")
+        lines.extend(
+            [
+                "",
+                "## Commands",
+                "",
+                "```bash",
+                "sdetkit gitlab-ci-quickstart --format text --strict",
+                "sdetkit gitlab-ci-quickstart --format json --variant strict --strict",
+                "sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict",
+                "sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict",
+                "sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict",
+                "```",
+            ]
+        )
+        rendered = "\n".join(lines) + "\n"
+    else:
+        rendered = (
+            "Day 16 GitLab CI quickstart\n"
+            f"page: {_PAGE_PATH}\n"
+            f"variant: {args.variant}\n"
+            f"score: {score} ({passed}/{total})\n"
+            f"missing checks: {len(missing)}\n"
+        )
+
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if args.strict and (missing or execution_failed):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -33,3 +33,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "startup-use-case" in out
     assert "enterprise-use-case" in out
     assert "github-actions-quickstart" in out
+    assert "gitlab-ci-quickstart" in out

--- a/tests/test_gitlab_ci_quickstart.py
+++ b/tests/test_gitlab_ci_quickstart.py
@@ -1,0 +1,151 @@
+import json
+
+from sdetkit import cli, gitlab_ci_quickstart
+
+
+def test_day16_quickstart_default_text(capsys):
+    rc = gitlab_ci_quickstart.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Day 16 GitLab CI quickstart" in out
+
+
+def test_day16_quickstart_json_and_strict_success(capsys):
+    rc = gitlab_ci_quickstart.main(["--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["name"] == "day16-gitlab-ci-quickstart"
+    assert data["passed_checks"] == data["total_checks"]
+    assert data["total_checks"] == 19
+
+
+def test_day16_quickstart_variant_switches_pipeline(capsys):
+    rc = gitlab_ci_quickstart.main(["--format", "json", "--variant", "strict", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["variant"] == "strict"
+    assert "strict-gate:" in data["selected_pipeline"]
+
+
+def test_day16_quickstart_strict_fails_when_content_missing(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/integrations-gitlab-ci-quickstart.md").write_text("# Placeholder\n", encoding="utf-8")
+    rc = gitlab_ci_quickstart.main(["--root", str(tmp_path), "--strict"])
+    assert rc == 1
+    assert "missing checks:" in capsys.readouterr().out
+
+
+def test_day16_quickstart_write_defaults_recovers_missing_file(tmp_path, capsys):
+    rc = gitlab_ci_quickstart.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["passed_checks"] == data["total_checks"]
+    assert data["touched_files"] == ["docs/integrations-gitlab-ci-quickstart.md"]
+
+
+def test_day16_quickstart_emit_pack(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/integrations-gitlab-ci-quickstart.md").write_text(
+        gitlab_ci_quickstart._DAY16_DEFAULT_PAGE, encoding="utf-8"
+    )
+    rc = gitlab_ci_quickstart.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "docs/artifacts/day16-gitlab-pack",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert len(data["pack_files"]) == 6
+    assert "docs/artifacts/day16-gitlab-pack/day16-sdetkit-strict.yml" in data["pack_files"]
+
+
+def test_day16_quickstart_execute_writes_evidence(monkeypatch, tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/integrations-gitlab-ci-quickstart.md").write_text(
+        gitlab_ci_quickstart._DAY16_DEFAULT_PAGE, encoding="utf-8"
+    )
+
+    class _Proc:
+        def __init__(self):
+            self.returncode = 0
+            self.stdout = "ok"
+            self.stderr = ""
+
+    monkeypatch.setattr(gitlab_ci_quickstart.subprocess, "run", lambda *a, **k: _Proc())
+
+    rc = gitlab_ci_quickstart.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--execute",
+            "--evidence-dir",
+            "docs/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["execution"]["failed_commands"] == 0
+    assert (tmp_path / "docs/evidence/day16-execution-summary.json").exists()
+
+
+def test_day16_quickstart_execute_strict_fails_on_command_error(monkeypatch, tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/integrations-gitlab-ci-quickstart.md").write_text(
+        gitlab_ci_quickstart._DAY16_DEFAULT_PAGE, encoding="utf-8"
+    )
+
+    class _Proc:
+        def __init__(self):
+            self.returncode = 1
+            self.stdout = ""
+            self.stderr = "boom"
+
+    monkeypatch.setattr(gitlab_ci_quickstart.subprocess, "run", lambda *a, **k: _Proc())
+
+    rc = gitlab_ci_quickstart.main(["--root", str(tmp_path), "--execute", "--format", "json", "--strict"])
+    assert rc == 1
+    data = json.loads(capsys.readouterr().out)
+    assert data["execution"]["failed_commands"] == 4
+
+
+def test_main_cli_dispatches_day16_quickstart(capsys):
+    rc = cli.main(["gitlab-ci-quickstart", "--format", "text"])
+    assert rc == 0
+    assert "Day 16 GitLab CI quickstart" in capsys.readouterr().out
+
+
+def test_day16_quickstart_bootstrap_pipeline_writes_selected_variant(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/integrations-gitlab-ci-quickstart.md").write_text(
+        gitlab_ci_quickstart._DAY16_DEFAULT_PAGE, encoding="utf-8"
+    )
+
+    rc = gitlab_ci_quickstart.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--variant",
+            "strict",
+            "--bootstrap-pipeline",
+            "--pipeline-path",
+            ".gitlab-ci.yml",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["bootstrapped_pipeline"] == ".gitlab-ci.yml"
+    assert ".gitlab-ci.yml" in data["touched_files"]
+    rendered = (tmp_path / ".gitlab-ci.yml").read_text(encoding="utf-8")
+    assert "strict-gate:" in rendered


### PR DESCRIPTION
### Motivation

- Close out Day 16 with a full, adoptable GitLab CI quickstart that can both validate docs and bootstrap a copy/paste-ready pipeline in consumers' repos. 
- Provide deterministic closeout gates and evidence capture so maintainers can validate, emit, and attach adoption-ready artifacts for merge-request quality gates.

### Description

- Add `sdetkit gitlab-ci-quickstart` implementation in `src/sdetkit/gitlab_ci_quickstart.py` with `--bootstrap-pipeline` and `--pipeline-path` to write selected pipeline variants, plus `--emit-pack-dir`, `--write-defaults`, `--execute`, and `--strict` support. 
- Wire the new command into the CLI dispatcher in `src/sdetkit/cli.py` and add unit tests in `tests/test_gitlab_ci_quickstart.py` (including a new bootstrap verification) and a small help-list update in `tests/test_cli_help_lists_subcommands.py`. 
- Add a Day 16 contract checker `scripts/check_day16_gitlab_ci_quickstart_contract.py`, update `scripts/check.sh` with `day15`/`day16` targets and include the new contract checks in `docs`/`all` modes, and update contract expectations to account for the bootstrap flow and new check total. 
- Refresh documentation and generated artifacts including `README.md`, `docs/cli.md`, `docs/index.md`, `docs/day-16-ultra-upgrade-report.md`, `docs/integrations-gitlab-ci-quickstart.md`, and emitted pack artifacts under `docs/artifacts/day16-gitlab-pack/` with validation commands and execution evidence. 

### Testing

- Ran unit tests with `python -m pytest -q tests/test_gitlab_ci_quickstart.py tests/test_cli_help_lists_subcommands.py tests/test_github_actions_quickstart.py`, and all tests passed (`20 passed`).
- Executed contract checks with `python scripts/check_day16_gitlab_ci_quickstart_contract.py` and `python scripts/check_day15_github_actions_quickstart_contract.py`, both reporting success. 
- Validated the local closeout flow with `bash scripts/check.sh day16` and exercised the CLI artifact/workflow commands such as `python -m sdetkit gitlab-ci-quickstart --emit-pack-dir ...`, `--variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml`, and `--execute --evidence-dir ...`, all of which completed successfully and produced the expected artifacts and evidence files.

------
