### PR TITLE
Upgrade Day 18 reliability pack with execution evidence lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,35 @@ python scripts/check_day17_quality_contribution_delta_contract.py
 python -m sdetkit quality-contribution-delta --current-signals-file docs/artifacts/day17-growth-signals.json --previous-signals-file docs/artifacts/day14-growth-signals.json --format json --strict
 ```
 
+## 🧱 Day 18 ultra: reliability evidence pack
+
+Day 18 now ships a production-grade **reliability operating pack** that consolidates Day 15/16 execution evidence and Day 17 quality+contribution deltas into one deterministic closeout lane.
+
+```bash
+python -m sdetkit reliability-evidence-pack --format text
+python -m sdetkit reliability-evidence-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --write-defaults --format json --strict
+python -m sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict
+```
+
+Export a markdown artifact for handoff:
+
+```bash
+python -m sdetkit reliability-evidence-pack --format markdown --output docs/artifacts/day18-reliability-evidence-pack-sample.md
+```
+
+See implementation details: [Day 18 ultra upgrade report](docs/day-18-ultra-upgrade-report.md).
+
+Day 18 closeout checks:
+
+```bash
+python -m pytest -q tests/test_reliability_evidence_pack.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day18_reliability_evidence_pack_contract.py
+python -m sdetkit reliability-evidence-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day18-reliability-evidence-pack-sample.md
+++ b/docs/artifacts/day18-reliability-evidence-pack-sample.md
@@ -1,0 +1,8 @@
+# Day 18 reliability evidence pack
+
+- Reliability score: **95.09**
+- Strict gates green: **True**
+- Gate status: **pass**
+
+## Recommendations
+- Reliability posture is strong; keep current CI and closeout operating cadence.

--- a/docs/artifacts/day18-reliability-pack/day18-reliability-checklist.md
+++ b/docs/artifacts/day18-reliability-pack/day18-reliability-checklist.md
@@ -1,0 +1,7 @@
+# Day 18 reliability closeout checklist
+
+- [ ] Day 15 GitHub Actions quickstart strict gate still green.
+- [ ] Day 16 GitLab CI quickstart strict gate still green.
+- [ ] Day 17 quality + contribution delta strict gates are green.
+- [ ] Reliability score is reviewed in weekly closeout.
+- [ ] Recommendations are tracked in planning backlog.

--- a/docs/artifacts/day18-reliability-pack/day18-reliability-scorecard.md
+++ b/docs/artifacts/day18-reliability-pack/day18-reliability-scorecard.md
@@ -1,0 +1,8 @@
+# Day 18 reliability evidence pack
+
+- Reliability score: **95.09**
+- Strict gates green: **True**
+- Gate status: **pass**
+
+## Recommendations
+- Reliability posture is strong; keep current CI and closeout operating cadence.

--- a/docs/artifacts/day18-reliability-pack/day18-reliability-summary.json
+++ b/docs/artifacts/day18-reliability-pack/day18-reliability-summary.json
@@ -1,0 +1,32 @@
+{
+  "inputs": {
+    "day15": {
+      "pass_rate": 100.0,
+      "score": 100.0,
+      "strict": true
+    },
+    "day16": {
+      "pass_rate": 100.0,
+      "score": 100.0,
+      "strict": true
+    },
+    "day17": {
+      "stability_score": 100.0,
+      "strict_failures": [],
+      "velocity_score": 75.44
+    }
+  },
+  "missing": [],
+  "name": "day18-reliability-evidence-pack",
+  "page": "docs/integrations-reliability-evidence-pack.md",
+  "recommendations": [
+    "Reliability posture is strong; keep current CI and closeout operating cadence."
+  ],
+  "score": 100.0,
+  "summary": {
+    "gate_status": "pass",
+    "reliability_score": 95.09,
+    "strict_all_green": true
+  },
+  "touched_files": []
+}

--- a/docs/artifacts/day18-reliability-pack/day18-validation-commands.md
+++ b/docs/artifacts/day18-reliability-pack/day18-validation-commands.md
@@ -1,0 +1,8 @@
+# Day 18 validation commands
+
+```bash
+python -m sdetkit reliability-evidence-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict
+python scripts/check_day18_reliability_evidence_pack_contract.py
+```

--- a/docs/artifacts/day18-reliability-pack/evidence/command-01.log
+++ b/docs/artifacts/day18-reliability-pack/evidence/command-01.log
@@ -1,0 +1,41 @@
+command: python -m sdetkit reliability-evidence-pack --format json --strict
+returncode: 0
+ok: True
+--- stdout ---
+{
+  "emitted_files": [],
+  "inputs": {
+    "day15": {
+      "pass_rate": 100.0,
+      "score": 100.0,
+      "strict": true
+    },
+    "day16": {
+      "pass_rate": 100.0,
+      "score": 100.0,
+      "strict": true
+    },
+    "day17": {
+      "stability_score": 100.0,
+      "strict_failures": [],
+      "velocity_score": 75.44
+    }
+  },
+  "missing": [],
+  "name": "day18-reliability-evidence-pack",
+  "page": "docs/integrations-reliability-evidence-pack.md",
+  "recommendations": [
+    "Reliability posture is strong; keep current CI and closeout operating cadence."
+  ],
+  "score": 100.0,
+  "strict_failures": [],
+  "summary": {
+    "gate_status": "pass",
+    "reliability_score": 95.09,
+    "strict_all_green": true
+  },
+  "touched_files": []
+}
+
+--- stderr ---
+

--- a/docs/artifacts/day18-reliability-pack/evidence/command-02.log
+++ b/docs/artifacts/day18-reliability-pack/evidence/command-02.log
@@ -1,0 +1,8 @@
+command: python scripts/check_day18_reliability_evidence_pack_contract.py --skip-evidence
+returncode: 0
+ok: True
+--- stdout ---
+day18-reliability-evidence-pack-contract check passed
+
+--- stderr ---
+

--- a/docs/artifacts/day18-reliability-pack/evidence/command-03.log
+++ b/docs/artifacts/day18-reliability-pack/evidence/command-03.log
@@ -1,0 +1,9 @@
+command: python -m pytest -q tests/test_cli_help_lists_subcommands.py
+returncode: 0
+ok: True
+--- stdout ---
+.                                                                        [100%]
+1 passed in 0.81s
+
+--- stderr ---
+

--- a/docs/artifacts/day18-reliability-pack/evidence/day18-execution-summary.json
+++ b/docs/artifacts/day18-reliability-pack/evidence/day18-execution-summary.json
@@ -1,0 +1,32 @@
+{
+  "name": "day18-reliability-execution",
+  "total_commands": 3,
+  "passed_commands": 3,
+  "failed_commands": 0,
+  "results": [
+    {
+      "index": 1,
+      "command": "python -m sdetkit reliability-evidence-pack --format json --strict",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "{\n  \"emitted_files\": [],\n  \"inputs\": {\n    \"day15\": {\n      \"pass_rate\": 100.0,\n      \"score\": 100.0,\n      \"strict\": true\n    },\n    \"day16\": {\n      \"pass_rate\": 100.0,\n      \"score\": 100.0,\n      \"strict\": true\n    },\n    \"day17\": {\n      \"stability_score\": 100.0,\n      \"strict_failures\": [],\n      \"velocity_score\": 75.44\n    }\n  },\n  \"missing\": [],\n  \"name\": \"day18-reliability-evidence-pack\",\n  \"page\": \"docs/integrations-reliability-evidence-pack.md\",\n  \"recommendations\": [\n    \"Reliability posture is strong; keep current CI and closeout operating cadence.\"\n  ],\n  \"score\": 100.0,\n  \"strict_failures\": [],\n  \"summary\": {\n    \"gate_status\": \"pass\",\n    \"reliability_score\": 95.09,\n    \"strict_all_green\": true\n  },\n  \"touched_files\": []\n}\n",
+      "stderr": ""
+    },
+    {
+      "index": 2,
+      "command": "python scripts/check_day18_reliability_evidence_pack_contract.py --skip-evidence",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "day18-reliability-evidence-pack-contract check passed\n",
+      "stderr": ""
+    },
+    {
+      "index": 3,
+      "command": "python -m pytest -q tests/test_cli_help_lists_subcommands.py",
+      "returncode": 0,
+      "ok": true,
+      "stdout": ".                                                                        [100%]\n1 passed in 0.81s\n",
+      "stderr": ""
+    }
+  ]
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -314,6 +314,31 @@ Useful flags: `--root`, `--current-signals-file`, `--previous-signals-file`, `--
 
 See: day-17-ultra-upgrade-report.md
 
+## reliability-evidence-pack
+
+Builds Day 18 reliability evidence by combining Day 15 GitHub execution logs, Day 16 GitLab execution logs, and Day 17 quality/contribution delta summary.
+
+Examples:
+
+- `sdetkit reliability-evidence-pack --format text`
+- `sdetkit reliability-evidence-pack --format json --strict`
+- `sdetkit reliability-evidence-pack --write-defaults --format json --strict`
+- `sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict`
+- `sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict`
+- `sdetkit reliability-evidence-pack --format markdown --output docs/artifacts/day18-reliability-evidence-pack-sample.md`
+
+Useful flags: `--root`, `--day15-summary`, `--day16-summary`, `--day17-summary`, `--min-reliability-score`, `--write-defaults`, `--emit-pack-dir`, `--execute`, `--evidence-dir`, `--timeout-sec`, `--strict`, `--format`, `--output`.
+
+`--write-defaults` writes a hardened Day 18 integration page if missing/incomplete, then validates it.
+
+`--emit-pack-dir` writes a Day 18 pack containing reliability summary JSON, scorecard markdown, closeout checklist markdown, and a validation commands file.
+
+`--execute` runs the Day 18 command chain and emits an execution summary plus per-command logs for closeout evidence.
+
+`--strict` returns non-zero if Day 18 required docs sections/commands are missing, strict gates are not green across Day 15/16/17 inputs, or reliability score falls below `--min-reliability-score`.
+
+See: day-18-ultra-upgrade-report.md
+
 ## patch
 
 Deterministic, spec-driven file edits (official CLI command).

--- a/docs/day-18-ultra-upgrade-report.md
+++ b/docs/day-18-ultra-upgrade-report.md
@@ -1,0 +1,28 @@
+# Day 18 ultra upgrade report
+
+## Day 18 big upgrade
+
+Day 18 is now closed with a full **reliability operating lane**: strict docs contracting, deterministic pack emission, and executable evidence logging tied to Day 15/16/17 upstream outputs.
+
+## What shipped
+
+- Upgraded `sdetkit reliability-evidence-pack` with Day 18 integration-page validation, strict gates, and weighted reliability score aggregation.
+- Added Day 18 auto-recovery mode with `--write-defaults` to regenerate a hardened integration page.
+- Added execution mode (`--execute --evidence-dir --timeout-sec`) that records deterministic command-level logs and summary JSON.
+- Expanded emitted pack payloads to include scorecard, checklist, and validation-commands artifact.
+- Added stronger Day 18 contract checker coverage across README/docs/page/report/artifacts/evidence.
+
+## Validation commands
+
+```bash
+python -m sdetkit reliability-evidence-pack --format text
+python -m sdetkit reliability-evidence-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --write-defaults --format json --strict
+python -m sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict
+python scripts/check_day18_reliability_evidence_pack_contract.py
+```
+
+## Closeout
+
+Day 18 now has one deterministic reliability score, one strict gate lane, and one artifact/evidence bundle ready for weekly closeout and release readiness reviews.

--- a/docs/index.md
+++ b/docs/index.md
@@ -301,3 +301,14 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Export markdown artifact: `sdetkit quality-contribution-delta --current-signals-file docs/artifacts/day17-growth-signals.json --previous-signals-file docs/artifacts/day14-growth-signals.json --format markdown --output docs/artifacts/day17-quality-contribution-delta-sample.md`.
 - Emit Day 17 delta pack: `sdetkit quality-contribution-delta --current-signals-file docs/artifacts/day17-growth-signals.json --previous-signals-file docs/artifacts/day14-growth-signals.json --emit-pack-dir docs/artifacts/day17-delta-pack --format json --strict`.
 - Review generated artifacts: [day17 quality/contribution sample](artifacts/day17-quality-contribution-delta-sample.md), [day17 delta summary](artifacts/day17-delta-pack/day17-delta-summary.json), and [day17 contribution action plan](artifacts/day17-delta-pack/day17-contribution-action-plan.md).
+
+
+## Day 18 ultra upgrades (reliability evidence pack)
+
+- Read the implementation report: [Day 18 ultra upgrade report](day-18-ultra-upgrade-report.md).
+- Run `sdetkit reliability-evidence-pack --format json --strict` to compose Day 15/16/17 evidence into one reliability score.
+- Auto-recover missing Day 18 integration docs: `sdetkit reliability-evidence-pack --write-defaults --format json --strict`.
+- Export markdown artifact: `sdetkit reliability-evidence-pack --format markdown --output docs/artifacts/day18-reliability-evidence-pack-sample.md`.
+- Emit Day 18 reliability pack: `sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict`.
+- Capture deterministic execution logs: `sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict`.
+- Review generated artifacts: [day18 reliability sample](artifacts/day18-reliability-evidence-pack-sample.md), [day18 reliability summary](artifacts/day18-reliability-pack/day18-reliability-summary.json), [day18 validation commands](artifacts/day18-reliability-pack/day18-validation-commands.md), and [day18 execution summary](artifacts/day18-reliability-pack/evidence/day18-execution-summary.json).

--- a/docs/integrations-reliability-evidence-pack.md
+++ b/docs/integrations-reliability-evidence-pack.md
@@ -1,0 +1,41 @@
+# Reliability evidence pack (Day 18)
+
+Operational recipe for rolling Day 15, Day 16, and Day 17 evidence into one reliability closeout signal.
+
+## Who this pack is for
+
+- Maintainers publishing a weekly reliability summary.
+- Engineering leads who need one deterministic pass/fail closeout checkpoint.
+- Contributors who need actionable evidence before tagging release candidates.
+
+## Reliability score model
+
+Day 18 score uses weighted Day 15/16 execution quality plus Day 17 stability/velocity.
+
+- Day 15 score weight: 25%
+- Day 16 score weight: 25%
+- Day 17 velocity score weight: 20%
+- Day 17 stability score weight: 20%
+- Day 15 pass-rate weight: 5%
+- Day 16 pass-rate weight: 5%
+
+## Fast verification commands
+
+```bash
+python -m sdetkit reliability-evidence-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict
+python scripts/check_day18_reliability_evidence_pack_contract.py
+```
+
+## Execution evidence mode
+
+`--execute` runs the Day 18 command chain and writes deterministic logs for each command into `--evidence-dir`.
+
+## Closeout checklist
+
+- [ ] Day 15 execution summary is green.
+- [ ] Day 16 execution summary is green.
+- [ ] Day 17 strict failures list is empty.
+- [ ] Reliability score meets minimum threshold.
+- [ ] Day 18 pack is attached to closeout notes.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -37,6 +37,7 @@ case "$mode" in
     python scripts/check_day4_skills_contract.py
     python scripts/check_day15_github_actions_quickstart_contract.py
     python scripts/check_day16_gitlab_ci_quickstart_contract.py
+    python scripts/check_day18_reliability_evidence_pack_contract.py
     ;;
   onboarding)
     python scripts/check_onboarding_contract.py
@@ -52,6 +53,7 @@ case "$mode" in
     ;;
   day16)
     python scripts/check_day16_gitlab_ci_quickstart_contract.py
+    python scripts/check_day18_reliability_evidence_pack_contract.py
     ;;
   all)
     ruff format --check .
@@ -65,6 +67,7 @@ case "$mode" in
     python scripts/check_day4_skills_contract.py
     python scripts/check_day15_github_actions_quickstart_contract.py
     python scripts/check_day16_gitlab_ci_quickstart_contract.py
+    python scripts/check_day18_reliability_evidence_pack_contract.py
     ;;
   *)
     echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|day3|day4|day15|day16|all}" >&2

--- a/scripts/check_day18_reliability_evidence_pack_contract.py
+++ b/scripts/check_day18_reliability_evidence_pack_contract.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+DAY18_PAGE = Path("docs/integrations-reliability-evidence-pack.md")
+DAY18_REPORT = Path("docs/day-18-ultra-upgrade-report.md")
+DAY18_ARTIFACT = Path("docs/artifacts/day18-reliability-evidence-pack-sample.md")
+DAY18_PACK_SUMMARY = Path("docs/artifacts/day18-reliability-pack/day18-reliability-summary.json")
+DAY18_PACK_SCORECARD = Path("docs/artifacts/day18-reliability-pack/day18-reliability-scorecard.md")
+DAY18_PACK_CHECKLIST = Path("docs/artifacts/day18-reliability-pack/day18-reliability-checklist.md")
+DAY18_PACK_VALIDATION = Path("docs/artifacts/day18-reliability-pack/day18-validation-commands.md")
+DAY18_EVIDENCE = Path("docs/artifacts/day18-reliability-pack/evidence/day18-execution-summary.json")
+MODULE = Path("src/sdetkit/reliability_evidence_pack.py")
+
+README_EXPECTED = [
+    "## 🧱 Day 18 ultra: reliability evidence pack",
+    "python -m sdetkit reliability-evidence-pack --format text",
+    "python -m sdetkit reliability-evidence-pack --format json --strict",
+    "python -m sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict",
+    "python -m sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict",
+    "python scripts/check_day18_reliability_evidence_pack_contract.py",
+]
+
+INDEX_EXPECTED = [
+    "Day 18 ultra upgrades (reliability evidence pack)",
+    "sdetkit reliability-evidence-pack --format json --strict",
+    "artifacts/day18-reliability-evidence-pack-sample.md",
+]
+
+CLI_EXPECTED = [
+    "## reliability-evidence-pack",
+    "--day15-summary",
+    "--day16-summary",
+    "--day17-summary",
+    "--min-reliability-score",
+    "--write-defaults",
+    "--execute",
+    "--evidence-dir",
+    "--timeout-sec",
+    "--emit-pack-dir",
+]
+
+PAGE_EXPECTED = [
+    "# Reliability evidence pack (Day 18)",
+    "## Reliability score model",
+    "## Fast verification commands",
+    "## Execution evidence mode",
+]
+
+REPORT_EXPECTED = [
+    "Day 18 big upgrade",
+    "reliability score",
+    "strict gates",
+    "--execute --evidence-dir",
+]
+
+SUMMARY_EXPECTED = [
+    '"name": "day18-reliability-evidence-pack"',
+    '"reliability_score":',
+    '"strict_all_green":',
+]
+
+EVIDENCE_EXPECTED = [
+    '"name": "day18-reliability-execution"',
+    '"total_commands": 3',
+]
+
+
+def _missing(path: Path, expected: list[str]) -> list[str]:
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    return [item for item in expected if item not in text]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skip-evidence", action="store_true")
+    ns = ap.parse_args(argv)
+
+    required = [
+        README,
+        DOCS_INDEX,
+        DOCS_CLI,
+        DAY18_PAGE,
+        DAY18_REPORT,
+        DAY18_ARTIFACT,
+        DAY18_PACK_SUMMARY,
+        DAY18_PACK_SCORECARD,
+        DAY18_PACK_CHECKLIST,
+        DAY18_PACK_VALIDATION,
+        MODULE,
+    ]
+    if not ns.skip_evidence:
+        required.append(DAY18_EVIDENCE)
+
+    errors: list[str] = []
+    for path in required:
+        if not path.exists():
+            errors.append(f"missing required file: {path}")
+
+    if not errors:
+        errors.extend(f"{README}: missing '{m}'" for m in _missing(README, README_EXPECTED))
+        errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
+        errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
+        errors.extend(f"{DAY18_PAGE}: missing '{m}'" for m in _missing(DAY18_PAGE, PAGE_EXPECTED))
+        errors.extend(f"{DAY18_REPORT}: missing '{m}'" for m in _missing(DAY18_REPORT, REPORT_EXPECTED))
+        errors.extend(f"{DAY18_PACK_SUMMARY}: missing '{m}'" for m in _missing(DAY18_PACK_SUMMARY, SUMMARY_EXPECTED))
+        if not ns.skip_evidence:
+            errors.extend(f"{DAY18_EVIDENCE}: missing '{m}'" for m in _missing(DAY18_EVIDENCE, EVIDENCE_EXPECTED))
+
+    if errors:
+        print("day18-reliability-evidence-pack-contract check failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print("day18-reliability-evidence-pack-contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -5,7 +5,32 @@ import os
 from collections.abc import Sequence
 from importlib import metadata
 
-from . import apiget, contributor_funnel, demo, docs_navigation, docs_qa, enterprise_use_case, evidence, first_contribution, github_actions_quickstart, gitlab_ci_quickstart, kvcli, notify, onboarding, ops, patch, policy, proof, quality_contribution_delta, repo, report, startup_use_case, triage_templates, weekly_review
+from . import (
+    apiget,
+    contributor_funnel,
+    demo,
+    docs_navigation,
+    docs_qa,
+    enterprise_use_case,
+    evidence,
+    first_contribution,
+    github_actions_quickstart,
+    gitlab_ci_quickstart,
+    kvcli,
+    notify,
+    onboarding,
+    ops,
+    patch,
+    policy,
+    proof,
+    quality_contribution_delta,
+    reliability_evidence_pack,
+    repo,
+    report,
+    startup_use_case,
+    triage_templates,
+    weekly_review,
+)
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
 from .security_gate import main as security_main
@@ -125,6 +150,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "quality-contribution-delta":
         return quality_contribution_delta.main(list(argv[1:]))
 
+    if argv and argv[0] == "reliability-evidence-pack":
+        return reliability_evidence_pack.main(list(argv[1:]))
+
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -216,6 +244,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     qcd = sub.add_parser("quality-contribution-delta")
     qcd.add_argument("args", nargs=argparse.REMAINDER)
 
+    rep = sub.add_parser("reliability-evidence-pack")
+    rep.add_argument("args", nargs=argparse.REMAINDER)
+
     ns = p.parse_args(argv)
 
     if ns.cmd == "kv":
@@ -295,6 +326,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "quality-contribution-delta":
         return quality_contribution_delta.main(ns.args)
+
+    if ns.cmd == "reliability-evidence-pack":
+        return reliability_evidence_pack.main(ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)

--- a/src/sdetkit/reliability_evidence_pack.py
+++ b/src/sdetkit/reliability_evidence_pack.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+_PAGE_PATH = "docs/integrations-reliability-evidence-pack.md"
+
+_SECTION_HEADER = "# Reliability evidence pack (Day 18)"
+_REQUIRED_SECTIONS = [
+    "## Who this pack is for",
+    "## Reliability score model",
+    "## Fast verification commands",
+    "## Execution evidence mode",
+    "## Closeout checklist",
+]
+
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit reliability-evidence-pack --format json --strict",
+    "python -m sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict",
+    "python -m sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict",
+    "python scripts/check_day18_reliability_evidence_pack_contract.py",
+]
+
+_REQUIRED_DAY17_KEYS = ("name", "quality", "contributions")
+
+_DAY18_DEFAULT_PAGE = """# Reliability evidence pack (Day 18)
+
+Operational recipe for rolling Day 15, Day 16, and Day 17 evidence into one reliability closeout signal.
+
+## Who this pack is for
+
+- Maintainers publishing a weekly reliability summary.
+- Engineering leads who need one deterministic pass/fail closeout checkpoint.
+- Contributors who need actionable evidence before tagging release candidates.
+
+## Reliability score model
+
+Day 18 score uses weighted Day 15/16 execution quality plus Day 17 stability/velocity.
+
+- Day 15 score weight: 25%
+- Day 16 score weight: 25%
+- Day 17 velocity score weight: 20%
+- Day 17 stability score weight: 20%
+- Day 15 pass-rate weight: 5%
+- Day 16 pass-rate weight: 5%
+
+## Fast verification commands
+
+```bash
+python -m sdetkit reliability-evidence-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict
+python -m sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict
+python scripts/check_day18_reliability_evidence_pack_contract.py
+```
+
+## Execution evidence mode
+
+`--execute` runs the Day 18 command chain and writes deterministic logs for each command into `--evidence-dir`.
+
+## Closeout checklist
+
+- [ ] Day 15 execution summary is green.
+- [ ] Day 16 execution summary is green.
+- [ ] Day 17 strict failures list is empty.
+- [ ] Reliability score meets minimum threshold.
+- [ ] Day 18 pack is attached to closeout notes.
+"""
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_json(path: str) -> dict[str, object]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _require_keys(payload: dict[str, object], keys: tuple[str, ...], source: str) -> None:
+    for key in keys:
+        if key not in payload:
+            raise ValueError(f"{source} missing required key: {key}")
+
+
+def _normalize_execution_summary(summary: dict[str, object], label: str) -> dict[str, float | bool]:
+    if {"score", "strict", "checks_passed", "checks_total"}.issubset(summary):
+        checks_passed = float(summary["checks_passed"])
+        checks_total = float(summary["checks_total"])
+        score = float(summary["score"])
+        strict = bool(summary["strict"])
+    elif {"passed_commands", "total_commands", "failed_commands"}.issubset(summary):
+        checks_passed = float(summary["passed_commands"])
+        checks_total = float(summary["total_commands"])
+        score = round((checks_passed / checks_total) * 100, 2) if checks_total else 0.0
+        strict = int(summary["failed_commands"]) == 0
+    else:
+        raise ValueError(
+            f"{label} summary must include score/strict/checks_* keys or passed_commands/total_commands/failed_commands keys"
+        )
+    return {"score": score, "strict": strict, "checks_passed": checks_passed, "checks_total": checks_total}
+
+
+def build_reliability_pack(
+    day15_summary: dict[str, object],
+    day16_summary: dict[str, object],
+    day17_summary: dict[str, object],
+) -> dict[str, object]:
+    day15 = _normalize_execution_summary(day15_summary, "day15")
+    day16 = _normalize_execution_summary(day16_summary, "day16")
+    _require_keys(day17_summary, _REQUIRED_DAY17_KEYS, "day17 summary")
+
+    day15_pass_rate = round((float(day15["checks_passed"]) / float(day15["checks_total"])) * 100, 2)
+    day16_pass_rate = round((float(day16["checks_passed"]) / float(day16["checks_total"])) * 100, 2)
+    day17_velocity = float(day17_summary["contributions"]["velocity_score"])
+    day17_stability = float(day17_summary["quality"]["stability_score"])
+
+    reliability_score = round(
+        (float(day15["score"]) * 0.25)
+        + (float(day16["score"]) * 0.25)
+        + (day17_velocity * 0.20)
+        + (day17_stability * 0.20)
+        + (day15_pass_rate * 0.05)
+        + (day16_pass_rate * 0.05),
+        2,
+    )
+
+    strict_all_green = bool(day15["strict"]) and bool(day16["strict"]) and not bool(
+        day17_summary.get("strict_failures")
+    )
+    recommendations: list[str] = []
+    if not strict_all_green:
+        recommendations.append("Resolve strict-gate failures before publishing the weekly reliability update.")
+    if day17_velocity < 70:
+        recommendations.append("Raise contribution velocity with targeted docs and release distribution this week.")
+    if day17_stability < 95:
+        recommendations.append("Recover quality stability by re-running quality deltas and closing artifact gaps.")
+    if reliability_score >= 95 and strict_all_green:
+        recommendations.append("Reliability posture is strong; keep current CI and closeout operating cadence.")
+
+    return {
+        "name": "day18-reliability-evidence-pack",
+        "inputs": {
+            "day15": {
+                "score": float(day15["score"]),
+                "strict": bool(day15["strict"]),
+                "pass_rate": day15_pass_rate,
+            },
+            "day16": {
+                "score": float(day16["score"]),
+                "strict": bool(day16["strict"]),
+                "pass_rate": day16_pass_rate,
+            },
+            "day17": {
+                "velocity_score": day17_velocity,
+                "stability_score": day17_stability,
+                "strict_failures": list(day17_summary.get("strict_failures", [])),
+            },
+        },
+        "summary": {
+            "reliability_score": reliability_score,
+            "strict_all_green": strict_all_green,
+            "gate_status": "pass" if strict_all_green and reliability_score >= 90 else "warn",
+        },
+        "recommendations": recommendations,
+    }
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [
+        "Day 18 reliability evidence pack",
+        "",
+        f"Reliability score: {payload['summary']['reliability_score']}",
+        f"Strict gates green: {payload['summary']['strict_all_green']}",
+        f"Gate status: {payload['summary']['gate_status']}",
+        "",
+        "Recommendations:",
+    ]
+    lines.extend(f"- {note}" for note in payload["recommendations"])
+    return "\n".join(lines) + "\n"
+
+
+def _render_markdown(payload: dict[str, object]) -> str:
+    return "\n".join(
+        [
+            "# Day 18 reliability evidence pack",
+            "",
+            f"- Reliability score: **{payload['summary']['reliability_score']}**",
+            f"- Strict gates green: **{payload['summary']['strict_all_green']}**",
+            f"- Gate status: **{payload['summary']['gate_status']}**",
+            "",
+            "## Recommendations",
+            *[f"- {note}" for note in payload["recommendations"]],
+            "",
+        ]
+    )
+
+
+def _emit_pack(path: str, payload: dict[str, object], base: Path) -> list[str]:
+    out_dir = base / path
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary_path = out_dir / "day18-reliability-summary.json"
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    scorecard_path = out_dir / "day18-reliability-scorecard.md"
+    scorecard_path.write_text(_render_markdown(payload), encoding="utf-8")
+
+    checklist_path = out_dir / "day18-reliability-checklist.md"
+    checklist_path.write_text(
+        "\n".join(
+            [
+                "# Day 18 reliability closeout checklist",
+                "",
+                "- [ ] Day 15 GitHub Actions quickstart strict gate still green.",
+                "- [ ] Day 16 GitLab CI quickstart strict gate still green.",
+                "- [ ] Day 17 quality + contribution delta strict gates are green.",
+                "- [ ] Reliability score is reviewed in weekly closeout.",
+                "- [ ] Recommendations are tracked in planning backlog.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    validation_path = out_dir / "day18-validation-commands.md"
+    validation_path.write_text(
+        "\n".join(["# Day 18 validation commands", "", "```bash", *_REQUIRED_COMMANDS, "```", ""]),
+        encoding="utf-8",
+    )
+
+    return [
+        str(summary_path.relative_to(base)),
+        str(scorecard_path.relative_to(base)),
+        str(checklist_path.relative_to(base)),
+        str(validation_path.relative_to(base)),
+    ]
+
+
+def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    for idx, command in enumerate(commands, start=1):
+        try:
+            proc = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout_sec, check=False)
+            results.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": proc.returncode,
+                    "ok": proc.returncode == 0,
+                    "stdout": proc.stdout,
+                    "stderr": proc.stderr,
+                }
+            )
+        except subprocess.TimeoutExpired as exc:
+            results.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": 124,
+                    "ok": False,
+                    "stdout": (exc.stdout or "") if isinstance(exc.stdout, str) else "",
+                    "stderr": (exc.stderr or "") if isinstance(exc.stderr, str) else "",
+                    "error": f"timed out after {timeout_sec}s",
+                }
+            )
+    return results
+
+
+def _write_execution_evidence(base: Path, out_dir: str, results: list[dict[str, object]]) -> list[str]:
+    root = base / out_dir
+    root.mkdir(parents=True, exist_ok=True)
+
+    summary = root / "day18-execution-summary.json"
+    payload = {
+        "name": "day18-reliability-execution",
+        "total_commands": len(results),
+        "passed_commands": len([r for r in results if r.get("ok")]),
+        "failed_commands": len([r for r in results if not r.get("ok")]),
+        "results": results,
+    }
+    summary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    emitted = [summary]
+    for row in results:
+        log_file = root / f"command-{row['index']:02d}.log"
+        log_file.write_text(
+            "\n".join(
+                [
+                    f"command: {row['command']}",
+                    f"returncode: {row['returncode']}",
+                    f"ok: {row['ok']}",
+                    "--- stdout ---",
+                    str(row.get("stdout", "")),
+                    "--- stderr ---",
+                    str(row.get("stderr", "")),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        emitted.append(log_file)
+
+    return [str(path.relative_to(base)) for path in emitted]
+
+
+def _write_defaults(base: Path) -> list[str]:
+    path = base / _PAGE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_DAY18_DEFAULT_PAGE, encoding="utf-8")
+    return [str(path.relative_to(base))]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit reliability-evidence-pack",
+        description="Build Day 18 reliability evidence by combining Day 15/16/17 outputs.",
+    )
+    parser.add_argument("--root", default=".", help="Repository root where docs and artifacts live.")
+    parser.add_argument("--day15-summary", default="docs/artifacts/day15-github-pack/evidence/day15-execution-summary.json")
+    parser.add_argument("--day16-summary", default="docs/artifacts/day16-gitlab-pack/evidence/day16-execution-summary.json")
+    parser.add_argument("--day17-summary", default="docs/artifacts/day17-delta-pack/day17-delta-summary.json")
+    parser.add_argument("--min-reliability-score", type=float, default=90.0)
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--write-defaults", action="store_true", help="Write default Day 18 reliability docs page.")
+    parser.add_argument("--emit-pack-dir", default="")
+    parser.add_argument("--execute", action="store_true", help="Execute Day 18 validation commands and capture evidence.")
+    parser.add_argument("--evidence-dir", default="", help="Output directory for Day 18 command execution logs.")
+    parser.add_argument("--timeout-sec", type=int, default=120)
+    parser.add_argument("--format", choices=["text", "markdown", "json"], default="text")
+    parser.add_argument("--output", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_parser().parse_args(argv)
+    base = Path(ns.root).resolve()
+
+    touched = _write_defaults(base) if ns.write_defaults else []
+    page_text = _read(base / _PAGE_PATH)
+
+    missing = []
+    if _SECTION_HEADER not in page_text:
+        missing.append(_SECTION_HEADER)
+    missing.extend(section for section in _REQUIRED_SECTIONS if section not in page_text)
+    missing.extend(cmd for cmd in _REQUIRED_COMMANDS if cmd not in page_text)
+
+    try:
+        day15_summary = _load_json(str(base / ns.day15_summary))
+        day16_summary = _load_json(str(base / ns.day16_summary))
+        day17_summary = _load_json(str(base / ns.day17_summary))
+        payload = build_reliability_pack(day15_summary, day16_summary, day17_summary)
+    except (OSError, ValueError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        print(str(exc))
+        return 2
+
+    payload["page"] = _PAGE_PATH
+    payload["missing"] = missing
+    payload["score"] = round(((len(_REQUIRED_SECTIONS) + len(_REQUIRED_COMMANDS) + 1 - len(missing)) / (len(_REQUIRED_SECTIONS) + len(_REQUIRED_COMMANDS) + 1)) * 100, 2)
+    payload["touched_files"] = touched
+
+    strict_failures: list[str] = []
+    if missing:
+        strict_failures.append(f"reliability page missing {len(missing)} required items")
+    if not payload["summary"]["strict_all_green"]:
+        strict_failures.append("strict status is not green across day15/day16/day17 inputs")
+    if float(payload["summary"]["reliability_score"]) < float(ns.min_reliability_score):
+        strict_failures.append(
+            f"reliability_score {payload['summary']['reliability_score']} is below minimum {ns.min_reliability_score}"
+        )
+
+    emitted: list[str] = []
+    if ns.emit_pack_dir:
+        emitted.extend(_emit_pack(ns.emit_pack_dir, payload, base))
+
+    if ns.execute:
+        commands = [
+            "python -m sdetkit reliability-evidence-pack --format json --strict",
+            "python scripts/check_day18_reliability_evidence_pack_contract.py --skip-evidence",
+            "python -m pytest -q tests/test_cli_help_lists_subcommands.py",
+        ]
+        results = _execute_commands(commands, timeout_sec=ns.timeout_sec)
+        evidence_dir = ns.evidence_dir or (ns.emit_pack_dir + "/evidence" if ns.emit_pack_dir else "")
+        payload["executed_commands"] = results
+        if evidence_dir:
+            emitted.extend(_write_execution_evidence(base, evidence_dir, results))
+        if any(not row.get("ok") for row in results):
+            strict_failures.append("execution mode detected failed command(s)")
+
+    payload["emitted_files"] = emitted
+    payload["strict_failures"] = strict_failures
+
+    if ns.format == "json":
+        rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    elif ns.format == "markdown":
+        rendered = _render_markdown(payload)
+    else:
+        rendered = _render_text(payload)
+
+    if ns.output:
+        (base / ns.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    if ns.strict and strict_failures:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -35,3 +35,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "github-actions-quickstart" in out
     assert "gitlab-ci-quickstart" in out
     assert "quality-contribution-delta" in out
+    assert "reliability-evidence-pack" in out

--- a/tests/test_reliability_evidence_pack.py
+++ b/tests/test_reliability_evidence_pack.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import reliability_evidence_pack as rep
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    day15 = tmp_path / "day15.json"
+    day16 = tmp_path / "day16.json"
+    day17 = tmp_path / "day17.json"
+    day15.write_text(
+        '{"score": 100.0, "strict": true, "checks_passed": 19, "checks_total": 19}\n',
+        encoding="utf-8",
+    )
+    day16.write_text(
+        '{"score": 100.0, "strict": true, "checks_passed": 19, "checks_total": 19}\n',
+        encoding="utf-8",
+    )
+    day17.write_text(
+        json.dumps(
+            {
+                "name": "day17-quality-contribution-delta",
+                "quality": {"stability_score": 100.0},
+                "contributions": {"velocity_score": 92.5},
+                "strict_failures": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return day15, day16, day17
+
+
+def _write_page(root: Path) -> None:
+    page = root / "docs/integrations-reliability-evidence-pack.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(rep._DAY18_DEFAULT_PAGE, encoding="utf-8")
+
+
+def test_day18_pack_builds_json(tmp_path: Path, capsys) -> None:
+    day15, day16, day17 = _write_inputs(tmp_path)
+    _write_page(tmp_path)
+
+    rc = rep.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day15-summary",
+            str(day15.relative_to(tmp_path)),
+            "--day16-summary",
+            str(day16.relative_to(tmp_path)),
+            "--day17-summary",
+            str(day17.relative_to(tmp_path)),
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day18-reliability-evidence-pack"
+    assert out["summary"]["strict_all_green"] is True
+    assert out["summary"]["reliability_score"] >= 90
+    assert out["score"] == 100.0
+
+
+def test_day18_pack_emits_bundle_and_evidence(tmp_path: Path) -> None:
+    day15, day16, day17 = _write_inputs(tmp_path)
+    _write_page(tmp_path)
+
+    rc = rep.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day15-summary",
+            str(day15.relative_to(tmp_path)),
+            "--day16-summary",
+            str(day16.relative_to(tmp_path)),
+            "--day17-summary",
+            str(day17.relative_to(tmp_path)),
+            "--emit-pack-dir",
+            "artifacts/day18-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day18-pack/evidence",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day18-pack/day18-reliability-summary.json").exists()
+    assert (tmp_path / "artifacts/day18-pack/day18-reliability-scorecard.md").exists()
+    assert (tmp_path / "artifacts/day18-pack/day18-reliability-checklist.md").exists()
+    assert (tmp_path / "artifacts/day18-pack/day18-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day18-pack/evidence/day18-execution-summary.json").exists()
+
+
+def test_day18_write_defaults(tmp_path: Path) -> None:
+    day15, day16, day17 = _write_inputs(tmp_path)
+    rc = rep.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--write-defaults",
+            "--day15-summary",
+            str(day15.relative_to(tmp_path)),
+            "--day16-summary",
+            str(day16.relative_to(tmp_path)),
+            "--day17-summary",
+            str(day17.relative_to(tmp_path)),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "docs/integrations-reliability-evidence-pack.md").exists()
+
+
+def test_day18_cli_dispatch(tmp_path: Path, capsys) -> None:
+    day15, day16, day17 = _write_inputs(tmp_path)
+    _write_page(tmp_path)
+
+    rc = cli.main(
+        [
+            "reliability-evidence-pack",
+            "--root",
+            str(tmp_path),
+            "--day15-summary",
+            str(day15.relative_to(tmp_path)),
+            "--day16-summary",
+            str(day16.relative_to(tmp_path)),
+            "--day17-summary",
+            str(day17.relative_to(tmp_path)),
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Day 18 reliability evidence pack" in out


### PR DESCRIPTION
### Motivation
- Deliver a production-grade Day 18 reliability closeout that composes Day 15/16 execution evidence with Day 17 quality/contribution deltas into one deterministic reliability signal and operating lane.
- Provide a hardened, auditable closeout flow that can auto-recover missing docs, emit a pack, and capture deterministic execution evidence for incident triage and weekly closeout.

### Description
- Add a new module `src/sdetkit/reliability_evidence_pack.py` implementing `sdetkit reliability-evidence-pack` with validation of a Day 18 integration page, weighted reliability score calculation, strict-gate checks, `--write-defaults`, `--emit-pack-dir`, `--execute`, `--evidence-dir`, and `--timeout-sec` support, plus JSON/markdown/text renderers.
- Wire the command into the top-level CLI by registering `reliability-evidence-pack` in `src/sdetkit/cli.py` and adding a subparser so the command is callable via `sdetkit reliability-evidence-pack`.
- Emit richer pack artifacts including `day18-reliability-summary.json`, `day18-reliability-scorecard.md`, `day18-reliability-checklist.md`, `day18-validation-commands.md`, and deterministic execution evidence (`day18-execution-summary.json` + per-command `command-XX.log`) under `docs/artifacts/day18-reliability-pack/`.
- Add tests `tests/test_reliability_evidence_pack.py` and update `tests/test_cli_help_lists_subcommands.py` to include the new command, and introduce a contract checker `scripts/check_day18_reliability_evidence_pack_contract.py` that accepts `--skip-evidence` to support self-execution.
- Update docs and onboarding surfaces: `README.md`, `docs/index.md`, `docs/cli.md`, `docs/integrations-reliability-evidence-pack.md`, and a Day 18 report `docs/day-18-ultra-upgrade-report.md` describing usage and validation commands.

### Testing
- Ran linter/format checks with `python -m ruff check src/sdetkit/reliability_evidence_pack.py tests/test_reliability_evidence_pack.py scripts/check_day18_reliability_evidence_pack_contract.py src/sdetkit/cli.py tests/test_cli_help_lists_subcommands.py` and it passed.
- Contract validation via `python scripts/check_day18_reliability_evidence_pack_contract.py` passed (the checker also supports `--skip-evidence` for execution flow).
- Unit tests `python -m pytest -q tests/test_reliability_evidence_pack.py tests/test_cli_help_lists_subcommands.py` passed (5 passed).
- CLI smoke and execution flows were exercised: `python -m sdetkit reliability-evidence-pack --format json --strict` produced a `reliability_score` (~95.09) and the emit+execute run produced the pack and evidence files under `docs/artifacts/day18-reliability-pack/` (all checks passed).

------