### PR TITLE
Harden Day 19 release readiness workflow and closeout checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,36 @@ python -m sdetkit reliability-evidence-pack --format json --strict
 python -m sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict
 ```
 
+
+## 🧭 Day 19 ultra: release readiness board
+
+Day 19 ships a deterministic **release readiness board** that combines Day 18 reliability posture with Day 14 KPI trend health into one go/no-go score.
+
+```bash
+python -m sdetkit release-readiness-board --format text
+python -m sdetkit release-readiness-board --format json --strict
+python -m sdetkit release-readiness-board --write-defaults --format json --strict
+python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict
+python -m sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict
+```
+
+Export a markdown artifact for handoff:
+
+```bash
+python -m sdetkit release-readiness-board --format markdown --output docs/artifacts/day19-release-readiness-board-sample.md
+```
+
+See implementation details: [Day 19 ultra upgrade report](docs/day-19-ultra-upgrade-report.md).
+
+Day 19 closeout checks:
+
+```bash
+python -m pytest -q tests/test_release_readiness_board.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day19_release_readiness_board_contract.py
+python -m sdetkit release-readiness-board --format json --strict
+python -m sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day19-release-readiness-board-sample.md
+++ b/docs/artifacts/day19-release-readiness-board-sample.md
@@ -1,0 +1,8 @@
+# Day 19 release readiness board
+
+- Release score: **96.56**
+- Strict gates green: **True**
+- Gate status: **pass**
+
+## Recommendations
+- Release posture is strong; proceed with release candidate tagging and notes preparation.

--- a/docs/artifacts/day19-release-readiness-pack/day19-release-decision.md
+++ b/docs/artifacts/day19-release-readiness-pack/day19-release-decision.md
@@ -1,0 +1,7 @@
+# Day 19 release decision
+
+- Gate status: **pass**
+- Release score: **96.56**
+- Strict all green: **True**
+
+Use this file as the final go/no-go note in release closeout.

--- a/docs/artifacts/day19-release-readiness-pack/day19-release-readiness-checklist.md
+++ b/docs/artifacts/day19-release-readiness-pack/day19-release-readiness-checklist.md
@@ -1,0 +1,6 @@
+# Day 19 release readiness closeout checklist
+
+- [ ] Day 18 reliability gate status is pass.
+- [ ] Day 14 KPI status is pass.
+- [ ] Release score is reviewed in closeout meeting.
+- [ ] Recommendations are assigned and tracked.

--- a/docs/artifacts/day19-release-readiness-pack/day19-release-readiness-scorecard.md
+++ b/docs/artifacts/day19-release-readiness-pack/day19-release-readiness-scorecard.md
@@ -1,0 +1,8 @@
+# Day 19 release readiness board
+
+- Release score: **96.56**
+- Strict gates green: **True**
+- Gate status: **pass**
+
+## Recommendations
+- Release posture is strong; proceed with release candidate tagging and notes preparation.

--- a/docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json
+++ b/docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json
@@ -1,0 +1,23 @@
+{
+  "inputs": {
+    "day14": {
+      "score": 100.0,
+      "status": "pass"
+    },
+    "day18": {
+      "gate_status": "pass",
+      "reliability_score": 95.09
+    }
+  },
+  "name": "day19-release-readiness-board",
+  "recommendations": [
+    "Release posture is strong; proceed with release candidate tagging and notes preparation."
+  ],
+  "score": 100.0,
+  "strict_failures": [],
+  "summary": {
+    "gate_status": "pass",
+    "release_score": 96.56,
+    "strict_all_green": true
+  }
+}

--- a/docs/artifacts/day19-release-readiness-pack/day19-validation-commands.md
+++ b/docs/artifacts/day19-release-readiness-pack/day19-validation-commands.md
@@ -1,0 +1,8 @@
+# Day 19 validation commands
+
+```bash
+python -m sdetkit release-readiness-board --format json --strict
+python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict
+python -m sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict
+python scripts/check_day19_release_readiness_board_contract.py
+```

--- a/docs/artifacts/day19-release-readiness-pack/evidence/command-01.log
+++ b/docs/artifacts/day19-release-readiness-pack/evidence/command-01.log
@@ -1,0 +1,30 @@
+command: python -m sdetkit release-readiness-board --format json --strict
+returncode: 0
+ok: True
+--- stdout ---
+{
+  "inputs": {
+    "day14": {
+      "score": 100.0,
+      "status": "pass"
+    },
+    "day18": {
+      "gate_status": "pass",
+      "reliability_score": 95.09
+    }
+  },
+  "name": "day19-release-readiness-board",
+  "recommendations": [
+    "Release posture is strong; proceed with release candidate tagging and notes preparation."
+  ],
+  "score": 100.0,
+  "strict_failures": [],
+  "summary": {
+    "gate_status": "pass",
+    "release_score": 96.56,
+    "strict_all_green": true
+  }
+}
+
+--- stderr ---
+

--- a/docs/artifacts/day19-release-readiness-pack/evidence/command-02.log
+++ b/docs/artifacts/day19-release-readiness-pack/evidence/command-02.log
@@ -1,0 +1,37 @@
+command: python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict
+returncode: 0
+ok: True
+--- stdout ---
+{
+  "emitted_pack_files": [
+    "docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json",
+    "docs/artifacts/day19-release-readiness-pack/day19-release-readiness-scorecard.md",
+    "docs/artifacts/day19-release-readiness-pack/day19-release-readiness-checklist.md",
+    "docs/artifacts/day19-release-readiness-pack/day19-validation-commands.md",
+    "docs/artifacts/day19-release-readiness-pack/day19-release-decision.md"
+  ],
+  "inputs": {
+    "day14": {
+      "score": 100.0,
+      "status": "pass"
+    },
+    "day18": {
+      "gate_status": "pass",
+      "reliability_score": 95.09
+    }
+  },
+  "name": "day19-release-readiness-board",
+  "recommendations": [
+    "Release posture is strong; proceed with release candidate tagging and notes preparation."
+  ],
+  "score": 100.0,
+  "strict_failures": [],
+  "summary": {
+    "gate_status": "pass",
+    "release_score": 96.56,
+    "strict_all_green": true
+  }
+}
+
+--- stderr ---
+

--- a/docs/artifacts/day19-release-readiness-pack/evidence/command-03.log
+++ b/docs/artifacts/day19-release-readiness-pack/evidence/command-03.log
@@ -1,0 +1,8 @@
+command: python scripts/check_day19_release_readiness_board_contract.py --skip-evidence
+returncode: 0
+ok: True
+--- stdout ---
+day19-release-readiness-board-contract check passed
+
+--- stderr ---
+

--- a/docs/artifacts/day19-release-readiness-pack/evidence/day19-execution-summary.json
+++ b/docs/artifacts/day19-release-readiness-pack/evidence/day19-execution-summary.json
@@ -1,0 +1,32 @@
+{
+  "name": "day19-release-readiness-execution",
+  "total_commands": 3,
+  "passed_commands": 3,
+  "failed_commands": 0,
+  "results": [
+    {
+      "index": 1,
+      "command": "python -m sdetkit release-readiness-board --format json --strict",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "{\n  \"inputs\": {\n    \"day14\": {\n      \"score\": 100.0,\n      \"status\": \"pass\"\n    },\n    \"day18\": {\n      \"gate_status\": \"pass\",\n      \"reliability_score\": 95.09\n    }\n  },\n  \"name\": \"day19-release-readiness-board\",\n  \"recommendations\": [\n    \"Release posture is strong; proceed with release candidate tagging and notes preparation.\"\n  ],\n  \"score\": 100.0,\n  \"strict_failures\": [],\n  \"summary\": {\n    \"gate_status\": \"pass\",\n    \"release_score\": 96.56,\n    \"strict_all_green\": true\n  }\n}\n",
+      "stderr": ""
+    },
+    {
+      "index": 2,
+      "command": "python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "{\n  \"emitted_pack_files\": [\n    \"docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json\",\n    \"docs/artifacts/day19-release-readiness-pack/day19-release-readiness-scorecard.md\",\n    \"docs/artifacts/day19-release-readiness-pack/day19-release-readiness-checklist.md\",\n    \"docs/artifacts/day19-release-readiness-pack/day19-validation-commands.md\",\n    \"docs/artifacts/day19-release-readiness-pack/day19-release-decision.md\"\n  ],\n  \"inputs\": {\n    \"day14\": {\n      \"score\": 100.0,\n      \"status\": \"pass\"\n    },\n    \"day18\": {\n      \"gate_status\": \"pass\",\n      \"reliability_score\": 95.09\n    }\n  },\n  \"name\": \"day19-release-readiness-board\",\n  \"recommendations\": [\n    \"Release posture is strong; proceed with release candidate tagging and notes preparation.\"\n  ],\n  \"score\": 100.0,\n  \"strict_failures\": [],\n  \"summary\": {\n    \"gate_status\": \"pass\",\n    \"release_score\": 96.56,\n    \"strict_all_green\": true\n  }\n}\n",
+      "stderr": ""
+    },
+    {
+      "index": 3,
+      "command": "python scripts/check_day19_release_readiness_board_contract.py --skip-evidence",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "day19-release-readiness-board-contract check passed\n",
+      "stderr": ""
+    }
+  ]
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -464,3 +464,27 @@ See: agentos-foundation.md, omnichannel-mcp-bridge.md, and automation-templates-
 - Agent/report commands use shared option names where applicable: `--history-dir`, `--output`, `--format`, `--config`, `--cache-dir`, `--no-cache`, `--approve`, `--output-dir`, and `--set`.
 - `--help` output includes default values for faster operator onboarding.
 - Normal user errors are emitted as single-line messages (`agent error: ...`, `report error: ...`) without stack traces.
+
+
+## release-readiness-board
+
+Builds Day 19 release-readiness evidence by combining Day 18 reliability summary and Day 14 weekly KPI summary.
+
+Examples:
+
+- `sdetkit release-readiness-board --format text`
+- `sdetkit release-readiness-board --format json --strict`
+- `sdetkit release-readiness-board --write-defaults --format json --strict`
+- `sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict`
+- `sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict`
+- `sdetkit release-readiness-board --format markdown --output docs/artifacts/day19-release-readiness-board-sample.md`
+
+Useful flags: `--root`, `--day18-summary`, `--day14-summary`, `--min-release-score`, `--write-defaults`, `--emit-pack-dir`, `--execute`, `--evidence-dir`, `--timeout-sec`, `--strict`, `--format`, `--output`.
+
+`--write-defaults` writes a hardened Day 19 integration page if missing/incomplete, then validates it.
+
+`--emit-pack-dir` writes a Day 19 pack containing summary JSON, scorecard markdown, closeout checklist markdown, and a validation commands file.
+
+`--execute` runs the Day 19 command chain and emits an execution summary plus per-command logs for closeout evidence.
+
+`--strict` returns non-zero if Day 19 required docs sections/commands are missing, strict gates are not green, or release score falls below `--min-release-score`.

--- a/docs/day-19-ultra-upgrade-report.md
+++ b/docs/day-19-ultra-upgrade-report.md
@@ -1,0 +1,26 @@
+# Day 19 ultra upgrade report
+
+## Day 19 big upgrade
+
+Day 19 closes with a deterministic **release readiness board** that fuses Day 18 reliability evidence and Day 14 KPI trend posture into one strict go/no-go signal.
+
+## What shipped
+
+- Added `sdetkit release-readiness-board` CLI to aggregate Day 18 and Day 14 summary inputs.
+- Added strict docs contract checks, default Day 19 integration page, and weighted release score model.
+- Added emitted pack outputs (summary, scorecard, checklist, validation commands, release decision note) for handoff.
+- Added execution evidence mode with deterministic command logs and summary JSON.
+
+## Validation commands
+
+```bash
+python -m sdetkit release-readiness-board --format text
+python -m sdetkit release-readiness-board --format json --strict
+python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict
+python -m sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict
+python scripts/check_day19_release_readiness_board_contract.py
+```
+
+## Closeout
+
+Day 19 now provides one release score, one strict gate lane, and one evidence bundle that can be attached directly to weekly closeout and release-candidate reviews.

--- a/docs/index.md
+++ b/docs/index.md
@@ -312,3 +312,14 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 18 reliability pack: `sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict`.
 - Capture deterministic execution logs: `sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict`.
 - Review generated artifacts: [day18 reliability sample](artifacts/day18-reliability-evidence-pack-sample.md), [day18 reliability summary](artifacts/day18-reliability-pack/day18-reliability-summary.json), [day18 validation commands](artifacts/day18-reliability-pack/day18-validation-commands.md), and [day18 execution summary](artifacts/day18-reliability-pack/evidence/day18-execution-summary.json).
+
+
+## Day 19 ultra upgrades (release readiness board)
+
+- Read the implementation report: [Day 19 ultra upgrade report](day-19-ultra-upgrade-report.md).
+- Run `sdetkit release-readiness-board --format json --strict` to generate Day 19 release readiness posture.
+- Auto-recover missing Day 19 integration docs: `sdetkit release-readiness-board --write-defaults --format json --strict`.
+- Export markdown artifact: `sdetkit release-readiness-board --format markdown --output docs/artifacts/day19-release-readiness-board-sample.md`.
+- Emit Day 19 release-readiness pack: `sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict`.
+- Capture deterministic execution logs: `sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict`.
+- Review generated artifacts: [day19 release readiness sample](artifacts/day19-release-readiness-board-sample.md), [day19 release summary](artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json), [day19 release decision](artifacts/day19-release-readiness-pack/day19-release-decision.md), [day19 validation commands](artifacts/day19-release-readiness-pack/day19-validation-commands.md), and [day19 execution summary](artifacts/day19-release-readiness-pack/evidence/day19-execution-summary.json).

--- a/docs/integrations-release-readiness-board.md
+++ b/docs/integrations-release-readiness-board.md
@@ -1,0 +1,34 @@
+# Release readiness board (Day 19)
+
+Day 19 composes Day 14 weekly trend health and Day 18 reliability posture into one release-candidate gate.
+
+## Who should run Day 19
+
+- Maintainers deciding if a release tag can be cut this week.
+- Team leads running closeout meetings and action tracking.
+- Contributors preparing evidence for release notes.
+
+## Score model
+
+- Day 18 reliability score weight: 70%
+- Day 14 KPI score weight: 30%
+
+## Fast verification commands
+
+```bash
+python -m sdetkit release-readiness-board --format json --strict
+python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict
+python -m sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict
+python scripts/check_day19_release_readiness_board_contract.py
+```
+
+## Execution evidence mode
+
+`--execute` runs the Day 19 command chain and writes deterministic logs into `--evidence-dir`.
+
+## Closeout checklist
+
+- [ ] Day 18 reliability gate status is `pass`.
+- [ ] Day 14 KPI score meets threshold.
+- [ ] Day 19 release score is reviewed by maintainers.
+- [ ] Day 19 recommendations are tracked in backlog.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -55,6 +55,9 @@ case "$mode" in
     python scripts/check_day16_gitlab_ci_quickstart_contract.py
     python scripts/check_day18_reliability_evidence_pack_contract.py
     ;;
+  day19)
+    python scripts/check_day19_release_readiness_board_contract.py --skip-evidence
+    ;;
   all)
     ruff format --check .
     ruff check .
@@ -70,7 +73,7 @@ case "$mode" in
     python scripts/check_day18_reliability_evidence_pack_contract.py
     ;;
   *)
-    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|day3|day4|day15|day16|all}" >&2
+    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|day3|day4|day15|day16|day19|all}" >&2
     exit 2
     ;;
 esac

--- a/scripts/check_day19_release_readiness_board_contract.py
+++ b/scripts/check_day19_release_readiness_board_contract.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+DAY19_PAGE = Path("docs/integrations-release-readiness-board.md")
+DAY19_REPORT = Path("docs/day-19-ultra-upgrade-report.md")
+DAY19_ARTIFACT = Path("docs/artifacts/day19-release-readiness-board-sample.md")
+DAY19_PACK_SUMMARY = Path("docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json")
+DAY19_PACK_SCORECARD = Path("docs/artifacts/day19-release-readiness-pack/day19-release-readiness-scorecard.md")
+DAY19_PACK_CHECKLIST = Path("docs/artifacts/day19-release-readiness-pack/day19-release-readiness-checklist.md")
+DAY19_PACK_VALIDATION = Path("docs/artifacts/day19-release-readiness-pack/day19-validation-commands.md")
+DAY19_PACK_DECISION = Path("docs/artifacts/day19-release-readiness-pack/day19-release-decision.md")
+DAY19_EVIDENCE = Path("docs/artifacts/day19-release-readiness-pack/evidence/day19-execution-summary.json")
+MODULE = Path("src/sdetkit/release_readiness_board.py")
+
+README_EXPECTED = [
+    "## 🧭 Day 19 ultra: release readiness board",
+    "python -m sdetkit release-readiness-board --format text",
+    "python -m sdetkit release-readiness-board --format json --strict",
+    "python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict",
+    "python -m sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict",
+    "python scripts/check_day19_release_readiness_board_contract.py",
+]
+
+INDEX_EXPECTED = [
+    "Day 19 ultra upgrades (release readiness board)",
+    "sdetkit release-readiness-board --format json --strict",
+    "artifacts/day19-release-readiness-board-sample.md",
+]
+
+CLI_EXPECTED = [
+    "## release-readiness-board",
+    "--day18-summary",
+    "--day14-summary",
+    "--min-release-score",
+    "--write-defaults",
+    "--execute",
+    "--evidence-dir",
+    "--timeout-sec",
+    "--emit-pack-dir",
+]
+
+PAGE_EXPECTED = [
+    "# Release readiness board (Day 19)",
+    "## Score model",
+    "## Fast verification commands",
+    "## Execution evidence mode",
+]
+
+REPORT_EXPECTED = ["Day 19 big upgrade", "release score", "strict", "--execute --evidence-dir"]
+SUMMARY_EXPECTED = [
+    '"name": "day19-release-readiness-board"',
+    '"release_score":',
+    '"strict_all_green":',
+]
+EVIDENCE_EXPECTED = ['"name": "day19-release-readiness-execution"', '"total_commands": 3']
+
+
+def _missing(path: Path, expected: list[str]) -> list[str]:
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    return [item for item in expected if item not in text]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skip-evidence", action="store_true")
+    ns = ap.parse_args(argv)
+
+    required = [
+        README,
+        DOCS_INDEX,
+        DOCS_CLI,
+        DAY19_PAGE,
+        DAY19_REPORT,
+        DAY19_ARTIFACT,
+        DAY19_PACK_SUMMARY,
+        DAY19_PACK_SCORECARD,
+        DAY19_PACK_CHECKLIST,
+        DAY19_PACK_VALIDATION,
+        DAY19_PACK_DECISION,
+        MODULE,
+    ]
+    if not ns.skip_evidence:
+        required.append(DAY19_EVIDENCE)
+
+    errors: list[str] = []
+    for path in required:
+        if not path.exists():
+            errors.append(f"missing required file: {path}")
+
+    if not errors:
+        errors.extend(f"{README}: missing '{m}'" for m in _missing(README, README_EXPECTED))
+        errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
+        errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
+        errors.extend(f"{DAY19_PAGE}: missing '{m}'" for m in _missing(DAY19_PAGE, PAGE_EXPECTED))
+        errors.extend(f"{DAY19_REPORT}: missing '{m}'" for m in _missing(DAY19_REPORT, REPORT_EXPECTED))
+        errors.extend(f"{DAY19_PACK_SUMMARY}: missing '{m}'" for m in _missing(DAY19_PACK_SUMMARY, SUMMARY_EXPECTED))
+        if not ns.skip_evidence:
+            errors.extend(f"{DAY19_EVIDENCE}: missing '{m}'" for m in _missing(DAY19_EVIDENCE, EVIDENCE_EXPECTED))
+
+    if errors:
+        print("day19-release-readiness-board-contract check failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print("day19-release-readiness-board-contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -24,6 +24,7 @@ from . import (
     policy,
     proof,
     quality_contribution_delta,
+    release_readiness_board,
     reliability_evidence_pack,
     repo,
     report,
@@ -153,6 +154,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "reliability-evidence-pack":
         return reliability_evidence_pack.main(list(argv[1:]))
 
+    if argv and argv[0] == "release-readiness-board":
+        return release_readiness_board.main(list(argv[1:]))
+
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -247,6 +251,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     rep = sub.add_parser("reliability-evidence-pack")
     rep.add_argument("args", nargs=argparse.REMAINDER)
 
+    rrb = sub.add_parser("release-readiness-board")
+    rrb.add_argument("args", nargs=argparse.REMAINDER)
+
     ns = p.parse_args(argv)
 
     if ns.cmd == "kv":
@@ -329,6 +336,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "reliability-evidence-pack":
         return reliability_evidence_pack.main(ns.args)
+
+    if ns.cmd == "release-readiness-board":
+        return release_readiness_board.main(ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)

--- a/src/sdetkit/release_readiness_board.py
+++ b/src/sdetkit/release_readiness_board.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+_PAGE_PATH = "docs/integrations-release-readiness-board.md"
+
+_SECTION_HEADER = "# Release readiness board (Day 19)"
+_REQUIRED_SECTIONS = [
+    "## Who should run Day 19",
+    "## Score model",
+    "## Fast verification commands",
+    "## Execution evidence mode",
+    "## Closeout checklist",
+]
+
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit release-readiness-board --format json --strict",
+    "python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict",
+    "python -m sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict",
+    "python scripts/check_day19_release_readiness_board_contract.py",
+]
+
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit release-readiness-board --format json --strict",
+    "python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict",
+    "python scripts/check_day19_release_readiness_board_contract.py --skip-evidence",
+]
+
+_DAY19_DEFAULT_PAGE = """# Release readiness board (Day 19)
+
+Day 19 composes Day 14 weekly trend health and Day 18 reliability posture into one release-candidate gate.
+
+## Who should run Day 19
+
+- Maintainers deciding if a release tag can be cut this week.
+- Team leads running closeout meetings and action tracking.
+- Contributors preparing evidence for release notes.
+
+## Score model
+
+- Day 18 reliability score weight: 70%
+- Day 14 KPI score weight: 30%
+
+## Fast verification commands
+
+```bash
+python -m sdetkit release-readiness-board --format json --strict
+python -m sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict
+python -m sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict
+python scripts/check_day19_release_readiness_board_contract.py
+```
+
+## Execution evidence mode
+
+`--execute` runs the Day 19 command chain and writes deterministic logs into `--evidence-dir`.
+
+## Closeout checklist
+
+- [ ] Day 18 reliability gate status is `pass`.
+- [ ] Day 14 KPI score meets threshold.
+- [ ] Day 19 release score is reviewed by maintainers.
+- [ ] Day 19 recommendations are tracked in backlog.
+"""
+
+
+_REQUIRED_DAY18_KEYS = ("summary",)
+_REQUIRED_DAY18_SUMMARY_KEYS = ("reliability_score", "gate_status")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _require_keys(payload: dict[str, object], keys: tuple[str, ...], label: str) -> None:
+    for key in keys:
+        if key not in payload:
+            raise ValueError(f"{label} missing required key: {key}")
+
+
+def _normalize_day14_summary(day14_summary: dict[str, object]) -> tuple[float, str]:
+    summary = day14_summary.get("summary")
+    if isinstance(summary, dict):
+        return float(summary.get("score", 0.0)), str(summary.get("status", "unknown"))
+
+    kpis = day14_summary.get("kpis")
+    if isinstance(kpis, dict):
+        score = float(kpis.get("completion_rate_percent", 0.0))
+        return score, "pass" if score >= 90 else "warn"
+
+    raise ValueError("day14 summary must include either summary.score or kpis.completion_rate_percent")
+
+
+def build_release_board(
+    day18_summary: dict[str, object],
+    day14_summary: dict[str, object],
+) -> dict[str, object]:
+    _require_keys(day18_summary, _REQUIRED_DAY18_KEYS, "day18 summary")
+    if not isinstance(day18_summary["summary"], dict):
+        raise ValueError("day18 summary.summary must be an object")
+
+    day18 = day18_summary["summary"]
+    _require_keys(day18, _REQUIRED_DAY18_SUMMARY_KEYS, "day18 summary.summary")
+
+    reliability_score = float(day18["reliability_score"])
+    reliability_gate = str(day18["gate_status"])
+    day14_score, day14_status = _normalize_day14_summary(day14_summary)
+
+    release_score = round((reliability_score * 0.70) + (day14_score * 0.30), 2)
+    strict_all_green = reliability_gate == "pass" and day14_score >= 90.0
+
+    recommendations: list[str] = []
+    if not strict_all_green:
+        recommendations.append(
+            "Resolve Day 18 reliability or Day 14 KPI gaps before cutting a release tag."
+        )
+    if release_score < 95:
+        recommendations.append(
+            "Raise release readiness score by improving reliability execution and KPI trend quality."
+        )
+    if strict_all_green and release_score >= 95:
+        recommendations.append(
+            "Release posture is strong; proceed with release candidate tagging and notes preparation."
+        )
+
+    return {
+        "name": "day19-release-readiness-board",
+        "inputs": {
+            "day18": {
+                "reliability_score": reliability_score,
+                "gate_status": reliability_gate,
+            },
+            "day14": {
+                "score": day14_score,
+                "status": day14_status,
+            },
+        },
+        "summary": {
+            "release_score": release_score,
+            "strict_all_green": strict_all_green,
+            "gate_status": "pass" if strict_all_green and release_score >= 90 else "warn",
+        },
+        "recommendations": recommendations,
+    }
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [
+        "Day 19 release readiness board",
+        "",
+        f"Release score: {payload['summary']['release_score']}",
+        f"Strict gates green: {payload['summary']['strict_all_green']}",
+        f"Gate status: {payload['summary']['gate_status']}",
+        "",
+        "Recommendations:",
+    ]
+    lines.extend(f"- {row}" for row in payload["recommendations"])
+    return "\n".join(lines) + "\n"
+
+
+def _render_markdown(payload: dict[str, object]) -> str:
+    return "\n".join(
+        [
+            "# Day 19 release readiness board",
+            "",
+            f"- Release score: **{payload['summary']['release_score']}**",
+            f"- Strict gates green: **{payload['summary']['strict_all_green']}**",
+            f"- Gate status: **{payload['summary']['gate_status']}**",
+            "",
+            "## Recommendations",
+            *[f"- {row}" for row in payload["recommendations"]],
+            "",
+        ]
+    )
+
+
+def _emit_pack(path: str, payload: dict[str, object], root: Path) -> list[str]:
+    out_dir = root / path
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = out_dir / "day19-release-readiness-summary.json"
+    scorecard = out_dir / "day19-release-readiness-scorecard.md"
+    checklist = out_dir / "day19-release-readiness-checklist.md"
+    validation = out_dir / "day19-validation-commands.md"
+    decision = out_dir / "day19-release-decision.md"
+
+    summary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    scorecard.write_text(_render_markdown(payload), encoding="utf-8")
+    checklist.write_text(
+        "\n".join(
+            [
+                "# Day 19 release readiness closeout checklist",
+                "",
+                "- [ ] Day 18 reliability gate status is pass.",
+                "- [ ] Day 14 KPI status is pass.",
+                "- [ ] Release score is reviewed in closeout meeting.",
+                "- [ ] Recommendations are assigned and tracked.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    validation.write_text(
+        "\n".join(["# Day 19 validation commands", "", "```bash", *_REQUIRED_COMMANDS, "```", ""]),
+        encoding="utf-8",
+    )
+    decision.write_text(
+        "\n".join(
+            [
+                "# Day 19 release decision",
+                "",
+                f"- Gate status: **{payload['summary']['gate_status']}**",
+                f"- Release score: **{payload['summary']['release_score']}**",
+                f"- Strict all green: **{payload['summary']['strict_all_green']}**",
+                "",
+                "Use this file as the final go/no-go note in release closeout.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    return [
+        str(summary.relative_to(root)),
+        str(scorecard.relative_to(root)),
+        str(checklist.relative_to(root)),
+        str(validation.relative_to(root)),
+        str(decision.relative_to(root)),
+    ]
+
+
+def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for idx, command in enumerate(commands, start=1):
+        try:
+            proc = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+                check=False,
+            )
+            rows.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": proc.returncode,
+                    "ok": proc.returncode == 0,
+                    "stdout": proc.stdout,
+                    "stderr": proc.stderr,
+                }
+            )
+        except subprocess.TimeoutExpired as exc:
+            rows.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": 124,
+                    "ok": False,
+                    "stdout": (exc.stdout or "") if isinstance(exc.stdout, str) else "",
+                    "stderr": (exc.stderr or "") if isinstance(exc.stderr, str) else "",
+                    "error": f"timed out after {timeout_sec}s",
+                }
+            )
+    return rows
+
+
+def _write_execution_evidence(
+    root: Path,
+    evidence_dir: str,
+    rows: list[dict[str, object]],
+) -> list[str]:
+    out = root / evidence_dir
+    out.mkdir(parents=True, exist_ok=True)
+    summary = out / "day19-execution-summary.json"
+    payload = {
+        "name": "day19-release-readiness-execution",
+        "total_commands": len(rows),
+        "passed_commands": len([r for r in rows if r["ok"]]),
+        "failed_commands": len([r for r in rows if not r["ok"]]),
+        "results": rows,
+    }
+    summary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    emitted = [summary]
+    for row in rows:
+        log = out / f"command-{row['index']:02d}.log"
+        log.write_text(
+            "\n".join(
+                [
+                    f"command: {row['command']}",
+                    f"returncode: {row['returncode']}",
+                    f"ok: {row['ok']}",
+                    "--- stdout ---",
+                    str(row.get("stdout", "")),
+                    "--- stderr ---",
+                    str(row.get("stderr", "")),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        emitted.append(log)
+
+    return [str(path.relative_to(root)) for path in emitted]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit release-readiness-board",
+        description="Build Day 19 release readiness signal from Day 18 and Day 14 summaries.",
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument(
+        "--day18-summary",
+        default="docs/artifacts/day18-reliability-pack/day18-reliability-summary.json",
+    )
+    parser.add_argument(
+        "--day14-summary",
+        default="docs/artifacts/day14-weekly-pack/day14-kpi-scorecard.json",
+    )
+    parser.add_argument("--min-release-score", type=float, default=90.0)
+    parser.add_argument("--write-defaults", action="store_true")
+    parser.add_argument("--emit-pack-dir", default="")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument(
+        "--evidence-dir",
+        default="docs/artifacts/day19-release-readiness-pack/evidence",
+    )
+    parser.add_argument("--timeout-sec", type=int, default=120)
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--format", choices=["text", "json", "markdown"], default="text")
+    parser.add_argument("--output", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    root = Path(args.root).resolve()
+
+    if args.write_defaults:
+        page_path = root / _PAGE_PATH
+        page_path.parent.mkdir(parents=True, exist_ok=True)
+        page_path.write_text(_DAY19_DEFAULT_PAGE, encoding="utf-8")
+
+    page_text = _read(root / _PAGE_PATH)
+    missing_sections = [
+        section
+        for section in [_SECTION_HEADER, *_REQUIRED_SECTIONS]
+        if section not in page_text
+    ]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+
+    payload = build_release_board(
+        _load_json(root / args.day18_summary),
+        _load_json(root / args.day14_summary),
+    )
+    payload["score"] = 100.0 if not (missing_sections or missing_commands) else 0.0
+    payload["strict_failures"] = [*missing_sections, *missing_commands]
+
+    if args.emit_pack_dir:
+        payload["emitted_pack_files"] = _emit_pack(args.emit_pack_dir, payload, root)
+    if args.execute:
+        payload["execution_artifacts"] = _write_execution_evidence(
+            root,
+            args.evidence_dir,
+            _execute_commands(_EXECUTION_COMMANDS, args.timeout_sec),
+        )
+
+    strict_failed = (
+        payload["summary"]["release_score"] < args.min_release_score
+        or not payload["summary"]["strict_all_green"]
+        or bool(payload["strict_failures"])
+    )
+
+    if args.format == "json":
+        output = json.dumps(payload, indent=2, sort_keys=True)
+    elif args.format == "markdown":
+        output = _render_markdown(payload)
+    else:
+        output = _render_text(payload)
+
+    if args.output:
+        out = root / args.output
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(output if output.endswith("\n") else output + "\n", encoding="utf-8")
+    else:
+        print(output, end="" if output.endswith("\n") else "\n")
+
+    return 1 if args.strict and strict_failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -36,3 +36,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "gitlab-ci-quickstart" in out
     assert "quality-contribution-delta" in out
     assert "reliability-evidence-pack" in out
+    assert "release-readiness-board" in out

--- a/tests/test_release_readiness_board.py
+++ b/tests/test_release_readiness_board.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import release_readiness_board as rrb
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    day18 = tmp_path / "day18.json"
+    day14 = tmp_path / "day14.json"
+    day18.write_text(
+        json.dumps({"summary": {"reliability_score": 97.5, "gate_status": "pass"}}) + "\n",
+        encoding="utf-8",
+    )
+    day14.write_text(
+        json.dumps({"summary": {"score": 96.0, "status": "pass"}}) + "\n",
+        encoding="utf-8",
+    )
+    return day18, day14
+
+
+def _write_page(root: Path) -> None:
+    path = root / "docs/integrations-release-readiness-board.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rrb._DAY19_DEFAULT_PAGE, encoding="utf-8")
+
+
+def test_day19_board_builds_json(tmp_path: Path, capsys) -> None:
+    day18, day14 = _write_inputs(tmp_path)
+    _write_page(tmp_path)
+
+    rc = rrb.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day18-summary",
+            str(day18.relative_to(tmp_path)),
+            "--day14-summary",
+            str(day14.relative_to(tmp_path)),
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day19-release-readiness-board"
+    assert out["summary"]["strict_all_green"] is True
+    assert out["summary"]["release_score"] >= 90
+
+
+def test_day19_board_emits_bundle_and_evidence(tmp_path: Path) -> None:
+    day18, day14 = _write_inputs(tmp_path)
+    _write_page(tmp_path)
+
+    rc = rrb.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day18-summary",
+            str(day18.relative_to(tmp_path)),
+            "--day14-summary",
+            str(day14.relative_to(tmp_path)),
+            "--emit-pack-dir",
+            "artifacts/day19-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day19-pack/evidence",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day19-pack/day19-release-readiness-summary.json").exists()
+    assert (tmp_path / "artifacts/day19-pack/day19-release-readiness-scorecard.md").exists()
+    assert (tmp_path / "artifacts/day19-pack/day19-release-readiness-checklist.md").exists()
+    assert (tmp_path / "artifacts/day19-pack/day19-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day19-pack/evidence/day19-execution-summary.json").exists()
+
+
+def test_day19_cli_dispatch(tmp_path: Path, capsys) -> None:
+    day18, day14 = _write_inputs(tmp_path)
+    _write_page(tmp_path)
+
+    rc = cli.main(
+        [
+            "release-readiness-board",
+            "--root",
+            str(tmp_path),
+            "--day18-summary",
+            str(day18.relative_to(tmp_path)),
+            "--day14-summary",
+            str(day14.relative_to(tmp_path)),
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 0
+    assert "Day 19 release readiness board" in capsys.readouterr().out
+
+
+def test_day19_board_supports_day14_kpis_payload(tmp_path: Path, capsys) -> None:
+    day18 = tmp_path / "day18.json"
+    day14 = tmp_path / "day14.json"
+    day18.write_text(json.dumps({"summary": {"reliability_score": 92.0, "gate_status": "pass"}}) + "\n", encoding="utf-8")
+    day14.write_text(json.dumps({"kpis": {"completion_rate_percent": 95}}) + "\n", encoding="utf-8")
+    _write_page(tmp_path)
+
+    rc = rrb.main([
+        "--root",
+        str(tmp_path),
+        "--day18-summary",
+        str(day18.relative_to(tmp_path)),
+        "--day14-summary",
+        str(day14.relative_to(tmp_path)),
+        "--format",
+        "json",
+        "--strict",
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["inputs"]["day14"]["status"] == "pass"
+    assert out["summary"]["release_score"] == 92.9


### PR DESCRIPTION
### Motivation
- Provide a deterministic Day 19 release-readiness signal that is strict and safe for release closeouts by validating inputs and failing predictably under `--strict`.
- Ensure compatibility with legacy Day 14 KPI payloads (`summary` or `kpis`) so the board accepts real-world inputs.
- Surface a concrete go/no-go artifact for handoff and make Day 19 part of local repo contract checks and docs.

### Description
- Add `src/sdetkit/release_readiness_board.py` implementing the `sdetkit release-readiness-board` CLI with scoring logic, Day 14 payload normalization, pack emission, execution evidence logging, `--write-defaults` page bootstrapping, and deterministic `--strict` behavior.
- Wire the command into the top-level CLI by updating `src/sdetkit/cli.py` to dispatch `release-readiness-board` and register its subcommand help.
- Add unit tests in `tests/test_release_readiness_board.py` (including regression for legacy Day 14 `kpis` payload) and update `tests/test_cli_help_lists_subcommands.py` to include the new subcommand.
- Add `scripts/check_day19_release_readiness_board_contract.py`, update `scripts/check.sh` with a `day19` mode, and add docs and emitted artifacts (`docs/integrations-release-readiness-board.md`, `docs/day-19-ultra-upgrade-report.md`, `docs/artifacts/day19-release-readiness-pack/*`, and sample outputs) including a new `day19-release-decision.md` decision note.

### Testing
- Ran unit tests with `python -m pytest -q tests/test_release_readiness_board.py tests/test_cli_help_lists_subcommands.py` which passed (`5 passed`).
- Ran the Day 19 contract check `python scripts/check_day19_release_readiness_board_contract.py` which passed (`day19-release-readiness-board-contract check passed`).
- Executed repository checks `bash scripts/check.sh day19` which completed successfully (`All checks passed!`).
- Exercised CLI flows including `python -m sdetkit release-readiness-board --format json --strict`, `--emit-pack-dir`, and `--execute --evidence-dir` which ran to completion and produced the expected artifacts.

------