### PR TITLE
Finalize Day 20 `release-narrative`: strict contract, evidence mode, and artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,35 @@ python -m sdetkit release-readiness-board --format json --strict
 python -m sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict
 ```
 
+## ✍️ Day 20 ultra: release narrative
+
+Day 20 now ships a deterministic **release narrative operating lane** that converts Day 19 readiness posture and changelog highlights into multi-channel, non-maintainer storytelling.
+
+```bash
+python -m sdetkit release-narrative --format text
+python -m sdetkit release-narrative --format json --strict
+python -m sdetkit release-narrative --write-defaults --format json --strict
+python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict
+python -m sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict
+```
+
+Export a markdown artifact for handoff:
+
+```bash
+python -m sdetkit release-narrative --format markdown --output docs/artifacts/day20-release-narrative-sample.md
+```
+
+See implementation details: [Day 20 ultra upgrade report](docs/day-20-ultra-upgrade-report.md).
+
+Day 20 closeout checks:
+
+```bash
+python -m pytest -q tests/test_release_narrative.py tests/test_cli_help_lists_subcommands.py
+python scripts/check_day20_release_narrative_contract.py
+python -m sdetkit release-narrative --format json --strict
+python -m sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict
+```
+
 ## ⚡ Quick start
 
 ```bash

--- a/docs/artifacts/day20-release-narrative-pack/day20-audience-blurbs.md
+++ b/docs/artifacts/day20-release-narrative-pack/day20-audience-blurbs.md
@@ -1,0 +1,5 @@
+# Day 20 audience blurbs
+
+- **Non Maintainers:** What changed: clearer quality gates, faster release confidence, and traceable evidence for audits.
+- **Engineering:** Ship with confidence by tying Day 19 release score to concrete checklist and evidence artifacts.
+- **Support:** Use highlights + risks sections to pre-brief known changes and probable user questions.

--- a/docs/artifacts/day20-release-narrative-pack/day20-channel-posts.md
+++ b/docs/artifacts/day20-release-narrative-pack/day20-channel-posts.md
@@ -1,0 +1,5 @@
+# Day 20 narrative channels
+
+- **Release Notes:** This release is ready to communicate broadly with a stable quality posture. Key highlights: Packaging: modernize license metadata.
+- **Community Post:** Shipping update: stronger quality gates, clearer evidence, and a smoother adoption path for teams.
+- **Internal Update:** Day 20 narrative pack is ready. Reuse the highlights/risks sections in weekly status and customer comms.

--- a/docs/artifacts/day20-release-narrative-pack/day20-release-narrative-summary.json
+++ b/docs/artifacts/day20-release-narrative-pack/day20-release-narrative-summary.json
@@ -1,0 +1,37 @@
+{
+  "audience_blurbs": {
+    "engineering": "Ship with confidence by tying Day 19 release score to concrete checklist and evidence artifacts.",
+    "non_maintainers": "What changed: clearer quality gates, faster release confidence, and traceable evidence for audits.",
+    "support": "Use highlights + risks sections to pre-brief known changes and probable user questions."
+  },
+  "call_to_action": "Share this narrative in release notes, weekly updates, and community announcements.",
+  "highlights": [
+    "Packaging: modernize license metadata.",
+    "CI gate: run `sdetkit doctor --all` and `sdetkit repo check --profile enterprise` on every PR.",
+    "Enterprise hardening: GitHub Actions pinned to commit SHAs.",
+    "Dependency hygiene: requirements pinned and lockfiles added.",
+    "Repo init/apply reliability: tolerate non-UTF-8 preset template files.",
+    "Repo cleanliness: ignore local SDETKit workspace and docs build output."
+  ],
+  "inputs": {
+    "changelog": "CHANGELOG.md",
+    "day19_summary": "docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json"
+  },
+  "name": "day20-release-narrative",
+  "narrative_channels": {
+    "community_post": "Shipping update: stronger quality gates, clearer evidence, and a smoother adoption path for teams.",
+    "internal_update": "Day 20 narrative pack is ready. Reuse the highlights/risks sections in weekly status and customer comms.",
+    "release_notes": "This release is ready to communicate broadly with a stable quality posture. Key highlights: Packaging: modernize license metadata."
+  },
+  "risks": [
+    "Release posture is strong; proceed with release candidate tagging and notes preparation."
+  ],
+  "score": 100.0,
+  "strict_failures": [],
+  "summary": {
+    "gate_status": "pass",
+    "headline": "This release is ready to communicate broadly with a stable quality posture.",
+    "readiness_label": "ready",
+    "release_score": 96.56
+  }
+}

--- a/docs/artifacts/day20-release-narrative-pack/day20-release-narrative.md
+++ b/docs/artifacts/day20-release-narrative-pack/day20-release-narrative.md
@@ -1,0 +1,36 @@
+# Day 20 release narrative
+
+**Headline:** This release is ready to communicate broadly with a stable quality posture.
+
+## Release posture
+
+- Release score: **96.56**
+- Gate status: **pass**
+- Readiness label: **ready**
+
+## Highlights
+
+- Packaging: modernize license metadata.
+- CI gate: run `sdetkit doctor --all` and `sdetkit repo check --profile enterprise` on every PR.
+- Enterprise hardening: GitHub Actions pinned to commit SHAs.
+- Dependency hygiene: requirements pinned and lockfiles added.
+- Repo init/apply reliability: tolerate non-UTF-8 preset template files.
+- Repo cleanliness: ignore local SDETKit workspace and docs build output.
+
+## Risks and follow-ups
+
+- Release posture is strong; proceed with release candidate tagging and notes preparation.
+
+## Audience blurbs
+
+- **Non Maintainers:** What changed: clearer quality gates, faster release confidence, and traceable evidence for audits.
+- **Engineering:** Ship with confidence by tying Day 19 release score to concrete checklist and evidence artifacts.
+- **Support:** Use highlights + risks sections to pre-brief known changes and probable user questions.
+
+## Narrative channels
+
+- **Release Notes:** This release is ready to communicate broadly with a stable quality posture. Key highlights: Packaging: modernize license metadata.
+- **Community Post:** Shipping update: stronger quality gates, clearer evidence, and a smoother adoption path for teams.
+- **Internal Update:** Day 20 narrative pack is ready. Reuse the highlights/risks sections in weekly status and customer comms.
+
+**Call to action:** Share this narrative in release notes, weekly updates, and community announcements.

--- a/docs/artifacts/day20-release-narrative-pack/day20-validation-commands.md
+++ b/docs/artifacts/day20-release-narrative-pack/day20-validation-commands.md
@@ -1,0 +1,8 @@
+# Day 20 validation commands
+
+```bash
+python -m sdetkit release-narrative --format json --strict
+python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict
+python -m sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict
+python scripts/check_day20_release_narrative_contract.py
+```

--- a/docs/artifacts/day20-release-narrative-pack/evidence/command-01.log
+++ b/docs/artifacts/day20-release-narrative-pack/evidence/command-01.log
@@ -1,0 +1,44 @@
+command: python -m sdetkit release-narrative --format json --strict
+returncode: 0
+ok: True
+--- stdout ---
+{
+  "audience_blurbs": {
+    "engineering": "Ship with confidence by tying Day 19 release score to concrete checklist and evidence artifacts.",
+    "non_maintainers": "What changed: clearer quality gates, faster release confidence, and traceable evidence for audits.",
+    "support": "Use highlights + risks sections to pre-brief known changes and probable user questions."
+  },
+  "call_to_action": "Share this narrative in release notes, weekly updates, and community announcements.",
+  "highlights": [
+    "Packaging: modernize license metadata.",
+    "CI gate: run `sdetkit doctor --all` and `sdetkit repo check --profile enterprise` on every PR.",
+    "Enterprise hardening: GitHub Actions pinned to commit SHAs.",
+    "Dependency hygiene: requirements pinned and lockfiles added.",
+    "Repo init/apply reliability: tolerate non-UTF-8 preset template files.",
+    "Repo cleanliness: ignore local SDETKit workspace and docs build output."
+  ],
+  "inputs": {
+    "changelog": "CHANGELOG.md",
+    "day19_summary": "docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json"
+  },
+  "name": "day20-release-narrative",
+  "narrative_channels": {
+    "community_post": "Shipping update: stronger quality gates, clearer evidence, and a smoother adoption path for teams.",
+    "internal_update": "Day 20 narrative pack is ready. Reuse the highlights/risks sections in weekly status and customer comms.",
+    "release_notes": "This release is ready to communicate broadly with a stable quality posture. Key highlights: Packaging: modernize license metadata."
+  },
+  "risks": [
+    "Release posture is strong; proceed with release candidate tagging and notes preparation."
+  ],
+  "score": 100.0,
+  "strict_failures": [],
+  "summary": {
+    "gate_status": "pass",
+    "headline": "This release is ready to communicate broadly with a stable quality posture.",
+    "readiness_label": "ready",
+    "release_score": 96.56
+  }
+}
+
+--- stderr ---
+

--- a/docs/artifacts/day20-release-narrative-pack/evidence/command-02.log
+++ b/docs/artifacts/day20-release-narrative-pack/evidence/command-02.log
@@ -1,0 +1,51 @@
+command: python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict
+returncode: 0
+ok: True
+--- stdout ---
+{
+  "audience_blurbs": {
+    "engineering": "Ship with confidence by tying Day 19 release score to concrete checklist and evidence artifacts.",
+    "non_maintainers": "What changed: clearer quality gates, faster release confidence, and traceable evidence for audits.",
+    "support": "Use highlights + risks sections to pre-brief known changes and probable user questions."
+  },
+  "call_to_action": "Share this narrative in release notes, weekly updates, and community announcements.",
+  "emitted_pack_files": [
+    "docs/artifacts/day20-release-narrative-pack/day20-release-narrative-summary.json",
+    "docs/artifacts/day20-release-narrative-pack/day20-release-narrative.md",
+    "docs/artifacts/day20-release-narrative-pack/day20-audience-blurbs.md",
+    "docs/artifacts/day20-release-narrative-pack/day20-channel-posts.md",
+    "docs/artifacts/day20-release-narrative-pack/day20-validation-commands.md"
+  ],
+  "highlights": [
+    "Packaging: modernize license metadata.",
+    "CI gate: run `sdetkit doctor --all` and `sdetkit repo check --profile enterprise` on every PR.",
+    "Enterprise hardening: GitHub Actions pinned to commit SHAs.",
+    "Dependency hygiene: requirements pinned and lockfiles added.",
+    "Repo init/apply reliability: tolerate non-UTF-8 preset template files.",
+    "Repo cleanliness: ignore local SDETKit workspace and docs build output."
+  ],
+  "inputs": {
+    "changelog": "CHANGELOG.md",
+    "day19_summary": "docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json"
+  },
+  "name": "day20-release-narrative",
+  "narrative_channels": {
+    "community_post": "Shipping update: stronger quality gates, clearer evidence, and a smoother adoption path for teams.",
+    "internal_update": "Day 20 narrative pack is ready. Reuse the highlights/risks sections in weekly status and customer comms.",
+    "release_notes": "This release is ready to communicate broadly with a stable quality posture. Key highlights: Packaging: modernize license metadata."
+  },
+  "risks": [
+    "Release posture is strong; proceed with release candidate tagging and notes preparation."
+  ],
+  "score": 100.0,
+  "strict_failures": [],
+  "summary": {
+    "gate_status": "pass",
+    "headline": "This release is ready to communicate broadly with a stable quality posture.",
+    "readiness_label": "ready",
+    "release_score": 96.56
+  }
+}
+
+--- stderr ---
+

--- a/docs/artifacts/day20-release-narrative-pack/evidence/command-03.log
+++ b/docs/artifacts/day20-release-narrative-pack/evidence/command-03.log
@@ -1,0 +1,8 @@
+command: python scripts/check_day20_release_narrative_contract.py --skip-evidence
+returncode: 0
+ok: True
+--- stdout ---
+day20-release-narrative-contract check passed
+
+--- stderr ---
+

--- a/docs/artifacts/day20-release-narrative-pack/evidence/day20-execution-summary.json
+++ b/docs/artifacts/day20-release-narrative-pack/evidence/day20-execution-summary.json
@@ -1,0 +1,32 @@
+{
+  "name": "day20-release-narrative-execution",
+  "total_commands": 3,
+  "passed_commands": 3,
+  "failed_commands": 0,
+  "results": [
+    {
+      "index": 1,
+      "command": "python -m sdetkit release-narrative --format json --strict",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "{\n  \"audience_blurbs\": {\n    \"engineering\": \"Ship with confidence by tying Day 19 release score to concrete checklist and evidence artifacts.\",\n    \"non_maintainers\": \"What changed: clearer quality gates, faster release confidence, and traceable evidence for audits.\",\n    \"support\": \"Use highlights + risks sections to pre-brief known changes and probable user questions.\"\n  },\n  \"call_to_action\": \"Share this narrative in release notes, weekly updates, and community announcements.\",\n  \"highlights\": [\n    \"Packaging: modernize license metadata.\",\n    \"CI gate: run `sdetkit doctor --all` and `sdetkit repo check --profile enterprise` on every PR.\",\n    \"Enterprise hardening: GitHub Actions pinned to commit SHAs.\",\n    \"Dependency hygiene: requirements pinned and lockfiles added.\",\n    \"Repo init/apply reliability: tolerate non-UTF-8 preset template files.\",\n    \"Repo cleanliness: ignore local SDETKit workspace and docs build output.\"\n  ],\n  \"inputs\": {\n    \"changelog\": \"CHANGELOG.md\",\n    \"day19_summary\": \"docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json\"\n  },\n  \"name\": \"day20-release-narrative\",\n  \"narrative_channels\": {\n    \"community_post\": \"Shipping update: stronger quality gates, clearer evidence, and a smoother adoption path for teams.\",\n    \"internal_update\": \"Day 20 narrative pack is ready. Reuse the highlights/risks sections in weekly status and customer comms.\",\n    \"release_notes\": \"This release is ready to communicate broadly with a stable quality posture. Key highlights: Packaging: modernize license metadata.\"\n  },\n  \"risks\": [\n    \"Release posture is strong; proceed with release candidate tagging and notes preparation.\"\n  ],\n  \"score\": 100.0,\n  \"strict_failures\": [],\n  \"summary\": {\n    \"gate_status\": \"pass\",\n    \"headline\": \"This release is ready to communicate broadly with a stable quality posture.\",\n    \"readiness_label\": \"ready\",\n    \"release_score\": 96.56\n  }\n}\n",
+      "stderr": ""
+    },
+    {
+      "index": 2,
+      "command": "python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "{\n  \"audience_blurbs\": {\n    \"engineering\": \"Ship with confidence by tying Day 19 release score to concrete checklist and evidence artifacts.\",\n    \"non_maintainers\": \"What changed: clearer quality gates, faster release confidence, and traceable evidence for audits.\",\n    \"support\": \"Use highlights + risks sections to pre-brief known changes and probable user questions.\"\n  },\n  \"call_to_action\": \"Share this narrative in release notes, weekly updates, and community announcements.\",\n  \"emitted_pack_files\": [\n    \"docs/artifacts/day20-release-narrative-pack/day20-release-narrative-summary.json\",\n    \"docs/artifacts/day20-release-narrative-pack/day20-release-narrative.md\",\n    \"docs/artifacts/day20-release-narrative-pack/day20-audience-blurbs.md\",\n    \"docs/artifacts/day20-release-narrative-pack/day20-channel-posts.md\",\n    \"docs/artifacts/day20-release-narrative-pack/day20-validation-commands.md\"\n  ],\n  \"highlights\": [\n    \"Packaging: modernize license metadata.\",\n    \"CI gate: run `sdetkit doctor --all` and `sdetkit repo check --profile enterprise` on every PR.\",\n    \"Enterprise hardening: GitHub Actions pinned to commit SHAs.\",\n    \"Dependency hygiene: requirements pinned and lockfiles added.\",\n    \"Repo init/apply reliability: tolerate non-UTF-8 preset template files.\",\n    \"Repo cleanliness: ignore local SDETKit workspace and docs build output.\"\n  ],\n  \"inputs\": {\n    \"changelog\": \"CHANGELOG.md\",\n    \"day19_summary\": \"docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json\"\n  },\n  \"name\": \"day20-release-narrative\",\n  \"narrative_channels\": {\n    \"community_post\": \"Shipping update: stronger quality gates, clearer evidence, and a smoother adoption path for teams.\",\n    \"internal_update\": \"Day 20 narrative pack is ready. Reuse the highlights/risks sections in weekly status and customer comms.\",\n    \"release_notes\": \"This release is ready to communicate broadly with a stable quality posture. Key highlights: Packaging: modernize license metadata.\"\n  },\n  \"risks\": [\n    \"Release posture is strong; proceed with release candidate tagging and notes preparation.\"\n  ],\n  \"score\": 100.0,\n  \"strict_failures\": [],\n  \"summary\": {\n    \"gate_status\": \"pass\",\n    \"headline\": \"This release is ready to communicate broadly with a stable quality posture.\",\n    \"readiness_label\": \"ready\",\n    \"release_score\": 96.56\n  }\n}\n",
+      "stderr": ""
+    },
+    {
+      "index": 3,
+      "command": "python scripts/check_day20_release_narrative_contract.py --skip-evidence",
+      "returncode": 0,
+      "ok": true,
+      "stdout": "day20-release-narrative-contract check passed\n",
+      "stderr": ""
+    }
+  ]
+}

--- a/docs/artifacts/day20-release-narrative-sample.md
+++ b/docs/artifacts/day20-release-narrative-sample.md
@@ -1,0 +1,36 @@
+# Day 20 release narrative
+
+**Headline:** This release is ready to communicate broadly with a stable quality posture.
+
+## Release posture
+
+- Release score: **96.56**
+- Gate status: **pass**
+- Readiness label: **ready**
+
+## Highlights
+
+- Packaging: modernize license metadata.
+- CI gate: run `sdetkit doctor --all` and `sdetkit repo check --profile enterprise` on every PR.
+- Enterprise hardening: GitHub Actions pinned to commit SHAs.
+- Dependency hygiene: requirements pinned and lockfiles added.
+- Repo init/apply reliability: tolerate non-UTF-8 preset template files.
+- Repo cleanliness: ignore local SDETKit workspace and docs build output.
+
+## Risks and follow-ups
+
+- Release posture is strong; proceed with release candidate tagging and notes preparation.
+
+## Audience blurbs
+
+- **Non Maintainers:** What changed: clearer quality gates, faster release confidence, and traceable evidence for audits.
+- **Engineering:** Ship with confidence by tying Day 19 release score to concrete checklist and evidence artifacts.
+- **Support:** Use highlights + risks sections to pre-brief known changes and probable user questions.
+
+## Narrative channels
+
+- **Release Notes:** This release is ready to communicate broadly with a stable quality posture. Key highlights: Packaging: modernize license metadata.
+- **Community Post:** Shipping update: stronger quality gates, clearer evidence, and a smoother adoption path for teams.
+- **Internal Update:** Day 20 narrative pack is ready. Reuse the highlights/risks sections in weekly status and customer comms.
+
+**Call to action:** Share this narrative in release notes, weekly updates, and community announcements.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -488,3 +488,26 @@ Useful flags: `--root`, `--day18-summary`, `--day14-summary`, `--min-release-sco
 `--execute` runs the Day 19 command chain and emits an execution summary plus per-command logs for closeout evidence.
 
 `--strict` returns non-zero if Day 19 required docs sections/commands are missing, strict gates are not green, or release score falls below `--min-release-score`.
+
+## release-narrative
+
+Builds Day 20 release storytelling from Day 19 release-readiness summary and changelog highlights.
+
+Examples:
+
+- `sdetkit release-narrative --format text`
+- `sdetkit release-narrative --format json --strict`
+- `sdetkit release-narrative --write-defaults --format json --strict`
+- `sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict`
+- `sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict`
+- `sdetkit release-narrative --format markdown --output docs/artifacts/day20-release-narrative-sample.md`
+
+Useful flags: `--root`, `--day19-summary`, `--changelog`, `--min-release-score`, `--write-defaults`, `--emit-pack-dir`, `--execute`, `--evidence-dir`, `--timeout-sec`, `--strict`, `--format`, `--output`.
+
+`--write-defaults` writes a hardened Day 20 integration page if missing/incomplete, then validates it.
+
+`--emit-pack-dir` writes a Day 20 pack containing summary JSON, narrative markdown, audience blurbs, narrative channels, and validation commands.
+
+`--execute` runs the Day 20 command chain and emits an execution summary plus per-command logs for closeout evidence.
+
+`--strict` returns non-zero if Day 20 required docs sections/commands are missing, release posture is not ready, or release score falls below `--min-release-score`.

--- a/docs/day-20-ultra-upgrade-report.md
+++ b/docs/day-20-ultra-upgrade-report.md
@@ -1,0 +1,27 @@
+# Day 20 ultra upgrade report
+
+## Day 20 big upgrade
+
+Day 20 ships a deterministic **release narrative operating lane** that converts Day 19 release posture and changelog highlights into reusable multi-channel storytelling with strict contract validation.
+
+## What shipped
+
+- Added `sdetkit release-narrative` CLI to build non-maintainer narratives from Day 19 summary evidence and changelog bullets.
+- Added strict docs contract checks (required sections + commands), minimum-score gates, and a score/failure model similar to Day 18/19 enforcement.
+- Added execution evidence mode (`--execute`) with deterministic command logs and summary JSON.
+- Expanded emit-pack outputs to include summary JSON, narrative markdown, audience blurbs, narrative channels, and validation commands.
+
+## Validation commands
+
+```bash
+python -m sdetkit release-narrative --format text
+python -m sdetkit release-narrative --format json --strict
+python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict
+python -m sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict
+python -m sdetkit release-narrative --format markdown --output docs/artifacts/day20-release-narrative-sample.md
+python scripts/check_day20_release_narrative_contract.py
+```
+
+## Closeout
+
+Day 20 now closes with one strict and auditable narrative lane: release story, channel-ready blurbs, validation commands, and execution evidence that can be reused across release notes, social distribution, and internal status updates.

--- a/docs/index.md
+++ b/docs/index.md
@@ -323,3 +323,15 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 19 release-readiness pack: `sdetkit release-readiness-board --emit-pack-dir docs/artifacts/day19-release-readiness-pack --format json --strict`.
 - Capture deterministic execution logs: `sdetkit release-readiness-board --execute --evidence-dir docs/artifacts/day19-release-readiness-pack/evidence --format json --strict`.
 - Review generated artifacts: [day19 release readiness sample](artifacts/day19-release-readiness-board-sample.md), [day19 release summary](artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json), [day19 release decision](artifacts/day19-release-readiness-pack/day19-release-decision.md), [day19 validation commands](artifacts/day19-release-readiness-pack/day19-validation-commands.md), and [day19 execution summary](artifacts/day19-release-readiness-pack/evidence/day19-execution-summary.json).
+
+
+## Day 20 ultra upgrades (release narrative)
+
+- Read the implementation report: [Day 20 ultra upgrade report](day-20-ultra-upgrade-report.md).
+- Run `sdetkit release-narrative --format json --strict` to translate Day 19 posture into a strict narrative summary.
+- Auto-recover missing Day 20 integration docs: `sdetkit release-narrative --write-defaults --format json --strict`.
+- Export markdown artifact: `sdetkit release-narrative --format markdown --output docs/artifacts/day20-release-narrative-sample.md`.
+- Emit Day 20 release narrative pack: `sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict`.
+- Capture deterministic execution logs: `sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict`.
+- Review generated artifacts: [day20 release narrative sample](artifacts/day20-release-narrative-sample.md), [day20 narrative summary](artifacts/day20-release-narrative-pack/day20-release-narrative-summary.json), [day20 channel posts](artifacts/day20-release-narrative-pack/day20-channel-posts.md), [day20 validation commands](artifacts/day20-release-narrative-pack/day20-validation-commands.md), and [day20 execution summary](artifacts/day20-release-narrative-pack/evidence/day20-execution-summary.json).
+

--- a/docs/integrations-release-narrative.md
+++ b/docs/integrations-release-narrative.md
@@ -1,0 +1,40 @@
+# Release narrative (Day 20)
+
+Day 20 translates release readiness evidence into non-maintainer changelog storytelling.
+
+## Who should run Day 20
+
+- Maintainers writing release notes for mixed technical/non-technical audiences.
+- Developer advocates preparing community launch posts.
+- Product and support teams aligning on what changed and why it matters.
+
+## Story inputs
+
+- Day 19 release-readiness summary (`release_score`, `gate_status`, recommendations).
+- Changelog highlights for user-visible updates.
+
+## Fast verification commands
+
+```bash
+python -m sdetkit release-narrative --format json --strict
+python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict
+python -m sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict
+python scripts/check_day20_release_narrative_contract.py
+```
+
+## Execution evidence mode
+
+`--execute` runs the Day 20 command chain and writes deterministic logs into `--evidence-dir`.
+
+## Narrative channels
+
+- Release notes (maintainer + product audiences)
+- Community post (social + discussion channels)
+- Internal weekly update (engineering + support)
+
+## Storytelling checklist
+
+- [ ] Outcome-first summary is present.
+- [ ] Risks and follow-ups are explicit.
+- [ ] Validation evidence is linked.
+- [ ] Audience-specific blurbs are generated.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -38,6 +38,7 @@ case "$mode" in
     python scripts/check_day15_github_actions_quickstart_contract.py
     python scripts/check_day16_gitlab_ci_quickstart_contract.py
     python scripts/check_day18_reliability_evidence_pack_contract.py
+    python scripts/check_day20_release_narrative_contract.py
     ;;
   onboarding)
     python scripts/check_onboarding_contract.py
@@ -58,6 +59,9 @@ case "$mode" in
   day19)
     python scripts/check_day19_release_readiness_board_contract.py --skip-evidence
     ;;
+  day20)
+    python scripts/check_day20_release_narrative_contract.py
+    ;;
   all)
     ruff format --check .
     ruff check .
@@ -71,9 +75,10 @@ case "$mode" in
     python scripts/check_day15_github_actions_quickstart_contract.py
     python scripts/check_day16_gitlab_ci_quickstart_contract.py
     python scripts/check_day18_reliability_evidence_pack_contract.py
+    python scripts/check_day20_release_narrative_contract.py
     ;;
   *)
-    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|day3|day4|day15|day16|day19|all}" >&2
+    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|day3|day4|day15|day16|day19|day20|all}" >&2
     exit 2
     ;;
 esac

--- a/scripts/check_day20_release_narrative_contract.py
+++ b/scripts/check_day20_release_narrative_contract.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+DAY20_PAGE = Path("docs/integrations-release-narrative.md")
+DAY20_REPORT = Path("docs/day-20-ultra-upgrade-report.md")
+DAY20_ARTIFACT = Path("docs/artifacts/day20-release-narrative-sample.md")
+DAY20_PACK_SUMMARY = Path("docs/artifacts/day20-release-narrative-pack/day20-release-narrative-summary.json")
+DAY20_PACK_MD = Path("docs/artifacts/day20-release-narrative-pack/day20-release-narrative.md")
+DAY20_PACK_BLURBS = Path("docs/artifacts/day20-release-narrative-pack/day20-audience-blurbs.md")
+DAY20_PACK_CHANNELS = Path("docs/artifacts/day20-release-narrative-pack/day20-channel-posts.md")
+DAY20_PACK_VALIDATION = Path("docs/artifacts/day20-release-narrative-pack/day20-validation-commands.md")
+DAY20_EVIDENCE = Path("docs/artifacts/day20-release-narrative-pack/evidence/day20-execution-summary.json")
+MODULE = Path("src/sdetkit/release_narrative.py")
+
+README_EXPECTED = [
+    "## ✍️ Day 20 ultra: release narrative",
+    "python -m sdetkit release-narrative --format json --strict",
+    "python -m sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict",
+    "python scripts/check_day20_release_narrative_contract.py",
+]
+INDEX_EXPECTED = [
+    "Day 20 ultra upgrades (release narrative)",
+    "sdetkit release-narrative --format json --strict",
+    "artifacts/day20-release-narrative-pack/day20-channel-posts.md",
+]
+CLI_EXPECTED = [
+    "## release-narrative",
+    "--day19-summary",
+    "--changelog",
+    "--min-release-score",
+    "--execute",
+    "--evidence-dir",
+    "--timeout-sec",
+    "--emit-pack-dir",
+]
+PAGE_EXPECTED = [
+    "# Release narrative (Day 20)",
+    "## Story inputs",
+    "## Fast verification commands",
+    "## Execution evidence mode",
+    "## Narrative channels",
+]
+REPORT_EXPECTED = ["Day 20 big upgrade", "strict", "--execute", "validation commands"]
+SUMMARY_EXPECTED = ['"name": "day20-release-narrative"', '"readiness_label":', '"narrative_channels":']
+EVIDENCE_EXPECTED = ['"name": "day20-release-narrative-execution"', '"total_commands": 3']
+
+
+def _missing(path: Path, expected: list[str]) -> list[str]:
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    return [item for item in expected if item not in text]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skip-evidence", action="store_true")
+    ns = ap.parse_args(argv)
+
+    required = [
+        README,
+        DOCS_INDEX,
+        DOCS_CLI,
+        DAY20_PAGE,
+        DAY20_REPORT,
+        DAY20_ARTIFACT,
+        DAY20_PACK_SUMMARY,
+        DAY20_PACK_MD,
+        DAY20_PACK_BLURBS,
+        DAY20_PACK_CHANNELS,
+        DAY20_PACK_VALIDATION,
+        MODULE,
+    ]
+    if not ns.skip_evidence:
+        required.append(DAY20_EVIDENCE)
+
+    errors: list[str] = []
+    for path in required:
+        if not path.exists():
+            errors.append(f"missing required file: {path}")
+
+    if not errors:
+        errors.extend(f"{README}: missing '{m}'" for m in _missing(README, README_EXPECTED))
+        errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
+        errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
+        errors.extend(f"{DAY20_PAGE}: missing '{m}'" for m in _missing(DAY20_PAGE, PAGE_EXPECTED))
+        errors.extend(f"{DAY20_REPORT}: missing '{m}'" for m in _missing(DAY20_REPORT, REPORT_EXPECTED))
+        errors.extend(f"{DAY20_PACK_SUMMARY}: missing '{m}'" for m in _missing(DAY20_PACK_SUMMARY, SUMMARY_EXPECTED))
+        if not ns.skip_evidence:
+            errors.extend(f"{DAY20_EVIDENCE}: missing '{m}'" for m in _missing(DAY20_EVIDENCE, EVIDENCE_EXPECTED))
+
+    if errors:
+        print("day20-release-narrative-contract check failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print("day20-release-narrative-contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -24,6 +24,7 @@ from . import (
     policy,
     proof,
     quality_contribution_delta,
+    release_narrative,
     release_readiness_board,
     reliability_evidence_pack,
     repo,
@@ -157,6 +158,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "release-readiness-board":
         return release_readiness_board.main(list(argv[1:]))
 
+    if argv and argv[0] == "release-narrative":
+        return release_narrative.main(list(argv[1:]))
+
     p = argparse.ArgumentParser(prog="sdetkit", add_help=True)
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -254,6 +258,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     rrb = sub.add_parser("release-readiness-board")
     rrb.add_argument("args", nargs=argparse.REMAINDER)
 
+    rn = sub.add_parser("release-narrative")
+    rn.add_argument("args", nargs=argparse.REMAINDER)
+
     ns = p.parse_args(argv)
 
     if ns.cmd == "kv":
@@ -339,6 +346,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "release-readiness-board":
         return release_readiness_board.main(ns.args)
+
+    if ns.cmd == "release-narrative":
+        return release_narrative.main(ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)

--- a/src/sdetkit/release_narrative.py
+++ b/src/sdetkit/release_narrative.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+_PAGE_PATH = "docs/integrations-release-narrative.md"
+
+_SECTION_HEADER = "# Release narrative (Day 20)"
+_REQUIRED_SECTIONS = [
+    "## Who should run Day 20",
+    "## Story inputs",
+    "## Fast verification commands",
+    "## Execution evidence mode",
+    "## Narrative channels",
+    "## Storytelling checklist",
+]
+
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit release-narrative --format json --strict",
+    "python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict",
+    "python -m sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict",
+    "python scripts/check_day20_release_narrative_contract.py",
+]
+
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit release-narrative --format json --strict",
+    "python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict",
+    "python scripts/check_day20_release_narrative_contract.py --skip-evidence",
+]
+
+_DAY20_DEFAULT_PAGE = """# Release narrative (Day 20)
+
+Day 20 translates release readiness evidence into non-maintainer changelog storytelling.
+
+## Who should run Day 20
+
+- Maintainers writing release notes for mixed technical/non-technical audiences.
+- Developer advocates preparing community launch posts.
+- Product and support teams aligning on what changed and why it matters.
+
+## Story inputs
+
+- Day 19 release-readiness summary (`release_score`, `gate_status`, recommendations).
+- Changelog highlights for user-visible updates.
+
+## Fast verification commands
+
+```bash
+python -m sdetkit release-narrative --format json --strict
+python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --format json --strict
+python -m sdetkit release-narrative --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict
+python scripts/check_day20_release_narrative_contract.py
+```
+
+## Execution evidence mode
+
+`--execute` runs the Day 20 command chain and writes deterministic logs into `--evidence-dir`.
+
+## Narrative channels
+
+- Release notes (maintainer + product audiences)
+- Community post (social + discussion channels)
+- Internal weekly update (engineering + support)
+
+## Storytelling checklist
+
+- [ ] Outcome-first summary is present.
+- [ ] Risks and follow-ups are explicit.
+- [ ] Validation evidence is linked.
+- [ ] Audience-specific blurbs are generated.
+"""
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _load_day19_summary(path: Path) -> tuple[float, str, list[str]]:
+    payload = _read_json(path)
+    summary = payload.get("summary", payload)
+    if not isinstance(summary, dict):
+        raise ValueError("day19 summary payload must include a summary object")
+
+    release_score_raw = summary.get("release_score", 0.0)
+    try:
+        release_score = float(release_score_raw)
+    except (TypeError, ValueError):
+        raise ValueError("day19 summary release_score must be numeric") from None
+
+    gate_status_raw = summary.get("gate_status", "review")
+    gate_status = str(gate_status_raw).strip().lower() or "review"
+
+    recommendations_raw = payload.get("recommendations", summary.get("recommendations", []))
+    recommendations: list[str] = []
+    if isinstance(recommendations_raw, list):
+        for item in recommendations_raw:
+            if isinstance(item, str) and item.strip():
+                recommendations.append(item.strip())
+
+    return release_score, gate_status, recommendations
+
+
+def _extract_changelog_bullets(path: Path, limit: int = 6) -> list[str]:
+    if not path.exists():
+        return ["No CHANGELOG entry was found; include notable user-impact updates before release."]
+
+    bullets: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line.startswith(("- ", "* ")):
+            bullets.append(line[2:].strip())
+        if len(bullets) >= limit:
+            break
+
+    if bullets:
+        return bullets
+    return ["CHANGELOG currently has no bullet highlights; add outcome-focused release notes."]
+
+
+def build_release_narrative(day19_summary: Path, changelog: Path, *, day19_label: str = "", changelog_label: str = "") -> dict[str, object]:
+    release_score, gate_status, recommendations = _load_day19_summary(day19_summary)
+    highlights = _extract_changelog_bullets(changelog)
+
+    readiness_label = "ready" if gate_status == "pass" and release_score >= 90 else "review"
+    headline = (
+        "This release is ready to communicate broadly with a stable quality posture."
+        if readiness_label == "ready"
+        else "This release needs focused follow-up before broad promotion."
+    )
+
+    risks = recommendations if recommendations else ["No explicit Day 19 recommendations were provided."]
+
+    channels = {
+        "release_notes": f"{headline} Key highlights: {highlights[0]}",
+        "community_post": "Shipping update: stronger quality gates, clearer evidence, and a smoother adoption path for teams.",
+        "internal_update": "Day 20 narrative pack is ready. Reuse the highlights/risks sections in weekly status and customer comms.",
+    }
+
+    return {
+        "name": "day20-release-narrative",
+        "inputs": {
+            "day19_summary": day19_label or str(day19_summary),
+            "changelog": changelog_label or str(changelog),
+        },
+        "summary": {
+            "release_score": round(release_score, 2),
+            "gate_status": gate_status,
+            "readiness_label": readiness_label,
+            "headline": headline,
+        },
+        "highlights": highlights,
+        "risks": risks,
+        "audience_blurbs": {
+            "non_maintainers": "What changed: clearer quality gates, faster release confidence, and traceable evidence for audits.",
+            "engineering": "Ship with confidence by tying Day 19 release score to concrete checklist and evidence artifacts.",
+            "support": "Use highlights + risks sections to pre-brief known changes and probable user questions.",
+        },
+        "narrative_channels": channels,
+        "call_to_action": "Share this narrative in release notes, weekly updates, and community announcements.",
+    }
+
+
+def _render_text(payload: dict[str, object]) -> str:
+    lines = [
+        "Day 20 release narrative",
+        "",
+        f"Headline: {payload['summary']['headline']}",
+        f"Release score: {payload['summary']['release_score']}",
+        f"Gate status: {payload['summary']['gate_status']}",
+        "",
+        "Highlights:",
+    ]
+    lines.extend(f"- {item}" for item in payload["highlights"])
+    lines.append("")
+    lines.append("Risks and follow-ups:")
+    lines.extend(f"- {item}" for item in payload["risks"])
+    lines.append("")
+    lines.append("Narrative channels:")
+    lines.extend(f"- {name}: {copy}" for name, copy in payload["narrative_channels"].items())
+    lines.append("")
+    lines.append(f"Call to action: {payload['call_to_action']}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# Day 20 release narrative",
+        "",
+        f"**Headline:** {payload['summary']['headline']}",
+        "",
+        "## Release posture",
+        "",
+        f"- Release score: **{payload['summary']['release_score']}**",
+        f"- Gate status: **{payload['summary']['gate_status']}**",
+        f"- Readiness label: **{payload['summary']['readiness_label']}**",
+        "",
+        "## Highlights",
+        "",
+    ]
+    lines.extend(f"- {item}" for item in payload["highlights"])
+    lines.extend(["", "## Risks and follow-ups", ""])
+    lines.extend(f"- {item}" for item in payload["risks"])
+    lines.extend(["", "## Audience blurbs", ""])
+    lines.extend(f"- **{k.replace('_', ' ').title()}:** {v}" for k, v in payload["audience_blurbs"].items())
+    lines.extend(["", "## Narrative channels", ""])
+    lines.extend(f"- **{k.replace('_', ' ').title()}:** {v}" for k, v in payload["narrative_channels"].items())
+    lines.extend(["", f"**Call to action:** {payload['call_to_action']}"])
+    return "\n".join(lines) + "\n"
+
+
+def _emit_pack(root: Path, out_dir: Path, payload: dict[str, object]) -> list[str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary = out_dir / "day20-release-narrative-summary.json"
+    markdown = out_dir / "day20-release-narrative.md"
+    blurbs = out_dir / "day20-audience-blurbs.md"
+    channels = out_dir / "day20-channel-posts.md"
+    validation = out_dir / "day20-validation-commands.md"
+
+    summary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown.write_text(_render_markdown(payload), encoding="utf-8")
+    blurbs.write_text(
+        "\n".join(
+            [
+                "# Day 20 audience blurbs",
+                "",
+                *[f"- **{k.replace('_', ' ').title()}:** {v}" for k, v in payload["audience_blurbs"].items()],
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    channels.write_text(
+        "\n".join(
+            [
+                "# Day 20 narrative channels",
+                "",
+                *[f"- **{k.replace('_', ' ').title()}:** {v}" for k, v in payload["narrative_channels"].items()],
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    validation.write_text(
+        "\n".join(["# Day 20 validation commands", "", "```bash", *_REQUIRED_COMMANDS, "```", ""]),
+        encoding="utf-8",
+    )
+
+    return [str(path.relative_to(root)) for path in (summary, markdown, blurbs, channels, validation)]
+
+
+def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for idx, command in enumerate(commands, start=1):
+        try:
+            proc = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+                check=False,
+            )
+            rows.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": proc.returncode,
+                    "ok": proc.returncode == 0,
+                    "stdout": proc.stdout,
+                    "stderr": proc.stderr,
+                }
+            )
+        except subprocess.TimeoutExpired as exc:
+            rows.append(
+                {
+                    "index": idx,
+                    "command": command,
+                    "returncode": 124,
+                    "ok": False,
+                    "stdout": (exc.stdout or "") if isinstance(exc.stdout, str) else "",
+                    "stderr": (exc.stderr or "") if isinstance(exc.stderr, str) else "",
+                    "error": f"timed out after {timeout_sec}s",
+                }
+            )
+    return rows
+
+
+def _write_execution_evidence(root: Path, evidence_dir: str, rows: list[dict[str, object]]) -> list[str]:
+    out = root / evidence_dir
+    out.mkdir(parents=True, exist_ok=True)
+    summary = out / "day20-execution-summary.json"
+    payload = {
+        "name": "day20-release-narrative-execution",
+        "total_commands": len(rows),
+        "passed_commands": len([r for r in rows if r["ok"]]),
+        "failed_commands": len([r for r in rows if not r["ok"]]),
+        "results": rows,
+    }
+    summary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    emitted = [summary]
+    for row in rows:
+        log = out / f"command-{row['index']:02d}.log"
+        log.write_text(
+            "\n".join(
+                [
+                    f"command: {row['command']}",
+                    f"returncode: {row['returncode']}",
+                    f"ok: {row['ok']}",
+                    "--- stdout ---",
+                    str(row.get("stdout", "")),
+                    "--- stderr ---",
+                    str(row.get("stderr", "")),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        emitted.append(log)
+
+    return [str(path.relative_to(root)) for path in emitted]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sdetkit release-narrative",
+        description="Generate Day 20 non-maintainer release storytelling from Day 19 posture.",
+    )
+    p.add_argument("--root", default=".", help="Repository root path.")
+    p.add_argument(
+        "--day19-summary",
+        default="docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json",
+        help="Path to Day 19 release summary JSON.",
+    )
+    p.add_argument("--changelog", default="CHANGELOG.md", help="Path to changelog markdown file.")
+    p.add_argument("--min-release-score", type=float, default=90.0, help="Minimum release score for strict pass.")
+    p.add_argument("--write-defaults", action="store_true", help="Create default Day 20 integration page if missing.")
+    p.add_argument("--emit-pack-dir", default="", help="Optional output directory for generated Day 20 files.")
+    p.add_argument("--execute", action="store_true", help="Run Day 20 command chain and emit evidence logs.")
+    p.add_argument(
+        "--evidence-dir",
+        default="docs/artifacts/day20-release-narrative-pack/evidence",
+        help="Output directory for execution evidence logs.",
+    )
+    p.add_argument("--timeout-sec", type=int, default=120, help="Per-command timeout used by --execute.")
+    p.add_argument("--strict", action="store_true", help="Fail when release posture or docs contract checks are not ready.")
+    p.add_argument("--format", choices=["text", "json", "markdown"], default="text", help="Output format.")
+    p.add_argument("--output", default="", help="Optional file to write primary output.")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_parser().parse_args(argv)
+    root = Path(ns.root).resolve()
+
+    page = root / _PAGE_PATH
+    if ns.write_defaults:
+        page.parent.mkdir(parents=True, exist_ok=True)
+        page.write_text(_DAY20_DEFAULT_PAGE, encoding="utf-8")
+
+    page_text = _read(page)
+    missing_sections = [section for section in [_SECTION_HEADER, *_REQUIRED_SECTIONS] if section not in page_text]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+
+    payload = build_release_narrative(
+        root / ns.day19_summary,
+        root / ns.changelog,
+        day19_label=ns.day19_summary,
+        changelog_label=ns.changelog,
+    )
+    payload["strict_failures"] = [*missing_sections, *missing_commands]
+    payload["score"] = 100.0 if not payload["strict_failures"] else 0.0
+
+    if ns.emit_pack_dir:
+        payload["emitted_pack_files"] = _emit_pack(root, root / ns.emit_pack_dir, payload)
+
+    if ns.execute:
+        payload["execution_artifacts"] = _write_execution_evidence(
+            root,
+            ns.evidence_dir,
+            _execute_commands(_EXECUTION_COMMANDS, ns.timeout_sec),
+        )
+
+    strict_failed = (
+        payload["summary"]["readiness_label"] != "ready"
+        or payload["summary"]["release_score"] < ns.min_release_score
+        or bool(payload["strict_failures"])
+    )
+
+    if ns.format == "json":
+        rendered = json.dumps(payload, indent=2, sort_keys=True)
+    elif ns.format == "markdown":
+        rendered = _render_markdown(payload)
+    else:
+        rendered = _render_text(payload)
+
+    if ns.output:
+        out = root / ns.output
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered if rendered.endswith("\n") else rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered, end="" if rendered.endswith("\n") else "\n")
+
+    return 1 if ns.strict and strict_failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -37,3 +37,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "quality-contribution-delta" in out
     assert "reliability-evidence-pack" in out
     assert "release-readiness-board" in out
+    assert "release-narrative" in out

--- a/tests/test_release_narrative.py
+++ b/tests/test_release_narrative.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import release_narrative as rn
+
+
+def _write_day19_summary(path: Path, gate_status: str = "pass", score: float = 96.4) -> Path:
+    summary = path / "day19.json"
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"release_score": score, "gate_status": gate_status},
+                "recommendations": ["Track one follow-up risk in backlog."],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def _write_day20_page(root: Path) -> None:
+    path = root / "docs/integrations-release-narrative.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rn._DAY20_DEFAULT_PAGE, encoding="utf-8")
+
+
+def test_day20_release_narrative_json(tmp_path: Path, capsys) -> None:
+    summary = _write_day19_summary(tmp_path)
+    _write_day20_page(tmp_path)
+
+    rc = rn.main(["--root", str(tmp_path), "--day19-summary", str(summary.relative_to(tmp_path)), "--format", "json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day20-release-narrative"
+    assert out["summary"]["readiness_label"] == "ready"
+    assert out["score"] == 100.0
+
+
+def test_day20_release_narrative_emit_pack_and_execute(tmp_path: Path) -> None:
+    summary = _write_day19_summary(tmp_path)
+    _write_day20_page(tmp_path)
+
+    rc = rn.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day19-summary",
+            str(summary.relative_to(tmp_path)),
+            "--emit-pack-dir",
+            "artifacts/day20-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day20-pack/evidence",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day20-pack/day20-release-narrative-summary.json").exists()
+    assert (tmp_path / "artifacts/day20-pack/day20-release-narrative.md").exists()
+    assert (tmp_path / "artifacts/day20-pack/day20-audience-blurbs.md").exists()
+    assert (tmp_path / "artifacts/day20-pack/day20-channel-posts.md").exists()
+    assert (tmp_path / "artifacts/day20-pack/day20-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day20-pack/evidence/day20-execution-summary.json").exists()
+
+
+def test_day20_release_narrative_strict_gate_fails_when_not_ready(tmp_path: Path) -> None:
+    summary = _write_day19_summary(tmp_path, gate_status="warn", score=83)
+    _write_day20_page(tmp_path)
+
+    rc = rn.main(
+        ["--root", str(tmp_path), "--day19-summary", str(summary.relative_to(tmp_path)), "--format", "json", "--strict"]
+    )
+    assert rc == 1
+
+
+def test_day20_release_narrative_strict_gate_fails_when_docs_contract_missing(tmp_path: Path) -> None:
+    summary = _write_day19_summary(tmp_path)
+    path = tmp_path / "docs/integrations-release-narrative.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# Release narrative (Day 20)\n", encoding="utf-8")
+
+    rc = rn.main(
+        ["--root", str(tmp_path), "--day19-summary", str(summary.relative_to(tmp_path)), "--format", "json", "--strict"]
+    )
+    assert rc == 1
+
+
+def test_day20_cli_dispatch(tmp_path: Path, capsys) -> None:
+    summary = _write_day19_summary(tmp_path)
+    _write_day20_page(tmp_path)
+
+    rc = cli.main(
+        [
+            "release-narrative",
+            "--root",
+            str(tmp_path),
+            "--day19-summary",
+            str(summary.relative_to(tmp_path)),
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 0
+    assert "Day 20 release narrative" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Close out Day 20 by providing a deterministic, auditable release-story workflow that translates Day 19 posture and changelog highlights into multi-channel narrative artifacts. 
- Enforce docs/contracts and minimum-score gates so narratives are only promoted when closeout checks and required documentation are present. 
- Provide execution evidence (deterministic command logs and summary JSON) so the narrative emit flow is verifiable for audits and handoff.

### Description
- Add a new CLI/library module `src/sdetkit/release_narrative.py` implementing `build_release_narrative`, rendering (`text|json|markdown`), `--emit-pack-dir` pack emission, `--execute` deterministic command chain, evidence writing, and strict docs/score gating. 
- Integrate the command into the top-level CLI by wiring `release-narrative` into `src/sdetkit/cli.py` so it dispatches and appears in help output. 
- Add a contract checker `scripts/check_day20_release_narrative_contract.py`, update `scripts/check.sh` to include Day 20, and include default Day 20 docs `docs/integrations-release-narrative.md` plus a Day 20 upgrade report `docs/day-20-ultra-upgrade-report.md`. 
- Emit and commit sample artifacts under `docs/artifacts/day20-release-narrative-pack/` (summary JSON, markdown, audience blurbs, channel posts, validation commands) and deterministic evidence logs, and add unit tests in `tests/test_release_narrative.py` and CLI help coverage update in `tests/test_cli_help_lists_subcommands.py`.
- Fix execution recursion risk by running the contract check with `--skip-evidence` during the `--execute` chain so evidence generation is recursion-safe.

### Testing
- Ran unit tests with `python -m pytest -q tests/test_release_narrative.py tests/test_cli_help_lists_subcommands.py` and all tests passed (`6 passed`).
- Executed the end-to-end emit+execute strict flow with `python -m sdetkit release-narrative --emit-pack-dir docs/artifacts/day20-release-narrative-pack --execute --evidence-dir docs/artifacts/day20-release-narrative-pack/evidence --format json --strict` and it completed with generated pack files and evidence logs. 
- Ran contract checks `python scripts/check_day20_release_narrative_contract.py` and `python scripts/check_day19_release_readiness_board_contract.py --skip-evidence` which both passed. 
- Performed additional strict verification `python -m sdetkit release-narrative --format json --strict` to validate readiness gating and rendering, which succeeded.

------
