### PR TITLE
fix(docs): add fast-start anchor to day11 sample

### DIFF
--- a/docs/artifacts/day11-docs-navigation-sample.md
+++ b/docs/artifacts/day11-docs-navigation-sample.md
@@ -3,6 +3,10 @@
 - Score: **100.0** (12/12)
 - Docs home: `docs/index.md`
 
+## Fast start
+
+- `sdetkit docs-nav --format json --strict`
+
 ## Top journeys
 
 - [ ] Run first command in under 60 seconds
@@ -12,11 +16,11 @@
 ## Required one-click links
 
 - `[⚡ Fast start](#fast-start)`
-- `[🛠 CLI commands](cli.md)`
-- `[🩺 Doctor checks](doctor.md)`
-- `[🤝 Contribute](contributing.md)`
-- `[✅ Day 10 ultra report](day-10-ultra-upgrade-report.md)`
-- `[🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md)`
+- `[🛠 CLI commands](../cli.md)`
+- `[🩺 Doctor checks](../doctor.md)`
+- `[🤝 Contribute](../contributing.md)`
+- `[✅ Day 10 ultra report](../day-10-ultra-upgrade-report.md)`
+- `[🧭 Day 11 ultra report](../day-11-ultra-upgrade-report.md)`
 
 ## Missing docs navigation content
 


### PR DESCRIPTION
## Summary

* Fix Day 11 docs navigation sample by adding a **Fast Start** anchor so internal links resolve correctly.

## Why

* The sample referenced a “fast-start” section, but the anchor/heading didn’t exist (or didn’t match), causing broken navigation in docs.

## How

* Updated `docs/artifacts/day11-docs-navigation-sample.md` to introduce/align the **Fast Start** heading/anchor and adjust surrounding text so links point to a valid target.

## Risk assessment

* Risk level: **low**
* Primary risk area: **Docs rendering / anchor matching** (Markdown-to-HTML anchor generation)

## Test evidence

* Commands run:

  * `bash quality.sh` (via pre-commit hooks)
  * (Optional if your workflow expects it) `bash ci.sh`
* Attach key output snippets/artifacts:

  * Pre-commit hooks passed: merge conflict check, EOF fix, whitespace trim, ascii doctor

## Rollback plan

* If this causes regressions, revert commit(s):

  * `git revert <commit_sha>`
* Mitigation while rollback executes:

  * Temporarily remove/avoid the broken link reference in the docs index/nav until the revert lands.

## Triage and ownership

* Reviewer owner: **Docs / QA reviewer**
* Target merge window: **next available**

## Checklist

* [ ] Tests added/updated (N/A — docs-only change)

* [ ] `bash ci.sh` passes (run if required by repo policy)

* [ ] `bash quality.sh` passes

* [x] Docs updated (if needed)

* [ ] Issue links / acceptance criteria mapped

* [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`