### PR TITLE
Fix typing, workflow diff stability, and contract script formatting

### DIFF
--- a/scripts/check_day10_first_contribution_contract.py
+++ b/scripts/check_day10_first_contribution_contract.py
@@ -1,96 +1,113 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-README = Path('README.md')
-CONTRIBUTING = Path('CONTRIBUTING.md')
-DOCS_INDEX = Path('docs/index.md')
-DOCS_CLI = Path('docs/cli.md')
-DOCS_CONTRIBUTING = Path('docs/contributing.md')
-DAY10_REPORT = Path('docs/day-10-ultra-upgrade-report.md')
-DAY10_ARTIFACT = Path('docs/artifacts/day10-first-contribution-checklist-sample.md')
+README = Path("README.md")
+CONTRIBUTING = Path("CONTRIBUTING.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+DOCS_CONTRIBUTING = Path("docs/contributing.md")
+DAY10_REPORT = Path("docs/day-10-ultra-upgrade-report.md")
+DAY10_ARTIFACT = Path("docs/artifacts/day10-first-contribution-checklist-sample.md")
 
 README_EXPECTED = [
-    '## ✅ Day 10 ultra: first-contribution checklist',
-    'python -m sdetkit first-contribution --format text --strict',
-    'python -m sdetkit first-contribution --write-defaults --format json --strict',
-    'python scripts/check_day10_first_contribution_contract.py',
-    'docs/day-10-ultra-upgrade-report.md',
+    "## ✅ Day 10 ultra: first-contribution checklist",
+    "python -m sdetkit first-contribution --format text --strict",
+    "python -m sdetkit first-contribution --write-defaults --format json --strict",
+    "python scripts/check_day10_first_contribution_contract.py",
+    "docs/day-10-ultra-upgrade-report.md",
 ]
 
 CONTRIBUTING_EXPECTED = [
-    '## 0) Day 10 first-contribution checklist',
-    'Fork the repository and clone your fork locally.',
-    'Create a branch named `feat/<topic>` or `fix/<topic>`.',
-    'Run full quality gates (`pre-commit`, `quality.sh`, docs build) before opening a PR.',
+    "## 0) Day 10 first-contribution checklist",
+    "Fork the repository and clone your fork locally.",
+    "Create a branch named `feat/<topic>` or `fix/<topic>`.",
+    "Run full quality gates (`pre-commit`, `quality.sh`, docs build) before opening a PR.",
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '## Day 10 ultra upgrades (first-contribution checklist)',
-    'sdetkit first-contribution --format text --strict',
-    'sdetkit first-contribution --write-defaults --format json --strict',
-    'artifacts/day10-first-contribution-checklist-sample.md',
+    "## Day 10 ultra upgrades (first-contribution checklist)",
+    "sdetkit first-contribution --format text --strict",
+    "sdetkit first-contribution --write-defaults --format json --strict",
+    "artifacts/day10-first-contribution-checklist-sample.md",
 ]
 
 DOCS_CLI_EXPECTED = [
-    '## first-contribution',
-    'sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md',
-    '--strict',
-    '--write-defaults',
+    "## first-contribution",
+    "sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md",
+    "--strict",
+    "--write-defaults",
 ]
 
 DOCS_CONTRIBUTING_EXPECTED = [
-    '## Day 10 first-contribution checklist',
-    'sdetkit first-contribution --format text --strict',
-    'sdetkit first-contribution --write-defaults --format json --strict',
+    "## Day 10 first-contribution checklist",
+    "sdetkit first-contribution --format text --strict",
+    "sdetkit first-contribution --write-defaults --format json --strict",
 ]
 
 REPORT_EXPECTED = [
-    'Day 10 big upgrade',
-    'python -m sdetkit first-contribution --format json --strict',
-    'python -m sdetkit first-contribution --write-defaults --format json --strict',
-    'scripts/check_day10_first_contribution_contract.py',
+    "Day 10 big upgrade",
+    "python -m sdetkit first-contribution --format json --strict",
+    "python -m sdetkit first-contribution --write-defaults --format json --strict",
+    "scripts/check_day10_first_contribution_contract.py",
 ]
 
 ARTIFACT_EXPECTED = [
-    '# Day 10 first-contribution checklist',
-    '- Score: **100.0** (14/14)',
+    "# Day 10 first-contribution checklist",
+    "- Score: **100.0** (14/14)",
 ]
 
 
 def _missing(path: Path, expected: list[str]) -> list[str]:
-    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
     return [item for item in expected if item not in text]
 
 
 def main() -> int:
     errors: list[str] = []
-    required = [README, CONTRIBUTING, DOCS_INDEX, DOCS_CLI, DOCS_CONTRIBUTING, DAY10_REPORT, DAY10_ARTIFACT]
+    required = [
+        README,
+        CONTRIBUTING,
+        DOCS_INDEX,
+        DOCS_CLI,
+        DOCS_CONTRIBUTING,
+        DAY10_REPORT,
+        DAY10_ARTIFACT,
+    ]
     for path in required:
         if not path.exists():
-            errors.append(f'missing required file: {path}')
+            errors.append(f"missing required file: {path}")
 
     if not errors:
         errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
-        errors.extend(f'{CONTRIBUTING}: missing "{m}"' for m in _missing(CONTRIBUTING, CONTRIBUTING_EXPECTED))
-        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(
+            f'{CONTRIBUTING}: missing "{m}"' for m in _missing(CONTRIBUTING, CONTRIBUTING_EXPECTED)
+        )
+        errors.extend(
+            f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED)
+        )
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
         errors.extend(
-            f'{DOCS_CONTRIBUTING}: missing "{m}"' for m in _missing(DOCS_CONTRIBUTING, DOCS_CONTRIBUTING_EXPECTED)
+            f'{DOCS_CONTRIBUTING}: missing "{m}"'
+            for m in _missing(DOCS_CONTRIBUTING, DOCS_CONTRIBUTING_EXPECTED)
         )
-        errors.extend(f'{DAY10_REPORT}: missing "{m}"' for m in _missing(DAY10_REPORT, REPORT_EXPECTED))
-        errors.extend(f'{DAY10_ARTIFACT}: missing "{m}"' for m in _missing(DAY10_ARTIFACT, ARTIFACT_EXPECTED))
+        errors.extend(
+            f'{DAY10_REPORT}: missing "{m}"' for m in _missing(DAY10_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY10_ARTIFACT}: missing "{m}"' for m in _missing(DAY10_ARTIFACT, ARTIFACT_EXPECTED)
+        )
 
     if errors:
-        print('day10-first-contribution-contract check failed:', file=sys.stderr)
+        print("day10-first-contribution-contract check failed:", file=sys.stderr)
         for error in errors:
-            print(f' - {error}', file=sys.stderr)
+            print(f" - {error}", file=sys.stderr)
         return 1
 
-    print('day10-first-contribution-contract check passed')
+    print("day10-first-contribution-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day11_docs_navigation_contract.py
+++ b/scripts/check_day11_docs_navigation_contract.py
@@ -1,54 +1,54 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DOCS_CLI = Path('docs/cli.md')
-DAY11_REPORT = Path('docs/day-11-ultra-upgrade-report.md')
-DAY11_ARTIFACT = Path('docs/artifacts/day11-docs-navigation-sample.md')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+DAY11_REPORT = Path("docs/day-11-ultra-upgrade-report.md")
+DAY11_ARTIFACT = Path("docs/artifacts/day11-docs-navigation-sample.md")
 
 README_EXPECTED = [
-    '## 🧭 Day 11 ultra: docs navigation tune-up',
-    'python -m sdetkit docs-nav --format text --strict',
-    'python -m sdetkit docs-nav --write-defaults --format json --strict',
-    'python scripts/check_day11_docs_navigation_contract.py',
-    'docs/day-11-ultra-upgrade-report.md',
+    "## 🧭 Day 11 ultra: docs navigation tune-up",
+    "python -m sdetkit docs-nav --format text --strict",
+    "python -m sdetkit docs-nav --write-defaults --format json --strict",
+    "python scripts/check_day11_docs_navigation_contract.py",
+    "docs/day-11-ultra-upgrade-report.md",
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '[🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md)',
-    '## Day 11 ultra upgrades (docs navigation tune-up)',
-    'sdetkit docs-nav --format text --strict',
-    'sdetkit docs-nav --write-defaults --format json --strict',
-    'Run first command in under 60 seconds',
-    'Validate docs links and anchors before publishing',
-    'Ship a first contribution with deterministic quality gates',
+    "[🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md)",
+    "## Day 11 ultra upgrades (docs navigation tune-up)",
+    "sdetkit docs-nav --format text --strict",
+    "sdetkit docs-nav --write-defaults --format json --strict",
+    "Run first command in under 60 seconds",
+    "Validate docs links and anchors before publishing",
+    "Ship a first contribution with deterministic quality gates",
 ]
 
 DOCS_CLI_EXPECTED = [
-    '## docs-nav',
-    'sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md',
-    '--strict',
-    '--write-defaults',
+    "## docs-nav",
+    "sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md",
+    "--strict",
+    "--write-defaults",
 ]
 
 REPORT_EXPECTED = [
-    'Day 11 big upgrade',
-    'python -m sdetkit docs-nav --format json --strict',
-    'python -m sdetkit docs-nav --write-defaults --format json --strict',
-    'scripts/check_day11_docs_navigation_contract.py',
+    "Day 11 big upgrade",
+    "python -m sdetkit docs-nav --format json --strict",
+    "python -m sdetkit docs-nav --write-defaults --format json --strict",
+    "scripts/check_day11_docs_navigation_contract.py",
 ]
 
 ARTIFACT_EXPECTED = [
-    '# Day 11 docs navigation tune-up',
-    '- Score: **100.0** (12/12)',
+    "# Day 11 docs navigation tune-up",
+    "- Score: **100.0** (12/12)",
 ]
 
 
 def _missing(path: Path, expected: list[str]) -> list[str]:
-    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
     return [item for item in expected if item not in text]
 
 
@@ -57,24 +57,30 @@ def main() -> int:
     required = [README, DOCS_INDEX, DOCS_CLI, DAY11_REPORT, DAY11_ARTIFACT]
     for path in required:
         if not path.exists():
-            errors.append(f'missing required file: {path}')
+            errors.append(f"missing required file: {path}")
 
     if not errors:
         errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
-        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(
+            f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED)
+        )
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
-        errors.extend(f'{DAY11_REPORT}: missing "{m}"' for m in _missing(DAY11_REPORT, REPORT_EXPECTED))
-        errors.extend(f'{DAY11_ARTIFACT}: missing "{m}"' for m in _missing(DAY11_ARTIFACT, ARTIFACT_EXPECTED))
+        errors.extend(
+            f'{DAY11_REPORT}: missing "{m}"' for m in _missing(DAY11_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY11_ARTIFACT}: missing "{m}"' for m in _missing(DAY11_ARTIFACT, ARTIFACT_EXPECTED)
+        )
 
     if errors:
-        print('day11-docs-navigation-contract check failed:', file=sys.stderr)
+        print("day11-docs-navigation-contract check failed:", file=sys.stderr)
         for error in errors:
-            print(f' - {error}', file=sys.stderr)
+            print(f" - {error}", file=sys.stderr)
         return 1
 
-    print('day11-docs-navigation-contract check passed')
+    print("day11-docs-navigation-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day12_startup_use_case_contract.py
+++ b/scripts/check_day12_startup_use_case_contract.py
@@ -1,99 +1,117 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DOCS_CLI = Path('docs/cli.md')
-USE_CASE_PAGE = Path('docs/use-cases-startup-small-team.md')
-DAY12_REPORT = Path('docs/day-12-ultra-upgrade-report.md')
-DAY12_ARTIFACT = Path('docs/artifacts/day12-startup-use-case-sample.md')
-DAY12_PACK_CI = Path('docs/artifacts/day12-startup-pack/startup-day12-ci.yml')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+USE_CASE_PAGE = Path("docs/use-cases-startup-small-team.md")
+DAY12_REPORT = Path("docs/day-12-ultra-upgrade-report.md")
+DAY12_ARTIFACT = Path("docs/artifacts/day12-startup-use-case-sample.md")
+DAY12_PACK_CI = Path("docs/artifacts/day12-startup-pack/startup-day12-ci.yml")
 
 README_EXPECTED = [
-    '## 🚀 Day 12 ultra: startup/small-team use-case page',
-    'python -m sdetkit startup-use-case --format text --strict',
-    'python -m sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
-    'python scripts/check_day12_startup_use_case_contract.py',
-    'docs/day-12-ultra-upgrade-report.md',
+    "## 🚀 Day 12 ultra: startup/small-team use-case page",
+    "python -m sdetkit startup-use-case --format text --strict",
+    "python -m sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict",
+    "python scripts/check_day12_startup_use_case_contract.py",
+    "docs/day-12-ultra-upgrade-report.md",
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '## Day 12 ultra upgrades (startup/small-team use-case page)',
-    'startup + small-team workflow',
-    'sdetkit startup-use-case --format text --strict',
-    'sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
-    'artifacts/day12-startup-use-case-sample.md',
+    "## Day 12 ultra upgrades (startup/small-team use-case page)",
+    "startup + small-team workflow",
+    "sdetkit startup-use-case --format text --strict",
+    "sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict",
+    "artifacts/day12-startup-use-case-sample.md",
 ]
 
 DOCS_CLI_EXPECTED = [
-    '## startup-use-case',
-    'sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md',
-    'sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
-    '--write-defaults',
+    "## startup-use-case",
+    "sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md",
+    "sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict",
+    "--write-defaults",
 ]
 
 USE_CASE_EXPECTED = [
-    '# Startup + small-team workflow',
-    '## 10-minute startup path',
-    'python -m sdetkit doctor --format text',
-    'python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py',
-    '## CI fast-lane recipe',
-    'name: startup-quality-fast-lane',
-    '## Exit criteria to graduate to enterprise workflow',
+    "# Startup + small-team workflow",
+    "## 10-minute startup path",
+    "python -m sdetkit doctor --format text",
+    "python -m pytest -q tests/test_startup_use_case.py tests/test_cli_help_lists_subcommands.py",
+    "## CI fast-lane recipe",
+    "name: startup-quality-fast-lane",
+    "## Exit criteria to graduate to enterprise workflow",
 ]
 
 REPORT_EXPECTED = [
-    'Day 12 big upgrade',
-    'python -m sdetkit startup-use-case --format json --strict',
-    'python -m sdetkit startup-use-case --write-defaults --format json --strict',
-    'python -m sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
-    'scripts/check_day12_startup_use_case_contract.py',
+    "Day 12 big upgrade",
+    "python -m sdetkit startup-use-case --format json --strict",
+    "python -m sdetkit startup-use-case --write-defaults --format json --strict",
+    "python -m sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict",
+    "scripts/check_day12_startup_use_case_contract.py",
 ]
 
 ARTIFACT_EXPECTED = [
-    '# Day 12 startup use-case page',
-    '- Score: **100.0** (14/14)',
-    'sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict',
+    "# Day 12 startup use-case page",
+    "- Score: **100.0** (14/14)",
+    "sdetkit startup-use-case --emit-pack-dir docs/artifacts/day12-startup-pack --format json --strict",
 ]
 
 PACK_CI_EXPECTED = [
-    'name: startup-quality-fast-lane',
-    'python -m sdetkit startup-use-case --format json --strict',
+    "name: startup-quality-fast-lane",
+    "python -m sdetkit startup-use-case --format json --strict",
 ]
 
 
 def _missing(path: Path, expected: list[str]) -> list[str]:
-    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
     return [item for item in expected if item not in text]
 
 
 def main() -> int:
     errors: list[str] = []
-    required = [README, DOCS_INDEX, DOCS_CLI, USE_CASE_PAGE, DAY12_REPORT, DAY12_ARTIFACT, DAY12_PACK_CI]
+    required = [
+        README,
+        DOCS_INDEX,
+        DOCS_CLI,
+        USE_CASE_PAGE,
+        DAY12_REPORT,
+        DAY12_ARTIFACT,
+        DAY12_PACK_CI,
+    ]
     for path in required:
         if not path.exists():
-            errors.append(f'missing required file: {path}')
+            errors.append(f"missing required file: {path}")
 
     if not errors:
         errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
-        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(
+            f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED)
+        )
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
-        errors.extend(f'{USE_CASE_PAGE}: missing "{m}"' for m in _missing(USE_CASE_PAGE, USE_CASE_EXPECTED))
-        errors.extend(f'{DAY12_REPORT}: missing "{m}"' for m in _missing(DAY12_REPORT, REPORT_EXPECTED))
-        errors.extend(f'{DAY12_ARTIFACT}: missing "{m}"' for m in _missing(DAY12_ARTIFACT, ARTIFACT_EXPECTED))
-        errors.extend(f'{DAY12_PACK_CI}: missing "{m}"' for m in _missing(DAY12_PACK_CI, PACK_CI_EXPECTED))
+        errors.extend(
+            f'{USE_CASE_PAGE}: missing "{m}"' for m in _missing(USE_CASE_PAGE, USE_CASE_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY12_REPORT}: missing "{m}"' for m in _missing(DAY12_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY12_ARTIFACT}: missing "{m}"' for m in _missing(DAY12_ARTIFACT, ARTIFACT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY12_PACK_CI}: missing "{m}"' for m in _missing(DAY12_PACK_CI, PACK_CI_EXPECTED)
+        )
 
     if errors:
-        print('day12-startup-use-case-contract check failed:', file=sys.stderr)
+        print("day12-startup-use-case-contract check failed:", file=sys.stderr)
         for error in errors:
-            print(f' - {error}', file=sys.stderr)
+            print(f" - {error}", file=sys.stderr)
         return 1
 
-    print('day12-startup-use-case-contract check passed')
+    print("day12-startup-use-case-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day13_enterprise_use_case_contract.py
+++ b/scripts/check_day13_enterprise_use_case_contract.py
@@ -1,74 +1,74 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DOCS_CLI = Path('docs/cli.md')
-USE_CASE_PAGE = Path('docs/use-cases-enterprise-regulated.md')
-DAY13_REPORT = Path('docs/day-13-ultra-upgrade-report.md')
-DAY13_ARTIFACT = Path('docs/artifacts/day13-enterprise-use-case-sample.md')
-DAY13_PACK_CI = Path('docs/artifacts/day13-enterprise-pack/enterprise-day13-ci.yml')
-DAY13_EVIDENCE = Path('docs/artifacts/day13-enterprise-pack/evidence/day13-execution-summary.json')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+USE_CASE_PAGE = Path("docs/use-cases-enterprise-regulated.md")
+DAY13_REPORT = Path("docs/day-13-ultra-upgrade-report.md")
+DAY13_ARTIFACT = Path("docs/artifacts/day13-enterprise-use-case-sample.md")
+DAY13_PACK_CI = Path("docs/artifacts/day13-enterprise-pack/enterprise-day13-ci.yml")
+DAY13_EVIDENCE = Path("docs/artifacts/day13-enterprise-pack/evidence/day13-execution-summary.json")
 
 README_EXPECTED = [
-    '## 🏢 Day 13 ultra: enterprise/regulated use-case page',
-    'python -m sdetkit enterprise-use-case --format text --strict',
-    'python -m sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict',
-    'python -m sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict',
-    'python scripts/check_day13_enterprise_use_case_contract.py',
-    'docs/day-13-ultra-upgrade-report.md',
+    "## 🏢 Day 13 ultra: enterprise/regulated use-case page",
+    "python -m sdetkit enterprise-use-case --format text --strict",
+    "python -m sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict",
+    "python -m sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict",
+    "python scripts/check_day13_enterprise_use_case_contract.py",
+    "docs/day-13-ultra-upgrade-report.md",
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '## Day 13 ultra upgrades (enterprise/regulated use-case page)',
-    'enterprise + regulated workflow',
-    'sdetkit enterprise-use-case --format text --strict',
-    'sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict',
-    'sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict',
-    'artifacts/day13-enterprise-use-case-sample.md',
+    "## Day 13 ultra upgrades (enterprise/regulated use-case page)",
+    "enterprise + regulated workflow",
+    "sdetkit enterprise-use-case --format text --strict",
+    "sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict",
+    "sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict",
+    "artifacts/day13-enterprise-use-case-sample.md",
 ]
 
 DOCS_CLI_EXPECTED = [
-    '## enterprise-use-case',
-    'sdetkit enterprise-use-case --format markdown --output docs/artifacts/day13-enterprise-use-case-sample.md',
-    'sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict',
-    'sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict',
-    '--write-defaults',
-    '--evidence-dir',
+    "## enterprise-use-case",
+    "sdetkit enterprise-use-case --format markdown --output docs/artifacts/day13-enterprise-use-case-sample.md",
+    "sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict",
+    "sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict",
+    "--write-defaults",
+    "--evidence-dir",
 ]
 
 USE_CASE_EXPECTED = [
-    '# Enterprise + regulated workflow',
-    '## 15-minute enterprise baseline',
-    'python -m sdetkit repo audit . --profile enterprise --format json',
-    'python -m pytest -q tests/test_enterprise_use_case.py tests/test_cli_help_lists_subcommands.py',
-    '## Automated evidence bundle',
-    'name: enterprise-compliance-lane',
-    '## Rollout model across business units',
+    "# Enterprise + regulated workflow",
+    "## 15-minute enterprise baseline",
+    "python -m sdetkit repo audit . --profile enterprise --format json",
+    "python -m pytest -q tests/test_enterprise_use_case.py tests/test_cli_help_lists_subcommands.py",
+    "## Automated evidence bundle",
+    "name: enterprise-compliance-lane",
+    "## Rollout model across business units",
 ]
 
 REPORT_EXPECTED = [
-    'Day 13 big upgrade',
-    'python -m sdetkit enterprise-use-case --format json --strict',
-    'python -m sdetkit enterprise-use-case --write-defaults --format json --strict',
-    'python -m sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict',
-    'python -m sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict',
-    'scripts/check_day13_enterprise_use_case_contract.py',
+    "Day 13 big upgrade",
+    "python -m sdetkit enterprise-use-case --format json --strict",
+    "python -m sdetkit enterprise-use-case --write-defaults --format json --strict",
+    "python -m sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict",
+    "python -m sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict",
+    "scripts/check_day13_enterprise_use_case_contract.py",
 ]
 
 ARTIFACT_EXPECTED = [
-    '# Day 13 enterprise use-case page',
-    '- Score: **100.0** (15/15)',
-    'sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict',
-    'sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict',
+    "# Day 13 enterprise use-case page",
+    "- Score: **100.0** (15/15)",
+    "sdetkit enterprise-use-case --emit-pack-dir docs/artifacts/day13-enterprise-pack --format json --strict",
+    "sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict",
 ]
 
 PACK_CI_EXPECTED = [
-    'name: enterprise-compliance-lane',
-    'python -m sdetkit enterprise-use-case --format json --strict',
-    'python -m sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict',
+    "name: enterprise-compliance-lane",
+    "python -m sdetkit enterprise-use-case --format json --strict",
+    "python -m sdetkit enterprise-use-case --execute --evidence-dir docs/artifacts/day13-enterprise-pack/evidence --format json --strict",
 ]
 
 EVIDENCE_EXPECTED = [
@@ -78,36 +78,57 @@ EVIDENCE_EXPECTED = [
 
 
 def _missing(path: Path, expected: list[str]) -> list[str]:
-    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
     return [item for item in expected if item not in text]
 
 
 def main() -> int:
     errors: list[str] = []
-    required = [README, DOCS_INDEX, DOCS_CLI, USE_CASE_PAGE, DAY13_REPORT, DAY13_ARTIFACT, DAY13_PACK_CI, DAY13_EVIDENCE]
+    required = [
+        README,
+        DOCS_INDEX,
+        DOCS_CLI,
+        USE_CASE_PAGE,
+        DAY13_REPORT,
+        DAY13_ARTIFACT,
+        DAY13_PACK_CI,
+        DAY13_EVIDENCE,
+    ]
     for path in required:
         if not path.exists():
-            errors.append(f'missing required file: {path}')
+            errors.append(f"missing required file: {path}")
 
     if not errors:
         errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
-        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(
+            f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED)
+        )
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
-        errors.extend(f'{USE_CASE_PAGE}: missing "{m}"' for m in _missing(USE_CASE_PAGE, USE_CASE_EXPECTED))
-        errors.extend(f'{DAY13_REPORT}: missing "{m}"' for m in _missing(DAY13_REPORT, REPORT_EXPECTED))
-        errors.extend(f'{DAY13_ARTIFACT}: missing "{m}"' for m in _missing(DAY13_ARTIFACT, ARTIFACT_EXPECTED))
-        errors.extend(f'{DAY13_PACK_CI}: missing "{m}"' for m in _missing(DAY13_PACK_CI, PACK_CI_EXPECTED))
-        errors.extend(f'{DAY13_EVIDENCE}: missing "{m}"' for m in _missing(DAY13_EVIDENCE, EVIDENCE_EXPECTED))
+        errors.extend(
+            f'{USE_CASE_PAGE}: missing "{m}"' for m in _missing(USE_CASE_PAGE, USE_CASE_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY13_REPORT}: missing "{m}"' for m in _missing(DAY13_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY13_ARTIFACT}: missing "{m}"' for m in _missing(DAY13_ARTIFACT, ARTIFACT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY13_PACK_CI}: missing "{m}"' for m in _missing(DAY13_PACK_CI, PACK_CI_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY13_EVIDENCE}: missing "{m}"' for m in _missing(DAY13_EVIDENCE, EVIDENCE_EXPECTED)
+        )
 
     if errors:
-        print('day13-enterprise-use-case-contract check failed:', file=sys.stderr)
+        print("day13-enterprise-use-case-contract check failed:", file=sys.stderr)
         for error in errors:
-            print(f' - {error}', file=sys.stderr)
+            print(f" - {error}", file=sys.stderr)
         return 1
 
-    print('day13-enterprise-use-case-contract check passed')
+    print("day13-enterprise-use-case-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day14_weekly_review_contract.py
+++ b/scripts/check_day14_weekly_review_contract.py
@@ -4,57 +4,57 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DOCS_CLI = Path('docs/cli.md')
-DAY14_REPORT = Path('docs/day-14-ultra-upgrade-report.md')
-DAY14_ARTIFACT = Path('docs/artifacts/day14-weekly-review-sample.md')
-DAY14_SIGNALS = Path('docs/artifacts/day14-growth-signals.json')
-DAY7_SIGNALS = Path('docs/artifacts/day7-growth-signals.json')
-DAY14_PACK_CHECKLIST = Path('docs/artifacts/day14-weekly-pack/day14-closeout-checklist.md')
-DAY14_PACK_SCORECARD = Path('docs/artifacts/day14-weekly-pack/day14-kpi-scorecard.json')
-DAY14_PACK_PLAN = Path('docs/artifacts/day14-weekly-pack/day14-blocker-action-plan.md')
-WEEKLY_MODULE = Path('src/sdetkit/weekly_review.py')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+DAY14_REPORT = Path("docs/day-14-ultra-upgrade-report.md")
+DAY14_ARTIFACT = Path("docs/artifacts/day14-weekly-review-sample.md")
+DAY14_SIGNALS = Path("docs/artifacts/day14-growth-signals.json")
+DAY7_SIGNALS = Path("docs/artifacts/day7-growth-signals.json")
+DAY14_PACK_CHECKLIST = Path("docs/artifacts/day14-weekly-pack/day14-closeout-checklist.md")
+DAY14_PACK_SCORECARD = Path("docs/artifacts/day14-weekly-pack/day14-kpi-scorecard.json")
+DAY14_PACK_PLAN = Path("docs/artifacts/day14-weekly-pack/day14-blocker-action-plan.md")
+WEEKLY_MODULE = Path("src/sdetkit/weekly_review.py")
 
 README_EXPECTED = [
-    '## 📈 Day 14 ultra: weekly review #2',
-    'python -m sdetkit weekly-review --week 2 --format text --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json',
-    'python -m sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --format json --strict',
-    'python scripts/check_day14_weekly_review_contract.py',
-    'docs/day-14-ultra-upgrade-report.md',
+    "## 📈 Day 14 ultra: weekly review #2",
+    "python -m sdetkit weekly-review --week 2 --format text --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json",
+    "python -m sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json --format json --strict",
+    "python scripts/check_day14_weekly_review_contract.py",
+    "docs/day-14-ultra-upgrade-report.md",
 ]
 
 INDEX_EXPECTED = [
-    'Day 14 ultra upgrades (weekly review #2 + KPI checkpoint)',
-    'sdetkit weekly-review --week 2 --format text --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json',
-    'artifacts/day14-weekly-review-sample.md',
-    'artifacts/day14-weekly-pack/day14-closeout-checklist.md',
+    "Day 14 ultra upgrades (weekly review #2 + KPI checkpoint)",
+    "sdetkit weekly-review --week 2 --format text --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json",
+    "artifacts/day14-weekly-review-sample.md",
+    "artifacts/day14-weekly-pack/day14-closeout-checklist.md",
 ]
 
 CLI_EXPECTED = [
-    'sdetkit weekly-review --week 2 --format json --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json',
-    'sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --format json --strict',
-    'Useful flags: `--root`, `--week`, `--signals-file`, `--previous-signals-file`, `--emit-pack-dir`, `--strict`, `--format`, `--output`.',
+    "sdetkit weekly-review --week 2 --format json --signals-file docs/artifacts/day14-growth-signals.json --previous-signals-file docs/artifacts/day7-growth-signals.json",
+    "sdetkit weekly-review --week 2 --emit-pack-dir docs/artifacts/day14-weekly-pack --format json --strict",
+    "Useful flags: `--root`, `--week`, `--signals-file`, `--previous-signals-file`, `--emit-pack-dir`, `--strict`, `--format`, `--output`.",
 ]
 
 REPORT_EXPECTED = [
-    'Day 14 big upgrade',
-    'src/sdetkit/weekly_review.py',
-    'tests/test_weekly_review.py',
-    'docs/artifacts/day14-weekly-pack/*',
-    'python scripts/check_day14_weekly_review_contract.py',
+    "Day 14 big upgrade",
+    "src/sdetkit/weekly_review.py",
+    "tests/test_weekly_review.py",
+    "docs/artifacts/day14-weekly-pack/*",
+    "python scripts/check_day14_weekly_review_contract.py",
 ]
 
 ARTIFACT_EXPECTED = [
-    '# Day 14 Weekly Review #2',
-    '## What shipped (Day 8-13)',
-    '## Week-two growth signals',
-    '## Week-over-week deltas',
+    "# Day 14 Weekly Review #2",
+    "## What shipped (Day 8-13)",
+    "## Week-two growth signals",
+    "## Week-over-week deltas",
 ]
 
 
 def _missing(path: Path, expected: list[str]) -> list[str]:
-    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
     return [item for item in expected if item not in text]
 
 
@@ -75,24 +75,28 @@ def main() -> int:
     ]
     for path in required:
         if not path.exists():
-            errors.append(f'missing required file: {path}')
+            errors.append(f"missing required file: {path}")
 
     if not errors:
         errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
         errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, CLI_EXPECTED))
-        errors.extend(f'{DAY14_REPORT}: missing "{m}"' for m in _missing(DAY14_REPORT, REPORT_EXPECTED))
-        errors.extend(f'{DAY14_ARTIFACT}: missing "{m}"' for m in _missing(DAY14_ARTIFACT, ARTIFACT_EXPECTED))
+        errors.extend(
+            f'{DAY14_REPORT}: missing "{m}"' for m in _missing(DAY14_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY14_ARTIFACT}: missing "{m}"' for m in _missing(DAY14_ARTIFACT, ARTIFACT_EXPECTED)
+        )
 
     if errors:
-        print('day14-weekly-review-contract check failed:', file=sys.stderr)
+        print("day14-weekly-review-contract check failed:", file=sys.stderr)
         for error in errors:
-            print(f' - {error}', file=sys.stderr)
+            print(f" - {error}", file=sys.stderr)
         return 1
 
-    print('day14-weekly-review-contract check passed')
+    print("day14-weekly-review-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day15_github_actions_quickstart_contract.py
+++ b/scripts/check_day15_github_actions_quickstart_contract.py
@@ -1,82 +1,82 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DOCS_CLI = Path('docs/cli.md')
-QUICKSTART_PAGE = Path('docs/integrations-github-actions-quickstart.md')
-DAY15_REPORT = Path('docs/day-15-ultra-upgrade-report.md')
-DAY15_ARTIFACT = Path('docs/artifacts/day15-github-actions-quickstart-sample.md')
-DAY15_PACK_STRICT = Path('docs/artifacts/day15-github-pack/day15-sdetkit-strict.yml')
-DAY15_PACK_NIGHTLY = Path('docs/artifacts/day15-github-pack/day15-sdetkit-nightly.yml')
-DAY15_EVIDENCE = Path('docs/artifacts/day15-github-pack/evidence/day15-execution-summary.json')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+QUICKSTART_PAGE = Path("docs/integrations-github-actions-quickstart.md")
+DAY15_REPORT = Path("docs/day-15-ultra-upgrade-report.md")
+DAY15_ARTIFACT = Path("docs/artifacts/day15-github-actions-quickstart-sample.md")
+DAY15_PACK_STRICT = Path("docs/artifacts/day15-github-pack/day15-sdetkit-strict.yml")
+DAY15_PACK_NIGHTLY = Path("docs/artifacts/day15-github-pack/day15-sdetkit-nightly.yml")
+DAY15_EVIDENCE = Path("docs/artifacts/day15-github-pack/evidence/day15-execution-summary.json")
 
 README_EXPECTED = [
-    '## 🔁 Day 15 ultra: GitHub Actions quickstart',
-    'python -m sdetkit github-actions-quickstart --format text --strict',
-    'python -m sdetkit github-actions-quickstart --format json --variant strict --strict',
-    'python -m sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict',
-    'python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
-    'python scripts/check_day15_github_actions_quickstart_contract.py',
-    'docs/day-15-ultra-upgrade-report.md',
+    "## 🔁 Day 15 ultra: GitHub Actions quickstart",
+    "python -m sdetkit github-actions-quickstart --format text --strict",
+    "python -m sdetkit github-actions-quickstart --format json --variant strict --strict",
+    "python -m sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict",
+    "python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict",
+    "python scripts/check_day15_github_actions_quickstart_contract.py",
+    "docs/day-15-ultra-upgrade-report.md",
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '## Day 15 ultra upgrades (GitHub Actions quickstart)',
-    'sdetkit github-actions-quickstart --format text --strict',
-    'sdetkit github-actions-quickstart --format json --variant strict --strict',
-    'sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict',
-    'sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
-    'artifacts/day15-github-actions-quickstart-sample.md',
+    "## Day 15 ultra upgrades (GitHub Actions quickstart)",
+    "sdetkit github-actions-quickstart --format text --strict",
+    "sdetkit github-actions-quickstart --format json --variant strict --strict",
+    "sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict",
+    "sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict",
+    "artifacts/day15-github-actions-quickstart-sample.md",
 ]
 
 DOCS_CLI_EXPECTED = [
-    '## github-actions-quickstart',
-    'sdetkit github-actions-quickstart --format markdown --variant strict --output docs/artifacts/day15-github-actions-quickstart-sample.md',
-    'sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict',
-    'sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
-    '--write-defaults',
-    '--variant',
-    '--evidence-dir',
+    "## github-actions-quickstart",
+    "sdetkit github-actions-quickstart --format markdown --variant strict --output docs/artifacts/day15-github-actions-quickstart-sample.md",
+    "sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict",
+    "sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict",
+    "--write-defaults",
+    "--variant",
+    "--evidence-dir",
 ]
 
 QUICKSTART_EXPECTED = [
-    '# GitHub Actions quickstart (Day 15)',
-    '## Strict workflow variant',
-    '## Nightly reliability variant',
-    '## Multi-channel distribution loop',
-    '## Failure recovery playbook',
-    'name: sdetkit-github-quickstart',
-    'name: sdetkit-github-strict',
-    'name: sdetkit-github-nightly',
-    'python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+    "# GitHub Actions quickstart (Day 15)",
+    "## Strict workflow variant",
+    "## Nightly reliability variant",
+    "## Multi-channel distribution loop",
+    "## Failure recovery playbook",
+    "name: sdetkit-github-quickstart",
+    "name: sdetkit-github-strict",
+    "name: sdetkit-github-nightly",
+    "python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict",
 ]
 
 REPORT_EXPECTED = [
-    'Day 15 big upgrade',
-    'python -m sdetkit github-actions-quickstart --format json --variant strict --strict',
-    'python -m sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict',
-    'python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
-    'scripts/check_day15_github_actions_quickstart_contract.py',
+    "Day 15 big upgrade",
+    "python -m sdetkit github-actions-quickstart --format json --variant strict --strict",
+    "python -m sdetkit github-actions-quickstart --emit-pack-dir docs/artifacts/day15-github-pack --format json --strict",
+    "python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict",
+    "scripts/check_day15_github_actions_quickstart_contract.py",
 ]
 
 ARTIFACT_EXPECTED = [
-    '# Day 15 GitHub Actions quickstart',
-    '- Variant: `strict`',
-    '- Score: **100.0** (18/18)',
-    'sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+    "# Day 15 GitHub Actions quickstart",
+    "- Variant: `strict`",
+    "- Score: **100.0** (18/18)",
+    "sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict",
 ]
 
 PACK_STRICT_EXPECTED = [
-    'name: sdetkit-github-strict',
-    'python -m sdetkit github-actions-quickstart --format json --strict',
+    "name: sdetkit-github-strict",
+    "python -m sdetkit github-actions-quickstart --format json --strict",
 ]
 
 PACK_NIGHTLY_EXPECTED = [
-    'name: sdetkit-github-nightly',
-    'python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict',
+    "name: sdetkit-github-nightly",
+    "python -m sdetkit github-actions-quickstart --execute --evidence-dir docs/artifacts/day15-github-pack/evidence --format json --strict",
 ]
 
 EVIDENCE_EXPECTED = [
@@ -86,37 +86,64 @@ EVIDENCE_EXPECTED = [
 
 
 def _missing(path: Path, expected: list[str]) -> list[str]:
-    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
     return [item for item in expected if item not in text]
 
 
 def main() -> int:
     errors: list[str] = []
-    required = [README, DOCS_INDEX, DOCS_CLI, QUICKSTART_PAGE, DAY15_REPORT, DAY15_ARTIFACT, DAY15_PACK_STRICT, DAY15_PACK_NIGHTLY, DAY15_EVIDENCE]
+    required = [
+        README,
+        DOCS_INDEX,
+        DOCS_CLI,
+        QUICKSTART_PAGE,
+        DAY15_REPORT,
+        DAY15_ARTIFACT,
+        DAY15_PACK_STRICT,
+        DAY15_PACK_NIGHTLY,
+        DAY15_EVIDENCE,
+    ]
     for path in required:
         if not path.exists():
-            errors.append(f'missing required file: {path}')
+            errors.append(f"missing required file: {path}")
 
     if not errors:
         errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
-        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(
+            f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED)
+        )
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
-        errors.extend(f'{QUICKSTART_PAGE}: missing "{m}"' for m in _missing(QUICKSTART_PAGE, QUICKSTART_EXPECTED))
-        errors.extend(f'{DAY15_REPORT}: missing "{m}"' for m in _missing(DAY15_REPORT, REPORT_EXPECTED))
-        errors.extend(f'{DAY15_ARTIFACT}: missing "{m}"' for m in _missing(DAY15_ARTIFACT, ARTIFACT_EXPECTED))
-        errors.extend(f'{DAY15_PACK_STRICT}: missing "{m}"' for m in _missing(DAY15_PACK_STRICT, PACK_STRICT_EXPECTED))
-        errors.extend(f'{DAY15_PACK_NIGHTLY}: missing "{m}"' for m in _missing(DAY15_PACK_NIGHTLY, PACK_NIGHTLY_EXPECTED))
-        errors.extend(f'{DAY15_EVIDENCE}: missing "{m}"' for m in _missing(DAY15_EVIDENCE, EVIDENCE_EXPECTED))
+        errors.extend(
+            f'{QUICKSTART_PAGE}: missing "{m}"'
+            for m in _missing(QUICKSTART_PAGE, QUICKSTART_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY15_REPORT}: missing "{m}"' for m in _missing(DAY15_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY15_ARTIFACT}: missing "{m}"' for m in _missing(DAY15_ARTIFACT, ARTIFACT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY15_PACK_STRICT}: missing "{m}"'
+            for m in _missing(DAY15_PACK_STRICT, PACK_STRICT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY15_PACK_NIGHTLY}: missing "{m}"'
+            for m in _missing(DAY15_PACK_NIGHTLY, PACK_NIGHTLY_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY15_EVIDENCE}: missing "{m}"' for m in _missing(DAY15_EVIDENCE, EVIDENCE_EXPECTED)
+        )
 
     if errors:
-        print('day15-github-actions-quickstart-contract check failed:', file=sys.stderr)
+        print("day15-github-actions-quickstart-contract check failed:", file=sys.stderr)
         for error in errors:
-            print(f' - {error}', file=sys.stderr)
+            print(f" - {error}", file=sys.stderr)
         return 1
 
-    print('day15-github-actions-quickstart-contract check passed')
+    print("day15-github-actions-quickstart-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day16_gitlab_ci_quickstart_contract.py
+++ b/scripts/check_day16_gitlab_ci_quickstart_contract.py
@@ -1,88 +1,88 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DOCS_CLI = Path('docs/cli.md')
-QUICKSTART_PAGE = Path('docs/integrations-gitlab-ci-quickstart.md')
-DAY16_REPORT = Path('docs/day-16-ultra-upgrade-report.md')
-DAY16_ARTIFACT = Path('docs/artifacts/day16-gitlab-ci-quickstart-sample.md')
-DAY16_PACK_STRICT = Path('docs/artifacts/day16-gitlab-pack/day16-sdetkit-strict.yml')
-DAY16_PACK_NIGHTLY = Path('docs/artifacts/day16-gitlab-pack/day16-sdetkit-nightly.yml')
-DAY16_EVIDENCE = Path('docs/artifacts/day16-gitlab-pack/evidence/day16-execution-summary.json')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+QUICKSTART_PAGE = Path("docs/integrations-gitlab-ci-quickstart.md")
+DAY16_REPORT = Path("docs/day-16-ultra-upgrade-report.md")
+DAY16_ARTIFACT = Path("docs/artifacts/day16-gitlab-ci-quickstart-sample.md")
+DAY16_PACK_STRICT = Path("docs/artifacts/day16-gitlab-pack/day16-sdetkit-strict.yml")
+DAY16_PACK_NIGHTLY = Path("docs/artifacts/day16-gitlab-pack/day16-sdetkit-nightly.yml")
+DAY16_EVIDENCE = Path("docs/artifacts/day16-gitlab-pack/evidence/day16-execution-summary.json")
 
 README_EXPECTED = [
-    '## 🦊 Day 16 ultra: GitLab CI quickstart',
-    'python -m sdetkit gitlab-ci-quickstart --format text --strict',
-    'python -m sdetkit gitlab-ci-quickstart --format json --variant strict --strict',
-    'python -m sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict',
-    'python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict',
-    'python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
-    'python scripts/check_day16_gitlab_ci_quickstart_contract.py',
-    'docs/day-16-ultra-upgrade-report.md',
+    "## 🦊 Day 16 ultra: GitLab CI quickstart",
+    "python -m sdetkit gitlab-ci-quickstart --format text --strict",
+    "python -m sdetkit gitlab-ci-quickstart --format json --variant strict --strict",
+    "python -m sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict",
+    "python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict",
+    "python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict",
+    "python scripts/check_day16_gitlab_ci_quickstart_contract.py",
+    "docs/day-16-ultra-upgrade-report.md",
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '## Day 16 ultra upgrades (GitLab CI quickstart)',
-    'sdetkit gitlab-ci-quickstart --format text --strict',
-    'sdetkit gitlab-ci-quickstart --format json --variant strict --strict',
-    'sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict',
-    'sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict',
-    'sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
-    'artifacts/day16-gitlab-ci-quickstart-sample.md',
+    "## Day 16 ultra upgrades (GitLab CI quickstart)",
+    "sdetkit gitlab-ci-quickstart --format text --strict",
+    "sdetkit gitlab-ci-quickstart --format json --variant strict --strict",
+    "sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict",
+    "sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict",
+    "sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict",
+    "artifacts/day16-gitlab-ci-quickstart-sample.md",
 ]
 
 DOCS_CLI_EXPECTED = [
-    '## gitlab-ci-quickstart',
-    'sdetkit gitlab-ci-quickstart --format markdown --variant strict --output docs/artifacts/day16-gitlab-ci-quickstart-sample.md',
-    'sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict',
-    'sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict',
-    'sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
-    '--write-defaults',
-    '--variant',
-    '--bootstrap-pipeline',
-    '--pipeline-path',
-    '--evidence-dir',
+    "## gitlab-ci-quickstart",
+    "sdetkit gitlab-ci-quickstart --format markdown --variant strict --output docs/artifacts/day16-gitlab-ci-quickstart-sample.md",
+    "sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict",
+    "sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict",
+    "sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict",
+    "--write-defaults",
+    "--variant",
+    "--bootstrap-pipeline",
+    "--pipeline-path",
+    "--evidence-dir",
 ]
 
 QUICKSTART_EXPECTED = [
-    '# GitLab CI quickstart (Day 16)',
-    '## Strict pipeline variant',
-    '## Nightly reliability variant',
-    '## Multi-channel distribution loop',
-    '## Failure recovery playbook',
-    'quickstart-gate:',
-    'strict-gate:',
-    'nightly-audit:',
-    'python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+    "# GitLab CI quickstart (Day 16)",
+    "## Strict pipeline variant",
+    "## Nightly reliability variant",
+    "## Multi-channel distribution loop",
+    "## Failure recovery playbook",
+    "quickstart-gate:",
+    "strict-gate:",
+    "nightly-audit:",
+    "python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict",
 ]
 
 REPORT_EXPECTED = [
-    'Day 16 big upgrade',
-    'python -m sdetkit gitlab-ci-quickstart --format json --variant strict --strict',
-    'python -m sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict',
-    'python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict',
-    'python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
-    'scripts/check_day16_gitlab_ci_quickstart_contract.py',
+    "Day 16 big upgrade",
+    "python -m sdetkit gitlab-ci-quickstart --format json --variant strict --strict",
+    "python -m sdetkit gitlab-ci-quickstart --emit-pack-dir docs/artifacts/day16-gitlab-pack --format json --strict",
+    "python -m sdetkit gitlab-ci-quickstart --variant strict --bootstrap-pipeline --pipeline-path .gitlab-ci.yml --format json --strict",
+    "python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict",
+    "scripts/check_day16_gitlab_ci_quickstart_contract.py",
 ]
 
 ARTIFACT_EXPECTED = [
-    '# Day 16 GitLab CI quickstart',
-    '- Variant: `strict`',
-    '- Score: **100.0** (19/19)',
-    'sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+    "# Day 16 GitLab CI quickstart",
+    "- Variant: `strict`",
+    "- Score: **100.0** (19/19)",
+    "sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict",
 ]
 
 PACK_STRICT_EXPECTED = [
-    'strict-gate:',
-    'python -m sdetkit gitlab-ci-quickstart --format json --strict',
+    "strict-gate:",
+    "python -m sdetkit gitlab-ci-quickstart --format json --strict",
 ]
 
 PACK_NIGHTLY_EXPECTED = [
-    'nightly-audit:',
-    'python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict',
+    "nightly-audit:",
+    "python -m sdetkit gitlab-ci-quickstart --execute --evidence-dir docs/artifacts/day16-gitlab-pack/evidence --format json --strict",
 ]
 
 EVIDENCE_EXPECTED = [
@@ -92,37 +92,64 @@ EVIDENCE_EXPECTED = [
 
 
 def _missing(path: Path, expected: list[str]) -> list[str]:
-    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
     return [item for item in expected if item not in text]
 
 
 def main() -> int:
     errors: list[str] = []
-    required = [README, DOCS_INDEX, DOCS_CLI, QUICKSTART_PAGE, DAY16_REPORT, DAY16_ARTIFACT, DAY16_PACK_STRICT, DAY16_PACK_NIGHTLY, DAY16_EVIDENCE]
+    required = [
+        README,
+        DOCS_INDEX,
+        DOCS_CLI,
+        QUICKSTART_PAGE,
+        DAY16_REPORT,
+        DAY16_ARTIFACT,
+        DAY16_PACK_STRICT,
+        DAY16_PACK_NIGHTLY,
+        DAY16_EVIDENCE,
+    ]
     for path in required:
         if not path.exists():
-            errors.append(f'missing required file: {path}')
+            errors.append(f"missing required file: {path}")
 
     if not errors:
         errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
-        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(
+            f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED)
+        )
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
-        errors.extend(f'{QUICKSTART_PAGE}: missing "{m}"' for m in _missing(QUICKSTART_PAGE, QUICKSTART_EXPECTED))
-        errors.extend(f'{DAY16_REPORT}: missing "{m}"' for m in _missing(DAY16_REPORT, REPORT_EXPECTED))
-        errors.extend(f'{DAY16_ARTIFACT}: missing "{m}"' for m in _missing(DAY16_ARTIFACT, ARTIFACT_EXPECTED))
-        errors.extend(f'{DAY16_PACK_STRICT}: missing "{m}"' for m in _missing(DAY16_PACK_STRICT, PACK_STRICT_EXPECTED))
-        errors.extend(f'{DAY16_PACK_NIGHTLY}: missing "{m}"' for m in _missing(DAY16_PACK_NIGHTLY, PACK_NIGHTLY_EXPECTED))
-        errors.extend(f'{DAY16_EVIDENCE}: missing "{m}"' for m in _missing(DAY16_EVIDENCE, EVIDENCE_EXPECTED))
+        errors.extend(
+            f'{QUICKSTART_PAGE}: missing "{m}"'
+            for m in _missing(QUICKSTART_PAGE, QUICKSTART_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY16_REPORT}: missing "{m}"' for m in _missing(DAY16_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY16_ARTIFACT}: missing "{m}"' for m in _missing(DAY16_ARTIFACT, ARTIFACT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY16_PACK_STRICT}: missing "{m}"'
+            for m in _missing(DAY16_PACK_STRICT, PACK_STRICT_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY16_PACK_NIGHTLY}: missing "{m}"'
+            for m in _missing(DAY16_PACK_NIGHTLY, PACK_NIGHTLY_EXPECTED)
+        )
+        errors.extend(
+            f'{DAY16_EVIDENCE}: missing "{m}"' for m in _missing(DAY16_EVIDENCE, EVIDENCE_EXPECTED)
+        )
 
     if errors:
-        print('day16-gitlab-ci-quickstart-contract check failed:', file=sys.stderr)
+        print("day16-gitlab-ci-quickstart-contract check failed:", file=sys.stderr)
         for error in errors:
-            print(f' - {error}', file=sys.stderr)
+            print(f" - {error}", file=sys.stderr)
         return 1
 
-    print('day16-gitlab-ci-quickstart-contract check passed')
+    print("day16-gitlab-ci-quickstart-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day17_quality_contribution_delta_contract.py
+++ b/scripts/check_day17_quality_contribution_delta_contract.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
@@ -77,8 +77,13 @@ def main() -> int:
         errors.extend(f"{README}: missing '{m}'" for m in _missing(README, README_EXPECTED))
         errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
-        errors.extend(f"{DAY17_REPORT}: missing '{m}'" for m in _missing(DAY17_REPORT, REPORT_EXPECTED))
-        errors.extend(f"{DAY17_PACK_SUMMARY}: missing '{m}'" for m in _missing(DAY17_PACK_SUMMARY, SUMMARY_EXPECTED))
+        errors.extend(
+            f"{DAY17_REPORT}: missing '{m}'" for m in _missing(DAY17_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f"{DAY17_PACK_SUMMARY}: missing '{m}'"
+            for m in _missing(DAY17_PACK_SUMMARY, SUMMARY_EXPECTED)
+        )
 
     if errors:
         print("day17-quality-contribution-delta-contract check failed:", file=sys.stderr)

--- a/scripts/check_day18_reliability_evidence_pack_contract.py
+++ b/scripts/check_day18_reliability_evidence_pack_contract.py
@@ -107,10 +107,18 @@ def main(argv: list[str] | None = None) -> int:
         errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
         errors.extend(f"{DAY18_PAGE}: missing '{m}'" for m in _missing(DAY18_PAGE, PAGE_EXPECTED))
-        errors.extend(f"{DAY18_REPORT}: missing '{m}'" for m in _missing(DAY18_REPORT, REPORT_EXPECTED))
-        errors.extend(f"{DAY18_PACK_SUMMARY}: missing '{m}'" for m in _missing(DAY18_PACK_SUMMARY, SUMMARY_EXPECTED))
+        errors.extend(
+            f"{DAY18_REPORT}: missing '{m}'" for m in _missing(DAY18_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f"{DAY18_PACK_SUMMARY}: missing '{m}'"
+            for m in _missing(DAY18_PACK_SUMMARY, SUMMARY_EXPECTED)
+        )
         if not ns.skip_evidence:
-            errors.extend(f"{DAY18_EVIDENCE}: missing '{m}'" for m in _missing(DAY18_EVIDENCE, EVIDENCE_EXPECTED))
+            errors.extend(
+                f"{DAY18_EVIDENCE}: missing '{m}'"
+                for m in _missing(DAY18_EVIDENCE, EVIDENCE_EXPECTED)
+            )
 
     if errors:
         print("day18-reliability-evidence-pack-contract check failed:", file=sys.stderr)

--- a/scripts/check_day19_release_readiness_board_contract.py
+++ b/scripts/check_day19_release_readiness_board_contract.py
@@ -10,12 +10,22 @@ DOCS_CLI = Path("docs/cli.md")
 DAY19_PAGE = Path("docs/integrations-release-readiness-board.md")
 DAY19_REPORT = Path("docs/day-19-ultra-upgrade-report.md")
 DAY19_ARTIFACT = Path("docs/artifacts/day19-release-readiness-board-sample.md")
-DAY19_PACK_SUMMARY = Path("docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json")
-DAY19_PACK_SCORECARD = Path("docs/artifacts/day19-release-readiness-pack/day19-release-readiness-scorecard.md")
-DAY19_PACK_CHECKLIST = Path("docs/artifacts/day19-release-readiness-pack/day19-release-readiness-checklist.md")
-DAY19_PACK_VALIDATION = Path("docs/artifacts/day19-release-readiness-pack/day19-validation-commands.md")
+DAY19_PACK_SUMMARY = Path(
+    "docs/artifacts/day19-release-readiness-pack/day19-release-readiness-summary.json"
+)
+DAY19_PACK_SCORECARD = Path(
+    "docs/artifacts/day19-release-readiness-pack/day19-release-readiness-scorecard.md"
+)
+DAY19_PACK_CHECKLIST = Path(
+    "docs/artifacts/day19-release-readiness-pack/day19-release-readiness-checklist.md"
+)
+DAY19_PACK_VALIDATION = Path(
+    "docs/artifacts/day19-release-readiness-pack/day19-validation-commands.md"
+)
 DAY19_PACK_DECISION = Path("docs/artifacts/day19-release-readiness-pack/day19-release-decision.md")
-DAY19_EVIDENCE = Path("docs/artifacts/day19-release-readiness-pack/evidence/day19-execution-summary.json")
+DAY19_EVIDENCE = Path(
+    "docs/artifacts/day19-release-readiness-pack/evidence/day19-execution-summary.json"
+)
 MODULE = Path("src/sdetkit/release_readiness_board.py")
 
 README_EXPECTED = [
@@ -98,10 +108,18 @@ def main(argv: list[str] | None = None) -> int:
         errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
         errors.extend(f"{DAY19_PAGE}: missing '{m}'" for m in _missing(DAY19_PAGE, PAGE_EXPECTED))
-        errors.extend(f"{DAY19_REPORT}: missing '{m}'" for m in _missing(DAY19_REPORT, REPORT_EXPECTED))
-        errors.extend(f"{DAY19_PACK_SUMMARY}: missing '{m}'" for m in _missing(DAY19_PACK_SUMMARY, SUMMARY_EXPECTED))
+        errors.extend(
+            f"{DAY19_REPORT}: missing '{m}'" for m in _missing(DAY19_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f"{DAY19_PACK_SUMMARY}: missing '{m}'"
+            for m in _missing(DAY19_PACK_SUMMARY, SUMMARY_EXPECTED)
+        )
         if not ns.skip_evidence:
-            errors.extend(f"{DAY19_EVIDENCE}: missing '{m}'" for m in _missing(DAY19_EVIDENCE, EVIDENCE_EXPECTED))
+            errors.extend(
+                f"{DAY19_EVIDENCE}: missing '{m}'"
+                for m in _missing(DAY19_EVIDENCE, EVIDENCE_EXPECTED)
+            )
 
     if errors:
         print("day19-release-readiness-board-contract check failed:", file=sys.stderr)

--- a/scripts/check_day20_release_narrative_contract.py
+++ b/scripts/check_day20_release_narrative_contract.py
@@ -10,12 +10,18 @@ DOCS_CLI = Path("docs/cli.md")
 DAY20_PAGE = Path("docs/integrations-release-narrative.md")
 DAY20_REPORT = Path("docs/day-20-ultra-upgrade-report.md")
 DAY20_ARTIFACT = Path("docs/artifacts/day20-release-narrative-sample.md")
-DAY20_PACK_SUMMARY = Path("docs/artifacts/day20-release-narrative-pack/day20-release-narrative-summary.json")
+DAY20_PACK_SUMMARY = Path(
+    "docs/artifacts/day20-release-narrative-pack/day20-release-narrative-summary.json"
+)
 DAY20_PACK_MD = Path("docs/artifacts/day20-release-narrative-pack/day20-release-narrative.md")
 DAY20_PACK_BLURBS = Path("docs/artifacts/day20-release-narrative-pack/day20-audience-blurbs.md")
 DAY20_PACK_CHANNELS = Path("docs/artifacts/day20-release-narrative-pack/day20-channel-posts.md")
-DAY20_PACK_VALIDATION = Path("docs/artifacts/day20-release-narrative-pack/day20-validation-commands.md")
-DAY20_EVIDENCE = Path("docs/artifacts/day20-release-narrative-pack/evidence/day20-execution-summary.json")
+DAY20_PACK_VALIDATION = Path(
+    "docs/artifacts/day20-release-narrative-pack/day20-validation-commands.md"
+)
+DAY20_EVIDENCE = Path(
+    "docs/artifacts/day20-release-narrative-pack/evidence/day20-execution-summary.json"
+)
 MODULE = Path("src/sdetkit/release_narrative.py")
 
 README_EXPECTED = [
@@ -47,7 +53,11 @@ PAGE_EXPECTED = [
     "## Narrative channels",
 ]
 REPORT_EXPECTED = ["Day 20 big upgrade", "strict", "--execute", "validation commands"]
-SUMMARY_EXPECTED = ['"name": "day20-release-narrative"', '"readiness_label":', '"narrative_channels":']
+SUMMARY_EXPECTED = [
+    '"name": "day20-release-narrative"',
+    '"readiness_label":',
+    '"narrative_channels":',
+]
 EVIDENCE_EXPECTED = ['"name": "day20-release-narrative-execution"', '"total_commands": 3']
 
 
@@ -88,10 +98,18 @@ def main(argv: list[str] | None = None) -> int:
         errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
         errors.extend(f"{DAY20_PAGE}: missing '{m}'" for m in _missing(DAY20_PAGE, PAGE_EXPECTED))
-        errors.extend(f"{DAY20_REPORT}: missing '{m}'" for m in _missing(DAY20_REPORT, REPORT_EXPECTED))
-        errors.extend(f"{DAY20_PACK_SUMMARY}: missing '{m}'" for m in _missing(DAY20_PACK_SUMMARY, SUMMARY_EXPECTED))
+        errors.extend(
+            f"{DAY20_REPORT}: missing '{m}'" for m in _missing(DAY20_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f"{DAY20_PACK_SUMMARY}: missing '{m}'"
+            for m in _missing(DAY20_PACK_SUMMARY, SUMMARY_EXPECTED)
+        )
         if not ns.skip_evidence:
-            errors.extend(f"{DAY20_EVIDENCE}: missing '{m}'" for m in _missing(DAY20_EVIDENCE, EVIDENCE_EXPECTED))
+            errors.extend(
+                f"{DAY20_EVIDENCE}: missing '{m}'"
+                for m in _missing(DAY20_EVIDENCE, EVIDENCE_EXPECTED)
+            )
 
     if errors:
         print("day20-release-narrative-contract check failed:", file=sys.stderr)

--- a/scripts/check_day22_trust_signal_upgrade_contract.py
+++ b/scripts/check_day22_trust_signal_upgrade_contract.py
@@ -48,7 +48,12 @@ PAGE_EXPECTED = [
     "## Visibility checklist",
 ]
 REPORT_EXPECTED = ["Day 22 big upgrade", "strict", "--execute", "validation commands"]
-SUMMARY_EXPECTED = ['"name": "day22-trust-signal-upgrade"', '"trust_score":', '"governance_checks":', '"critical_failures":']
+SUMMARY_EXPECTED = [
+    '"name": "day22-trust-signal-upgrade"',
+    '"trust_score":',
+    '"governance_checks":',
+    '"critical_failures":',
+]
 EVIDENCE_EXPECTED = ['"name": "day22-trust-signal-upgrade-execution"', '"total_commands": 3']
 
 
@@ -89,10 +94,18 @@ def main(argv: list[str] | None = None) -> int:
         errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
         errors.extend(f"{DAY22_PAGE}: missing '{m}'" for m in _missing(DAY22_PAGE, PAGE_EXPECTED))
-        errors.extend(f"{DAY22_REPORT}: missing '{m}'" for m in _missing(DAY22_REPORT, REPORT_EXPECTED))
-        errors.extend(f"{DAY22_PACK_SUMMARY}: missing '{m}'" for m in _missing(DAY22_PACK_SUMMARY, SUMMARY_EXPECTED))
+        errors.extend(
+            f"{DAY22_REPORT}: missing '{m}'" for m in _missing(DAY22_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f"{DAY22_PACK_SUMMARY}: missing '{m}'"
+            for m in _missing(DAY22_PACK_SUMMARY, SUMMARY_EXPECTED)
+        )
         if not ns.skip_evidence:
-            errors.extend(f"{DAY22_EVIDENCE}: missing '{m}'" for m in _missing(DAY22_EVIDENCE, EVIDENCE_EXPECTED))
+            errors.extend(
+                f"{DAY22_EVIDENCE}: missing '{m}'"
+                for m in _missing(DAY22_EVIDENCE, EVIDENCE_EXPECTED)
+            )
 
     if errors:
         print("day22-trust-signal-upgrade-contract check failed:", file=sys.stderr)

--- a/scripts/check_day6_conversion_contract.py
+++ b/scripts/check_day6_conversion_contract.py
@@ -4,36 +4,36 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DAY6_REPORT = Path('docs/day-6-ultra-upgrade-report.md')
-DAY6_ARTIFACT = Path('docs/artifacts/day6-conversion-qa-sample.md')
-DOCS_QA_MODULE = Path('src/sdetkit/docs_qa.py')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DAY6_REPORT = Path("docs/day-6-ultra-upgrade-report.md")
+DAY6_ARTIFACT = Path("docs/artifacts/day6-conversion-qa-sample.md")
+DOCS_QA_MODULE = Path("src/sdetkit/docs_qa.py")
 
 REQUIRED_README_SNIPPETS = [
-    '## 🔗 Day 6 ultra: conversion QA hardening',
-    'python -m sdetkit docs-qa --format text',
-    'python -m sdetkit docs-qa --format markdown --output docs/artifacts/day6-conversion-qa-sample.md',
-    'docs/day-6-ultra-upgrade-report.md',
+    "## 🔗 Day 6 ultra: conversion QA hardening",
+    "python -m sdetkit docs-qa --format text",
+    "python -m sdetkit docs-qa --format markdown --output docs/artifacts/day6-conversion-qa-sample.md",
+    "docs/day-6-ultra-upgrade-report.md",
 ]
 
 REQUIRED_INDEX_SNIPPETS = [
-    'Day 6 ultra upgrade report',
-    'sdetkit docs-qa --format text',
+    "Day 6 ultra upgrade report",
+    "sdetkit docs-qa --format text",
 ]
 
 REQUIRED_REPORT_SNIPPETS = [
-    'Day 6 big upgrade',
-    'src/sdetkit/docs_qa.py',
-    'tests/test_docs_qa.py',
-    'python scripts/check_day6_conversion_contract.py',
+    "Day 6 big upgrade",
+    "src/sdetkit/docs_qa.py",
+    "tests/test_docs_qa.py",
+    "python scripts/check_day6_conversion_contract.py",
 ]
 
 
 def _read(path: Path) -> str:
     if not path.exists():
-        return ''
-    return path.read_text(encoding='utf-8')
+        return ""
+    return path.read_text(encoding="utf-8")
 
 
 def main() -> int:
@@ -45,29 +45,29 @@ def main() -> int:
 
     for s in REQUIRED_README_SNIPPETS:
         if s not in readme:
-            errors.append(f'missing README snippet: {s}')
+            errors.append(f"missing README snippet: {s}")
 
     for s in REQUIRED_INDEX_SNIPPETS:
         if s not in docs_index:
-            errors.append(f'missing docs/index snippet: {s}')
+            errors.append(f"missing docs/index snippet: {s}")
 
     for s in REQUIRED_REPORT_SNIPPETS:
         if s not in report:
-            errors.append(f'missing Day 6 report snippet: {s}')
+            errors.append(f"missing Day 6 report snippet: {s}")
 
     for p in [DAY6_REPORT, DAY6_ARTIFACT, DOCS_QA_MODULE]:
         if not p.exists():
-            errors.append(f'missing required file: {p}')
+            errors.append(f"missing required file: {p}")
 
     if errors:
-        print('day6-conversion-contract check failed:', file=sys.stderr)
+        print("day6-conversion-contract check failed:", file=sys.stderr)
         for e in errors:
-            print(f'- {e}', file=sys.stderr)
+            print(f"- {e}", file=sys.stderr)
         return 1
 
-    print('day6-conversion-contract check passed')
+    print("day6-conversion-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day7_weekly_review_contract.py
+++ b/scripts/check_day7_weekly_review_contract.py
@@ -4,36 +4,36 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DAY7_REPORT = Path('docs/day-7-ultra-upgrade-report.md')
-DAY7_ARTIFACT = Path('docs/artifacts/day7-weekly-review-sample.md')
-WEEKLY_MODULE = Path('src/sdetkit/weekly_review.py')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DAY7_REPORT = Path("docs/day-7-ultra-upgrade-report.md")
+DAY7_ARTIFACT = Path("docs/artifacts/day7-weekly-review-sample.md")
+WEEKLY_MODULE = Path("src/sdetkit/weekly_review.py")
 
 REQUIRED_README_SNIPPETS = [
-    '## 📊 Day 7 ultra: weekly review #1',
-    'python -m sdetkit weekly-review --format text',
-    'python -m sdetkit weekly-review --format markdown --output docs/artifacts/day7-weekly-review-sample.md',
-    'docs/day-7-ultra-upgrade-report.md',
+    "## 📊 Day 7 ultra: weekly review #1",
+    "python -m sdetkit weekly-review --format text",
+    "python -m sdetkit weekly-review --format markdown --output docs/artifacts/day7-weekly-review-sample.md",
+    "docs/day-7-ultra-upgrade-report.md",
 ]
 
 REQUIRED_INDEX_SNIPPETS = [
-    'Day 7 ultra upgrade report',
-    'sdetkit weekly-review --format text',
+    "Day 7 ultra upgrade report",
+    "sdetkit weekly-review --format text",
 ]
 
 REQUIRED_REPORT_SNIPPETS = [
-    'Day 7 big upgrade',
-    'src/sdetkit/weekly_review.py',
-    'tests/test_weekly_review.py',
-    'python scripts/check_day7_weekly_review_contract.py',
+    "Day 7 big upgrade",
+    "src/sdetkit/weekly_review.py",
+    "tests/test_weekly_review.py",
+    "python scripts/check_day7_weekly_review_contract.py",
 ]
 
 
 def _read(path: Path) -> str:
     if not path.exists():
-        return ''
-    return path.read_text(encoding='utf-8')
+        return ""
+    return path.read_text(encoding="utf-8")
 
 
 def main() -> int:
@@ -45,29 +45,29 @@ def main() -> int:
 
     for s in REQUIRED_README_SNIPPETS:
         if s not in readme:
-            errors.append(f'missing README snippet: {s}')
+            errors.append(f"missing README snippet: {s}")
 
     for s in REQUIRED_INDEX_SNIPPETS:
         if s not in docs_index:
-            errors.append(f'missing docs/index snippet: {s}')
+            errors.append(f"missing docs/index snippet: {s}")
 
     for s in REQUIRED_REPORT_SNIPPETS:
         if s not in report:
-            errors.append(f'missing Day 7 report snippet: {s}')
+            errors.append(f"missing Day 7 report snippet: {s}")
 
     for p in [DAY7_REPORT, DAY7_ARTIFACT, WEEKLY_MODULE]:
         if not p.exists():
-            errors.append(f'missing required file: {p}')
+            errors.append(f"missing required file: {p}")
 
     if errors:
-        print('day7-weekly-review-contract check failed:', file=sys.stderr)
+        print("day7-weekly-review-contract check failed:", file=sys.stderr)
         for e in errors:
-            print(f'- {e}', file=sys.stderr)
+            print(f"- {e}", file=sys.stderr)
         return 1
 
-    print('day7-weekly-review-contract check passed')
+    print("day7-weekly-review-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day8_contributor_funnel_contract.py
+++ b/scripts/check_day8_contributor_funnel_contract.py
@@ -4,38 +4,38 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DAY8_REPORT = Path('docs/day-8-ultra-upgrade-report.md')
-DAY8_ARTIFACT = Path('docs/artifacts/day8-good-first-issues-sample.md')
-DAY8_ISSUE_PACK = Path('docs/artifacts/day8-issue-pack')
-DAY8_MODULE = Path('src/sdetkit/contributor_funnel.py')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DAY8_REPORT = Path("docs/day-8-ultra-upgrade-report.md")
+DAY8_ARTIFACT = Path("docs/artifacts/day8-good-first-issues-sample.md")
+DAY8_ISSUE_PACK = Path("docs/artifacts/day8-issue-pack")
+DAY8_MODULE = Path("src/sdetkit/contributor_funnel.py")
 
 REQUIRED_README_SNIPPETS = [
-    '## 🧲 Day 8 ultra: contributor funnel backlog',
-    'python -m sdetkit contributor-funnel --format text --strict',
-    'python -m sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/day8-issue-pack',
-    'docs/day-8-ultra-upgrade-report.md',
+    "## 🧲 Day 8 ultra: contributor funnel backlog",
+    "python -m sdetkit contributor-funnel --format text --strict",
+    "python -m sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/day8-issue-pack",
+    "docs/day-8-ultra-upgrade-report.md",
 ]
 
 REQUIRED_INDEX_SNIPPETS = [
-    'Day 8 ultra upgrade report',
-    'sdetkit contributor-funnel --format text --strict',
-    'sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/day8-issue-pack',
+    "Day 8 ultra upgrade report",
+    "sdetkit contributor-funnel --format text --strict",
+    "sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/day8-issue-pack",
 ]
 
 REQUIRED_REPORT_SNIPPETS = [
-    'Day 8 big upgrade',
-    'src/sdetkit/contributor_funnel.py',
-    'tests/test_contributor_funnel.py',
-    'python scripts/check_day8_contributor_funnel_contract.py',
+    "Day 8 big upgrade",
+    "src/sdetkit/contributor_funnel.py",
+    "tests/test_contributor_funnel.py",
+    "python scripts/check_day8_contributor_funnel_contract.py",
 ]
 
 
 def _read(path: Path) -> str:
     if not path.exists():
-        return ''
-    return path.read_text(encoding='utf-8')
+        return ""
+    return path.read_text(encoding="utf-8")
 
 
 def main() -> int:
@@ -47,33 +47,33 @@ def main() -> int:
 
     for s in REQUIRED_README_SNIPPETS:
         if s not in readme:
-            errors.append(f'missing README snippet: {s}')
+            errors.append(f"missing README snippet: {s}")
 
     for s in REQUIRED_INDEX_SNIPPETS:
         if s not in docs_index:
-            errors.append(f'missing docs/index snippet: {s}')
+            errors.append(f"missing docs/index snippet: {s}")
 
     for s in REQUIRED_REPORT_SNIPPETS:
         if s not in report:
-            errors.append(f'missing Day 8 report snippet: {s}')
+            errors.append(f"missing Day 8 report snippet: {s}")
 
     for p in [DAY8_REPORT, DAY8_ARTIFACT, DAY8_MODULE]:
         if not p.exists():
-            errors.append(f'missing required file: {p}')
+            errors.append(f"missing required file: {p}")
 
-    issue_pack_files = sorted(DAY8_ISSUE_PACK.glob('gfi-*.md')) if DAY8_ISSUE_PACK.exists() else []
+    issue_pack_files = sorted(DAY8_ISSUE_PACK.glob("gfi-*.md")) if DAY8_ISSUE_PACK.exists() else []
     if len(issue_pack_files) < 5:
-        errors.append('missing issue-pack artifacts: expected at least 5 gfi-*.md files')
+        errors.append("missing issue-pack artifacts: expected at least 5 gfi-*.md files")
 
     if errors:
-        print('day8-contributor-funnel-contract check failed:', file=sys.stderr)
+        print("day8-contributor-funnel-contract check failed:", file=sys.stderr)
         for e in errors:
-            print(f'- {e}', file=sys.stderr)
+            print(f"- {e}", file=sys.stderr)
         return 1
 
-    print('day8-contributor-funnel-contract check passed')
+    print("day8-contributor-funnel-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_day9_contribution_templates_contract.py
+++ b/scripts/check_day9_contribution_templates_contract.py
@@ -1,53 +1,53 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-README = Path('README.md')
-DOCS_INDEX = Path('docs/index.md')
-DOCS_CLI = Path('docs/cli.md')
-DAY9_REPORT = Path('docs/day-9-ultra-upgrade-report.md')
-DAY9_ARTIFACT = Path('docs/artifacts/day9-triage-templates-sample.md')
-ISSUE_CONFIG = Path('.github/ISSUE_TEMPLATE/config.yml')
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+DAY9_REPORT = Path("docs/day-9-ultra-upgrade-report.md")
+DAY9_ARTIFACT = Path("docs/artifacts/day9-triage-templates-sample.md")
+ISSUE_CONFIG = Path(".github/ISSUE_TEMPLATE/config.yml")
 
 README_EXPECTED = [
-    '## 🧩 Day 9 ultra: contribution templates',
-    'python -m sdetkit triage-templates --format text --strict',
-    'python -m sdetkit triage-templates --write-defaults --format json --strict',
-    'docs/day-9-ultra-upgrade-report.md',
+    "## 🧩 Day 9 ultra: contribution templates",
+    "python -m sdetkit triage-templates --format text --strict",
+    "python -m sdetkit triage-templates --write-defaults --format json --strict",
+    "docs/day-9-ultra-upgrade-report.md",
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '## Day 9 ultra upgrades (contribution templates)',
-    'sdetkit triage-templates --format text --strict',
-    'sdetkit triage-templates --write-defaults --format json --strict',
-    'artifacts/day9-triage-templates-sample.md',
+    "## Day 9 ultra upgrades (contribution templates)",
+    "sdetkit triage-templates --format text --strict",
+    "sdetkit triage-templates --write-defaults --format json --strict",
+    "artifacts/day9-triage-templates-sample.md",
 ]
 
 DOCS_CLI_EXPECTED = [
-    '## triage-templates',
-    '--write-defaults',
-    '--root',
-    'sdetkit triage-templates --format markdown --output docs/artifacts/day9-triage-templates-sample.md',
+    "## triage-templates",
+    "--write-defaults",
+    "--root",
+    "sdetkit triage-templates --format markdown --output docs/artifacts/day9-triage-templates-sample.md",
 ]
 
 REPORT_EXPECTED = [
-    'Day 9 big upgrade',
-    'python -m sdetkit triage-templates --format json --strict',
-    'python -m sdetkit triage-templates --write-defaults --format json --strict',
-    'scripts/check_day9_contribution_templates_contract.py',
+    "Day 9 big upgrade",
+    "python -m sdetkit triage-templates --format json --strict",
+    "python -m sdetkit triage-templates --write-defaults --format json --strict",
+    "scripts/check_day9_contribution_templates_contract.py",
 ]
 
 ISSUE_CONFIG_EXPECTED = [
-    'blank_issues_enabled: false',
-    'contact_links:',
-    'Security report',
-    'Questions / discussion',
+    "blank_issues_enabled: false",
+    "contact_links:",
+    "Security report",
+    "Questions / discussion",
 ]
 
 
 def _missing(path: Path, expected: list[str]) -> list[str]:
-    text = path.read_text(encoding='utf-8') if path.exists() else ''
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
     return [item for item in expected if item not in text]
 
 
@@ -55,24 +55,30 @@ def main() -> int:
     errors: list[str] = []
     for path in [README, DOCS_INDEX, DOCS_CLI, DAY9_REPORT, DAY9_ARTIFACT, ISSUE_CONFIG]:
         if not path.exists():
-            errors.append(f'missing required file: {path}')
+            errors.append(f"missing required file: {path}")
 
     if not errors:
         errors.extend(f'{README}: missing "{m}"' for m in _missing(README, README_EXPECTED))
-        errors.extend(f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED))
+        errors.extend(
+            f'{DOCS_INDEX}: missing "{m}"' for m in _missing(DOCS_INDEX, DOCS_INDEX_EXPECTED)
+        )
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
-        errors.extend(f'{DAY9_REPORT}: missing "{m}"' for m in _missing(DAY9_REPORT, REPORT_EXPECTED))
-        errors.extend(f'{ISSUE_CONFIG}: missing "{m}"' for m in _missing(ISSUE_CONFIG, ISSUE_CONFIG_EXPECTED))
+        errors.extend(
+            f'{DAY9_REPORT}: missing "{m}"' for m in _missing(DAY9_REPORT, REPORT_EXPECTED)
+        )
+        errors.extend(
+            f'{ISSUE_CONFIG}: missing "{m}"' for m in _missing(ISSUE_CONFIG, ISSUE_CONFIG_EXPECTED)
+        )
 
     if errors:
-        print('day9-contribution-templates-contract check failed:', file=sys.stderr)
+        print("day9-contribution-templates-contract check failed:", file=sys.stderr)
         for error in errors:
-            print(f' - {error}', file=sys.stderr)
+            print(f" - {error}", file=sys.stderr)
         return 1
 
-    print('day9-contribution-templates-contract check passed')
+    print("day9-contribution-templates-contract check passed")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -30,8 +30,8 @@ from . import (
     repo,
     report,
     startup_use_case,
-    trust_signal_upgrade,
     triage_templates,
+    trust_signal_upgrade,
     weekly_review,
 )
 from .agent.cli import main as agent_main

--- a/src/sdetkit/contributor_funnel.py
+++ b/src/sdetkit/contributor_funnel.py
@@ -5,6 +5,7 @@ import json
 from collections import Counter
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 _DAY8_ISSUES = [
     {
@@ -120,13 +121,13 @@ _DAY8_ISSUES = [
 ]
 
 
-def build_backlog(area: str = "all") -> list[dict[str, object]]:
+def build_backlog(area: str = "all") -> list[dict[str, Any]]:
     if area == "all":
         return list(_DAY8_ISSUES)
     return [item for item in _DAY8_ISSUES if item["area"] == area]
 
 
-def validate_backlog(backlog: list[dict[str, object]]) -> list[str]:
+def validate_backlog(backlog: list[dict[str, Any]]) -> list[str]:
     errors: list[str] = []
     if len(backlog) != 10:
         errors.append(f"expected 10 issues, got {len(backlog)}")
@@ -164,7 +165,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _render_text(backlog: list[dict[str, object]]) -> str:
+def _render_text(backlog: list[dict[str, Any]]) -> str:
     lines = ["Day 8 contributor funnel backlog", ""]
     for issue in backlog:
         lines.append(f"[{issue['id']}] {issue['title']}")
@@ -176,7 +177,7 @@ def _render_text(backlog: list[dict[str, object]]) -> str:
     return "\n".join(lines)
 
 
-def _render_markdown(backlog: list[dict[str, object]]) -> str:
+def _render_markdown(backlog: list[dict[str, Any]]) -> str:
     lines = [
         "# Day 8 contributor funnel backlog",
         "",
@@ -202,7 +203,7 @@ def _render_markdown(backlog: list[dict[str, object]]) -> str:
     return "\n".join(lines)
 
 
-def _render_json(backlog: list[dict[str, object]]) -> str:
+def _render_json(backlog: list[dict[str, Any]]) -> str:
     area_counts = Counter(str(i["area"]) for i in backlog)
     payload = {
         "name": "day8-contributor-funnel",
@@ -216,7 +217,7 @@ def _render_json(backlog: list[dict[str, object]]) -> str:
     return json.dumps(payload, indent=2) + "\n"
 
 
-def _write_issue_pack(backlog: list[dict[str, object]], issue_pack_dir: str) -> None:
+def _write_issue_pack(backlog: list[dict[str, Any]], issue_pack_dir: str) -> None:
     out_dir = Path(issue_pack_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     for issue in backlog:

--- a/src/sdetkit/docs_navigation.py
+++ b/src/sdetkit/docs_navigation.py
@@ -4,26 +4,27 @@ import argparse
 import json
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 _QUICK_JUMP_START = '<div class="quick-jump" markdown>'
-_QUICK_JUMP_END = '</div>'
+_QUICK_JUMP_END = "</div>"
 
 _REQUIRED_LINKS = [
-    '[⚡ Fast start](#fast-start)',
-    '[🛠 CLI commands](cli.md)',
-    '[🩺 Doctor checks](doctor.md)',
-    '[🤝 Contribute](contributing.md)',
-    '[✅ Day 10 ultra report](day-10-ultra-upgrade-report.md)',
-    '[🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md)',
+    "[⚡ Fast start](#fast-start)",
+    "[🛠 CLI commands](cli.md)",
+    "[🩺 Doctor checks](doctor.md)",
+    "[🤝 Contribute](contributing.md)",
+    "[✅ Day 10 ultra report](day-10-ultra-upgrade-report.md)",
+    "[🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md)",
 ]
 
-_DAY11_SECTION_HEADER = '## Day 11 ultra upgrades (docs navigation tune-up)'
-_DAY11_JOURNEYS_HEADER = '### Day 11 top journeys'
+_DAY11_SECTION_HEADER = "## Day 11 ultra upgrades (docs navigation tune-up)"
+_DAY11_JOURNEYS_HEADER = "### Day 11 top journeys"
 
 _TOP_JOURNEYS = [
-    'Run first command in under 60 seconds',
-    'Validate docs links and anchors before publishing',
-    'Ship a first contribution with deterministic quality gates',
+    "Run first command in under 60 seconds",
+    "Validate docs links and anchors before publishing",
+    "Ship a first contribution with deterministic quality gates",
 ]
 
 _DAY11_QUICK_JUMP_BLOCK = """<div class=\"quick-jump\" markdown>
@@ -43,93 +44,101 @@ _DAY11_JOURNEYS_BLOCK = """### Day 11 top journeys
 
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        prog='sdetkit docs-nav',
-        description='Render and validate Day 11 docs navigation one-click journeys from docs home.',
+        prog="sdetkit docs-nav",
+        description="Render and validate Day 11 docs navigation one-click journeys from docs home.",
     )
-    p.add_argument('--format', choices=['text', 'markdown', 'json'], default='text')
-    p.add_argument('--root', default='.', help='Repository root where docs/index.md lives.')
-    p.add_argument('--output', default='', help='Optional output file path.')
-    p.add_argument('--strict', action='store_true', help='Return non-zero when required docs navigation entries are missing.')
+    p.add_argument("--format", choices=["text", "markdown", "json"], default="text")
+    p.add_argument("--root", default=".", help="Repository root where docs/index.md lives.")
+    p.add_argument("--output", default="", help="Optional output file path.")
     p.add_argument(
-        '--write-defaults',
-        action='store_true',
-        help='Repair Day 11 quick-jump + top-journey baseline content in docs/index.md, then validate again.',
+        "--strict",
+        action="store_true",
+        help="Return non-zero when required docs navigation entries are missing.",
+    )
+    p.add_argument(
+        "--write-defaults",
+        action="store_true",
+        help="Repair Day 11 quick-jump + top-journey baseline content in docs/index.md, then validate again.",
     )
     return p
 
 
 def _read(path: Path) -> str:
     if not path.exists():
-        return ''
-    return path.read_text(encoding='utf-8')
+        return ""
+    return path.read_text(encoding="utf-8")
 
 
 def _extract_quick_jump(text: str) -> str:
     start = text.find(_QUICK_JUMP_START)
     if start < 0:
-        return ''
+        return ""
     end = text.find(_QUICK_JUMP_END, start)
     if end < 0:
-        return ''
+        return ""
     return text[start : end + len(_QUICK_JUMP_END)]
 
 
-def _replace_or_append_block(text: str, start_marker: str, end_marker: str, block: str) -> tuple[str, bool]:
+def _replace_or_append_block(
+    text: str, start_marker: str, end_marker: str, block: str
+) -> tuple[str, bool]:
     start = text.find(start_marker)
     end = text.find(end_marker, start) if start >= 0 else -1
     if start >= 0 and end >= 0:
         updated = text[:start] + block + text[end + len(end_marker) :]
         return updated, updated != text
-    updated = text.rstrip() + ('\n\n' if text.strip() else '') + block
+    updated = text.rstrip() + ("\n\n" if text.strip() else "") + block
     return updated, updated != text
 
 
 def _ensure_day11_section_header(text: str) -> tuple[str, bool]:
     if _DAY11_SECTION_HEADER in text:
         return text, False
-    updated = text.rstrip() + '\n\n' + _DAY11_SECTION_HEADER + '\n'
+    updated = text.rstrip() + "\n\n" + _DAY11_SECTION_HEADER + "\n"
     return updated, updated != text
 
 
 def _ensure_journey_block(text: str) -> tuple[str, bool]:
-    if _DAY11_JOURNEYS_HEADER in text and all(f'- {journey}' in text for journey in _TOP_JOURNEYS):
+    if _DAY11_JOURNEYS_HEADER in text and all(f"- {journey}" in text for journey in _TOP_JOURNEYS):
         return text, False
 
-    updated = text.rstrip() + '\n\n' + _DAY11_JOURNEYS_BLOCK + '\n'
+    updated = text.rstrip() + "\n\n" + _DAY11_JOURNEYS_BLOCK + "\n"
     return updated, updated != text
 
 
-def _check_results(index_text: str) -> list[dict[str, object]]:
+def _check_results(index_text: str) -> list[dict[str, Any]]:
     quick_jump = _extract_quick_jump(index_text)
     checks: list[tuple[str, str, str]] = [
-        ('quick-jump-wrapper', _QUICK_JUMP_START, 'quick_jump'),
-        ('day11-upgrade-section', _DAY11_SECTION_HEADER, 'index'),
-        ('day11-top-journeys-header', _DAY11_JOURNEYS_HEADER, 'index'),
+        ("quick-jump-wrapper", _QUICK_JUMP_START, "quick_jump"),
+        ("day11-upgrade-section", _DAY11_SECTION_HEADER, "index"),
+        ("day11-top-journeys-header", _DAY11_JOURNEYS_HEADER, "index"),
     ]
-    checks.extend((f'quick-jump-link:{link}', link, 'quick_jump') for link in _REQUIRED_LINKS)
-    checks.extend((f'top-journey:{journey}', f'- {journey}', 'index') for journey in _TOP_JOURNEYS)
+    checks.extend((f"quick-jump-link:{link}", link, "quick_jump") for link in _REQUIRED_LINKS)
+    checks.extend((f"top-journey:{journey}", f"- {journey}", "index") for journey in _TOP_JOURNEYS)
 
-    results: list[dict[str, object]] = []
+    results: list[dict[str, Any]] = []
     for check_id, needle, scope in checks:
-        target = quick_jump if scope == 'quick_jump' else index_text
+        target = quick_jump if scope == "quick_jump" else index_text
         results.append(
             {
-                'id': check_id,
-                'scope': scope,
-                'needle': needle,
-                'present': needle in target,
+                "id": check_id,
+                "scope": scope,
+                "needle": needle,
+                "present": needle in target,
             }
         )
     return results
 
 
 def _write_defaults(base: Path) -> list[str]:
-    path = base / 'docs/index.md'
+    path = base / "docs/index.md"
     current = _read(path)
     if not current:
-        current = '# Documentation Home\n\n'
+        current = "# Documentation Home\n\n"
 
-    updated, changed_quick_jump = _replace_or_append_block(current, _QUICK_JUMP_START, _QUICK_JUMP_END, _DAY11_QUICK_JUMP_BLOCK)
+    updated, changed_quick_jump = _replace_or_append_block(
+        current, _QUICK_JUMP_START, _QUICK_JUMP_END, _DAY11_QUICK_JUMP_BLOCK
+    )
     updated, changed_section = _ensure_day11_section_header(updated)
     updated, changed_journeys = _ensure_journey_block(updated)
 
@@ -137,94 +146,94 @@ def _write_defaults(base: Path) -> list[str]:
         return []
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(updated, encoding='utf-8')
-    return ['docs/index.md']
+    path.write_text(updated, encoding="utf-8")
+    return ["docs/index.md"]
 
 
-def build_docs_navigation_status(root: str = '.') -> dict[str, object]:
+def build_docs_navigation_status(root: str = ".") -> dict[str, Any]:
     base = Path(root)
-    docs_index = base / 'docs/index.md'
+    docs_index = base / "docs/index.md"
     index_text = _read(docs_index)
     checks = _check_results(index_text)
-    missing = [str(check['needle']) for check in checks if not check['present']]
+    missing = [str(check["needle"]) for check in checks if not check["present"]]
 
     total_checks = len(checks)
-    passed_checks = sum(1 for check in checks if check['present'])
+    passed_checks = sum(1 for check in checks if check["present"])
     score = round((passed_checks / total_checks) * 100, 1) if total_checks else 0.0
 
     return {
-        'name': 'day11-docs-navigation',
-        'score': score,
-        'total_checks': total_checks,
-        'passed_checks': passed_checks,
-        'journeys': list(_TOP_JOURNEYS),
-        'required_links': list(_REQUIRED_LINKS),
-        'docs_index': str(docs_index),
-        'missing': missing,
-        'checks': checks,
-        'actions': {
-            'open_docs_home': 'docs/index.md',
-            'validate': 'sdetkit docs-nav --format json --strict',
-            'write_defaults': 'sdetkit docs-nav --write-defaults --format json --strict',
-            'artifact': 'sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md',
+        "name": "day11-docs-navigation",
+        "score": score,
+        "total_checks": total_checks,
+        "passed_checks": passed_checks,
+        "journeys": list(_TOP_JOURNEYS),
+        "required_links": list(_REQUIRED_LINKS),
+        "docs_index": str(docs_index),
+        "missing": missing,
+        "checks": checks,
+        "actions": {
+            "open_docs_home": "docs/index.md",
+            "validate": "sdetkit docs-nav --format json --strict",
+            "write_defaults": "sdetkit docs-nav --write-defaults --format json --strict",
+            "artifact": "sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md",
         },
     }
 
 
-def _render_text(payload: dict[str, object]) -> str:
+def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        'Day 11 docs navigation tune-up',
+        "Day 11 docs navigation tune-up",
         f"score: {payload['score']} ({payload['passed_checks']}/{payload['total_checks']})",
-        '',
-        'top journeys:',
+        "",
+        "top journeys:",
     ]
-    for idx, item in enumerate(payload['journeys'], start=1):
-        lines.append(f'{idx}. {item}')
-    lines.extend(['', 'required links:'])
-    for link in payload['required_links']:
-        lines.append(f'- {link}')
-    lines.extend(['', f"docs home: {payload['docs_index']}"])
-    if payload['missing']:
-        lines.append('missing docs navigation content:')
-        for item in payload['missing']:
-            lines.append(f'- {item}')
+    for idx, item in enumerate(payload["journeys"], start=1):
+        lines.append(f"{idx}. {item}")
+    lines.extend(["", "required links:"])
+    for link in payload["required_links"]:
+        lines.append(f"- {link}")
+    lines.extend(["", f"docs home: {payload['docs_index']}"])
+    if payload["missing"]:
+        lines.append("missing docs navigation content:")
+        for item in payload["missing"]:
+            lines.append(f"- {item}")
     else:
-        lines.append('missing docs navigation content: none')
-    lines.extend(['', 'actions:'])
+        lines.append("missing docs navigation content: none")
+    lines.extend(["", "actions:"])
     lines.append(f"- open docs home: {payload['actions']['open_docs_home']}")
     lines.append(f"- validate: {payload['actions']['validate']}")
     lines.append(f"- write defaults: {payload['actions']['write_defaults']}")
     lines.append(f"- export artifact: {payload['actions']['artifact']}")
-    return '\n'.join(lines) + '\n'
+    return "\n".join(lines) + "\n"
 
 
-def _render_markdown(payload: dict[str, object]) -> str:
+def _render_markdown(payload: dict[str, Any]) -> str:
     lines = [
-        '# Day 11 docs navigation tune-up',
-        '',
+        "# Day 11 docs navigation tune-up",
+        "",
         f"- Score: **{payload['score']}** ({payload['passed_checks']}/{payload['total_checks']})",
         f"- Docs home: `{payload['docs_index']}`",
-        '',
-        '## Top journeys',
-        '',
+        "",
+        "## Top journeys",
+        "",
     ]
-    for item in payload['journeys']:
-        lines.append(f'- [ ] {item}')
-    lines.extend(['', '## Required one-click links', ''])
-    for item in payload['required_links']:
-        lines.append(f'- `{item}`')
-    lines.extend(['', '## Missing docs navigation content', ''])
-    if payload['missing']:
-        for item in payload['missing']:
-            lines.append(f'- `{item}`')
+    for item in payload["journeys"]:
+        lines.append(f"- [ ] {item}")
+    lines.extend(["", "## Required one-click links", ""])
+    for item in payload["required_links"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Missing docs navigation content", ""])
+    if payload["missing"]:
+        for item in payload["missing"]:
+            lines.append(f"- `{item}`")
     else:
-        lines.append('- none')
-    lines.extend(['', '## Actions', ''])
+        lines.append("- none")
+    lines.extend(["", "## Actions", ""])
     lines.append(f"- `{payload['actions']['open_docs_home']}`")
     lines.append(f"- `{payload['actions']['validate']}`")
     lines.append(f"- `{payload['actions']['write_defaults']}`")
     lines.append(f"- `{payload['actions']['artifact']}`")
-    return '\n'.join(lines) + '\n'
+    return "\n".join(lines) + "\n"
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -235,11 +244,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         touched = _write_defaults(Path(args.root))
 
     payload = build_docs_navigation_status(args.root)
-    payload['touched_files'] = touched
+    payload["touched_files"] = touched
 
-    if args.format == 'json':
-        rendered = json.dumps(payload, indent=2) + '\n'
-    elif args.format == 'markdown':
+    if args.format == "json":
+        rendered = json.dumps(payload, indent=2) + "\n"
+    elif args.format == "markdown":
         rendered = _render_markdown(payload)
     else:
         rendered = _render_text(payload)
@@ -247,14 +256,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.output:
         out = Path(args.output)
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(rendered, encoding='utf-8')
+        out.write_text(rendered, encoding="utf-8")
 
-    print(rendered, end='')
+    print(rendered, end="")
 
-    if args.strict and payload['passed_checks'] != payload['total_checks']:
+    if args.strict and payload["passed_checks"] != payload["total_checks"]:
         return 1
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/first_contribution.py
+++ b/src/sdetkit/first_contribution.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 _CHECKLIST_SECTION_HEADER = "## 0) Day 10 first-contribution checklist"
 
@@ -60,7 +61,11 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--format", choices=["text", "markdown", "json"], default="text")
     p.add_argument("--root", default=".", help="Repository root where CONTRIBUTING.md lives.")
     p.add_argument("--output", default="", help="Optional output file path.")
-    p.add_argument("--strict", action="store_true", help="Return non-zero if required checklist content is missing.")
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero if required checklist content is missing.",
+    )
     p.add_argument(
         "--write-defaults",
         action="store_true",
@@ -95,7 +100,7 @@ def _write_defaults(base: Path) -> list[str]:
     return ["CONTRIBUTING.md"]
 
 
-def build_first_contribution_status(root: str = ".") -> dict[str, object]:
+def build_first_contribution_status(root: str = ".") -> dict[str, Any]:
     base = Path(root)
     guide = base / "CONTRIBUTING.md"
     guide_text = _read(guide)
@@ -123,7 +128,7 @@ def build_first_contribution_status(root: str = ".") -> dict[str, object]:
     }
 
 
-def _render_text(payload: dict[str, object]) -> str:
+def _render_text(payload: dict[str, Any]) -> str:
     lines = [
         "Day 10 first-contribution checklist",
         f"score: {payload['score']} ({payload['passed_checks']}/{payload['total_checks']})",
@@ -150,7 +155,7 @@ def _render_text(payload: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _render_markdown(payload: dict[str, object]) -> str:
+def _render_markdown(payload: dict[str, Any]) -> str:
     lines = [
         "# Day 10 first-contribution checklist",
         "",

--- a/src/sdetkit/github_actions_quickstart.py
+++ b/src/sdetkit/github_actions_quickstart.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import subprocess
 from pathlib import Path
+from typing import Any, cast
 
 _PAGE_PATH = "docs/integrations-github-actions-quickstart.md"
 
@@ -109,19 +110,19 @@ A production-ready integration recipe to run `sdetkit` quality checks in GitHub 
 ## Minimal workflow
 
 ```yaml
-{_workflow_content('minimal').rstrip()}
+{_workflow_content("minimal").rstrip()}
 ```
 
 ## Strict workflow variant
 
 ```yaml
-{_workflow_content('strict').rstrip()}
+{_workflow_content("strict").rstrip()}
 ```
 
 ## Nightly reliability variant
 
 ```yaml
-{_workflow_content('nightly').rstrip()}
+{_workflow_content("nightly").rstrip()}
 ```
 
 ## Fast verification commands
@@ -166,13 +167,41 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--format", choices=["text", "markdown", "json"], default="text")
     parser.add_argument("--root", default=".", help="Repository root where docs live.")
     parser.add_argument("--output", default="", help="Optional output file path.")
-    parser.add_argument("--strict", action="store_true", help="Return non-zero when required quickstart content is missing.")
-    parser.add_argument("--write-defaults", action="store_true", help="Write or repair the Day 15 quickstart page before validation.")
-    parser.add_argument("--emit-pack-dir", default="", help="Optional path to emit a Day 15 quickstart pack.")
-    parser.add_argument("--variant", choices=["minimal", "strict", "nightly"], default="minimal", help="Workflow variant for markdown/text snippets.")
-    parser.add_argument("--execute", action="store_true", help="Run Day 15 command sequence and capture pass/fail details.")
-    parser.add_argument("--evidence-dir", default="", help="Optional output directory for execution summary JSON and command logs.")
-    parser.add_argument("--timeout-sec", type=int, default=300, help="Per-command timeout in seconds for --execute mode.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero when required quickstart content is missing.",
+    )
+    parser.add_argument(
+        "--write-defaults",
+        action="store_true",
+        help="Write or repair the Day 15 quickstart page before validation.",
+    )
+    parser.add_argument(
+        "--emit-pack-dir", default="", help="Optional path to emit a Day 15 quickstart pack."
+    )
+    parser.add_argument(
+        "--variant",
+        choices=["minimal", "strict", "nightly"],
+        default="minimal",
+        help="Workflow variant for markdown/text snippets.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Run Day 15 command sequence and capture pass/fail details.",
+    )
+    parser.add_argument(
+        "--evidence-dir",
+        default="",
+        help="Optional output directory for execution summary JSON and command logs.",
+    )
+    parser.add_argument(
+        "--timeout-sec",
+        type=int,
+        default=300,
+        help="Per-command timeout in seconds for --execute mode.",
+    )
     return parser
 
 
@@ -181,7 +210,14 @@ def _read(path: Path) -> str:
 
 
 def _missing_checks(page_text: str) -> list[str]:
-    checks = [_SECTION_HEADER, *_REQUIRED_SECTIONS, *_REQUIRED_COMMANDS, "name: sdetkit-github-quickstart", "name: sdetkit-github-strict", "name: sdetkit-github-nightly"]
+    checks = [
+        _SECTION_HEADER,
+        *_REQUIRED_SECTIONS,
+        *_REQUIRED_COMMANDS,
+        "name: sdetkit-github-quickstart",
+        "name: sdetkit-github-strict",
+        "name: sdetkit-github-nightly",
+    ]
     return [item for item in checks if item not in page_text]
 
 
@@ -245,21 +281,36 @@ def _emit_pack(base: Path, out_dir: str) -> list[str]:
 
     validation = root / "day15-validation-commands.md"
     validation.write_text(
-        "\n".join(["# Day 15 validation commands", "", "```bash", *_REQUIRED_COMMANDS, "```", ""]) + "\n",
+        "\n".join(["# Day 15 validation commands", "", "```bash", *_REQUIRED_COMMANDS, "```", ""])
+        + "\n",
         encoding="utf-8",
     )
 
     return [
         str(path.relative_to(base))
-        for path in (checklist, minimal_workflow, strict_workflow, nightly_workflow, distribution_plan, validation)
+        for path in (
+            checklist,
+            minimal_workflow,
+            strict_workflow,
+            nightly_workflow,
+            distribution_plan,
+            validation,
+        )
     ]
 
 
-def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, object]]:
-    results: list[dict[str, object]] = []
+def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
     for idx, command in enumerate(commands, start=1):
         try:
-            proc = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout_sec, check=False)
+            proc = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+                check=False,
+            )
             results.append(
                 {
                     "index": idx,
@@ -285,7 +336,7 @@ def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, o
     return results
 
 
-def _write_execution_evidence(base: Path, out_dir: str, results: list[dict[str, object]]) -> list[str]:
+def _write_execution_evidence(base: Path, out_dir: str, results: list[dict[str, Any]]) -> list[str]:
     root = base / out_dir
     root.mkdir(parents=True, exist_ok=True)
 
@@ -331,11 +382,20 @@ def main(argv: list[str] | None = None) -> int:
     text = _read(page)
 
     missing = _missing_checks(text)
-    total = len([_SECTION_HEADER, *_REQUIRED_SECTIONS, *_REQUIRED_COMMANDS, "name: sdetkit-github-quickstart", "name: sdetkit-github-strict", "name: sdetkit-github-nightly"])
+    total = len(
+        [
+            _SECTION_HEADER,
+            *_REQUIRED_SECTIONS,
+            *_REQUIRED_COMMANDS,
+            "name: sdetkit-github-quickstart",
+            "name: sdetkit-github-strict",
+            "name: sdetkit-github-nightly",
+        ]
+    )
     passed = total - len(missing)
     score = round((passed / total) * 100, 1)
 
-    payload: dict[str, object] = {
+    payload: dict[str, Any] = {
         "name": "day15-github-actions-quickstart",
         "page": _PAGE_PATH,
         "variant": args.variant,
@@ -366,7 +426,7 @@ def main(argv: list[str] | None = None) -> int:
             "results": results,
         }
         payload["execution"] = execution
-        execution_failed = execution["failed_commands"] > 0
+        execution_failed = int(cast(Any, execution["failed_commands"])) > 0
 
         evidence_dir = args.evidence_dir or "docs/artifacts/day15-github-pack/evidence"
         payload["evidence_files"] = _write_execution_evidence(base, evidence_dir, results)

--- a/src/sdetkit/onboarding.py
+++ b/src/sdetkit/onboarding.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 _ROLE_PLAYBOOK = {
     "sdet": {
@@ -91,13 +92,14 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _platform_payload(platform: str) -> dict[str, dict[str, object]]:
+def _platform_payload(platform: str) -> dict[str, dict[str, Any]]:
     if platform == "all":
         return {name: details for name, details in _PLATFORM_SETUP.items()}
     return {platform: _PLATFORM_SETUP[platform]}
 
 
 def _as_json(role: str, platform: str) -> str:
+    payload: dict[str, Any]
     if role == "all":
         payload = {name: details for name, details in _ROLE_PLAYBOOK.items()}
     else:

--- a/src/sdetkit/release_readiness_board.py
+++ b/src/sdetkit/release_readiness_board.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import subprocess
 from pathlib import Path
+from typing import Any
 
 _PAGE_PATH = "docs/integrations-release-readiness-board.md"
 
@@ -74,20 +75,20 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def _load_json(path: Path) -> dict[str, object]:
+def _load_json(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"{path} must contain a JSON object")
     return payload
 
 
-def _require_keys(payload: dict[str, object], keys: tuple[str, ...], label: str) -> None:
+def _require_keys(payload: dict[str, Any], keys: tuple[str, ...], label: str) -> None:
     for key in keys:
         if key not in payload:
             raise ValueError(f"{label} missing required key: {key}")
 
 
-def _normalize_day14_summary(day14_summary: dict[str, object]) -> tuple[float, str]:
+def _normalize_day14_summary(day14_summary: dict[str, Any]) -> tuple[float, str]:
     summary = day14_summary.get("summary")
     if isinstance(summary, dict):
         return float(summary.get("score", 0.0)), str(summary.get("status", "unknown"))
@@ -97,13 +98,15 @@ def _normalize_day14_summary(day14_summary: dict[str, object]) -> tuple[float, s
         score = float(kpis.get("completion_rate_percent", 0.0))
         return score, "pass" if score >= 90 else "warn"
 
-    raise ValueError("day14 summary must include either summary.score or kpis.completion_rate_percent")
+    raise ValueError(
+        "day14 summary must include either summary.score or kpis.completion_rate_percent"
+    )
 
 
 def build_release_board(
-    day18_summary: dict[str, object],
-    day14_summary: dict[str, object],
-) -> dict[str, object]:
+    day18_summary: dict[str, Any],
+    day14_summary: dict[str, Any],
+) -> dict[str, Any]:
     _require_keys(day18_summary, _REQUIRED_DAY18_KEYS, "day18 summary")
     if not isinstance(day18_summary["summary"], dict):
         raise ValueError("day18 summary.summary must be an object")
@@ -153,7 +156,7 @@ def build_release_board(
     }
 
 
-def _render_text(payload: dict[str, object]) -> str:
+def _render_text(payload: dict[str, Any]) -> str:
     lines = [
         "Day 19 release readiness board",
         "",
@@ -167,7 +170,7 @@ def _render_text(payload: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _render_markdown(payload: dict[str, object]) -> str:
+def _render_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(
         [
             "# Day 19 release readiness board",
@@ -183,7 +186,7 @@ def _render_markdown(payload: dict[str, object]) -> str:
     )
 
 
-def _emit_pack(path: str, payload: dict[str, object], root: Path) -> list[str]:
+def _emit_pack(path: str, payload: dict[str, Any], root: Path) -> list[str]:
     out_dir = root / path
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -238,8 +241,8 @@ def _emit_pack(path: str, payload: dict[str, object], root: Path) -> list[str]:
     ]
 
 
-def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, object]]:
-    rows: list[dict[str, object]] = []
+def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     for idx, command in enumerate(commands, start=1):
         try:
             proc = subprocess.run(
@@ -278,7 +281,7 @@ def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, o
 def _write_execution_evidence(
     root: Path,
     evidence_dir: str,
-    rows: list[dict[str, object]],
+    rows: list[dict[str, Any]],
 ) -> list[str]:
     out = root / evidence_dir
     out.mkdir(parents=True, exist_ok=True)
@@ -355,9 +358,7 @@ def main(argv: list[str] | None = None) -> int:
 
     page_text = _read(root / _PAGE_PATH)
     missing_sections = [
-        section
-        for section in [_SECTION_HEADER, *_REQUIRED_SECTIONS]
-        if section not in page_text
+        section for section in [_SECTION_HEADER, *_REQUIRED_SECTIONS] if section not in page_text
     ]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
 

--- a/src/sdetkit/startup_use_case.py
+++ b/src/sdetkit/startup_use_case.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 _PAGE_PATH = "docs/use-cases-startup-small-team.md"
 
@@ -113,7 +114,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--format", choices=["text", "markdown", "json"], default="text")
     parser.add_argument("--root", default=".", help="Repository root where docs live.")
     parser.add_argument("--output", default="", help="Optional output file path.")
-    parser.add_argument("--strict", action="store_true", help="Return non-zero when required use-case content is missing.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero when required use-case content is missing.",
+    )
     parser.add_argument(
         "--write-defaults",
         action="store_true",
@@ -134,7 +139,12 @@ def _read(path: Path) -> str:
 
 
 def _missing_checks(page_text: str) -> list[str]:
-    checks = [_SECTION_HEADER, *_REQUIRED_SECTIONS, *_REQUIRED_COMMANDS, "name: startup-quality-fast-lane"]
+    checks = [
+        _SECTION_HEADER,
+        *_REQUIRED_SECTIONS,
+        *_REQUIRED_COMMANDS,
+        "name: startup-quality-fast-lane",
+    ]
     return [item for item in checks if item not in page_text]
 
 
@@ -193,13 +203,20 @@ def _emit_pack(base: Path, out_dir: str) -> list[str]:
     return [str(path.relative_to(base)) for path in [checklist, ci_recipe, risk_register]]
 
 
-def build_startup_use_case_status(root: str = ".") -> dict[str, object]:
+def build_startup_use_case_status(root: str = ".") -> dict[str, Any]:
     base = Path(root)
     page = base / _PAGE_PATH
     page_text = _read(page)
     missing = _missing_checks(page_text)
 
-    total_checks = len([_SECTION_HEADER, *_REQUIRED_SECTIONS, *_REQUIRED_COMMANDS, "name: startup-quality-fast-lane"])
+    total_checks = len(
+        [
+            _SECTION_HEADER,
+            *_REQUIRED_SECTIONS,
+            *_REQUIRED_COMMANDS,
+            "name: startup-quality-fast-lane",
+        ]
+    )
     passed_checks = total_checks - len(missing)
     score = round((passed_checks / total_checks) * 100, 1) if total_checks else 0.0
 
@@ -222,7 +239,7 @@ def build_startup_use_case_status(root: str = ".") -> dict[str, object]:
     }
 
 
-def _render_text(payload: dict[str, object]) -> str:
+def _render_text(payload: dict[str, Any]) -> str:
     lines = [
         "Day 12 startup use-case page",
         f"score: {payload['score']} ({payload['passed_checks']}/{payload['total_checks']})",
@@ -250,7 +267,7 @@ def _render_text(payload: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _render_markdown(payload: dict[str, object]) -> str:
+def _render_markdown(payload: dict[str, Any]) -> str:
     lines = [
         "# Day 12 startup use-case page",
         "",

--- a/src/sdetkit/triage_templates.py
+++ b/src/sdetkit/triage_templates.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 _TEMPLATE_PATHS = {
     "bug": Path(".github/ISSUE_TEMPLATE/bug_report.yml"),
@@ -246,7 +247,7 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _template_result(name: str, path: Path, missing: list[str], total: int) -> dict[str, object]:
+def _template_result(name: str, path: Path, missing: list[str], total: int) -> dict[str, Any]:
     passed = total - len(missing)
     return {
         "name": name,
@@ -257,7 +258,7 @@ def _template_result(name: str, path: Path, missing: list[str], total: int) -> d
     }
 
 
-def build_template_health(root: str = ".") -> dict[str, object]:
+def build_template_health(root: str = ".") -> dict[str, Any]:
     base = Path(root)
 
     bug_text = _read(base / _TEMPLATE_PATHS["bug"])
@@ -276,9 +277,13 @@ def build_template_health(root: str = ".") -> dict[str, object]:
 
     templates = [
         _template_result("bug", _TEMPLATE_PATHS["bug"], bug_missing, len(_BUG_REQUIRED_IDS)),
-        _template_result("feature", _TEMPLATE_PATHS["feature"], feature_missing, len(_FEATURE_REQUIRED_IDS)),
+        _template_result(
+            "feature", _TEMPLATE_PATHS["feature"], feature_missing, len(_FEATURE_REQUIRED_IDS)
+        ),
         _template_result("pr", _TEMPLATE_PATHS["pr"], pr_missing, len(_PR_REQUIRED_HEADINGS)),
-        _template_result("config", _TEMPLATE_PATHS["config"], cfg_missing, len(_CONFIG_REQUIRED_TOKENS)),
+        _template_result(
+            "config", _TEMPLATE_PATHS["config"], cfg_missing, len(_CONFIG_REQUIRED_TOKENS)
+        ),
     ]
 
     total_checks = sum(int(item["coverage"].split("/")[1]) for item in templates)
@@ -320,7 +325,7 @@ def write_default_templates(root: str = ".") -> list[str]:
     return touched
 
 
-def _render_text(payload: dict[str, object]) -> str:
+def _render_text(payload: dict[str, Any]) -> str:
     lines = [
         "Day 9 contribution templates health",
         f"score: {payload['score']} ({payload['passed_checks']}/{payload['total_checks']})",
@@ -349,7 +354,7 @@ def _render_text(payload: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
-def _render_markdown(payload: dict[str, object]) -> str:
+def _render_markdown(payload: dict[str, Any]) -> str:
     lines = [
         "# Day 9 contribution templates health",
         "",
@@ -391,7 +396,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--format", choices=["text", "markdown", "json"], default="text")
     p.add_argument("--root", default=".", help="Repository root to inspect.")
     p.add_argument("--output", default="", help="Optional output file path.")
-    p.add_argument("--strict", action="store_true", help="Return non-zero if any requirement is missing.")
+    p.add_argument(
+        "--strict", action="store_true", help="Return non-zero if any requirement is missing."
+    )
     p.add_argument(
         "--write-defaults",
         action="store_true",

--- a/src/sdetkit/weekly_review.py
+++ b/src/sdetkit/weekly_review.py
@@ -16,30 +16,138 @@ class DayShipped:
 
 
 DAY1_TO_6: tuple[DayShipped, ...] = (
-    DayShipped(1, "Core positioning + role onboarding", "docs/day-1-ultra-upgrade-report.md", "docs/artifacts/day1-onboarding-sample.md", "python -m sdetkit onboarding --format text"),
-    DayShipped(2, "60-second demo workflow", "docs/day-2-ultra-upgrade-report.md", "docs/artifacts/day2-demo-sample.md", "python -m sdetkit demo --execute --format text"),
-    DayShipped(3, "Proof pack with runnable checks", "docs/day-3-ultra-upgrade-report.md", "docs/artifacts/day3-proof-sample.md", "python -m sdetkit proof --execute --strict --format text"),
-    DayShipped(4, "Template/skill expansion run-all", "docs/day-4-ultra-upgrade-report.md", "docs/artifacts/day4-skills-sample.md", "python -m sdetkit agent templates run-all --output-dir .sdetkit/agent/template-runs"),
-    DayShipped(5, "Cross-platform onboarding snippets", "docs/day-5-ultra-upgrade-report.md", "docs/artifacts/day5-platform-onboarding-sample.md", "python -m sdetkit onboarding --format text --platform all"),
-    DayShipped(6, "Docs conversion QA gate", "docs/day-6-ultra-upgrade-report.md", "docs/artifacts/day6-conversion-qa-sample.md", "python -m sdetkit docs-qa --format text"),
+    DayShipped(
+        1,
+        "Core positioning + role onboarding",
+        "docs/day-1-ultra-upgrade-report.md",
+        "docs/artifacts/day1-onboarding-sample.md",
+        "python -m sdetkit onboarding --format text",
+    ),
+    DayShipped(
+        2,
+        "60-second demo workflow",
+        "docs/day-2-ultra-upgrade-report.md",
+        "docs/artifacts/day2-demo-sample.md",
+        "python -m sdetkit demo --execute --format text",
+    ),
+    DayShipped(
+        3,
+        "Proof pack with runnable checks",
+        "docs/day-3-ultra-upgrade-report.md",
+        "docs/artifacts/day3-proof-sample.md",
+        "python -m sdetkit proof --execute --strict --format text",
+    ),
+    DayShipped(
+        4,
+        "Template/skill expansion run-all",
+        "docs/day-4-ultra-upgrade-report.md",
+        "docs/artifacts/day4-skills-sample.md",
+        "python -m sdetkit agent templates run-all --output-dir .sdetkit/agent/template-runs",
+    ),
+    DayShipped(
+        5,
+        "Cross-platform onboarding snippets",
+        "docs/day-5-ultra-upgrade-report.md",
+        "docs/artifacts/day5-platform-onboarding-sample.md",
+        "python -m sdetkit onboarding --format text --platform all",
+    ),
+    DayShipped(
+        6,
+        "Docs conversion QA gate",
+        "docs/day-6-ultra-upgrade-report.md",
+        "docs/artifacts/day6-conversion-qa-sample.md",
+        "python -m sdetkit docs-qa --format text",
+    ),
 )
 
 DAY8_TO_13: tuple[DayShipped, ...] = (
-    DayShipped(8, "Good-first-issue accelerator pack", "docs/day-8-ultra-upgrade-report.md", "docs/artifacts/day8-good-first-issues-sample.md", "python -m sdetkit contributor-funnel --format markdown --output docs/artifacts/day8-good-first-issues-sample.md --strict"),
-    DayShipped(9, "Triage-ready issue + PR templates", "docs/day-9-ultra-upgrade-report.md", "docs/artifacts/day9-triage-templates-sample.md", "python -m sdetkit triage-templates --format markdown --output docs/artifacts/day9-triage-templates-sample.md --strict"),
-    DayShipped(10, "First-contribution checklist", "docs/day-10-ultra-upgrade-report.md", "docs/artifacts/day10-first-contribution-checklist-sample.md", "python -m sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md --strict"),
-    DayShipped(11, "Docs navigation tune-up", "docs/day-11-ultra-upgrade-report.md", "docs/artifacts/day11-docs-navigation-sample.md", "python -m sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md --strict"),
-    DayShipped(12, "Startup/small-team workflow", "docs/day-12-ultra-upgrade-report.md", "docs/artifacts/day12-startup-use-case-sample.md", "python -m sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md --strict"),
-    DayShipped(13, "Enterprise/regulated workflow", "docs/day-13-ultra-upgrade-report.md", "docs/artifacts/day13-enterprise-use-case-sample.md", "python -m sdetkit enterprise-use-case --format markdown --output docs/artifacts/day13-enterprise-use-case-sample.md --strict"),
+    DayShipped(
+        8,
+        "Good-first-issue accelerator pack",
+        "docs/day-8-ultra-upgrade-report.md",
+        "docs/artifacts/day8-good-first-issues-sample.md",
+        "python -m sdetkit contributor-funnel --format markdown --output docs/artifacts/day8-good-first-issues-sample.md --strict",
+    ),
+    DayShipped(
+        9,
+        "Triage-ready issue + PR templates",
+        "docs/day-9-ultra-upgrade-report.md",
+        "docs/artifacts/day9-triage-templates-sample.md",
+        "python -m sdetkit triage-templates --format markdown --output docs/artifacts/day9-triage-templates-sample.md --strict",
+    ),
+    DayShipped(
+        10,
+        "First-contribution checklist",
+        "docs/day-10-ultra-upgrade-report.md",
+        "docs/artifacts/day10-first-contribution-checklist-sample.md",
+        "python -m sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md --strict",
+    ),
+    DayShipped(
+        11,
+        "Docs navigation tune-up",
+        "docs/day-11-ultra-upgrade-report.md",
+        "docs/artifacts/day11-docs-navigation-sample.md",
+        "python -m sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md --strict",
+    ),
+    DayShipped(
+        12,
+        "Startup/small-team workflow",
+        "docs/day-12-ultra-upgrade-report.md",
+        "docs/artifacts/day12-startup-use-case-sample.md",
+        "python -m sdetkit startup-use-case --format markdown --output docs/artifacts/day12-startup-use-case-sample.md --strict",
+    ),
+    DayShipped(
+        13,
+        "Enterprise/regulated workflow",
+        "docs/day-13-ultra-upgrade-report.md",
+        "docs/artifacts/day13-enterprise-use-case-sample.md",
+        "python -m sdetkit enterprise-use-case --format markdown --output docs/artifacts/day13-enterprise-use-case-sample.md --strict",
+    ),
 )
 
 DAY15_TO_20: tuple[DayShipped, ...] = (
-    DayShipped(15, "GitHub Actions integration quickstart", "docs/day-15-ultra-upgrade-report.md", "docs/artifacts/day15-github-actions-quickstart-sample.md", "python -m sdetkit github-actions-quickstart --format json --strict"),
-    DayShipped(16, "GitLab CI integration quickstart", "docs/day-16-ultra-upgrade-report.md", "docs/artifacts/day16-gitlab-ci-quickstart-sample.md", "python -m sdetkit gitlab-ci-quickstart --format json --strict"),
-    DayShipped(17, "Quality + contribution delta evidence", "docs/day-17-ultra-upgrade-report.md", "docs/artifacts/day17-quality-contribution-delta-sample.md", "python -m sdetkit quality-contribution-delta --current-signals-file docs/artifacts/day17-growth-signals.json --previous-signals-file docs/artifacts/day14-growth-signals.json --format json --strict"),
-    DayShipped(18, "Reliability evidence operating pack", "docs/day-18-ultra-upgrade-report.md", "docs/artifacts/day18-reliability-evidence-pack-sample.md", "python -m sdetkit reliability-evidence-pack --format json --strict"),
-    DayShipped(19, "Release readiness board", "docs/day-19-ultra-upgrade-report.md", "docs/artifacts/day19-release-readiness-board-sample.md", "python -m sdetkit release-readiness-board --format json --strict"),
-    DayShipped(20, "Release narrative storytelling pack", "docs/day-20-ultra-upgrade-report.md", "docs/artifacts/day20-release-narrative-sample.md", "python -m sdetkit weekly-review --week 3 --format markdown --signals-file docs/artifacts/day21-growth-signals.json --previous-signals-file docs/artifacts/day14-growth-signals.json --output docs/artifacts/day21-weekly-review-sample.md"),
+    DayShipped(
+        15,
+        "GitHub Actions integration quickstart",
+        "docs/day-15-ultra-upgrade-report.md",
+        "docs/artifacts/day15-github-actions-quickstart-sample.md",
+        "python -m sdetkit github-actions-quickstart --format json --strict",
+    ),
+    DayShipped(
+        16,
+        "GitLab CI integration quickstart",
+        "docs/day-16-ultra-upgrade-report.md",
+        "docs/artifacts/day16-gitlab-ci-quickstart-sample.md",
+        "python -m sdetkit gitlab-ci-quickstart --format json --strict",
+    ),
+    DayShipped(
+        17,
+        "Quality + contribution delta evidence",
+        "docs/day-17-ultra-upgrade-report.md",
+        "docs/artifacts/day17-quality-contribution-delta-sample.md",
+        "python -m sdetkit quality-contribution-delta --current-signals-file docs/artifacts/day17-growth-signals.json --previous-signals-file docs/artifacts/day14-growth-signals.json --format json --strict",
+    ),
+    DayShipped(
+        18,
+        "Reliability evidence operating pack",
+        "docs/day-18-ultra-upgrade-report.md",
+        "docs/artifacts/day18-reliability-evidence-pack-sample.md",
+        "python -m sdetkit reliability-evidence-pack --format json --strict",
+    ),
+    DayShipped(
+        19,
+        "Release readiness board",
+        "docs/day-19-ultra-upgrade-report.md",
+        "docs/artifacts/day19-release-readiness-board-sample.md",
+        "python -m sdetkit release-readiness-board --format json --strict",
+    ),
+    DayShipped(
+        20,
+        "Release narrative storytelling pack",
+        "docs/day-20-ultra-upgrade-report.md",
+        "docs/artifacts/day20-release-narrative-sample.md",
+        "python -m sdetkit weekly-review --week 3 --format markdown --signals-file docs/artifacts/day21-growth-signals.json --previous-signals-file docs/artifacts/day14-growth-signals.json --output docs/artifacts/day21-weekly-review-sample.md",
+    ),
 )
 
 _GROWTH_KEYS = ("traffic", "stars", "discussions", "blocker_fixes")
@@ -146,7 +254,9 @@ def build_weekly_review(
 
 def _render_text(review: WeeklyReview) -> str:
     review_day = 21 if review.week == 3 else 14 if review.week == 2 else 7
-    shipped_window = "Day 15-20" if review.week == 3 else "Day 8-13" if review.week == 2 else "Day 1-6"
+    shipped_window = (
+        "Day 15-20" if review.week == 3 else "Day 8-13" if review.week == 2 else "Day 1-6"
+    )
     lines = [
         f"Day {review_day} weekly review #{review.week}",
         "",
@@ -198,7 +308,9 @@ def _render_text(review: WeeklyReview) -> str:
 
 def _render_markdown(review: WeeklyReview) -> str:
     review_day = 21 if review.week == 3 else 14 if review.week == 2 else 7
-    shipped_window = "Day 15-20" if review.week == 3 else "Day 8-13" if review.week == 2 else "Day 1-6"
+    shipped_window = (
+        "Day 15-20" if review.week == 3 else "Day 8-13" if review.week == 2 else "Day 1-6"
+    )
     lines = [
         f"# Day {review_day} Weekly Review #{review.week}",
         "",
@@ -371,7 +483,9 @@ def _emit_week3_pack(base: Path, out_dir: str, review: WeeklyReview) -> list[str
     )
 
     traffic_delta = f"{review.growth_deltas['traffic']:+d}" if review.growth_deltas else "n/a"
-    discussions_delta_fmt = f"{review.growth_deltas['discussions']:+d}" if review.growth_deltas else "n/a"
+    discussions_delta_fmt = (
+        f"{review.growth_deltas['discussions']:+d}" if review.growth_deltas else "n/a"
+    )
 
     narrative_brief = root / "day21-release-narrative-brief.md"
     narrative_brief.write_text(
@@ -400,7 +514,10 @@ def _emit_week3_pack(base: Path, out_dir: str, review: WeeklyReview) -> list[str
         encoding="utf-8",
     )
 
-    return [str(path.relative_to(base)) for path in (checklist, scorecard, contributor_plan, narrative_brief)]
+    return [
+        str(path.relative_to(base))
+        for path in (checklist, scorecard, contributor_plan, narrative_brief)
+    ]
 
 
 def _emit_pack(base: Path, out_dir: str, review: WeeklyReview) -> list[str]:
@@ -412,13 +529,37 @@ def _emit_pack(base: Path, out_dir: str, review: WeeklyReview) -> list[str]:
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="sdetkit weekly-review", description="Generate day-based weekly review summaries.")
+    p = argparse.ArgumentParser(
+        prog="sdetkit weekly-review", description="Generate day-based weekly review summaries."
+    )
     p.add_argument("--root", default=".", help="Repository root path.")
-    p.add_argument("--week", type=int, choices=[1, 2, 3], default=1, help="Weekly review window (1=Day 1-6, 2=Day 8-13, 3=Day 15-20).")
-    p.add_argument("--signals-file", default="", help="Optional JSON file with week growth signals: traffic, stars, discussions, blocker_fixes.")
-    p.add_argument("--previous-signals-file", default="", help="Optional previous-week JSON signal file to compute week-over-week deltas.")
-    p.add_argument("--emit-pack-dir", default="", help="Optional output directory to emit week closeout pack files (week 2 and week 3).")
-    p.add_argument("--strict", action="store_true", help="Return non-zero if shipped coverage is incomplete (or growth signals are missing for week 2/3).")
+    p.add_argument(
+        "--week",
+        type=int,
+        choices=[1, 2, 3],
+        default=1,
+        help="Weekly review window (1=Day 1-6, 2=Day 8-13, 3=Day 15-20).",
+    )
+    p.add_argument(
+        "--signals-file",
+        default="",
+        help="Optional JSON file with week growth signals: traffic, stars, discussions, blocker_fixes.",
+    )
+    p.add_argument(
+        "--previous-signals-file",
+        default="",
+        help="Optional previous-week JSON signal file to compute week-over-week deltas.",
+    )
+    p.add_argument(
+        "--emit-pack-dir",
+        default="",
+        help="Optional output directory to emit week closeout pack files (week 2 and week 3).",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero if shipped coverage is incomplete (or growth signals are missing for week 2/3).",
+    )
     p.add_argument("--format", choices=["text", "json", "markdown"], default="text")
     p.add_argument("--output", default=None, help="Optional output path for the report.")
     return p
@@ -428,7 +569,9 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
 
     signals = _load_signals(args.signals_file) if args.signals_file else None
-    previous_signals = _load_signals(args.previous_signals_file) if args.previous_signals_file else None
+    previous_signals = (
+        _load_signals(args.previous_signals_file) if args.previous_signals_file else None
+    )
 
     review = build_weekly_review(
         Path(args.root).resolve(),

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -4,7 +4,9 @@ import subprocess
 import sys
 
 
-def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_weekly_review_first_contribution_contributor_funnel_triage_templates_and_docs_nav_and_startup_and_enterprise_and_github_actions_quickstart_use_case() -> None:
+def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_weekly_review_first_contribution_contributor_funnel_triage_templates_and_docs_nav_and_startup_and_enterprise_and_github_actions_quickstart_use_case() -> (
+    None
+):
     r = subprocess.run(
         [sys.executable, "-m", "sdetkit", "--help"],
         text=True,

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -76,7 +76,12 @@ top findings:
 
 def test_demo_execute_sla_can_fail(monkeypatch, capsys):
     def fake_run(_command: str, _timeout: float):
-        return 0, "doctor score:\nrecommendations:\nRepo audit:\nResult:\nsecurity scan:\ntop findings:\n", "", 30.0
+        return (
+            0,
+            "doctor score:\nrecommendations:\nRepo audit:\nResult:\nsecurity scan:\ntop findings:\n",
+            "",
+            30.0,
+        )
 
     monkeypatch.setattr(demo, "_run_command", fake_run)
     rc = demo.main(["--execute", "--target-seconds", "60", "--format", "json"])

--- a/tests/test_docs_navigation.py
+++ b/tests/test_docs_navigation.py
@@ -33,10 +33,12 @@ def test_docs_navigation_strict_fails_when_content_missing(tmp_path, capsys):
 def test_docs_navigation_write_defaults_recovers_missing_quick_jump(tmp_path, capsys):
     (tmp_path / "docs").mkdir(parents=True)
     (tmp_path / "docs/index.md").write_text(
-        "## Day 11 ultra upgrades (docs navigation tune-up)\n\n<div class=\"quick-jump\" markdown>\nold\n</div>\n",
+        '## Day 11 ultra upgrades (docs navigation tune-up)\n\n<div class="quick-jump" markdown>\nold\n</div>\n',
         encoding="utf-8",
     )
-    rc = docs_navigation.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    rc = docs_navigation.main(
+        ["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"]
+    )
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     assert data["touched_files"] == ["docs/index.md"]
@@ -47,7 +49,9 @@ def test_docs_navigation_write_defaults_recovers_missing_quick_jump(tmp_path, ca
 
 
 def test_docs_navigation_write_defaults_bootstraps_missing_docs_index(tmp_path, capsys):
-    rc = docs_navigation.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    rc = docs_navigation.main(
+        ["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"]
+    )
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     assert data["touched_files"] == ["docs/index.md"]

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -6,43 +6,43 @@ from sdetkit import docs_qa
 
 
 def test_docs_qa_passes_repo_docs() -> None:
-    report = docs_qa.run_docs_qa(Path('.').resolve())
+    report = docs_qa.run_docs_qa(Path(".").resolve())
     assert report.files_checked >= 2
     assert report.links_checked >= 10
     assert report.ok
 
 
 def test_docs_qa_detects_missing_anchor(tmp_path: Path) -> None:
-    (tmp_path / 'README.md').write_text('# Title\n\n[bad](#missing)\n', encoding='utf-8')
-    (tmp_path / 'docs').mkdir()
+    (tmp_path / "README.md").write_text("# Title\n\n[bad](#missing)\n", encoding="utf-8")
+    (tmp_path / "docs").mkdir()
     report = docs_qa.run_docs_qa(tmp_path)
     assert not report.ok
-    assert any('missing local anchor' in issue.message for issue in report.issues)
+    assert any("missing local anchor" in issue.message for issue in report.issues)
 
 
 def test_docs_qa_handles_reference_links_and_duplicate_headings(tmp_path: Path) -> None:
-    (tmp_path / 'README.md').write_text(
-        '# Intro\n\n'
-        '## Section\n\n'
-        '## Section\n\n'
-        '[ok-ref][guide]\n\n'
-        '[guide]: docs/guide.md#section-1\n',
-        encoding='utf-8',
+    (tmp_path / "README.md").write_text(
+        "# Intro\n\n"
+        "## Section\n\n"
+        "## Section\n\n"
+        "[ok-ref][guide]\n\n"
+        "[guide]: docs/guide.md#section-1\n",
+        encoding="utf-8",
     )
-    docs = tmp_path / 'docs'
+    docs = tmp_path / "docs"
     docs.mkdir()
-    (docs / 'guide.md').write_text('# Guide\n\n## Section\n\n## Section\n', encoding='utf-8')
+    (docs / "guide.md").write_text("# Guide\n\n## Section\n\n## Section\n", encoding="utf-8")
 
     report = docs_qa.run_docs_qa(tmp_path)
     assert report.ok
 
 
 def test_docs_qa_ignores_links_inside_fenced_code_blocks(tmp_path: Path) -> None:
-    (tmp_path / 'README.md').write_text(
-        '# Intro\n\n```bash\n[broken](docs/missing.md)\n```\n',
-        encoding='utf-8',
+    (tmp_path / "README.md").write_text(
+        "# Intro\n\n```bash\n[broken](docs/missing.md)\n```\n",
+        encoding="utf-8",
     )
-    (tmp_path / 'docs').mkdir()
+    (tmp_path / "docs").mkdir()
 
     report = docs_qa.run_docs_qa(tmp_path)
     assert report.ok

--- a/tests/test_enterprise_use_case.py
+++ b/tests/test_enterprise_use_case.py
@@ -22,7 +22,9 @@ def test_enterprise_use_case_json_and_strict_success(capsys):
 
 def test_enterprise_use_case_strict_fails_when_content_missing(tmp_path, capsys):
     (tmp_path / "docs").mkdir(parents=True)
-    (tmp_path / "docs/use-cases-enterprise-regulated.md").write_text("# Placeholder\n", encoding="utf-8")
+    (tmp_path / "docs/use-cases-enterprise-regulated.md").write_text(
+        "# Placeholder\n", encoding="utf-8"
+    )
     rc = enterprise_use_case.main(["--root", str(tmp_path), "--strict"])
     assert rc == 1
     out = capsys.readouterr().out
@@ -30,7 +32,9 @@ def test_enterprise_use_case_strict_fails_when_content_missing(tmp_path, capsys)
 
 
 def test_enterprise_use_case_write_defaults_recovers_missing_file(tmp_path, capsys):
-    rc = enterprise_use_case.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    rc = enterprise_use_case.main(
+        ["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"]
+    )
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     assert data["passed_checks"] == data["total_checks"]
@@ -40,7 +44,9 @@ def test_enterprise_use_case_write_defaults_recovers_missing_file(tmp_path, caps
 
 def test_enterprise_use_case_emit_pack(tmp_path, capsys):
     (tmp_path / "docs").mkdir(parents=True)
-    (tmp_path / "docs/use-cases-enterprise-regulated.md").write_text("# Enterprise + regulated workflow\n", encoding="utf-8")
+    (tmp_path / "docs/use-cases-enterprise-regulated.md").write_text(
+        "# Enterprise + regulated workflow\n", encoding="utf-8"
+    )
     rc = enterprise_use_case.main(
         [
             "--root",
@@ -105,7 +111,9 @@ def test_enterprise_use_case_execute_strict_fails_on_command_error(monkeypatch, 
 
     monkeypatch.setattr(enterprise_use_case.subprocess, "run", lambda *a, **k: _Proc())
 
-    rc = enterprise_use_case.main(["--root", str(tmp_path), "--execute", "--format", "json", "--strict"])
+    rc = enterprise_use_case.main(
+        ["--root", str(tmp_path), "--execute", "--format", "json", "--strict"]
+    )
     assert rc == 1
     data = json.loads(capsys.readouterr().out)
     assert data["execution"]["failed_commands"] == 5

--- a/tests/test_first_contribution.py
+++ b/tests/test_first_contribution.py
@@ -30,7 +30,9 @@ def test_first_contribution_strict_fails_when_content_missing(tmp_path, capsys):
 
 
 def test_first_contribution_write_defaults_recovers_missing_file(tmp_path, capsys):
-    rc = first_contribution.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    rc = first_contribution.main(
+        ["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"]
+    )
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     assert data["passed_checks"] == data["total_checks"]

--- a/tests/test_github_actions_quickstart.py
+++ b/tests/test_github_actions_quickstart.py
@@ -29,7 +29,9 @@ def test_day15_quickstart_variant_switches_workflow(capsys):
 
 def test_day15_quickstart_strict_fails_when_content_missing(tmp_path, capsys):
     (tmp_path / "docs").mkdir(parents=True)
-    (tmp_path / "docs/integrations-github-actions-quickstart.md").write_text("# Placeholder\n", encoding="utf-8")
+    (tmp_path / "docs/integrations-github-actions-quickstart.md").write_text(
+        "# Placeholder\n", encoding="utf-8"
+    )
     rc = github_actions_quickstart.main(["--root", str(tmp_path), "--strict"])
     assert rc == 1
     out = capsys.readouterr().out
@@ -37,7 +39,9 @@ def test_day15_quickstart_strict_fails_when_content_missing(tmp_path, capsys):
 
 
 def test_day15_quickstart_write_defaults_recovers_missing_file(tmp_path, capsys):
-    rc = github_actions_quickstart.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    rc = github_actions_quickstart.main(
+        ["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"]
+    )
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     assert data["passed_checks"] == data["total_checks"]
@@ -112,7 +116,9 @@ def test_day15_quickstart_execute_strict_fails_on_command_error(monkeypatch, tmp
 
     monkeypatch.setattr(github_actions_quickstart.subprocess, "run", lambda *a, **k: _Proc())
 
-    rc = github_actions_quickstart.main(["--root", str(tmp_path), "--execute", "--format", "json", "--strict"])
+    rc = github_actions_quickstart.main(
+        ["--root", str(tmp_path), "--execute", "--format", "json", "--strict"]
+    )
     assert rc == 1
     data = json.loads(capsys.readouterr().out)
     assert data["execution"]["failed_commands"] == 4

--- a/tests/test_gitlab_ci_quickstart.py
+++ b/tests/test_gitlab_ci_quickstart.py
@@ -29,14 +29,18 @@ def test_day16_quickstart_variant_switches_pipeline(capsys):
 
 def test_day16_quickstart_strict_fails_when_content_missing(tmp_path, capsys):
     (tmp_path / "docs").mkdir(parents=True)
-    (tmp_path / "docs/integrations-gitlab-ci-quickstart.md").write_text("# Placeholder\n", encoding="utf-8")
+    (tmp_path / "docs/integrations-gitlab-ci-quickstart.md").write_text(
+        "# Placeholder\n", encoding="utf-8"
+    )
     rc = gitlab_ci_quickstart.main(["--root", str(tmp_path), "--strict"])
     assert rc == 1
     assert "missing checks:" in capsys.readouterr().out
 
 
 def test_day16_quickstart_write_defaults_recovers_missing_file(tmp_path, capsys):
-    rc = gitlab_ci_quickstart.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    rc = gitlab_ci_quickstart.main(
+        ["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"]
+    )
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     assert data["passed_checks"] == data["total_checks"]
@@ -111,7 +115,9 @@ def test_day16_quickstart_execute_strict_fails_on_command_error(monkeypatch, tmp
 
     monkeypatch.setattr(gitlab_ci_quickstart.subprocess, "run", lambda *a, **k: _Proc())
 
-    rc = gitlab_ci_quickstart.main(["--root", str(tmp_path), "--execute", "--format", "json", "--strict"])
+    rc = gitlab_ci_quickstart.main(
+        ["--root", str(tmp_path), "--execute", "--format", "json", "--strict"]
+    )
     assert rc == 1
     data = json.loads(capsys.readouterr().out)
     assert data["execution"]["failed_commands"] == 4

--- a/tests/test_release_narrative.py
+++ b/tests/test_release_narrative.py
@@ -32,7 +32,16 @@ def test_day20_release_narrative_json(tmp_path: Path, capsys) -> None:
     summary = _write_day19_summary(tmp_path)
     _write_day20_page(tmp_path)
 
-    rc = rn.main(["--root", str(tmp_path), "--day19-summary", str(summary.relative_to(tmp_path)), "--format", "json"])
+    rc = rn.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day19-summary",
+            str(summary.relative_to(tmp_path)),
+            "--format",
+            "json",
+        ]
+    )
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
     assert out["name"] == "day20-release-narrative"
@@ -73,19 +82,37 @@ def test_day20_release_narrative_strict_gate_fails_when_not_ready(tmp_path: Path
     _write_day20_page(tmp_path)
 
     rc = rn.main(
-        ["--root", str(tmp_path), "--day19-summary", str(summary.relative_to(tmp_path)), "--format", "json", "--strict"]
+        [
+            "--root",
+            str(tmp_path),
+            "--day19-summary",
+            str(summary.relative_to(tmp_path)),
+            "--format",
+            "json",
+            "--strict",
+        ]
     )
     assert rc == 1
 
 
-def test_day20_release_narrative_strict_gate_fails_when_docs_contract_missing(tmp_path: Path) -> None:
+def test_day20_release_narrative_strict_gate_fails_when_docs_contract_missing(
+    tmp_path: Path,
+) -> None:
     summary = _write_day19_summary(tmp_path)
     path = tmp_path / "docs/integrations-release-narrative.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("# Release narrative (Day 20)\n", encoding="utf-8")
 
     rc = rn.main(
-        ["--root", str(tmp_path), "--day19-summary", str(summary.relative_to(tmp_path)), "--format", "json", "--strict"]
+        [
+            "--root",
+            str(tmp_path),
+            "--day19-summary",
+            str(summary.relative_to(tmp_path)),
+            "--format",
+            "json",
+            "--strict",
+        ]
     )
     assert rc == 1
 

--- a/tests/test_release_readiness_board.py
+++ b/tests/test_release_readiness_board.py
@@ -104,21 +104,26 @@ def test_day19_cli_dispatch(tmp_path: Path, capsys) -> None:
 def test_day19_board_supports_day14_kpis_payload(tmp_path: Path, capsys) -> None:
     day18 = tmp_path / "day18.json"
     day14 = tmp_path / "day14.json"
-    day18.write_text(json.dumps({"summary": {"reliability_score": 92.0, "gate_status": "pass"}}) + "\n", encoding="utf-8")
+    day18.write_text(
+        json.dumps({"summary": {"reliability_score": 92.0, "gate_status": "pass"}}) + "\n",
+        encoding="utf-8",
+    )
     day14.write_text(json.dumps({"kpis": {"completion_rate_percent": 95}}) + "\n", encoding="utf-8")
     _write_page(tmp_path)
 
-    rc = rrb.main([
-        "--root",
-        str(tmp_path),
-        "--day18-summary",
-        str(day18.relative_to(tmp_path)),
-        "--day14-summary",
-        str(day14.relative_to(tmp_path)),
-        "--format",
-        "json",
-        "--strict",
-    ])
+    rc = rrb.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day18-summary",
+            str(day18.relative_to(tmp_path)),
+            "--day14-summary",
+            str(day14.relative_to(tmp_path)),
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
     assert out["inputs"]["day14"]["status"] == "pass"

--- a/tests/test_startup_use_case.py
+++ b/tests/test_startup_use_case.py
@@ -22,7 +22,9 @@ def test_startup_use_case_json_and_strict_success(capsys):
 
 def test_startup_use_case_strict_fails_when_content_missing(tmp_path, capsys):
     (tmp_path / "docs").mkdir(parents=True)
-    (tmp_path / "docs/use-cases-startup-small-team.md").write_text("# Placeholder\n", encoding="utf-8")
+    (tmp_path / "docs/use-cases-startup-small-team.md").write_text(
+        "# Placeholder\n", encoding="utf-8"
+    )
     rc = startup_use_case.main(["--root", str(tmp_path), "--strict"])
     assert rc == 1
     out = capsys.readouterr().out
@@ -30,7 +32,9 @@ def test_startup_use_case_strict_fails_when_content_missing(tmp_path, capsys):
 
 
 def test_startup_use_case_write_defaults_recovers_missing_file(tmp_path, capsys):
-    rc = startup_use_case.main(["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"])
+    rc = startup_use_case.main(
+        ["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"]
+    )
     assert rc == 0
     data = json.loads(capsys.readouterr().out)
     assert data["passed_checks"] == data["total_checks"]
@@ -40,7 +44,9 @@ def test_startup_use_case_write_defaults_recovers_missing_file(tmp_path, capsys)
 
 def test_startup_use_case_emit_pack(tmp_path, capsys):
     (tmp_path / "docs").mkdir(parents=True)
-    (tmp_path / "docs/use-cases-startup-small-team.md").write_text("# Startup + small-team workflow\n", encoding="utf-8")
+    (tmp_path / "docs/use-cases-startup-small-team.md").write_text(
+        "# Startup + small-team workflow\n", encoding="utf-8"
+    )
     rc = startup_use_case.main(
         [
             "--root",

--- a/tests/test_triage_templates.py
+++ b/tests/test_triage_templates.py
@@ -8,7 +8,9 @@ from sdetkit import triage_templates
 def _seed_templates(root: Path) -> None:
     issue_dir = root / ".github" / "ISSUE_TEMPLATE"
     issue_dir.mkdir(parents=True)
-    (issue_dir / "bug_report.yml").write_text(triage_templates._DEFAULT_BUG_TEMPLATE, encoding="utf-8")
+    (issue_dir / "bug_report.yml").write_text(
+        triage_templates._DEFAULT_BUG_TEMPLATE, encoding="utf-8"
+    )
     (issue_dir / "feature_request.yml").write_text(
         triage_templates._DEFAULT_FEATURE_TEMPLATE,
         encoding="utf-8",
@@ -50,7 +52,9 @@ def test_markdown_export_writes_day9_artifact(tmp_path: Path) -> None:
 
 
 def test_write_defaults_repairs_missing_files(tmp_path: Path) -> None:
-    rc = triage_templates.main(["--root", str(tmp_path), "--write-defaults", "--strict", "--format", "json"])
+    rc = triage_templates.main(
+        ["--root", str(tmp_path), "--write-defaults", "--strict", "--format", "json"]
+    )
     assert rc == 0
     assert (tmp_path / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml").exists()
     assert (tmp_path / ".github" / "ISSUE_TEMPLATE" / "feature_request.yml").exists()

--- a/tests/test_trust_signal_upgrade.py
+++ b/tests/test_trust_signal_upgrade.py
@@ -15,7 +15,11 @@ def _write_day22_page(root: Path) -> None:
 
 def _write_repo_basics(root: Path, *, include_policy_link: bool = True) -> None:
     readme = root / "README.md"
-    policy_link = "[policy baselines](docs/policy-and-baselines.md)" if include_policy_link else "policy baselines"
+    policy_link = (
+        "[policy baselines](docs/policy-and-baselines.md)"
+        if include_policy_link
+        else "policy baselines"
+    )
     readme.write_text(
         "\n".join(
             [

--- a/tests/test_weekly_review.py
+++ b/tests/test_weekly_review.py
@@ -6,104 +6,124 @@ from sdetkit import weekly_review
 
 
 def test_weekly_review_repo_passes_core_kpis() -> None:
-    review = weekly_review.build_weekly_review(Path('.').resolve())
-    assert review.kpis['days_planned'] == 6
-    assert review.kpis['days_completed'] >= 6
-    assert review.kpis['completion_rate_percent'] == 100
+    review = weekly_review.build_weekly_review(Path(".").resolve())
+    assert review.kpis["days_planned"] == 6
+    assert review.kpis["days_completed"] >= 6
+    assert review.kpis["completion_rate_percent"] == 100
 
 
 def test_week2_review_repo_passes_core_kpis() -> None:
-    review = weekly_review.build_weekly_review(Path('.').resolve(), week=2)
+    review = weekly_review.build_weekly_review(Path(".").resolve(), week=2)
     assert review.week == 2
-    assert review.kpis['days_planned'] == 6
-    assert review.kpis['days_completed'] >= 6
-    assert review.kpis['completion_rate_percent'] == 100
+    assert review.kpis["days_planned"] == 6
+    assert review.kpis["days_completed"] >= 6
+    assert review.kpis["completion_rate_percent"] == 100
 
 
 def test_week2_review_adds_growth_signals_and_deltas() -> None:
     review = weekly_review.build_weekly_review(
-        Path('.').resolve(),
+        Path(".").resolve(),
         week=2,
-        signals={'traffic': 1800, 'stars': 90, 'discussions': 24, 'blocker_fixes': 7},
-        previous_signals={'traffic': 1200, 'stars': 77, 'discussions': 18, 'blocker_fixes': 5},
+        signals={"traffic": 1800, "stars": 90, "discussions": 24, "blocker_fixes": 7},
+        previous_signals={"traffic": 1200, "stars": 77, "discussions": 18, "blocker_fixes": 5},
     )
-    assert review.growth_signals == {'traffic': 1800, 'stars': 90, 'discussions': 24, 'blocker_fixes': 7}
-    assert review.growth_deltas == {'traffic': 600, 'stars': 13, 'discussions': 6, 'blocker_fixes': 2}
+    assert review.growth_signals == {
+        "traffic": 1800,
+        "stars": 90,
+        "discussions": 24,
+        "blocker_fixes": 7,
+    }
+    assert review.growth_deltas == {
+        "traffic": 600,
+        "stars": 13,
+        "discussions": 6,
+        "blocker_fixes": 2,
+    }
 
 
 def test_weekly_review_flags_missing_files(tmp_path: Path) -> None:
-    (tmp_path / 'README.md').write_text('# temp\n', encoding='utf-8')
-    (tmp_path / 'docs').mkdir()
-    (tmp_path / 'docs' / 'day-1-ultra-upgrade-report.md').write_text('ok\n', encoding='utf-8')
+    (tmp_path / "README.md").write_text("# temp\n", encoding="utf-8")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "day-1-ultra-upgrade-report.md").write_text("ok\n", encoding="utf-8")
 
     review = weekly_review.build_weekly_review(tmp_path)
-    assert review.kpis['days_completed'] < review.kpis['days_planned']
-    assert any(item['status'] == 'incomplete' for item in review.shipped)
+    assert review.kpis["days_completed"] < review.kpis["days_planned"]
+    assert any(item["status"] == "incomplete" for item in review.shipped)
 
 
 def test_week3_review_repo_passes_core_kpis() -> None:
-    review = weekly_review.build_weekly_review(Path('.').resolve(), week=3)
+    review = weekly_review.build_weekly_review(Path(".").resolve(), week=3)
     assert review.week == 3
-    assert review.kpis['days_planned'] == 6
-    assert review.kpis['days_completed'] >= 6
-    assert review.kpis['completion_rate_percent'] == 100
+    assert review.kpis["days_planned"] == 6
+    assert review.kpis["days_completed"] >= 6
+    assert review.kpis["completion_rate_percent"] == 100
 
 
 def test_week3_review_adds_growth_signals_and_deltas() -> None:
     review = weekly_review.build_weekly_review(
-        Path('.').resolve(),
+        Path(".").resolve(),
         week=3,
-        signals={'traffic': 2550, 'stars': 132, 'discussions': 33, 'blocker_fixes': 10},
-        previous_signals={'traffic': 2100, 'stars': 120, 'discussions': 28, 'blocker_fixes': 8},
+        signals={"traffic": 2550, "stars": 132, "discussions": 33, "blocker_fixes": 10},
+        previous_signals={"traffic": 2100, "stars": 120, "discussions": 28, "blocker_fixes": 8},
     )
-    assert review.growth_signals == {'traffic': 2550, 'stars': 132, 'discussions': 33, 'blocker_fixes': 10}
-    assert review.growth_deltas == {'traffic': 450, 'stars': 12, 'discussions': 5, 'blocker_fixes': 2}
-
+    assert review.growth_signals == {
+        "traffic": 2550,
+        "stars": 132,
+        "discussions": 33,
+        "blocker_fixes": 10,
+    }
+    assert review.growth_deltas == {
+        "traffic": 450,
+        "stars": 12,
+        "discussions": 5,
+        "blocker_fixes": 2,
+    }
 
 
 def test_week3_emit_pack_writes_closeout_artifacts(tmp_path: Path) -> None:
-    root = tmp_path / 'repo'
-    (root / 'docs' / 'artifacts').mkdir(parents=True)
+    root = tmp_path / "repo"
+    (root / "docs" / "artifacts").mkdir(parents=True)
 
     for day in range(15, 21):
-        (root / 'docs' / f'day-{day}-ultra-upgrade-report.md').write_text('ok\n', encoding='utf-8')
+        (root / "docs" / f"day-{day}-ultra-upgrade-report.md").write_text("ok\n", encoding="utf-8")
     for artifact in (
-        'day15-github-actions-quickstart-sample.md',
-        'day16-gitlab-ci-quickstart-sample.md',
-        'day17-quality-contribution-delta-sample.md',
-        'day18-reliability-evidence-pack-sample.md',
-        'day19-release-readiness-board-sample.md',
-        'day20-release-narrative-sample.md',
+        "day15-github-actions-quickstart-sample.md",
+        "day16-gitlab-ci-quickstart-sample.md",
+        "day17-quality-contribution-delta-sample.md",
+        "day18-reliability-evidence-pack-sample.md",
+        "day19-release-readiness-board-sample.md",
+        "day20-release-narrative-sample.md",
     ):
-        (root / 'docs' / 'artifacts' / artifact).write_text('ok\n', encoding='utf-8')
+        (root / "docs" / "artifacts" / artifact).write_text("ok\n", encoding="utf-8")
 
     args = [
-        '--root',
+        "--root",
         str(root),
-        '--week',
-        '3',
-        '--signals-file',
-        'docs/artifacts/day21-growth-signals.json',
-        '--previous-signals-file',
-        'docs/artifacts/day14-growth-signals.json',
-        '--emit-pack-dir',
-        'docs/artifacts/day21-weekly-pack',
-        '--format',
-        'json',
-        '--strict',
+        "--week",
+        "3",
+        "--signals-file",
+        "docs/artifacts/day21-growth-signals.json",
+        "--previous-signals-file",
+        "docs/artifacts/day14-growth-signals.json",
+        "--emit-pack-dir",
+        "docs/artifacts/day21-weekly-pack",
+        "--format",
+        "json",
+        "--strict",
     ]
 
-    (root / 'docs' / 'artifacts' / 'day21-growth-signals.json').write_text(
-        '{"traffic": 2550, "stars": 132, "discussions": 33, "blocker_fixes": 10}\n', encoding='utf-8'
+    (root / "docs" / "artifacts" / "day21-growth-signals.json").write_text(
+        '{"traffic": 2550, "stars": 132, "discussions": 33, "blocker_fixes": 10}\n',
+        encoding="utf-8",
     )
-    (root / 'docs' / 'artifacts' / 'day14-growth-signals.json').write_text(
-        '{"traffic": 1800, "stars": 90, "discussions": 24, "blocker_fixes": 7}\n', encoding='utf-8'
+    (root / "docs" / "artifacts" / "day14-growth-signals.json").write_text(
+        '{"traffic": 1800, "stars": 90, "discussions": 24, "blocker_fixes": 7}\n', encoding="utf-8"
     )
 
     assert weekly_review.main(args) == 0
 
-    pack = root / 'docs' / 'artifacts' / 'day21-weekly-pack'
-    assert (pack / 'day21-closeout-checklist.md').exists()
-    assert (pack / 'day21-kpi-scorecard.json').exists()
-    assert (pack / 'day21-contributor-response-plan.md').exists()
-    assert (pack / 'day21-release-narrative-brief.md').exists()
+    pack = root / "docs" / "artifacts" / "day21-weekly-pack"
+    assert (pack / "day21-closeout-checklist.md").exists()
+    assert (pack / "day21-kpi-scorecard.json").exists()
+    assert (pack / "day21-contributor-response-plan.md").exists()
+    assert (pack / "day21-release-narrative-brief.md").exists()


### PR DESCRIPTION
## Summary

* Fix typing/mypy issues across `sdetkit` modules (and related contracts/tests) with safer, more explicit types and casts.
* Stabilize workflow history diffing so two identical runs don’t report false “changed steps”.
* Reformat/normalize contract scripts and related files to satisfy the quality gates.

## Why

* `bash quality.sh` was failing due to mypy type errors (mostly from overly-generic `object` values flowing into logic).
* `diff_runs()` produced false positives in workflow history replay tests.
* Contract scripts/import blocks needed consistent formatting to keep ruff checks clean.

## How

* Tightened annotations and intermediate variable types (e.g., replacing ambiguous `object` usage, adding `cast(...)` where runtime shapes are dynamic).
* Updated command execution helpers to safely accept both `str` and `Sequence[str]` (only `shlex.split` for string commands).
* Normalized diff input fields to ignore run-to-run ephemeral values (IDs/timestamps/etc.) while still detecting meaningful step changes.
* Ran formatting fixes so `ruff`/`ruff format`/pre-commit checks pass.

## Risk assessment

* Risk level: **medium**
* Primary risk area:

  * Workflow diff normalization (risk of hiding legitimate diffs if normalization is too aggressive)
  * Cross-module typing changes (risk of subtle behavior change via refactors)

## Test evidence

* Commands run:

  * `bash quality.sh`
  * `pytest -q`
* Result:

  * `639 passed`
  * Coverage: `77.72%` (>= 70% required)

## Rollback plan

* Revert the commit:

  * `git revert b12a23d`
* If urgent:

  * Revert workflow diff changes first (narrow rollback) to restore previous diff behavior quickly.

## Checklist

* [x] `bash quality.sh` passes
* [x] `pytest -q` passes (639 tests)
* [ ] `bash ci.sh` passes (if applicable in CI)
* [ ] Docs updated (if needed)
* [ ] Issue links / acceptance criteria mapped
* [ ] Premium guideline reference reviewed: `docs/premium-quality-gate.md`