### PR TITLE
Fix MkDocs strict build warnings for artifact quick-start links

### DIFF
--- a/docs/artifacts/day1-onboarding-sample.md
+++ b/docs/artifacts/day1-onboarding-sample.md
@@ -5,4 +5,4 @@
 | Security / compliance lead | `sdetkit security --format markdown` | Apply policy controls from `docs/security.md` and `docs/policy-and-baselines.md`. |
 | Engineering manager / tech lead | `sdetkit doctor --format markdown` | Standardize team workflows using `docs/automation-os.md` and `docs/repo-tour.md`. |
 
-Quick start: [README quick start](../../README.md#quick-start)
+Quick start: [Repo audit quick start](../repo-audit.md#quick-start)

--- a/docs/artifacts/day2-demo-sample.md
+++ b/docs/artifacts/day2-demo-sample.md
@@ -26,4 +26,4 @@
 - Use --format markdown --output docs/artifacts/day2-demo-closeout.md to save a shareable run artifact.
 - If a snippet check fails, rerun a single command manually and compare output with the expected markers.
 
-Related docs: [README quick start](../../README.md#quick-start), [repo audit](../repo-audit.md).
+Related docs: [Repo audit quick start](../repo-audit.md#quick-start), [repo audit](../repo-audit.md).

--- a/docs/artifacts/day5-platform-onboarding-sample.md
+++ b/docs/artifacts/day5-platform-onboarding-sample.md
@@ -34,4 +34,4 @@ python -m pip install -r requirements-test.txt -e .
 python -m sdetkit doctor --format text
 ```
 
-Quick start: [README quick start](../../README.md#quick-start)
+Quick start: [Repo audit quick start](../repo-audit.md#quick-start)


### PR DESCRIPTION
### Motivation
- MkDocs strict builds were failing due to artifact pages linking to `../../README.md#quick-start`, which points outside the documentation set and triggers strict-mode link warnings.
- Update artifact pages to reference an internal docs quick-start so `mkdocs build --strict` can complete successfully.

### Description
- Updated `docs/artifacts/day1-onboarding-sample.md`, `docs/artifacts/day2-demo-sample.md`, and `docs/artifacts/day5-platform-onboarding-sample.md` to replace `../../README.md#quick-start` with `../repo-audit.md#quick-start`.
- No other content changes were introduced.

### Testing
- Ran `python -m mkdocs build --strict` and the build completed successfully after the changes, with only informational "not in nav" messages remaining.
- The previous strict-mode failure caused by external README links no longer occurs.

