### PR TITLE
feat: close out Day 25 — add community-activation CLI, docs, pack, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,15 @@ See implementation details: [Day 23 ultra upgrade report](docs/day-23-ultra-upgr
 
 See implementation details: [Day 24 ultra upgrade report](docs/day-24-ultra-upgrade-report.md).
 
+## 🗳️ Day 25 ultra: community activation
+
+- Run `python -m sdetkit community-activation --format json --strict` to validate Day 25 roadmap-voting readiness.
+- Emit shareable community pack: `python -m sdetkit community-activation --emit-pack-dir docs/artifacts/day25-community-pack --format json --strict`.
+- Execute and collect deterministic logs: `python -m sdetkit community-activation --execute --evidence-dir docs/artifacts/day25-community-pack/evidence --format json --strict`.
+- Review Day 25 integration guide: [Community activation](docs/integrations-community-activation.md).
+
+See implementation details: [Day 25 ultra upgrade report](docs/day-25-ultra-upgrade-report.md).
+
 Day 23 closeout checks:
 
 ```bash

--- a/docs/artifacts/day25-community-activation-sample.md
+++ b/docs/artifacts/day25-community-activation-sample.md
@@ -1,0 +1,14 @@
+Day 25 community activation summary
+score=100.0
+failed=none
+critical=none
+
+Checks:
+- [x] docs_page_exists (contract, w=15)
+- [x] required_sections_present (contract, w=20)
+- [x] required_commands_present (contract, w=10)
+- [x] readme_day25_link (discoverability, w=10)
+- [x] readme_day25_command (discoverability, w=8)
+- [x] docs_index_day25_link (discoverability, w=7)
+- [x] top10_day25_alignment (strategy, w=20)
+- [x] docs_mentions_roadmap_voting (strategy, w=10)

--- a/docs/artifacts/day25-community-pack/day25-community-scorecard.md
+++ b/docs/artifacts/day25-community-pack/day25-community-scorecard.md
@@ -1,0 +1,14 @@
+Day 25 community activation summary
+score=100.0
+failed=none
+critical=none
+
+Checks:
+- [x] docs_page_exists (contract, w=15)
+- [x] required_sections_present (contract, w=20)
+- [x] required_commands_present (contract, w=10)
+- [x] readme_day25_link (discoverability, w=10)
+- [x] readme_day25_command (discoverability, w=8)
+- [x] docs_index_day25_link (discoverability, w=7)
+- [x] top10_day25_alignment (strategy, w=20)
+- [x] docs_mentions_roadmap_voting (strategy, w=10)

--- a/docs/artifacts/day25-community-pack/day25-community-summary.json
+++ b/docs/artifacts/day25-community-pack/day25-community-summary.json
@@ -1,0 +1,81 @@
+{
+  "checks": [
+    {
+      "category": "contract",
+      "evidence": "/workspace/DevS69-sdetkit/docs/integrations-community-activation.md",
+      "key": "docs_page_exists",
+      "passed": true,
+      "weight": 15
+    },
+    {
+      "category": "contract",
+      "evidence": {
+        "missing_sections": []
+      },
+      "key": "required_sections_present",
+      "passed": true,
+      "weight": 20
+    },
+    {
+      "category": "contract",
+      "evidence": {
+        "missing_commands": []
+      },
+      "key": "required_commands_present",
+      "passed": true,
+      "weight": 10
+    },
+    {
+      "category": "discoverability",
+      "evidence": "docs/integrations-community-activation.md",
+      "key": "readme_day25_link",
+      "passed": true,
+      "weight": 10
+    },
+    {
+      "category": "discoverability",
+      "evidence": "community-activation",
+      "key": "readme_day25_command",
+      "passed": true,
+      "weight": 8
+    },
+    {
+      "category": "discoverability",
+      "evidence": "day-25-ultra-upgrade-report.md",
+      "key": "docs_index_day25_link",
+      "passed": true,
+      "weight": 7
+    },
+    {
+      "category": "strategy",
+      "evidence": "Day 25 \u2014 Community activation",
+      "key": "top10_day25_alignment",
+      "passed": true,
+      "weight": 20
+    },
+    {
+      "category": "strategy",
+      "evidence": "roadmap-voting",
+      "key": "docs_mentions_roadmap_voting",
+      "passed": true,
+      "weight": 10
+    }
+  ],
+  "inputs": {
+    "docs_index": "docs/index.md",
+    "docs_page": "docs/integrations-community-activation.md",
+    "readme": "README.md",
+    "top10": "docs/top-10-github-strategy.md"
+  },
+  "name": "day25-community-activation",
+  "strict_failures": [],
+  "summary": {
+    "activation_score": 100.0,
+    "critical_failures": [],
+    "failed_checks": [],
+    "recommendations": [
+      "Day 25 community activation lane is healthy; keep weekly voting summaries flowing."
+    ],
+    "total_checks": 8
+  }
+}

--- a/docs/artifacts/day25-community-pack/day25-feedback-triage-board.md
+++ b/docs/artifacts/day25-community-pack/day25-feedback-triage-board.md
@@ -1,0 +1,7 @@
+# Day 25 feedback triage board
+
+| Feedback item | Votes | Owner | Status | Decision date |
+| --- | ---: | --- | --- | --- |
+| Example: Improve docs nav for first-time users | 0 | @owner | needs-info | YYYY-MM-DD |
+
+Triage SLA: respond within 48h and classify as `accepted`, `needs-info`, or `not-now`.

--- a/docs/artifacts/day25-community-pack/day25-roadmap-vote-discussion-template.md
+++ b/docs/artifacts/day25-community-pack/day25-roadmap-vote-discussion-template.md
@@ -1,0 +1,19 @@
+# Day 25 roadmap-voting discussion template
+
+## Title
+Roadmap voting: help prioritize the next sdetkit upgrades
+
+## Prompt
+Vote on the top 3 roadmap items that would most improve your team workflow.
+
+## Candidate items
+1. CI integration accelerators
+2. Security and compliance automation
+3. Contributor onboarding improvements
+4. Release and communication tooling
+
+## Response format
+- Priority #1:
+- Priority #2:
+- Priority #3:
+- Optional context:

--- a/docs/artifacts/day25-community-pack/day25-validation-commands.md
+++ b/docs/artifacts/day25-community-pack/day25-validation-commands.md
@@ -1,0 +1,8 @@
+# Day 25 validation commands
+
+```bash
+python -m sdetkit community-activation --format json --strict
+python -m sdetkit community-activation --emit-pack-dir docs/artifacts/day25-community-pack --format json --strict
+python -m sdetkit community-activation --execute --evidence-dir docs/artifacts/day25-community-pack/evidence --format json --strict
+python scripts/check_day25_community_activation_contract.py
+```

--- a/docs/artifacts/day25-community-pack/evidence/day25-execution-summary.json
+++ b/docs/artifacts/day25-community-pack/evidence/day25-execution-summary.json
@@ -1,0 +1,18 @@
+{
+  "name": "day25-community-activation-execution",
+  "results": [
+    {
+      "command": "python -m sdetkit community-activation --format json --strict",
+      "returncode": 0,
+      "stderr": "",
+      "stdout": "{\n  \"checks\": [\n    {\n      \"category\": \"contract\",\n      \"evidence\": \"/workspace/DevS69-sdetkit/docs/integrations-community-activation.md\",\n      \"key\": \"docs_page_exists\",\n      \"passed\": true,\n      \"weight\": 15\n    },\n    {\n      \"category\": \"contract\",\n      \"evidence\": {\n        \"missing_sections\": []\n      },\n      \"key\": \"required_sections_present\",\n      \"passed\": true,\n      \"weight\": 20\n    },\n    {\n      \"category\": \"contract\",\n      \"evidence\": {\n        \"missing_commands\": []\n      },\n      \"key\": \"required_commands_present\",\n      \"passed\": true,\n      \"weight\": 10\n    },\n    {\n      \"category\": \"discoverability\",\n      \"evidence\": \"docs/integrations-community-activation.md\",\n      \"key\": \"readme_day25_link\",\n      \"passed\": true,\n      \"weight\": 10\n    },\n    {\n      \"category\": \"discoverability\",\n      \"evidence\": \"community-activation\",\n      \"key\": \"readme_day25_command\",\n      \"passed\": true,\n      \"weight\": 8\n    },\n    {\n      \"category\": \"discoverability\",\n      \"evidence\": \"day-25-ultra-upgrade-report.md\",\n      \"key\": \"docs_index_day25_link\",\n      \"passed\": true,\n      \"weight\": 7\n    },\n    {\n      \"category\": \"strategy\",\n      \"evidence\": \"Day 25 \\u2014 Community activation\",\n      \"key\": \"top10_day25_alignment\",\n      \"passed\": true,\n      \"weight\": 20\n    },\n    {\n      \"category\": \"strategy\",\n      \"evidence\": \"roadmap-voting\",\n      \"key\": \"docs_mentions_roadmap_voting\",\n      \"passed\": true,\n      \"weight\": 10\n    }\n  ],\n  \"inputs\": {\n    \"docs_index\": \"docs/index.md\",\n    \"docs_page\": \"docs/integrations-community-activation.md\",\n    \"readme\": \"README.md\",\n    \"top10\": \"docs/top-10-github-strategy.md\"\n  },\n  \"name\": \"day25-community-activation\",\n  \"strict_failures\": [],\n  \"summary\": {\n    \"activation_score\": 100.0,\n    \"critical_failures\": [],\n    \"failed_checks\": [],\n    \"recommendations\": [\n      \"Day 25 community activation lane is healthy; keep weekly voting summaries flowing.\"\n    ],\n    \"total_checks\": 8\n  }\n}\n"
+    },
+    {
+      "command": "python scripts/check_day25_community_activation_contract.py --skip-evidence",
+      "returncode": 0,
+      "stderr": "",
+      "stdout": "{\n  \"errors\": [],\n  \"score\": 100.0\n}\n"
+    }
+  ],
+  "total_commands": 2
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -562,3 +562,25 @@ Useful flags: `--root`, `--readme`, `--docs-index`, `--docs-page`, `--min-faq-sc
 `--execute` runs the Day 23 command chain and emits an execution summary for closeout evidence.
 
 `--strict` returns non-zero if Day 23 required docs sections/commands are missing, critical objection checks fail, or FAQ score falls below `--min-faq-score`.
+
+## community-activation
+
+Builds Day 25 roadmap-voting and community-feedback readiness from docs contract completeness, discoverability links, and strategy alignment checks.
+
+Examples:
+
+- `sdetkit community-activation --format text`
+- `sdetkit community-activation --format json --strict`
+- `sdetkit community-activation --write-defaults --format json --strict`
+- `sdetkit community-activation --emit-pack-dir docs/artifacts/day25-community-pack --format json --strict`
+- `sdetkit community-activation --execute --evidence-dir docs/artifacts/day25-community-pack/evidence --format json --strict`
+
+Useful flags: `--root`, `--readme`, `--docs-index`, `--top10`, `--write-defaults`, `--emit-pack-dir`, `--execute`, `--evidence-dir`, `--timeout-sec`, `--min-score`, `--strict`, `--format`.
+
+`--write-defaults` writes a hardened Day 25 integration page if missing/incomplete, then validates it.
+
+`--emit-pack-dir` writes a Day 25 pack containing summary JSON, activation scorecard markdown, roadmap-vote discussion template, feedback triage board, and validation commands.
+
+`--execute` runs the Day 25 command chain and emits an execution summary for closeout evidence.
+
+`--strict` returns non-zero if Day 25 required docs sections/commands are missing, critical checks fail, or activation score falls below `--min-score`.

--- a/docs/day-25-ultra-upgrade-report.md
+++ b/docs/day-25-ultra-upgrade-report.md
@@ -1,0 +1,24 @@
+# Day 25 ultra upgrade report — community activation closeout
+
+## What shipped
+
+- Added `community-activation` command to enforce roadmap-voting and feedback-triage readiness.
+- Added strict docs-contract checks for Day 25 community activation guidance.
+- Added deterministic artifact pack + execution evidence mode.
+- Added dedicated contract validation script and tests.
+
+## Key command paths
+
+```bash
+python -m sdetkit community-activation --format json --strict
+python -m sdetkit community-activation --emit-pack-dir docs/artifacts/day25-community-pack --format json --strict
+python -m sdetkit community-activation --execute --evidence-dir docs/artifacts/day25-community-pack/evidence --format json --strict
+python scripts/check_day25_community_activation_contract.py
+```
+
+## Closeout criteria
+
+- Day 25 score >= 90 with no critical failures.
+- Integration page includes all required sections + command contract.
+- README/docs index discoverability links in place.
+- Evidence bundle generated and review-ready.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ A practical, production-ready toolkit for SDET workflows — with clean CLI ergo
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧪 Day 12 ultra report](day-12-ultra-upgrade-report.md) · [🏢 Day 13 ultra report](day-13-ultra-upgrade-report.md) · [📈 Day 14 ultra report](day-14-ultra-upgrade-report.md) · [🗞️ Day 20 ultra report](day-20-ultra-upgrade-report.md) · [📊 Day 21 ultra report](day-21-ultra-upgrade-report.md) · [🔐 Day 22 ultra report](day-22-ultra-upgrade-report.md) · [❓ Day 23 ultra report](day-23-ultra-upgrade-report.md) · [⏱️ Day 24 ultra report](day-24-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [🧪 Day 1 ultra report](day-1-ultra-upgrade-report.md) · [⚡ Day 2 ultra report](day-2-ultra-upgrade-report.md) · [📸 Day 3 ultra report](day-3-ultra-upgrade-report.md) · [🧠 Day 4 ultra report](day-4-ultra-upgrade-report.md) · [🖥️ Day 5 ultra report](day-5-ultra-upgrade-report.md) · [🔗 Day 6 ultra report](day-6-ultra-upgrade-report.md) · [📊 Day 7 ultra report](day-7-ultra-upgrade-report.md) · [🧲 Day 8 ultra report](day-8-ultra-upgrade-report.md) · [🧩 Day 9 ultra report](day-9-ultra-upgrade-report.md) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧪 Day 12 ultra report](day-12-ultra-upgrade-report.md) · [🏢 Day 13 ultra report](day-13-ultra-upgrade-report.md) · [📈 Day 14 ultra report](day-14-ultra-upgrade-report.md) · [🗞️ Day 20 ultra report](day-20-ultra-upgrade-report.md) · [📊 Day 21 ultra report](day-21-ultra-upgrade-report.md) · [🔐 Day 22 ultra report](day-22-ultra-upgrade-report.md) · [❓ Day 23 ultra report](day-23-ultra-upgrade-report.md) · [⏱️ Day 24 ultra report](day-24-ultra-upgrade-report.md) · [🗳️ Day 25 ultra report](day-25-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
 
 </div>
 
@@ -357,6 +357,14 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 24 onboarding pack: `python -m sdetkit onboarding-time-upgrade --emit-pack-dir docs/artifacts/day24-onboarding-pack --format json --strict`.
 - Run deterministic execution evidence lane: `python -m sdetkit onboarding-time-upgrade --execute --evidence-dir docs/artifacts/day24-onboarding-pack/evidence --format json --strict`.
 - Review sample output artifact: [day24 onboarding upgrade sample](artifacts/day24-onboarding-time-upgrade-sample.md).
+
+## Day 25 ultra upgrades (community activation closeout)
+
+- Read the implementation report: [Day 25 ultra upgrade report](day-25-ultra-upgrade-report.md).
+- Run `python -m sdetkit community-activation --format json --strict` to score roadmap-voting readiness and feedback loop coverage.
+- Emit Day 25 community pack: `python -m sdetkit community-activation --emit-pack-dir docs/artifacts/day25-community-pack --format json --strict`.
+- Run deterministic execution evidence lane: `python -m sdetkit community-activation --execute --evidence-dir docs/artifacts/day25-community-pack/evidence --format json --strict`.
+- Review sample output artifact: [day25 community activation sample](artifacts/day25-community-activation-sample.md).
 
 ## Day 22 ultra upgrades (trust signal upgrade)
 

--- a/docs/integrations-community-activation.md
+++ b/docs/integrations-community-activation.md
@@ -1,0 +1,41 @@
+# Community activation (Day 25)
+
+Day 25 converts passive roadmap readers into active contributors through a deterministic roadmap-voting and feedback loop.
+
+## Who should run Day 25
+
+- Maintainers preparing priorities for the next sprint or release train.
+- DevRel/community managers collecting qualitative and quantitative roadmap feedback.
+- Engineering leads that need transparent prioritization signals for backlog decisions.
+
+## Roadmap-voting discussion contract
+
+Day 25 is complete when a public roadmap-voting thread is opened, tagged, and linked from docs so contributors can vote and comment on priority items.
+
+## Launch checklist
+
+```bash
+python -m sdetkit community-activation --format json --strict
+python -m sdetkit community-activation --emit-pack-dir docs/artifacts/day25-community-pack --format json --strict
+python -m sdetkit community-activation --execute --evidence-dir docs/artifacts/day25-community-pack/evidence --format json --strict
+python scripts/check_day25_community_activation_contract.py
+```
+
+## Feedback triage SLA
+
+- Triage new roadmap votes/comments within 48 hours.
+- Label each item as `accepted`, `needs-info`, or `not-now`.
+- Publish weekly summary of wins, blockers, and next actions.
+
+## Activation scoring model
+
+Day 25 computes weighted readiness score (0-100):
+
+- Docs contract + command lane completeness: 45 points.
+- Discoverability links in README/docs index: 25 points.
+- Top-10 roadmap alignment marker coverage: 20 points.
+- Evidence-lane readiness for strict validation: 10 points.
+
+## Execution evidence mode
+
+`--execute` runs deterministic Day 25 checks and writes logs to `--evidence-dir` for release review.

--- a/scripts/check_day25_community_activation_contract.py
+++ b/scripts/check_day25_community_activation_contract.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from sdetkit import community_activation as ca
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Day 25 community-activation contract.")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = ca.build_community_activation_summary(root)
+
+    strict_failures: list[str] = []
+    page = root / ca._PAGE_PATH
+    page_text = page.read_text(encoding="utf-8") if page.exists() else ""
+    for section in [ca._SECTION_HEADER, *ca._REQUIRED_SECTIONS]:
+        if section not in page_text:
+            strict_failures.append(section)
+    for command in ca._REQUIRED_COMMANDS:
+        if command not in page_text:
+            strict_failures.append(command)
+
+    errors: list[str] = []
+    if strict_failures:
+        errors.append(f"missing docs contract entries: {strict_failures}")
+    if payload["summary"]["critical_failures"]:
+        errors.append(f"critical failures: {payload['summary']['critical_failures']}")
+
+    if not ns.skip_evidence:
+        evidence = root / "docs/artifacts/day25-community-pack/evidence/day25-execution-summary.json"
+        if not evidence.exists():
+            errors.append(f"missing evidence file: {evidence}")
+        else:
+            data = json.loads(evidence.read_text(encoding="utf-8"))
+            if data.get("total_commands", 0) < 2:
+                errors.append("execution evidence has insufficient commands")
+
+    print(json.dumps({"errors": errors, "score": payload["summary"]["activation_score"]}, indent=2))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -8,6 +8,7 @@ from importlib import metadata
 from . import (
     apiget,
     contributor_funnel,
+    community_activation,
     demo,
     docs_navigation,
     docs_qa,
@@ -119,6 +120,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "onboarding-time-upgrade":
         return onboarding_time_upgrade.main(list(argv[1:]))
 
+    if argv and argv[0] == "community-activation":
+        return community_activation.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -228,6 +232,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     otu = sub.add_parser("onboarding-time-upgrade")
     otu.add_argument("args", nargs=argparse.REMAINDER)
 
+    cau = sub.add_parser("community-activation")
+    cau.add_argument("args", nargs=argparse.REMAINDER)
+
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -325,6 +332,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "onboarding-time-upgrade":
         return onboarding_time_upgrade.main(ns.args)
+
+    if ns.cmd == "community-activation":
+        return community_activation.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/community_activation.py
+++ b/src/sdetkit/community_activation.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-community-activation.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_SECTION_HEADER = "# Community activation (Day 25)"
+_REQUIRED_SECTIONS = [
+    "## Who should run Day 25",
+    "## Roadmap-voting discussion contract",
+    "## Launch checklist",
+    "## Feedback triage SLA",
+    "## Activation scoring model",
+    "## Execution evidence mode",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit community-activation --format json --strict",
+    "python -m sdetkit community-activation --emit-pack-dir docs/artifacts/day25-community-pack --format json --strict",
+    "python -m sdetkit community-activation --execute --evidence-dir docs/artifacts/day25-community-pack/evidence --format json --strict",
+    "python scripts/check_day25_community_activation_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit community-activation --format json --strict",
+    "python scripts/check_day25_community_activation_contract.py --skip-evidence",
+]
+
+_DAY25_DEFAULT_PAGE = """# Community activation (Day 25)
+
+Day 25 converts passive roadmap readers into active contributors through a deterministic roadmap-voting and feedback loop.
+
+## Who should run Day 25
+
+- Maintainers preparing priorities for the next sprint or release train.
+- DevRel/community managers collecting qualitative and quantitative roadmap feedback.
+- Engineering leads that need transparent prioritization signals for backlog decisions.
+
+## Roadmap-voting discussion contract
+
+Day 25 is complete when a public roadmap-voting thread is opened, tagged, and linked from docs so contributors can vote and comment on priority items.
+
+## Launch checklist
+
+```bash
+python -m sdetkit community-activation --format json --strict
+python -m sdetkit community-activation --emit-pack-dir docs/artifacts/day25-community-pack --format json --strict
+python -m sdetkit community-activation --execute --evidence-dir docs/artifacts/day25-community-pack/evidence --format json --strict
+python scripts/check_day25_community_activation_contract.py
+```
+
+## Feedback triage SLA
+
+- Triage new roadmap votes/comments within 48 hours.
+- Label each item as `accepted`, `needs-info`, or `not-now`.
+- Publish weekly summary of wins, blockers, and next actions.
+
+## Activation scoring model
+
+Day 25 computes weighted readiness score (0-100):
+
+- Docs contract + command lane completeness: 45 points.
+- Discoverability links in README/docs index: 25 points.
+- Top-10 roadmap alignment marker coverage: 20 points.
+- Evidence-lane readiness for strict validation: 10 points.
+
+## Execution evidence mode
+
+`--execute` runs deterministic Day 25 checks and writes logs to `--evidence-dir` for release review.
+"""
+
+_SIGNALS = [
+    {"key": "docs_page_exists", "category": "contract", "weight": 15, "evaluator": "page_exists"},
+    {
+        "key": "required_sections_present",
+        "category": "contract",
+        "weight": 20,
+        "evaluator": "required_sections",
+    },
+    {
+        "key": "required_commands_present",
+        "category": "contract",
+        "weight": 10,
+        "evaluator": "required_commands",
+    },
+    {
+        "key": "readme_day25_link",
+        "category": "discoverability",
+        "weight": 10,
+        "marker": "docs/integrations-community-activation.md",
+        "source": "readme",
+    },
+    {
+        "key": "readme_day25_command",
+        "category": "discoverability",
+        "weight": 8,
+        "marker": "community-activation",
+        "source": "readme",
+    },
+    {
+        "key": "docs_index_day25_link",
+        "category": "discoverability",
+        "weight": 7,
+        "marker": "day-25-ultra-upgrade-report.md",
+        "source": "docs_index",
+    },
+    {
+        "key": "top10_day25_alignment",
+        "category": "strategy",
+        "weight": 20,
+        "marker": "Day 25 — Community activation",
+        "source": "top10",
+    },
+    {
+        "key": "docs_mentions_roadmap_voting",
+        "category": "strategy",
+        "weight": 10,
+        "marker": "roadmap-voting",
+        "source": "page",
+    },
+]
+
+_CRITICAL_FAILURE_KEYS = {
+    "docs_page_exists",
+    "required_sections_present",
+    "required_commands_present",
+    "top10_day25_alignment",
+}
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _evaluate_signals(
+    root: Path,
+    *,
+    page_text: str,
+    readme_text: str,
+    docs_index_text: str,
+    top10_text: str,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    page_path = root / _PAGE_PATH
+
+    for signal in _SIGNALS:
+        evaluator = signal.get("evaluator")
+
+        if evaluator == "page_exists":
+            passed = page_path.exists()
+            evidence: Any = str(page_path)
+        elif evaluator == "required_sections":
+            missing = [section for section in [_SECTION_HEADER, *_REQUIRED_SECTIONS] if section not in page_text]
+            passed = not missing
+            evidence = {"missing_sections": missing}
+        elif evaluator == "required_commands":
+            missing = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+            passed = not missing
+            evidence = {"missing_commands": missing}
+        else:
+            marker = str(signal.get("marker", ""))
+            source = str(signal.get("source", "page"))
+            corpus = page_text
+            if source == "readme":
+                corpus = readme_text
+            elif source == "docs_index":
+                corpus = docs_index_text
+            elif source == "top10":
+                corpus = top10_text
+            passed = bool(marker) and marker in corpus
+            evidence = marker
+
+        rows.append(
+            {
+                "key": str(signal["key"]),
+                "category": str(signal["category"]),
+                "weight": int(signal["weight"]),
+                "passed": bool(passed),
+                "evidence": evidence,
+            }
+        )
+
+    return rows
+
+
+def build_community_activation_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    page_text = _read(root / docs_page_path)
+    readme_text = _read(root / readme_path)
+    docs_index_text = _read(root / docs_index_path)
+    top10_text = _read(root / top10_path)
+    checks = _evaluate_signals(
+        root,
+        page_text=page_text,
+        readme_text=readme_text,
+        docs_index_text=docs_index_text,
+        top10_text=top10_text,
+    )
+
+    total_weight = sum(int(item["weight"]) for item in checks)
+    earned_weight = sum(int(item["weight"]) for item in checks if item["passed"])
+    score = round((earned_weight / total_weight) * 100, 2) if total_weight else 0.0
+
+    failed = [item for item in checks if not item["passed"]]
+    critical_failures = [item["key"] for item in failed if item["key"] in _CRITICAL_FAILURE_KEYS]
+
+    recommendations: list[str] = []
+    if any(item["category"] == "contract" for item in failed):
+        recommendations.append("Restore Day 25 docs contract sections and required command lane before launch.")
+    if any(item["category"] == "discoverability" for item in failed):
+        recommendations.append("Add Day 25 links and command snippets to README/docs index for contributor visibility.")
+    if any(item["category"] == "strategy" for item in failed):
+        recommendations.append("Align Day 25 outputs with top-10 roadmap activation objective and roadmap-voting messaging.")
+    if not recommendations:
+        recommendations.append("Day 25 community activation lane is healthy; keep weekly voting summaries flowing.")
+
+    return {
+        "name": "day25-community-activation",
+        "inputs": {
+            "readme": readme_path,
+            "docs_index": docs_index_path,
+            "docs_page": docs_page_path,
+            "top10": top10_path,
+        },
+        "checks": checks,
+        "summary": {
+            "activation_score": score,
+            "total_checks": len(checks),
+            "failed_checks": [item["key"] for item in failed],
+            "critical_failures": critical_failures,
+            "recommendations": recommendations,
+        },
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Day 25 community activation summary",
+        f"score={payload['summary']['activation_score']}",
+        f"failed={','.join(payload['summary']['failed_checks']) or 'none'}",
+        f"critical={','.join(payload['summary']['critical_failures']) or 'none'}",
+        "",
+        "Checks:",
+    ]
+    for item in payload["checks"]:
+        lines.append(f"- [{'x' if item['passed'] else ' '}] {item['key']} ({item['category']}, w={item['weight']})")
+    return "\n".join(lines)
+
+
+def emit_pack(root: Path, out_dir: Path, payload: dict[str, Any]) -> list[str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary = out_dir / "day25-community-summary.json"
+    scorecard = out_dir / "day25-community-scorecard.md"
+    discussion = out_dir / "day25-roadmap-vote-discussion-template.md"
+    triage = out_dir / "day25-feedback-triage-board.md"
+    validation = out_dir / "day25-validation-commands.md"
+
+    summary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    scorecard.write_text(_render_text(payload) + "\n", encoding="utf-8")
+    discussion.write_text(
+        "\n".join(
+            [
+                "# Day 25 roadmap-voting discussion template",
+                "",
+                "## Title",
+                "Roadmap voting: help prioritize the next sdetkit upgrades",
+                "",
+                "## Prompt",
+                "Vote on the top 3 roadmap items that would most improve your team workflow.",
+                "",
+                "## Candidate items",
+                "1. CI integration accelerators",
+                "2. Security and compliance automation",
+                "3. Contributor onboarding improvements",
+                "4. Release and communication tooling",
+                "",
+                "## Response format",
+                "- Priority #1:",
+                "- Priority #2:",
+                "- Priority #3:",
+                "- Optional context:",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    triage.write_text(
+        "\n".join(
+            [
+                "# Day 25 feedback triage board",
+                "",
+                "| Feedback item | Votes | Owner | Status | Decision date |",
+                "| --- | ---: | --- | --- | --- |",
+                "| Example: Improve docs nav for first-time users | 0 | @owner | needs-info | YYYY-MM-DD |",
+                "",
+                "Triage SLA: respond within 48h and classify as `accepted`, `needs-info`, or `not-now`.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    validation.write_text(
+        "\n".join(["# Day 25 validation commands", "", "```bash", *_REQUIRED_COMMANDS, "```"]) + "\n",
+        encoding="utf-8",
+    )
+
+    return [str(path.relative_to(root)) for path in [summary, scorecard, discussion, triage, validation]]
+
+
+def execute_commands(root: Path, evidence_dir: Path, timeout_sec: int) -> dict[str, Any]:
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    results: list[dict[str, Any]] = []
+    for command in _EXECUTION_COMMANDS:
+        proc = subprocess.run(
+            shlex.split(command), cwd=root, text=True, capture_output=True, timeout=timeout_sec
+        )
+        results.append(
+            {
+                "command": command,
+                "returncode": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            }
+        )
+    payload = {
+        "name": "day25-community-activation-execution",
+        "total_commands": len(_EXECUTION_COMMANDS),
+        "results": results,
+    }
+    (evidence_dir / "day25-execution-summary.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit community-activation",
+        description="Day 25 community activation and roadmap-voting closeout lane.",
+    )
+    parser.add_argument("--root", default=".", help="Repository root path.")
+    parser.add_argument("--readme", default="README.md", help="README path for discoverability checks.")
+    parser.add_argument("--docs-index", default="docs/index.md", help="Docs index path for discoverability checks.")
+    parser.add_argument("--top10", default=_TOP10_PATH, help="Top-10 roadmap strategy path.")
+    parser.add_argument("--write-defaults", action="store_true", help="Create default Day 25 integration page.")
+    parser.add_argument("--emit-pack-dir", default="", help="Optional output directory for generated Day 25 files.")
+    parser.add_argument("--execute", action="store_true", help="Run Day 25 command chain and emit evidence logs.")
+    parser.add_argument(
+        "--evidence-dir",
+        default="docs/artifacts/day25-community-pack/evidence",
+        help="Output directory for execution evidence logs.",
+    )
+    parser.add_argument("--timeout-sec", type=int, default=120, help="Per-command timeout used by --execute.")
+    parser.add_argument("--min-score", type=float, default=90.0, help="Minimum score for strict pass.")
+    parser.add_argument("--strict", action="store_true", help="Fail when score or critical checks are not ready.")
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="Output format.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = build_parser().parse_args(argv)
+    root = Path(ns.root).resolve()
+    page = root / _PAGE_PATH
+
+    if ns.write_defaults:
+        page.parent.mkdir(parents=True, exist_ok=True)
+        page.write_text(_DAY25_DEFAULT_PAGE, encoding="utf-8")
+
+    payload = build_community_activation_summary(
+        root,
+        readme_path=ns.readme,
+        docs_index_path=ns.docs_index,
+        top10_path=ns.top10,
+    )
+    page_text = _read(page)
+    missing_sections = [section for section in [_SECTION_HEADER, *_REQUIRED_SECTIONS] if section not in page_text]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+    payload["strict_failures"] = [*missing_sections, *missing_commands]
+
+    if ns.emit_pack_dir:
+        payload["emitted_pack_files"] = emit_pack(root, root / ns.emit_pack_dir, payload)
+    if ns.execute:
+        payload["execution"] = execute_commands(root, root / ns.evidence_dir, ns.timeout_sec)
+
+    strict_failed = (
+        bool(payload["strict_failures"])
+        or payload["summary"]["activation_score"] < ns.min_score
+        or bool(payload["summary"]["critical_failures"])
+    )
+
+    if ns.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_render_text(payload))
+
+    return 1 if ns.strict and strict_failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -42,3 +42,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "release-narrative" in out
     assert "trust-signal-upgrade" in out
     assert "faq-objections" in out
+    assert "community-activation" in out

--- a/tests/test_community_activation.py
+++ b/tests/test_community_activation.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import community_activation as ca
+
+
+def _seed(root: Path) -> None:
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text("day-25-ultra-upgrade-report.md\n", encoding="utf-8")
+    (root / "README.md").write_text(
+        "docs/integrations-community-activation.md\ncommunity-activation\n", encoding="utf-8"
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 25 — Community activation:** open roadmap-voting discussion and collect feedback.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-community-activation.md").write_text(ca._DAY25_DEFAULT_PAGE, encoding="utf-8")
+
+
+def test_day25_community_activation_json(tmp_path: Path, capsys) -> None:
+    _seed(tmp_path)
+
+    rc = ca.main(["--root", str(tmp_path), "--format", "json"])
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day25-community-activation"
+    assert out["summary"]["activation_score"] == 100.0
+
+
+def test_day25_community_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed(tmp_path)
+
+    rc = ca.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day25-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day25-pack/evidence",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    assert (tmp_path / "artifacts/day25-pack/day25-community-summary.json").exists()
+    assert (tmp_path / "artifacts/day25-pack/day25-community-scorecard.md").exists()
+    assert (tmp_path / "artifacts/day25-pack/day25-roadmap-vote-discussion-template.md").exists()
+    assert (tmp_path / "artifacts/day25-pack/day25-feedback-triage-board.md").exists()
+    assert (tmp_path / "artifacts/day25-pack/day25-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day25-pack/evidence/day25-execution-summary.json").exists()
+
+
+def test_day25_community_strict_fails_when_sections_missing(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    (tmp_path / "docs/integrations-community-activation.md").write_text(
+        "# Community activation (Day 25)\n", encoding="utf-8"
+    )
+
+    rc = ca.main(["--root", str(tmp_path), "--strict", "--format", "json"])
+
+    assert rc == 1
+
+
+def test_day25_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed(tmp_path)
+
+    rc = cli.main(["community-activation", "--root", str(tmp_path), "--format", "text"])
+
+    assert rc == 0
+    assert "Day 25 community activation summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Close out Day 25 by adding an operational lane to convert roadmap readers into contributors via a deterministic roadmap-voting and feedback-triage flow. 
- Provide a strict, reproducible check (docs contract + discoverability + strategy alignment) that can emit artifact packs and deterministic execution evidence. 
- Expose the new lane from the top-level CLI so teams can run the workflow like other Day N closeout commands.

### Description
- Add a new `src/sdetkit/community_activation.py` module implementing scoring, checks, pack emission, execution evidence, recommendations, and `--write-defaults` behavior. 
- Wire the command into the top-level CLI by importing and registering `community-activation` in `src/sdetkit/cli.py` so it appears in both direct dispatch and `--help` output. 
- Add a contract validation script `scripts/check_day25_community_activation_contract.py` and integration docs `docs/integrations-community-activation.md` and `docs/day-25-ultra-upgrade-report.md`. 
- Emit generated artifact samples under `docs/artifacts/day25-community-pack/` and add a focused test suite `tests/test_community_activation.py`, plus update CLI help tests in `tests/test_cli_help_lists_subcommands.py`.

### Testing
- Ran unit/behavior tests with `python -m pytest -q tests/test_community_activation.py tests/test_cli_help_lists_subcommands.py` and all tests passed (`5 passed`).
- Ran the Day 25 contract check script with `python scripts/check_day25_community_activation_contract.py` and it returned no errors and reported `score: 100.0`.
- Executed the full pack flow with `python -m sdetkit community-activation --emit-pack-dir docs/artifacts/day25-community-pack --execute --evidence-dir docs/artifacts/day25-community-pack/evidence --format json --strict` and observed successful emission and evidence (activation score 100, no critical failures).

------