### PR TITLE
feat: close Day 29 with phase-1 hardening command and contract checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,6 +955,16 @@ See implementation details: [Day 27 ultra upgrade report](docs/day-27-ultra-upgr
 
 See implementation details: [Day 28 ultra upgrade report](docs/day-28-ultra-upgrade-report.md).
 
+
+## 🧱 Day 29 ultra: Phase-1 hardening closeout
+
+- Run `python -m sdetkit day29-phase1-hardening --format json --strict` to validate Day 29 entry-page hardening readiness.
+- Emit shareable hardening pack: `python -m sdetkit day29-phase1-hardening --emit-pack-dir docs/artifacts/day29-hardening-pack --format json --strict`.
+- Execute and collect deterministic logs: `python -m sdetkit day29-phase1-hardening --execute --evidence-dir docs/artifacts/day29-hardening-pack/evidence --format json --strict`.
+- Review Day 29 integration guide: [Phase-1 hardening](docs/integrations-day29-phase1-hardening.md).
+
+See implementation details: [Day 29 ultra upgrade report](docs/day-29-ultra-upgrade-report.md).
+
 Day 23 closeout checks:
 
 ```bash

--- a/docs/artifacts/day29-phase1-hardening-sample.md
+++ b/docs/artifacts/day29-phase1-hardening-sample.md
@@ -1,0 +1,12 @@
+# Day 29 phase-1 hardening sample output
+
+- Activation score: `100`
+- Strict pass: `true`
+- Stale marker hits: `none`
+
+## Key checks passed
+
+- `required_sections_present`
+- `readme_day29_link`
+- `docs_index_day29_links`
+- `top10_day29_alignment`

--- a/docs/day-29-ultra-upgrade-report.md
+++ b/docs/day-29-ultra-upgrade-report.md
@@ -1,0 +1,24 @@
+# Day 29 ultra upgrade report — phase-1 hardening closeout
+
+## What shipped
+
+- Added `day29-phase1-hardening` command to score docs hardening readiness across top entry pages.
+- Added Day 29 docs contract validation and deterministic execution evidence lane.
+- Added Day 29 pack generation with stale-gap scan and corrective-action output.
+- Added dedicated Day 29 contract-check script and automated tests.
+
+## Key command paths
+
+```bash
+python -m sdetkit day29-phase1-hardening --format json --strict
+python -m sdetkit day29-phase1-hardening --emit-pack-dir docs/artifacts/day29-hardening-pack --format json --strict
+python -m sdetkit day29-phase1-hardening --execute --evidence-dir docs/artifacts/day29-hardening-pack/evidence --format json --strict
+python scripts/check_day29_phase1_hardening_contract.py
+```
+
+## Closeout criteria
+
+- Day 29 score >= 90 with no critical failures.
+- Top entry pages link Day 29 integration + report docs.
+- Strategy page explicitly tracks Day 29 hardening objective.
+- Evidence bundle generated and review-ready.

--- a/docs/index.md
+++ b/docs/index.md
@@ -401,3 +401,13 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 28 weekly pack: `python -m sdetkit day28-weekly-review --emit-pack-dir docs/artifacts/day28-weekly-pack --format json --strict`.
 - Run deterministic execution evidence lane: `python -m sdetkit day28-weekly-review --execute --evidence-dir docs/artifacts/day28-weekly-pack/evidence --format json --strict`.
 - Review sample output artifact: [day28 weekly review sample](artifacts/day28-weekly-review-sample.md).
+
+
+## Day 29 ultra upgrades (phase-1 hardening closeout)
+
+- Read the implementation report: [Day 29 ultra upgrade report](day-29-ultra-upgrade-report.md).
+- Run `python -m sdetkit day29-phase1-hardening --format json --strict` to score entry-page hardening readiness.
+- Emit Day 29 hardening pack: `python -m sdetkit day29-phase1-hardening --emit-pack-dir docs/artifacts/day29-hardening-pack --format json --strict`.
+- Run deterministic execution evidence lane: `python -m sdetkit day29-phase1-hardening --execute --evidence-dir docs/artifacts/day29-hardening-pack/evidence --format json --strict`.
+- Review sample output artifact: [day29 hardening sample](artifacts/day29-phase1-hardening-sample.md).
+- Review integration guide: [Day 29 phase-1 hardening](integrations-day29-phase1-hardening.md).

--- a/docs/integrations-day29-phase1-hardening.md
+++ b/docs/integrations-day29-phase1-hardening.md
@@ -1,0 +1,45 @@
+# Day 29 — Phase-1 hardening
+
+Day 29 closes Phase-1 by hardening top entry pages, removing stale guidance, and publishing a deterministic closeout lane.
+
+## Why Day 29 exists
+
+- Preserve trust by ensuring README + docs index + strategy pages are mutually consistent.
+- Close stale docs gaps before Day 30 phase wrap and handoff.
+- Produce a reviewable hardening artifact pack for maintainers.
+
+## Hardening scope
+
+- README entry-page checks and command-lane verification.
+- Docs index discoverability checks for Day 29 integration/report pages.
+- Strategy alignment checks against `docs/top-10-github-strategy.md` Day 29 objective.
+- Stale marker scans across top entry pages and recent integration docs.
+
+## Day 29 command lane
+
+```bash
+python -m sdetkit day29-phase1-hardening --format json --strict
+python -m sdetkit day29-phase1-hardening --emit-pack-dir docs/artifacts/day29-hardening-pack --format json --strict
+python -m sdetkit day29-phase1-hardening --execute --evidence-dir docs/artifacts/day29-hardening-pack/evidence --format json --strict
+python scripts/check_day29_phase1_hardening_contract.py
+```
+
+## Scoring model
+
+Day 29 weighted score (0-100):
+
+- Docs contract and command-lane completeness: 35 points.
+- Entry-page discoverability + strategy alignment: 35 points.
+- Stale marker elimination in top pages: 20 points.
+- Artifact/report wiring for Phase-1 closeout: 10 points.
+
+## Entry page polish checklist
+
+- README includes Day 29 section and command lane.
+- Docs index links both integration guide and Day 29 report.
+- Top-10 strategy includes Day 29 hardening objective.
+- No stale placeholder markers in top entry pages.
+
+## Evidence mode
+
+`--execute` runs deterministic checks and captures command logs in `--evidence-dir`.

--- a/scripts/check_day29_phase1_hardening_contract.py
+++ b/scripts/check_day29_phase1_hardening_contract.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from sdetkit import day29_phase1_hardening as d29
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Day 29 phase-1 hardening contract.")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d29.build_day29_phase1_hardening_summary(root)
+
+    strict_failures: list[str] = []
+    page = root / d29._PAGE_PATH
+    page_text = page.read_text(encoding="utf-8") if page.exists() else ""
+    for section in [d29._SECTION_HEADER, *d29._REQUIRED_SECTIONS]:
+        if section not in page_text:
+            strict_failures.append(section)
+    for command in d29._REQUIRED_COMMANDS:
+        if command not in page_text:
+            strict_failures.append(command)
+
+    errors: list[str] = []
+    if strict_failures:
+        errors.append(f"missing docs contract entries: {strict_failures}")
+    if payload["summary"]["critical_failures"]:
+        errors.append(f"critical failures: {payload['summary']['critical_failures']}")
+
+    if not ns.skip_evidence:
+        evidence = root / "docs/artifacts/day29-hardening-pack/evidence/day29-execution-summary.json"
+        if not evidence.exists():
+            errors.append(f"missing evidence file: {evidence}")
+        else:
+            data = json.loads(evidence.read_text(encoding="utf-8"))
+            if data.get("total_commands", 0) < 2:
+                errors.append("execution evidence has insufficient commands")
+
+    print(json.dumps({"errors": errors, "score": payload["summary"]["activation_score"]}, indent=2))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -10,6 +10,7 @@ from . import (
     contributor_funnel,
     community_activation,
     external_contribution_push,
+    day29_phase1_hardening,
     day28_weekly_review,
     kpi_audit,
     demo,
@@ -135,6 +136,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day28-weekly-review":
         return day28_weekly_review.main(list(argv[1:]))
 
+    if argv and argv[0] == "day29-phase1-hardening":
+        return day29_phase1_hardening.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -256,6 +260,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     dwr = sub.add_parser("day28-weekly-review")
     dwr.add_argument("args", nargs=argparse.REMAINDER)
 
+    d29 = sub.add_parser("day29-phase1-hardening")
+    d29.add_argument("args", nargs=argparse.REMAINDER)
+
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -365,6 +372,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "day28-weekly-review":
         return day28_weekly_review.main(ns.args)
+
+    if ns.cmd == "day29-phase1-hardening":
+        return day29_phase1_hardening.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/day29_phase1_hardening.py
+++ b/src/sdetkit/day29_phase1_hardening.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-day29-phase1-hardening.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_SECTION_HEADER = "# Day 29 — Phase-1 hardening"
+_REQUIRED_SECTIONS = [
+    "## Why Day 29 exists",
+    "## Hardening scope",
+    "## Day 29 command lane",
+    "## Scoring model",
+    "## Entry page polish checklist",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit day29-phase1-hardening --format json --strict",
+    "python -m sdetkit day29-phase1-hardening --emit-pack-dir docs/artifacts/day29-hardening-pack --format json --strict",
+    "python -m sdetkit day29-phase1-hardening --execute --evidence-dir docs/artifacts/day29-hardening-pack/evidence --format json --strict",
+    "python scripts/check_day29_phase1_hardening_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit day29-phase1-hardening --format json --strict",
+    "python scripts/check_day29_phase1_hardening_contract.py --skip-evidence",
+]
+_STALE_MARKERS = ["TODO", "TBD", "lorem ipsum", "coming soon"]
+
+_DAY29_DEFAULT_PAGE = """# Day 29 — Phase-1 hardening
+
+Day 29 closes Phase-1 by hardening top entry pages, removing stale guidance, and publishing a deterministic closeout lane.
+
+## Why Day 29 exists
+
+- Preserve trust by ensuring README + docs index + strategy pages are mutually consistent.
+- Close stale docs gaps before Day 30 phase wrap and handoff.
+- Produce a reviewable hardening artifact pack for maintainers.
+
+## Hardening scope
+
+- README entry-page checks and command-lane verification.
+- Docs index discoverability checks for Day 29 integration/report pages.
+- Strategy alignment checks against `docs/top-10-github-strategy.md` Day 29 objective.
+- Stale marker scans across top entry pages and recent integration docs.
+
+## Day 29 command lane
+
+```bash
+python -m sdetkit day29-phase1-hardening --format json --strict
+python -m sdetkit day29-phase1-hardening --emit-pack-dir docs/artifacts/day29-hardening-pack --format json --strict
+python -m sdetkit day29-phase1-hardening --execute --evidence-dir docs/artifacts/day29-hardening-pack/evidence --format json --strict
+python scripts/check_day29_phase1_hardening_contract.py
+```
+
+## Scoring model
+
+Day 29 weighted score (0-100):
+
+- Docs contract and command-lane completeness: 35 points.
+- Entry-page discoverability + strategy alignment: 35 points.
+- Stale marker elimination in top pages: 20 points.
+- Artifact/report wiring for Phase-1 closeout: 10 points.
+
+## Entry page polish checklist
+
+- README includes Day 29 section and command lane.
+- Docs index links both integration guide and Day 29 report.
+- Top-10 strategy includes Day 29 hardening objective.
+- No stale placeholder markers in top entry pages.
+"""
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def build_day29_phase1_hardening_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    page = root / docs_page_path
+    readme = root / readme_path
+    docs_index = root / docs_index_path
+    top10 = root / top10_path
+    report = root / "docs/day-29-ultra-upgrade-report.md"
+
+    page_text = _read(page)
+    readme_text = _read(readme)
+    docs_index_text = _read(docs_index)
+    top10_text = _read(top10)
+
+    missing_sections = [s for s in [_SECTION_HEADER, *_REQUIRED_SECTIONS] if s not in page_text]
+    missing_commands = [c for c in _REQUIRED_COMMANDS if c not in page_text]
+
+    scanned_files = {
+        "README.md": readme_text,
+        "docs/index.md": docs_index_text,
+        "docs/top-10-github-strategy.md": top10_text,
+        "docs/integrations-day29-phase1-hardening.md": page_text,
+        "docs/integrations-day28-weekly-review.md": _read(root / "docs/integrations-day28-weekly-review.md"),
+    }
+    stale_hits: dict[str, list[str]] = {}
+    for path, text in scanned_files.items():
+        hits = [marker for marker in _STALE_MARKERS if marker.lower() in text.lower()]
+        if hits:
+            stale_hits[path] = hits
+
+    checks: list[dict[str, Any]] = [
+        {"key": "docs_page_exists", "weight": 10, "passed": page.exists(), "evidence": str(page)},
+        {"key": "required_sections_present", "weight": 15, "passed": not missing_sections, "evidence": {"missing_sections": missing_sections}},
+        {"key": "required_commands_present", "weight": 10, "passed": not missing_commands, "evidence": {"missing_commands": missing_commands}},
+        {"key": "readme_day29_link", "weight": 12, "passed": "docs/integrations-day29-phase1-hardening.md" in readme_text, "evidence": "docs/integrations-day29-phase1-hardening.md"},
+        {"key": "docs_index_day29_links", "weight": 12, "passed": all(token in docs_index_text for token in ["day-29-ultra-upgrade-report.md", "integrations-day29-phase1-hardening.md"]), "evidence": "day-29-ultra-upgrade-report.md + integrations-day29-phase1-hardening.md"},
+        {"key": "top10_day29_alignment", "weight": 11, "passed": "Day 29 — Phase-1 hardening" in top10_text, "evidence": "Day 29 — Phase-1 hardening"},
+        {"key": "report_exists", "weight": 10, "passed": report.exists(), "evidence": str(report)},
+        {"key": "stale_markers_clean", "weight": 20, "passed": not stale_hits, "evidence": stale_hits},
+    ]
+    failed = [check["key"] for check in checks if not check["passed"]]
+    score = round(sum(check["weight"] for check in checks if check["passed"]), 2)
+    critical_failures = [name for name in ["docs_page_exists", "required_sections_present", "required_commands_present"] if name in failed]
+
+    gaps = []
+    if missing_sections:
+        gaps.append("Missing required Day 29 sections in integration page.")
+    if missing_commands:
+        gaps.append("Missing required command lane entries in integration page.")
+    if stale_hits:
+        gaps.append("Stale marker tokens detected across top entry pages.")
+
+    return {
+        "name": "day29-phase1-hardening",
+        "paths": {
+            "root": str(root),
+            "docs_page": str(page.relative_to(root)) if page.exists() else docs_page_path,
+            "report_page": str(report.relative_to(root)) if report.exists() else "docs/day-29-ultra-upgrade-report.md",
+        },
+        "checks": checks,
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "stale_hits": stale_hits,
+        "gaps": gaps,
+        "wins": [f"{check['key']} passed" for check in checks if check["passed"]],
+        "corrective_actions": [f"Fix check: {check}" for check in failed],
+    }
+
+
+def _to_text(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    return (
+        "Day 29 phase-1 hardening summary\n"
+        f"Activation score: {summary['activation_score']}\n"
+        f"Passed checks: {summary['passed_checks']}\n"
+        f"Failed checks: {summary['failed_checks']}\n"
+        f"Critical failures: {', '.join(summary['critical_failures']) if summary['critical_failures'] else 'none'}\n"
+    )
+
+
+def _to_markdown(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    lines = [
+        "# Day 29 phase-1 hardening summary",
+        "",
+        f"- Activation score: **{summary['activation_score']}**",
+        f"- Passed checks: **{summary['passed_checks']}**",
+        f"- Failed checks: **{summary['failed_checks']}**",
+        f"- Critical failures: **{', '.join(summary['critical_failures']) if summary['critical_failures'] else 'none'}**",
+        "",
+        "## Gaps",
+        *[f"- {g}" for g in payload["gaps"] or ["No gaps detected."]],
+        "",
+        "## Corrective actions",
+        *[f"- [ ] {a}" for a in payload["corrective_actions"] or ["No corrective actions required."]],
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
+    target = (root / pack_dir).resolve() if not pack_dir.is_absolute() else pack_dir
+    target.mkdir(parents=True, exist_ok=True)
+    _write(target / "day29-phase1-hardening-summary.json", json.dumps(payload, indent=2) + "\n")
+    _write(target / "day29-phase1-hardening-summary.md", _to_markdown(payload))
+    _write(target / "day29-stale-gaps.json", json.dumps(payload["stale_hits"], indent=2) + "\n")
+    _write(target / "day29-validation-commands.md", "# Day 29 validation commands\n\n```bash\n" + "\n".join(_REQUIRED_COMMANDS) + "\n```\n")
+
+
+def _run_execution(root: Path, evidence_dir: Path) -> None:
+    target = (root / evidence_dir).resolve() if not evidence_dir.is_absolute() else evidence_dir
+    target.mkdir(parents=True, exist_ok=True)
+    logs: list[dict[str, Any]] = []
+    for command in _EXECUTION_COMMANDS:
+        proc = subprocess.run(shlex.split(command), cwd=root, text=True, capture_output=True, check=False)
+        logs.append({"command": command, "returncode": proc.returncode, "stdout": proc.stdout, "stderr": proc.stderr})
+    summary = {
+        "name": "day29-phase1-hardening-execution",
+        "total_commands": len(logs),
+        "failed_commands": [log["command"] for log in logs if log["returncode"] != 0],
+        "commands": logs,
+    }
+    _write(target / "day29-execution-summary.json", json.dumps(summary, indent=2) + "\n")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Day 29 phase-1 hardening scorer.")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["text", "json", "markdown"], default="text")
+    parser.add_argument("--output")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-defaults", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    ns = parser.parse_args(argv)
+    root = Path(ns.root).resolve()
+
+    if ns.write_defaults:
+        page = root / _PAGE_PATH
+        if not page.exists():
+            _write(page, _DAY29_DEFAULT_PAGE)
+
+    payload = build_day29_phase1_hardening_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, payload, Path(ns.emit_pack_dir))
+    if ns.execute:
+        ev_dir = Path(ns.evidence_dir) if ns.evidence_dir else Path("docs/artifacts/day29-hardening-pack/evidence")
+        _run_execution(root, ev_dir)
+
+    if ns.format == "json":
+        rendered = json.dumps(payload, indent=2) + "\n"
+    elif ns.format == "markdown":
+        rendered = _to_markdown(payload)
+    else:
+        rendered = _to_text(payload)
+
+    if ns.output:
+        _write((root / ns.output).resolve() if not Path(ns.output).is_absolute() else Path(ns.output), rendered)
+    else:
+        print(rendered, end="")
+
+    if ns.strict and (payload["summary"]["failed_checks"] > 0 or payload["summary"]["critical_failures"]):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -45,3 +45,4 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "community-activation" in out
     assert "external-contribution-push" in out
     assert "kpi-audit" in out
+    assert "day29-phase1-hardening" in out

--- a/tests/test_day29_phase1_hardening.py
+++ b/tests/test_day29_phase1_hardening.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day29_phase1_hardening as d29
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text(
+        "docs/integrations-day29-phase1-hardening.md\nday29-phase1-hardening\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-29-ultra-upgrade-report.md\nintegrations-day29-phase1-hardening.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 29 — Phase-1 hardening:** close stale docs gaps and polish top entry pages.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day28-weekly-review.md").write_text("# Weekly review #4 (Day 28)\n", encoding="utf-8")
+    (root / "docs/integrations-day29-phase1-hardening.md").write_text(d29._DAY29_DEFAULT_PAGE, encoding="utf-8")
+    (root / "docs/day-29-ultra-upgrade-report.md").write_text("# Day 29 report\n", encoding="utf-8")
+
+
+def test_day29_hardening_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d29.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day29-phase1-hardening"
+    assert out["summary"]["activation_score"] >= 90
+
+
+def test_day29_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d29.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day29-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day29-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day29-pack/day29-phase1-hardening-summary.json").exists()
+    assert (tmp_path / "artifacts/day29-pack/day29-phase1-hardening-summary.md").exists()
+    assert (tmp_path / "artifacts/day29-pack/day29-stale-gaps.json").exists()
+    assert (tmp_path / "artifacts/day29-pack/day29-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day29-pack/evidence/day29-execution-summary.json").exists()
+
+
+def test_day29_strict_fails_when_sections_missing(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "docs/integrations-day29-phase1-hardening.md").write_text("# Day 29 — Phase-1 hardening\n", encoding="utf-8")
+    rc = d29.main(["--root", str(tmp_path), "--strict", "--format", "json"])
+    assert rc == 1
+
+
+def test_day29_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day29-phase1-hardening", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 29 phase-1 hardening summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Close Phase‑1 by shipping a concrete Day 29 hardening lane that polishes top entry pages and closes stale docs gaps before Phase‑1 wrap.  
- Provide a deterministic, auditable command lane that scores discoverability, required sections/commands, and stale-marker elimination.  
- Surface explicit corrective actions and emit a shareable artifact pack + execution evidence for maintainers to validate handoff readiness.  

### Description
- Added a new CLI workflow `day29-phase1-hardening` implemented in `src/sdetkit/day29_phase1_hardening.py` that builds a hardening summary, scans for stale markers, emits pack artifacts, and runs deterministic execution commands.  
- Wired the command into the fast-path and argparse subcommands in `src/sdetkit/cli.py` and updated the help coverage test.  
- Added a contract-check helper `scripts/check_day29_phase1_hardening_contract.py` to validate docs sections/commands and evidence expectations.  
- Published Day 29 docs and artifacts: `docs/integrations-day29-phase1-hardening.md`, `docs/day-29-ultra-upgrade-report.md`, and `docs/artifacts/day29-phase1-hardening-sample.md`, and updated `README.md` and `docs/index.md` for discoverability.  
- Added tests `tests/test_day29_phase1_hardening.py` and updated `tests/test_cli_help_lists_subcommands.py` to include the new subcommand.  

### Testing
- Ran unit tests: `python -m pytest -q tests/test_day29_phase1_hardening.py tests/test_cli_help_lists_subcommands.py`, which completed successfully (`5 passed`).  
- Ran the new CLI scoring command: `python -m sdetkit day29-phase1-hardening --format json --strict` and verified a healthy activation score (100) in the JSON output.  
- Ran contract checks: `python scripts/check_day29_phase1_hardening_contract.py --skip-evidence` and a full emit+execute+check run (`--execute` + `--emit-pack-dir`) and observed no errors from the checker.

------
