### PR TITLE
Add Day 57 KPI deep-audit closeout lane with CLI, docs, tests, and contract checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1577,3 +1577,12 @@ See implementation details: [Day 55 big upgrade report](docs/day-55-big-upgrade-
 
 See implementation details: [Day 56 big upgrade report](docs/day-56-big-upgrade-report.md).
 
+### Day 57 — KPI deep audit closeout lane
+
+- Run `python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict` to validate Day 57 KPI deep-audit readiness.
+- Emit shareable Day 57 KPI deep-audit pack: `python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict`.
+- Execute and collect deterministic logs: `python -m sdetkit day57-kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict`.
+- Review Day 57 integration guide: [KPI deep audit closeout lane](docs/integrations-day57-kpi-deep-audit-closeout.md).
+
+See implementation details: [Day 57 big upgrade report](docs/day-57-big-upgrade-report.md).
+

--- a/docs/day-57-big-upgrade-report.md
+++ b/docs/day-57-big-upgrade-report.md
@@ -1,0 +1,25 @@
+# Day 57 Big Upgrade Report
+
+## Objective
+
+Close Day 57 with a high-confidence KPI deep-audit lane that converts Day 56 stabilization outcomes into deterministic Day 58 execution priorities.
+
+## Big upgrades delivered
+
+- Added a dedicated Day 57 CLI lane: `day57-kpi-deep-audit-closeout`.
+- Added strict KPI deep-audit contract checks and discoverability checks.
+- Added artifact-pack emission for audit brief, risk ledger, KPI scorecard, and execution logs.
+- Added deterministic execution evidence capture for repeatable closeout verification.
+
+## Commands
+
+```bash
+python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict
+python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict
+python -m sdetkit day57-kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict
+python scripts/check_day57_kpi_deep_audit_closeout_contract.py
+```
+
+## Outcome
+
+Day 57 is now an evidence-backed closeout lane with strict continuity to Day 56 and deterministic handoff into Day 58 execution planning.

--- a/docs/index.md
+++ b/docs/index.md
@@ -649,3 +649,12 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Run deterministic execution evidence lane: `python -m sdetkit day56-stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict`.
 - Review integration guide: [Day 56 stabilization closeout lane](integrations-day56-stabilization-closeout.md).
 
+
+## Day 57 KPI deep audit closeout lane
+
+- Read the implementation report: [Day 57 big upgrade report](day-57-big-upgrade-report.md).
+- Run `python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict` to score KPI deep-audit closeout readiness.
+- Emit Day 57 KPI deep-audit closeout pack: `python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict`.
+- Run deterministic execution evidence lane: `python -m sdetkit day57-kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict`.
+- Review integration guide: [Day 57 KPI deep audit closeout lane](integrations-day57-kpi-deep-audit-closeout.md).
+

--- a/docs/integrations-day57-kpi-deep-audit-closeout.md
+++ b/docs/integrations-day57-kpi-deep-audit-closeout.md
@@ -1,0 +1,55 @@
+# Day 57 — KPI deep audit closeout lane
+
+Day 57 closes with a major KPI deep-audit upgrade that turns Day 56 stabilization outcomes into deterministic trendline governance.
+
+## Why Day 57 matters
+
+- Converts Day 56 stabilization evidence into repeatable KPI anomaly triage loops.
+- Protects quality with ownership, command proof, and KPI rollback guardrails.
+- Produces a deterministic handoff from Day 57 closeout into Day 58 execution planning.
+
+## Required inputs (Day 56)
+
+- `docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json`
+- `docs/artifacts/day56-stabilization-closeout-pack/day56-delivery-board.md`
+
+## Day 57 command lane
+
+```bash
+python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict
+python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict
+python -m sdetkit day57-kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict
+python scripts/check_day57_kpi_deep_audit_closeout_contract.py
+```
+
+## KPI deep audit contract
+
+- Single owner + backup reviewer are assigned for Day 57 KPI deep-audit execution and signal triage.
+- The Day 57 lane references Day 56 stabilization outcomes and unresolved risks.
+- Every Day 57 section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 57 closeout records deep-audit outcomes and Day 58 execution priorities.
+
+## KPI deep audit quality checklist
+
+- [ ] Includes KPI trendline digest, anomaly triage, and rollback strategy
+- [ ] Every section has owner, review window, KPI threshold, and risk flag
+- [ ] CTA links point to docs + runnable command evidence
+- [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each KPI
+- [ ] Artifact pack includes audit brief, risk ledger, KPI scorecard, and execution log
+
+## Day 57 delivery board
+
+- [ ] Day 57 KPI deep audit brief committed
+- [ ] Day 57 deep-audit plan reviewed with owner + backup
+- [ ] Day 57 risk ledger exported
+- [ ] Day 57 KPI scorecard snapshot exported
+- [ ] Day 58 execution priorities drafted from Day 57 learnings
+
+## Scoring model
+
+Day 57 weighted score (0-100):
+
+- Contract + command lane completeness: 30 points.
+- Discoverability alignment (README/docs index/top-10): 20 points.
+- Day 56 continuity and strict baseline carryover: 35 points.
+- KPI deep-audit contract lock + delivery board readiness: 15 points.

--- a/docs/top-10-github-strategy.md
+++ b/docs/top-10-github-strategy.md
@@ -198,7 +198,7 @@ Phase 2 converts early traction into repeatable growth loops. Each day ships one
 - **Day 55 — Contributor activation #2:** highlight advanced issues for repeat contributors.
 - **Day 56 — Stabilization closeout:** enforce deterministic follow-through, KPI recovery, and risk rollback proof.
 
-- **Day 57 — KPI deep audit:** validate 30-day trendlines (stars, CTR, discussions, PRs, returning users).
+- **Day 57 — KPI deep audit closeout:** lock 30-day trendlines (stars, CTR, discussions, PRs, returning users) with strict anomaly triage.
 - **Day 58 — Phase-2 hardening:** polish highest-traffic pages and remove top friction points.
 - **Day 59 — Phase-3 pre-plan:** convert Phase-2 learnings into Phase-3 priorities.
 - **Day 60 — Phase-2 wrap + handoff:** publish full Phase-2 report and lock Phase-3 execution board.

--- a/scripts/check_day57_kpi_deep_audit_closeout_contract.py
+++ b/scripts/check_day57_kpi_deep_audit_closeout_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import day57_kpi_deep_audit_closeout as d57
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Day 57 KPI deep audit closeout contract")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d57.build_day57_kpi_deep_audit_closeout_summary(root)
+    errors: list[str] = []
+
+    if payload["summary"]["activation_score"] < 95:
+        errors.append(f"activation_score too low: {payload['summary']['activation_score']}")
+    if not payload["summary"]["strict_pass"]:
+        errors.append("strict_pass is false")
+
+    failed = [check["check_id"] for check in payload["checks"] if not check["passed"]]
+    if failed:
+        errors.append(f"failed checks: {failed}")
+
+    if not ns.skip_evidence:
+        evidence = root / "docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence/day57-execution-summary.json"
+        if not evidence.exists():
+            errors.append(f"missing evidence summary: {evidence}")
+        else:
+            try:
+                summary = json.loads(evidence.read_text(encoding="utf-8"))
+                if int(summary.get("total_commands", 0)) < 3:
+                    errors.append("expected >=3 executed commands")
+            except Exception as exc:  # pragma: no cover
+                errors.append(f"failed to parse evidence summary: {exc}")
+
+    if errors:
+        print("day57-kpi-deep-audit-closeout contract check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        return 1
+
+    print("day57-kpi-deep-audit-closeout contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -37,6 +37,7 @@ from . import (
     day53_docs_loop_closeout,
     day55_contributor_activation_closeout,
     day56_stabilization_closeout,
+    day57_kpi_deep_audit_closeout,
     demo,
     docs_navigation,
     docs_qa,
@@ -236,6 +237,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day56-stabilization-closeout":
         return day56_stabilization_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "day57-kpi-deep-audit-closeout":
+        return day57_kpi_deep_audit_closeout.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -433,6 +437,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     d56 = sub.add_parser("day56-stabilization-closeout")
     d56.add_argument("args", nargs=argparse.REMAINDER)
 
+    d57 = sub.add_parser("day57-kpi-deep-audit-closeout")
+    d57.add_argument("args", nargs=argparse.REMAINDER)
+
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -616,6 +623,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "day56-stabilization-closeout":
         return day56_stabilization_closeout.main(ns.args)
+
+    if ns.cmd == "day57-kpi-deep-audit-closeout":
+        return day57_kpi_deep_audit_closeout.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/day57_kpi_deep_audit_closeout.py
+++ b/src/sdetkit/day57_kpi_deep_audit_closeout.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-day57-kpi-deep-audit-closeout.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_DAY56_SUMMARY_PATH = "docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json"
+_DAY56_BOARD_PATH = "docs/artifacts/day56-stabilization-closeout-pack/day56-delivery-board.md"
+_SECTION_HEADER = "# Day 57 — KPI deep audit closeout lane"
+_REQUIRED_SECTIONS = [
+    "## Why Day 57 matters",
+    "## Required inputs (Day 56)",
+    "## Day 57 command lane",
+    "## KPI deep audit contract",
+    "## KPI deep audit quality checklist",
+    "## Day 57 delivery board",
+    "## Scoring model",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict",
+    "python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict",
+    "python -m sdetkit day57-kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict",
+    "python scripts/check_day57_kpi_deep_audit_closeout_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict",
+    "python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict",
+    "python scripts/check_day57_kpi_deep_audit_closeout_contract.py --skip-evidence",
+]
+_REQUIRED_CONTRACT_LINES = [
+    "Single owner + backup reviewer are assigned for Day 57 KPI deep-audit execution and signal triage.",
+    "The Day 57 lane references Day 56 stabilization outcomes and unresolved risks.",
+    "Every Day 57 section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "Day 57 closeout records deep-audit outcomes and Day 58 execution priorities.",
+]
+_REQUIRED_QUALITY_LINES = [
+    "- [ ] Includes KPI trendline digest, anomaly triage, and rollback strategy",
+    "- [ ] Every section has owner, review window, KPI threshold, and risk flag",
+    "- [ ] CTA links point to docs + runnable command evidence",
+    "- [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each KPI",
+    "- [ ] Artifact pack includes audit brief, risk ledger, KPI scorecard, and execution log",
+]
+_REQUIRED_DELIVERY_BOARD_LINES = [
+    "- [ ] Day 57 KPI deep audit brief committed",
+    "- [ ] Day 57 deep-audit plan reviewed with owner + backup",
+    "- [ ] Day 57 risk ledger exported",
+    "- [ ] Day 57 KPI scorecard snapshot exported",
+    "- [ ] Day 58 execution priorities drafted from Day 57 learnings",
+]
+
+_DAY57_DEFAULT_PAGE = """# Day 57 — KPI deep audit closeout lane
+
+Day 57 closes with a major KPI deep-audit upgrade that turns Day 56 stabilization outcomes into deterministic trendline governance.
+
+## Why Day 57 matters
+
+- Converts Day 56 stabilization evidence into repeatable KPI anomaly triage loops.
+- Protects quality with ownership, command proof, and KPI rollback guardrails.
+- Produces a deterministic handoff from Day 57 closeout into Day 58 execution planning.
+
+## Required inputs (Day 56)
+
+- `docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json`
+- `docs/artifacts/day56-stabilization-closeout-pack/day56-delivery-board.md`
+
+## Day 57 command lane
+
+```bash
+python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict
+python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict
+python -m sdetkit day57-kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict
+python scripts/check_day57_kpi_deep_audit_closeout_contract.py
+```
+
+## KPI deep audit contract
+
+- Single owner + backup reviewer are assigned for Day 57 KPI deep-audit execution and signal triage.
+- The Day 57 lane references Day 56 stabilization outcomes and unresolved risks.
+- Every Day 57 section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 57 closeout records deep-audit outcomes and Day 58 execution priorities.
+
+## KPI deep audit quality checklist
+
+- [ ] Includes KPI trendline digest, anomaly triage, and rollback strategy
+- [ ] Every section has owner, review window, KPI threshold, and risk flag
+- [ ] CTA links point to docs + runnable command evidence
+- [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each KPI
+- [ ] Artifact pack includes audit brief, risk ledger, KPI scorecard, and execution log
+
+## Day 57 delivery board
+
+- [ ] Day 57 KPI deep audit brief committed
+- [ ] Day 57 deep-audit plan reviewed with owner + backup
+- [ ] Day 57 risk ledger exported
+- [ ] Day 57 KPI scorecard snapshot exported
+- [ ] Day 58 execution priorities drafted from Day 57 learnings
+
+## Scoring model
+
+Day 57 weighted score (0-100):
+
+- Contract + command lane completeness: 30 points.
+- Discoverability alignment (README/docs index/top-10): 20 points.
+- Day 56 continuity and strict baseline carryover: 35 points.
+- KPI deep-audit contract lock + delivery board readiness: 15 points.
+"""
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _load_day56(path: Path) -> tuple[int, bool, int]:
+    payload = _load_json(path)
+    if not payload:
+        return 0, False, 0
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    checks = payload.get("checks") if isinstance(payload.get("checks"), list) else []
+    score = int(summary.get("activation_score", 0) or 0)
+    strict = bool(summary.get("strict_pass", False))
+    return score, strict, len(checks)
+
+
+def _load_board(path: Path) -> tuple[int, bool]:
+    if not path.exists():
+        return 0, False
+    lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines()]
+    items = [line for line in lines if line.startswith("- [")]
+    has_day56 = any("Day 56" in line for line in lines)
+    return len(items), has_day56
+
+
+def build_day57_kpi_deep_audit_closeout_summary(root: Path) -> dict[str, Any]:
+    readme_text = _read(root / "README.md")
+    docs_index_text = _read(root / "docs/index.md")
+    page_path = root / _PAGE_PATH
+    page_text = _read(page_path)
+    top10_text = _read(root / _TOP10_PATH)
+    day56_summary = root / _DAY56_SUMMARY_PATH
+    day56_board = root / _DAY56_BOARD_PATH
+
+    day56_score, day56_strict, day56_check_count = _load_day56(day56_summary)
+    board_count, board_has_day56 = _load_board(day56_board)
+
+    missing_sections = [s for s in _REQUIRED_SECTIONS if s not in page_text]
+    missing_commands = [c for c in _REQUIRED_COMMANDS if c not in page_text]
+    missing_contract_lines = [line for line in _REQUIRED_CONTRACT_LINES if line not in page_text]
+    missing_quality_lines = [line for line in _REQUIRED_QUALITY_LINES if line not in page_text]
+    missing_board_items = [line for line in _REQUIRED_DELIVERY_BOARD_LINES if line not in page_text]
+
+    checks: list[dict[str, Any]] = [
+        {"check_id": "docs_page_exists", "weight": 10, "passed": page_path.exists(), "evidence": str(page_path)},
+        {"check_id": "required_sections_present", "weight": 10, "passed": not missing_sections, "evidence": {"missing_sections": missing_sections}},
+        {"check_id": "required_commands_present", "weight": 10, "passed": not missing_commands, "evidence": {"missing_commands": missing_commands}},
+        {"check_id": "readme_day57_link", "weight": 8, "passed": _PAGE_PATH in readme_text, "evidence": _PAGE_PATH},
+        {"check_id": "readme_day57_command", "weight": 4, "passed": "day57-kpi-deep-audit-closeout" in readme_text, "evidence": "day57-kpi-deep-audit-closeout"},
+        {
+            "check_id": "docs_index_day57_links",
+            "weight": 8,
+            "passed": ("day-57-big-upgrade-report.md" in docs_index_text and "integrations-day57-kpi-deep-audit-closeout.md" in docs_index_text),
+            "evidence": "day-57-big-upgrade-report.md + integrations-day57-kpi-deep-audit-closeout.md",
+        },
+        {"check_id": "top10_day57_alignment", "weight": 5, "passed": ("Day 57" in top10_text and "Day 58" in top10_text), "evidence": "Day 57 + Day 58 strategy chain"},
+        {"check_id": "day56_summary_present", "weight": 10, "passed": day56_summary.exists(), "evidence": str(day56_summary)},
+        {"check_id": "day56_delivery_board_present", "weight": 8, "passed": day56_board.exists(), "evidence": str(day56_board)},
+        {
+            "check_id": "day56_quality_floor",
+            "weight": 10,
+            "passed": day56_strict and day56_score >= 95,
+            "evidence": {"day56_score": day56_score, "strict_pass": day56_strict, "day56_checks": day56_check_count},
+        },
+        {"check_id": "day56_board_integrity", "weight": 7, "passed": board_count >= 5 and board_has_day56, "evidence": {"board_items": board_count, "contains_day56": board_has_day56}},
+        {"check_id": "kpi_deep_audit_contract_locked", "weight": 5, "passed": not missing_contract_lines, "evidence": {"missing_contract_lines": missing_contract_lines}},
+        {"check_id": "kpi_deep_audit_quality_checklist_locked", "weight": 3, "passed": not missing_quality_lines, "evidence": {"missing_quality_items": missing_quality_lines}},
+        {"check_id": "delivery_board_locked", "weight": 2, "passed": not missing_board_items, "evidence": {"missing_board_items": missing_board_items}},
+    ]
+
+    failed = [c for c in checks if not c["passed"]]
+    critical_failures: list[str] = []
+    if not day56_summary.exists() or not day56_board.exists():
+        critical_failures.append("day56_handoff_inputs")
+    if not day56_strict:
+        critical_failures.append("day56_strict_baseline")
+
+    wins: list[str] = []
+    misses: list[str] = []
+    handoff_actions: list[str] = []
+
+    if day56_strict:
+        wins.append(f"Day 56 continuity is strict-pass with activation score={day56_score}.")
+    else:
+        misses.append("Day 56 strict continuity signal is missing.")
+        handoff_actions.append("Re-run Day 56 stabilization closeout command and restore strict baseline before Day 57 lock.")
+
+    if board_count >= 5 and board_has_day56:
+        wins.append(f"Day 56 delivery board integrity validated with {board_count} checklist items.")
+    else:
+        misses.append("Day 56 delivery board integrity is incomplete (needs >=5 items and Day 56 anchors).")
+        handoff_actions.append("Repair Day 56 delivery board entries to include Day 56 anchors.")
+
+    if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
+        wins.append("KPI deep-audit contract + quality checklist is fully locked for execution.")
+    else:
+        misses.append("KPI deep-audit contract, quality checklist, or delivery board entries are missing.")
+        handoff_actions.append("Complete all Day 57 contract lines, quality checklist entries, and delivery board tasks in docs.")
+
+    if not failed and not critical_failures:
+        wins.append("Day 57 KPI deep-audit closeout lane is fully complete and ready for Day 58 execution lane.")
+
+    score = int(round(sum(c["weight"] for c in checks if c["passed"])))
+    return {
+        "name": "day57-kpi-deep-audit-closeout",
+        "inputs": {
+            "readme": "README.md",
+            "docs_index": "docs/index.md",
+            "docs_page": _PAGE_PATH,
+            "top10": _TOP10_PATH,
+            "day56_summary": str(day56_summary.relative_to(root)) if day56_summary.exists() else str(day56_summary),
+            "day56_delivery_board": str(day56_board.relative_to(root)) if day56_board.exists() else str(day56_board),
+        },
+        "checks": checks,
+        "rollup": {"day56_activation_score": day56_score, "day56_checks": day56_check_count, "day56_delivery_board_items": board_count},
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "wins": wins,
+        "misses": misses,
+        "handoff_actions": handoff_actions,
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Day 57 KPI deep-audit closeout summary",
+        f"- Activation score: {payload['summary']['activation_score']}",
+        f"- Passed checks: {payload['summary']['passed_checks']}",
+        f"- Failed checks: {payload['summary']['failed_checks']}",
+        f"- Critical failures: {payload['summary']['critical_failures']}",
+    ]
+    return "\n".join(lines)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
+    target = pack_dir if pack_dir.is_absolute() else root / pack_dir
+    _write(target / "day57-kpi-deep-audit-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
+    _write(target / "day57-kpi-deep-audit-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "day57-kpi-deep-audit-brief.md", "# Day 57 KPI deep-audit brief\n")
+    _write(target / "day57-risk-ledger.csv", "risk,owner,mitigation,status\n")
+    _write(target / "day57-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "day57-execution-log.md", "# Day 57 execution log\n")
+    _write(target / "day57-delivery-board.md", "\n".join(["# Day 57 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n")
+    _write(target / "day57-validation-commands.md", "# Day 57 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n")
+
+
+def _execute_commands(root: Path, evidence_dir: Path) -> None:
+    events: list[dict[str, Any]] = []
+    out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
+        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        event = {"command": command, "returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+        events.append(event)
+        _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
+    _write(out_dir / "day57-execution-summary.json", json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Day 57 KPI deep audit closeout checks")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-default-doc", action="store_true")
+    ns = parser.parse_args(argv)
+
+    root = Path(ns.root).resolve()
+    if ns.write_default_doc:
+        _write(root / _PAGE_PATH, _DAY57_DEFAULT_PAGE)
+
+    payload = build_day57_kpi_deep_audit_closeout_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, Path(ns.emit_pack_dir), payload)
+    if ns.execute:
+        evidence_dir = Path(ns.evidence_dir) if ns.evidence_dir else Path("docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence")
+        _execute_commands(root, evidence_dir)
+
+    print(json.dumps(payload, indent=2) if ns.format == "json" else _render_text(payload))
+    return 1 if ns.strict and not payload["summary"]["strict_pass"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_day57_kpi_deep_audit_closeout.py
+++ b/tests/test_day57_kpi_deep_audit_closeout.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day57_kpi_deep_audit_closeout as d57
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text(
+        "docs/integrations-day57-kpi-deep-audit-closeout.md\nday57-kpi-deep-audit-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-57-big-upgrade-report.md\nintegrations-day57-kpi-deep-audit-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 57 — KPI deep audit:** validate strict trendlines and blockers.\n"
+        "- **Day 58 — Execution sprint:** convert audit outcomes into shipped changes.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day57-kpi-deep-audit-closeout.md").write_text(d57._DAY57_DEFAULT_PAGE, encoding="utf-8")
+    (root / "docs/day-57-big-upgrade-report.md").write_text("# Day 57 report\n", encoding="utf-8")
+
+    summary = root / "docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json"
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(json.dumps({"summary": {"activation_score": 100, "strict_pass": True}, "checks": [{"passed": True}]}, indent=2), encoding="utf-8")
+    board = root / "docs/artifacts/day56-stabilization-closeout-pack/day56-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 56 delivery board",
+                "- [ ] Day 56 stabilization brief committed",
+                "- [ ] Day 56 stabilization plan reviewed with owner + backup",
+                "- [ ] Day 56 risk ledger exported",
+                "- [ ] Day 56 KPI scorecard snapshot exported",
+                "- [ ] Day 57 deep-audit priorities drafted from Day 56 learnings",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_day57_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d57.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day57-kpi-deep-audit-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day57_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d57.main(["--root", str(tmp_path), "--emit-pack-dir", "artifacts/day57-pack", "--execute", "--evidence-dir", "artifacts/day57-pack/evidence", "--format", "json", "--strict"])
+    assert rc == 0
+    assert (tmp_path / "artifacts/day57-pack/day57-kpi-deep-audit-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day57-pack/day57-kpi-deep-audit-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/day57-kpi-deep-audit-brief.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/day57-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/day57-pack/day57-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day57-pack/day57-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/day57-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/day57-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/evidence/day57-execution-summary.json").exists()
+
+
+def test_day57_strict_fails_without_day56(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json").unlink()
+    assert d57.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
+
+
+def test_day57_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day57-kpi-deep-audit-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 57 KPI deep-audit closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation

- Continue the Day N closeout workflow by adding a Day 57 KPI deep-audit closeout lane that picks up Day 56 stabilization outputs and enforces strict trendline governance. 
- Provide deterministic evidence capture, pack emission, and a strict scoring model so Day 57 can be validated end-to-end. 
- Make the new lane discoverable and operable via the `sdetkit` CLI and CI-friendly contract checks.

### Description

- Added a new implementation module `src/sdetkit/day57_kpi_deep_audit_closeout.py` that performs discoverability checks, Day 56 continuity checks, scoring, artifact pack emission, and deterministic execution evidence capture. 
- Wired the command into the CLI by updating `src/sdetkit/cli.py` so `python -m sdetkit day57-kpi-deep-audit-closeout ...` is supported and registered. 
- Added documentation and discoverability assets: `docs/integrations-day57-kpi-deep-audit-closeout.md`, `docs/day-57-big-upgrade-report.md`, plus README/docs/index/top-10 updates to reference the new lane. 
- Added a contract checker script `scripts/check_day57_kpi_deep_audit_closeout_contract.py` and comprehensive tests `tests/test_day57_kpi_deep_audit_closeout.py` to validate JSON output, strict-mode behavior, pack/evidence emission, and CLI dispatch.

### Testing

- Run compilation check with `python -m compileall -q src/sdetkit/day57_kpi_deep_audit_closeout.py scripts/check_day57_kpi_deep_audit_closeout_contract.py tests/test_day57_kpi_deep_audit_closeout.py`, which completed successfully (`OK`).
- Ran `pytest -q tests/test_day57_kpi_deep_audit_closeout.py tests/test_day56_stabilization_closeout.py`; after an initial failing run that surfaced a scoring/consistency issue, fixes were applied and the final test run passed with `8 passed`.
- The new tests cover JSON output, pack emission + evidence generation, strict-mode failure behavior when Day 56 artifacts are absent, and CLI dispatch; all automated tests now succeed.

------