### PR TITLE
Add dedicated live detail pages for Command HUD, Repo Map, and Diff Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,25 +106,25 @@
   <table>
     <tr>
       <td align="center">
-        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/hud-showcase/#command-hud">
+        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/command-hud-live/">
           <img src="docs/assets/devs69-card-hud.svg" width="360" alt="DevS69 Command HUD" />
         </a>
         <br />
-        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/hud-showcase/#command-hud"><strong>🕹️ Open Command HUD (large)</strong></a>
+        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/command-hud-live/"><strong>🕹️ Open Command HUD (large)</strong></a>
       </td>
       <td align="center">
-        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/hud-showcase/#repo-map">
+        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/repo-map-live/">
           <img src="docs/assets/devs69-card-repo-map.svg" width="360" alt="DevS69 Repo Map" />
         </a>
         <br />
-        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/hud-showcase/#repo-map"><strong>🗺️ Open Repo Map (large)</strong></a>
+        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/repo-map-live/"><strong>🗺️ Open Repo Map (large)</strong></a>
       </td>
       <td align="center">
-        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/hud-showcase/#diff-to-decision">
+        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/diff-flow-live/">
           <img src="docs/assets/devs69-card-diff-flow.svg" width="360" alt="DevS69 Diff to Decision" />
         </a>
         <br />
-        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/hud-showcase/#diff-to-decision"><strong>🔄 Open Diff Flow (large)</strong></a>
+        <a href="https://sherif69-sa.github.io/DevS69-sdetkit/diff-flow-live/"><strong>🔄 Open Diff Flow (large)</strong></a>
       </td>
     </tr>
   </table>

--- a/docs/command-hud-live.md
+++ b/docs/command-hud-live.md
@@ -1,0 +1,28 @@
+# 🕹️ DevS69 Command HUD — Live Detail View
+
+This page is the dedicated **full Command HUD view**.
+
+[![DevS69 Command HUD](assets/devs69-card-hud.svg)](assets/devs69-card-hud.svg){ target=_blank }
+
+## Command lanes (full detail)
+
+| HUD lane | Command | Expected output | Why it matters |
+|---|---|---|---|
+| Health baseline | `python -m sdetkit doctor --format markdown` | Health score + recommended next actions | Fast system readiness check |
+| Governance checks | `python -m sdetkit repo audit --format markdown` | Policy and hygiene findings | Keeps repo quality enforceable |
+| Security hardening | `python -m sdetkit security scan --format text` | Vulnerability/risk overview | Reduces release risk |
+| Workflow orchestration | `python -m sdetkit agent run 'action repo.audit {"profile":"default"}' --approve` | Deterministic automation execution | Scales repeatable operations |
+
+## Live + auto-updated signals
+
+These pull directly from GitHub and update whenever CI/workflows or the default branch changes.
+
+- ![Pages](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/pages.yml/badge.svg)
+- ![CI](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml/badge.svg)
+- ![Last commit](https://img.shields.io/github/last-commit/sherif69-sa/DevS69-sdetkit)
+- ![Latest release](https://img.shields.io/github/v/release/sherif69-sa/DevS69-sdetkit?sort=semver)
+
+## Related links
+
+- [Open docs portal home](https://sherif69-sa.github.io/DevS69-sdetkit/)
+- [Open HUD showcase index](hud-showcase.md)

--- a/docs/diff-flow-live.md
+++ b/docs/diff-flow-live.md
@@ -1,0 +1,27 @@
+# 🔄 DevS69 Diff-to-Decision — Live Detail View
+
+This page is the dedicated **full Diff-to-Decision view**.
+
+[![DevS69 Diff-to-Decision](assets/devs69-card-diff-flow.svg)](assets/devs69-card-diff-flow.svg){ target=_blank }
+
+## Decision flow (full detail)
+
+| Stage | Command | Artifact |
+|---|---|---|
+| Validate | `python -m pytest -q` | Test pass/fail signal |
+| Audit | `python -m sdetkit repo audit --format markdown` | Quality findings |
+| Secure | `python -m sdetkit security report --format sarif --output build/security.sarif` | SARIF output |
+| Publish evidence | `python -m sdetkit proof --execute --strict --format markdown --output docs/artifacts/day3-proof-sample.md` | Shareable proof pack |
+| Decide | `python -m sdetkit release-narrative --format markdown --output docs/artifacts/day20-release-narrative-sample.md` | Release decision narrative |
+
+## Live + auto-updated signals
+
+- ![CI](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml/badge.svg)
+- ![Mutation Tests](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/mutation-tests.yml/badge.svg)
+- ![Security](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/security.yml/badge.svg)
+- ![Last commit](https://img.shields.io/github/last-commit/sherif69-sa/DevS69-sdetkit)
+
+## Related links
+
+- [Open docs portal home](https://sherif69-sa.github.io/DevS69-sdetkit/)
+- [Open HUD showcase index](hud-showcase.md)

--- a/docs/hud-showcase.md
+++ b/docs/hud-showcase.md
@@ -6,24 +6,24 @@ Large, clickable visual cards with quick usage hints.
 
 ## Command HUD
 
-[![DevS69 Command HUD](assets/devs69-card-hud.svg)](assets/devs69-card-hud.svg)
+[![DevS69 Command HUD](assets/devs69-card-hud.svg)](command-hud-live.md)
 
 **Quick hint:** Start with `python -m sdetkit doctor --format markdown` to get your baseline health score and next actions.
 
-[Open in live portal](https://sherif69-sa.github.io/DevS69-sdetkit/)
+[Open full Command HUD view](command-hud-live.md)
 
 ## Repo Map
 
-[![DevS69 Repo Map](assets/devs69-card-repo-map.svg)](assets/devs69-card-repo-map.svg)
+[![DevS69 Repo Map](assets/devs69-card-repo-map.svg)](repo-map-live.md)
 
 **Quick hint:** Use this visual to understand where source, tests, docs, templates, and tooling are located.
 
-[Open in live portal](https://sherif69-sa.github.io/DevS69-sdetkit/)
+[Open full Repo Map view](repo-map-live.md)
 
 ## Diff-to-Decision
 
-[![DevS69 Diff-to-Decision](assets/devs69-card-diff-flow.svg)](assets/devs69-card-diff-flow.svg)
+[![DevS69 Diff-to-Decision](assets/devs69-card-diff-flow.svg)](diff-flow-live.md)
 
 **Quick hint:** Follow the sequence: tests → repo audit → security → proof pack → release narrative.
 
-[Open in live portal](https://sherif69-sa.github.io/DevS69-sdetkit/)
+[Open full Diff-to-Decision view](diff-flow-live.md)

--- a/docs/repo-map-live.md
+++ b/docs/repo-map-live.md
@@ -1,0 +1,27 @@
+# 🗺️ DevS69 Repo Map — Live Detail View
+
+This page is the dedicated **full Repo Map view**.
+
+[![DevS69 Repo Map](assets/devs69-card-repo-map.svg)](assets/devs69-card-repo-map.svg){ target=_blank }
+
+## Repository zones (full detail)
+
+| Zone | Purpose | Primary path |
+|---|---|---|
+| Source | CLI and orchestration implementation | [`src/sdetkit`](https://github.com/sherif69-sa/DevS69-sdetkit/tree/main/src/sdetkit) |
+| Tests | Deterministic checks/contracts | [`tests`](https://github.com/sherif69-sa/DevS69-sdetkit/tree/main/tests) |
+| Docs | Guides, references, runbooks | [`docs`](https://github.com/sherif69-sa/DevS69-sdetkit/tree/main/docs) |
+| Templates | Reusable automation templates | [`templates`](https://github.com/sherif69-sa/DevS69-sdetkit/tree/main/templates) |
+| Tools | Utility scripts and governance helpers | [`tools`](https://github.com/sherif69-sa/DevS69-sdetkit/tree/main/tools) |
+
+## Live + auto-updated signals
+
+- ![Pages](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/pages.yml/badge.svg)
+- ![Quality](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/quality.yml/badge.svg)
+- ![Security](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/security.yml/badge.svg)
+- ![Last commit](https://img.shields.io/github/last-commit/sherif69-sa/DevS69-sdetkit)
+
+## Related links
+
+- [Open docs portal home](https://sherif69-sa.github.io/DevS69-sdetkit/)
+- [Open HUD showcase index](hud-showcase.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,11 @@ nav:
       - Automation templates engine: automation-templates-engine.md
       - CI Contract: ci-contract.md
       - Startup + small-team workflow: use-cases-startup-small-team.md
+  - Visual HUD:
+      - HUD showcase: hud-showcase.md
+      - Command HUD (live): command-hud-live.md
+      - Repo Map (live): repo-map-live.md
+      - Diff-to-Decision (live): diff-flow-live.md
   - Integrations:
       - GitHub Action: github-action.md
       - n8n integration: n8n.md


### PR DESCRIPTION
### Motivation
- Provide a dedicated, full-size page for each HUD card so each README/Cards "Open ... (large)" action opens a single topic-focused view. 
- Surface real-time signals (CI/pages badges, last commit, latest release) on the per-topic pages so the visual HUD displays live status at-a-glance. 
- Improve discoverability by adding the pages to the docs navigation and replacing anchor-based behavior with explicit detail pages. 

### Description
- Added three new documentation pages: `docs/command-hud-live.md`, `docs/repo-map-live.md`, and `docs/diff-flow-live.md` that contain full visuals, detailed command/zone/flow tables, and live GitHub badges. 
- Updated `docs/hud-showcase.md` to link each card to its matching detail page and updated `README.md` card links to point at the GitHub Pages paths for the live views. 
- Updated `mkdocs.yml` to add a new "Visual HUD" nav group exposing the new pages in the site navigation, and canonicalized repo links in `repo-map-live.md` to point at the GitHub tree. 
- Included live/auto-updated status signals (workflow badges, last commit, latest release) on the new pages and captured preview screenshots during build. 

### Testing
- Ran `mkdocs build -q` which completed successfully (build warning about MkDocs/Material compatibility was observed but did not block the build). 
- Ran a local serve and an automated Playwright capture to render pages and generate screenshots of `hud-showcase` and `command-hud-live`, which completed successfully. 
- Verified the modified docs files are included in the built site and the new nav entries appear in `mkdocs.yml` without build errors.

------