### PR TITLE
Add Day 79 scale upgrade closeout lane

### DIFF
--- a/.day79-scale-upgrade-plan.json
+++ b/.day79-scale-upgrade-plan.json
@@ -1,0 +1,27 @@
+{
+  "plan_id": "day79-scale-upgrade-v1",
+  "contributors": ["maintainer", "enterprise-lead"],
+  "scale_tracks": [
+    {
+      "name": "enterprise-onboarding-checklist",
+      "baseline": 2,
+      "target": 5,
+      "owner": "enterprise-lead"
+    },
+    {
+      "name": "adoption-evidence-pack",
+      "baseline": 3,
+      "target": 6,
+      "owner": "maintainer"
+    }
+  ],
+  "baseline": {
+    "ecosystem_score": 85,
+    "confidence": 0.82
+  },
+  "target": {
+    "scale_score": 90,
+    "confidence": 0.92
+  },
+  "owner": "scale-program-owner"
+}

--- a/README.md
+++ b/README.md
@@ -1794,6 +1794,16 @@ See implementation details: [Day 77 big upgrade report](docs/day-77-big-upgrade-
 
 See implementation details: [Day 78 big upgrade report](docs/day-78-big-upgrade-report.md).
 
+
+### Day 79 — Scale upgrade closeout lane
+
+- Run `python -m sdetkit day79-scale-upgrade-closeout --format json --strict` to validate Day 79 scale upgrade readiness.
+- Emit shareable Day 79 scale upgrade pack: `python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict`.
+- Execute and collect deterministic logs: `python -m sdetkit day79-scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict`.
+- Review Day 79 integration guide: [Scale upgrade closeout lane](docs/integrations-day79-scale-upgrade-closeout.md).
+
+See implementation details: [Day 79 big upgrade report](docs/day-79-big-upgrade-report.md).
+
 ## 🧱 Repository navigation (short version)
 
 For a cleaner README experience, the giant file listings were removed.

--- a/docs/day-79-big-upgrade-report.md
+++ b/docs/day-79-big-upgrade-report.md
@@ -1,0 +1,16 @@
+# Day 79 big upgrade report
+
+Day 79 delivers a closeout-grade scale upgrade lane that promotes Day 78 ecosystem outcomes into enterprise onboarding execution readiness with strict contract checks, deterministic command evidence, and Day 80 handoff coverage.
+
+## What shipped
+
+- New command: `python -m sdetkit day79-scale-upgrade-closeout`.
+- New integration guide: `docs/integrations-day79-scale-upgrade-closeout.md`.
+- New contract checker: `python scripts/check_day79_scale_upgrade_closeout_contract.py`.
+- New artifact schema emitted via `--emit-pack-dir` and deterministic evidence via `--execute`.
+
+## Why this is a big upgrade
+
+- Establishes a continuity gate from Day 78 ecosystem priorities before Day 79 can pass strict mode.
+- Adds a weighted scoring model (0-100) with explicit quality and rollout controls.
+- Produces a deterministic artifact pack for downstream Day 80 partner-outreach execution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -834,3 +834,12 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 78 ecosystem priorities closeout pack: `python -m sdetkit day78-ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict`.
 - Run deterministic execution evidence lane: `python -m sdetkit day78-ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack/evidence --format json --strict`.
 - Review integration guide: [Day 78 ecosystem priorities closeout lane](integrations-day78-ecosystem-priorities-closeout.md).
+
+
+## Day 79 scale upgrade closeout lane
+
+- Read the implementation report: [Day 79 big upgrade report](day-79-big-upgrade-report.md).
+- Run `python -m sdetkit day79-scale-upgrade-closeout --format json --strict` to score scale upgrade readiness.
+- Emit Day 79 scale upgrade closeout pack: `python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict`.
+- Run deterministic execution evidence lane: `python -m sdetkit day79-scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict`.
+- Review integration guide: [Day 79 scale upgrade closeout lane](integrations-day79-scale-upgrade-closeout.md).

--- a/docs/integrations-day79-scale-upgrade-closeout.md
+++ b/docs/integrations-day79-scale-upgrade-closeout.md
@@ -1,0 +1,55 @@
+# Day 79 — Scale upgrade closeout lane
+
+Day 79 closes with a major upgrade that converts Day 78 ecosystem priorities into an enterprise-scale onboarding execution pack.
+
+## Why Day 79 matters
+
+- Turns Day 78 ecosystem priorities into enterprise onboarding readiness proof across docs, rollout, and adoption loops.
+- Protects scale quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.
+- Creates a deterministic handoff from Day 79 scale upgrades into Day 80 partner outreach priorities.
+
+## Required inputs (Day 78)
+
+- `docs/artifacts/day78-ecosystem-priorities-closeout-pack/day78-ecosystem-priorities-closeout-summary.json`
+- `docs/artifacts/day78-ecosystem-priorities-closeout-pack/day78-delivery-board.md`
+- `.day79-scale-upgrade-plan.json`
+
+## Day 79 command lane
+
+```bash
+python -m sdetkit day79-scale-upgrade-closeout --format json --strict
+python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict
+python -m sdetkit day79-scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict
+python scripts/check_day79_scale_upgrade_closeout_contract.py
+```
+
+## Scale upgrade contract
+
+- Single owner + backup reviewer are assigned for Day 79 scale upgrade execution and signoff.
+- The Day 79 lane references Day 78 outcomes, controls, and KPI continuity signals.
+- Every Day 79 section includes enterprise CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 79 closeout records enterprise onboarding outcomes, confidence notes, and Day 80 partner outreach priorities.
+
+## Scale upgrade quality checklist
+
+- [ ] Includes enterprise onboarding baseline, role coverage cadence, and stakeholder assumptions
+- [ ] Every scale lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to docs + runnable command evidence
+- [ ] Scorecard captures scale score delta, ecosystem carryover delta, confidence, and rollback owner
+- [ ] Artifact pack includes integration brief, scale upgrade plan, execution ledger, KPI scorecard, and execution log
+
+## Day 79 delivery board
+
+- [ ] Day 79 integration brief committed
+- [ ] Day 79 scale upgrade plan committed
+- [ ] Day 79 enterprise execution ledger exported
+- [ ] Day 79 enterprise KPI scorecard snapshot exported
+- [ ] Day 80 partner outreach priorities drafted from Day 79 learnings
+
+## Scoring model
+
+Day 79 weighted score (0-100):
+
+- Contract + command lane integrity (35)
+- Day 78 continuity baseline quality (35)
+- Scale evidence data + delivery board completeness (30)

--- a/scripts/check_day79_scale_upgrade_closeout_contract.py
+++ b/scripts/check_day79_scale_upgrade_closeout_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import day79_scale_upgrade_closeout as d79
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Day 79 scale upgrade closeout contract")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d79.build_day79_scale_upgrade_closeout_summary(root)
+    errors: list[str] = []
+
+    if payload["summary"]["activation_score"] < 95:
+        errors.append(f"activation_score too low: {payload['summary']['activation_score']}")
+    if not payload["summary"]["strict_pass"]:
+        errors.append("strict_pass is false")
+
+    failed = [check["check_id"] for check in payload["checks"] if not check["passed"]]
+    if failed:
+        errors.append(f"failed checks: {failed}")
+
+    if not ns.skip_evidence:
+        evidence = root / "docs/artifacts/day79-scale-upgrade-closeout-pack/evidence/day79-execution-summary.json"
+        if not evidence.exists():
+            errors.append(f"missing evidence summary: {evidence}")
+        else:
+            try:
+                summary = json.loads(evidence.read_text(encoding="utf-8"))
+                if int(summary.get("total_commands", 0)) < 3:
+                    errors.append("expected >=3 executed commands")
+            except Exception as exc:  # pragma: no cover
+                errors.append(f"failed to parse evidence summary: {exc}")
+
+    if errors:
+        print("day79-scale-upgrade-closeout contract check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        return 1
+
+    print("day79-scale-upgrade-closeout contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -59,6 +59,7 @@ from . import (
     day76_contributor_recognition_closeout,
     day77_community_touchpoint_closeout,
     day78_ecosystem_priorities_closeout,
+    day79_scale_upgrade_closeout,
     demo,
     docs_navigation,
     docs_qa,
@@ -324,6 +325,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day78-ecosystem-priorities-closeout":
         return day78_ecosystem_priorities_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "day79-scale-upgrade-closeout":
+        return day79_scale_upgrade_closeout.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -575,6 +579,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     d77.add_argument("args", nargs=argparse.REMAINDER)
     d78 = sub.add_parser("day78-ecosystem-priorities-closeout")
     d78.add_argument("args", nargs=argparse.REMAINDER)
+    d79 = sub.add_parser("day79-scale-upgrade-closeout")
+    d79.add_argument("args", nargs=argparse.REMAINDER)
 
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
@@ -822,6 +828,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "day78-ecosystem-priorities-closeout":
         return day78_ecosystem_priorities_closeout.main(ns.args)
+
+    if ns.cmd == "day79-scale-upgrade-closeout":
+        return day79_scale_upgrade_closeout.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/day79_scale_upgrade_closeout.py
+++ b/src/sdetkit/day79_scale_upgrade_closeout.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-day79-scale-upgrade-closeout.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_DAY78_SUMMARY_PATH = "docs/artifacts/day78-ecosystem-priorities-closeout-pack/day78-ecosystem-priorities-closeout-summary.json"
+_DAY78_BOARD_PATH = "docs/artifacts/day78-ecosystem-priorities-closeout-pack/day78-delivery-board.md"
+_PLAN_PATH = ".day79-scale-upgrade-plan.json"
+_SECTION_HEADER = "# Day 79 — Scale upgrade closeout lane"
+_REQUIRED_SECTIONS = [
+    "## Why Day 79 matters",
+    "## Required inputs (Day 78)",
+    "## Day 79 command lane",
+    "## Scale upgrade contract",
+    "## Scale upgrade quality checklist",
+    "## Day 79 delivery board",
+    "## Scoring model",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit day79-scale-upgrade-closeout --format json --strict",
+    "python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict",
+    "python -m sdetkit day79-scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict",
+    "python scripts/check_day79_scale_upgrade_closeout_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit day79-scale-upgrade-closeout --format json --strict",
+    "python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict",
+    "python scripts/check_day79_scale_upgrade_closeout_contract.py --skip-evidence",
+]
+_REQUIRED_CONTRACT_LINES = [
+    "Single owner + backup reviewer are assigned for Day 79 scale upgrade execution and signoff.",
+    "The Day 79 lane references Day 78 outcomes, controls, and KPI continuity signals.",
+    "Every Day 79 section includes enterprise CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "Day 79 closeout records enterprise onboarding outcomes, confidence notes, and Day 80 partner outreach priorities.",
+]
+_REQUIRED_QUALITY_LINES = [
+    "- [ ] Includes enterprise onboarding baseline, role coverage cadence, and stakeholder assumptions",
+    "- [ ] Every scale lane row has owner, execution window, KPI threshold, and risk flag",
+    "- [ ] CTA links point to docs + runnable command evidence",
+    "- [ ] Scorecard captures scale score delta, ecosystem carryover delta, confidence, and rollback owner",
+    "- [ ] Artifact pack includes integration brief, scale upgrade plan, execution ledger, KPI scorecard, and execution log",
+]
+_REQUIRED_DELIVERY_BOARD_LINES = [
+    "- [ ] Day 79 integration brief committed",
+    "- [ ] Day 79 scale upgrade plan committed",
+    "- [ ] Day 79 enterprise execution ledger exported",
+    "- [ ] Day 79 enterprise KPI scorecard snapshot exported",
+    "- [ ] Day 80 partner outreach priorities drafted from Day 79 learnings",
+]
+_REQUIRED_DATA_KEYS = ['"plan_id"', '"contributors"', '"scale_tracks"', '"baseline"', '"target"', '"owner"']
+
+_DAY79_DEFAULT_PAGE = """# Day 79 — Scale upgrade closeout lane
+
+Day 79 closes with a major upgrade that converts Day 78 ecosystem priorities into an enterprise-scale onboarding execution pack.
+
+## Why Day 79 matters
+
+- Turns Day 78 ecosystem priorities into enterprise onboarding readiness proof across docs, rollout, and adoption loops.
+- Protects scale quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.
+- Creates a deterministic handoff from Day 79 scale upgrades into Day 80 partner outreach priorities.
+
+## Required inputs (Day 78)
+
+- `docs/artifacts/day78-ecosystem-priorities-closeout-pack/day78-ecosystem-priorities-closeout-summary.json`
+- `docs/artifacts/day78-ecosystem-priorities-closeout-pack/day78-delivery-board.md`
+- `.day79-scale-upgrade-plan.json`
+
+## Day 79 command lane
+
+```bash
+python -m sdetkit day79-scale-upgrade-closeout --format json --strict
+python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict
+python -m sdetkit day79-scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict
+python scripts/check_day79_scale_upgrade_closeout_contract.py
+```
+
+## Scale upgrade contract
+
+- Single owner + backup reviewer are assigned for Day 79 scale upgrade execution and signoff.
+- The Day 79 lane references Day 78 outcomes, controls, and KPI continuity signals.
+- Every Day 79 section includes enterprise CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 79 closeout records enterprise onboarding outcomes, confidence notes, and Day 80 partner outreach priorities.
+
+## Scale upgrade quality checklist
+
+- [ ] Includes enterprise onboarding baseline, role coverage cadence, and stakeholder assumptions
+- [ ] Every scale lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to docs + runnable command evidence
+- [ ] Scorecard captures scale score delta, ecosystem carryover delta, confidence, and rollback owner
+- [ ] Artifact pack includes integration brief, scale upgrade plan, execution ledger, KPI scorecard, and execution log
+
+## Day 79 delivery board
+
+- [ ] Day 79 integration brief committed
+- [ ] Day 79 scale upgrade plan committed
+- [ ] Day 79 enterprise execution ledger exported
+- [ ] Day 79 enterprise KPI scorecard snapshot exported
+- [ ] Day 80 partner outreach priorities drafted from Day 79 learnings
+
+## Scoring model
+
+Day 79 weighted score (0-100):
+
+- Contract + command lane integrity (35)
+- Day 78 continuity baseline quality (35)
+- Scale evidence data + delivery board completeness (30)
+"""
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def build_day79_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
+    readme_text = _read_text(root / "README.md")
+    docs_index_text = _read_text(root / "docs/index.md")
+    page_text = _read_text(root / _PAGE_PATH)
+    top10_text = _read_text(root / _TOP10_PATH)
+
+    day78_summary = root / _DAY78_SUMMARY_PATH
+    day78_board = root / _DAY78_BOARD_PATH
+    plan_path = root / _PLAN_PATH
+
+    day78_payload = _load_json(day78_summary)
+    day78_score = int(day78_payload.get("summary", {}).get("activation_score", 0) or 0)
+    day78_strict = bool(day78_payload.get("summary", {}).get("strict_pass", False))
+    day78_check_count = len(day78_payload.get("checks", []))
+
+    board_text = _read_text(day78_board)
+    board_count = sum(1 for line in board_text.splitlines() if line.strip().startswith("- [ ]"))
+    board_has_day78 = "Day 78" in board_text
+
+    plan_text = _read_text(plan_path)
+
+    missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
+    missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
+    missing_contract_lines = [x for x in _REQUIRED_CONTRACT_LINES if x not in page_text]
+    missing_quality_lines = [x for x in _REQUIRED_QUALITY_LINES if x not in page_text]
+    missing_board_items = [x for x in _REQUIRED_DELIVERY_BOARD_LINES if x not in page_text]
+    missing_plan_keys = [x for x in _REQUIRED_DATA_KEYS if x not in plan_text]
+
+    checks: list[dict[str, Any]] = [
+        {"check_id": "readme_day79_command", "weight": 7, "passed": ("day79-scale-upgrade-closeout" in readme_text), "evidence": "README day79 command lane"},
+        {
+            "check_id": "docs_index_day79_links",
+            "weight": 8,
+            "passed": ("day-79-big-upgrade-report.md" in docs_index_text and "integrations-day79-scale-upgrade-closeout.md" in docs_index_text),
+            "evidence": "day-79-big-upgrade-report.md + integrations-day79-scale-upgrade-closeout.md",
+        },
+        {"check_id": "top10_day79_alignment", "weight": 5, "passed": ("Day 78" in top10_text and "Day 79" in top10_text), "evidence": "Day 78 + Day 79 strategy chain"},
+        {"check_id": "day78_summary_present", "weight": 10, "passed": day78_summary.exists(), "evidence": str(day78_summary)},
+        {"check_id": "day78_delivery_board_present", "weight": 7, "passed": day78_board.exists(), "evidence": str(day78_board)},
+        {
+            "check_id": "day78_quality_floor",
+            "weight": 13,
+            "passed": day78_score >= 85,
+            "evidence": {"day78_score": day78_score, "strict_pass": day78_strict, "day78_checks": day78_check_count},
+        },
+        {
+            "check_id": "day78_board_integrity",
+            "weight": 5,
+            "passed": board_count >= 5 and board_has_day78,
+            "evidence": {"board_items": board_count, "contains_day78": board_has_day78},
+        },
+        {"check_id": "page_header", "weight": 7, "passed": _SECTION_HEADER in page_text, "evidence": _SECTION_HEADER},
+        {"check_id": "required_sections", "weight": 8, "passed": not missing_sections, "evidence": missing_sections or "all sections present"},
+        {"check_id": "required_commands", "weight": 5, "passed": not missing_commands, "evidence": missing_commands or "all commands present"},
+        {"check_id": "contract_lock", "weight": 5, "passed": not missing_contract_lines, "evidence": missing_contract_lines or "contract locked"},
+        {"check_id": "quality_checklist_lock", "weight": 5, "passed": not missing_quality_lines, "evidence": missing_quality_lines or "quality checklist locked"},
+        {"check_id": "delivery_board_lock", "weight": 5, "passed": not missing_board_items, "evidence": missing_board_items or "delivery board locked"},
+        {"check_id": "scale_plan_data_present", "weight": 10, "passed": not missing_plan_keys, "evidence": missing_plan_keys or _PLAN_PATH},
+    ]
+
+    failed = [c for c in checks if not c["passed"]]
+    critical_failures: list[str] = []
+    if not day78_summary.exists() or not day78_board.exists():
+        critical_failures.append("day78_handoff_inputs")
+
+    wins: list[str] = []
+    misses: list[str] = []
+    handoff_actions: list[str] = []
+
+    if day78_score >= 85:
+        wins.append(f"Day 78 continuity baseline is stable with activation score={day78_score}.")
+    else:
+        misses.append("Day 78 continuity baseline is below the floor (<85).")
+        handoff_actions.append("Re-run Day 78 closeout command and raise baseline quality above 85 before Day 79 lock.")
+
+    if board_count >= 5 and board_has_day78:
+        wins.append(f"Day 78 delivery board integrity validated with {board_count} checklist items.")
+    else:
+        misses.append("Day 78 delivery board integrity is incomplete (needs >=5 items and Day 78 anchors).")
+        handoff_actions.append("Repair Day 78 delivery board entries to include Day 78 anchors.")
+
+    if not missing_plan_keys:
+        wins.append("Day 79 scale upgrade dataset is available for launch execution.")
+    else:
+        misses.append("Day 79 scale upgrade dataset is missing required keys.")
+        handoff_actions.append("Update .day79-scale-upgrade-plan.json to restore required keys.")
+
+    if not failed and not critical_failures:
+        wins.append("Day 79 scale upgrade closeout lane is fully complete and ready for Day 80 partner outreach priorities.")
+
+    score = int(round(sum(c["weight"] for c in checks if c["passed"])))
+    return {
+        "name": "day79-scale-upgrade-closeout",
+        "inputs": {
+            "readme": "README.md",
+            "docs_index": "docs/index.md",
+            "docs_page": _PAGE_PATH,
+            "top10": _TOP10_PATH,
+            "day78_summary": str(day78_summary.relative_to(root)) if day78_summary.exists() else str(day78_summary),
+            "day78_delivery_board": str(day78_board.relative_to(root)) if day78_board.exists() else str(day78_board),
+            "scale_upgrade_plan": _PLAN_PATH,
+        },
+        "checks": checks,
+        "rollup": {"day78_activation_score": day78_score, "day78_checks": day78_check_count, "day78_delivery_board_items": board_count},
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "wins": wins,
+        "misses": misses,
+        "handoff_actions": handoff_actions,
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Day 79 scale upgrade closeout summary",
+        f"- Activation score: {payload['summary']['activation_score']}",
+        f"- Passed checks: {payload['summary']['passed_checks']}",
+        f"- Failed checks: {payload['summary']['failed_checks']}",
+        f"- Critical failures: {payload['summary']['critical_failures']}",
+    ]
+    return "\n".join(lines)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
+    target = pack_dir if pack_dir.is_absolute() else root / pack_dir
+    _write(target / "day79-scale-upgrade-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
+    _write(target / "day79-scale-upgrade-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "day79-integration-brief.md", "# Day 79 integration brief\n")
+    _write(target / "day79-scale-upgrade-plan.md", "# Day 79 scale upgrade plan\n")
+    _write(target / "day79-enterprise-execution-ledger.json", json.dumps({"executions": []}, indent=2) + "\n")
+    _write(target / "day79-enterprise-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "day79-execution-log.md", "# Day 79 execution log\n")
+    _write(target / "day79-delivery-board.md", "\n".join(["# Day 79 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n")
+    _write(target / "day79-validation-commands.md", "# Day 79 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n")
+
+
+def _execute_commands(root: Path, evidence_dir: Path) -> None:
+    events: list[dict[str, Any]] = []
+    out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
+        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        event = {"command": command, "returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+        events.append(event)
+        _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
+    _write(out_dir / "day79-execution-summary.json", json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Day 79 scale upgrade closeout checks")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-default-doc", action="store_true")
+    ns = parser.parse_args(argv)
+
+    root = Path(ns.root).resolve()
+    if ns.write_default_doc:
+        _write(root / _PAGE_PATH, _DAY79_DEFAULT_PAGE)
+
+    payload = build_day79_scale_upgrade_closeout_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, Path(ns.emit_pack_dir), payload)
+    if ns.execute:
+        evidence_dir = Path(ns.evidence_dir) if ns.evidence_dir else Path("docs/artifacts/day79-scale-upgrade-closeout-pack/evidence")
+        _execute_commands(root, evidence_dir)
+
+    print(json.dumps(payload, indent=2) if ns.format == "json" else _render_text(payload))
+    return 1 if ns.strict and not payload["summary"]["strict_pass"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_day79_scale_upgrade_closeout.py
+++ b/tests/test_day79_scale_upgrade_closeout.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day79_scale_upgrade_closeout as d79
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text(
+        "docs/integrations-day79-scale-upgrade-closeout.md\nday79-scale-upgrade-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-79-big-upgrade-report.md\nintegrations-day79-scale-upgrade-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 78 — Ecosystem priorities closeout:** lock partner workflow baselines.\n"
+        "- **Day 79 — Enterprise onboarding path:** publish role-based onboarding checklist.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day79-scale-upgrade-closeout.md").write_text(
+        d79._DAY79_DEFAULT_PAGE, encoding="utf-8"
+    )
+    (root / "docs/day-79-big-upgrade-report.md").write_text("# Day 79 report\n", encoding="utf-8")
+
+    summary = (
+        root
+        / "docs/artifacts/day78-ecosystem-priorities-closeout-pack/day78-ecosystem-priorities-closeout-summary.json"
+    )
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 100, "strict_pass": True},
+                "checks": [{"passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = root / "docs/artifacts/day78-ecosystem-priorities-closeout-pack/day78-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 78 delivery board",
+                "- [ ] Day 78 integration brief committed",
+                "- [ ] Day 78 ecosystem priorities plan committed",
+                "- [ ] Day 78 ecosystem workstream ledger exported",
+                "- [ ] Day 78 ecosystem KPI scorecard snapshot exported",
+                "- [ ] Day 79 scale priorities drafted from Day 78 learnings",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    scale_plan = root / ".day79-scale-upgrade-plan.json"
+    scale_plan.write_text(
+        json.dumps(
+            {
+                "plan_id": "day79-scale-upgrade-001",
+                "contributors": ["maintainers", "enterprise-success"],
+                "scale_tracks": ["role-based-onboarding", "control-plane-rollout"],
+                "baseline": {"activated_orgs": 3, "setup_time_days": 12},
+                "target": {"activated_orgs": 6, "setup_time_days": 7},
+                "owner": "enterprise-ops",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_day79_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d79.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day79-scale-upgrade-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day79_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d79.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day79-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day79-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day79-pack/day79-scale-upgrade-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day79-pack/day79-scale-upgrade-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day79-pack/day79-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/day79-pack/day79-scale-upgrade-plan.md").exists()
+    assert (tmp_path / "artifacts/day79-pack/day79-enterprise-execution-ledger.json").exists()
+    assert (tmp_path / "artifacts/day79-pack/day79-enterprise-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day79-pack/day79-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day79-pack/day79-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day79-pack/day79-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day79-pack/evidence/day79-execution-summary.json").exists()
+
+
+def test_day79_strict_fails_without_day78(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (
+        tmp_path
+        / "docs/artifacts/day78-ecosystem-priorities-closeout-pack/day78-ecosystem-priorities-closeout-summary.json"
+    ).unlink()
+    assert d79.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
+
+
+def test_day79_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day79-scale-upgrade-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 79 scale upgrade closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation

- Add a Day 79 closeout lane to finish Phase-3 week-of-work by converting Day 78 ecosystem priorities into an enterprise-scale onboarding execution pack with strict gating. 
- Provide deterministic artifact emission and execution evidence so downstream Day 80 partner-outreach work can consume verified outputs. 
- Expose the new lane as a first-class CLI subcommand and provide automation for contract validation and CI-friendly tests.

### Description

- Add new closeout implementation `src/sdetkit/day79_scale_upgrade_closeout.py` that builds a scoring summary, emits an artifact pack, runs deterministic execution commands, and supports `--format`, `--strict`, `--emit-pack-dir`, `--execute`, and `--write-default-doc` options. 
- Wire the command into the CLI by registering `day79-scale-upgrade-closeout` for direct dispatch and argparse subcommands in `src/sdetkit/cli.py`. 
- Add a contract checker script `scripts/check_day79_scale_upgrade_closeout_contract.py`, a seed plan `.day79-scale-upgrade-plan.json`, integration docs `docs/integrations-day79-scale-upgrade-closeout.md`, and a big-upgrade report `docs/day-79-big-upgrade-report.md`. 
- Add tests `tests/test_day79_scale_upgrade_closeout.py` and update top-level docs (`README.md`, `docs/index.md`) with Day 79 links and examples of the runnable commands.

### Testing

- Ran `pytest -q tests/test_day79_scale_upgrade_closeout.py` and all tests passed (4 passed). 
- Executed the command lane and contract check via `python -m sdetkit day79-scale-upgrade-closeout --format json --strict` and `python scripts/check_day79_scale_upgrade_closeout_contract.py --skip-evidence`, and the contract check reported success.

------