### PR TITLE
Add Day 80 partner outreach closeout lane with CLI, docs, and validation

### DIFF
--- a/.day80-partner-outreach-plan.json
+++ b/.day80-partner-outreach-plan.json
@@ -1,0 +1,8 @@
+{
+  "plan_id": "day80-partner-outreach-main",
+  "contributors": ["maintainers", "partner-success", "field-enablement"],
+  "partner_tracks": ["co-marketing", "integration-acceleration", "partner-onboarding"],
+  "baseline": {"activated_partners": 5, "first-response-hours": 48},
+  "target": {"activated_partners": 12, "first-response-hours": 24},
+  "owner": "partner-ops"
+}

--- a/README.md
+++ b/README.md
@@ -1804,6 +1804,16 @@ See implementation details: [Day 78 big upgrade report](docs/day-78-big-upgrade-
 
 See implementation details: [Day 79 big upgrade report](docs/day-79-big-upgrade-report.md).
 
+
+### Day 80 — Partner outreach closeout lane
+
+- Run `python -m sdetkit day80-partner-outreach-closeout --format json --strict` to validate Day 80 partner outreach readiness.
+- Emit shareable Day 80 partner outreach pack: `python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict`.
+- Execute and collect deterministic logs: `python -m sdetkit day80-partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict`.
+- Review Day 80 integration guide: [Partner outreach closeout lane](docs/integrations-day80-partner-outreach-closeout.md).
+
+See implementation details: [Day 80 big upgrade report](docs/day-80-big-upgrade-report.md).
+
 ## 🧱 Repository navigation (short version)
 
 For a cleaner README experience, the giant file listings were removed.

--- a/docs/day-80-big-upgrade-report.md
+++ b/docs/day-80-big-upgrade-report.md
@@ -1,0 +1,9 @@
+# Day 80 Big Upgrade Report
+
+Day 80 closes partner outreach execution by converting Day 79 scale signals into a deterministic launch lane.
+
+## Delivered upgrades
+
+- Added a strict Day 80 partner outreach CLI lane with scoring, pack emission, and evidence execution hooks.
+- Added contract validation script and test coverage for strict closeout checks.
+- Added docs navigation and strategy continuity references for Day 80 execution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -843,3 +843,12 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 79 scale upgrade closeout pack: `python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict`.
 - Run deterministic execution evidence lane: `python -m sdetkit day79-scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict`.
 - Review integration guide: [Day 79 scale upgrade closeout lane](integrations-day79-scale-upgrade-closeout.md).
+
+
+## Day 80 partner outreach closeout lane
+
+- Read the implementation report: [Day 80 big upgrade report](day-80-big-upgrade-report.md).
+- Run `python -m sdetkit day80-partner-outreach-closeout --format json --strict` to score partner outreach readiness.
+- Emit Day 80 partner outreach closeout pack: `python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict`.
+- Run deterministic execution evidence lane: `python -m sdetkit day80-partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict`.
+- Review integration guide: [Day 80 partner outreach closeout lane](integrations-day80-partner-outreach-closeout.md).

--- a/docs/integrations-day80-partner-outreach-closeout.md
+++ b/docs/integrations-day80-partner-outreach-closeout.md
@@ -1,0 +1,56 @@
+# Day 80 — Partner outreach closeout lane
+
+Day 80 closes with a major upgrade that converts Day 79 scale outcomes into a partner-outreach execution pack.
+
+## Why Day 80 matters
+
+- Turns Day 79 scale outcomes into partner onboarding proof across docs, rollout, and adoption loops.
+- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.
+- Creates a deterministic handoff from Day 80 partner outreach into Day 81 growth campaign priorities.
+
+## Required inputs (Day 79)
+
+- `docs/artifacts/day79-scale-upgrade-closeout-pack/day79-scale-upgrade-closeout-summary.json`
+- `docs/artifacts/day79-scale-upgrade-closeout-pack/day79-delivery-board.md`
+- `.day80-partner-outreach-plan.json`
+
+## Day 80 command lane
+
+```bash
+python -m sdetkit day80-partner-outreach-closeout --format json --strict
+python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict
+python -m sdetkit day80-partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict
+python scripts/check_day80_partner_outreach_closeout_contract.py
+```
+
+## Partner outreach contract
+
+- Single owner + backup reviewer are assigned for Day 80 partner outreach execution and signoff.
+- The Day 80 lane references Day 79 outcomes, controls, and KPI continuity signals.
+- Every Day 80 section includes partner CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 80 closeout records partner onboarding outcomes, confidence notes, and Day 81 growth campaign priorities.
+
+## Partner outreach quality checklist
+
+- [ ] Includes partner onboarding baseline, enablement cadence, and stakeholder assumptions
+- [ ] Every partner lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to docs + runnable command evidence
+- [ ] Scorecard captures partner score delta, scale carryover delta, confidence, and rollback owner
+- [ ] Artifact pack includes integration brief, partner outreach plan, execution ledger, KPI scorecard, and execution log
+
+## Day 80 delivery board
+
+- [ ] Day 80 integration brief committed
+- [ ] Day 80 partner outreach plan committed
+- [ ] Day 80 partner execution ledger exported
+- [ ] Day 80 partner KPI scorecard snapshot exported
+- [ ] Day 81 growth campaign priorities drafted from Day 80 learnings
+
+## Scoring model
+
+Day 80 weighted score (0-100):
+
+- Contract + command lane integrity (35)
+- Day 79 continuity baseline quality (35)
+- Partner evidence data + delivery board completeness (30)
+

--- a/scripts/check_day80_partner_outreach_closeout_contract.py
+++ b/scripts/check_day80_partner_outreach_closeout_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import day80_partner_outreach_closeout as d80
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Day 80 partner outreach closeout contract")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d80.build_day80_partner_outreach_closeout_summary(root)
+    errors: list[str] = []
+
+    if payload["summary"]["activation_score"] < 95:
+        errors.append(f"activation_score too low: {payload['summary']['activation_score']}")
+    if not payload["summary"]["strict_pass"]:
+        errors.append("strict_pass is false")
+
+    failed = [check["check_id"] for check in payload["checks"] if not check["passed"]]
+    if failed:
+        errors.append(f"failed checks: {failed}")
+
+    if not ns.skip_evidence:
+        evidence = root / "docs/artifacts/day80-partner-outreach-closeout-pack/evidence/day80-execution-summary.json"
+        if not evidence.exists():
+            errors.append(f"missing evidence summary: {evidence}")
+        else:
+            try:
+                summary = json.loads(evidence.read_text(encoding="utf-8"))
+                if int(summary.get("total_commands", 0)) < 3:
+                    errors.append("expected >=3 executed commands")
+            except Exception as exc:  # pragma: no cover
+                errors.append(f"failed to parse evidence summary: {exc}")
+
+    if errors:
+        print("day80-partner-outreach-closeout contract check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        return 1
+
+    print("day80-partner-outreach-closeout contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -60,6 +60,7 @@ from . import (
     day77_community_touchpoint_closeout,
     day78_ecosystem_priorities_closeout,
     day79_scale_upgrade_closeout,
+    day80_partner_outreach_closeout,
     demo,
     docs_navigation,
     docs_qa,
@@ -328,6 +329,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day79-scale-upgrade-closeout":
         return day79_scale_upgrade_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "day80-partner-outreach-closeout":
+        return day80_partner_outreach_closeout.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -581,6 +585,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     d78.add_argument("args", nargs=argparse.REMAINDER)
     d79 = sub.add_parser("day79-scale-upgrade-closeout")
     d79.add_argument("args", nargs=argparse.REMAINDER)
+    d80 = sub.add_parser("day80-partner-outreach-closeout")
+    d80.add_argument("args", nargs=argparse.REMAINDER)
 
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
@@ -831,6 +837,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "day79-scale-upgrade-closeout":
         return day79_scale_upgrade_closeout.main(ns.args)
+
+    if ns.cmd == "day80-partner-outreach-closeout":
+        return day80_partner_outreach_closeout.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/day80_partner_outreach_closeout.py
+++ b/src/sdetkit/day80_partner_outreach_closeout.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-day80-partner-outreach-closeout.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_DAY79_SUMMARY_PATH = "docs/artifacts/day79-scale-upgrade-closeout-pack/day79-scale-upgrade-closeout-summary.json"
+_DAY79_BOARD_PATH = "docs/artifacts/day79-scale-upgrade-closeout-pack/day79-delivery-board.md"
+_PLAN_PATH = ".day80-partner-outreach-plan.json"
+_SECTION_HEADER = "# Day 80 — Partner outreach closeout lane"
+_REQUIRED_SECTIONS = [
+    "## Why Day 80 matters",
+    "## Required inputs (Day 79)",
+    "## Day 80 command lane",
+    "## Partner outreach contract",
+    "## Partner outreach quality checklist",
+    "## Day 80 delivery board",
+    "## Scoring model",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit day80-partner-outreach-closeout --format json --strict",
+    "python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict",
+    "python -m sdetkit day80-partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict",
+    "python scripts/check_day80_partner_outreach_closeout_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit day80-partner-outreach-closeout --format json --strict",
+    "python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict",
+    "python scripts/check_day80_partner_outreach_closeout_contract.py --skip-evidence",
+]
+_REQUIRED_CONTRACT_LINES = [
+    "Single owner + backup reviewer are assigned for Day 80 partner outreach execution and signoff.",
+    "The Day 80 lane references Day 79 outcomes, controls, and KPI continuity signals.",
+    "Every Day 80 section includes partner CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "Day 80 closeout records partner onboarding outcomes, confidence notes, and Day 81 growth campaign priorities.",
+]
+_REQUIRED_QUALITY_LINES = [
+    "- [ ] Includes partner onboarding baseline, enablement cadence, and stakeholder assumptions",
+    "- [ ] Every partner lane row has owner, execution window, KPI threshold, and risk flag",
+    "- [ ] CTA links point to docs + runnable command evidence",
+    "- [ ] Scorecard captures partner score delta, scale carryover delta, confidence, and rollback owner",
+    "- [ ] Artifact pack includes integration brief, partner outreach plan, execution ledger, KPI scorecard, and execution log",
+]
+_REQUIRED_DELIVERY_BOARD_LINES = [
+    "- [ ] Day 80 integration brief committed",
+    "- [ ] Day 80 partner outreach plan committed",
+    "- [ ] Day 80 partner execution ledger exported",
+    "- [ ] Day 80 partner KPI scorecard snapshot exported",
+    "- [ ] Day 81 growth campaign priorities drafted from Day 80 learnings",
+]
+_REQUIRED_DATA_KEYS = ['"plan_id"', '"contributors"', '"partner_tracks"', '"baseline"', '"target"', '"owner"']
+
+_DAY80_DEFAULT_PAGE = """# Day 80 — Partner outreach closeout lane
+
+Day 80 closes with a major upgrade that converts Day 79 scale outcomes into a partner-outreach execution pack.
+
+## Why Day 80 matters
+
+- Turns Day 79 scale outcomes into partner onboarding proof across docs, rollout, and adoption loops.
+- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.
+- Creates a deterministic handoff from Day 80 partner outreach into Day 81 growth campaign priorities.
+
+## Required inputs (Day 79)
+
+- `docs/artifacts/day79-scale-upgrade-closeout-pack/day79-scale-upgrade-closeout-summary.json`
+- `docs/artifacts/day79-scale-upgrade-closeout-pack/day79-delivery-board.md`
+- `.day80-partner-outreach-plan.json`
+
+## Day 80 command lane
+
+```bash
+python -m sdetkit day80-partner-outreach-closeout --format json --strict
+python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict
+python -m sdetkit day80-partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict
+python scripts/check_day80_partner_outreach_closeout_contract.py
+```
+
+## Partner outreach contract
+
+- Single owner + backup reviewer are assigned for Day 80 partner outreach execution and signoff.
+- The Day 80 lane references Day 79 outcomes, controls, and KPI continuity signals.
+- Every Day 80 section includes partner CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 80 closeout records partner onboarding outcomes, confidence notes, and Day 81 growth campaign priorities.
+
+## Partner outreach quality checklist
+
+- [ ] Includes partner onboarding baseline, enablement cadence, and stakeholder assumptions
+- [ ] Every partner lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to docs + runnable command evidence
+- [ ] Scorecard captures partner score delta, scale carryover delta, confidence, and rollback owner
+- [ ] Artifact pack includes integration brief, partner outreach plan, execution ledger, KPI scorecard, and execution log
+
+## Day 80 delivery board
+
+- [ ] Day 80 integration brief committed
+- [ ] Day 80 partner outreach plan committed
+- [ ] Day 80 partner execution ledger exported
+- [ ] Day 80 partner KPI scorecard snapshot exported
+- [ ] Day 81 growth campaign priorities drafted from Day 80 learnings
+
+## Scoring model
+
+Day 80 weighted score (0-100):
+
+- Contract + command lane integrity (35)
+- Day 79 continuity baseline quality (35)
+- Partner evidence data + delivery board completeness (30)
+"""
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def build_day80_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
+    readme_text = _read_text(root / "README.md")
+    docs_index_text = _read_text(root / "docs/index.md")
+    page_text = _read_text(root / _PAGE_PATH)
+    top10_text = _read_text(root / _TOP10_PATH)
+
+    day79_summary = root / _DAY79_SUMMARY_PATH
+    day79_board = root / _DAY79_BOARD_PATH
+    day79_payload = _load_json(day79_summary)
+    day79_score = int(day79_payload.get("summary", {}).get("activation_score", 0) or 0)
+    day79_strict = bool(day79_payload.get("summary", {}).get("strict_pass", False))
+    day79_check_count = len(day79_payload.get("checks", [])) if isinstance(day79_payload.get("checks", []), list) else 0
+
+    board_lines = [line.strip() for line in _read_text(day79_board).splitlines() if line.strip().startswith("- [")]
+    board_count = len(board_lines)
+    board_has_day79 = any("Day 79" in line for line in board_lines)
+
+    missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+    missing_contract_lines = [line for line in _REQUIRED_CONTRACT_LINES if line not in page_text]
+    missing_quality_lines = [line for line in _REQUIRED_QUALITY_LINES if line not in page_text]
+    missing_board_items = [item for item in _REQUIRED_DELIVERY_BOARD_LINES if item not in page_text]
+
+    plan_text = _read_text(root / _PLAN_PATH)
+    missing_plan_keys = [key for key in _REQUIRED_DATA_KEYS if key not in plan_text]
+
+    checks: list[dict[str, Any]] = [
+        {"check_id": "readme_day80_command", "weight": 7, "passed": ("day80-partner-outreach-closeout" in readme_text), "evidence": "README day80 command lane"},
+        {
+            "check_id": "docs_index_day80_links",
+            "weight": 8,
+            "passed": ("day-80-big-upgrade-report.md" in docs_index_text and "integrations-day80-partner-outreach-closeout.md" in docs_index_text),
+            "evidence": "day-80-big-upgrade-report.md + integrations-day80-partner-outreach-closeout.md",
+        },
+        {"check_id": "top10_day80_alignment", "weight": 5, "passed": ("Day 79" in top10_text and "Day 80" in top10_text), "evidence": "Day 79 + Day 80 strategy chain"},
+        {"check_id": "day79_summary_present", "weight": 10, "passed": day79_summary.exists(), "evidence": str(day79_summary)},
+        {"check_id": "day79_delivery_board_present", "weight": 7, "passed": day79_board.exists(), "evidence": str(day79_board)},
+        {
+            "check_id": "day79_quality_floor",
+            "weight": 13,
+            "passed": day79_score >= 85,
+            "evidence": {"day79_score": day79_score, "strict_pass": day79_strict, "day79_checks": day79_check_count},
+        },
+        {
+            "check_id": "day79_board_integrity",
+            "weight": 5,
+            "passed": board_count >= 5 and board_has_day79,
+            "evidence": {"board_items": board_count, "contains_day79": board_has_day79},
+        },
+        {"check_id": "page_header", "weight": 7, "passed": _SECTION_HEADER in page_text, "evidence": _SECTION_HEADER},
+        {"check_id": "required_sections", "weight": 8, "passed": not missing_sections, "evidence": missing_sections or "all sections present"},
+        {"check_id": "required_commands", "weight": 5, "passed": not missing_commands, "evidence": missing_commands or "all commands present"},
+        {"check_id": "contract_lock", "weight": 5, "passed": not missing_contract_lines, "evidence": missing_contract_lines or "contract locked"},
+        {"check_id": "quality_checklist_lock", "weight": 5, "passed": not missing_quality_lines, "evidence": missing_quality_lines or "quality checklist locked"},
+        {"check_id": "delivery_board_lock", "weight": 5, "passed": not missing_board_items, "evidence": missing_board_items or "delivery board locked"},
+        {"check_id": "partner_plan_data_present", "weight": 10, "passed": not missing_plan_keys, "evidence": missing_plan_keys or _PLAN_PATH},
+    ]
+
+    failed = [c for c in checks if not c["passed"]]
+    critical_failures: list[str] = []
+    if not day79_summary.exists() or not day79_board.exists():
+        critical_failures.append("day79_handoff_inputs")
+
+    wins: list[str] = []
+    misses: list[str] = []
+    handoff_actions: list[str] = []
+
+    if day79_score >= 85:
+        wins.append(f"Day 79 continuity baseline is stable with activation score={day79_score}.")
+    else:
+        misses.append("Day 79 continuity baseline is below the floor (<85).")
+        handoff_actions.append("Re-run Day 79 closeout command and raise baseline quality above 85 before Day 80 lock.")
+
+    if board_count >= 5 and board_has_day79:
+        wins.append(f"Day 79 delivery board integrity validated with {board_count} checklist items.")
+    else:
+        misses.append("Day 79 delivery board integrity is incomplete (needs >=5 items and Day 79 anchors).")
+        handoff_actions.append("Repair Day 79 delivery board entries to include Day 79 anchors.")
+
+    if not missing_plan_keys:
+        wins.append("Day 80 partner outreach dataset is available for launch execution.")
+    else:
+        misses.append("Day 80 partner outreach dataset is missing required keys.")
+        handoff_actions.append("Update .day80-partner-outreach-plan.json to restore required keys.")
+
+    if not failed and not critical_failures:
+        wins.append("Day 80 partner outreach closeout lane is fully complete and ready for Day 81 growth campaign priorities.")
+
+    score = int(round(sum(c["weight"] for c in checks if c["passed"])))
+    return {
+        "name": "day80-partner-outreach-closeout",
+        "inputs": {
+            "readme": "README.md",
+            "docs_index": "docs/index.md",
+            "docs_page": _PAGE_PATH,
+            "top10": _TOP10_PATH,
+            "day79_summary": str(day79_summary.relative_to(root)) if day79_summary.exists() else str(day79_summary),
+            "day79_delivery_board": str(day79_board.relative_to(root)) if day79_board.exists() else str(day79_board),
+            "partner_outreach_plan": _PLAN_PATH,
+        },
+        "checks": checks,
+        "rollup": {"day79_activation_score": day79_score, "day79_checks": day79_check_count, "day79_delivery_board_items": board_count},
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "wins": wins,
+        "misses": misses,
+        "handoff_actions": handoff_actions,
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Day 80 partner outreach closeout summary",
+        f"- Activation score: {payload['summary']['activation_score']}",
+        f"- Passed checks: {payload['summary']['passed_checks']}",
+        f"- Failed checks: {payload['summary']['failed_checks']}",
+        f"- Critical failures: {payload['summary']['critical_failures']}",
+    ]
+    return "\n".join(lines)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
+    target = pack_dir if pack_dir.is_absolute() else root / pack_dir
+    _write(target / "day80-partner-outreach-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
+    _write(target / "day80-partner-outreach-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "day80-integration-brief.md", "# Day 80 integration brief\n")
+    _write(target / "day80-partner-outreach-plan.md", "# Day 80 partner outreach plan\n")
+    _write(target / "day80-partner-execution-ledger.json", json.dumps({"executions": []}, indent=2) + "\n")
+    _write(target / "day80-partner-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "day80-execution-log.md", "# Day 80 execution log\n")
+    _write(target / "day80-delivery-board.md", "\n".join(["# Day 80 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n")
+    _write(target / "day80-validation-commands.md", "# Day 80 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n")
+
+
+def _execute_commands(root: Path, evidence_dir: Path) -> None:
+    events: list[dict[str, Any]] = []
+    out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
+        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        event = {"command": command, "returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+        events.append(event)
+        _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
+    _write(out_dir / "day80-execution-summary.json", json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Day 80 partner outreach closeout checks")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-default-doc", action="store_true")
+    ns = parser.parse_args(argv)
+
+    root = Path(ns.root).resolve()
+    if ns.write_default_doc:
+        _write(root / _PAGE_PATH, _DAY80_DEFAULT_PAGE)
+
+    payload = build_day80_partner_outreach_closeout_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, Path(ns.emit_pack_dir), payload)
+    if ns.execute:
+        evidence_dir = Path(ns.evidence_dir) if ns.evidence_dir else Path("docs/artifacts/day80-partner-outreach-closeout-pack/evidence")
+        _execute_commands(root, evidence_dir)
+
+    print(json.dumps(payload, indent=2) if ns.format == "json" else _render_text(payload))
+    return 1 if ns.strict and not payload["summary"]["strict_pass"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_day80_partner_outreach_closeout.py
+++ b/tests/test_day80_partner_outreach_closeout.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day80_partner_outreach_closeout as d80
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text(
+        "docs/integrations-day80-partner-outreach-closeout.md\nday80-partner-outreach-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-80-big-upgrade-report.md\nintegrations-day80-partner-outreach-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 79 — Scale upgrade closeout:** lock enterprise onboarding improvements.\n"
+        "- **Day 80 — Partner outreach closeout:** publish partner onboarding execution checklist.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day80-partner-outreach-closeout.md").write_text(
+        d80._DAY80_DEFAULT_PAGE, encoding="utf-8"
+    )
+    (root / "docs/day-80-big-upgrade-report.md").write_text("# Day 80 report\n", encoding="utf-8")
+
+    summary = root / "docs/artifacts/day79-scale-upgrade-closeout-pack/day79-scale-upgrade-closeout-summary.json"
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 100, "strict_pass": True},
+                "checks": [{"passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = root / "docs/artifacts/day79-scale-upgrade-closeout-pack/day79-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 79 delivery board",
+                "- [ ] Day 79 integration brief committed",
+                "- [ ] Day 79 scale upgrade plan committed",
+                "- [ ] Day 79 enterprise execution ledger exported",
+                "- [ ] Day 79 enterprise KPI scorecard snapshot exported",
+                "- [ ] Day 80 partner outreach priorities drafted from Day 79 learnings",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    plan = root / ".day80-partner-outreach-plan.json"
+    plan.write_text(
+        json.dumps(
+            {
+                "plan_id": "day80-partner-outreach-001",
+                "contributors": ["maintainers", "partner-success"],
+                "partner_tracks": ["partner-onboarding", "joint-go-to-market"],
+                "baseline": {"activated_partners": 4, "sla_days": 9},
+                "target": {"activated_partners": 8, "sla_days": 5},
+                "owner": "partner-ops",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_day80_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d80.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day80-partner-outreach-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day80_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d80.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day80-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day80-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day80-pack/day80-partner-outreach-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day80-pack/day80-partner-outreach-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day80-pack/day80-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/day80-pack/day80-partner-outreach-plan.md").exists()
+    assert (tmp_path / "artifacts/day80-pack/day80-partner-execution-ledger.json").exists()
+    assert (tmp_path / "artifacts/day80-pack/day80-partner-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day80-pack/day80-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day80-pack/day80-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day80-pack/day80-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day80-pack/evidence/day80-execution-summary.json").exists()
+
+
+def test_day80_strict_fails_without_day79(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "docs/artifacts/day79-scale-upgrade-closeout-pack/day79-scale-upgrade-closeout-summary.json").unlink()
+    assert d80.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
+
+
+def test_day80_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day80-partner-outreach-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 80 partner outreach closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Introduce a Day 80 closeout lane to continue the Day 79 -> Day 80 execution handoff and capture partner outreach readiness. 
- Provide a deterministic, testable CLI command that scores Day 80 readiness, emits an artifact pack, and can execute evidence collection. 
- Surface the new lane in docs/navigation and provide a contract checker to enforce strict pass criteria and evidence requirements. 

### Description
- Add a new command implementation in `src/sdetkit/day80_partner_outreach_closeout.py` which builds a Day 80 summary, emits artifact packs, executes validation commands, and supports `--format`, `--emit-pack-dir`, `--execute`, and `--strict` modes. 
- Wire the new command into CLI dispatch and subparser in `src/sdetkit/cli.py` so both direct argv routing and parsed subcommand routing work with `day80-partner-outreach-closeout`. 
- Add a contract validation script `scripts/check_day80_partner_outreach_closeout_contract.py` that validates activation score, strict pass, failed checks, and evidence execution summary. 
- Add documentation and planning assets: `docs/integrations-day80-partner-outreach-closeout.md`, `docs/day-80-big-upgrade-report.md`, `.day80-partner-outreach-plan.json`, and update `README.md` and `docs/index.md` to include Day 80 command links. 
- Add end-to-end tests `tests/test_day80_partner_outreach_closeout.py` to cover JSON/text output, strict failure behavior, pack emission & execution, and CLI dispatch. 

### Testing
- Ran `pytest -q tests/test_day80_partner_outreach_closeout.py` and observed `4 passed`. 
- Ran `pytest -q tests/test_day79_scale_upgrade_closeout.py tests/test_day80_partner_outreach_closeout.py` and observed `8 passed` (both suites together). 
- All added tests passed successfully, validating JSON/text output, pack emission/execution artifacts, strict-mode failure behavior, and CLI dispatch.

------