### PR TITLE
Add Day 82 integration feedback closeout lane

### DIFF
--- a/.day82-integration-feedback-plan.json
+++ b/.day82-integration-feedback-plan.json
@@ -1,0 +1,24 @@
+{
+  "plan_id": "day82-integration-feedback-001",
+  "contributors": [
+    "maintainers",
+    "docs-ops",
+    "community-ops"
+  ],
+  "feedback_channels": [
+    "office-hours",
+    "issues",
+    "discussion-threads"
+  ],
+  "baseline": {
+    "feedback_items": 24,
+    "docs_resolution_rate": 0.58,
+    "community_engagement_rate": 0.33
+  },
+  "target": {
+    "feedback_items": 40,
+    "docs_resolution_rate": 0.75,
+    "community_engagement_rate": 0.48
+  },
+  "owner": "docs-ops"
+}

--- a/README.md
+++ b/README.md
@@ -1824,6 +1824,16 @@ See implementation details: [Day 80 big upgrade report](docs/day-80-big-upgrade-
 
 See implementation details: [Day 81 big upgrade report](docs/day-81-big-upgrade-report.md).
 
+
+### Day 82 — Integration feedback closeout lane
+
+- Run `python -m sdetkit day82-integration-feedback-closeout --format json --strict` to validate Day 82 integration feedback readiness.
+- Emit shareable Day 82 integration feedback pack: `python -m sdetkit day82-integration-feedback-closeout --emit-pack-dir docs/artifacts/day82-integration-feedback-closeout-pack --format json --strict`.
+- Execute and collect deterministic logs: `python -m sdetkit day82-integration-feedback-closeout --execute --evidence-dir docs/artifacts/day82-integration-feedback-closeout-pack/evidence --format json --strict`.
+- Review Day 82 integration guide: [Integration feedback closeout lane](docs/integrations-day82-integration-feedback-closeout.md).
+
+See implementation details: [Day 82 big upgrade report](docs/day-82-big-upgrade-report.md).
+
 ## 🧱 Repository navigation (short version)
 
 For a cleaner README experience, the giant file listings were removed.

--- a/docs/day-82-big-upgrade-report.md
+++ b/docs/day-82-big-upgrade-report.md
@@ -1,0 +1,9 @@
+# Day 82 Big Upgrade Report
+
+Day 82 closes integration feedback execution by converting Day 81 growth-campaign outcomes into deterministic docs/template upgrade controls and community touchpoint proof.
+
+## Delivered upgrades
+
+- Added a strict Day 82 integration feedback CLI lane with scoring, pack emission, and evidence execution hooks.
+- Added contract validation script and test coverage for strict closeout checks.
+- Added docs navigation and strategy continuity references for Day 82 execution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -861,3 +861,12 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 81 growth campaign closeout pack: `python -m sdetkit day81-growth-campaign-closeout --emit-pack-dir docs/artifacts/day81-growth-campaign-closeout-pack --format json --strict`.
 - Run deterministic execution evidence lane: `python -m sdetkit day81-growth-campaign-closeout --execute --evidence-dir docs/artifacts/day81-growth-campaign-closeout-pack/evidence --format json --strict`.
 - Review integration guide: [Day 81 growth campaign closeout lane](integrations-day81-growth-campaign-closeout.md).
+
+
+## Day 82 integration feedback closeout lane
+
+- Read the implementation report: [Day 82 big upgrade report](day-82-big-upgrade-report.md).
+- Run `python -m sdetkit day82-integration-feedback-closeout --format json --strict` to score integration feedback readiness.
+- Emit Day 82 integration feedback closeout pack: `python -m sdetkit day82-integration-feedback-closeout --emit-pack-dir docs/artifacts/day82-integration-feedback-closeout-pack --format json --strict`.
+- Run deterministic execution evidence lane: `python -m sdetkit day82-integration-feedback-closeout --execute --evidence-dir docs/artifacts/day82-integration-feedback-closeout-pack/evidence --format json --strict`.
+- Review integration guide: [Day 82 integration feedback closeout lane](integrations-day82-integration-feedback-closeout.md).

--- a/docs/integrations-day82-integration-feedback-closeout.md
+++ b/docs/integrations-day82-integration-feedback-closeout.md
@@ -1,0 +1,55 @@
+# Day 82 — Integration feedback loop closeout lane
+
+Day 82 closes with a major upgrade that folds Day 81 growth campaign outcomes into docs/template upgrades and community touchpoint execution.
+
+## Why Day 82 matters
+
+- Turns Day 81 growth campaign outcomes into deterministic integration feedback loops across docs, templates, and community operations.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 82 closeout into Day 83 trust FAQ expansion priorities.
+
+## Required inputs (Day 81)
+
+- `docs/artifacts/day81-growth-campaign-closeout-pack/day81-growth-campaign-closeout-summary.json`
+- `docs/artifacts/day81-growth-campaign-closeout-pack/day81-delivery-board.md`
+- `.day82-integration-feedback-plan.json`
+
+## Day 82 command lane
+
+```bash
+python -m sdetkit day82-integration-feedback-closeout --format json --strict
+python -m sdetkit day82-integration-feedback-closeout --emit-pack-dir docs/artifacts/day82-integration-feedback-closeout-pack --format json --strict
+python -m sdetkit day82-integration-feedback-closeout --execute --evidence-dir docs/artifacts/day82-integration-feedback-closeout-pack/evidence --format json --strict
+python scripts/check_day82_integration_feedback_closeout_contract.py
+```
+
+## Integration feedback contract
+
+- Single owner + backup reviewer are assigned for Day 82 integration feedback execution and signoff.
+- The Day 82 lane references Day 81 outcomes, controls, and campaign continuity signals.
+- Every Day 82 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 82 closeout records docs-template upgrades, community touchpoint outcomes, and Day 83 trust FAQ priorities.
+
+## Integration feedback quality checklist
+
+- [ ] Includes baseline feedback volume, segmentation assumptions, and response SLA targets
+- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to docs/templates + runnable command evidence
+- [ ] Scorecard captures docs adoption delta, community engagement delta, confidence, and rollback owner
+- [ ] Artifact pack includes integration brief, feedback plan, template diffs, office-hours ledger, KPI scorecard, and execution log
+
+## Day 82 delivery board
+
+- [ ] Day 82 integration brief committed
+- [ ] Day 82 integration feedback plan committed
+- [ ] Day 82 template upgrade ledger exported
+- [ ] Day 82 office-hours outcome ledger exported
+- [ ] Day 83 trust FAQ priorities drafted from Day 82 feedback
+
+## Scoring model
+
+Day 82 weighted score (0-100):
+
+- Contract + command lane integrity (35)
+- Day 81 continuity baseline quality (35)
+- Feedback evidence data + delivery board completeness (30)

--- a/scripts/check_day82_integration_feedback_closeout_contract.py
+++ b/scripts/check_day82_integration_feedback_closeout_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import day82_integration_feedback_closeout as d82
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Day 82 integration feedback closeout contract")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d82.build_day82_integration_feedback_closeout_summary(root)
+    errors: list[str] = []
+
+    if payload["summary"]["activation_score"] < 95:
+        errors.append(f"activation_score too low: {payload['summary']['activation_score']}")
+    if not payload["summary"]["strict_pass"]:
+        errors.append("strict_pass is false")
+
+    failed = [check["check_id"] for check in payload["checks"] if not check["passed"]]
+    if failed:
+        errors.append(f"failed checks: {failed}")
+
+    if not ns.skip_evidence:
+        evidence = root / "docs/artifacts/day82-integration-feedback-closeout-pack/evidence/day82-execution-summary.json"
+        if not evidence.exists():
+            errors.append(f"missing evidence summary: {evidence}")
+        else:
+            try:
+                summary = json.loads(evidence.read_text(encoding="utf-8"))
+                if int(summary.get("total_commands", 0)) < 3:
+                    errors.append("expected >=3 executed commands")
+            except Exception as exc:  # pragma: no cover
+                errors.append(f"failed to parse evidence summary: {exc}")
+
+    if errors:
+        print("day82-integration-feedback-closeout contract check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        return 1
+
+    print("day82-integration-feedback-closeout contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -62,6 +62,7 @@ from . import (
     day79_scale_upgrade_closeout,
     day80_partner_outreach_closeout,
     day81_growth_campaign_closeout,
+    day82_integration_feedback_closeout,
     demo,
     docs_navigation,
     docs_qa,
@@ -336,6 +337,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day81-growth-campaign-closeout":
         return day81_growth_campaign_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "day82-integration-feedback-closeout":
+        return day82_integration_feedback_closeout.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -593,6 +597,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     d80.add_argument("args", nargs=argparse.REMAINDER)
     d81 = sub.add_parser("day81-growth-campaign-closeout")
     d81.add_argument("args", nargs=argparse.REMAINDER)
+    d82 = sub.add_parser("day82-integration-feedback-closeout")
+    d82.add_argument("args", nargs=argparse.REMAINDER)
 
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
@@ -849,6 +855,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "day81-growth-campaign-closeout":
         return day81_growth_campaign_closeout.main(ns.args)
+
+    if ns.cmd == "day82-integration-feedback-closeout":
+        return day82_integration_feedback_closeout.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/day82_integration_feedback_closeout.py
+++ b/src/sdetkit/day82_integration_feedback_closeout.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-day82-integration-feedback-closeout.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_DAY81_SUMMARY_PATH = "docs/artifacts/day81-growth-campaign-closeout-pack/day81-growth-campaign-closeout-summary.json"
+_DAY81_BOARD_PATH = "docs/artifacts/day81-growth-campaign-closeout-pack/day81-delivery-board.md"
+_PLAN_PATH = ".day82-integration-feedback-plan.json"
+_SECTION_HEADER = "# Day 82 — Integration feedback loop closeout lane"
+_REQUIRED_SECTIONS = [
+    "## Why Day 82 matters",
+    "## Required inputs (Day 81)",
+    "## Day 82 command lane",
+    "## Integration feedback contract",
+    "## Integration feedback quality checklist",
+    "## Day 82 delivery board",
+    "## Scoring model",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit day82-integration-feedback-closeout --format json --strict",
+    "python -m sdetkit day82-integration-feedback-closeout --emit-pack-dir docs/artifacts/day82-integration-feedback-closeout-pack --format json --strict",
+    "python -m sdetkit day82-integration-feedback-closeout --execute --evidence-dir docs/artifacts/day82-integration-feedback-closeout-pack/evidence --format json --strict",
+    "python scripts/check_day82_integration_feedback_closeout_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit day82-integration-feedback-closeout --format json --strict",
+    "python -m sdetkit day82-integration-feedback-closeout --emit-pack-dir docs/artifacts/day82-integration-feedback-closeout-pack --format json --strict",
+    "python scripts/check_day82_integration_feedback_closeout_contract.py --skip-evidence",
+]
+_REQUIRED_CONTRACT_LINES = [
+    "Single owner + backup reviewer are assigned for Day 82 integration feedback execution and signoff.",
+    "The Day 82 lane references Day 81 outcomes, controls, and campaign continuity signals.",
+    "Every Day 82 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "Day 82 closeout records docs-template upgrades, community touchpoint outcomes, and Day 83 trust FAQ priorities.",
+]
+_REQUIRED_QUALITY_LINES = [
+    "- [ ] Includes baseline feedback volume, segmentation assumptions, and response SLA targets",
+    "- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag",
+    "- [ ] CTA links point to docs/templates + runnable command evidence",
+    "- [ ] Scorecard captures docs adoption delta, community engagement delta, confidence, and rollback owner",
+    "- [ ] Artifact pack includes integration brief, feedback plan, template diffs, office-hours ledger, KPI scorecard, and execution log",
+]
+_REQUIRED_DELIVERY_BOARD_LINES = [
+    "- [ ] Day 82 integration brief committed",
+    "- [ ] Day 82 integration feedback plan committed",
+    "- [ ] Day 82 template upgrade ledger exported",
+    "- [ ] Day 82 office-hours outcome ledger exported",
+    "- [ ] Day 83 trust FAQ priorities drafted from Day 82 feedback",
+]
+_REQUIRED_DATA_KEYS = ['"plan_id"', '"contributors"', '"feedback_channels"', '"baseline"', '"target"', '"owner"']
+
+_DAY82_DEFAULT_PAGE = """# Day 82 — Integration feedback loop closeout lane
+
+Day 82 closes with a major upgrade that folds Day 81 growth campaign outcomes into docs/template upgrades and community touchpoint execution.
+
+## Why Day 82 matters
+
+- Turns Day 81 growth campaign outcomes into deterministic integration feedback loops across docs, templates, and community operations.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 82 closeout into Day 83 trust FAQ expansion priorities.
+
+## Required inputs (Day 81)
+
+- `docs/artifacts/day81-growth-campaign-closeout-pack/day81-growth-campaign-closeout-summary.json`
+- `docs/artifacts/day81-growth-campaign-closeout-pack/day81-delivery-board.md`
+- `.day82-integration-feedback-plan.json`
+
+## Day 82 command lane
+
+```bash
+python -m sdetkit day82-integration-feedback-closeout --format json --strict
+python -m sdetkit day82-integration-feedback-closeout --emit-pack-dir docs/artifacts/day82-integration-feedback-closeout-pack --format json --strict
+python -m sdetkit day82-integration-feedback-closeout --execute --evidence-dir docs/artifacts/day82-integration-feedback-closeout-pack/evidence --format json --strict
+python scripts/check_day82_integration_feedback_closeout_contract.py
+```
+
+## Integration feedback contract
+
+- Single owner + backup reviewer are assigned for Day 82 integration feedback execution and signoff.
+- The Day 82 lane references Day 81 outcomes, controls, and campaign continuity signals.
+- Every Day 82 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 82 closeout records docs-template upgrades, community touchpoint outcomes, and Day 83 trust FAQ priorities.
+
+## Integration feedback quality checklist
+
+- [ ] Includes baseline feedback volume, segmentation assumptions, and response SLA targets
+- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to docs/templates + runnable command evidence
+- [ ] Scorecard captures docs adoption delta, community engagement delta, confidence, and rollback owner
+- [ ] Artifact pack includes integration brief, feedback plan, template diffs, office-hours ledger, KPI scorecard, and execution log
+
+## Day 82 delivery board
+
+- [ ] Day 82 integration brief committed
+- [ ] Day 82 integration feedback plan committed
+- [ ] Day 82 template upgrade ledger exported
+- [ ] Day 82 office-hours outcome ledger exported
+- [ ] Day 83 trust FAQ priorities drafted from Day 82 feedback
+
+## Scoring model
+
+Day 82 weighted score (0-100):
+
+- Contract + command lane integrity (35)
+- Day 81 continuity baseline quality (35)
+- Feedback evidence data + delivery board completeness (30)
+"""
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def _checklist_count(markdown: str) -> int:
+    return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
+
+
+def build_day82_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
+    readme_text = _read_text(root / "README.md")
+    docs_index_text = _read_text(root / "docs/index.md")
+    page_text = _read_text(root / _PAGE_PATH)
+    top10_text = _read_text(root / _TOP10_PATH)
+    day81_summary = root / _DAY81_SUMMARY_PATH
+    day81_board = root / _DAY81_BOARD_PATH
+
+    day81_data = _load_json(day81_summary)
+    day81_summary_data = day81_data.get("summary", {}) if isinstance(day81_data.get("summary"), dict) else {}
+    day81_score = int(day81_summary_data.get("activation_score", 0) or 0)
+    day81_strict = bool(day81_summary_data.get("strict_pass", False))
+    day81_check_count = len(day81_data.get("checks", [])) if isinstance(day81_data.get("checks"), list) else 0
+
+    board_text = _read_text(day81_board)
+    board_count = _checklist_count(board_text)
+    board_has_day81 = "Day 81" in board_text
+
+    missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+    missing_contract_lines = [line for line in _REQUIRED_CONTRACT_LINES if line not in page_text]
+    missing_quality_lines = [line for line in _REQUIRED_QUALITY_LINES if line not in page_text]
+    missing_board_items = [item for item in _REQUIRED_DELIVERY_BOARD_LINES if item not in page_text]
+
+    plan_text = _read_text(root / _PLAN_PATH)
+    missing_plan_keys = [key for key in _REQUIRED_DATA_KEYS if key not in plan_text]
+
+    checks: list[dict[str, Any]] = [
+        {
+            "check_id": "readme_day82_command",
+            "weight": 7,
+            "passed": ("day82-integration-feedback-closeout" in readme_text),
+            "evidence": "README day82 command lane",
+        },
+        {
+            "check_id": "docs_index_day82_links",
+            "weight": 8,
+            "passed": ("day-82-big-upgrade-report.md" in docs_index_text and "integrations-day82-integration-feedback-closeout.md" in docs_index_text),
+            "evidence": "day-82-big-upgrade-report.md + integrations-day82-integration-feedback-closeout.md",
+        },
+        {
+            "check_id": "top10_day82_alignment",
+            "weight": 5,
+            "passed": ("Day 81" in top10_text and "Day 82" in top10_text),
+            "evidence": "Day 81 + Day 82 strategy chain",
+        },
+        {"check_id": "day81_summary_present", "weight": 10, "passed": day81_summary.exists(), "evidence": str(day81_summary)},
+        {"check_id": "day81_delivery_board_present", "weight": 7, "passed": day81_board.exists(), "evidence": str(day81_board)},
+        {
+            "check_id": "day81_quality_floor",
+            "weight": 13,
+            "passed": day81_score >= 85 and day81_strict,
+            "evidence": {"day81_score": day81_score, "strict_pass": day81_strict, "day81_checks": day81_check_count},
+        },
+        {
+            "check_id": "day81_board_integrity",
+            "weight": 5,
+            "passed": board_count >= 5 and board_has_day81,
+            "evidence": {"board_items": board_count, "contains_day81": board_has_day81},
+        },
+        {"check_id": "page_header", "weight": 7, "passed": _SECTION_HEADER in page_text, "evidence": _SECTION_HEADER},
+        {"check_id": "required_sections", "weight": 8, "passed": not missing_sections, "evidence": missing_sections or "all sections present"},
+        {"check_id": "required_commands", "weight": 5, "passed": not missing_commands, "evidence": missing_commands or "all commands present"},
+        {"check_id": "contract_lock", "weight": 5, "passed": not missing_contract_lines, "evidence": missing_contract_lines or "contract locked"},
+        {"check_id": "quality_checklist_lock", "weight": 5, "passed": not missing_quality_lines, "evidence": missing_quality_lines or "quality checklist locked"},
+        {"check_id": "delivery_board_lock", "weight": 5, "passed": not missing_board_items, "evidence": missing_board_items or "delivery board locked"},
+        {"check_id": "feedback_plan_data_present", "weight": 10, "passed": not missing_plan_keys, "evidence": missing_plan_keys or _PLAN_PATH},
+    ]
+
+    failed = [c for c in checks if not c["passed"]]
+    critical_failures: list[str] = []
+    if not day81_summary.exists() or not day81_board.exists():
+        critical_failures.append("day81_handoff_inputs")
+
+    wins: list[str] = []
+    misses: list[str] = []
+    handoff_actions: list[str] = []
+
+    if day81_score >= 85 and day81_strict:
+        wins.append(f"Day 81 continuity baseline is stable with activation score={day81_score}.")
+    else:
+        misses.append("Day 81 continuity baseline is below the floor (<85) or not strict-pass.")
+        handoff_actions.append("Re-run Day 81 closeout command and raise baseline quality above 85 with strict pass before Day 82 lock.")
+
+    if board_count >= 5 and board_has_day81:
+        wins.append(f"Day 81 delivery board integrity validated with {board_count} checklist items.")
+    else:
+        misses.append("Day 81 delivery board integrity is incomplete (needs >=5 items and Day 81 anchors).")
+        handoff_actions.append("Repair Day 81 delivery board entries to include Day 81 anchors.")
+
+    if not missing_plan_keys:
+        wins.append("Day 82 integration feedback dataset is available for launch execution.")
+    else:
+        misses.append("Day 82 integration feedback dataset is missing required keys.")
+        handoff_actions.append("Update .day82-integration-feedback-plan.json to restore required keys.")
+
+    if not failed and not critical_failures:
+        wins.append("Day 82 integration feedback closeout lane is fully complete and ready for Day 83 trust FAQ priorities.")
+
+    score = int(round(sum(c["weight"] for c in checks if c["passed"])))
+    return {
+        "name": "day82-integration-feedback-closeout",
+        "inputs": {
+            "readme": "README.md",
+            "docs_index": "docs/index.md",
+            "docs_page": _PAGE_PATH,
+            "top10": _TOP10_PATH,
+            "day81_summary": str(day81_summary.relative_to(root)) if day81_summary.exists() else str(day81_summary),
+            "day81_delivery_board": str(day81_board.relative_to(root)) if day81_board.exists() else str(day81_board),
+            "integration_feedback_plan": _PLAN_PATH,
+        },
+        "checks": checks,
+        "rollup": {"day81_activation_score": day81_score, "day81_checks": day81_check_count, "day81_delivery_board_items": board_count},
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "wins": wins,
+        "misses": misses,
+        "handoff_actions": handoff_actions,
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Day 82 integration feedback closeout summary",
+        f"- Activation score: {payload['summary']['activation_score']}",
+        f"- Passed checks: {payload['summary']['passed_checks']}",
+        f"- Failed checks: {payload['summary']['failed_checks']}",
+        f"- Critical failures: {payload['summary']['critical_failures']}",
+    ]
+    return "\n".join(lines)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
+    target = pack_dir if pack_dir.is_absolute() else root / pack_dir
+    _write(target / "day82-integration-feedback-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
+    _write(target / "day82-integration-feedback-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "day82-integration-brief.md", "# Day 82 integration brief\n")
+    _write(target / "day82-integration-feedback-plan.md", "# Day 82 integration feedback plan\n")
+    _write(target / "day82-template-upgrade-ledger.json", json.dumps({"upgrades": []}, indent=2) + "\n")
+    _write(target / "day82-office-hours-outcomes-ledger.json", json.dumps({"outcomes": []}, indent=2) + "\n")
+    _write(target / "day82-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "day82-execution-log.md", "# Day 82 execution log\n")
+    _write(target / "day82-delivery-board.md", "\n".join(["# Day 82 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n")
+    _write(target / "day82-validation-commands.md", "# Day 82 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n")
+
+
+def _execute_commands(root: Path, evidence_dir: Path) -> None:
+    events: list[dict[str, Any]] = []
+    out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
+        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        event = {"command": command, "returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+        events.append(event)
+        _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
+    _write(out_dir / "day82-execution-summary.json", json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Day 82 integration feedback closeout checks")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-default-doc", action="store_true")
+    ns = parser.parse_args(argv)
+
+    root = Path(ns.root).resolve()
+    if ns.write_default_doc:
+        _write(root / _PAGE_PATH, _DAY82_DEFAULT_PAGE)
+
+    payload = build_day82_integration_feedback_closeout_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, Path(ns.emit_pack_dir), payload)
+    if ns.execute:
+        evidence_dir = Path(ns.evidence_dir) if ns.evidence_dir else Path("docs/artifacts/day82-integration-feedback-closeout-pack/evidence")
+        _execute_commands(root, evidence_dir)
+
+    print(json.dumps(payload, indent=2) if ns.format == "json" else _render_text(payload))
+    return 1 if ns.strict and not payload["summary"]["strict_pass"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_day82_integration_feedback_closeout.py
+++ b/tests/test_day82_integration_feedback_closeout.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day82_integration_feedback_closeout as d82
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text(
+        "docs/integrations-day82-integration-feedback-closeout.md\nday82-integration-feedback-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-82-big-upgrade-report.md\nintegrations-day82-integration-feedback-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 81 — Growth campaign closeout:** convert partner outcomes into deterministic campaign controls.\n"
+        "- **Day 82 — Integration feedback loop:** fold field feedback into docs/templates.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day82-integration-feedback-closeout.md").write_text(
+        d82._DAY82_DEFAULT_PAGE, encoding="utf-8"
+    )
+    (root / "docs/day-82-big-upgrade-report.md").write_text("# Day 82 report\n", encoding="utf-8")
+
+    summary = root / "docs/artifacts/day81-growth-campaign-closeout-pack/day81-growth-campaign-closeout-summary.json"
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 100, "strict_pass": True},
+                "checks": [{"passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = root / "docs/artifacts/day81-growth-campaign-closeout-pack/day81-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 81 delivery board",
+                "- [ ] Day 81 integration brief committed",
+                "- [ ] Day 81 growth campaign plan committed",
+                "- [ ] Day 81 campaign execution ledger exported",
+                "- [ ] Day 81 campaign KPI scorecard snapshot exported",
+                "- [ ] Day 82 execution priorities drafted from Day 81 learnings",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    plan = root / ".day82-integration-feedback-plan.json"
+    plan.write_text(
+        json.dumps(
+            {
+                "plan_id": "day82-integration-feedback-001",
+                "contributors": ["maintainers", "docs-ops"],
+                "feedback_channels": ["office-hours", "issues"],
+                "baseline": {"feedback_items": 24, "docs_resolution_rate": 0.58},
+                "target": {"feedback_items": 40, "docs_resolution_rate": 0.75},
+                "owner": "docs-ops",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_day82_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d82.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day82-integration-feedback-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day82_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d82.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day82-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day82-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day82-pack/day82-integration-feedback-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day82-pack/day82-integration-feedback-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day82-pack/day82-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/day82-pack/day82-integration-feedback-plan.md").exists()
+    assert (tmp_path / "artifacts/day82-pack/day82-template-upgrade-ledger.json").exists()
+    assert (tmp_path / "artifacts/day82-pack/day82-office-hours-outcomes-ledger.json").exists()
+    assert (tmp_path / "artifacts/day82-pack/day82-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day82-pack/day82-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day82-pack/day82-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day82-pack/day82-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day82-pack/evidence/day82-execution-summary.json").exists()
+
+
+def test_day82_strict_fails_without_day81(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (
+        tmp_path / "docs/artifacts/day81-growth-campaign-closeout-pack/day81-growth-campaign-closeout-summary.json"
+    ).unlink()
+    assert d82.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
+
+
+def test_day82_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day82-integration-feedback-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 82 integration feedback closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Continue the Phase-3 closeout chain by converting Day 81 growth-campaign outcomes into a deterministic Day 82 integration feedback loop for docs/templates and community touchpoints. 
- Provide a strict, auditable CLI lane that enforces contract/quality gates and emits an artifact pack plus execution evidence for downstream handoffs. 
- Surface Day 82 in the docs/navigation so the workflow is discoverable and can be run by automation or maintainers.

### Description
- Added a new CLI module `src/sdetkit/day82_integration_feedback_closeout.py` implementing scoring, checks against Day 81 handoff artifacts, pack emission, and evidence execution. 
- Added a contract validation script at `scripts/check_day82_integration_feedback_closeout_contract.py` and a default plan file `.day82-integration-feedback-plan.json` plus the integration doc `docs/integrations-day82-integration-feedback-closeout.md` and upgrade report `docs/day-82-big-upgrade-report.md`. 
- Wired the command into the global CLI by importing and registering `day82-integration-feedback-closeout` in `src/sdetkit/cli.py` and added README/docs index entries to expose the new lane. 
- Added tests in `tests/test_day82_integration_feedback_closeout.py` that seed repo artifacts, validate JSON strict scoring, pack emission + evidence execution, strict failure behavior, and CLI dispatch.

### Testing
- Ran `pytest -q tests/test_day82_integration_feedback_closeout.py` and it passed: `4 passed`. 
- Ran `pytest -q tests/test_day81_growth_campaign_closeout.py` to ensure Day 81 compatibility and it passed: `4 passed`. 
- The new Day 82 lane is exercised by the tests which validate pack emission and evidence artifacts were created successfully.

------