### PR TITLE
Add Day 83 trust FAQ expansion closeout workflow

### DIFF
--- a/.day83-trust-faq-expansion-plan.json
+++ b/.day83-trust-faq-expansion-plan.json
@@ -1,0 +1,16 @@
+{
+  "plan_id": "day83-trust-faq-expansion-001",
+  "contributors": ["docs-ops", "support-ops", "developer-relations"],
+  "objection_channels": ["issues", "discussions", "office-hours", "faq-form"],
+  "baseline": {
+    "faq_coverage": 0.63,
+    "deflection_rate": 0.45,
+    "sla_hours": 36
+  },
+  "target": {
+    "faq_coverage": 0.84,
+    "deflection_rate": 0.62,
+    "sla_hours": 18
+  },
+  "owner": "docs-ops"
+}

--- a/README.md
+++ b/README.md
@@ -1834,6 +1834,15 @@ See implementation details: [Day 81 big upgrade report](docs/day-81-big-upgrade-
 
 See implementation details: [Day 82 big upgrade report](docs/day-82-big-upgrade-report.md).
 
+### Day 83 — Trust FAQ expansion closeout lane
+
+- Run `python -m sdetkit day83-trust-faq-expansion-closeout --format json --strict` to validate Day 83 trust FAQ expansion readiness.
+- Emit shareable Day 83 trust FAQ expansion pack: `python -m sdetkit day83-trust-faq-expansion-closeout --emit-pack-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack --format json --strict`.
+- Execute and collect deterministic logs: `python -m sdetkit day83-trust-faq-expansion-closeout --execute --evidence-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack/evidence --format json --strict`.
+- Review Day 83 integration guide: [Trust FAQ expansion closeout lane](docs/integrations-day83-trust-faq-expansion-closeout.md).
+
+See implementation details: [Day 83 big upgrade report](docs/day-83-big-upgrade-report.md).
+
 ## 🧱 Repository navigation (short version)
 
 For a cleaner README experience, the giant file listings were removed.

--- a/docs/day-83-big-upgrade-report.md
+++ b/docs/day-83-big-upgrade-report.md
@@ -1,0 +1,9 @@
+# Day 83 Big Upgrade Report
+
+Day 83 closes trust FAQ expansion execution by converting Day 82 integration feedback outcomes into deterministic trust-content upgrades and escalation controls.
+
+## Delivered upgrades
+
+- Added a strict Day 83 trust FAQ expansion CLI lane with scoring, pack emission, and evidence execution hooks.
+- Added contract validation script and dedicated test coverage for strict closeout checks.
+- Added docs navigation and strategy continuity references for Day 83 execution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -870,3 +870,12 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 82 integration feedback closeout pack: `python -m sdetkit day82-integration-feedback-closeout --emit-pack-dir docs/artifacts/day82-integration-feedback-closeout-pack --format json --strict`.
 - Run deterministic execution evidence lane: `python -m sdetkit day82-integration-feedback-closeout --execute --evidence-dir docs/artifacts/day82-integration-feedback-closeout-pack/evidence --format json --strict`.
 - Review integration guide: [Day 82 integration feedback closeout lane](integrations-day82-integration-feedback-closeout.md).
+
+
+## Day 83 trust FAQ expansion closeout lane
+
+- Read the implementation report: [Day 83 big upgrade report](day-83-big-upgrade-report.md).
+- Run `python -m sdetkit day83-trust-faq-expansion-closeout --format json --strict` to score trust FAQ expansion readiness.
+- Emit Day 83 trust FAQ expansion closeout pack: `python -m sdetkit day83-trust-faq-expansion-closeout --emit-pack-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack --format json --strict`.
+- Run deterministic execution evidence lane: `python -m sdetkit day83-trust-faq-expansion-closeout --execute --evidence-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack/evidence --format json --strict`.
+- Review integration guide: [Day 83 trust FAQ expansion closeout lane](integrations-day83-trust-faq-expansion-closeout.md).

--- a/docs/integrations-day83-trust-faq-expansion-closeout.md
+++ b/docs/integrations-day83-trust-faq-expansion-closeout.md
@@ -1,0 +1,55 @@
+# Day 83 — Trust FAQ expansion loop closeout lane
+
+Day 83 closes with a major upgrade that folds Day 82 integration feedback outcomes into trust FAQ coverage upgrades and escalation-readiness execution.
+
+## Why Day 83 matters
+
+- Turns Day 82 integration feedback outcomes into deterministic trust FAQ expansion loops across docs, templates, and support operations.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 83 closeout into Day 84 evidence narrative priorities.
+
+## Required inputs (Day 82)
+
+- `docs/artifacts/day82-integration-feedback-closeout-pack/day82-integration-feedback-closeout-summary.json`
+- `docs/artifacts/day82-integration-feedback-closeout-pack/day82-delivery-board.md`
+- `.day83-trust-faq-expansion-plan.json`
+
+## Day 83 command lane
+
+```bash
+python -m sdetkit day83-trust-faq-expansion-closeout --format json --strict
+python -m sdetkit day83-trust-faq-expansion-closeout --emit-pack-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack --format json --strict
+python -m sdetkit day83-trust-faq-expansion-closeout --execute --evidence-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack/evidence --format json --strict
+python scripts/check_day83_trust_faq_expansion_closeout_contract.py
+```
+
+## Trust FAQ expansion contract
+
+- Single owner + backup reviewer are assigned for Day 83 trust FAQ expansion execution and signoff.
+- The Day 83 lane references Day 82 outcomes, controls, and campaign continuity signals.
+- Every Day 83 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 83 closeout records trust FAQ content upgrades, escalation outcomes, and Day 84 evidence narrative priorities.
+
+## Trust FAQ expansion quality checklist
+
+- [ ] Includes baseline trust FAQ coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every trust lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to trust docs/templates + runnable command evidence
+- [ ] Scorecard captures trust FAQ adoption delta, objection deflection delta, confidence, and rollback owner
+- [ ] Artifact pack includes trust brief, FAQ expansion plan, template diffs, escalation ledger, KPI scorecard, and execution log
+
+## Day 83 delivery board
+
+- [ ] Day 83 trust FAQ brief committed
+- [ ] Day 83 trust FAQ expansion plan committed
+- [ ] Day 83 trust template upgrade ledger exported
+- [ ] Day 83 escalation outcomes ledger exported
+- [ ] Day 84 evidence narrative priorities drafted from Day 83 outcomes
+
+## Scoring model
+
+Day 83 weighted score (0-100):
+
+- Contract + command lane integrity (35)
+- Day 82 continuity baseline quality (35)
+- Feedback evidence data + delivery board completeness (30)

--- a/docs/top-10-github-strategy.md
+++ b/docs/top-10-github-strategy.md
@@ -258,6 +258,8 @@ Phase 3 turns growth into durable ecosystem trust: stronger community rituals, d
 - **Day 81 — Growth campaign closeout:** convert partner signals into measurable campaign execution controls.
 - **Day 82 — Integration feedback loop:** fold field feedback into docs/templates.
 - **Day 82 — Community touchpoint #2:** run second office-hours/community Q&A session.
+- **Day 83 — Trust FAQ expansion loop:** translate Day 82 signals into trust FAQ upgrades with clear rollback controls.
+- **Day 83 — Escalation safety lane:** document objection escalation paths, SLA gates, and evidence owners.
 - **Day 83 — Trust FAQ expansion:** answer top compliance/security objections from real users.
 - **Day 84 — Weekly review #12:** compare Phase-3 week-over-week ecosystem metrics.
 

--- a/scripts/check_day83_trust_faq_expansion_closeout_contract.py
+++ b/scripts/check_day83_trust_faq_expansion_closeout_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import day83_trust_faq_expansion_closeout as d83
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Day 83 trust FAQ expansion closeout contract")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d83.build_day83_trust_faq_expansion_closeout_summary(root)
+    errors: list[str] = []
+
+    if payload["summary"]["activation_score"] < 95:
+        errors.append(f"activation_score too low: {payload['summary']['activation_score']}")
+    if not payload["summary"]["strict_pass"]:
+        errors.append("strict_pass is false")
+
+    failed = [check["check_id"] for check in payload["checks"] if not check["passed"]]
+    if failed:
+        errors.append(f"failed checks: {failed}")
+
+    if not ns.skip_evidence:
+        evidence = root / "docs/artifacts/day83-trust-faq-expansion-closeout-pack/evidence/day83-execution-summary.json"
+        if not evidence.exists():
+            errors.append(f"missing evidence summary: {evidence}")
+        else:
+            try:
+                summary = json.loads(evidence.read_text(encoding="utf-8"))
+                if int(summary.get("total_commands", 0)) < 3:
+                    errors.append("expected >=3 executed commands")
+            except Exception as exc:  # pragma: no cover
+                errors.append(f"failed to parse evidence summary: {exc}")
+
+    if errors:
+        print("day83-trust-faq-expansion-closeout contract check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        return 1
+
+    print("day83-trust-faq-expansion-closeout contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -63,6 +63,7 @@ from . import (
     day80_partner_outreach_closeout,
     day81_growth_campaign_closeout,
     day82_integration_feedback_closeout,
+    day83_trust_faq_expansion_closeout,
     demo,
     docs_navigation,
     docs_qa,
@@ -340,6 +341,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day82-integration-feedback-closeout":
         return day82_integration_feedback_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "day83-trust-faq-expansion-closeout":
+        return day83_trust_faq_expansion_closeout.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -599,6 +603,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     d81.add_argument("args", nargs=argparse.REMAINDER)
     d82 = sub.add_parser("day82-integration-feedback-closeout")
     d82.add_argument("args", nargs=argparse.REMAINDER)
+    d83 = sub.add_parser("day83-trust-faq-expansion-closeout")
+    d83.add_argument("args", nargs=argparse.REMAINDER)
 
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
@@ -858,6 +864,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "day82-integration-feedback-closeout":
         return day82_integration_feedback_closeout.main(ns.args)
+
+    if ns.cmd == "day83-trust-faq-expansion-closeout":
+        return day83_trust_faq_expansion_closeout.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/day83_trust_faq_expansion_closeout.py
+++ b/src/sdetkit/day83_trust_faq_expansion_closeout.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-day83-trust-faq-expansion-closeout.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_DAY82_SUMMARY_PATH = "docs/artifacts/day82-integration-feedback-closeout-pack/day82-integration-feedback-closeout-summary.json"
+_DAY82_BOARD_PATH = "docs/artifacts/day82-integration-feedback-closeout-pack/day82-delivery-board.md"
+_PLAN_PATH = ".day83-trust-faq-expansion-plan.json"
+_SECTION_HEADER = "# Day 83 — Trust FAQ expansion loop closeout lane"
+_REQUIRED_SECTIONS = [
+    "## Why Day 83 matters",
+    "## Required inputs (Day 82)",
+    "## Day 83 command lane",
+    "## Trust FAQ expansion contract",
+    "## Trust FAQ expansion quality checklist",
+    "## Day 83 delivery board",
+    "## Scoring model",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit day83-trust-faq-expansion-closeout --format json --strict",
+    "python -m sdetkit day83-trust-faq-expansion-closeout --emit-pack-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack --format json --strict",
+    "python -m sdetkit day83-trust-faq-expansion-closeout --execute --evidence-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack/evidence --format json --strict",
+    "python scripts/check_day83_trust_faq_expansion_closeout_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit day83-trust-faq-expansion-closeout --format json --strict",
+    "python -m sdetkit day83-trust-faq-expansion-closeout --emit-pack-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack --format json --strict",
+    "python scripts/check_day83_trust_faq_expansion_closeout_contract.py --skip-evidence",
+]
+_REQUIRED_CONTRACT_LINES = [
+    "Single owner + backup reviewer are assigned for Day 83 trust FAQ expansion execution and signoff.",
+    "The Day 83 lane references Day 82 outcomes, controls, and campaign continuity signals.",
+    "Every Day 83 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "Day 83 closeout records trust FAQ content upgrades, escalation outcomes, and Day 84 evidence narrative priorities.",
+]
+_REQUIRED_QUALITY_LINES = [
+    "- [ ] Includes baseline trust FAQ coverage, objection segmentation assumptions, and response SLA targets",
+    "- [ ] Every trust lane row has owner, execution window, KPI threshold, and risk flag",
+    "- [ ] CTA links point to trust docs/templates + runnable command evidence",
+    "- [ ] Scorecard captures trust FAQ adoption delta, objection deflection delta, confidence, and rollback owner",
+    "- [ ] Artifact pack includes trust brief, FAQ expansion plan, template diffs, escalation ledger, KPI scorecard, and execution log",
+]
+_REQUIRED_DELIVERY_BOARD_LINES = [
+    "- [ ] Day 83 trust FAQ brief committed",
+    "- [ ] Day 83 trust FAQ expansion plan committed",
+    "- [ ] Day 83 trust template upgrade ledger exported",
+    "- [ ] Day 83 escalation outcomes ledger exported",
+    "- [ ] Day 84 evidence narrative priorities drafted from Day 83 outcomes",
+]
+_REQUIRED_DATA_KEYS = ['"plan_id"', '"contributors"', '"objection_channels"', '"baseline"', '"target"', '"owner"']
+
+_DAY83_DEFAULT_PAGE = """# Day 83 — Trust FAQ expansion loop closeout lane
+
+Day 83 closes with a major upgrade that folds Day 82 integration feedback outcomes into trust FAQ coverage upgrades and escalation-readiness execution.
+
+## Why Day 83 matters
+
+- Turns Day 82 integration feedback outcomes into deterministic trust FAQ expansion loops across docs, templates, and support operations.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 83 closeout into Day 84 evidence narrative priorities.
+
+## Required inputs (Day 82)
+
+- `docs/artifacts/day82-integration-feedback-closeout-pack/day82-integration-feedback-closeout-summary.json`
+- `docs/artifacts/day82-integration-feedback-closeout-pack/day82-delivery-board.md`
+- `.day83-trust-faq-expansion-plan.json`
+
+## Day 83 command lane
+
+```bash
+python -m sdetkit day83-trust-faq-expansion-closeout --format json --strict
+python -m sdetkit day83-trust-faq-expansion-closeout --emit-pack-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack --format json --strict
+python -m sdetkit day83-trust-faq-expansion-closeout --execute --evidence-dir docs/artifacts/day83-trust-faq-expansion-closeout-pack/evidence --format json --strict
+python scripts/check_day83_trust_faq_expansion_closeout_contract.py
+```
+
+## Trust FAQ expansion contract
+
+- Single owner + backup reviewer are assigned for Day 83 trust FAQ expansion execution and signoff.
+- The Day 83 lane references Day 82 outcomes, controls, and campaign continuity signals.
+- Every Day 83 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 83 closeout records trust FAQ content upgrades, escalation outcomes, and Day 84 evidence narrative priorities.
+
+## Trust FAQ expansion quality checklist
+
+- [ ] Includes baseline trust FAQ coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every trust lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to trust docs/templates + runnable command evidence
+- [ ] Scorecard captures trust FAQ adoption delta, objection deflection delta, confidence, and rollback owner
+- [ ] Artifact pack includes trust brief, FAQ expansion plan, template diffs, escalation ledger, KPI scorecard, and execution log
+
+## Day 83 delivery board
+
+- [ ] Day 83 trust FAQ brief committed
+- [ ] Day 83 trust FAQ expansion plan committed
+- [ ] Day 83 trust template upgrade ledger exported
+- [ ] Day 83 escalation outcomes ledger exported
+- [ ] Day 84 evidence narrative priorities drafted from Day 83 outcomes
+
+## Scoring model
+
+Day 83 weighted score (0-100):
+
+- Contract + command lane integrity (35)
+- Day 82 continuity baseline quality (35)
+- Feedback evidence data + delivery board completeness (30)
+"""
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def _checklist_count(markdown: str) -> int:
+    return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
+
+
+def build_day83_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
+    readme_text = _read_text(root / "README.md")
+    docs_index_text = _read_text(root / "docs/index.md")
+    page_text = _read_text(root / _PAGE_PATH)
+    top10_text = _read_text(root / _TOP10_PATH)
+    day82_summary = root / _DAY82_SUMMARY_PATH
+    day82_board = root / _DAY82_BOARD_PATH
+
+    day82_data = _load_json(day82_summary)
+    day82_summary_data = day82_data.get("summary", {}) if isinstance(day82_data.get("summary"), dict) else {}
+    day82_score = int(day82_summary_data.get("activation_score", 0) or 0)
+    day82_strict = bool(day82_summary_data.get("strict_pass", False))
+    day82_check_count = len(day82_data.get("checks", [])) if isinstance(day82_data.get("checks"), list) else 0
+
+    board_text = _read_text(day82_board)
+    board_count = _checklist_count(board_text)
+    board_has_day82 = "Day 82" in board_text
+
+    missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+    missing_contract_lines = [line for line in _REQUIRED_CONTRACT_LINES if line not in page_text]
+    missing_quality_lines = [line for line in _REQUIRED_QUALITY_LINES if line not in page_text]
+    missing_board_items = [item for item in _REQUIRED_DELIVERY_BOARD_LINES if item not in page_text]
+
+    plan_text = _read_text(root / _PLAN_PATH)
+    missing_plan_keys = [key for key in _REQUIRED_DATA_KEYS if key not in plan_text]
+
+    checks: list[dict[str, Any]] = [
+        {
+            "check_id": "readme_day83_command",
+            "weight": 7,
+            "passed": ("day83-trust-faq-expansion-closeout" in readme_text),
+            "evidence": "README day83 command lane",
+        },
+        {
+            "check_id": "docs_index_day83_links",
+            "weight": 8,
+            "passed": ("day-83-big-upgrade-report.md" in docs_index_text and "integrations-day83-trust-faq-expansion-closeout.md" in docs_index_text),
+            "evidence": "day-83-big-upgrade-report.md + integrations-day83-trust-faq-expansion-closeout.md",
+        },
+        {
+            "check_id": "top10_day83_alignment",
+            "weight": 5,
+            "passed": ("Day 82" in top10_text and "Day 83" in top10_text),
+            "evidence": "Day 82 + Day 83 strategy chain",
+        },
+        {"check_id": "day82_summary_present", "weight": 10, "passed": day82_summary.exists(), "evidence": str(day82_summary)},
+        {"check_id": "day82_delivery_board_present", "weight": 7, "passed": day82_board.exists(), "evidence": str(day82_board)},
+        {
+            "check_id": "day82_quality_floor",
+            "weight": 13,
+            "passed": day82_score >= 85 and day82_strict,
+            "evidence": {"day82_score": day82_score, "strict_pass": day82_strict, "day82_checks": day82_check_count},
+        },
+        {
+            "check_id": "day82_board_integrity",
+            "weight": 5,
+            "passed": board_count >= 5 and board_has_day82,
+            "evidence": {"board_items": board_count, "contains_day82": board_has_day82},
+        },
+        {"check_id": "page_header", "weight": 7, "passed": _SECTION_HEADER in page_text, "evidence": _SECTION_HEADER},
+        {"check_id": "required_sections", "weight": 8, "passed": not missing_sections, "evidence": missing_sections or "all sections present"},
+        {"check_id": "required_commands", "weight": 5, "passed": not missing_commands, "evidence": missing_commands or "all commands present"},
+        {"check_id": "contract_lock", "weight": 5, "passed": not missing_contract_lines, "evidence": missing_contract_lines or "contract locked"},
+        {"check_id": "quality_checklist_lock", "weight": 5, "passed": not missing_quality_lines, "evidence": missing_quality_lines or "quality checklist locked"},
+        {"check_id": "delivery_board_lock", "weight": 5, "passed": not missing_board_items, "evidence": missing_board_items or "delivery board locked"},
+        {"check_id": "feedback_plan_data_present", "weight": 10, "passed": not missing_plan_keys, "evidence": missing_plan_keys or _PLAN_PATH},
+    ]
+
+    failed = [c for c in checks if not c["passed"]]
+    critical_failures: list[str] = []
+    if not day82_summary.exists() or not day82_board.exists():
+        critical_failures.append("day82_handoff_inputs")
+
+    wins: list[str] = []
+    misses: list[str] = []
+    handoff_actions: list[str] = []
+
+    if day82_score >= 85 and day82_strict:
+        wins.append(f"Day 82 continuity baseline is stable with activation score={day82_score}.")
+    else:
+        misses.append("Day 82 continuity baseline is below the floor (<85) or not strict-pass.")
+        handoff_actions.append("Re-run Day 82 closeout command and raise baseline quality above 85 with strict pass before Day 83 lock.")
+
+    if board_count >= 5 and board_has_day82:
+        wins.append(f"Day 82 delivery board integrity validated with {board_count} checklist items.")
+    else:
+        misses.append("Day 82 delivery board integrity is incomplete (needs >=5 items and Day 82 anchors).")
+        handoff_actions.append("Repair Day 82 delivery board entries to include Day 82 anchors.")
+
+    if not missing_plan_keys:
+        wins.append("Day 83 trust FAQ expansion dataset is available for launch execution.")
+    else:
+        misses.append("Day 83 trust FAQ expansion dataset is missing required keys.")
+        handoff_actions.append("Update .day83-trust-faq-expansion-plan.json to restore required keys.")
+
+    if not failed and not critical_failures:
+        wins.append("Day 83 trust FAQ expansion closeout lane is fully complete and ready for Day 84 evidence narrative priorities.")
+
+    score = int(round(sum(c["weight"] for c in checks if c["passed"])))
+    return {
+        "name": "day83-trust-faq-expansion-closeout",
+        "inputs": {
+            "readme": "README.md",
+            "docs_index": "docs/index.md",
+            "docs_page": _PAGE_PATH,
+            "top10": _TOP10_PATH,
+            "day82_summary": str(day82_summary.relative_to(root)) if day82_summary.exists() else str(day82_summary),
+            "day82_delivery_board": str(day82_board.relative_to(root)) if day82_board.exists() else str(day82_board),
+            "trust_faq_plan": _PLAN_PATH,
+        },
+        "checks": checks,
+        "rollup": {"day82_activation_score": day82_score, "day82_checks": day82_check_count, "day82_delivery_board_items": board_count},
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "wins": wins,
+        "misses": misses,
+        "handoff_actions": handoff_actions,
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Day 83 trust FAQ expansion closeout summary",
+        f"- Activation score: {payload['summary']['activation_score']}",
+        f"- Passed checks: {payload['summary']['passed_checks']}",
+        f"- Failed checks: {payload['summary']['failed_checks']}",
+        f"- Critical failures: {payload['summary']['critical_failures']}",
+    ]
+    return "\n".join(lines)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
+    target = pack_dir if pack_dir.is_absolute() else root / pack_dir
+    _write(target / "day83-trust-faq-expansion-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
+    _write(target / "day83-trust-faq-expansion-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "day83-trust-faq-brief.md", "# Day 83 trust FAQ brief\n")
+    _write(target / "day83-trust-faq-expansion-plan.md", "# Day 83 trust FAQ expansion plan\n")
+    _write(target / "day83-trust-template-upgrade-ledger.json", json.dumps({"upgrades": []}, indent=2) + "\n")
+    _write(target / "day83-escalation-outcomes-ledger.json", json.dumps({"outcomes": []}, indent=2) + "\n")
+    _write(target / "day83-trust-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "day83-execution-log.md", "# Day 83 execution log\n")
+    _write(target / "day83-delivery-board.md", "\n".join(["# Day 83 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n")
+    _write(target / "day83-validation-commands.md", "# Day 83 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n")
+
+
+def _execute_commands(root: Path, evidence_dir: Path) -> None:
+    events: list[dict[str, Any]] = []
+    out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
+        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        event = {"command": command, "returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+        events.append(event)
+        _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
+    _write(out_dir / "day83-execution-summary.json", json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Day 83 trust FAQ expansion closeout checks")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-default-doc", action="store_true")
+    ns = parser.parse_args(argv)
+
+    root = Path(ns.root).resolve()
+    if ns.write_default_doc:
+        _write(root / _PAGE_PATH, _DAY83_DEFAULT_PAGE)
+
+    payload = build_day83_trust_faq_expansion_closeout_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, Path(ns.emit_pack_dir), payload)
+    if ns.execute:
+        evidence_dir = Path(ns.evidence_dir) if ns.evidence_dir else Path("docs/artifacts/day83-trust-faq-expansion-closeout-pack/evidence")
+        _execute_commands(root, evidence_dir)
+
+    print(json.dumps(payload, indent=2) if ns.format == "json" else _render_text(payload))
+    return 1 if ns.strict and not payload["summary"]["strict_pass"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_day83_trust_faq_expansion_closeout.py
+++ b/tests/test_day83_trust_faq_expansion_closeout.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day83_trust_faq_expansion_closeout as d83
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text(
+        "docs/integrations-day83-trust-faq-expansion-closeout.md\nday83-trust-faq-expansion-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-83-big-upgrade-report.md\nintegrations-day83-trust-faq-expansion-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 82 — Integration feedback loop:** fold field feedback into docs/templates.\n"
+        "- **Day 83 — Trust FAQ expansion loop:** convert field objections into deterministic trust upgrades.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day83-trust-faq-expansion-closeout.md").write_text(
+        d83._DAY83_DEFAULT_PAGE, encoding="utf-8"
+    )
+    (root / "docs/day-83-big-upgrade-report.md").write_text("# Day 83 report\n", encoding="utf-8")
+
+    summary = root / "docs/artifacts/day82-integration-feedback-closeout-pack/day82-integration-feedback-closeout-summary.json"
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 100, "strict_pass": True},
+                "checks": [{"passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = root / "docs/artifacts/day82-integration-feedback-closeout-pack/day82-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 82 delivery board",
+                "- [ ] Day 82 integration brief committed",
+                "- [ ] Day 82 integration feedback plan committed",
+                "- [ ] Day 82 template upgrade ledger exported",
+                "- [ ] Day 82 office-hours outcome ledger exported",
+                "- [ ] Day 83 trust FAQ priorities drafted from Day 82 feedback",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    plan = root / ".day83-trust-faq-expansion-plan.json"
+    plan.write_text(
+        json.dumps(
+            {
+                "plan_id": "day83-trust-faq-expansion-001",
+                "contributors": ["maintainers", "docs-ops"],
+                "objection_channels": ["office-hours", "issues", "faq-form"],
+                "baseline": {"faq_coverage": 0.61, "deflection_rate": 0.43},
+                "target": {"faq_coverage": 0.82, "deflection_rate": 0.62},
+                "owner": "docs-ops",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_day83_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d83.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day83-trust-faq-expansion-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day83_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d83.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day83-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day83-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day83-pack/day83-trust-faq-expansion-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day83-pack/day83-trust-faq-expansion-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day83-pack/day83-trust-faq-brief.md").exists()
+    assert (tmp_path / "artifacts/day83-pack/day83-trust-faq-expansion-plan.md").exists()
+    assert (tmp_path / "artifacts/day83-pack/day83-trust-template-upgrade-ledger.json").exists()
+    assert (tmp_path / "artifacts/day83-pack/day83-escalation-outcomes-ledger.json").exists()
+    assert (tmp_path / "artifacts/day83-pack/day83-trust-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day83-pack/day83-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day83-pack/day83-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day83-pack/day83-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day83-pack/evidence/day83-execution-summary.json").exists()
+
+
+def test_day83_strict_fails_without_day82(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (
+        tmp_path / "docs/artifacts/day82-integration-feedback-closeout-pack/day82-integration-feedback-closeout-summary.json"
+    ).unlink()
+    assert d83.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
+
+
+def test_day83_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day83-trust-faq-expansion-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 83 trust FAQ expansion closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Introduce a Day 83 closeout lane to convert Day 82 integration feedback into trust FAQ coverage upgrades and escalation-readiness with deterministic scoring and evidence collection.
- Provide a strict, testable handoff so Day 83 can be validated, emitted as an artifact pack, and executed with reproducible logs for Day 84 planning.

### Description
- Add implementation module `src/sdetkit/day83_trust_faq_expansion_closeout.py` that mirrors the Day 82 workflow with checks, pack emission, command execution, and summary rendering.
- Wire the new command into the CLI via `src/sdetkit/cli.py` (direct argv dispatch and argparse subparser) as `day83-trust-faq-expansion-closeout`.
- Add contract checker script `scripts/check_day83_trust_faq_expansion_closeout_contract.py`, unit tests `tests/test_day83_trust_faq_expansion_closeout.py`, docs `docs/integrations-day83-trust-faq-expansion-closeout.md` and `docs/day-83-big-upgrade-report.md`, and a plan seed `.day83-trust-faq-expansion-plan.json`.
- Update navigation and references in `README.md`, `docs/index.md`, and `docs/top-10-github-strategy.md` to include Day 83 commands and links.

### Testing
- Ran `pytest -q tests/test_day83_trust_faq_expansion_closeout.py tests/test_day82_integration_feedback_closeout.py` and all tests passed (`8 passed`).
- Executed the new CLI lane with `python -m sdetkit day83-trust-faq-expansion-closeout --format text` and observed a human-readable summary output and successful execution (exit code 0 as part of test coverage).

------