### PR TITLE
Add Day 85 release prioritization closeout lane with CLI, docs, tests, and contract validation

### DIFF
--- a/.day85-release-prioritization-plan.json
+++ b/.day85-release-prioritization-plan.json
@@ -1,0 +1,14 @@
+{
+  "plan_id": "day85-release-prioritization-001",
+  "contributors": ["maintainers", "release-ops", "docs-ops"],
+  "narrative_channels": ["release-report", "runbook", "incident-review"],
+  "baseline": {
+    "priority_precision": 0.58,
+    "execution_readiness": 0.49
+  },
+  "target": {
+    "priority_precision": 0.82,
+    "execution_readiness": 0.74
+  },
+  "owner": "release-ops"
+}

--- a/README.md
+++ b/README.md
@@ -1852,6 +1852,15 @@ See implementation details: [Day 83 big upgrade report](docs/day-83-big-upgrade-
 
 See implementation details: [Day 84 big upgrade report](docs/day-84-big-upgrade-report.md).
 
+### Day 85 — Release prioritization closeout lane
+
+- Run `python -m sdetkit day85-release-prioritization-closeout --format json --strict` to validate Day 85 release prioritization readiness.
+- Emit shareable Day 85 release prioritization pack: `python -m sdetkit day85-release-prioritization-closeout --emit-pack-dir docs/artifacts/day85-release-prioritization-closeout-pack --format json --strict`.
+- Execute and collect deterministic logs: `python -m sdetkit day85-release-prioritization-closeout --execute --evidence-dir docs/artifacts/day85-release-prioritization-closeout-pack/evidence --format json --strict`.
+- Review Day 85 integration guide: [Release prioritization closeout lane](docs/integrations-day85-release-prioritization-closeout.md).
+
+See implementation details: [Day 85 big upgrade report](docs/day-85-big-upgrade-report.md).
+
 ## 🧱 Repository navigation (short version)
 
 For a cleaner README experience, the giant file listings were removed.

--- a/docs/day-85-big-upgrade-report.md
+++ b/docs/day-85-big-upgrade-report.md
@@ -1,0 +1,16 @@
+# Day 85 big upgrade report
+
+## What shipped
+
+- Added `day85-release-prioritization-closeout` command to score Day 85 readiness from Day 84 evidence narrative handoff artifacts.
+- Added deterministic pack emission and execution evidence generation for release prioritization closeout proof.
+- Added strict contract validation script and tests that enforce Day 85 closeout quality gates and handoff integrity.
+
+## Command lane
+
+```bash
+python -m sdetkit day85-release-prioritization-closeout --format json --strict
+python -m sdetkit day85-release-prioritization-closeout --emit-pack-dir docs/artifacts/day85-release-prioritization-closeout-pack --format json --strict
+python -m sdetkit day85-release-prioritization-closeout --execute --evidence-dir docs/artifacts/day85-release-prioritization-closeout-pack/evidence --format json --strict
+python scripts/check_day85_release_prioritization_closeout_contract.py
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -887,3 +887,11 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 84 evidence narrative closeout pack: `python -m sdetkit day84-evidence-narrative-closeout --emit-pack-dir docs/artifacts/day84-evidence-narrative-closeout-pack --format json --strict`.
 - Run deterministic execution evidence lane: `python -m sdetkit day84-evidence-narrative-closeout --execute --evidence-dir docs/artifacts/day84-evidence-narrative-closeout-pack/evidence --format json --strict`.
 - Review integration guide: [Day 84 evidence narrative closeout lane](integrations-day84-evidence-narrative-closeout.md).
+
+## Day 85 release prioritization closeout lane
+
+- Read the implementation report: [Day 85 big upgrade report](day-85-big-upgrade-report.md).
+- Run `python -m sdetkit day85-release-prioritization-closeout --format json --strict` to score release prioritization readiness.
+- Emit Day 85 release prioritization closeout pack: `python -m sdetkit day85-release-prioritization-closeout --emit-pack-dir docs/artifacts/day85-release-prioritization-closeout-pack --format json --strict`.
+- Run deterministic execution evidence lane: `python -m sdetkit day85-release-prioritization-closeout --execute --evidence-dir docs/artifacts/day85-release-prioritization-closeout-pack/evidence --format json --strict`.
+- Review integration guide: [Day 85 release prioritization closeout lane](integrations-day85-release-prioritization-closeout.md).

--- a/docs/integrations-day85-release-prioritization-closeout.md
+++ b/docs/integrations-day85-release-prioritization-closeout.md
@@ -1,0 +1,51 @@
+# Day 85 — Release prioritization closeout lane
+
+Day 85 closes with a major upgrade that converts Day 84 evidence narrative outcomes into a deterministic release prioritization operating lane.
+
+## Why Day 85 matters
+
+- Converts Day 84 evidence narrative outcomes into reusable release prioritization decisions across docs, release notes, and escalation playbooks.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 85 closeout into Day 86 launch priorities.
+
+## Required inputs (Day 84)
+
+- `docs/artifacts/day84-evidence-narrative-closeout-pack/day84-evidence-narrative-closeout-summary.json`
+- `docs/artifacts/day84-evidence-narrative-closeout-pack/day84-delivery-board.md`
+- `.day85-release-prioritization-plan.json`
+
+## Day 85 command lane
+
+```bash
+python -m sdetkit day85-release-prioritization-closeout --format json --strict
+python -m sdetkit day85-release-prioritization-closeout --emit-pack-dir docs/artifacts/day85-release-prioritization-closeout-pack --format json --strict
+python -m sdetkit day85-release-prioritization-closeout --execute --evidence-dir docs/artifacts/day85-release-prioritization-closeout-pack/evidence --format json --strict
+python scripts/check_day85_release_prioritization_closeout_contract.py
+```
+
+## Release prioritization contract
+
+- Single owner + backup reviewer are assigned for Day 85 release prioritization execution and signoff.
+- The Day 85 lane references Day 84 outcomes, controls, and trust continuity signals.
+- Every Day 85 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 85 closeout records release prioritization pack upgrades, storyline outcomes, and Day 86 launch priorities.
+
+## Release prioritization quality checklist
+
+- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to narrative docs/templates + runnable command evidence
+- [ ] Scorecard captures release prioritization adoption delta, objection deflection delta, confidence, and rollback owner
+- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log
+
+## Day 85 delivery board
+
+- [ ] Day 85 evidence brief committed
+- [ ] Day 85 release prioritization plan committed
+- [ ] Day 85 narrative template upgrade ledger exported
+- [ ] Day 85 storyline outcomes ledger exported
+- [ ] Day 86 launch priorities drafted from Day 85 outcomes
+
+## Scoring model
+
+Day 85 weights continuity + execution contract + release-priority artifact readiness for a 100-point activation score.

--- a/scripts/check_day85_release_prioritization_closeout_contract.py
+++ b/scripts/check_day85_release_prioritization_closeout_contract.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import day85_release_prioritization_closeout as d85
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Day 85 release prioritization closeout contract")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d85.build_day85_release_prioritization_closeout_summary(root)
+    errors: list[str] = []
+
+    if not payload.get("summary", {}).get("strict_pass", False):
+        errors.append("summary.strict_pass is false")
+
+    if payload.get("summary", {}).get("activation_score", 0) < 95:
+        errors.append("activation_score below 95")
+
+    if payload.get("summary", {}).get("critical_failures"):
+        errors.append("critical_failures is not empty")
+
+    if not ns.skip_evidence:
+        evidence = root / "docs/artifacts/day85-release-prioritization-closeout-pack/evidence/day85-execution-summary.json"
+        if not evidence.exists():
+            errors.append(f"missing evidence summary: {evidence}")
+        else:
+            data = json.loads(evidence.read_text(encoding="utf-8"))
+            if int(data.get("total_commands", 0)) < 3:
+                errors.append("evidence total_commands below 3")
+
+    if errors:
+        print("day85-release-prioritization-closeout contract check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("day85-release-prioritization-closeout contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -65,6 +65,7 @@ from . import (
     day82_integration_feedback_closeout,
     day83_trust_faq_expansion_closeout,
     day84_evidence_narrative_closeout,
+    day85_release_prioritization_closeout,
     demo,
     docs_navigation,
     docs_qa,
@@ -348,6 +349,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day84-evidence-narrative-closeout":
         return day84_evidence_narrative_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "day85-release-prioritization-closeout":
+        return day85_release_prioritization_closeout.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -611,6 +615,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     d83.add_argument("args", nargs=argparse.REMAINDER)
     d84 = sub.add_parser("day84-evidence-narrative-closeout")
     d84.add_argument("args", nargs=argparse.REMAINDER)
+    d85 = sub.add_parser("day85-release-prioritization-closeout")
+    d85.add_argument("args", nargs=argparse.REMAINDER)
 
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
@@ -876,6 +882,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "day84-evidence-narrative-closeout":
         return day84_evidence_narrative_closeout.main(ns.args)
+
+    if ns.cmd == "day85-release-prioritization-closeout":
+        return day85_release_prioritization_closeout.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/day85_release_prioritization_closeout.py
+++ b/src/sdetkit/day85_release_prioritization_closeout.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-day85-release-prioritization-closeout.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_DAY84_SUMMARY_PATH = "docs/artifacts/day84-evidence-narrative-closeout-pack/day84-evidence-narrative-closeout-summary.json"
+_DAY84_BOARD_PATH = "docs/artifacts/day84-evidence-narrative-closeout-pack/day84-delivery-board.md"
+_PLAN_PATH = ".day85-release-prioritization-plan.json"
+_SECTION_HEADER = "# Day 85 — Release prioritization closeout lane"
+_REQUIRED_SECTIONS = [
+    "## Why Day 85 matters",
+    "## Required inputs (Day 84)",
+    "## Day 85 command lane",
+    "## Release prioritization contract",
+    "## Release prioritization quality checklist",
+    "## Day 85 delivery board",
+    "## Scoring model",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit day85-release-prioritization-closeout --format json --strict",
+    "python -m sdetkit day85-release-prioritization-closeout --emit-pack-dir docs/artifacts/day85-release-prioritization-closeout-pack --format json --strict",
+    "python -m sdetkit day85-release-prioritization-closeout --execute --evidence-dir docs/artifacts/day85-release-prioritization-closeout-pack/evidence --format json --strict",
+    "python scripts/check_day85_release_prioritization_closeout_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit day85-release-prioritization-closeout --format json --strict",
+    "python -m sdetkit day85-release-prioritization-closeout --emit-pack-dir docs/artifacts/day85-release-prioritization-closeout-pack --format json --strict",
+    "python scripts/check_day85_release_prioritization_closeout_contract.py --skip-evidence",
+]
+_REQUIRED_CONTRACT_LINES = [
+    "Single owner + backup reviewer are assigned for Day 85 release prioritization execution and signoff.",
+    "The Day 85 lane references Day 84 outcomes, controls, and trust continuity signals.",
+    "Every Day 85 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "Day 85 closeout records release prioritization pack upgrades, storyline outcomes, and Day 86 launch priorities.",
+]
+_REQUIRED_QUALITY_LINES = [
+    "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
+    "- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag",
+    "- [ ] CTA links point to narrative docs/templates + runnable command evidence",
+    "- [ ] Scorecard captures release prioritization adoption delta, objection deflection delta, confidence, and rollback owner",
+    "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
+]
+_REQUIRED_DELIVERY_BOARD_LINES = [
+    "- [ ] Day 85 evidence brief committed",
+    "- [ ] Day 85 release prioritization plan committed",
+    "- [ ] Day 85 narrative template upgrade ledger exported",
+    "- [ ] Day 85 storyline outcomes ledger exported",
+    "- [ ] Day 86 launch priorities drafted from Day 85 outcomes",
+]
+_REQUIRED_DATA_KEYS = ['"plan_id"', '"contributors"', '"narrative_channels"', '"baseline"', '"target"', '"owner"']
+
+_DAY85_DEFAULT_PAGE = """# Day 85 — Release prioritization closeout lane
+
+Day 85 closes with a major upgrade that converts Day 84 evidence narrative outcomes into a deterministic release prioritization operating lane.
+
+## Why Day 85 matters
+
+- Converts Day 84 evidence narrative outcomes into reusable release prioritization decisions across docs, release notes, and escalation playbooks.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 85 closeout into Day 86 launch priorities.
+
+## Required inputs (Day 84)
+
+- `docs/artifacts/day84-evidence-narrative-closeout-pack/day84-evidence-narrative-closeout-summary.json`
+- `docs/artifacts/day84-evidence-narrative-closeout-pack/day84-delivery-board.md`
+- `.day85-release-prioritization-plan.json`
+
+## Day 85 command lane
+
+```bash
+python -m sdetkit day85-release-prioritization-closeout --format json --strict
+python -m sdetkit day85-release-prioritization-closeout --emit-pack-dir docs/artifacts/day85-release-prioritization-closeout-pack --format json --strict
+python -m sdetkit day85-release-prioritization-closeout --execute --evidence-dir docs/artifacts/day85-release-prioritization-closeout-pack/evidence --format json --strict
+python scripts/check_day85_release_prioritization_closeout_contract.py
+```
+
+## Release prioritization contract
+
+- Single owner + backup reviewer are assigned for Day 85 release prioritization execution and signoff.
+- The Day 85 lane references Day 84 outcomes, controls, and trust continuity signals.
+- Every Day 85 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 85 closeout records release prioritization pack upgrades, storyline outcomes, and Day 86 launch priorities.
+
+## Release prioritization quality checklist
+
+- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to narrative docs/templates + runnable command evidence
+- [ ] Scorecard captures release prioritization adoption delta, objection deflection delta, confidence, and rollback owner
+- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log
+
+## Day 85 delivery board
+
+- [ ] Day 85 evidence brief committed
+- [ ] Day 85 release prioritization plan committed
+- [ ] Day 85 narrative template upgrade ledger exported
+- [ ] Day 85 storyline outcomes ledger exported
+- [ ] Day 86 launch priorities drafted from Day 85 outcomes
+
+## Scoring model
+
+Day 85 weights continuity + execution contract + release-priority artifact readiness for a 100-point activation score.
+"""
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _checklist_count(markdown: str) -> int:
+    return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
+
+
+def build_day85_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
+    readme_text = _read_text(root / "README.md")
+    docs_index_text = _read_text(root / "docs/index.md")
+    page_text = _read_text(root / _PAGE_PATH)
+    top10_text = _read_text(root / _TOP10_PATH)
+    day84_summary = root / _DAY84_SUMMARY_PATH
+    day84_board = root / _DAY84_BOARD_PATH
+
+    day84_data = _load_json(day84_summary)
+    day84_summary_data = day84_data.get("summary", {}) if isinstance(day84_data.get("summary"), dict) else {}
+    day84_score = int(day84_summary_data.get("activation_score", 0) or 0)
+    day84_strict = bool(day84_summary_data.get("strict_pass", False))
+    day84_check_count = len(day84_data.get("checks", [])) if isinstance(day84_data.get("checks"), list) else 0
+
+    board_text = _read_text(day84_board)
+    board_count = _checklist_count(board_text)
+    board_has_day84 = "Day 84" in board_text
+
+    missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+    missing_contract_lines = [line for line in _REQUIRED_CONTRACT_LINES if line not in page_text]
+    missing_quality_lines = [line for line in _REQUIRED_QUALITY_LINES if line not in page_text]
+    missing_board_items = [item for item in _REQUIRED_DELIVERY_BOARD_LINES if item not in page_text]
+
+    plan_text = _read_text(root / _PLAN_PATH)
+    missing_plan_keys = [key for key in _REQUIRED_DATA_KEYS if key not in plan_text]
+
+    checks: list[dict[str, Any]] = [
+        {"check_id": "readme_day85_command", "weight": 7, "passed": ("day85-release-prioritization-closeout" in readme_text), "evidence": "README day85 command lane"},
+        {
+            "check_id": "docs_index_day85_links",
+            "weight": 8,
+            "passed": ("day-85-big-upgrade-report.md" in docs_index_text and "integrations-day85-release-prioritization-closeout.md" in docs_index_text),
+            "evidence": "day-85-big-upgrade-report.md + integrations-day85-release-prioritization-closeout.md",
+        },
+        {"check_id": "top10_day85_alignment", "weight": 5, "passed": ("Day 84" in top10_text and "Day 85" in top10_text), "evidence": "Day 84 + Day 85 strategy chain"},
+        {"check_id": "day84_summary_present", "weight": 10, "passed": day84_summary.exists(), "evidence": str(day84_summary)},
+        {"check_id": "day84_delivery_board_present", "weight": 7, "passed": day84_board.exists(), "evidence": str(day84_board)},
+        {
+            "check_id": "day84_quality_floor",
+            "weight": 13,
+            "passed": day84_score >= 85 and day84_strict,
+            "evidence": {"day84_score": day84_score, "strict_pass": day84_strict, "day84_checks": day84_check_count},
+        },
+        {
+            "check_id": "day84_board_integrity",
+            "weight": 5,
+            "passed": board_count >= 5 and board_has_day84,
+            "evidence": {"board_items": board_count, "contains_day84": board_has_day84},
+        },
+        {"check_id": "page_header", "weight": 7, "passed": _SECTION_HEADER in page_text, "evidence": _SECTION_HEADER},
+        {"check_id": "required_sections", "weight": 8, "passed": not missing_sections, "evidence": missing_sections or "all sections present"},
+        {"check_id": "required_commands", "weight": 5, "passed": not missing_commands, "evidence": missing_commands or "all commands present"},
+        {"check_id": "contract_lock", "weight": 5, "passed": not missing_contract_lines, "evidence": missing_contract_lines or "contract locked"},
+        {"check_id": "quality_checklist_lock", "weight": 5, "passed": not missing_quality_lines, "evidence": missing_quality_lines or "quality checklist locked"},
+        {"check_id": "delivery_board_lock", "weight": 5, "passed": not missing_board_items, "evidence": missing_board_items or "delivery board locked"},
+        {"check_id": "evidence_plan_data_present", "weight": 10, "passed": not missing_plan_keys, "evidence": missing_plan_keys or _PLAN_PATH},
+    ]
+
+    failed = [c for c in checks if not c["passed"]]
+    critical_failures: list[str] = []
+    if not day84_summary.exists() or not day84_board.exists():
+        critical_failures.append("day84_handoff_inputs")
+
+    wins: list[str] = []
+    misses: list[str] = []
+    handoff_actions: list[str] = []
+
+    if day84_score >= 85 and day84_strict:
+        wins.append(f"Day 84 continuity baseline is stable with activation score={day84_score}.")
+    else:
+        misses.append("Day 84 continuity baseline is below the floor (<85) or not strict-pass.")
+        handoff_actions.append("Re-run Day 84 closeout command and raise baseline quality above 85 with strict pass before Day 85 lock.")
+
+    if board_count >= 5 and board_has_day84:
+        wins.append(f"Day 84 delivery board integrity validated with {board_count} checklist items.")
+    else:
+        misses.append("Day 84 delivery board integrity is incomplete (needs >=5 items and Day 84 anchors).")
+        handoff_actions.append("Repair Day 84 delivery board entries to include Day 84 anchors.")
+
+    if not missing_plan_keys:
+        wins.append("Day 85 release prioritization dataset is available for launch execution.")
+    else:
+        misses.append("Day 85 release prioritization dataset is missing required keys.")
+        handoff_actions.append("Update .day85-release-prioritization-plan.json to restore required keys.")
+
+    if not failed and not critical_failures:
+        wins.append("Day 85 release prioritization closeout lane is fully complete and ready for Day 86 launch prioritization.")
+
+    score = int(round(sum(c["weight"] for c in checks if c["passed"])))
+    return {
+        "name": "day85-release-prioritization-closeout",
+        "inputs": {
+            "readme": "README.md",
+            "docs_index": "docs/index.md",
+            "docs_page": _PAGE_PATH,
+            "top10": _TOP10_PATH,
+            "day84_summary": str(day84_summary.relative_to(root)) if day84_summary.exists() else str(day84_summary),
+            "day84_delivery_board": str(day84_board.relative_to(root)) if day84_board.exists() else str(day84_board),
+            "release_prioritization_plan": _PLAN_PATH,
+        },
+        "checks": checks,
+        "rollup": {"day84_activation_score": day84_score, "day84_checks": day84_check_count, "day84_delivery_board_items": board_count},
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "wins": wins,
+        "misses": misses,
+        "handoff_actions": handoff_actions,
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Day 85 release prioritization closeout summary",
+        f"- Activation score: {payload['summary']['activation_score']}",
+        f"- Passed checks: {payload['summary']['passed_checks']}",
+        f"- Failed checks: {payload['summary']['failed_checks']}",
+        f"- Critical failures: {payload['summary']['critical_failures']}",
+    ]
+    return "\n".join(lines)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
+    target = pack_dir if pack_dir.is_absolute() else root / pack_dir
+    _write(target / "day85-release-prioritization-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
+    _write(target / "day85-release-prioritization-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "day85-evidence-brief.md", "# Day 85 release prioritization brief\n")
+    _write(target / "day85-release-prioritization-plan.md", "# Day 85 release prioritization plan\n")
+    _write(target / "day85-narrative-template-upgrade-ledger.json", json.dumps({"upgrades": []}, indent=2) + "\n")
+    _write(target / "day85-storyline-outcomes-ledger.json", json.dumps({"outcomes": []}, indent=2) + "\n")
+    _write(target / "day85-narrative-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "day85-execution-log.md", "# Day 85 execution log\n")
+    _write(target / "day85-delivery-board.md", "\n".join(["# Day 85 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n")
+    _write(target / "day85-validation-commands.md", "# Day 85 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n")
+
+
+def _execute_commands(root: Path, evidence_dir: Path) -> None:
+    events: list[dict[str, Any]] = []
+    out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
+        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        event = {"command": command, "returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+        events.append(event)
+        _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
+    _write(out_dir / "day85-execution-summary.json", json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Day 85 release prioritization closeout checks")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-default-doc", action="store_true")
+    ns = parser.parse_args(argv)
+
+    root = Path(ns.root).resolve()
+    if ns.write_default_doc:
+        _write(root / _PAGE_PATH, _DAY85_DEFAULT_PAGE)
+
+    payload = build_day85_release_prioritization_closeout_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, Path(ns.emit_pack_dir), payload)
+    if ns.execute:
+        evidence_dir = Path(ns.evidence_dir) if ns.evidence_dir else Path("docs/artifacts/day85-release-prioritization-closeout-pack/evidence")
+        _execute_commands(root, evidence_dir)
+
+    print(json.dumps(payload, indent=2) if ns.format == "json" else _render_text(payload))
+    return 1 if ns.strict and not payload["summary"]["strict_pass"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_day85_release_prioritization_closeout.py
+++ b/tests/test_day85_release_prioritization_closeout.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day85_release_prioritization_closeout as d85
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text(
+        "docs/integrations-day85-release-prioritization-closeout.md\nday85-release-prioritization-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-85-big-upgrade-report.md\nintegrations-day85-release-prioritization-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 84 — Evidence narrative closeout lane:** convert field objections into deterministic trust upgrades.\n"
+        "- **Day 85 — Release prioritization closeout lane:** convert trust outcomes into release-ready narrative proof packs.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day85-release-prioritization-closeout.md").write_text(
+        d85._DAY85_DEFAULT_PAGE, encoding="utf-8"
+    )
+    (root / "docs/day-85-big-upgrade-report.md").write_text("# Day 85 report\n", encoding="utf-8")
+
+    summary = root / "docs/artifacts/day84-evidence-narrative-closeout-pack/day84-evidence-narrative-closeout-summary.json"
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 100, "strict_pass": True},
+                "checks": [{"passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = root / "docs/artifacts/day84-evidence-narrative-closeout-pack/day84-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 84 delivery board",
+                "- [ ] Day 84 evidence brief committed",
+                "- [ ] Day 84 evidence narrative plan committed",
+                "- [ ] Day 84 narrative template upgrade ledger exported",
+                "- [ ] Day 84 storyline outcomes ledger exported",
+                "- [ ] Day 85 release priorities drafted from Day 84 outcomes",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    plan = root / ".day85-release-prioritization-plan.json"
+    plan.write_text(
+        json.dumps(
+            {
+                "plan_id": "day85-release-prioritization-001",
+                "contributors": ["maintainers", "docs-ops"],
+                "narrative_channels": ["release-report", "runbook", "faq"],
+                "baseline": {"evidence_coverage": 0.64, "narrative_reuse": 0.42},
+                "target": {"evidence_coverage": 0.86, "narrative_reuse": 0.67},
+                "owner": "docs-ops",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_day85_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d85.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day85-release-prioritization-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day85_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d85.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day85-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day85-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day85-pack/day85-release-prioritization-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day85-pack/day85-release-prioritization-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day85-pack/day85-evidence-brief.md").exists()
+    assert (tmp_path / "artifacts/day85-pack/day85-release-prioritization-plan.md").exists()
+    assert (tmp_path / "artifacts/day85-pack/day85-narrative-template-upgrade-ledger.json").exists()
+    assert (tmp_path / "artifacts/day85-pack/day85-storyline-outcomes-ledger.json").exists()
+    assert (tmp_path / "artifacts/day85-pack/day85-narrative-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day85-pack/day85-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day85-pack/day85-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day85-pack/day85-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day85-pack/evidence/day85-execution-summary.json").exists()
+
+
+def test_day85_strict_fails_without_day84(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "docs/artifacts/day84-evidence-narrative-closeout-pack/day84-evidence-narrative-closeout-summary.json").unlink()
+    assert d85.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
+
+
+def test_day85_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day85-release-prioritization-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 85 release prioritization closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation

- Introduce Day 85 as a dedicated closeout lane to convert Day 84 evidence narrative outputs into deterministic release prioritization decisions and preserve a strict handoff into the next launch cycle. 
- Provide a reproducible command, deterministic pack emission, and execution evidence to enforce quality gates and handoff integrity.

### Description

- Add a new command module `src/sdetkit/day85_release_prioritization_closeout.py` that implements scoring, strict-pass logic, pack emission, and deterministic execution logging for `day85-release-prioritization-closeout`.
- Wire the command into the top-level CLI by registering the parser and dispatch paths in `src/sdetkit/cli.py` and add a plan seed file `.day85-release-prioritization-plan.json` to support strict checks.
- Add docs and integration artifacts: `docs/integrations-day85-release-prioritization-closeout.md`, `docs/day-85-big-upgrade-report.md`, and README/docs/index references to expose usage and command lanes.
- Add a contract validation script `scripts/check_day85_release_prioritization_closeout_contract.py` and a test suite `tests/test_day85_release_prioritization_closeout.py` covering JSON output, pack emission+execute flow, strict-fail behavior, and CLI dispatch.

### Testing

- Ran `pytest -q tests/test_day85_release_prioritization_closeout.py tests/test_day84_evidence_narrative_closeout.py` and all tests passed (`8 passed`).
- Executed `python -m sdetkit day85-release-prioritization-closeout --format json` to validate runtime JSON payload generation and observed the expected payload structure and checks. 
- Verified CLI wiring by calling the command via `cli.main` in tests and confirmed correct textual summary output.

------