### PR TITLE
feat: add Day 89 governance scale closeout lane

### DIFF
--- a/.day89-governance-scale-plan.json
+++ b/.day89-governance-scale-plan.json
@@ -1,0 +1,16 @@
+{
+  "plan_id": "day89-governance-scale-001",
+  "contributors": ["release-ops", "maintainers", "community-moderation"],
+  "narrative_channels": ["governance-brief", "maintainer-update", "release-notes"],
+  "baseline": {
+    "adoption_rate": 0.62,
+    "objection_deflection": 0.51,
+    "confidence": 0.66
+  },
+  "target": {
+    "adoption_rate": 0.84,
+    "objection_deflection": 0.73,
+    "confidence": 0.88
+  },
+  "owner": "release-ops"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Dependency hygiene: requirements pinned and lockfiles added.
 - Repo init/apply reliability: tolerate non-UTF-8 preset template files.
 - Repo cleanliness: ignore local SDETKit workspace and docs build output.
+- feat: add `day89-governance-scale-closeout` with strict closeout checks, pack emission, and execution evidence lane.

--- a/README.md
+++ b/README.md
@@ -1898,3 +1898,13 @@ See implementation details: [Day 87 big upgrade report](docs/day-87-big-upgrade-
 - Review Day 88 integration guide: [Governance priorities closeout lane](docs/integrations-day88-governance-priorities-closeout.md).
 
 See implementation details: [Day 88 big upgrade report](docs/day-88-big-upgrade-report.md).
+
+
+### Day 89 — Governance scale closeout lane
+
+- Run `python -m sdetkit day89-governance-scale-closeout --format json --strict` to validate Day 89 governance scale readiness.
+- Emit shareable Day 89 governance scale pack: `python -m sdetkit day89-governance-scale-closeout --emit-pack-dir docs/artifacts/day89-governance-scale-closeout-pack --format json --strict`.
+- Execute and collect deterministic logs: `python -m sdetkit day89-governance-scale-closeout --execute --evidence-dir docs/artifacts/day89-governance-scale-closeout-pack/evidence --format json --strict`.
+- Review Day 89 integration guide: [Governance scale closeout lane](docs/integrations-day89-governance-scale-closeout.md).
+
+See implementation details: [Day 89 big upgrade report](docs/day-89-big-upgrade-report.md).

--- a/docs/day-89-big-upgrade-report.md
+++ b/docs/day-89-big-upgrade-report.md
@@ -1,0 +1,16 @@
+# Day 89 big upgrade report
+
+## What shipped
+
+- Added `day89-governance-scale-closeout` command to score Day 89 readiness from Day 88 governance handoff artifacts.
+- Added deterministic pack emission and execution evidence generation for governance scale closeout proof.
+- Added strict contract validation script and tests that enforce Day 89 closeout quality gates and handoff integrity.
+
+## Command lane
+
+```bash
+python -m sdetkit day89-governance-scale-closeout --format json --strict
+python -m sdetkit day89-governance-scale-closeout --emit-pack-dir docs/artifacts/day89-governance-scale-closeout-pack --format json --strict
+python -m sdetkit day89-governance-scale-closeout --execute --evidence-dir docs/artifacts/day89-governance-scale-closeout-pack/evidence --format json --strict
+python scripts/check_day89_governance_scale_closeout_contract.py
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -922,3 +922,12 @@ Free for personal/educational noncommercial use. Commercial use requires a paid 
 - Emit Day 88 governance priorities closeout pack: `python -m sdetkit day88-governance-priorities-closeout --emit-pack-dir docs/artifacts/day88-governance-priorities-closeout-pack --format json --strict`.
 - Run deterministic execution evidence lane: `python -m sdetkit day88-governance-priorities-closeout --execute --evidence-dir docs/artifacts/day88-governance-priorities-closeout-pack/evidence --format json --strict`.
 - Review integration guide: [Day 88 governance priorities closeout lane](integrations-day88-governance-priorities-closeout.md).
+
+
+## Day 89 governance scale closeout lane
+
+- Read the implementation report: [Day 89 big upgrade report](day-89-big-upgrade-report.md).
+- Run `python -m sdetkit day89-governance-scale-closeout --format json --strict` to score governance scale readiness.
+- Emit Day 89 governance scale closeout pack: `python -m sdetkit day89-governance-scale-closeout --emit-pack-dir docs/artifacts/day89-governance-scale-closeout-pack --format json --strict`.
+- Run deterministic execution evidence lane: `python -m sdetkit day89-governance-scale-closeout --execute --evidence-dir docs/artifacts/day89-governance-scale-closeout-pack/evidence --format json --strict`.
+- Review integration guide: [Day 89 governance scale closeout lane](integrations-day89-governance-scale-closeout.md).

--- a/docs/integrations-day89-governance-scale-closeout.md
+++ b/docs/integrations-day89-governance-scale-closeout.md
@@ -1,0 +1,51 @@
+# Day 89 — Governance scale closeout lane
+
+Day 89 closes with a major upgrade that converts Day 88 governance handoff outcomes into a deterministic governance scale operating lane.
+
+## Why Day 89 matters
+
+- Converts Day 88 governance handoff outcomes into reusable governance scale decisions across governance rituals, roadmap reviews, and maintainer escalation paths.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 89 closeout into Day 90 governance planning inputs.
+
+## Required inputs (Day 88)
+
+- `docs/artifacts/day88-governance-priorities-closeout-pack/day88-governance-priorities-closeout-summary.json`
+- `docs/artifacts/day88-governance-priorities-closeout-pack/day88-delivery-board.md`
+- `.day89-governance-scale-plan.json`
+
+## Day 89 command lane
+
+```bash
+python -m sdetkit day89-governance-scale-closeout --format json --strict
+python -m sdetkit day89-governance-scale-closeout --emit-pack-dir docs/artifacts/day89-governance-scale-closeout-pack --format json --strict
+python -m sdetkit day89-governance-scale-closeout --execute --evidence-dir docs/artifacts/day89-governance-scale-closeout-pack/evidence --format json --strict
+python scripts/check_day89_governance_scale_closeout_contract.py
+```
+
+## Governance scale contract
+
+- Single owner + backup reviewer are assigned for Day 89 governance scale execution and signoff.
+- The Day 89 lane references Day 88 outcomes, controls, and trust continuity signals.
+- Every Day 89 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 89 closeout records governance scale pack upgrades, storyline outcomes, and Day 90 governance planning inputs.
+
+## Governance scale quality checklist
+
+- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to narrative docs/templates + runnable command evidence
+- [ ] Scorecard captures governance scale adoption delta, objection deflection delta, confidence, and rollback owner
+- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log
+
+## Day 89 delivery board
+
+- [ ] Day 89 evidence brief committed
+- [ ] Day 89 governance scale plan committed
+- [ ] Day 89 narrative template upgrade ledger exported
+- [ ] Day 89 storyline outcomes ledger exported
+- [ ] Day 90 governance planning drafted from Day 89 outcomes
+
+## Scoring model
+
+Day 89 weights continuity + execution contract + governance artifact readiness for a 100-point activation score.

--- a/docs/top-10-github-strategy.md
+++ b/docs/top-10-github-strategy.md
@@ -335,3 +335,5 @@ A score of **28+/35 for 3 consecutive months** indicates strong category leaders
 - **Day 48 — Objection lane continuation:** convert Day 47 reliability wins into objection-handling plays.
 - **Day 49 — Weekly review lane continuation:** convert Day 48 objection wins into prioritized execution plays.
 - **Day 50 — Execution prioritization lane continuation:** convert Day 49 weekly-review wins into deterministic release-priority plays.
+
+- **Day 89 — Governance scale closeout lane:** scale Day 88 governance priorities outcomes with strict quality gates and deterministic evidence.

--- a/scripts/check_day89_governance_scale_closeout_contract.py
+++ b/scripts/check_day89_governance_scale_closeout_contract.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import day89_governance_scale_closeout as d89
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Day 89 governance scale closeout contract")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d89.build_day89_governance_scale_closeout_summary(root)
+    errors: list[str] = []
+
+    if not payload.get("summary", {}).get("strict_pass", False):
+        errors.append("summary.strict_pass is false")
+
+    if payload.get("summary", {}).get("activation_score", 0) < 95:
+        errors.append("activation_score below 95")
+
+    if payload.get("summary", {}).get("critical_failures"):
+        errors.append("critical_failures is not empty")
+
+    if not ns.skip_evidence:
+        evidence = root / "docs/artifacts/day89-governance-scale-closeout-pack/evidence/day89-execution-summary.json"
+        if not evidence.exists():
+            errors.append(f"missing evidence summary: {evidence}")
+        else:
+            data = json.loads(evidence.read_text(encoding="utf-8"))
+            if int(data.get("total_commands", 0)) < 3:
+                errors.append("evidence total_commands below 3")
+
+    if errors:
+        print("day89-governance-scale-closeout contract check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("day89-governance-scale-closeout contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -69,6 +69,7 @@ from . import (
     day86_launch_readiness_closeout,
     day87_governance_handoff_closeout,
     day88_governance_priorities_closeout,
+    day89_governance_scale_closeout,
     demo,
     docs_navigation,
     docs_qa,
@@ -364,6 +365,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day88-governance-priorities-closeout":
         return day88_governance_priorities_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "day89-governance-scale-closeout":
+        return day89_governance_scale_closeout.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -635,6 +639,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     d87.add_argument("args", nargs=argparse.REMAINDER)
     d88 = sub.add_parser("day88-governance-priorities-closeout")
     d88.add_argument("args", nargs=argparse.REMAINDER)
+    d89 = sub.add_parser("day89-governance-scale-closeout")
+    d89.add_argument("args", nargs=argparse.REMAINDER)
 
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
@@ -912,6 +918,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "day88-governance-priorities-closeout":
         return day88_governance_priorities_closeout.main(ns.args)
+
+    if ns.cmd == "day89-governance-scale-closeout":
+        return day89_governance_scale_closeout.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/day89_governance_scale_closeout.py
+++ b/src/sdetkit/day89_governance_scale_closeout.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-day89-governance-scale-closeout.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_DAY88_SUMMARY_PATH = "docs/artifacts/day88-governance-priorities-closeout-pack/day88-governance-priorities-closeout-summary.json"
+_DAY88_BOARD_PATH = "docs/artifacts/day88-governance-priorities-closeout-pack/day88-delivery-board.md"
+_PLAN_PATH = ".day89-governance-scale-plan.json"
+_SECTION_HEADER = "# Day 89 — Governance scale closeout lane"
+_REQUIRED_SECTIONS = [
+    "## Why Day 89 matters",
+    "## Required inputs (Day 88)",
+    "## Day 89 command lane",
+    "## Governance scale contract",
+    "## Governance scale quality checklist",
+    "## Day 89 delivery board",
+    "## Scoring model",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit day89-governance-scale-closeout --format json --strict",
+    "python -m sdetkit day89-governance-scale-closeout --emit-pack-dir docs/artifacts/day89-governance-scale-closeout-pack --format json --strict",
+    "python -m sdetkit day89-governance-scale-closeout --execute --evidence-dir docs/artifacts/day89-governance-scale-closeout-pack/evidence --format json --strict",
+    "python scripts/check_day89_governance_scale_closeout_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit day89-governance-scale-closeout --format json --strict",
+    "python -m sdetkit day89-governance-scale-closeout --emit-pack-dir docs/artifacts/day89-governance-scale-closeout-pack --format json --strict",
+    "python scripts/check_day89_governance_scale_closeout_contract.py --skip-evidence",
+]
+_REQUIRED_CONTRACT_LINES = [
+    "Single owner + backup reviewer are assigned for Day 89 governance scale execution and signoff.",
+    "The Day 89 lane references Day 88 outcomes, controls, and trust continuity signals.",
+    "Every Day 89 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "Day 89 closeout records governance scale pack upgrades, storyline outcomes, and Day 90 governance planning inputs.",
+]
+_REQUIRED_QUALITY_LINES = [
+    "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
+    "- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag",
+    "- [ ] CTA links point to narrative docs/templates + runnable command evidence",
+    "- [ ] Scorecard captures governance scale adoption delta, objection deflection delta, confidence, and rollback owner",
+    "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
+]
+_REQUIRED_DELIVERY_BOARD_LINES = [
+    "- [ ] Day 89 evidence brief committed",
+    "- [ ] Day 89 governance scale plan committed",
+    "- [ ] Day 89 narrative template upgrade ledger exported",
+    "- [ ] Day 89 storyline outcomes ledger exported",
+    "- [ ] Day 90 governance planning drafted from Day 89 outcomes",
+]
+_REQUIRED_DATA_KEYS = ['"plan_id"', '"contributors"', '"narrative_channels"', '"baseline"', '"target"', '"owner"']
+
+_DAY89_DEFAULT_PAGE = """# Day 89 — Governance scale closeout lane
+
+Day 89 closes with a major upgrade that converts Day 88 governance handoff outcomes into a deterministic governance scale operating lane.
+
+## Why Day 89 matters
+
+- Converts Day 88 governance handoff outcomes into reusable governance scale decisions across governance rituals, roadmap reviews, and maintainer escalation paths.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 89 closeout into Day 90 governance planning.
+
+## Required inputs (Day 88)
+
+- `docs/artifacts/day88-governance-priorities-closeout-pack/day88-governance-priorities-closeout-summary.json`
+- `docs/artifacts/day88-governance-priorities-closeout-pack/day88-delivery-board.md`
+- `.day89-governance-scale-plan.json`
+
+## Day 89 command lane
+
+```bash
+python -m sdetkit day89-governance-scale-closeout --format json --strict
+python -m sdetkit day89-governance-scale-closeout --emit-pack-dir docs/artifacts/day89-governance-scale-closeout-pack --format json --strict
+python -m sdetkit day89-governance-scale-closeout --execute --evidence-dir docs/artifacts/day89-governance-scale-closeout-pack/evidence --format json --strict
+python scripts/check_day89_governance_scale_closeout_contract.py
+```
+
+## Governance scale contract
+
+- Single owner + backup reviewer are assigned for Day 89 governance scale execution and signoff.
+- The Day 89 lane references Day 88 outcomes, controls, and trust continuity signals.
+- Every Day 89 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 89 closeout records governance scale pack upgrades, storyline outcomes, and Day 90 governance planning inputs.
+
+## Governance scale quality checklist
+
+- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to narrative docs/templates + runnable command evidence
+- [ ] Scorecard captures governance scale adoption delta, objection deflection delta, confidence, and rollback owner
+- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log
+
+## Day 89 delivery board
+
+- [ ] Day 89 evidence brief committed
+- [ ] Day 89 governance scale plan committed
+- [ ] Day 89 narrative template upgrade ledger exported
+- [ ] Day 89 storyline outcomes ledger exported
+- [ ] Day 90 governance planning drafted from Day 89 outcomes
+
+## Scoring model
+
+Day 89 weights continuity + execution contract + governance artifact readiness for a 100-point activation score.
+"""
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _checklist_count(markdown: str) -> int:
+    return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
+
+
+def build_day89_governance_scale_closeout_summary(root: Path) -> dict[str, Any]:
+    readme_text = _read_text(root / "README.md")
+    docs_index_text = _read_text(root / "docs/index.md")
+    page_text = _read_text(root / _PAGE_PATH)
+    top10_text = _read_text(root / _TOP10_PATH)
+    day88_summary = root / _DAY88_SUMMARY_PATH
+    day88_board = root / _DAY88_BOARD_PATH
+
+    day88_data = _load_json(day88_summary)
+    day88_summary_data = day88_data.get("summary", {}) if isinstance(day88_data.get("summary"), dict) else {}
+    day88_score = int(day88_summary_data.get("activation_score", 0) or 0)
+    day88_strict = bool(day88_summary_data.get("strict_pass", False))
+    day88_check_count = len(day88_data.get("checks", [])) if isinstance(day88_data.get("checks"), list) else 0
+
+    board_text = _read_text(day88_board)
+    board_count = _checklist_count(board_text)
+    board_has_day88 = "Day 88" in board_text
+
+    missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+    missing_contract_lines = [line for line in _REQUIRED_CONTRACT_LINES if line not in page_text]
+    missing_quality_lines = [line for line in _REQUIRED_QUALITY_LINES if line not in page_text]
+    missing_board_items = [item for item in _REQUIRED_DELIVERY_BOARD_LINES if item not in page_text]
+
+    plan_text = _read_text(root / _PLAN_PATH)
+    missing_plan_keys = [key for key in _REQUIRED_DATA_KEYS if key not in plan_text]
+
+    checks: list[dict[str, Any]] = [
+        {"check_id": "readme_day89_command", "weight": 7, "passed": ("day89-governance-scale-closeout" in readme_text), "evidence": "README day89 command lane"},
+        {
+            "check_id": "docs_index_day89_links",
+            "weight": 8,
+            "passed": ("day-89-big-upgrade-report.md" in docs_index_text and "integrations-day89-governance-scale-closeout.md" in docs_index_text),
+            "evidence": "day-89-big-upgrade-report.md + integrations-day89-governance-scale-closeout.md",
+        },
+        {"check_id": "top10_day89_alignment", "weight": 5, "passed": ("Day 88" in top10_text and "Day 89" in top10_text), "evidence": "Day 88 + Day 89 strategy chain"},
+        {"check_id": "day88_summary_present", "weight": 10, "passed": day88_summary.exists(), "evidence": str(day88_summary)},
+        {"check_id": "day88_delivery_board_present", "weight": 7, "passed": day88_board.exists(), "evidence": str(day88_board)},
+        {
+            "check_id": "day88_quality_floor",
+            "weight": 13,
+            "passed": day88_score >= 85 and day88_strict,
+            "evidence": {"day88_score": day88_score, "strict_pass": day88_strict, "day88_checks": day88_check_count},
+        },
+        {
+            "check_id": "day88_board_integrity",
+            "weight": 5,
+            "passed": board_count >= 5 and board_has_day88,
+            "evidence": {"board_items": board_count, "contains_day88": board_has_day88},
+        },
+        {"check_id": "page_header", "weight": 7, "passed": _SECTION_HEADER in page_text, "evidence": _SECTION_HEADER},
+        {"check_id": "required_sections", "weight": 8, "passed": not missing_sections, "evidence": missing_sections or "all sections present"},
+        {"check_id": "required_commands", "weight": 5, "passed": not missing_commands, "evidence": missing_commands or "all commands present"},
+        {"check_id": "contract_lock", "weight": 5, "passed": not missing_contract_lines, "evidence": missing_contract_lines or "contract locked"},
+        {"check_id": "quality_checklist_lock", "weight": 5, "passed": not missing_quality_lines, "evidence": missing_quality_lines or "quality checklist locked"},
+        {"check_id": "delivery_board_lock", "weight": 5, "passed": not missing_board_items, "evidence": missing_board_items or "delivery board locked"},
+        {"check_id": "evidence_plan_data_present", "weight": 10, "passed": not missing_plan_keys, "evidence": missing_plan_keys or _PLAN_PATH},
+    ]
+
+    failed = [c for c in checks if not c["passed"]]
+    critical_failures: list[str] = []
+    if not day88_summary.exists() or not day88_board.exists():
+        critical_failures.append("day88_handoff_inputs")
+
+    wins: list[str] = []
+    misses: list[str] = []
+    handoff_actions: list[str] = []
+
+    if day88_score >= 85 and day88_strict:
+        wins.append(f"Day 88 continuity baseline is stable with activation score={day88_score}.")
+    else:
+        misses.append("Day 88 continuity baseline is below the floor (<85) or not strict-pass.")
+        handoff_actions.append("Re-run Day 88 closeout command and raise baseline quality above 85 with strict pass before Day 89 lock.")
+
+    if board_count >= 5 and board_has_day88:
+        wins.append(f"Day 88 delivery board integrity validated with {board_count} checklist items.")
+    else:
+        misses.append("Day 88 delivery board integrity is incomplete (needs >=5 items and Day 88 anchors).")
+        handoff_actions.append("Repair Day 88 delivery board entries to include Day 88 anchors.")
+
+    if not missing_plan_keys:
+        wins.append("Day 89 governance scale dataset is available for governance execution.")
+    else:
+        misses.append("Day 89 governance scale dataset is missing required keys.")
+        handoff_actions.append("Update .day89-governance-scale-plan.json to restore required keys.")
+
+    if not failed and not critical_failures:
+        wins.append("Day 89 governance scale closeout lane is fully complete and ready for Day 90 governance planning.")
+
+    score = int(round(sum(c["weight"] for c in checks if c["passed"])))
+    return {
+        "name": "day89-governance-scale-closeout",
+        "inputs": {
+            "readme": "README.md",
+            "docs_index": "docs/index.md",
+            "docs_page": _PAGE_PATH,
+            "top10": _TOP10_PATH,
+            "day88_summary": str(day88_summary.relative_to(root)) if day88_summary.exists() else str(day88_summary),
+            "day88_delivery_board": str(day88_board.relative_to(root)) if day88_board.exists() else str(day88_board),
+            "governance_scale_plan": _PLAN_PATH,
+        },
+        "checks": checks,
+        "rollup": {"day88_activation_score": day88_score, "day88_checks": day88_check_count, "day88_delivery_board_items": board_count},
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "wins": wins,
+        "misses": misses,
+        "handoff_actions": handoff_actions,
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Day 89 governance scale closeout summary",
+        f"- Activation score: {payload['summary']['activation_score']}",
+        f"- Passed checks: {payload['summary']['passed_checks']}",
+        f"- Failed checks: {payload['summary']['failed_checks']}",
+        f"- Critical failures: {payload['summary']['critical_failures']}",
+    ]
+    return "\n".join(lines)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
+    target = pack_dir if pack_dir.is_absolute() else root / pack_dir
+    _write(target / "day89-governance-scale-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
+    _write(target / "day89-governance-scale-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "day89-evidence-brief.md", "# Day 89 governance scale brief\n")
+    _write(target / "day89-governance-scale-plan.md", "# Day 89 governance scale plan\n")
+    _write(target / "day89-narrative-template-upgrade-ledger.json", json.dumps({"upgrades": []}, indent=2) + "\n")
+    _write(target / "day89-storyline-outcomes-ledger.json", json.dumps({"outcomes": []}, indent=2) + "\n")
+    _write(target / "day89-narrative-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "day89-execution-log.md", "# Day 89 execution log\n")
+    _write(target / "day89-delivery-board.md", "\n".join(["# Day 89 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n")
+    _write(target / "day89-validation-commands.md", "# Day 89 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n")
+
+
+def _execute_commands(root: Path, evidence_dir: Path) -> None:
+    events: list[dict[str, Any]] = []
+    out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
+        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        event = {"command": command, "returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr}
+        events.append(event)
+        _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
+    _write(out_dir / "day89-execution-summary.json", json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Day 89 governance scale closeout checks")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-default-doc", action="store_true")
+    ns = parser.parse_args(argv)
+
+    root = Path(ns.root).resolve()
+    if ns.write_default_doc:
+        _write(root / _PAGE_PATH, _DAY89_DEFAULT_PAGE)
+
+    payload = build_day89_governance_scale_closeout_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, Path(ns.emit_pack_dir), payload)
+    if ns.execute:
+        evidence_dir = Path(ns.evidence_dir) if ns.evidence_dir else Path("docs/artifacts/day89-governance-scale-closeout-pack/evidence")
+        _execute_commands(root, evidence_dir)
+
+    print(json.dumps(payload, indent=2) if ns.format == "json" else _render_text(payload))
+    return 1 if ns.strict and not payload["summary"]["strict_pass"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_day89_governance_scale_closeout.py
+++ b/tests/test_day89_governance_scale_closeout.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day89_governance_scale_closeout as d89
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "README.md").write_text(
+        "docs/integrations-day89-governance-scale-closeout.md\nday89-governance-scale-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-89-big-upgrade-report.md\nintegrations-day89-governance-scale-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 88 — Governance priorities closeout lane:** convert governance handoff outcomes into governance priorities.\n"
+        "- **Day 89 — Governance scale closeout lane:** scale governance priorities into deterministic execution lanes.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day89-governance-scale-closeout.md").write_text(d89._DAY89_DEFAULT_PAGE, encoding="utf-8")
+    (root / "docs/day-89-big-upgrade-report.md").write_text("# Day 89 report\n", encoding="utf-8")
+
+    summary = root / "docs/artifacts/day88-governance-priorities-closeout-pack/day88-governance-priorities-closeout-summary.json"
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 100, "strict_pass": True},
+                "checks": [{"passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = root / "docs/artifacts/day88-governance-priorities-closeout-pack/day88-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 88 delivery board",
+                "- [ ] Day 88 evidence brief committed",
+                "- [ ] Day 88 governance priorities plan committed",
+                "- [ ] Day 88 narrative template upgrade ledger exported",
+                "- [ ] Day 88 storyline outcomes ledger exported",
+                "- [ ] Day 89 governance priorities drafted from Day 88 outcomes",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    plan = root / ".day89-governance-scale-plan.json"
+    plan.write_text(
+        json.dumps(
+            {
+                "plan_id": "day89-governance-scale-001",
+                "contributors": ["maintainers", "release-ops"],
+                "narrative_channels": ["launch-brief", "release-report", "faq"],
+                "baseline": {"launch_confidence": 0.64, "narrative_reuse": 0.42},
+                "target": {"launch_confidence": 0.86, "narrative_reuse": 0.67},
+                "owner": "release-ops",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_day89_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d89.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day89-governance-scale-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day89_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d89.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day89-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day89-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day89-pack/day89-governance-scale-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day89-pack/day89-governance-scale-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day89-pack/day89-evidence-brief.md").exists()
+    assert (tmp_path / "artifacts/day89-pack/day89-governance-scale-plan.md").exists()
+    assert (tmp_path / "artifacts/day89-pack/day89-narrative-template-upgrade-ledger.json").exists()
+    assert (tmp_path / "artifacts/day89-pack/day89-storyline-outcomes-ledger.json").exists()
+    assert (tmp_path / "artifacts/day89-pack/day89-narrative-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day89-pack/day89-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day89-pack/day89-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day89-pack/day89-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day89-pack/evidence/day89-execution-summary.json").exists()
+
+
+def test_day89_strict_fails_without_day88(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "docs/artifacts/day88-governance-priorities-closeout-pack/day88-governance-priorities-closeout-summary.json").unlink()
+    assert d89.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
+
+
+def test_day89_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day89-governance-scale-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 89 governance scale closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Close out Day 89 with a new "governance scale" upgrade that consumes Day 88 outputs and provides a deterministic closeout+handoff lane into Day 90 planning. 
- Provide the same strict contract, artifact pack emission, deterministic execution evidence, and test coverage used by prior closeout lanes.

### Description
- Added `src/sdetkit/day89_governance_scale_closeout.py` implementing the Day 89 closeout checks, pack emission, execution evidence, and CLI entry `day89-governance-scale-closeout`.
- Wired the command into the CLI by registering the subparser and fast-dispatch and added unit tests in `tests/test_day89_governance_scale_closeout.py` following the Day 88 pattern.
- Added `scripts/check_day89_governance_scale_closeout_contract.py`, seeded `.day89-governance-scale-plan.json`, and created docs/artifacts: `docs/integrations-day89-governance-scale-closeout.md`, `docs/day-89-big-upgrade-report.md`, README/docs/index/top-10 and `CHANGELOG.md` updates.
- Included test harness and pack naming parity with existing lanes and ensured `--emit-pack-dir`/`--execute`/`--strict` flows are supported and produce the expected files.

### Testing
- Ran `pytest -q tests/test_day89_governance_scale_closeout.py` and `pytest -q tests/test_day88_governance_priorities_closeout.py tests/test_day89_governance_scale_closeout.py` and all tests passed (total tests passed shown in logs: `8 passed`).
- Executed the new CLI command `python -m sdetkit day89-governance-scale-closeout --format text --strict` which produced a successful closeout summary (strict pass).
- Ran the contract validator `python scripts/check_day89_governance_scale_closeout_contract.py --skip-evidence` which passed.

------