### PR TITLE
Fix/python exec and doctor

### DIFF
--- a/src/sdetkit/community_activation.py
+++ b/src/sdetkit/community_activation.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -344,9 +345,10 @@ def execute_commands(root: Path, evidence_dir: Path, timeout_sec: int) -> dict[s
     evidence_dir.mkdir(parents=True, exist_ok=True)
     results: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, timeout=timeout_sec
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, timeout=timeout_sec)
         results.append(
             {
                 "command": command,

--- a/src/sdetkit/day28_weekly_review.py
+++ b/src/sdetkit/day28_weekly_review.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -350,9 +351,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day29_phase1_hardening.py
+++ b/src/sdetkit/day29_phase1_hardening.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -265,9 +266,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day30_phase1_wrap.py
+++ b/src/sdetkit/day30_phase1_wrap.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -358,9 +359,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day31_phase2_kickoff.py
+++ b/src/sdetkit/day31_phase2_kickoff.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -422,9 +423,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day32_release_cadence.py
+++ b/src/sdetkit/day32_release_cadence.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -452,9 +453,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day33_demo_asset.py
+++ b/src/sdetkit/day33_demo_asset.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -443,9 +444,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day34_demo_asset2.py
+++ b/src/sdetkit/day34_demo_asset2.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -445,9 +446,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day35_kpi_instrumentation.py
+++ b/src/sdetkit/day35_kpi_instrumentation.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -439,9 +440,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day36_distribution_closeout.py
+++ b/src/sdetkit/day36_distribution_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -454,9 +455,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day37_experiment_lane.py
+++ b/src/sdetkit/day37_experiment_lane.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -483,9 +484,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day38_distribution_batch.py
+++ b/src/sdetkit/day38_distribution_batch.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -483,9 +484,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day39_playbook_post.py
+++ b/src/sdetkit/day39_playbook_post.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -477,9 +478,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day40_scale_lane.py
+++ b/src/sdetkit/day40_scale_lane.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -473,9 +474,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day41_expansion_automation.py
+++ b/src/sdetkit/day41_expansion_automation.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -475,9 +476,10 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
     logs: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         logs.append(
             {
                 "command": command,

--- a/src/sdetkit/day42_optimization_closeout.py
+++ b/src/sdetkit/day42_optimization_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -433,9 +434,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day43_acceleration_closeout.py
+++ b/src/sdetkit/day43_acceleration_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -433,9 +434,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day44_scale_closeout.py
+++ b/src/sdetkit/day44_scale_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -427,9 +428,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day45_expansion_closeout.py
+++ b/src/sdetkit/day45_expansion_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -429,9 +430,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day46_optimization_closeout.py
+++ b/src/sdetkit/day46_optimization_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -432,9 +433,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day47_reliability_closeout.py
+++ b/src/sdetkit/day47_reliability_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -430,9 +431,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day48_objection_closeout.py
+++ b/src/sdetkit/day48_objection_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -430,9 +431,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day49_weekly_review_closeout.py
+++ b/src/sdetkit/day49_weekly_review_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -432,9 +433,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day50_execution_prioritization_closeout.py
+++ b/src/sdetkit/day50_execution_prioritization_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -439,9 +440,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day51_case_snippet_closeout.py
+++ b/src/sdetkit/day51_case_snippet_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -434,9 +435,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day52_narrative_closeout.py
+++ b/src/sdetkit/day52_narrative_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -432,9 +433,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day53_docs_loop_closeout.py
+++ b/src/sdetkit/day53_docs_loop_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -432,9 +433,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     evidence_path.mkdir(parents=True, exist_ok=True)
     events: list[dict[str, Any]] = []
     for index, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, check=False
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, check=False)
         event = {
             "command": command,
             "returncode": proc.returncode,

--- a/src/sdetkit/day55_contributor_activation_closeout.py
+++ b/src/sdetkit/day55_contributor_activation_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -395,7 +396,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day56_stabilization_closeout.py
+++ b/src/sdetkit/day56_stabilization_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -389,7 +390,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day57_kpi_deep_audit_closeout.py
+++ b/src/sdetkit/day57_kpi_deep_audit_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -380,7 +381,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day58_phase2_hardening_closeout.py
+++ b/src/sdetkit/day58_phase2_hardening_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -381,7 +382,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day59_phase3_preplan_closeout.py
+++ b/src/sdetkit/day59_phase3_preplan_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -369,7 +370,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day60_phase2_wrap_handoff_closeout.py
+++ b/src/sdetkit/day60_phase2_wrap_handoff_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -374,7 +375,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day61_phase3_kickoff_closeout.py
+++ b/src/sdetkit/day61_phase3_kickoff_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -370,7 +371,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day62_community_program_closeout.py
+++ b/src/sdetkit/day62_community_program_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -377,7 +378,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day63_onboarding_activation_closeout.py
+++ b/src/sdetkit/day63_onboarding_activation_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -374,7 +375,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day64_integration_expansion_closeout.py
+++ b/src/sdetkit/day64_integration_expansion_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -390,7 +391,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day65_weekly_review_closeout.py
+++ b/src/sdetkit/day65_weekly_review_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -383,7 +384,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day66_integration_expansion2_closeout.py
+++ b/src/sdetkit/day66_integration_expansion2_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -394,7 +395,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day67_integration_expansion3_closeout.py
+++ b/src/sdetkit/day67_integration_expansion3_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -394,7 +395,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day68_integration_expansion4_closeout.py
+++ b/src/sdetkit/day68_integration_expansion4_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -394,7 +395,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day69_case_study_prep1_closeout.py
+++ b/src/sdetkit/day69_case_study_prep1_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -387,7 +388,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day70_case_study_prep2_closeout.py
+++ b/src/sdetkit/day70_case_study_prep2_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -385,7 +386,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day71_case_study_prep3_closeout.py
+++ b/src/sdetkit/day71_case_study_prep3_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -385,7 +386,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day72_case_study_prep4_closeout.py
+++ b/src/sdetkit/day72_case_study_prep4_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -385,7 +386,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day73_case_study_launch_closeout.py
+++ b/src/sdetkit/day73_case_study_launch_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -381,7 +382,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day74_distribution_scaling_closeout.py
+++ b/src/sdetkit/day74_distribution_scaling_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -385,7 +386,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day75_trust_assets_refresh_closeout.py
+++ b/src/sdetkit/day75_trust_assets_refresh_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -382,7 +383,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day76_contributor_recognition_closeout.py
+++ b/src/sdetkit/day76_contributor_recognition_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -391,7 +392,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day77_community_touchpoint_closeout.py
+++ b/src/sdetkit/day77_community_touchpoint_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -387,7 +388,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day78_ecosystem_priorities_closeout.py
+++ b/src/sdetkit/day78_ecosystem_priorities_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -383,7 +384,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day79_scale_upgrade_closeout.py
+++ b/src/sdetkit/day79_scale_upgrade_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -380,7 +381,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day80_partner_outreach_closeout.py
+++ b/src/sdetkit/day80_partner_outreach_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -385,7 +386,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day81_growth_campaign_closeout.py
+++ b/src/sdetkit/day81_growth_campaign_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -378,7 +379,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day82_integration_feedback_closeout.py
+++ b/src/sdetkit/day82_integration_feedback_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -393,7 +394,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day83_trust_faq_expansion_closeout.py
+++ b/src/sdetkit/day83_trust_faq_expansion_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -394,7 +395,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day84_evidence_narrative_closeout.py
+++ b/src/sdetkit/day84_evidence_narrative_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -384,7 +385,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day85_release_prioritization_closeout.py
+++ b/src/sdetkit/day85_release_prioritization_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -388,7 +389,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day86_launch_readiness_closeout.py
+++ b/src/sdetkit/day86_launch_readiness_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -384,7 +385,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day87_governance_handoff_closeout.py
+++ b/src/sdetkit/day87_governance_handoff_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -384,7 +385,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day88_governance_priorities_closeout.py
+++ b/src/sdetkit/day88_governance_priorities_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -384,7 +385,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day89_governance_scale_closeout.py
+++ b/src/sdetkit/day89_governance_scale_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -384,7 +385,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/day90_phase3_wrap_publication_closeout.py
+++ b/src/sdetkit/day90_phase3_wrap_publication_closeout.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -390,7 +391,10 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
     out_dir.mkdir(parents=True, exist_ok=True)
     for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
-        result = subprocess.run(shlex.split(command), cwd=root, capture_output=True, text=True)
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
         event = {
             "command": command,
             "returncode": result.returncode,

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import shutil
@@ -242,10 +243,17 @@ def _check_clean_tree(root: Path) -> bool:
 
 
 def _check_tools() -> tuple[list[str], list[str]]:
-    want = ["git", "pytest", "ruff", "python3"]
-    present = sorted([t for t in want if shutil.which(t)])
-    missing = sorted([t for t in want if t not in present])
-    return present, missing
+    want_bins = ["git", "python3"]
+    want_mods = {"pytest": "pytest", "ruff": "ruff"}
+    present: set[str] = set()
+    for t in want_bins:
+        if shutil.which(t):
+            present.add(t)
+    for tool, mod in want_mods.items():
+        if shutil.which(tool) or importlib.util.find_spec(mod) is not None:
+            present.add(tool)
+    missing = sorted([t for t in (want_bins + list(want_mods)) if t not in present])
+    return sorted(present), missing
 
 
 def _calculate_score(checks: list[bool]) -> int:

--- a/src/sdetkit/enterprise_use_case.py
+++ b/src/sdetkit/enterprise_use_case.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -239,8 +240,11 @@ def _execute_commands(
     results: list[dict[str, Any]] = []
     for idx, command in enumerate(commands, start=1):
         try:
+            argv = shlex.split(command)
+            if argv and argv[0] == "python":
+                argv[0] = sys.executable
             proc = subprocess.run(
-                shlex.split(command),
+                argv,
                 shell=False,
                 capture_output=True,
                 text=True,

--- a/src/sdetkit/external_contribution_push.py
+++ b/src/sdetkit/external_contribution_push.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -342,9 +343,10 @@ def execute_commands(root: Path, evidence_dir: Path, timeout_sec: int) -> dict[s
     evidence_dir.mkdir(parents=True, exist_ok=True)
     results: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, timeout=timeout_sec
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, timeout=timeout_sec)
         results.append(
             {
                 "command": command,

--- a/src/sdetkit/faq_objections.py
+++ b/src/sdetkit/faq_objections.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -373,8 +374,11 @@ def execute_commands(root: Path, evidence_dir: Path, timeout_sec: int) -> dict[s
     results: list[dict[str, Any]] = []
 
     for command in _EXECUTION_COMMANDS:
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
         proc = subprocess.run(
-            shlex.split(command),
+            argv,
             cwd=root,
             text=True,
             capture_output=True,

--- a/src/sdetkit/github_actions_quickstart.py
+++ b/src/sdetkit/github_actions_quickstart.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any, cast
 
@@ -304,8 +305,11 @@ def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, A
     results: list[dict[str, Any]] = []
     for idx, command in enumerate(commands, start=1):
         try:
+            argv = shlex.split(command)
+            if argv and argv[0] == "python":
+                argv[0] = sys.executable
             proc = subprocess.run(
-                shlex.split(command),
+                argv,
                 shell=False,
                 capture_output=True,
                 text=True,

--- a/src/sdetkit/gitlab_ci_quickstart.py
+++ b/src/sdetkit/gitlab_ci_quickstart.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any, cast
 
@@ -315,8 +316,11 @@ def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, A
     results: list[dict[str, Any]] = []
     for idx, command in enumerate(commands, start=1):
         try:
+            argv = shlex.split(command)
+            if argv and argv[0] == "python":
+                argv[0] = sys.executable
             proc = subprocess.run(
-                shlex.split(command),
+                argv,
                 shell=False,
                 capture_output=True,
                 text=True,

--- a/src/sdetkit/kpi_audit.py
+++ b/src/sdetkit/kpi_audit.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -377,9 +378,10 @@ def execute_commands(root: Path, evidence_dir: Path, timeout_sec: int) -> dict[s
     evidence_dir.mkdir(parents=True, exist_ok=True)
     results: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, timeout=timeout_sec
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, timeout=timeout_sec)
         results.append(
             {
                 "command": command,

--- a/src/sdetkit/onboarding_time_upgrade.py
+++ b/src/sdetkit/onboarding_time_upgrade.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -341,9 +342,10 @@ def execute_commands(root: Path, evidence_dir: Path, timeout_sec: int) -> dict[s
     evidence_dir.mkdir(parents=True, exist_ok=True)
     results: list[dict[str, Any]] = []
     for command in _EXECUTION_COMMANDS:
-        proc = subprocess.run(
-            shlex.split(command), cwd=root, text=True, capture_output=True, timeout=timeout_sec
-        )
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        proc = subprocess.run(argv, cwd=root, text=True, capture_output=True, timeout=timeout_sec)
         results.append(
             {
                 "command": command,

--- a/src/sdetkit/release_narrative.py
+++ b/src/sdetkit/release_narrative.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -282,8 +283,11 @@ def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, A
     rows: list[dict[str, Any]] = []
     for idx, command in enumerate(commands, start=1):
         try:
+            argv = shlex.split(command)
+            if argv and argv[0] == "python":
+                argv[0] = sys.executable
             proc = subprocess.run(
-                shlex.split(command),
+                argv,
                 shell=False,
                 capture_output=True,
                 text=True,

--- a/src/sdetkit/release_readiness_board.py
+++ b/src/sdetkit/release_readiness_board.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -246,8 +247,11 @@ def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, A
     rows: list[dict[str, Any]] = []
     for idx, command in enumerate(commands, start=1):
         try:
+            argv = shlex.split(command)
+            if argv and argv[0] == "python":
+                argv[0] = sys.executable
             proc = subprocess.run(
-                shlex.split(command),
+                argv,
                 shell=False,
                 capture_output=True,
                 text=True,

--- a/src/sdetkit/reliability_evidence_pack.py
+++ b/src/sdetkit/reliability_evidence_pack.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -261,8 +262,11 @@ def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, A
     results: list[dict[str, Any]] = []
     for idx, command in enumerate(commands, start=1):
         try:
+            argv = shlex.split(command)
+            if argv and argv[0] == "python":
+                argv[0] = sys.executable
             proc = subprocess.run(
-                shlex.split(command),
+                argv,
                 shell=False,
                 capture_output=True,
                 text=True,

--- a/src/sdetkit/trust_signal_upgrade.py
+++ b/src/sdetkit/trust_signal_upgrade.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -343,8 +344,11 @@ def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, A
     rows: list[dict[str, Any]] = []
     for idx, command in enumerate(commands, start=1):
         try:
+            argv = shlex.split(command)
+            if argv and argv[0] == "python":
+                argv[0] = sys.executable
             proc = subprocess.run(
-                shlex.split(command),
+                argv,
                 shell=False,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
**Summary**
Fix portability issues where subprocess runners assume `python` exists on PATH; improve `doctor --dev` so it detects `pytest`/`ruff` by import when binaries aren’t on PATH.

**Why**
Some environments only ship `python3` (no `python` symlink). This caused day lanes + tool bridge to fail with `FileNotFoundError: 'python'`, and caused `doctor --dev` to incorrectly report missing tools.

**How**

* Normalize subprocess commands that begin with `python` to use `sys.executable`
* Update `doctor --dev` to accept module presence via `importlib.util.find_spec`

**Risk assessment**
Risk level: **low**
Primary risk area: subprocess launch behavior (command wiring)

**Test evidence**
Commands run:

* `python -m pytest -q`
  Key output:
* `896 passed ...`

**Rollback plan**
Revert commit: “Fix python subprocess portability and doctor dev tool detection”
Mitigation while rollback executes: temporarily pin to previous release/tag.