### PR TITLE
roadmap: add manifest generator and enforce freshness

### DIFF
--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -1,383 +1,471 @@
 {
-  "schema_version": 1,
   "days": [
     {
       "day": 1,
-      "report_file": "day-1-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-1-ultra-upgrade-report.md",
+      "report_title": "Day 1 Ultra Upgrade Report \u2014 Core Positioning Refresh"
     },
     {
       "day": 2,
-      "report_file": "day-2-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-2-ultra-upgrade-report.md",
+      "report_title": "Day 2 Ultra Upgrade Report \u2014 60-Second Demo Path Closeout"
     },
     {
       "day": 3,
-      "report_file": "day-3-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-3-ultra-upgrade-report.md",
+      "report_title": "Day 3 Ultra Upgrade Report \u2014 Proof Pack + Evidence Boost"
     },
     {
       "day": 4,
-      "report_file": "day-4-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-4-ultra-upgrade-report.md",
+      "report_title": "Day 4 Ultra Upgrade Report \u2014 Skills Expansion + Full Template Sweep"
     },
     {
       "day": 5,
-      "report_file": "day-5-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-5-ultra-upgrade-report.md",
+      "report_title": "Day 5 Ultra Upgrade Report \u2014 Platform Onboarding + Boost"
     },
     {
       "day": 6,
-      "report_file": "day-6-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-6-ultra-upgrade-report.md",
+      "report_title": "Day 6 Ultra Upgrade Report \u2014 Conversion QA Hardening"
     },
     {
       "day": 7,
-      "report_file": "day-7-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-7-ultra-upgrade-report.md",
+      "report_title": "Day 7 Ultra Upgrade Report \u2014 Weekly Review #1"
     },
     {
       "day": 8,
-      "report_file": "day-8-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-8-ultra-upgrade-report.md",
+      "report_title": "Day 8 Ultra Upgrade Report \u2014 Contributor Funnel Start"
     },
     {
       "day": 9,
-      "report_file": "day-9-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-9-ultra-upgrade-report.md",
+      "report_title": "Day 9 Ultra Upgrade Report \u2014 Contribution Template Triage"
     },
     {
       "day": 10,
-      "report_file": "day-10-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-10-ultra-upgrade-report.md",
+      "report_title": "Day 10 Ultra Upgrade Report \u2014 First-Contribution Checklist"
     },
     {
       "day": 11,
-      "report_file": "day-11-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-11-ultra-upgrade-report.md",
+      "report_title": "Day 11 Ultra Upgrade Report \u2014 Docs Navigation Tune-Up"
     },
     {
       "day": 12,
-      "report_file": "day-12-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-12-ultra-upgrade-report.md",
+      "report_title": "Day 12 Ultra Upgrade Report \u2014 Startup/Small-Team Use-Case Page"
     },
     {
       "day": 13,
-      "report_file": "day-13-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-13-ultra-upgrade-report.md",
+      "report_title": "Day 13 Ultra Upgrade Report"
     },
     {
       "day": 14,
-      "report_file": "day-14-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-14-ultra-upgrade-report.md",
+      "report_title": "Day 14 Ultra Upgrade Report \u2014 Weekly Review #2"
     },
     {
       "day": 15,
-      "report_file": "day-15-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-15-ultra-upgrade-report.md",
+      "report_title": "Day 15 ultra upgrade report"
     },
     {
       "day": 16,
-      "report_file": "day-16-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-16-ultra-upgrade-report.md",
+      "report_title": "Day 16 ultra upgrade report"
     },
     {
       "day": 17,
-      "report_file": "day-17-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-17-ultra-upgrade-report.md",
+      "report_title": "Day 17 ultra upgrade report"
     },
     {
       "day": 18,
-      "report_file": "day-18-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-18-ultra-upgrade-report.md",
+      "report_title": "Day 18 ultra upgrade report"
     },
     {
       "day": 19,
-      "report_file": "day-19-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-19-ultra-upgrade-report.md",
+      "report_title": "Day 19 ultra upgrade report"
     },
     {
       "day": 20,
-      "report_file": "day-20-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-20-ultra-upgrade-report.md",
+      "report_title": "Day 20 ultra upgrade report"
     },
     {
       "day": 21,
-      "report_file": "day-21-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-21-ultra-upgrade-report.md",
+      "report_title": "Day 21 ultra upgrade report"
     },
     {
       "day": 22,
-      "report_file": "day-22-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-22-ultra-upgrade-report.md",
+      "report_title": "Day 22 ultra upgrade report"
     },
     {
       "day": 23,
-      "report_file": "day-23-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-23-ultra-upgrade-report.md",
+      "report_title": "Day 23 ultra upgrade report"
     },
     {
       "day": 24,
-      "report_file": "day-24-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-24-ultra-upgrade-report.md",
+      "report_title": "Day 24 ultra upgrade report \u2014 onboarding time-to-first-success closeout"
     },
     {
       "day": 25,
-      "report_file": "day-25-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-25-ultra-upgrade-report.md",
+      "report_title": "Day 25 ultra upgrade report \u2014 community activation closeout"
     },
     {
       "day": 26,
-      "report_file": "day-26-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-26-ultra-upgrade-report.md",
+      "report_title": "Day 26 ultra upgrade report \u2014 external contribution push closeout"
     },
     {
       "day": 27,
-      "report_file": "day-27-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-27-ultra-upgrade-report.md",
+      "report_title": "Day 27 ultra upgrade report \u2014 KPI audit closeout"
     },
     {
       "day": 28,
-      "report_file": "day-28-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-28-ultra-upgrade-report.md",
+      "report_title": "Day 28 ultra upgrade report \u2014 weekly review #4 closeout"
     },
     {
       "day": 29,
-      "report_file": "day-29-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-29-ultra-upgrade-report.md",
+      "report_title": "Day 29 ultra upgrade report \u2014 phase-1 hardening closeout"
     },
     {
       "day": 30,
-      "report_file": "day-30-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-30-ultra-upgrade-report.md",
+      "report_title": "Day 30 ultra upgrade report \u2014 Phase-1 wrap + Phase-2 handoff"
     },
     {
       "day": 31,
-      "report_file": "day-31-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-31-ultra-upgrade-report.md",
+      "report_title": "Day 31 ultra upgrade report \u2014 Phase-2 kickoff baseline closeout"
     },
     {
       "day": 32,
-      "report_file": "day-32-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-32-ultra-upgrade-report.md",
+      "report_title": "Day 32 \u2014 Ultra Upgrade Report (Release cadence setup)"
     },
     {
       "day": 33,
-      "report_file": "day-33-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-33-ultra-upgrade-report.md",
+      "report_title": "Day 33 Ultra Upgrade Report"
     },
     {
       "day": 34,
-      "report_file": "day-34-ultra-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-34-ultra-upgrade-report.md",
+      "report_title": "Day 34 Ultra Upgrade Report"
     },
     {
       "day": 35,
-      "report_file": "day-35-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-35-big-upgrade-report.md",
+      "report_title": "Day 35 Big Upgrade Report"
     },
     {
       "day": 36,
-      "report_file": "day-36-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-36-big-upgrade-report.md",
+      "report_title": "Day 36 Big Upgrade Report"
     },
     {
       "day": 37,
-      "report_file": "day-37-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-37-big-upgrade-report.md",
+      "report_title": "Day 37 Big Upgrade Report"
     },
     {
       "day": 38,
-      "report_file": "day-38-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-38-big-upgrade-report.md",
+      "report_title": "Day 38 Big Upgrade Report"
     },
     {
       "day": 39,
-      "report_file": "day-39-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-39-big-upgrade-report.md",
+      "report_title": "Day 39 Big Upgrade Report"
     },
     {
       "day": 40,
-      "report_file": "day-40-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-40-big-upgrade-report.md",
+      "report_title": "Day 40 Big Upgrade Report"
     },
     {
       "day": 41,
-      "report_file": "day-41-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-41-big-upgrade-report.md",
+      "report_title": "Day 41 Big Upgrade Report"
     },
     {
       "day": 42,
-      "report_file": "day-42-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-42-big-upgrade-report.md",
+      "report_title": "Day 42 Big Upgrade Report"
     },
     {
       "day": 43,
-      "report_file": "day-43-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-43-big-upgrade-report.md",
+      "report_title": "Day 43 big upgrade report"
     },
     {
       "day": 44,
-      "report_file": "day-44-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-44-big-upgrade-report.md",
+      "report_title": "Day 44 big upgrade report"
     },
     {
       "day": 45,
-      "report_file": "day-45-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-45-big-upgrade-report.md",
+      "report_title": "Day 45 big upgrade report"
     },
     {
       "day": 46,
-      "report_file": "day-46-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-46-big-upgrade-report.md",
+      "report_title": "Day 46 big upgrade report"
     },
     {
       "day": 47,
-      "report_file": "day-47-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-47-big-upgrade-report.md",
+      "report_title": "Day 47 big upgrade report"
     },
     {
       "day": 48,
-      "report_file": "day-48-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-48-big-upgrade-report.md",
+      "report_title": "Day 48 big upgrade report"
     },
     {
       "day": 49,
-      "report_file": "day-49-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-49-big-upgrade-report.md",
+      "report_title": "Day 49 Big Upgrade Report"
     },
     {
       "day": 50,
-      "report_file": "day-50-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-50-big-upgrade-report.md",
+      "report_title": "Day 50 Big Upgrade Report"
     },
     {
       "day": 51,
-      "report_file": "day-51-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-51-big-upgrade-report.md",
+      "report_title": "Day 51 Big Upgrade Report"
     },
     {
       "day": 52,
-      "report_file": "day-52-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-52-big-upgrade-report.md",
+      "report_title": "Day 52 Big Upgrade Report"
     },
     {
       "day": 53,
-      "report_file": "day-53-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-53-big-upgrade-report.md",
+      "report_title": "Day 53 Big Upgrade Report"
     },
     {
       "day": 55,
-      "report_file": "day-55-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-55-big-upgrade-report.md",
+      "report_title": "Day 55 Big Upgrade Report"
     },
     {
       "day": 56,
-      "report_file": "day-56-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-56-big-upgrade-report.md",
+      "report_title": "Day 56 Big Upgrade Report"
     },
     {
       "day": 57,
-      "report_file": "day-57-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-57-big-upgrade-report.md",
+      "report_title": "Day 57 Big Upgrade Report"
     },
     {
       "day": 58,
-      "report_file": "day-58-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-58-big-upgrade-report.md",
+      "report_title": "Day 58 Big Upgrade Report"
     },
     {
       "day": 59,
-      "report_file": "day-59-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-59-big-upgrade-report.md",
+      "report_title": "Day 59 Big Upgrade Report"
     },
     {
       "day": 60,
-      "report_file": "day-60-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-60-big-upgrade-report.md",
+      "report_title": "Day 60 Big Upgrade Report"
     },
     {
       "day": 61,
-      "report_file": "day-61-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-61-big-upgrade-report.md",
+      "report_title": "Day 61 Big Upgrade Report"
     },
     {
       "day": 62,
-      "report_file": "day-62-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-62-big-upgrade-report.md",
+      "report_title": "Day 62 big upgrade report"
     },
     {
       "day": 63,
-      "report_file": "day-63-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-63-big-upgrade-report.md",
+      "report_title": "Day 63 big upgrade report"
     },
     {
       "day": 64,
-      "report_file": "day-64-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-64-big-upgrade-report.md",
+      "report_title": "Day 64 big upgrade report"
     },
     {
       "day": 65,
-      "report_file": "day-65-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-65-big-upgrade-report.md",
+      "report_title": "Day 65 big upgrade report"
     },
     {
       "day": 66,
-      "report_file": "day-66-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-66-big-upgrade-report.md",
+      "report_title": "Day 66 big upgrade report"
     },
     {
       "day": 67,
-      "report_file": "day-67-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-67-big-upgrade-report.md",
+      "report_title": "Day 67 big upgrade report"
     },
     {
       "day": 68,
-      "report_file": "day-68-big-upgrade-report.md"
+      "report_path": "docs/roadmap/reports/day-68-big-upgrade-report.md",
+      "report_title": "Day 68 big upgrade report"
     },
     {
       "day": 69,
-      "report_file": "day-69-big-upgrade-report.md",
-      "plan_file": ".day69-reliability-case-study.json"
+      "plan_path": "docs/roadmap/phase3/plans/day69-reliability-case-study.json",
+      "report_path": "docs/roadmap/reports/day-69-big-upgrade-report.md",
+      "report_title": "Day 69 big upgrade report"
     },
     {
       "day": 70,
-      "report_file": "day-70-big-upgrade-report.md",
-      "plan_file": ".day70-triage-speed-case-study.json"
+      "plan_path": "docs/roadmap/phase3/plans/day70-triage-speed-case-study.json",
+      "report_path": "docs/roadmap/reports/day-70-big-upgrade-report.md",
+      "report_title": "Day 70 big upgrade report"
     },
     {
       "day": 71,
-      "report_file": "day-71-big-upgrade-report.md",
-      "plan_file": ".day71-escalation-quality-case-study.json"
+      "plan_path": "docs/roadmap/phase3/plans/day71-escalation-quality-case-study.json",
+      "report_path": "docs/roadmap/reports/day-71-big-upgrade-report.md",
+      "report_title": "Day 71 big upgrade report"
     },
     {
       "day": 72,
-      "report_file": "day-72-big-upgrade-report.md",
-      "plan_file": ".day72-publication-quality-case-study.json"
+      "plan_path": "docs/roadmap/phase3/plans/day72-publication-quality-case-study.json",
+      "report_path": "docs/roadmap/reports/day-72-big-upgrade-report.md",
+      "report_title": "Day 72 big upgrade report"
     },
     {
       "day": 73,
-      "report_file": "day-73-big-upgrade-report.md",
-      "plan_file": ".day73-published-case-study.json"
+      "plan_path": "docs/roadmap/phase3/plans/day73-published-case-study.json",
+      "report_path": "docs/roadmap/reports/day-73-big-upgrade-report.md",
+      "report_title": "Day 73 big upgrade report"
     },
     {
       "day": 74,
-      "report_file": "day-74-big-upgrade-report.md",
-      "plan_file": ".day74-distribution-scaling-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day74-distribution-scaling-plan.json",
+      "report_path": "docs/roadmap/reports/day-74-big-upgrade-report.md",
+      "report_title": "Day 74 big upgrade report"
     },
     {
       "day": 75,
-      "report_file": "day-75-big-upgrade-report.md",
-      "plan_file": ".day75-trust-assets-refresh-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day75-trust-assets-refresh-plan.json",
+      "report_path": "docs/roadmap/reports/day-75-big-upgrade-report.md",
+      "report_title": "Day 75 big upgrade report"
     },
     {
       "day": 76,
-      "report_file": "day-76-big-upgrade-report.md",
-      "plan_file": ".day76-contributor-recognition-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day76-contributor-recognition-plan.json",
+      "report_path": "docs/roadmap/reports/day-76-big-upgrade-report.md",
+      "report_title": "Day 76 big upgrade report"
     },
     {
       "day": 77,
-      "report_file": "day-77-big-upgrade-report.md",
-      "plan_file": ".day77-community-touchpoint-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day77-community-touchpoint-plan.json",
+      "report_path": "docs/roadmap/reports/day-77-big-upgrade-report.md",
+      "report_title": "Day 77 big upgrade report"
     },
     {
       "day": 78,
-      "report_file": "day-78-big-upgrade-report.md",
-      "plan_file": ".day78-ecosystem-priorities-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day78-ecosystem-priorities-plan.json",
+      "report_path": "docs/roadmap/reports/day-78-big-upgrade-report.md",
+      "report_title": "Day 78 big upgrade report"
     },
     {
       "day": 79,
-      "report_file": "day-79-big-upgrade-report.md",
-      "plan_file": ".day79-scale-upgrade-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day79-scale-upgrade-plan.json",
+      "report_path": "docs/roadmap/reports/day-79-big-upgrade-report.md",
+      "report_title": "Day 79 big upgrade report"
     },
     {
       "day": 80,
-      "report_file": "day-80-big-upgrade-report.md",
-      "plan_file": ".day80-partner-outreach-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day80-partner-outreach-plan.json",
+      "report_path": "docs/roadmap/reports/day-80-big-upgrade-report.md",
+      "report_title": "Day 80 Big Upgrade Report"
     },
     {
       "day": 81,
-      "report_file": "day-81-big-upgrade-report.md",
-      "plan_file": ".day81-growth-campaign-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day81-growth-campaign-plan.json",
+      "report_path": "docs/roadmap/reports/day-81-big-upgrade-report.md",
+      "report_title": "Day 81 Big Upgrade Report"
     },
     {
       "day": 82,
-      "report_file": "day-82-big-upgrade-report.md",
-      "plan_file": ".day82-integration-feedback-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day82-integration-feedback-plan.json",
+      "report_path": "docs/roadmap/reports/day-82-big-upgrade-report.md",
+      "report_title": "Day 82 Big Upgrade Report"
     },
     {
       "day": 83,
-      "report_file": "day-83-big-upgrade-report.md",
-      "plan_file": ".day83-trust-faq-expansion-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day83-trust-faq-expansion-plan.json",
+      "report_path": "docs/roadmap/reports/day-83-big-upgrade-report.md",
+      "report_title": "Day 83 Big Upgrade Report"
     },
     {
       "day": 84,
-      "report_file": "day-84-big-upgrade-report.md",
-      "plan_file": ".day84-evidence-narrative-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day84-evidence-narrative-plan.json",
+      "report_path": "docs/roadmap/reports/day-84-big-upgrade-report.md",
+      "report_title": "Day 84 big upgrade report"
     },
     {
       "day": 85,
-      "report_file": "day-85-big-upgrade-report.md",
-      "plan_file": ".day85-release-prioritization-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day85-release-prioritization-plan.json",
+      "report_path": "docs/roadmap/reports/day-85-big-upgrade-report.md",
+      "report_title": "Day 85 big upgrade report"
     },
     {
       "day": 86,
-      "report_file": "day-86-big-upgrade-report.md",
-      "plan_file": ".day86-launch-readiness-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day86-launch-readiness-plan.json",
+      "report_path": "docs/roadmap/reports/day-86-big-upgrade-report.md",
+      "report_title": "Day 86 big upgrade report"
     },
     {
       "day": 87,
-      "report_file": "day-87-big-upgrade-report.md",
-      "plan_file": ".day87-governance-handoff-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day87-governance-handoff-plan.json",
+      "report_path": "docs/roadmap/reports/day-87-big-upgrade-report.md",
+      "report_title": "Day 87 big upgrade report"
     },
     {
       "day": 88,
-      "report_file": "day-88-big-upgrade-report.md",
-      "plan_file": ".day88-governance-priorities-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day88-governance-priorities-plan.json",
+      "report_path": "docs/roadmap/reports/day-88-big-upgrade-report.md",
+      "report_title": "Day 88 big upgrade report"
     },
     {
       "day": 89,
-      "report_file": "day-89-big-upgrade-report.md",
-      "plan_file": ".day89-governance-scale-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day89-governance-scale-plan.json",
+      "report_path": "docs/roadmap/reports/day-89-big-upgrade-report.md",
+      "report_title": "Day 89 big upgrade report"
     },
     {
       "day": 90,
-      "report_file": "day-90-big-upgrade-report.md",
-      "plan_file": ".day90-phase3-wrap-publication-plan.json"
+      "plan_path": "docs/roadmap/phase3/plans/day90-phase3-wrap-publication-plan.json",
+      "report_path": "docs/roadmap/reports/day-90-big-upgrade-report.md",
+      "report_title": "Day 90 big upgrade report"
     }
   ]
 }

--- a/src/sdetkit/roadmap_manifest.py
+++ b/src/sdetkit/roadmap_manifest.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPORT_RE = re.compile(r"^day-(\d+)-.*-report\.md$")
+_PLAN_RE = re.compile(r"^day(\d+)-.*\.json$")
+
+
+def _repo_root(start: Path | None = None) -> Path:
+    here = (start or Path(__file__)).resolve()
+    for p in [here] + list(here.parents):
+        if (p / "pyproject.toml").exists():
+            return p
+    return Path.cwd()
+
+
+def _first_heading(md: str) -> str | None:
+    for ln in md.splitlines():
+        s = ln.strip()
+        if s.startswith("#"):
+            title = s.lstrip("#").strip()
+            if title:
+                return title
+    return None
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_manifest(repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    docs_root = root / "docs" / "roadmap"
+    reports_dir = docs_root / "reports"
+    plans_dir = docs_root / "phase3" / "plans"
+
+    items: dict[int, dict[str, Any]] = {}
+
+    if reports_dir.exists():
+        for p in sorted(reports_dir.glob("day-*-*-report.md")):
+            m = _REPORT_RE.match(p.name)
+            if not m:
+                continue
+            day = int(m.group(1))
+            e = items.setdefault(day, {"day": day})
+            if "report_path" in e:
+                raise ValueError(f"duplicate report for day {day}: {e['report_path']} and {p}")
+            rel = p.relative_to(root).as_posix()
+            title = _first_heading(p.read_text(encoding="utf-8")) or p.name
+            e["report_path"] = rel
+            e["report_title"] = title
+
+    if plans_dir.exists():
+        for p in sorted(plans_dir.glob("day*.json")):
+            m = _PLAN_RE.match(p.name)
+            if not m:
+                continue
+            day = int(m.group(1))
+            e = items.setdefault(day, {"day": day})
+            if "plan_path" in e:
+                raise ValueError(f"duplicate plan for day {day}: {e['plan_path']} and {p}")
+            rel = p.relative_to(root).as_posix()
+            data = _load_json(p)
+            title = None
+            if isinstance(data, dict):
+                for k in ("title", "name"):
+                    v = data.get(k)
+                    if isinstance(v, str) and v.strip():
+                        title = v.strip()
+                        break
+            e["plan_path"] = rel
+            if title:
+                e["plan_title"] = title
+
+    days = [items[k] for k in sorted(items)]
+    return {"days": days}
+
+
+def render_manifest_json(repo_root: Path | None = None) -> str:
+    obj = build_manifest(repo_root=repo_root)
+    return json.dumps(obj, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+
+
+def manifest_path(repo_root: Path | None = None) -> Path:
+    root = repo_root or _repo_root()
+    return root / "docs" / "roadmap" / "manifest.json"
+
+
+def write_manifest(repo_root: Path | None = None) -> Path:
+    root = repo_root or _repo_root()
+    out_path = manifest_path(root)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(render_manifest_json(root), encoding="utf-8", newline="\n")
+    return out_path
+
+
+def check_manifest(repo_root: Path | None = None) -> bool:
+    root = repo_root or _repo_root()
+    out_path = manifest_path(root)
+    if not out_path.exists():
+        return False
+    expected = out_path.read_text(encoding="utf-8")
+    actual = render_manifest_json(root)
+    return expected == actual
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args or args[0] in {"-h", "--help"}:
+        print("usage: python -m sdetkit.roadmap_manifest {print|write|check}")
+        return 0
+
+    cmd = args[0]
+    if cmd == "print":
+        sys.stdout.write(render_manifest_json())
+        return 0
+    if cmd == "write":
+        p = write_manifest()
+        print(p.as_posix())
+        return 0
+    if cmd == "check":
+        ok = check_manifest()
+        if ok:
+            return 0
+        print(
+            "roadmap manifest is stale; run: python -m sdetkit.roadmap_manifest write",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("unknown command", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_roadmap_manifest_tooling.py
+++ b/tests/test_roadmap_manifest_tooling.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit.roadmap_manifest import check_manifest
+
+
+def test_roadmap_manifest_is_fresh() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    ok = check_manifest(repo_root=repo_root)
+    assert ok, "docs/roadmap/manifest.json is stale; run: python -m sdetkit.roadmap_manifest write"


### PR DESCRIPTION
## Summary

* Add `sdetkit.roadmap_manifest` module to generate `docs/roadmap/manifest.json` from the canonical roadmap docs layout.
* Regenerate `docs/roadmap/manifest.json` to include stable `report_path`/`plan_path` and human-readable `report_title`.
* Add a test that fails CI when `docs/roadmap/manifest.json` is stale, with a clear regeneration command.

## Why

* The roadmap manifest is a derived artifact that can silently drift when reports/plans move or titles change.
* Enforcing freshness keeps the CLI/navigation layer reliable and prevents broken links, missing days, or outdated titles from shipping.

## How

* Implement a manifest generator that:

  * Scans `docs/roadmap/reports/` and `docs/roadmap/phase3/plans/`
  * Extracts day numbers from filenames
  * Reads the first markdown heading as `report_title` when available
  * Writes deterministic JSON output for `docs/roadmap/manifest.json`
* Add `tests/test_roadmap_manifest_tooling.py` to verify the checked-in manifest matches what the generator would produce.

## Risk assessment

* Risk level: **low**
* Primary risk area: **Docs/tooling drift enforcement** (CI may start failing if contributors forget to regenerate the manifest after editing roadmap files).

## Test evidence

* Commands run:

  * `python -m pytest -q`
* Attach key output snippets/artifacts:

  * `900 passed in 87.54s`
  * Manifest freshness failure message includes remediation: `python -m sdetkit.roadmap_manifest write`

## Rollback plan

* If this causes regressions, revert commit(s):

  * Revert **4761d61** (roadmap: add manifest generator and enforce freshness)
* Mitigation while rollback executes:

  * Temporarily regenerate and commit `docs/roadmap/manifest.json` to unblock CI while investigating any discrepancies.

## Triage and ownership

* Reviewer owner: @sherif69-sa
* Target merge window: Next available green CI + review slot

## Checklist

* [x] Tests added/updated

* [x] `bash ci.sh` passes *(ran via pre-commit/CI equivalent checks; run in CI for confirmation)*

* [x] `bash quality.sh` passes *(ran via pre-commit hooks; run in CI for confirmation)*

* [x] Docs updated (if needed) *(manifest regenerated)*

* [ ] Issue links / acceptance criteria mapped

* [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`
