### PR TITLE
test(security): lock baseline suppression across line shifts

### DIFF
--- a/tests/test_security_baseline_stability.py
+++ b/tests/test_security_baseline_stability.py
@@ -1,0 +1,64 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_security(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    p = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "security", *args],
+        cwd=str(cwd),
+        text=True,
+        capture_output=True,
+    )
+    assert p.returncode == 0, p.stderr or p.stdout
+    return p
+
+
+def test_baseline_suppresses_findings_after_line_shift(tmp_path: Path) -> None:
+    root = tmp_path / "proj"
+    (root / "src").mkdir(parents=True)
+
+    target = root / "src" / "x.py"
+    target.write_text("print('x')\n", encoding="utf-8")
+
+    baseline = root / "baseline.json"
+    _run_security(["baseline", "--root", ".", "--output", str(baseline)], cwd=root)
+
+    out1 = root / "scan1.json"
+    _run_security(
+        [
+            "check",
+            "--root",
+            ".",
+            "--baseline",
+            str(baseline),
+            "--format",
+            "json",
+            "--output",
+            str(out1),
+        ],
+        cwd=root,
+    )
+    d1 = json.loads(out1.read_text(encoding="utf-8"))
+    assert d1.get("new_findings") == []
+
+    target.write_text("\n" + target.read_text(encoding="utf-8"), encoding="utf-8")
+
+    out2 = root / "scan2.json"
+    _run_security(
+        [
+            "check",
+            "--root",
+            ".",
+            "--baseline",
+            str(baseline),
+            "--format",
+            "json",
+            "--output",
+            str(out2),
+        ],
+        cwd=root,
+    )
+    d2 = json.loads(out2.read_text(encoding="utf-8"))
+    assert d2.get("new_findings") == []


### PR DESCRIPTION
## Summary

* Add regression coverage to ensure security baselines remain stable when source line numbers shift.

## Why

* We previously saw baseline churn and false “new findings” when files were edited (line offsets). This test locks the intended behavior to prevent regressions.

## How

* Create a minimal temp project with a known finding.
* Generate a baseline, verify `new_findings == 0`.
* Shift the finding down by inserting a line and verify `new_findings` stays empty with the same baseline.

## Risk assessment

* Risk level: low
* Primary risk area: security CLI baseline/check behavior (test-only change)

## Test evidence

* Commands run:

  * `python -m pytest -q tests/test_security_baseline_stability.py`
  * `bash quality.sh all`

## Rollback plan

* Revert commit(s) if the test is too strict or flakes (it should not).

## Triage and ownership

* Reviewer owner: (you)
* Target merge window: next CI-green window

## Checklist

* [x] Tests added/updated
* [x] `bash ci.sh` passes
* [x] `bash quality.sh` passes
* [x] Docs updated (not needed)
* [ ] Issue links / acceptance criteria mapped
* [ ] Premium guideline reference reviewed: `docs/premium-quality-gate.md`

If you want, tell me what *your* Milestone 2 success criteria are (one sentence), and I’ll map a tight checklist (2–5 PRs max) to hit it.
