### PR TITLE
milestone2: make gate scripts auto-bootstrap the pinned toolchain

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+ensure_venv() {
+  if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+    return 0
+  fi
+
+  if [[ -f ".venv/bin/activate" ]]; then
+    . .venv/bin/activate
+    return 0
+  fi
+
+  bash scripts/bootstrap.sh
+  . .venv/bin/activate
+}
+
+ensure_venv
 python3 scripts/check_repo_layout.py
 
 mode="${1:-all}"

--- a/quality.sh
+++ b/quality.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+ensure_venv() {
+  if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+    return 0
+  fi
+
+  if [[ -f ".venv/bin/activate" ]]; then
+    . .venv/bin/activate
+    return 0
+  fi
+
+  bash scripts/bootstrap.sh
+  . .venv/bin/activate
+}
+
+ensure_venv
 python3 scripts/check_repo_layout.py
 
 mode=${1:-all}

--- a/tests/test_gate_scripts_auto_bootstrap.py
+++ b/tests/test_gate_scripts_auto_bootstrap.py
@@ -1,0 +1,14 @@
+import re
+from pathlib import Path
+
+
+def test_gate_scripts_auto_bootstrap_and_no_pip_upgrade() -> None:
+    root = Path(__file__).resolve().parents[1]
+    for rel in ["ci.sh", "quality.sh"]:
+        p = root / rel
+        txt = p.read_text(encoding="utf-8")
+        assert "ensure_venv" in txt
+        assert "bash scripts/bootstrap.sh" in txt
+        assert ". .venv/bin/activate" in txt
+        assert re.search(r"pip install\s+-U\s+pip", txt) is None
+        assert re.search(r"python\s+-m\s+pip\s+install\s+-U\s+pip", txt) is None


### PR DESCRIPTION

* **Summary**: auto-run `scripts/bootstrap.sh` + activate `.venv` in `ci.sh` / `quality.sh`; add a test locking this invariant.
* **Why**: removes common local/CI friction (“missing tool: ruff”, “python not found”) when venv isn’t active.
* **Risk**: low (dev scripts only; bootstrap is idempotent).
* **Test evidence**: `bash quality.sh all`, `bash security.sh`, `pytest -q tests/test_gate_scripts_auto_bootstrap.py`.