### PR TITLE
milestone3: add dev entrypoint for bootstrap + gates

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'USAGE'
+usage: scripts/dev.sh <cmd> [--fast]
+
+Commands:
+  bootstrap   Create/refresh the pinned toolchain (.venv, deps)
+  quality     Run quality gate (quality.sh all)
+  security    Run security gate (security.sh)
+  test        Run pytest (full suite unless --fast)
+  all         Run quality + security + tests
+
+Flags:
+  --fast      For "test": run a smaller smoke set (no full suite)
+  -h,--help   Show help
+USAGE
+}
+
+cmd="${1:-}"
+case "${cmd}" in
+  -h|--help|"")
+    usage
+    exit 0
+    ;;
+esac
+shift || true
+
+fast=0
+for a in "$@"; do
+  case "$a" in
+    --fast) fast=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $a" >&2; usage; exit 2 ;;
+  esac
+done
+
+bootstrap() {
+  bash "$root/scripts/bootstrap.sh"
+}
+
+activate() {
+  if [[ ! -f "$root/.venv/bin/activate" ]]; then
+    bootstrap
+  fi
+  # shellcheck disable=SC1091
+  . "$root/.venv/bin/activate"
+}
+
+run_quality() {
+  activate
+  bash "$root/quality.sh" all
+}
+
+run_security() {
+  activate
+  bash "$root/security.sh"
+}
+
+run_test() {
+  activate
+  if [[ "$fast" -eq 1 ]]; then
+    python -m pytest -q tests/test_security_info_default.py tests/test_ci_templates_bootstrap.py tests/test_gate_scripts_auto_bootstrap.py
+  else
+    python -m pytest -q
+  fi
+}
+
+case "$cmd" in
+  bootstrap) bootstrap ;;
+  quality) run_quality ;;
+  security) run_security ;;
+  test) run_test ;;
+  all)
+    run_quality
+    run_security
+    run_test
+    ;;
+  *)
+    echo "unknown cmd: $cmd" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/tests/test_dev_entrypoint.py
+++ b/tests/test_dev_entrypoint.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_dev_entrypoint_help_is_stable() -> None:
+    root = Path(__file__).resolve().parents[1]
+    dev = root / "scripts" / "dev.sh"
+    assert dev.exists()
+
+    res = subprocess.run(
+        ["bash", str(dev), "--help"],
+        cwd=root / "docs",
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    out = res.stdout
+    assert "usage:" in out
+    assert "bootstrap" in out
+    assert "quality" in out
+    assert "security" in out
+    assert "test" in out
+    assert "--fast" in out


### PR DESCRIPTION
## Summary

* Add `scripts/dev.sh` as a single dev entrypoint for bootstrap/quality/security/tests.
* Add `tests/test_dev_entrypoint.py` to lock `dev.sh --help` contract and ensure it works from non-root CWD.

## Why

* Reduce “works on my machine” issues by standardizing how contributors bootstrap the pinned toolchain and run gates.
* Make local + CI workflows easier to follow and harder to break silently.

## How

* Implement `scripts/dev.sh` commands:

  * `bootstrap`: runs `scripts/bootstrap.sh`
  * `quality`: runs `quality.sh all` (auto-bootstrap + activate)
  * `security`: runs `security.sh` (auto-bootstrap + activate)
  * `test`: runs `pytest -q` (or `--fast` smoke set)
  * `all`: runs quality + security + tests
* Add test that:

  * Runs `bash scripts/dev.sh --help` from `docs/` to validate path robustness.
  * Asserts help text includes required commands and `--fast`.

## Risk assessment

* Risk level: **low**
* Primary risk area: dev ergonomics only (new script + a small test); no production runtime behavior.

## Test evidence

* Commands run:

  * `python -m pytest -q tests/test_dev_entrypoint.py`
  * `bash quality.sh all`
  * `bash security.sh`
* Key output:

  * All checks green (pytest/ruff/doctor/security).

## Rollback plan

* If this causes regressions, revert commit(s):

  * `milestone3: add dev entrypoint for bootstrap + gates`
* Mitigation while rollback executes:

  * Contributors can continue using existing `scripts/bootstrap.sh`, `quality.sh`, `security.sh`, `pytest`.

## Triage and ownership

* Reviewer owner: *(add reviewer)*
* Target merge window: *(add date/time)*

## Checklist

* [x] Tests added/updated
* [x] `bash ci.sh` passes
* [x] `bash quality.sh` passes
* [x] Docs updated (if needed)
* [ ] Issue links / acceptance criteria mapped
* [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`