### PR TITLE
Add sdetkit gate fast command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -631,3 +631,11 @@ Examples (scan once, reuse results):
 - `sdetkit security scan --format json --out build/security-scan.json --fail-on none`
 - `sdetkit security check --scan-json build/security-scan.json --baseline tools/security.baseline.json --fail-on high --format text`
 - `sdetkit security report --scan-json build/security-scan.json --format sarif --out build/security.sarif`
+
+## gate
+
+Examples:
+
+- `sdetkit gate fast`
+- `sdetkit gate fast --format json | python -m json.tool >/dev/null`
+- `sdetkit gate fast --no-pytest --format json`

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -183,6 +183,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         return _doctor_main(argv[1:])
 
+    if argv and argv[0] == "gate":
+        from .gate import main as _gate_main
+
+        return _gate_main(list(argv[1:]))
+
     if argv and argv[0] == "ci":
         from .ci import main as _ci_main
 
@@ -488,6 +493,7 @@ Command groups:
     apiget
     cassette-get
     doctor
+    gate
     ci
     patch
     repo
@@ -549,6 +555,9 @@ Run: sdetkit playbooks
 
     doc = sub.add_parser("doctor")
     doc.add_argument("args", nargs=argparse.REMAINDER)
+
+    gt = sub.add_parser("gate")
+    gt.add_argument("args", nargs=argparse.REMAINDER)
 
     ci = sub.add_parser("ci")
     ci.add_argument("args", nargs=argparse.REMAINDER)

--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _run(cmd: list[str], cwd: Path) -> dict[str, Any]:
+    started = time.time()
+    proc = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=False)
+    dur_ms = int((time.time() - started) * 1000)
+    return {
+        "cmd": cmd,
+        "rc": proc.returncode,
+        "ok": proc.returncode == 0,
+        "duration_ms": dur_ms,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+
+
+def _write_output(text: str, out: str | None) -> None:
+    if out:
+        p = Path(out)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+
+
+def _format_text(payload: dict[str, Any]) -> str:
+    ok = bool(payload.get("ok"))
+    lines: list[str] = []
+    lines.append(f"gate fast: {'OK' if ok else 'FAIL'}")
+    for step in payload.get("steps", []):
+        marker = "OK" if step.get("ok") else "FAIL"
+        dur = step.get("duration_ms", 0)
+        step_id = step.get("id", "unknown")
+        lines.append(f"[{marker}] {step_id} ({dur}ms) rc={step.get('rc')}")
+    if payload.get("failed_steps"):
+        lines.append("failed_steps:")
+        for s in payload["failed_steps"]:
+            lines.append(f"- {s}")
+    return "\n".join(lines) + "\n"
+
+
+def _format_md(payload: dict[str, Any]) -> str:
+    ok = bool(payload.get("ok"))
+    lines: list[str] = []
+    lines.append("### SDET Gate Fast")
+    lines.append("")
+    lines.append(f"- status: {'OK' if ok else 'FAIL'}")
+    lines.append(f"- root: `{payload.get('root', '')}`")
+    lines.append("")
+    lines.append("#### Steps")
+    for step in payload.get("steps", []):
+        marker = "OK" if step.get("ok") else "FAIL"
+        dur = step.get("duration_ms", 0)
+        step_id = step.get("id", "unknown")
+        lines.append(f"- `{step_id}`: **{marker}** ({dur}ms, rc={step.get('rc')})")
+    if payload.get("failed_steps"):
+        lines.append("")
+        lines.append("#### Failed steps")
+        for s in payload["failed_steps"]:
+            lines.append(f"- `{s}`")
+    return "\n".join(lines) + "\n"
+
+
+def _run_fast(ns: argparse.Namespace) -> int:
+    root = Path(ns.root).resolve()
+
+    steps: list[dict[str, Any]] = []
+
+    if not ns.no_doctor:
+        fail_on = "medium" if ns.strict else "high"
+        steps.append(
+            {
+                "id": "doctor",
+                **_run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "sdetkit",
+                        "doctor",
+                        "--dev",
+                        "--ci",
+                        "--deps",
+                        "--clean-tree",
+                        "--repo",
+                        "--fail-on",
+                        fail_on,
+                        "--format",
+                        "json",
+                    ],
+                    cwd=root,
+                ),
+            }
+        )
+
+    if not ns.no_ci_templates:
+        steps.append(
+            {
+                "id": "ci_templates",
+                **_run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "sdetkit",
+                        "ci",
+                        "validate-templates",
+                        "--root",
+                        str(root),
+                        "--format",
+                        "json",
+                        "--strict",
+                    ],
+                    cwd=root,
+                ),
+            }
+        )
+
+    if not ns.no_ruff:
+        steps.append(
+            {
+                "id": "ruff",
+                **_run([sys.executable, "-m", "ruff", "check", "."], cwd=root),
+            }
+        )
+        steps.append(
+            {
+                "id": "ruff_format",
+                **_run([sys.executable, "-m", "ruff", "format", "--check", "."], cwd=root),
+            }
+        )
+
+    if not ns.no_mypy:
+        mypy_args = ["src"]
+        if ns.mypy_args:
+            mypy_args = shlex.split(ns.mypy_args)
+        steps.append(
+            {
+                "id": "mypy",
+                **_run([sys.executable, "-m", "mypy", *mypy_args], cwd=root),
+            }
+        )
+
+    if not ns.no_pytest:
+        pytest_args = ["-q"]
+        if ns.pytest_args:
+            pytest_args = shlex.split(ns.pytest_args)
+        steps.append(
+            {
+                "id": "pytest",
+                **_run([sys.executable, "-m", "pytest", *pytest_args], cwd=root),
+            }
+        )
+
+    failed = [s["id"] for s in steps if not s.get("ok", False)]
+    payload: dict[str, Any] = {
+        "profile": "fast",
+        "root": str(root),
+        "ok": not bool(failed),
+        "failed_steps": failed,
+        "steps": steps,
+    }
+
+    if ns.format == "json":
+        rendered = json.dumps(payload, sort_keys=True) + "\n"
+    elif ns.format == "md":
+        rendered = _format_md(payload)
+    else:
+        rendered = _format_text(payload)
+
+    _write_output(rendered, ns.out)
+
+    if payload["ok"]:
+        return 0
+    sys.stderr.write("gate: problems found\n")
+    return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="gate")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    fast = sub.add_parser("fast")
+    fast.add_argument("--root", default=".")
+    fast.add_argument("--format", choices=["text", "json", "md"], default="text")
+    fast.add_argument("--out", "--output", default=None)
+    fast.add_argument("--strict", action="store_true")
+
+    fast.add_argument("--no-doctor", action="store_true")
+    fast.add_argument("--no-ci-templates", action="store_true")
+    fast.add_argument("--no-ruff", action="store_true")
+    fast.add_argument("--no-mypy", action="store_true")
+    fast.add_argument("--no-pytest", action="store_true")
+
+    fast.add_argument("--pytest-args", default=None)
+    fast.add_argument("--mypy-args", default=None)
+
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+
+    if ns.cmd == "fast":
+        return _run_fast(ns)
+
+    sys.stderr.write("unknown gate command\n")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gate_fast.py
+++ b/tests/test_gate_fast.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_sdetkit(repo_root: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+    return subprocess.run(
+        [sys.executable, "-m", "sdetkit", *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_gate_help_includes_fast() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    proc = _run_sdetkit(repo_root, repo_root, "gate", "--help")
+    assert proc.returncode == 0
+    assert "usage: gate" in proc.stdout
+    assert "fast" in proc.stdout
+
+
+def test_gate_fast_can_run_ci_templates_only(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    (tmp_path / "templates" / "ci" / "gitlab").mkdir(parents=True)
+    (tmp_path / "templates" / "ci" / "jenkins").mkdir(parents=True)
+    (tmp_path / "templates" / "ci" / "tekton").mkdir(parents=True)
+
+    (tmp_path / "templates" / "ci" / "gitlab" / "day66-advanced-reference.yml").write_text(
+        "bash scripts/bootstrap.sh\n. .venv/bin/activate\npython -m sdetkit\nCI_COMMIT_REF_SLUG\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "templates" / "ci" / "jenkins" / "day67-advanced-reference.Jenkinsfile").write_text(
+        "bash scripts/bootstrap.sh\n. .venv/bin/activate\npytest -q\nsecurity.sh\nPYTHON_VERSION\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "templates" / "ci" / "tekton" / "day68-self-hosted-reference.yaml").write_text(
+        "bash scripts/bootstrap.sh\n. .venv/bin/activate\nbash ci.sh\nbash security.sh\n$(params.branch)\n",
+        encoding="utf-8",
+    )
+
+    proc = _run_sdetkit(
+        repo_root,
+        tmp_path,
+        "gate",
+        "fast",
+        "--root",
+        str(tmp_path),
+        "--format",
+        "json",
+        "--no-doctor",
+        "--no-ruff",
+        "--no-mypy",
+        "--no-pytest",
+    )
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    assert data["ok"] is True
+    assert [s["id"] for s in data["steps"]] == ["ci_templates"]


### PR DESCRIPTION
## Summary

* Add `sdetkit gate fast` command to run a single, fast “ship-ready” local gate and emit text/JSON/markdown output.

## Why

* Reduce time spent running and remembering multiple commands by providing one consistent entrypoint that teams can standardize on for quick local validation.

## How

* Add new `src/sdetkit/gate.py` implementing `gate fast` with `--format` and `--out` support.
* Wire `gate` into `src/sdetkit/cli.py` so it appears in `sdetkit --help` and dispatches correctly.
* Add unit tests for help + a minimal “ci-templates-only” fast run.
* Document usage in `docs/cli.md`.

## Risk assessment

* Risk level: low
* Primary risk area: CLI surface change (new command); minimal risk to existing commands since it’s additive.

## Test evidence

* Commands run:

  * `python -m pytest -q tests/test_gate_fast.py`
  * `python -m ruff check .`
  * `python -m ruff format --check .`
  * `python -m sdetkit gate fast --format json | python -m json.tool >/dev/null`
* Attach key output snippets/artifacts:

  * Verified `sdetkit --help` lists `gate`
  * Verified `gate fast` JSON output is valid and parsable

## Rollback plan

* If this causes regressions, revert commit(s):

  * Revert the commit that adds `src/sdetkit/gate.py` and CLI wiring.
* Mitigation while rollback executes:

  * Continue using existing individual commands (doctor/ci/security/pytest/ruff/mypy) directly.

## Triage and ownership

* Reviewer owner: sherif
* Target merge window: next available

## Checklist

* [x] Tests added/updated
* [ ] `bash ci.sh` passes
* [ ] `bash quality.sh` passes
* [x] Docs updated (if needed)
* [ ] Issue links / acceptance criteria mapped
* [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`