### PR TITLE
gate: add --fix and --fix-only to gate fast

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -639,3 +639,5 @@ Examples:
 - `sdetkit gate fast`
 - `sdetkit gate fast --format json | python -m json.tool >/dev/null`
 - `sdetkit gate fast --no-pytest --format json`
+- `sdetkit gate fast --fix`
+- `sdetkit gate fast --fix-only --format json`

--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -76,6 +76,26 @@ def _run_fast(ns: argparse.Namespace) -> int:
 
     steps: list[dict[str, Any]] = []
 
+    if ns.fix or ns.fix_only:
+        steps.append(
+            {
+                "id": "ruff_fix",
+                **_run([sys.executable, "-m", "ruff", "check", "--fix", "."], cwd=root),
+            }
+        )
+        steps.append(
+            {
+                "id": "ruff_format_apply",
+                **_run([sys.executable, "-m", "ruff", "format", "."], cwd=root),
+            }
+        )
+        if ns.fix_only:
+            ns.no_doctor = True
+            ns.no_ci_templates = True
+            ns.no_ruff = True
+            ns.no_mypy = True
+            ns.no_pytest = True
+
     if not ns.no_doctor:
         fail_on = "medium" if ns.strict else "high"
         steps.append(
@@ -193,6 +213,9 @@ def main(argv: list[str] | None = None) -> int:
     fast.add_argument("--format", choices=["text", "json", "md"], default="text")
     fast.add_argument("--out", "--output", default=None)
     fast.add_argument("--strict", action="store_true")
+
+    fast.add_argument("--fix", action="store_true")
+    fast.add_argument("--fix-only", dest="fix_only", action="store_true")
 
     fast.add_argument("--no-doctor", action="store_true")
     fast.add_argument("--no-ci-templates", action="store_true")

--- a/tests/test_gate_fast.py
+++ b/tests/test_gate_fast.py
@@ -66,3 +66,54 @@ def test_gate_fast_can_run_ci_templates_only(tmp_path: Path) -> None:
     data = json.loads(proc.stdout)
     assert data["ok"] is True
     assert [s["id"] for s in data["steps"]] == ["ci_templates"]
+
+
+def test_gate_fast_fix_only_formats_files(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    (tmp_path / "a.py").write_text("x=1\n", encoding="utf-8")
+
+    proc = _run_sdetkit(
+        repo_root,
+        tmp_path,
+        "gate",
+        "fast",
+        "--root",
+        str(tmp_path),
+        "--format",
+        "json",
+        "--fix-only",
+    )
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    assert [s["id"] for s in data["steps"]] == ["ruff_fix", "ruff_format_apply"]
+    assert (tmp_path / "a.py").read_text(encoding="utf-8") == "x = 1\n"
+
+
+def test_gate_fast_fix_runs_before_ruff_checks(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    (tmp_path / "a.py").write_text("x=1\n", encoding="utf-8")
+
+    proc = _run_sdetkit(
+        repo_root,
+        tmp_path,
+        "gate",
+        "fast",
+        "--root",
+        str(tmp_path),
+        "--format",
+        "json",
+        "--fix",
+        "--no-doctor",
+        "--no-ci-templates",
+        "--no-mypy",
+        "--no-pytest",
+    )
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    assert [s["id"] for s in data["steps"]] == [
+        "ruff_fix",
+        "ruff_format_apply",
+        "ruff",
+        "ruff_format",
+    ]
+    assert (tmp_path / "a.py").read_text(encoding="utf-8") == "x = 1\n"


### PR DESCRIPTION
## Summary

* Add opt-in auto-fix support to `sdetkit gate fast`:

  * `--fix` applies safe fixes (ruff autofix + ruff format) before running the fast gate
  * `--fix-only` applies fixes and exits
* Document the new flags in `docs/cli.md`.

## Why

* Make the fast path more ergonomic for local development: one command can both fix trivial issues and validate the repo.
* Keep CI and default usage non-mutating and predictable (no surprise edits unless explicitly requested).

## How

* Extend `gate fast` arguments with `--fix` and `--fix-only`.
* When enabled, run:

  * `python -m ruff check --fix .`
  * `python -m ruff format .`
    and record these as steps in the JSON output (`ruff_fix`, `ruff_format_apply`).
* Add tests to verify:

  * `--fix-only` formats a file and returns JSON steps in the expected order
  * `--fix` runs fix steps before ruff check steps.

## Risk assessment

* Risk level: **low**
* Primary risk area: **workspace mutation** (only when `--fix`/`--fix-only` is used). Default behavior remains unchanged.

## Test evidence

* Commands run:

  * `python -m pytest -q tests/test_gate_fast.py`
  * `python -m ruff check .`
  * `python -m ruff format --check .`
  * `python -m mypy src`
  * `python -m pytest -q`
  * `python -m sdetkit gate fast --format json`
  * `python -m pre_commit run -a`
* Key output snippets/artifacts:

  * Gate fast remains OK with unchanged defaults; new tests cover fix flags.

## Rollback plan

* If this causes regressions, revert commit(s):

  * `a81d7bb`
* Mitigation while rollback executes:

  * Use existing non-mutating `sdetkit gate fast` without `--fix`.

## Triage and ownership

* Reviewer owner: **(fill in)**
* Target merge window: **(fill in)**

## Checklist

* [x] Tests added/updated
* [ ] `bash ci.sh` passes
* [ ] `bash quality.sh` passes
* [x] Docs updated (if needed)
* [ ] Issue links / acceptance criteria mapped
* [ ] Premium guideline reference reviewed: `docs/premium-quality-gate.md`