### PR TITLE
doctor: add --treat and --treat-only

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,6 +37,8 @@ See: doctor.md
 - `sdetkit doctor --list-checks`
 - `sdetkit doctor --only pyproject,clean_tree --format json`
 - `sdetkit doctor --skip deps,pre_commit --format json`
+- `sdetkit doctor --treat --format json`
+- `sdetkit doctor --treat-only --format json`
 
 ## ci
 

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -458,6 +458,38 @@ def _calculate_score(checks: list[bool]) -> int:
     return round((passed / len(checks)) * 100)
 
 
+def _treatments(root: Path) -> list[dict[str, Any]]:
+    steps: list[dict[str, Any]] = []
+
+    cmd = [sys.executable, "-m", "ruff", "check", "--fix", "."]
+    rc, out, err = _run(cmd, cwd=root)
+    steps.append(
+        {
+            "id": "ruff_fix",
+            "cmd": cmd,
+            "rc": rc,
+            "ok": rc == 0,
+            "stdout": out,
+            "stderr": err,
+        }
+    )
+
+    cmd = [sys.executable, "-m", "ruff", "format", "."]
+    rc, out, err = _run(cmd, cwd=root)
+    steps.append(
+        {
+            "id": "ruff_format_apply",
+            "cmd": cmd,
+            "rc": rc,
+            "ok": rc == 0,
+            "stdout": out,
+            "stderr": err,
+        }
+    )
+
+    return steps
+
+
 def _recommendations(data: dict[str, Any]) -> list[str]:
     recs: list[str] = []
     if data.get("venv_ok") is False:
@@ -694,6 +726,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fail-on", choices=["low", "medium", "high"])
     parser.add_argument("--strict", action="store_true")
     parser.add_argument("--out", default=None)
+    parser.add_argument("--treat", action="store_true")
+    parser.add_argument("--treat-only", dest="treat_only", action="store_true")
     parser.add_argument("--list-checks", action="store_true")
     parser.add_argument("--only", default=None)
     parser.add_argument("--skip", default=None)
@@ -780,11 +814,35 @@ def main(argv: list[str] | None = None) -> int:
     if ns.dev and (ns.ci or ns.deps or ns.clean_tree):
         ns.pyproject = True
 
+    treat_steps: list[dict[str, Any]] = []
+    data_treat_ok = True
+
+    if ns.treat or getattr(ns, "treat_only", False):
+        treat_steps = _treatments(root)
+        data_treat_ok = all(bool(s.get("ok")) for s in treat_steps)
+        if getattr(ns, "treat_only", False):
+            payload = {
+                "ok": data_treat_ok,
+                "treatments": treat_steps,
+                "treatments_ok": data_treat_ok,
+                "post_treat_ok": data_treat_ok,
+            }
+            rendered = json.dumps(payload) + "\n"
+            if ns.out:
+                Path(ns.out).write_text(rendered, encoding="utf-8")
+            else:
+                sys.stdout.write(rendered)
+            return 0 if data_treat_ok else 2
+
     data: dict[str, Any] = {
         "python": _python_info(),
         "package": _package_info(),
         "checks": _baseline_checks(),
     }
+    if ns.treat:
+        data["treatments"] = treat_steps
+        data["treatments_ok"] = data_treat_ok
+
     score_items: list[bool] = []
 
     if _is_selected("stdlib_shadowing"):

--- a/tests/test_doctor_treat.py
+++ b/tests/test_doctor_treat.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import doctor
+
+
+def test_doctor_treat_only_emits_treatments(tmp_path: Path, monkeypatch, capsys) -> None:
+    (tmp_path / "a.py").write_text("x=1\n", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *, cwd=None):
+        calls.append(list(cmd))
+        return 0, "", ""
+
+    monkeypatch.setattr(doctor, "_run", fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    rc = doctor.main(["--treat-only", "--format", "json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert [s["id"] for s in data["treatments"]] == ["ruff_fix", "ruff_format_apply"]
+    assert data["treatments_ok"] is True
+    assert data["post_treat_ok"] is True
+    assert calls
+
+
+def test_doctor_treat_includes_treatments_in_full_payload(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="x"\nversion="1.2.3"\n', encoding="utf-8"
+    )
+    (tmp_path / "a.py").write_text("x=1\n", encoding="utf-8")
+
+    def fake_run(cmd, *, cwd=None):
+        if cmd == ["git", "status", "--porcelain"]:
+            return 0, "", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(doctor, "_run", fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    rc = doctor.main(["--treat", "--only", "pyproject", "--format", "json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert [s["id"] for s in data["treatments"]] == ["ruff_fix", "ruff_format_apply"]
+    assert data["checks"]["pyproject"]["ok"] is True


### PR DESCRIPTION
## Summary

* Add `doctor --treat` and `doctor --treat-only` to apply safe workspace fixes (ruff autofix + formatting) with deterministic JSON evidence.
* Include treatment results in doctor JSON (`treatments`, `treatments_ok`, `post_treat_ok`) and keep defaults non-mutating.

## Why

* Make doctor a true “surgical” tool: diagnose + optionally treat the common low-friction issues.
* Preserve CI safety and fast defaults; workspace mutation only happens when explicitly requested.

## How

* Add new flags:

  * `--treat` runs ruff fix/format then executes selected checks.
  * `--treat-only` runs treatments and exits with rc based on treatment success.
* Record treatment commands/results in JSON output for reproducibility.

## Risk assessment

* Risk level: **medium**
* Primary risk area: **workspace mutation** (explicit, opt-in).

## Test evidence

* Commands run:

  * `python -m pytest -q tests/test_doctor_treat.py`
  * `python -m pytest -q`
  * `python -m ruff check .`
  * `python -m ruff format --check .`
  * `python -m mypy src`
  * `python -m sdetkit gate fast --format json`
  * `python -m pre_commit run -a`

## Rollback plan

* Revert commit(s): `<commit-hash>`
* Mitigation: run `doctor` without `--treat` flags (non-mutating).

## Checklist

* [x] Tests added/updated
* [ ] `bash ci.sh` passes
* [ ] `bash quality.sh` passes
* [x] Docs updated (if needed)
* [ ] Issue links / acceptance criteria mapped
* [ ] Premium guideline reference reviewed: `docs/premium-quality-gate.md`