### PR TITLE
doctor: add deterministic --plan and --apply-plan

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,6 +39,8 @@ See: doctor.md
 - `sdetkit doctor --skip deps,pre_commit --format json`
 - `sdetkit doctor --treat --format json`
 - `sdetkit doctor --treat-only --format json`
+- `sdetkit doctor --plan --format json`
+- `sdetkit doctor --apply-plan <plan_id> --format json`
 
 ## ci
 

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import json
 import os
@@ -462,32 +463,92 @@ def _treatments(root: Path) -> list[dict[str, Any]]:
     steps: list[dict[str, Any]] = []
 
     cmd = [sys.executable, "-m", "ruff", "check", "--fix", "."]
-    rc, out, err = _run(cmd, cwd=root)
+    rc, stdout_text, stderr_text = _run(cmd, cwd=root)
     steps.append(
         {
             "id": "ruff_fix",
             "cmd": cmd,
             "rc": rc,
             "ok": rc == 0,
-            "stdout": out,
-            "stderr": err,
+            "stdout": stdout_text,
+            "stderr": stderr_text,
         }
     )
 
     cmd = [sys.executable, "-m", "ruff", "format", "."]
-    rc, out, err = _run(cmd, cwd=root)
+    rc, stdout_text, stderr_text = _run(cmd, cwd=root)
     steps.append(
         {
             "id": "ruff_format_apply",
             "cmd": cmd,
             "rc": rc,
             "ok": rc == 0,
-            "stdout": out,
-            "stderr": err,
+            "stdout": stdout_text,
+            "stderr": stderr_text,
         }
     )
 
     return steps
+
+
+def _plan_id(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(raw).hexdigest()[:12]
+
+
+def _build_plan(ns, is_selected) -> dict[str, Any]:
+    actions: list[dict[str, Any]] = []
+    actions.append(
+        {
+            "id": "ruff_fix",
+            "cmd": [sys.executable, "-m", "ruff", "check", "--fix", "."],
+            "reason": "Apply safe autofixes.",
+            "affects_checks": [],
+        }
+    )
+    actions.append(
+        {
+            "id": "ruff_format_apply",
+            "cmd": [sys.executable, "-m", "ruff", "format", "."],
+            "reason": "Normalize formatting.",
+            "affects_checks": [],
+        }
+    )
+    if getattr(ns, "pre_commit", False) and is_selected("pre_commit"):
+        actions.append(
+            {
+                "id": "pre_commit_run",
+                "cmd": [sys.executable, "-m", "pre_commit", "run", "-a"],
+                "reason": "Apply repo hooks consistently.",
+                "affects_checks": ["pre_commit"],
+            }
+        )
+    plan: dict[str, Any] = {"actions": actions}
+    plan["plan_id"] = _plan_id(plan)
+    return plan
+
+
+def _apply_plan(plan: dict[str, Any], root: Path) -> tuple[list[dict[str, Any]], bool]:
+    steps: list[dict[str, Any]] = []
+    for a in plan.get("actions", []):
+        cmd = a.get("cmd")
+        if not isinstance(cmd, list) or not cmd:
+            continue
+        rc, stdout_text, stderr_text = _run(cmd, cwd=root)
+        steps.append(
+            {
+                "id": a.get("id"),
+                "cmd": cmd,
+                "rc": rc,
+                "ok": rc == 0,
+                "stdout": stdout_text,
+                "stderr": stderr_text,
+            }
+        )
+    ok = all(bool(s.get("ok")) for s in steps)
+    return steps, ok
 
 
 def _recommendations(data: dict[str, Any]) -> list[str]:
@@ -728,6 +789,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out", default=None)
     parser.add_argument("--treat", action="store_true")
     parser.add_argument("--treat-only", dest="treat_only", action="store_true")
+    parser.add_argument("--plan", action="store_true")
+    parser.add_argument("--apply-plan", dest="apply_plan", default=None)
     parser.add_argument("--list-checks", action="store_true")
     parser.add_argument("--only", default=None)
     parser.add_argument("--skip", default=None)
@@ -793,6 +856,36 @@ def main(argv: list[str] | None = None) -> int:
 
     release_any = bool(ns.release or getattr(ns, "release_full", False))
 
+    plan = _build_plan(ns, _is_selected)
+
+    if getattr(ns, "plan", False):
+        payload = {"ok": True, "plan": plan}
+        rendered = json.dumps(payload) + "\n"
+        if ns.out:
+            Path(ns.out).write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+        return 0
+
+    plan_steps: list[dict[str, Any]] = []
+    plan_ok = True
+    if isinstance(getattr(ns, "apply_plan", None), str) and ns.apply_plan:
+        if ns.apply_plan != plan.get("plan_id"):
+            payload = {
+                "ok": False,
+                "error": "plan_id_mismatch",
+                "expected": plan.get("plan_id"),
+                "provided": ns.apply_plan,
+                "plan": plan,
+            }
+            rendered = json.dumps(payload) + "\n"
+            if ns.out:
+                Path(ns.out).write_text(rendered, encoding="utf-8")
+            else:
+                sys.stdout.write(rendered)
+            return 2
+        plan_steps, plan_ok = _apply_plan(plan, root)
+
     if ns.all:
         ns.ascii = True
         ns.ci = True
@@ -842,6 +935,11 @@ def main(argv: list[str] | None = None) -> int:
     if ns.treat:
         data["treatments"] = treat_steps
         data["treatments_ok"] = data_treat_ok
+
+    if isinstance(getattr(ns, "apply_plan", None), str) and ns.apply_plan:
+        data["plan"] = plan
+        data["plan_steps"] = plan_steps
+        data["plan_ok"] = plan_ok
 
     score_items: list[bool] = []
 
@@ -1141,6 +1239,8 @@ def main(argv: list[str] | None = None) -> int:
     data["ok"] = bool(gate_ok)
     if failed_checks:
         data["failed_checks"] = failed_checks
+    if isinstance(getattr(ns, "apply_plan", None), str) and ns.apply_plan:
+        data["post_plan_ok"] = bool(data.get("ok")) and bool(data.get("plan_ok"))
 
     if ns.format == "json" or ns.json:
         output = json.dumps(data, sort_keys=True) + "\n"

--- a/tests/test_doctor_plan.py
+++ b/tests/test_doctor_plan.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import doctor
+
+
+def test_doctor_plan_is_deterministic(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    rc1 = doctor.main(["--plan", "--format", "json"])
+    data1 = json.loads(capsys.readouterr().out)
+    assert rc1 == 0
+    plan1 = data1["plan"]
+
+    rc2 = doctor.main(["--plan", "--format", "json"])
+    data2 = json.loads(capsys.readouterr().out)
+    assert rc2 == 0
+    plan2 = data2["plan"]
+
+    assert plan1["plan_id"] == plan2["plan_id"]
+    assert [a["id"] for a in plan1["actions"]] == ["ruff_fix", "ruff_format_apply"]
+
+
+def test_doctor_apply_plan_rejects_mismatch(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    rc = doctor.main(["--plan", "--format", "json"])
+    plan = json.loads(capsys.readouterr().out)["plan"]
+    assert rc == 0
+
+    rc2 = doctor.main(["--apply-plan", "deadbeefdead", "--format", "json"])
+    data2 = json.loads(capsys.readouterr().out)
+    assert rc2 == 2
+    assert data2["error"] == "plan_id_mismatch"
+    assert data2["expected"] == plan["plan_id"]
+
+
+def test_doctor_apply_plan_runs_actions(tmp_path: Path, monkeypatch, capsys) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="x"\nversion="1.2.3"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *, cwd=None):
+        calls.append(list(cmd))
+        if cmd == ["git", "status", "--porcelain"]:
+            return 0, "", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(doctor, "_run", fake_run)
+
+    rc = doctor.main(["--plan", "--format", "json"])
+    plan = json.loads(capsys.readouterr().out)["plan"]
+    assert rc == 0
+
+    rc2 = doctor.main(["--apply-plan", plan["plan_id"], "--only", "pyproject", "--format", "json"])
+    data2 = json.loads(capsys.readouterr().out)
+    assert rc2 == 0
+    assert data2["plan"]["plan_id"] == plan["plan_id"]
+    assert [s["id"] for s in data2["plan_steps"]] == ["ruff_fix", "ruff_format_apply"]
+    assert any(c[:3] == [doctor.sys.executable, "-m", "ruff"] for c in calls)


### PR DESCRIPTION
**Summary**

* Add deterministic doctor protocol support:

  * `--plan` prints an auditable treatment plan with a stable `plan_id`
  * `--apply-plan <plan_id>` applies the plan only if it matches, then reports execution steps in JSON

**Why**

* Enables safe, reproducible workspace treatment without surprise mutations.
* Makes doctor outputs CI/PR friendly (artifact-like plan + applied steps).

**How**

* Compute `plan_id` from canonical JSON of actions.
* Apply plan actions via `_run`, record `plan_steps`, `plan_ok`, `post_plan_ok`.

**Risk**

* Medium (workspace mutation), fully opt-in and guarded by `plan_id` match.