### PR TITLE
doctor: add --snapshot and --diff-snapshot

### DIFF
--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -452,6 +452,22 @@ def _parse_check_csv(value: str | None) -> list[str]:
     return out
 
 
+def _stable_json(data: dict[str, Any]) -> str:
+    return (
+        json.dumps(
+            data,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+        + "\n"
+    )
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
 def _calculate_score(checks: list[bool]) -> int:
     if not checks:
         return 100
@@ -791,6 +807,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--treat-only", dest="treat_only", action="store_true")
     parser.add_argument("--plan", action="store_true")
     parser.add_argument("--apply-plan", dest="apply_plan", default=None)
+    parser.add_argument("--snapshot", default=None)
+    parser.add_argument("--diff-snapshot", dest="diff_snapshot", default=None)
     parser.add_argument("--list-checks", action="store_true")
     parser.add_argument("--only", default=None)
     parser.add_argument("--skip", default=None)
@@ -1261,6 +1279,30 @@ def main(argv: list[str] | None = None) -> int:
         output = "\n".join(lines) + "\n"
         is_json = False
 
+    snap_base = data
+    stable_text = _stable_json(snap_base)
+
+    if isinstance(getattr(ns, "snapshot", None), str) and ns.snapshot:
+        Path(ns.snapshot).write_text(stable_text, encoding="utf-8")
+
+    if isinstance(getattr(ns, "diff_snapshot", None), str) and ns.diff_snapshot:
+        snap_path = Path(ns.diff_snapshot)
+        snap_text = _read_text(snap_path) if snap_path.exists() else ""
+        diff_ok = snap_text == stable_text
+        diff_summary: list[str] = []
+        if not diff_ok:
+            diff_summary.append("snapshot drift detected")
+            if not snap_path.exists():
+                diff_summary.append("snapshot file missing")
+            gate_ok = False
+            data["ok"] = False
+
+        data["snapshot_diff_ok"] = diff_ok
+        data["snapshot_diff_summary"] = diff_summary
+
+        if ns.json:
+            output = _stable_json(data)
+
     if ns.out:
         Path(ns.out).write_text(output, encoding="utf-8")
 
@@ -1268,6 +1310,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not gate_ok and not is_json:
         sys.stderr.write("doctor: problems found\n")
+
     return 0 if gate_ok else 2
 
 

--- a/tests/test_doctor_snapshot.py
+++ b/tests/test_doctor_snapshot.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import doctor
+
+
+def test_doctor_snapshot_writes_stable_json(tmp_path: Path, monkeypatch, capsys) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="x"\nversion="1.2.3"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    snap = tmp_path / "snap.json"
+    rc = doctor.main(["--only", "pyproject", "--format", "json", "--snapshot", str(snap)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert snap.exists()
+    assert snap.read_text(encoding="utf-8").endswith("\n")
+    json.loads(snap.read_text(encoding="utf-8"))
+    json.loads(out)
+
+
+def test_doctor_diff_snapshot_ok_when_equal(tmp_path: Path, monkeypatch, capsys) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="x"\nversion="1.2.3"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    snap = tmp_path / "snap.json"
+    rc1 = doctor.main(["--only", "pyproject", "--format", "json", "--snapshot", str(snap)])
+    assert rc1 == 0
+    capsys.readouterr()
+
+    rc2 = doctor.main(["--only", "pyproject", "--format", "json", "--diff-snapshot", str(snap)])
+    data2 = json.loads(capsys.readouterr().out)
+    assert rc2 == 0
+    assert data2["snapshot_diff_ok"] is True
+
+
+def test_doctor_diff_snapshot_fails_on_missing_file(tmp_path: Path, monkeypatch, capsys) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="x"\nversion="1.2.3"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    snap = tmp_path / "missing.json"
+    rc = doctor.main(["--only", "pyproject", "--format", "json", "--diff-snapshot", str(snap)])
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert data["snapshot_diff_ok"] is False


### PR DESCRIPTION
## Summary

* Add deterministic doctor snapshots:

  * `--snapshot <path>` writes a normalized JSON snapshot
  * `--diff-snapshot <path>` detects drift, annotates JSON (`snapshot_diff_ok`, `snapshot_diff_summary`), and returns rc=2 on mismatch.

## Why

* Makes doctor output artifact-grade and diffable in CI/PR workflows.
* Enables “golden repo health” without adding heavy gates.

## How

* Serialize stable JSON via `_stable_json(...)` with sorted keys + compact separators.
* Compare against snapshot file and flip `gate_ok` on drift.
* Re-render JSON output when diff is requested so stdout contains the diff fields.

## Risk assessment

* Risk level: low
* Primary risk area: output/exit code behavior under `--diff-snapshot` (opt-in only).

## Test evidence

* `python -m pytest -q tests/test_doctor_snapshot.py`
* `python -m mypy src`
* `python -m pytest -q`
* `python -m sdetkit gate fast --format json`
* `python -m pre_commit run -a`