### PR TITLE
doctor: add baseline write/check for snapshots

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,6 +41,9 @@ See: doctor.md
 - `sdetkit doctor --treat-only --format json`
 - `sdetkit doctor --plan --format json`
 - `sdetkit doctor --apply-plan <plan_id> --format json`
+- `sdetkit doctor baseline write`
+- `sdetkit doctor baseline check`
+- `sdetkit doctor baseline check -- --only pyproject`
 
 ## ci
 

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -452,6 +452,40 @@ def _parse_check_csv(value: str | None) -> list[str]:
     return out
 
 
+def _baseline_snapshot_path(root: Path) -> Path:
+    return root / ".sdetkit" / "doctor.snapshot.json"
+
+
+def _baseline_cmd(argv: list[str]) -> int:
+    bp = argparse.ArgumentParser(prog="doctor baseline")
+    bp.add_argument("action", choices=["write", "check"])
+    bp.add_argument("--path", default=None)
+    ns, extra = bp.parse_known_args(argv)
+    if extra and extra[0] == "--":
+        extra = extra[1:]
+
+    root = Path.cwd()
+    snap = Path(ns.path) if isinstance(ns.path, str) and ns.path else _baseline_snapshot_path(root)
+    if not snap.is_absolute():
+        snap = root / snap
+    snap.parent.mkdir(parents=True, exist_ok=True)
+
+    base = [
+        "--dev",
+        "--ci",
+        "--deps",
+        "--clean-tree",
+        "--repo",
+        "--fail-on",
+        "high",
+        "--format",
+        "json",
+    ]
+    if ns.action == "write":
+        return main(base + ["--snapshot", str(snap)] + list(extra))
+    return main(base + ["--diff-snapshot", str(snap)] + list(extra))
+
+
 def _stable_json(data: dict[str, Any]) -> str:
     return (
         json.dumps(
@@ -783,6 +817,29 @@ def _evaluate_gate(checks: dict[str, dict[str, Any]], threshold: str) -> tuple[b
 
 
 def main(argv: list[str] | None = None) -> int:
+    raw = list(argv) if argv is not None else None
+    args0 = raw if raw is not None else list(sys.argv[1:])
+    value_opts = {
+        "--format",
+        "--fail-on",
+        "--policy",
+        "--out",
+        "--only",
+        "--skip",
+        "--apply-plan",
+        "--snapshot",
+        "--diff-snapshot",
+    }
+    i = 0
+    while i < len(args0):
+        a = args0[i]
+        if a in value_opts:
+            i += 2
+            continue
+        if a == "baseline":
+            return _baseline_cmd(args0[i + 1 :])
+        i += 1
+
     parser = argparse.ArgumentParser(prog="doctor")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--format", choices=["text", "json", "md", "markdown"], default="text")

--- a/tests/test_doctor_baseline.py
+++ b/tests/test_doctor_baseline.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import doctor
+
+
+def test_doctor_baseline_write_creates_default_snapshot(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="x"\nversion="1.2.3"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    rc = doctor.main(["baseline", "write", "--", "--only", "pyproject"])
+    capsys.readouterr()
+    assert rc == 0
+
+    snap = tmp_path / ".sdetkit" / "doctor.snapshot.json"
+    assert snap.exists()
+    assert snap.read_text(encoding="utf-8").endswith("\n")
+    json.loads(snap.read_text(encoding="utf-8"))
+
+
+def test_doctor_baseline_check_passes_when_equal(tmp_path: Path, monkeypatch, capsys) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="x"\nversion="1.2.3"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    rc1 = doctor.main(["baseline", "write", "--", "--only", "pyproject"])
+    assert rc1 == 0
+    capsys.readouterr()
+
+    rc2 = doctor.main(["baseline", "check", "--", "--only", "pyproject"])
+    data = json.loads(capsys.readouterr().out)
+    assert rc2 == 0
+    assert data["snapshot_diff_ok"] is True
+
+
+def test_doctor_baseline_check_fails_when_missing(tmp_path: Path, monkeypatch, capsys) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="x"\nversion="1.2.3"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    rc = doctor.main(["baseline", "check", "--", "--only", "pyproject"])
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert data["snapshot_diff_ok"] is False


### PR DESCRIPTION
## Summary

* Add `sdetkit doctor baseline write|check` as a stable, CI-friendly wrapper around doctor snapshots.
* Standardize snapshot location to `.sdetkit/doctor.snapshot.json` by default.
* Support passthrough doctor args via `-- ...` (example: `-- --only pyproject`).

## Why

* Removes ambiguity about where snapshots should live and how to check drift.
* Makes CI/PR usage trivial and deterministic: one command to write, one command to validate.
* Keeps defaults fast and non-invasive (baseline commands just compose existing doctor behavior).

## How

* Implement baseline dispatcher in `src/sdetkit/doctor.py`:

  * `baseline write` runs doctor with `--snapshot <path>` and default fast-doctor flags.
  * `baseline check` runs doctor with `--diff-snapshot <path>` and default fast-doctor flags.
  * Default path is `.sdetkit/doctor.snapshot.json` (auto-creates directory).
  * Extra doctor args passed after `--` are appended to the doctor invocation.
* Add tests covering:

  * default snapshot file creation with trailing newline
  * baseline check passes when equal
  * baseline check fails when snapshot missing

## Risk assessment

* Risk level: **low**
* Primary risk area: CLI dispatch edge cases (parsing passthrough args); mitigated by tests and conservative parsing.

## Test evidence

* Commands run:

  * `python -m pytest -q tests/test_doctor_baseline.py`
  * `python -m ruff check .`
  * `python -m ruff format --check .`
  * `python -m mypy src`
  * `python -m pytest -q`
  * `python -m sdetkit gate fast --format json`
  * `python -m pre_commit run -a`

## Rollback plan

* If regressions occur, revert commit(s):

  * `5398d83`
* Mitigation while rollback executes:

  * Continue using `doctor --snapshot/--diff-snapshot` directly with explicit paths.

## Triage and ownership

* Reviewer owner: **(fill in)**
* Target merge window: **(fill in)**

## Checklist

* [x] Tests added/updated
* [ ] `bash ci.sh` passes
* [ ] `bash quality.sh` passes
* [x] Docs updated (if needed)
* [ ] Issue links / acceptance criteria mapped
* [ ] Premium guideline reference reviewed: `docs/premium-quality-gate.md`