### PR TITLE
gate: add baseline write/check for fast gate snapshots

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -651,3 +651,5 @@ Examples:
 - `sdetkit gate fast --no-pytest --format json`
 - `sdetkit gate fast --fix`
 - `sdetkit gate fast --fix-only --format json`
+- `sdetkit gate baseline write`
+- `sdetkit gate baseline check`

--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -10,6 +10,48 @@ from pathlib import Path
 from typing import Any
 
 
+def _normalize_gate_payload(payload: dict[str, object]) -> dict[str, object]:
+    out: dict[str, object] = dict(payload)
+    root = out.get("root")
+    root_str = root if isinstance(root, str) else ""
+    out["root"] = "<repo>"
+    steps = out.get("steps")
+    if isinstance(steps, list):
+        new_steps: list[object] = []
+        for s in steps:
+            if isinstance(s, dict):
+                sd: dict[str, object] = dict(s)
+                sd.pop("duration_ms", None)
+                cmd = sd.get("cmd")
+                if isinstance(cmd, list):
+                    new_cmd: list[object] = []
+                    for tok in cmd:
+                        if isinstance(tok, str):
+                            if root_str and (tok == root_str or tok.startswith(root_str + "/")):
+                                tok = tok.replace(root_str, "<repo>", 1)
+                            if tok.startswith("/") and tok.rsplit("/", 1)[-1].startswith("python"):
+                                tok = "python"
+                        new_cmd.append(tok)
+                    sd["cmd"] = new_cmd
+                new_steps.append(sd)
+            else:
+                new_steps.append(s)
+        out["steps"] = new_steps
+    return out
+
+
+def _stable_json(data: dict[str, object]) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n"
+
+
+def _baseline_snapshot_path(root: Path) -> Path:
+    return root / ".sdetkit" / "gate.fast.snapshot.json"
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
 def _run(cmd: list[str], cwd: Path) -> dict[str, Any]:
     started = time.time()
     proc = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=False)
@@ -205,6 +247,60 @@ def _run_fast(ns: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    raw = list(argv) if argv is not None else None
+    args0 = raw if raw is not None else list(sys.argv[1:])
+    if args0 and args0[0] == "baseline":
+        bp = argparse.ArgumentParser(prog="gate baseline")
+        bp.add_argument("action", choices=["write", "check"])
+        bp.add_argument("--path", default=None)
+        ns, extra = bp.parse_known_args(args0[1:])
+        if extra and extra[0] == "--":
+            extra = extra[1:]
+
+        root = Path.cwd()
+        snap = (
+            Path(ns.path) if isinstance(ns.path, str) and ns.path else _baseline_snapshot_path(root)
+        )
+        if not snap.is_absolute():
+            snap = root / snap
+        snap.parent.mkdir(parents=True, exist_ok=True)
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc_fast = main(["fast", "--format", "json"] + list(extra))
+        cur_text = buf.getvalue()
+        if rc_fast != 0:
+            return rc_fast
+
+        try:
+            cur_obj = json.loads(cur_text)
+        except Exception:
+            cur_obj = None
+
+        if isinstance(cur_obj, dict):
+            norm = _normalize_gate_payload(cur_obj)
+            cur_text = _stable_json(norm)
+
+        if ns.action == "write":
+            snap.write_text(cur_text, encoding="utf-8")
+            return 0
+
+        snap_text = _read_text(snap) if snap.exists() else ""
+        diff_ok = snap_text == cur_text
+        try:
+            out_obj = json.loads(cur_text)
+            if isinstance(out_obj, dict):
+                out_obj["snapshot_diff_ok"] = diff_ok
+                out_obj["snapshot_diff_summary"] = [] if diff_ok else ["snapshot drift detected"]
+                cur_text = _stable_json(out_obj)
+        except Exception:
+            pass
+        sys.stdout.write(cur_text)
+        return 0 if diff_ok else 2
+
     parser = argparse.ArgumentParser(prog="gate")
     sub = parser.add_subparsers(dest="cmd", required=True)
 

--- a/tests/test_gate_baseline.py
+++ b/tests/test_gate_baseline.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import gate
+
+
+def test_gate_baseline_write_creates_snapshot(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = gate.main(
+        ["baseline", "write", "--", "--no-doctor", "--no-ci-templates", "--no-mypy", "--no-pytest"]
+    )
+    assert rc == 0
+    snap = tmp_path / ".sdetkit" / "gate.fast.snapshot.json"
+    assert snap.exists()
+    assert snap.read_text(encoding="utf-8").endswith("\n")
+    json.loads(snap.read_text(encoding="utf-8"))
+
+
+def test_gate_baseline_check_passes_when_equal(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc1 = gate.main(
+        ["baseline", "write", "--", "--no-doctor", "--no-ci-templates", "--no-mypy", "--no-pytest"]
+    )
+    assert rc1 == 0
+    capsys.readouterr()
+
+    rc2 = gate.main(
+        ["baseline", "check", "--", "--no-doctor", "--no-ci-templates", "--no-mypy", "--no-pytest"]
+    )
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert rc2 == 0
+    assert data["snapshot_diff_ok"] is True
+
+
+def test_gate_baseline_check_fails_when_missing(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = gate.main(
+        ["baseline", "check", "--", "--no-doctor", "--no-ci-templates", "--no-mypy", "--no-pytest"]
+    )
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert rc == 2
+    assert data["snapshot_diff_ok"] is False


### PR DESCRIPTION
## Summary

* Add `sdetkit gate baseline write|check` to snapshot and validate `gate fast` output deterministically.
* Default snapshot path: `.sdetkit/gate.fast.snapshot.json`.
* Normalize volatile fields (durations, absolute paths) before writing/comparing.

## Why

* Enables quick CI/PR drift detection for the repo’s fast quality signal.
* Keeps the default workflow fast and stable while making regressions obvious.

## How

* Capture `gate fast --format json` output, normalize and store as stable JSON.
* `baseline check` compares current normalized output to snapshot and returns rc=2 on drift, annotating JSON with `snapshot_diff_ok`.

## Risk

* Low (opt-in wrapper; does not change `gate fast` defaults).