### PR TITLE
cli: add baseline write/check umbrella command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,4 +1,7 @@
 # CLI
+- `sdetkit baseline write`
+- `sdetkit baseline check`
+- `sdetkit baseline check --format json`
 
 ## kv
 

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -546,6 +546,8 @@ Run: sdetkit playbooks
     )
     p.add_argument("--version", action="version", version=_tool_version())
     sub = p.add_subparsers(dest="cmd", required=True, metavar="command")
+    bsl = sub.add_parser("baseline")
+    bsl.add_argument("args", nargs=argparse.REMAINDER)
     sub.add_parser("playbooks", help="List playbooks and legacy flows")
     kv = sub.add_parser("kv")
     kv.add_argument("args", nargs=argparse.REMAINDER)
@@ -841,6 +843,60 @@ Run: sdetkit playbooks
     _hide_help_subcommands(sub)
 
     ns = p.parse_args(argv)
+
+    if ns.cmd == "baseline":
+        import io
+        import json
+        from contextlib import redirect_stderr, redirect_stdout
+
+        bp = argparse.ArgumentParser(prog="sdetkit baseline")
+        bp.add_argument("action", choices=["write", "check"])
+        bp.add_argument("--format", choices=["text", "json"], default="text")
+        bns, extra = bp.parse_known_args(list(getattr(ns, "args", [])))
+        if extra and extra[0] == "--":
+            extra = extra[1:]
+
+        from sdetkit import doctor, gate
+
+        steps: list[dict[str, object]] = []
+        failed: list[str] = []
+        for sid, fn in [
+            ("doctor_baseline", doctor.main),
+            ("gate_baseline", gate.main),
+        ]:
+            buf_out = io.StringIO()
+            buf_err = io.StringIO()
+            with redirect_stdout(buf_out), redirect_stderr(buf_err):
+                rc = fn(["baseline", bns.action] + (["--"] + extra if extra else []))
+            step = {
+                "id": sid,
+                "rc": rc,
+                "ok": rc == 0,
+                "stdout": buf_out.getvalue(),
+                "stderr": buf_err.getvalue(),
+            }
+            steps.append(step)
+            if rc != 0:
+                failed.append(sid)
+
+        ok = not failed
+        payload: dict[str, object] = {"ok": ok, "steps": steps, "failed_steps": failed}
+        if bns.format == "json":
+            sys.stdout.write(
+                json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n"
+            )
+        else:
+            lines: list[str] = []
+            lines.append(f"baseline: {'OK' if ok else 'FAIL'}")
+            for s in steps:
+                marker = "OK" if s.get("ok") else "FAIL"
+                lines.append(f"[{marker}] {s.get('id')} rc={s.get('rc')}")
+            if failed:
+                lines.append("failed_steps:")
+                for f in failed:
+                    lines.append(f"- {f}")
+            sys.stdout.write("\n".join(lines) + "\n")
+        return 0 if ok else 2
 
     if ns.cmd == "playbooks":
         _print_playbooks(sub)

--- a/tests/test_baseline_umbrella.py
+++ b/tests/test_baseline_umbrella.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+
+
+def test_baseline_write_and_check(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    import sdetkit.doctor
+    import sdetkit.gate
+
+    monkeypatch.setattr(sdetkit.doctor, "main", lambda argv=None: 0)
+    monkeypatch.setattr(sdetkit.gate, "main", lambda argv=None: 0)
+
+    rc1 = cli.main(["baseline", "write", "--format", "json"])
+    data1 = json.loads(capsys.readouterr().out)
+    assert rc1 == 0
+    assert data1["ok"] is True
+    assert [s["id"] for s in data1["steps"]] == ["doctor_baseline", "gate_baseline"]
+
+    rc2 = cli.main(["baseline", "check", "--format", "json"])
+    data2 = json.loads(capsys.readouterr().out)
+    assert rc2 == 0
+    assert data2["ok"] is True


### PR DESCRIPTION
## Summary

* Add `sdetkit baseline write|check` as an umbrella command that composes:

  * `sdetkit doctor baseline write|check`
  * `sdetkit gate baseline write|check`
* Support deterministic, CI-friendly output with `--format json` (aggregated `ok`, `steps`, `failed_steps`).

## Why

* Make repo baseline maintenance and drift detection a single fast command for local + CI.
* Reduce workflow complexity: one entrypoint to refresh baselines and one to validate them.
* Improve UX and consistency across doctor/gate baseline flows.

## How

* Add a new `baseline` top-level CLI subcommand in `src/sdetkit/cli.py`.
* Parse `baseline <action> [--format text|json]` via `parse_known_args` to avoid swallowing flags.
* Execute doctor/gate baseline commands in-process, capture stdout/stderr per step, and return rc=0 only if both succeed (else rc=2).
* Add tests validating JSON output and success path when underlying calls succeed.
* Update docs with baseline examples.

## Risk assessment

* Risk level: **low**
* Primary risk area: CLI parsing/dispatch (handled via focused test + conservative parsing).

## Test evidence

* Commands run:

  * `python -m pytest -q tests/test_baseline_umbrella.py`
  * `python -m ruff check .`
  * `python -m ruff format --check .`
  * `python -m mypy src`
  * `python -m pytest -q`
  * `python -m sdetkit gate fast --format json`
  * `python -m pre_commit run -a`
* Attach key output snippets/artifacts:

  * Baseline JSON includes `ok`, `steps[]` with `id/rc/ok/stdout/stderr`, and `failed_steps[]`.

## Rollback plan

* If this causes regressions, revert commit(s):

  * `<fill in commit SHA(s) from the PR>`
* Mitigation while rollback executes:

  * Use `sdetkit doctor baseline ...` and `sdetkit gate baseline ...` directly.

## Triage and ownership

* Reviewer owner: **(fill in)**
* Target merge window: **(fill in)**

## Checklist

* [x] Tests added/updated
* [ ] `bash ci.sh` passes
* [ ] `bash quality.sh` passes
* [x] Docs updated (if needed)
* [ ] Issue links / acceptance criteria mapped
* [ ] Premium guideline reference reviewed: `docs/premium-quality-gate.md`