### PR TITLE
**baseline: add deterministic drift diffs for doctor/gate/umbrella**

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -664,3 +664,20 @@ Examples:
 Useful flags: `--root`, `--format`, `--out`/`--output`, `--strict`, `--fix`, `--fix-only`, `--list-steps`, `--only`, `--skip`, `--no-doctor`, `--no-ci-templates`, `--no-ruff`, `--no-mypy`, `--no-pytest`, `--mypy-args`, `--pytest-args`, `--full-pytest`.
 
 Note: `gate fast` uses a default smoke pytest subset for speed. Use `--full-pytest` or explicit `--pytest-args` to run the full test suite.
+
+### Baselines: show drift diff
+
+When a baseline check fails, you can request a deterministic unified diff between the stored snapshot and the current normalized output.
+
+- Show drift diff (JSON output):
+
+  python -m sdetkit baseline check --format json --diff
+
+- Limit diff context lines:
+
+  python -m sdetkit baseline check --format json --diff --diff-context 1
+
+- Per-step baselines:
+
+  python -m sdetkit doctor baseline check --diff
+  python -m sdetkit gate baseline check --diff

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -852,6 +852,8 @@ Run: sdetkit playbooks
         bp = argparse.ArgumentParser(prog="sdetkit baseline")
         bp.add_argument("action", choices=["write", "check"])
         bp.add_argument("--format", choices=["text", "json"], default="text")
+        bp.add_argument("--diff", action="store_true")
+        bp.add_argument("--diff-context", type=int, default=3)
         bns, extra = bp.parse_known_args(list(getattr(ns, "args", [])))
         if extra and extra[0] == "--":
             extra = extra[1:]
@@ -860,6 +862,11 @@ Run: sdetkit playbooks
 
         steps: list[dict[str, object]] = []
         failed: list[str] = []
+
+        diff_args: list[str] = []
+        if getattr(bns, "diff", False):
+            diff_args.append("--diff")
+            diff_args.extend(["--diff-context", str(getattr(bns, "diff_context", 3))])
         for sid, fn in [
             ("doctor_baseline", doctor.main),
             ("gate_baseline", gate.main),
@@ -867,7 +874,7 @@ Run: sdetkit playbooks
             buf_out = io.StringIO()
             buf_err = io.StringIO()
             with redirect_stdout(buf_out), redirect_stderr(buf_err):
-                rc = fn(["baseline", bns.action] + (["--"] + extra if extra else []))
+                rc = fn(["baseline", bns.action] + diff_args + (["--"] + extra if extra else []))
             step = {
                 "id": sid,
                 "rc": rc,

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import hashlib
 import importlib.util
 import json
@@ -460,6 +461,8 @@ def _baseline_cmd(argv: list[str]) -> int:
     bp = argparse.ArgumentParser(prog="doctor baseline")
     bp.add_argument("action", choices=["write", "check"])
     bp.add_argument("--path", default=None)
+    bp.add_argument("--diff", action="store_true")
+    bp.add_argument("--diff-context", type=int, default=3)
     ns, extra = bp.parse_known_args(argv)
     if extra and extra[0] == "--":
         extra = extra[1:]
@@ -485,7 +488,13 @@ def _baseline_cmd(argv: list[str]) -> int:
         base.extend(["--skip", "clean_tree"])
     if ns.action == "write":
         return main(base + ["--snapshot", str(snap)] + list(extra))
-    return main(base + ["--diff-snapshot", str(snap)] + list(extra))
+
+    diff_args: list[str] = []
+    if getattr(ns, "diff", False):
+        diff_args.append("--diff")
+        diff_args.extend(["--diff-context", str(getattr(ns, "diff_context", 3))])
+
+    return main(base + ["--diff-snapshot", str(snap)] + diff_args + list(extra))
 
 
 def _stable_json(data: dict[str, Any]) -> str:
@@ -868,6 +877,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--apply-plan", dest="apply_plan", default=None)
     parser.add_argument("--snapshot", default=None)
     parser.add_argument("--diff-snapshot", dest="diff_snapshot", default=None)
+    parser.add_argument("--diff", action="store_true")
+    parser.add_argument("--diff-context", type=int, default=3)
     parser.add_argument("--list-checks", action="store_true")
     parser.add_argument("--only", default=None)
     parser.add_argument("--skip", default=None)
@@ -1359,7 +1370,34 @@ def main(argv: list[str] | None = None) -> int:
         data["snapshot_diff_ok"] = diff_ok
         data["snapshot_diff_summary"] = diff_summary
 
-        if ns.json:
+        if getattr(ns, "diff", False) and not diff_ok:
+            n = int(getattr(ns, "diff_context", 3) or 0)
+            n = n if n >= 0 else 0
+            a = snap_text
+            b = stable_text
+            try:
+                ao = json.loads(a)
+                a = json.dumps(ao, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+            except Exception:
+                pass
+            try:
+                bo = json.loads(b)
+                b = json.dumps(bo, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+            except Exception:
+                pass
+            diff_lines = difflib.unified_diff(
+                a.splitlines(keepends=True),
+                b.splitlines(keepends=True),
+                fromfile="snapshot",
+                tofile="current",
+                n=n,
+            )
+            diff_text = "".join(diff_lines)
+            if diff_text and not diff_text.endswith("\n"):
+                diff_text += "\n"
+            data["snapshot_diff"] = diff_text
+
+        if is_json:
             output = _stable_json(data)
 
     if ns.out:

--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import json
 import shlex
 import subprocess
@@ -301,6 +302,8 @@ def main(argv: list[str] | None = None) -> int:
         bp = argparse.ArgumentParser(prog="gate baseline")
         bp.add_argument("action", choices=["write", "check"])
         bp.add_argument("--path", default=None)
+        bp.add_argument("--diff", action="store_true")
+        bp.add_argument("--diff-context", type=int, default=3)
         ns, extra = bp.parse_known_args(args0[1:])
         if extra and extra[0] == "--":
             extra = extra[1:]
@@ -338,6 +341,33 @@ def main(argv: list[str] | None = None) -> int:
 
         snap_text = _read_text(snap) if snap.exists() else ""
         diff_ok = snap_text == cur_text
+
+        diff_payload = ""
+        if getattr(ns, "diff", False) and not diff_ok:
+            n = int(getattr(ns, "diff_context", 3) or 0)
+            n = n if n >= 0 else 0
+            a = snap_text
+            b = cur_text
+            try:
+                ao = json.loads(a)
+                a = json.dumps(ao, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+            except Exception:
+                pass
+            try:
+                bo = json.loads(b)
+                b = json.dumps(bo, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+            except Exception:
+                pass
+            diff_lines = difflib.unified_diff(
+                a.splitlines(keepends=True),
+                b.splitlines(keepends=True),
+                fromfile="snapshot",
+                tofile="current",
+                n=n,
+            )
+            diff_payload = "".join(diff_lines)
+            if diff_payload and not diff_payload.endswith("\n"):
+                diff_payload += "\n"
         out_obj: dict[str, object] | None = None
         try:
             parsed = json.loads(cur_text)
@@ -347,7 +377,15 @@ def main(argv: list[str] | None = None) -> int:
             out_obj = parsed
         if out_obj is not None:
             out_obj["snapshot_diff_ok"] = diff_ok
-            out_obj["snapshot_diff_summary"] = [] if diff_ok else ["snapshot drift detected"]
+            if diff_ok:
+                out_obj["snapshot_diff_summary"] = []
+            else:
+                summary = ["snapshot drift detected"]
+                if not snap.exists():
+                    summary.append("snapshot file missing")
+                out_obj["snapshot_diff_summary"] = summary
+            if diff_payload:
+                out_obj["snapshot_diff"] = diff_payload
             cur_text = _stable_json(out_obj)
         sys.stdout.write(cur_text)
         return 0 if diff_ok else 2

--- a/tests/test_baseline_umbrella.py
+++ b/tests/test_baseline_umbrella.py
@@ -25,3 +25,26 @@ def test_baseline_write_and_check(tmp_path: Path, monkeypatch, capsys) -> None:
     data2 = json.loads(capsys.readouterr().out)
     assert rc2 == 0
     assert data2["ok"] is True
+
+
+def test_baseline_check_forwards_diff_flags(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    import sdetkit.doctor
+    import sdetkit.gate
+
+    calls: list[list[str]] = []
+
+    def rec(argv=None) -> int:
+        calls.append(list(argv) if argv is not None else [])
+        return 0
+
+    monkeypatch.setattr(sdetkit.doctor, "main", rec)
+    monkeypatch.setattr(sdetkit.gate, "main", rec)
+
+    rc = cli.main(["baseline", "check", "--format", "json", "--diff", "--diff-context", "7"])
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert data["ok"] is True
+    assert calls[0][:5] == ["baseline", "check", "--diff", "--diff-context", "7"]
+    assert calls[1][:5] == ["baseline", "check", "--diff", "--diff-context", "7"]

--- a/tests/test_doctor_baseline.py
+++ b/tests/test_doctor_baseline.py
@@ -50,3 +50,30 @@ def test_doctor_baseline_check_fails_when_missing(tmp_path: Path, monkeypatch, c
     data = json.loads(capsys.readouterr().out)
     assert rc == 2
     assert data["snapshot_diff_ok"] is False
+    assert "snapshot_diff" not in data
+
+
+def test_doctor_baseline_check_includes_diff_when_requested(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="x"\nversion="1.2.3"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    rc1 = doctor.main(["baseline", "write", "--", "--only", "pyproject"])
+    assert rc1 == 0
+    capsys.readouterr()
+
+    snap = tmp_path / ".sdetkit" / "doctor.snapshot.json"
+    snap.write_text("{}\n", encoding="utf-8")
+
+    rc2 = doctor.main(
+        ["baseline", "check", "--diff", "--diff-context", "1", "--", "--only", "pyproject"]
+    )
+    data = json.loads(capsys.readouterr().out)
+    assert rc2 == 2
+    assert data["snapshot_diff_ok"] is False
+    assert "snapshot drift detected" in data["snapshot_diff_summary"]
+    assert isinstance(data.get("snapshot_diff"), str)
+    assert data["snapshot_diff"].startswith("--- snapshot\n+++ current\n")

--- a/tests/test_gate_baseline.py
+++ b/tests/test_gate_baseline.py
@@ -44,3 +44,40 @@ def test_gate_baseline_check_fails_when_missing(tmp_path: Path, monkeypatch, cap
     data = json.loads(out)
     assert rc == 2
     assert data["snapshot_diff_ok"] is False
+    assert "snapshot_diff" not in data
+
+
+def test_gate_baseline_check_includes_diff_when_requested(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc1 = gate.main(
+        ["baseline", "write", "--", "--no-doctor", "--no-ci-templates", "--no-mypy", "--no-pytest"]
+    )
+    assert rc1 == 0
+    capsys.readouterr()
+
+    snap = tmp_path / ".sdetkit" / "gate.fast.snapshot.json"
+    snap.write_text("{}\n", encoding="utf-8")
+
+    rc2 = gate.main(
+        [
+            "baseline",
+            "check",
+            "--diff",
+            "--diff-context",
+            "1",
+            "--",
+            "--no-doctor",
+            "--no-ci-templates",
+            "--no-mypy",
+            "--no-pytest",
+        ]
+    )
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert rc2 == 2
+    assert data["snapshot_diff_ok"] is False
+    assert "snapshot drift detected" in data["snapshot_diff_summary"]
+    assert isinstance(data.get("snapshot_diff"), str)
+    assert data["snapshot_diff"].startswith("--- snapshot\n+++ current\n")


### PR DESCRIPTION
* **What**

  * Add `--diff` and `--diff-context N` to:

    * `sdetkit doctor baseline check`
    * `sdetkit gate baseline check`
    * `sdetkit baseline check` (umbrella forwards flags)
  * When a baseline check fails (drift or missing snapshot), JSON output can include `snapshot_diff` with a deterministic unified diff.
  * Diff is generated from a pretty, stable JSON render (indent=2, sort_keys) for readability, while snapshot files remain compact and deterministic.

* **Why**

  * Baseline failures in CI were actionable only via “snapshot drift detected”. This adds a fast, deterministic “what changed” view without changing default behavior.

* **Usage**

  * `python -m sdetkit baseline check --format json --diff`
  * `python -m sdetkit baseline check --format json --diff --diff-context 1`
  * `python -m sdetkit doctor baseline check --diff`
  * `python -m sdetkit gate baseline check --diff`

* **How tested**

  * `python -m pytest -q`
  * `python -m sdetkit gate fast`
  * `python -m sdetkit baseline check --format json`
