### PR TITLE
Normalize release JSON output, add policy --fail-on=security, tighten default coverage, and test updates

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -669,6 +669,8 @@ Useful flags (`gate fast`): `--root`, `--format`, `--out`/`--output`, `--strict`
 
 Useful flags (`gate release`): `--root`, `--format`, `--out`/`--output`, `--dry-run`, `--release-full`, `--playbooks-all`, `--playbooks-legacy`, `--playbooks-aliases`, `--playbook-name` (repeatable).
 
+Release JSON output is deterministic for CI/baseline usage: it normalizes repo paths and omits volatile runtime fields.
+
 Note: `gate fast` uses a default smoke pytest subset for speed. Use `--full-pytest` or explicit `--pytest-args` to run the full test suite.
 
 ### Baselines: show drift diff

--- a/quality.sh
+++ b/quality.sh
@@ -19,7 +19,9 @@ ensure_venv
 python3 scripts/check_repo_layout.py
 
 mode=${1:-all}
-cov_fail_under=${COV_FAIL_UNDER:-70}
+# Keep the default gate realistic for full-repo runs, while still allowing
+# stricter enforcement in CI/release jobs via COV_FAIL_UNDER=95.
+cov_fail_under=${COV_FAIL_UNDER:-80}
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 && return 0

--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -340,6 +340,20 @@ def _format_release_text(payload: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _normalize_release_steps(steps: list[dict[str, Any]], root: Path) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for step in steps:
+        cleaned: dict[str, Any] = dict(step)
+        cleaned.pop("duration_ms", None)
+        cleaned.pop("stdout", None)
+        cleaned.pop("stderr", None)
+        step_cmd = cleaned.get("cmd")
+        if isinstance(step_cmd, list):
+            cleaned["cmd"] = _normalize_release_cmd([str(t) for t in step_cmd], root)
+        normalized.append(cleaned)
+    return normalized
+
+
 def _run_release(ns: argparse.Namespace) -> int:
     root = Path(ns.root).resolve()
     doctor_cmd = [sys.executable, "-m", "sdetkit", "doctor", "--release", "--format", "json"]
@@ -391,10 +405,7 @@ def _run_release(ns: argparse.Namespace) -> int:
             steps.append({"id": step_id, **_run(cmd, cwd=root)})
 
     failed = [s["id"] for s in steps if not s.get("ok", False)]
-    for step in steps:
-        step_cmd = step.get("cmd")
-        if isinstance(step_cmd, list):
-            step["cmd"] = _normalize_release_cmd([str(t) for t in step_cmd], root)
+    steps = _normalize_release_steps(steps, root)
 
     payload = {
         "profile": "release",

--- a/src/sdetkit/policy.py
+++ b/src/sdetkit/policy.py
@@ -100,6 +100,11 @@ def main(argv: list[str] | None = None) -> int:
     if ns.cmd == "check":
         for item in regressions:
             sys.stdout.write(json.dumps(item, sort_keys=True) + "\n")
+        if ns.fail_on == "security":
+            security_only = [
+                item for item in regressions if item.get("type") == "security_rule_increase"
+            ]
+            return 1 if security_only else 0
         return 1 if regressions else 0
 
     payload = {"baseline": baseline.as_posix(), "regressions": regressions}

--- a/tests/test_ci_templates_cli.py
+++ b/tests/test_ci_templates_cli.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import ci
+
+
+def _write_templates(root: Path) -> None:
+    for template_id, spec in ci._TEMPLATE_SPECS.items():
+        path = root / str(spec["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = "\n".join(str(marker) for marker in spec["markers"])
+        path.write_text(f"# {template_id}\n{content}\n", encoding="utf-8")
+
+
+def test_ci_validate_templates_json_strict_pass(tmp_path: Path, capsys) -> None:
+    _write_templates(tmp_path)
+
+    rc = ci.main(["validate-templates", "--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["missing"] == []
+    assert [item["id"] for item in payload["checked"]] == sorted(ci._TEMPLATE_SPECS)
+
+
+def test_ci_validate_templates_missing_markers_respects_strict_flag(tmp_path: Path, capsys) -> None:
+    _write_templates(tmp_path)
+    gitlab = tmp_path / ci._TEMPLATE_SPECS["gitlab"]["path"]
+    gitlab.write_text("# gitlab template without required markers\n", encoding="utf-8")
+
+    rc_non_strict = ci.main(["validate-templates", "--root", str(tmp_path)])
+    io_non_strict = capsys.readouterr()
+    assert rc_non_strict == 0
+    assert "ci template validation: FAIL" in io_non_strict.out
+
+    rc_strict = ci.main(
+        ["validate-templates", "--root", str(tmp_path), "--strict", "--format", "json"]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc_strict == 2
+    assert payload["ok"] is False
+    bad = next(item for item in payload["checked"] if item["id"] == "gitlab")
+    assert bad["ok"] is False
+    assert bad["errors"]
+
+
+def test_ci_validate_templates_writes_out_file(tmp_path: Path, capsys) -> None:
+    _write_templates(tmp_path)
+    out = tmp_path / "build" / "ci-validate.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    rc = ci.main(
+        [
+            "validate-templates",
+            "--root",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+    assert rc == 0
+
+    stdout_payload = json.loads(capsys.readouterr().out)
+    file_payload = json.loads(out.read_text(encoding="utf-8"))
+    assert stdout_payload == file_payload
+
+
+def test_ci_validate_templates_missing_file_recorded(tmp_path: Path, capsys) -> None:
+    _write_templates(tmp_path)
+    missing_template = tmp_path / str(ci._TEMPLATE_SPECS["tekton"]["path"])
+    missing_template.unlink()
+
+    rc = ci.main(["validate-templates", "--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 2
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["missing"] == [str(ci._TEMPLATE_SPECS["tekton"]["path"])]
+    tekton = next(item for item in payload["checked"] if item["id"] == "tekton")
+    assert tekton["ok"] is False
+    assert tekton["errors"] == [f"missing file: {ci._TEMPLATE_SPECS['tekton']['path']}"]

--- a/tests/test_gate_release.py
+++ b/tests/test_gate_release.py
@@ -34,6 +34,9 @@ def test_gate_release_runs_expected_commands(monkeypatch, tmp_path: Path, capsys
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
+    assert "duration_ms" not in payload["steps"][0]
+    assert "stdout" not in payload["steps"][0]
+    assert "stderr" not in payload["steps"][0]
     assert [step["id"] for step in payload["steps"]] == [
         "doctor_release",
         "playbooks_validate",
@@ -58,6 +61,22 @@ def test_gate_release_passes_playbook_selection_flags(monkeypatch, tmp_path: Pat
     assert rc == 0
     _ = json.loads(capsys.readouterr().out)
     assert calls[1][3:] == ["playbooks", "validate", "--legacy", "--format", "json"]
+
+
+def test_gate_release_passes_playbooks_all_selection(monkeypatch, tmp_path: Path, capsys) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], cwd: Path) -> dict[str, object]:
+        calls.append(cmd)
+        return {"cmd": cmd, "rc": 0, "ok": True, "duration_ms": 1, "stdout": "", "stderr": ""}
+
+    monkeypatch.setattr(gate, "_run", fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    rc = gate.main(["release", "--format", "json", "--playbooks-all"])
+    assert rc == 0
+    _ = json.loads(capsys.readouterr().out)
+    assert calls[1][3:] == ["playbooks", "validate", "--all", "--format", "json"]
 
 
 def test_gate_release_passes_named_playbooks(monkeypatch, tmp_path: Path, capsys) -> None:

--- a/tests/test_main_cassette_get_extra.py
+++ b/tests/test_main_cassette_get_extra.py
@@ -96,3 +96,141 @@ def test_main_cassette_get_exception_path(monkeypatch: pytest.MonkeyPatch, capsy
     err = capsys.readouterr().err
     assert rc == 2
     assert "boom" in err
+
+
+def test_main_delegates_to_cli_main_when_not_cassette_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sdetkit.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "main", lambda: None)
+
+    old_argv = sys.argv[:]
+    try:
+        sys.argv = ["sdetkit", "doctor", "--help"]
+        rc = mainmod.main()
+    finally:
+        sys.argv = old_argv
+
+    assert rc == 0
+
+
+def test_cassette_get_disallows_unapproved_scheme(capsys) -> None:
+    rc = mainmod._cassette_get(["file:///tmp/nope.json"])
+    io = capsys.readouterr()
+
+    assert rc == 2
+    assert "is not allowed" in io.err
+
+
+def test_cassette_get_replay_allow_absolute_uses_assert_exhausted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    import httpx
+
+    import sdetkit.cassette as cassette_mod
+
+    seen: dict[str, object] = {}
+
+    class _ReplayTransport:
+        def __init__(self, cass) -> None:
+            seen["cass"] = cass
+
+        def assert_exhausted(self) -> None:
+            seen["assert_exhausted_called"] = True
+
+    class _Client2(_Client):
+        pass
+
+    def fake_load(path: Path, allow_absolute: bool = False):
+        seen["path"] = path
+        seen["allow_absolute"] = allow_absolute
+        return object()
+
+    monkeypatch.setattr(cassette_mod.Cassette, "load", staticmethod(fake_load))
+    monkeypatch.setattr(cassette_mod, "CassetteReplayTransport", _ReplayTransport)
+    monkeypatch.setattr(httpx, "Client", _Client2)
+
+    p = tmp_path / "replay.json"
+    p.write_text("{}", encoding="utf-8")
+
+    rc = mainmod._cassette_get(
+        ["https://example.invalid", "--replay", str(p), "--allow-absolute-path"]
+    )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True}
+    assert seen["path"] == p
+    assert seen["allow_absolute"] is True
+    assert seen["assert_exhausted_called"] is True
+
+
+def test_cassette_get_record_force_writes_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    import sdetkit.cassette as cassette_mod
+
+    seen: dict[str, object] = {}
+
+    class _FakeCassette:
+        def to_json(self):
+            return {"records": [{"method": "GET", "url": "https://example.invalid"}]}
+
+    class _RecordTransport:
+        def __init__(self, cass, inner) -> None:
+            seen["cass"] = cass
+            seen["inner"] = inner
+
+    monkeypatch.setattr(cassette_mod, "Cassette", _FakeCassette)
+    monkeypatch.setattr(cassette_mod, "CassetteRecordTransport", _RecordTransport)
+    monkeypatch.setattr(httpx, "Client", _Client)
+    monkeypatch.setattr(httpx, "HTTPTransport", lambda: "http-transport")
+    monkeypatch.setattr(
+        mainmod,
+        "atomic_write_text",
+        lambda path, payload: seen.update({"path": path, "payload": payload}),
+    )
+
+    out_path = tmp_path / "cassette.json"
+    out_path.write_text("{}", encoding="utf-8")
+
+    old_cwd = Path.cwd()
+    try:
+        import os
+
+        os.chdir(tmp_path)
+        rc = mainmod._cassette_get(
+            ["https://example.invalid", "--record", "cassette.json", "--force"]
+        )
+    finally:
+        os.chdir(old_cwd)
+
+    assert rc == 0
+    assert seen["path"] == out_path
+    assert '"records"' in str(seen["payload"])
+
+
+def test_cassette_get_allow_scheme_accepts_extra_scheme(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+
+    rc = mainmod._cassette_get(["ftp://example.invalid", "--allow-scheme", "ftp"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"ok": True}
+
+
+def test_cassette_get_record_safe_path_security_error(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        mainmod,
+        "safe_path",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(mainmod.SecurityError("blocked path")),
+    )
+
+    rc = mainmod._cassette_get(["https://example.invalid", "--record", "../escape.json"])
+    io = capsys.readouterr()
+    assert rc == 2
+    assert "blocked path" in io.err

--- a/tests/test_playbooks_validate.py
+++ b/tests/test_playbooks_validate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 from sdetkit import playbooks_cli
 
@@ -43,3 +44,49 @@ def test_playbooks_validate_aliases_are_only_alias_names(capsys) -> None:
     assert payload["results"]
     assert all(not item["name"].startswith("day") for item in payload["results"])
     assert all(item["canonical"].startswith("day") for item in payload["results"])
+
+
+def test_playbooks_validate_all_includes_multiple_groups(capsys) -> None:
+    rc = playbooks_cli.main(["validate", "--all", "--format", "json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    names = [item["name"] for item in payload["results"]]
+    assert "onboarding" in names
+    assert any(name.startswith("day") for name in names)
+
+
+def test_playbooks_validate_scan_handles_missing_main(monkeypatch, capsys) -> None:
+    real_import_module = playbooks_cli.import_module
+
+    def fake_import_module(name: str):
+        if name == "sdetkit.onboarding":
+            return SimpleNamespace()
+        return real_import_module(name)
+
+    monkeypatch.setattr(playbooks_cli, "import_module", fake_import_module)
+
+    rc = playbooks_cli.main(["validate", "--name", "onboarding", "--format", "json"])
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["failed"] == ["onboarding"]
+    assert payload["results"][0]["error"] == "missing callable main"
+
+
+def test_playbooks_validate_scan_handles_import_error(monkeypatch, capsys) -> None:
+    real_import_module = playbooks_cli.import_module
+
+    def fake_import_module(name: str):
+        if name == "sdetkit.onboarding":
+            raise RuntimeError("boom")
+        return real_import_module(name)
+
+    monkeypatch.setattr(playbooks_cli, "import_module", fake_import_module)
+
+    rc = playbooks_cli.main(["validate", "--name", "onboarding", "--format", "json"])
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["failed"] == ["onboarding"]
+    assert payload["results"][0]["error"] == "boom"

--- a/tests/test_policy_fail_on.py
+++ b/tests/test_policy_fail_on.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import policy
+
+
+def test_policy_check_fail_on_security_ignores_non_security_regressions(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+
+    base = tmp_path / "baseline.json"
+    assert policy.main(["snapshot", "--output", str(base)]) == 0
+
+    # trigger a non-security regression only (stdlib shadowing)
+    (tmp_path / "src" / "json.py").write_text("x=1\n", encoding="utf-8")
+
+    assert policy.main(["check", "--baseline", str(base), "--fail-on", "security"]) == 0
+
+
+def test_policy_check_fail_on_security_fails_on_security_regression(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    base_payload = {
+        "version": 1,
+        "security": {"rule_counts": {}},
+        "repo": {"summary": {}},
+        "hygiene": {"non_ascii_files": [], "stdlib_shadowing": []},
+    }
+    base = tmp_path / "baseline.json"
+    base.write_text(json.dumps(base_payload), encoding="utf-8")
+
+    monkeypatch.setattr(
+        policy,
+        "_snapshot",
+        lambda _root: {
+            "version": 1,
+            "security": {"rule_counts": {"SECRET_GENERIC": 1}},
+            "repo": {"summary": {}},
+            "hygiene": {"non_ascii_files": [], "stdlib_shadowing": []},
+        },
+    )
+
+    assert policy.main(["check", "--baseline", str(base), "--fail-on", "security"]) == 1
+
+
+def test_policy_diff_text_and_missing_baseline(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    missing = tmp_path / "missing.json"
+    assert policy.main(["check", "--baseline", str(missing)]) == 2
+    assert "baseline not found" in capsys.readouterr().out
+
+    base = tmp_path / "baseline.json"
+    base.write_text(
+        '{"version":1,"security":{"rule_counts":{}},"repo":{"summary":{}},"hygiene":{"non_ascii_files":[],"stdlib_shadowing":[]}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        policy,
+        "_snapshot",
+        lambda _root: {
+            "version": 1,
+            "security": {"rule_counts": {"SECRET_GENERIC": 2}},
+            "repo": {"summary": {}},
+            "hygiene": {"non_ascii_files": [], "stdlib_shadowing": []},
+        },
+    )
+
+    assert policy.main(["diff", "--baseline", str(base), "--format", "text"]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("RED-FLAG security_rule_increase")

--- a/tests/test_roadmap_cli.py
+++ b/tests/test_roadmap_cli.py
@@ -1,23 +1,119 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from sdetkit import roadmap
-from sdetkit.cli import main as cli_main
 
 
-def test_roadmap_manifest_has_entries() -> None:
+def test_load_manifest_resolves_report_and_plan_paths(tmp_path: Path, monkeypatch) -> None:
+    manifest_dir = tmp_path / "docs" / "roadmap"
+    manifest_dir.mkdir(parents=True)
+
+    report = tmp_path / "docs" / "roadmap" / "reports" / "day01-report.md"
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("report", encoding="utf-8")
+
+    plan = tmp_path / "docs" / "roadmap" / "phase3" / "plans" / "day01-plan.json"
+    plan.parent.mkdir(parents=True, exist_ok=True)
+    plan.write_text("{}", encoding="utf-8")
+
+    (manifest_dir / "manifest.json").write_text(
+        json.dumps(
+            {"days": [{"day": 1, "report_file": "day01-report.md", "plan_file": "day01-plan.json"}]}
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(roadmap, "_repo_root", lambda: tmp_path)
     entries = roadmap.load_manifest()
-    assert len(entries) > 0
+
+    assert len(entries) == 1
+    assert entries[0].report_path == "docs/roadmap/reports/day01-report.md"
+    assert entries[0].plan_path == "docs/roadmap/phase3/plans/day01-plan.json"
 
 
-def test_roadmap_day69_plan_resolves_if_present() -> None:
-    e = roadmap.get_entry(69)
-    assert e is not None
-    if e.plan_file is not None:
-        assert e.plan_path is not None
+def test_load_manifest_handles_dot_prefixed_plan_candidates(tmp_path: Path, monkeypatch) -> None:
+    manifest_dir = tmp_path / "docs" / "roadmap"
+    manifest_dir.mkdir(parents=True)
+
+    dot_plan = tmp_path / ".day02-plan.json"
+    dot_plan.write_text("{}", encoding="utf-8")
+    (manifest_dir / "manifest.json").write_text(
+        json.dumps({"days": [{"day": 2, "report_file": None, "plan_file": ".day02-plan.json"}]}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(roadmap, "_repo_root", lambda: tmp_path)
+    entries = roadmap.load_manifest()
+
+    assert len(entries) == 1
+    assert entries[0].report_path is None
+    assert entries[0].plan_path == ".day02-plan.json"
 
 
-def test_cli_roadmap_list_smoke(capsys) -> None:
-    rc = cli_main(["roadmap", "list"])
-    out = capsys.readouterr().out
-    assert rc == 0
-    assert out.strip() != ""
+def test_roadmap_main_show_open_and_error_paths(monkeypatch, capsys, tmp_path: Path) -> None:
+    entry = roadmap.RoadmapEntry(
+        day=9,
+        report_file="day09-report.md",
+        plan_file="day09-plan.json",
+        report_path="docs/day09-report.md",
+        plan_path="docs/day09-plan.json",
+    )
+    monkeypatch.setattr(roadmap, "load_manifest", lambda: [entry])
+    monkeypatch.setattr(roadmap, "_repo_root", lambda: tmp_path)
+
+    assert roadmap.main(["show", "9"]) == 0
+    show_payload = json.loads(capsys.readouterr().out)
+    assert show_payload["day"] == 9
+
+    assert roadmap.main(["open", "9", "plan"]) == 0
+    open_out = capsys.readouterr().out.strip()
+    assert open_out.endswith("/docs/day09-plan.json")
+
+    assert roadmap.main(["open", "9", "report"]) == 0
+    assert capsys.readouterr().out.strip().endswith("/docs/day09-report.md")
+
+    assert roadmap.main(["show", "not-a-day"]) == 2
+    assert capsys.readouterr().err.strip() == "roadmap: invalid day"
+
+    assert roadmap.main(["show", "99"]) == 2
+    assert capsys.readouterr().err.strip() == "roadmap: unknown day"
+
+
+def test_roadmap_open_file_not_found_for_selected_kind(monkeypatch, capsys) -> None:
+    entry = roadmap.RoadmapEntry(
+        day=10,
+        report_file="day10-report.md",
+        plan_file="day10-plan.json",
+        report_path="docs/day10-report.md",
+        plan_path=None,
+    )
+    monkeypatch.setattr(roadmap, "load_manifest", lambda: [entry])
+
+    assert roadmap.main(["open", "10", "plan"]) == 2
+    assert capsys.readouterr().err.strip() == "roadmap: file not found"
+
+
+def test_roadmap_main_list_help_and_unknown_command(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        roadmap,
+        "load_manifest",
+        lambda: [
+            roadmap.RoadmapEntry(1, None, None, None, None),
+            roadmap.RoadmapEntry(2, "r.md", "p.json", "docs/r.md", "docs/p.json"),
+        ],
+    )
+
+    assert roadmap.main([]) == 0
+    assert "usage: sdetkit roadmap" in capsys.readouterr().out
+
+    assert roadmap.main(["list"]) == 0
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == ["01 - -", "02 R P"]
+
+    assert roadmap.main(["open"]) == 2
+    assert capsys.readouterr().err.strip() == "roadmap: missing day"
+
+    assert roadmap.main(["wat"]) == 2
+    assert capsys.readouterr().err.strip() == "roadmap: unknown command"


### PR DESCRIPTION
### Motivation

- Make JSON output from `gate release` deterministic and omit volatile runtime fields for CI/baseline usage.
- Allow `policy check` to selectively fail only on security regressions via a `--fail-on security` option.
- Use a slightly stricter default coverage fail threshold for local `quality.sh` runs while keeping CI override possible.

### Description

- Added `_normalize_release_steps` to `src/sdetkit/gate.py` to strip volatile fields (`duration_ms`, `stdout`, `stderr`) and normalize `cmd` entries before emitting JSON, and wired it into the release flow.
- Updated CLI docs in `docs/cli.md` to note that release JSON is deterministic and omits volatile runtime fields.
- Changed default coverage failure threshold in `quality.sh` from `70` to `80` and documented the rationale in a comment, keeping `COV_FAIL_UNDER` as an override.
- Extended `src/sdetkit/policy.py` to support `--fail-on security` during `check` so the command returns non-zero only when security regressions are present.
- Added and updated tests to cover the new behaviors and edge cases, including release JSON normalization, policy `fail-on` behavior, CI template validation, playbooks validation, cassette get behaviors, and roadmap manifest handling.

### Testing

- Ran the unit test suite (`pytest`) including the new/modified tests: `tests/test_gate_release.py`, `tests/test_policy_fail_on.py`, `tests/test_ci_templates_cli.py`, `tests/test_playbooks_validate.py`, `tests/test_main_cassette_get_extra.py`, and `tests/test_roadmap_cli.py` and they passed.
- Exercised JSON output paths for `gate release` and `policy check` to validate normalized payloads and exit codes via the added tests using `capsys` and `monkeypatch` helpers.
- Verified `quality.sh` local behavior with the updated `cov_fail_under` default; CI can still enforce a stricter threshold via `COV_FAIL_UNDER`.

------