### PR TITLE
Support non-day playbook aliases and add 'advanced weekly review control tower' playbook (day49) with tests

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -163,11 +163,29 @@ def _print_playbooks(sub) -> None:
     print("Tip: these commands still run directly, e.g. sdetkit <name> --help")
 
 
+def _resolve_non_day_playbook_alias(cmd: str) -> str:
+    """Resolve hidden day* playbook aliases like `weekly-review-closeout`."""
+    try:
+        from . import playbooks_cli
+
+        cmd_to_mod, alias_to_canonical = playbooks_cli._build_registry(playbooks_cli._pkg_dir())
+    except Exception:
+        return cmd
+
+    if cmd in alias_to_canonical and cmd in cmd_to_mod:
+        return alias_to_canonical[cmd]
+    return cmd
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     import sys
 
     if argv is None:
         argv = sys.argv[1:]
+
+    if argv:
+        argv = list(argv)
+        argv[0] = _resolve_non_day_playbook_alias(str(argv[0]))
 
     if argv and argv[0] == "playbooks":
         from .playbooks_cli import main as _playbooks_main
@@ -313,7 +331,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         return day47_reliability_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day48-objection-closeout":
         return day48_objection_closeout.main(list(argv[1:]))
-    if argv and argv[0] == "day49-weekly-review-closeout":
+    if argv and argv[0] in {
+        "day49-weekly-review-closeout",
+        "day49-advanced-weekly-review-control-tower",
+    }:
         return day49_weekly_review_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day50-execution-prioritization-closeout":
         return day50_execution_prioritization_closeout.main(list(argv[1:]))
@@ -683,6 +704,8 @@ Run: sdetkit playbooks
     d48.add_argument("args", nargs=argparse.REMAINDER)
     d49 = sub.add_parser("day49-weekly-review-closeout")
     d49.add_argument("args", nargs=argparse.REMAINDER)
+    d49_adv = sub.add_parser("day49-advanced-weekly-review-control-tower")
+    d49_adv.add_argument("args", nargs=argparse.REMAINDER)
     d50 = sub.add_parser("day50-execution-prioritization-closeout")
     d50.add_argument("args", nargs=argparse.REMAINDER)
     d51 = sub.add_parser("day51-case-snippet-closeout")
@@ -1027,7 +1050,7 @@ Run: sdetkit playbooks
         return day47_reliability_closeout.main(ns.args)
     if ns.cmd == "day48-objection-closeout":
         return day48_objection_closeout.main(ns.args)
-    if ns.cmd == "day49-weekly-review-closeout":
+    if ns.cmd in {"day49-weekly-review-closeout", "day49-advanced-weekly-review-control-tower"}:
         return day49_weekly_review_closeout.main(ns.args)
     if ns.cmd == "day50-execution-prioritization-closeout":
         return day50_execution_prioritization_closeout.main(ns.args)

--- a/src/sdetkit/day49_weekly_review_closeout.py
+++ b/src/sdetkit/day49_weekly_review_closeout.py
@@ -319,11 +319,12 @@ def build_day49_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
 
     if not failed and not critical_failures:
         wins.append(
-            "Day 49 weekly review closeout lane is fully complete and ready for Day 50 execution lane."
+            "Day 49 advanced weekly review control tower is fully complete and ready for Day 50 execution lane."
         )
 
     return {
-        "name": "day49-weekly-review-closeout",
+        "name": "day49-advanced-weekly-review-control-tower",
+        "legacy_name": "day49-weekly-review-closeout",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -357,7 +358,7 @@ def build_day49_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 49 weekly review closeout summary",
+        "Day 49 advanced weekly review control tower summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -415,6 +416,31 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         + "\n",
     )
     _write(
+        target / "day49-advanced-priority-matrix.json",
+        json.dumps(
+            {
+                "priority_model": "weighted-weekly-review",
+                "inputs": {
+                    "passed_checks": payload["summary"]["passed_checks"],
+                    "failed_checks": payload["summary"]["failed_checks"],
+                    "critical_failures": payload["summary"]["critical_failures"],
+                },
+                "priorities": [
+                    {
+                        "lane": "stability",
+                        "score": max(0, 100 - payload["summary"]["failed_checks"] * 10),
+                    },
+                    {
+                        "lane": "delivery",
+                        "score": max(0, 100 - len(payload["summary"]["critical_failures"]) * 25),
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+    _write(
         target / "day49-execution-log.md",
         "# Day 49 Execution Log\n\n- [ ] 2026-03-17: Record misses, wins, and Day 50 execution priorities.\n",
     )
@@ -452,7 +478,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Day 49 weekly review closeout checks")
+    parser = argparse.ArgumentParser(
+        description="Day 49 advanced weekly review control tower checks"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/playbooks_cli.py
+++ b/src/sdetkit/playbooks_cli.py
@@ -113,6 +113,18 @@ def _alias_for_day_closeout(mod: str) -> str | None:
     return alias_cmd
 
 
+def _alias_for_day_module(mod: str) -> str | None:
+    if not _DAY_PREFIX.match(mod):
+        return None
+    alias_mod = _DAY_PREFIX.sub("", mod, count=1)
+    if not alias_mod:
+        return None
+    alias_cmd = _mod_to_cmd(alias_mod)
+    if alias_cmd in RESERVED_NAMES:
+        return None
+    return alias_cmd
+
+
 def _build_registry(pkg_dir: Path) -> tuple[dict[str, str], dict[str, str]]:
     cmd_to_mod: dict[str, str] = {}
     alias_to_canonical: dict[str, str] = {}
@@ -130,6 +142,11 @@ def _build_registry(pkg_dir: Path) -> tuple[dict[str, str], dict[str, str]]:
         if alias and alias not in cmd_to_mod:
             cmd_to_mod[alias] = mod
             alias_to_canonical[alias] = canonical
+
+        generic_alias = _alias_for_day_module(mod)
+        if generic_alias and generic_alias not in cmd_to_mod:
+            cmd_to_mod[generic_alias] = mod
+            alias_to_canonical[generic_alias] = canonical
 
     return cmd_to_mod, alias_to_canonical
 

--- a/tests/test_coverage_boost_targets.py
+++ b/tests/test_coverage_boost_targets.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from sdetkit import cli, docs_qa, gate, netclient, playbooks_cli, proof
+from sdetkit.maintenance import registry
+from sdetkit.maintenance.checks import lint_check
+from sdetkit.maintenance.types import MaintenanceContext
+
+
+def test_maintenance_main_module_executes_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sdetkit.maintenance.cli as mcli
+
+    monkeypatch.setattr(mcli, "main", lambda: 7)
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_module("sdetkit.maintenance.__main__", run_name="__main__")
+    assert exc.value.code == 7
+
+
+def test_registry_discover_and_mode_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        registry.pkgutil,
+        "iter_modules",
+        lambda _path: [SimpleNamespace(name="_private"), SimpleNamespace(name="alpha")],
+    )
+
+    mod = SimpleNamespace(CHECK_NAME="alpha", run=lambda _ctx: None, CHECK_MODES="bad")
+    monkeypatch.setattr(registry.importlib, "import_module", lambda _name: mod)
+
+    found = registry.discover_checks()
+    assert found and found[0][0] == "alpha"
+    assert found[0][2] == {"quick", "full"}
+    assert registry.checks_for_mode("quick")[0][0] == "alpha"
+
+
+def test_lint_check_fix_mode_and_failure_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe="python",
+        mode="quick",
+        fix=True,
+        env={},
+        logger=object(),
+    )
+    monkeypatch.setattr(
+        lint_check.shutil,
+        "which",
+        lambda tool: "/usr/bin/x" if tool in {"ruff", "pre-commit"} else None,
+    )
+
+    calls: list[list[str]] = []
+
+    def _run(cmd: list[str], *, cwd: Path):
+        calls.append(cmd)
+        if cmd[-2:] == ["--check", "."]:
+            return SimpleNamespace(returncode=1, stdout="fmt", stderr="")
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(lint_check, "run_cmd", _run)
+    result = lint_check.run(ctx)
+    assert result.ok is False
+    assert any(a.id == "precommit-hygiene" for a in result.actions)
+    assert any(cmd[:4] == ["python", "-m", "pre_commit", "run"] for cmd in calls)
+
+
+def test_proof_timeout_markdown_and_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    def _fake_run(_command: str, _timeout: float):
+        raise subprocess.TimeoutExpired("cmd", 1)  # type: ignore[name-defined]
+
+    import subprocess
+
+    monkeypatch.setattr(proof, "_run_command", _fake_run)
+    out = tmp_path / "proof.md"
+    rc = proof.main(["--execute", "--format", "markdown", "--output", str(out), "--strict"])
+    captured = capsys.readouterr().out
+    assert rc == 1
+    assert "Execution results" in captured
+    assert out.exists()
+
+
+def test_playbooks_list_and_run_with_double_dash(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    rc = playbooks_cli.main(["list", "--aliases", "--search", "weekly", "--format", "json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "counts" in payload
+
+    class FakeMod:
+        @staticmethod
+        def main(args: list[str]) -> int:
+            assert args == ["--format", "json"]
+            return 0
+
+    monkeypatch.setattr(
+        playbooks_cli, "_build_registry", lambda _pkg: ({"onboarding": "onboarding"}, {})
+    )
+    monkeypatch.setattr(playbooks_cli, "import_module", lambda _name: FakeMod)
+    rc = playbooks_cli.main(["run", "onboarding", "--", "--format", "json"])
+    assert rc == 0
+
+
+def test_gate_helpers_cover_normalization_and_output(tmp_path: Path, capsys) -> None:
+    payload = {
+        "root": str(tmp_path),
+        "steps": [
+            {
+                "id": "x",
+                "cmd": ["/usr/bin/python3", str(tmp_path / "a")],
+                "duration_ms": 11,
+                "stdout": "a",
+                "stderr": "b",
+            }
+        ],
+    }
+    normalized = gate._normalize_gate_payload(payload)
+    assert normalized["root"] == "<repo>"
+    assert normalized["steps"][0]["cmd"][0] == "python"
+    assert normalized["steps"][0]["cmd"][1] == "<repo>/a"
+    assert gate._parse_step_filter("ruff,,doctor") == {"ruff", "doctor"}
+
+    gate._write_output("ok", None)
+    assert capsys.readouterr().out == "ok"
+
+
+def test_docs_qa_reference_missing_and_main_output(tmp_path: Path, capsys) -> None:
+    (tmp_path / "README.md").write_text("[missing][ref]\n", encoding="utf-8")
+    report = docs_qa.run_docs_qa(tmp_path)
+    assert report.ok is False
+    assert "missing reference definition" in report.issues[0].message
+
+    rc = docs_qa.main(["--root", str(tmp_path), "--format", "json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+
+
+def test_netclient_helper_branches() -> None:
+    assert netclient._retry_after_seconds({"Retry-After": "abc"}) is None
+    hdrs, rid = netclient._merge_headers({"A": "B"}, None, "rid")
+    assert hdrs == {"A": "B"}
+    assert rid == "rid"
+
+    req = httpx.Request("GET", "https://example.test/a")
+    resp = httpx.Response(200, request=req, headers={"Link": "<b>; rel=next"})
+    assert netclient._link_next_url(resp) == "https://example.test/b"
+
+
+def test_cli_alias_resolver_fallback_and_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        playbooks_cli,
+        "_build_registry",
+        lambda _pkg: (
+            {"weekly-review-closeout": "day49_weekly_review_closeout"},
+            {"weekly-review-closeout": "day49-weekly-review-closeout"},
+        ),
+    )
+    monkeypatch.setattr(playbooks_cli, "_pkg_dir", lambda: Path("."))
+    assert (
+        cli._resolve_non_day_playbook_alias("weekly-review-closeout")
+        == "day49-weekly-review-closeout"
+    )
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(playbooks_cli, "_build_registry", _boom)
+    assert cli._resolve_non_day_playbook_alias("weekly-review-closeout") == "weekly-review-closeout"
+
+
+def test_cli_alias_resolver_real_non_day_day_module_alias() -> None:
+    resolved = cli._resolve_non_day_playbook_alias("phase1-hardening")
+    assert resolved == "day29-phase1-hardening"

--- a/tests/test_day48_objection_closeout.py
+++ b/tests/test_day48_objection_closeout.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day48_objection_closeout as d48
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "templates/ci/gitlab").mkdir(parents=True, exist_ok=True)
+    (root / "templates/ci/jenkins").mkdir(parents=True, exist_ok=True)
+    (root / "templates/ci/tekton").mkdir(parents=True, exist_ok=True)
+    (root / "docs/roadmap/plans").mkdir(parents=True, exist_ok=True)
+    (root / "docs/roadmap/reports").mkdir(parents=True, exist_ok=True)
+
+    (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_text(
+        "docs/integrations-day48-objection-closeout.md\nday48-objection-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-48-big-upgrade-report.md\nintegrations-day48-objection-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 48 — Objection closeout lock:** convert reliability wins into deterministic objection playbooks.\n"
+        "- **Day 49 — Weekly review closeout:** harden the evidence-to-priorities loop.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day48-objection-closeout.md").write_text(
+        d48._DAY48_DEFAULT_PAGE, encoding="utf-8"
+    )
+    (root / "docs/day-48-big-upgrade-report.md").write_text("# Day 48 report\n", encoding="utf-8")
+
+    summary = (
+        root
+        / "docs/artifacts/day47-reliability-closeout-pack/day47-reliability-closeout-summary.json"
+    )
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 99, "strict_pass": True},
+                "checks": [{"check_id": "ok", "passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = root / "docs/artifacts/day47-reliability-closeout-pack/day47-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 47 delivery board",
+                "- [ ] Day 47 reliability closeout brief committed",
+                "- [ ] Day 47 winners and misses reviewed with owner + backup",
+                "- [ ] Day 47 risk register exported",
+                "- [ ] Day 47 KPI scorecard snapshot exported",
+                "- [ ] Day 48 objection priorities drafted from Day 47 learnings",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_day48_objection_closeout_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d48.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day48-objection-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day48_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d48.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day48-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day48-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day48-pack/day48-objection-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day48-pack/day48-objection-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day48-pack/day48-objection-plan.md").exists()
+    assert (tmp_path / "artifacts/day48-pack/day48-faq-objection-map.csv").exists()
+    assert (tmp_path / "artifacts/day48-pack/day48-objection-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day48-pack/day48-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day48-pack/day48-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day48-pack/day48-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day48-pack/evidence/day48-execution-summary.json").exists()
+
+
+def test_day48_strict_fails_when_day47_inputs_missing(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (
+        tmp_path
+        / "docs/artifacts/day47-reliability-closeout-pack/day47-reliability-closeout-summary.json"
+    ).unlink()
+    rc = d48.main(["--root", str(tmp_path), "--strict", "--format", "json"])
+    assert rc == 1
+
+
+def test_day48_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day48-objection-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 48 objection closeout summary" in capsys.readouterr().out

--- a/tests/test_day49_weekly_review_closeout.py
+++ b/tests/test_day49_weekly_review_closeout.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day49_weekly_review_closeout as d49
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "templates/ci/gitlab").mkdir(parents=True, exist_ok=True)
+    (root / "templates/ci/jenkins").mkdir(parents=True, exist_ok=True)
+    (root / "templates/ci/tekton").mkdir(parents=True, exist_ok=True)
+    (root / "docs/roadmap/plans").mkdir(parents=True, exist_ok=True)
+    (root / "docs/roadmap/reports").mkdir(parents=True, exist_ok=True)
+
+    (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_text(
+        "docs/integrations-day49-weekly-review-closeout.md\nday49-weekly-review-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-49-big-upgrade-report.md\nintegrations-day49-weekly-review-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 49 — Weekly review closeout:** convert objection wins into deterministic weekly review loops.\n"
+        "- **Day 50 — Execution prioritization:** lock ownership and priorities for release motion.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day49-weekly-review-closeout.md").write_text(
+        d49._DAY49_DEFAULT_PAGE, encoding="utf-8"
+    )
+    (root / "docs/day-49-big-upgrade-report.md").write_text("# Day 49 report\n", encoding="utf-8")
+
+    summary = (
+        root / "docs/artifacts/day48-objection-closeout-pack/day48-objection-closeout-summary.json"
+    )
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 99, "strict_pass": True},
+                "checks": [{"check_id": "ok", "passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = root / "docs/artifacts/day48-objection-closeout-pack/day48-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 48 delivery board",
+                "- [ ] Day 48 objection plan draft committed",
+                "- [ ] Day 48 review notes captured with owner + backup",
+                "- [ ] Day 48 FAQ objection map exported",
+                "- [ ] Day 48 KPI scorecard snapshot exported",
+                "- [ ] Day 49 weekly-review priorities drafted from Day 48 learnings",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_day49_weekly_review_closeout_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d49.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day49-advanced-weekly-review-control-tower"
+    assert out["legacy_name"] == "day49-weekly-review-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day49_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d49.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day49-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day49-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day49-pack/day49-weekly-review-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day49-pack/day49-weekly-review-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day49-pack/day49-weekly-review-brief.md").exists()
+    assert (tmp_path / "artifacts/day49-pack/day49-weekly-review-risk-register.csv").exists()
+    assert (tmp_path / "artifacts/day49-pack/day49-weekly-review-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day49-pack/day49-advanced-priority-matrix.json").exists()
+    assert (tmp_path / "artifacts/day49-pack/day49-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day49-pack/day49-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day49-pack/day49-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day49-pack/evidence/day49-execution-summary.json").exists()
+
+
+def test_day49_strict_fails_when_day48_inputs_missing(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (
+        tmp_path
+        / "docs/artifacts/day48-objection-closeout-pack/day48-objection-closeout-summary.json"
+    ).unlink()
+    rc = d49.main(["--root", str(tmp_path), "--strict", "--format", "json"])
+    assert rc == 1
+
+
+def test_day49_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day49-weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 49 advanced weekly review control tower summary" in capsys.readouterr().out
+
+
+def test_day49_advanced_alias_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(
+        ["day49-advanced-weekly-review-control-tower", "--root", str(tmp_path), "--format", "text"]
+    )
+    assert rc == 0
+    assert "advanced weekly review control tower" in capsys.readouterr().out
+
+
+def test_day49_non_day_alias_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "advanced weekly review control tower" in capsys.readouterr().out

--- a/tests/test_day68_integration_expansion4_closeout.py
+++ b/tests/test_day68_integration_expansion4_closeout.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day68_integration_expansion4_closeout as d68
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "templates/ci/tekton").mkdir(parents=True, exist_ok=True)
+    (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_text(
+        "day68-integration-expansion4-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-68-big-upgrade-report.md\nintegrations-day68-integration-expansion4-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- Day 68 integration expansion\n- Day 69 case study prep\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day68-integration-expansion4-closeout.md").write_text(
+        d68._DAY68_DEFAULT_PAGE,
+        encoding="utf-8",
+    )
+    (root / "templates/ci/tekton/day68-self-hosted-reference.yaml").write_text(
+        "\n".join(d68._REQUIRED_REFERENCE_LINES) + "\n",
+        encoding="utf-8",
+    )
+
+    summary = (
+        root
+        / "docs/artifacts/day67-integration-expansion3-closeout-pack/day67-integration-expansion3-closeout-summary.json"
+    )
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 99, "strict_pass": True},
+                "checks": [{"check_id": "ok", "passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = (
+        root / "docs/artifacts/day67-integration-expansion3-closeout-pack/day67-delivery-board.md"
+    )
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 67 delivery board",
+                "- [ ] task 1",
+                "- [ ] task 2",
+                "- [ ] task 3",
+                "- [ ] task 4",
+                "- [ ] task 5",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_day68_json_strict(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d68.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["name"] == "day68-integration-expansion4-closeout"
+    assert payload["summary"]["activation_score"] >= 95
+
+
+def test_day68_emit_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d68.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day68-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day68-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (
+        tmp_path / "artifacts/day68-pack/day68-integration-expansion4-closeout-summary.json"
+    ).exists()
+    assert (tmp_path / "artifacts/day68-pack/day68-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/day68-pack/day68-self-hosted-blueprint.md").exists()
+    assert (tmp_path / "artifacts/day68-pack/day68-policy-plan.json").exists()
+    assert (tmp_path / "artifacts/day68-pack/day68-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day68-pack/evidence/day68-execution-summary.json").exists()
+
+
+def test_day68_strict_fails_without_day67_summary(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (
+        tmp_path
+        / "docs/artifacts/day67-integration-expansion3-closeout-pack/day67-integration-expansion3-closeout-summary.json"
+    ).unlink()
+    rc = d68.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 1
+
+
+def test_day68_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(
+        ["day68-integration-expansion4-closeout", "--root", str(tmp_path), "--format", "text"]
+    )
+    assert rc == 0
+    assert "Day 68 integration expansion #4 closeout summary" in capsys.readouterr().out

--- a/tests/test_maintenance_cli.py
+++ b/tests/test_maintenance_cli.py
@@ -4,11 +4,20 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from sdetkit.maintenance import cli
-from sdetkit.maintenance.checks import lint_check, security_check
+from sdetkit.maintenance.checks import (
+    clean_tree_check,
+    custom_example_check,
+    deps_check,
+    doctor_check,
+    lint_check,
+    security_check,
+    tests_check,
+)
 from sdetkit.maintenance.types import MaintenanceContext
 from sdetkit.security import SecurityError
 
@@ -99,6 +108,139 @@ def test_fix_mode_records_actions() -> None:
     payload = json.loads(proc.stdout)
     lint_actions = payload["checks"]["lint_check"]["actions"]
     assert lint_actions
+
+
+def test_doctor_check_handles_empty_output(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor_check.doctor, "main", lambda _args: 2)
+    ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe=sys.executable,
+        mode="quick",
+        fix=False,
+        env={},
+        logger=object(),
+    )
+
+    result = doctor_check.run(ctx)
+    assert result.ok is False
+    assert result.summary == "doctor returned no JSON output"
+
+
+def test_doctor_check_full_mode_and_bad_json(monkeypatch, tmp_path: Path, capsys) -> None:
+    def _fake_main(args: list[str]) -> int:
+        print("not-json")
+        assert args == ["--format", "json", "--all"]
+        return 3
+
+    monkeypatch.setattr(doctor_check.doctor, "main", _fake_main)
+    ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe=sys.executable,
+        mode="full",
+        fix=False,
+        env={},
+        logger=object(),
+    )
+
+    result = doctor_check.run(ctx)
+    assert result.ok is False
+    assert result.summary == "doctor output was not valid JSON"
+    capsys.readouterr()
+
+
+def test_deps_check_deterministic_and_conflict_paths(monkeypatch, tmp_path: Path) -> None:
+    pip_conflict = SimpleNamespace(returncode=1, stdout="", stderr="broken")
+    monkeypatch.setattr(deps_check, "run_cmd", lambda _cmd, cwd: pip_conflict)
+
+    deterministic_ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe=sys.executable,
+        mode="quick",
+        fix=False,
+        env={"SDETKIT_DETERMINISTIC": "1"},
+        logger=object(),
+    )
+    deterministic = deps_check.run(deterministic_ctx)
+    assert deterministic.ok is False
+    assert deterministic.details["outdated"]["note"] == "skipped in deterministic mode"
+
+    calls: list[list[str]] = []
+
+    def _run(cmd: list[str], *, cwd: Path):
+        calls.append(cmd)
+        if cmd[-1] == "check":
+            return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+        return SimpleNamespace(returncode=1, stdout="fallback", stderr="")
+
+    monkeypatch.setattr(deps_check, "run_cmd", _run)
+    ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe=sys.executable,
+        mode="quick",
+        fix=False,
+        env={},
+        logger=object(),
+    )
+    nondeterministic = deps_check.run(ctx)
+    assert nondeterministic.ok is True
+    assert nondeterministic.details["outdated"]["ok"] is False
+    assert any("--outdated" in c for cmd in calls for c in cmd)
+
+
+def test_clean_tree_check_paths(monkeypatch, tmp_path: Path) -> None:
+    ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe=sys.executable,
+        mode="quick",
+        fix=False,
+        env={},
+        logger=object(),
+    )
+
+    monkeypatch.setattr(clean_tree_check.shutil, "which", lambda _tool: None)
+    missing = clean_tree_check.run(ctx)
+    assert missing.summary == "git is not available"
+
+    monkeypatch.setattr(clean_tree_check.shutil, "which", lambda _tool: "/usr/bin/git")
+    monkeypatch.setattr(
+        clean_tree_check,
+        "run_cmd",
+        lambda _cmd, cwd: SimpleNamespace(returncode=1, stdout="", stderr="boom"),
+    )
+    failed = clean_tree_check.run(ctx)
+    assert failed.summary == "git status failed"
+
+    monkeypatch.setattr(
+        clean_tree_check,
+        "run_cmd",
+        lambda _cmd, cwd: SimpleNamespace(returncode=0, stdout=" M foo.py\n", stderr=""),
+    )
+    dirty = clean_tree_check.run(ctx)
+    assert dirty.ok is False
+    assert dirty.details["count"] == 1
+
+
+def test_custom_example_and_tests_check(monkeypatch, tmp_path: Path) -> None:
+    ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe=sys.executable,
+        mode="full",
+        fix=False,
+        env={},
+        logger=object(),
+    )
+    custom = custom_example_check.run(ctx)
+    assert custom.ok is True
+    assert custom.details["mode"] == "full"
+
+    monkeypatch.setattr(
+        tests_check,
+        "run_cmd",
+        lambda _cmd, cwd: SimpleNamespace(returncode=1, stdout="", stderr="failed"),
+    )
+    failed = tests_check.run(ctx)
+    assert failed.ok is False
+    assert failed.summary == "pytest reported failures"
 
 
 def test_render_markdown_escapes_table_breaking_content() -> None:

--- a/tests/test_playbooks_validate.py
+++ b/tests/test_playbooks_validate.py
@@ -46,6 +46,14 @@ def test_playbooks_validate_aliases_are_only_alias_names(capsys) -> None:
     assert all(item["canonical"].startswith("day") for item in payload["results"])
 
 
+def test_playbooks_validate_aliases_include_non_closeout_day_aliases(capsys) -> None:
+    rc = playbooks_cli.main(["validate", "--aliases", "--format", "json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    names = [item["name"] for item in payload["results"]]
+    assert "phase1-hardening" in names
+
+
 def test_playbooks_validate_all_includes_multiple_groups(capsys) -> None:
     rc = playbooks_cli.main(["validate", "--all", "--format", "json"])
     assert rc == 0


### PR DESCRIPTION
### Motivation

- Allow non-`day*` playbook alias names (e.g. `weekly-review-closeout`, `phase1-hardening`) to resolve to canonical `day*` modules so users can invoke them with concise names.
- Introduce an advanced variant of the Day 49 playbook with a clearer name and additional emitted artifacts while preserving the legacy canonical name for compatibility.

### Description

- Add `cli._resolve_non_day_playbook_alias` to map non-day aliases to canonical `day*` commands and apply it to `main` so the first CLI arg is normalized before dispatch.
- Extend `playbooks_cli` with `_alias_for_day_module` and include generic day-module aliases in the registry returned by `_build_registry` so non-closeout day aliases are discoverable and listed as aliases.
- Treat `day49-advanced-weekly-review-control-tower` as the canonical (new) name in the Day 49 module while keeping `legacy_name` set to `day49-weekly-review-closeout` for backwards compatibility and update printed summaries and parser description accordingly.
- Emit an additional `day49-advanced-priority-matrix.json` artifact from the Day 49 emit pack and add the new `day49-advanced-weekly-review-control-tower` subcommand entry and alias handling in the CLI/playbooks listing and dispatch.
- Update CLI playbooks listing and parser branches to accept both the legacy and advanced Day 49 names and to register the advanced alias as an available command.
- Add numerous tests covering alias resolution, playbooks registry/validation, day48/day49/day68 playbook behaviors, maintenance checks, and CLI markdown rendering.

### Testing

- Added unit tests under `tests/` including `test_day49_weekly_review_closeout.py`, `test_day48_objection_closeout.py`, `test_day68_integration_expansion4_closeout.py`, `test_playbooks_validate.py` changes, and several maintenance and CLI tests in `test_maintenance_cli.py` and `test_coverage_boost_targets.py` to cover the new alias resolution and artifact emission paths.
- Ran the test suite with `pytest` and verified the new tests and existing tests exercise the alias resolver, playbook dispatch, emitted files, and maintenance checks, with the suite completing successfully.

------