### PR TITLE
Add unit tests and raise CI coverage gate to 95%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Coverage gate
         env:
-          COV_FAIL_UNDER: "70"
+          COV_FAIL_UNDER: "95"
         run: bash quality.sh cov
 
       - name: Docs build

--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -31,7 +31,7 @@ jobs:
         id: quality
         continue-on-error: true
         env:
-          COV_FAIL_UNDER: "70"
+          COV_FAIL_UNDER: "95"
         run: |
           bash quality.sh cov 2>&1 | tee quality.log
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -42,6 +42,6 @@ jobs:
 
       - name: Tests
         env:
-          COV_FAIL_UNDER: "70"
+          COV_FAIL_UNDER: "95"
         run: |
           bash quality.sh cov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install + quality gates
         shell: bash
         env:
-          COV_FAIL_UNDER: "70"
+          COV_FAIL_UNDER: "95"
         run: |
           set -euo pipefail
           python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .

--- a/tests/test_maintenance_utils.py
+++ b/tests/test_maintenance_utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit.maintenance.utils import run_cmd
+
+
+def test_run_cmd_returns_completed_process(tmp_path: Path) -> None:
+    proc = run_cmd(["python", "-c", "print('ok')"], cwd=tmp_path)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == "ok"
+    assert proc.stderr == ""

--- a/tests/test_notify_core_extra.py
+++ b/tests/test_notify_core_extra.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sdetkit import notify
+
+
+@dataclass
+class _EP:
+    name: str
+    value: object
+
+    def load(self):
+        return self.value
+
+
+class _EPs:
+    def __init__(self, items: list[_EP]) -> None:
+        self._items = items
+
+    def select(self, *, group: str):
+        return self._items if group == "sdetkit.notify_adapters" else []
+
+
+class _Record:
+    def __init__(self, factory):
+        self.factory = factory
+
+
+def test_entrypoint_adapters_handles_invalid_and_errors(monkeypatch) -> None:
+    class Good:
+        name = "good"
+
+        def send(self, _args) -> int:
+            return 0
+
+    class BadMissingSend:
+        name = "bad"
+
+    class BadLoad:
+        name = "boom"
+
+        @staticmethod
+        def load():
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        notify.metadata,
+        "entry_points",
+        lambda: _EPs([_EP("good", Good), _EP("bad", BadMissingSend), BadLoad()]),
+    )
+
+    adapters = notify._entrypoint_adapters()
+    assert set(adapters) == {"good"}
+
+
+def test_adapter_map_merges_entrypoints_and_local_plugins(monkeypatch) -> None:
+    class EPAdapter:
+        name = "ep"
+
+        def send(self, _args) -> int:
+            return 0
+
+    class LocalAdapter:
+        name = "local"
+
+        def send(self, _args) -> int:
+            return 0
+
+    class InvalidPlugin:
+        name = "invalid"
+
+    monkeypatch.setattr(notify, "_entrypoint_adapters", lambda: {"ep": EPAdapter()})
+    monkeypatch.setattr(
+        notify,
+        "discover",
+        lambda *_args, **_kwargs: [
+            _Record(lambda: LocalAdapter()),
+            _Record(lambda: InvalidPlugin()),
+            _Record(lambda: (_ for _ in ()).throw(RuntimeError("x"))),
+        ],
+    )
+
+    adapters = notify._adapter_map()
+    assert "stdout" in adapters
+    assert "telegram" in adapters
+    assert "whatsapp" in adapters
+    assert "ep" in adapters
+    assert "local" in adapters
+    assert "invalid" not in adapters
+
+
+def test_main_list_help_and_unknown(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(notify, "_adapter_map", lambda: {"stdout": object(), "x": object()})
+
+    assert notify.main(["--list"]) == 0
+    out = capsys.readouterr().out
+    assert "stdout" in out
+    assert "x" in out
+
+    assert notify.main([]) == 2
+    assert "usage:" in capsys.readouterr().out
+
+    assert notify.main(["missing", "--message", "hello"]) == 2
+    assert "not installed" in capsys.readouterr().out
+
+
+def test_main_sends_when_not_dry_run(monkeypatch) -> None:
+    called: dict[str, str] = {}
+
+    class Adapter:
+        def send(self, args) -> int:
+            called["message"] = args.message
+            return 7
+
+    monkeypatch.setattr(notify, "_adapter_map", lambda: {"a": Adapter()})
+    rc = notify.main(["a", "--message", "ping"])
+    assert rc == 7
+    assert called == {"message": "ping"}

--- a/tests/test_notify_plugins_extra.py
+++ b/tests/test_notify_plugins_extra.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+
+from sdetkit import notify_plugins
+
+
+def test_stdout_adapter_send_writes_message(capsys) -> None:
+    args = argparse.Namespace(message="hello")
+    rc = notify_plugins.StdoutAdapter().send(args)
+    assert rc == 0
+    assert capsys.readouterr().out == "hello\n"
+
+
+def test_telegram_adapter_configured_path(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("SDETKIT_TELEGRAM_TOKEN", "token")
+    monkeypatch.setenv("SDETKIT_TELEGRAM_CHAT_ID", "chat")
+    args = argparse.Namespace(message="ignored")
+    rc = notify_plugins.TelegramAdapter().send(args)
+    assert rc == 0
+    assert "configured" in capsys.readouterr().out
+
+
+def test_whatsapp_adapter_configured_path(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("SDETKIT_WHATSAPP_API_KEY", "k")
+    args = argparse.Namespace(message="ignored")
+    rc = notify_plugins.WhatsAppAdapter().send(args)
+    assert rc == 0
+    assert "configured" in capsys.readouterr().out
+
+
+def test_adapter_factory_helpers_return_expected_types() -> None:
+    assert isinstance(notify_plugins.stdout_adapter(), notify_plugins.StdoutAdapter)
+    assert isinstance(notify_plugins.telegram_adapter(), notify_plugins.TelegramAdapter)
+    assert isinstance(notify_plugins.whatsapp_adapter(), notify_plugins.WhatsAppAdapter)

--- a/tests/test_ops_cli_extra.py
+++ b/tests/test_ops_cli_extra.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit import ops
+
+
+def _write_minimal_workflow(path: Path) -> None:
+    path.write_text(
+        """
+[workflow]
+name = "mini"
+version = "1"
+[[workflow.steps]]
+id = "a"
+type = "write_file"
+inputs = { path = "a.txt", text = "ok" }
+""",
+        encoding="utf-8",
+    )
+
+
+def test_sanitize_workflow_filename_accepts_and_rejects() -> None:
+    assert ops._sanitize_workflow_filename(Path("wf.toml")) == "wf.toml"
+    with pytest.raises(ValueError):
+        ops._sanitize_workflow_filename(Path("nested/wf.toml"))
+    with pytest.raises(ValueError):
+        ops._sanitize_workflow_filename(Path("wf.exe"))
+
+
+def test_main_list_and_init_template(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert ops.main(["list", "--history-dir", "."]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"runs": []}
+
+    out = tmp_path / "templates" / "quick.toml"
+    with pytest.raises(ValueError, match="unknown template"):
+        ops.main(["init-template", "quickstart", "--output", str(out)])
+
+
+def test_main_run_replay_and_diff_json(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    wf = Path("wf.toml")
+    _write_minimal_workflow(wf)
+
+    assert (
+        ops.main(
+            [
+                "run",
+                "wf.toml",
+                "--inputs",
+                "{}",
+                "--artifacts-dir",
+                "art",
+                "--history-dir",
+                ".",
+            ]
+        )
+        == 0
+    )
+    first = json.loads(capsys.readouterr().out)
+
+    with pytest.raises(ValueError, match="relative"):
+        ops.main(["replay", first["run_id"], "--history-dir", "."])
+
+    assert (
+        ops.main(
+            ["diff", first["run_id"], first["run_id"], "--history-dir", ".", "--format", "json"]
+        )
+        == 0
+    )
+    diff = json.loads(capsys.readouterr().out)
+    assert diff["changed_steps"] == []
+
+
+def test_main_run_rejects_non_object_inputs(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    wf = Path("wf.toml")
+    _write_minimal_workflow(wf)
+
+    with pytest.raises(ValueError, match="JSON object"):
+        ops.main(["run", "wf.toml", "--inputs", "[]"])


### PR DESCRIPTION
### Motivation
- Raise the test coverage requirement to catch regressions earlier and enforce a higher quality bar. 
- Expand unit test coverage for notification adapters, notification plugins, operations CLI, and a maintenance utility to reach the new gate. 
- Ensure PR, quality, and release workflows enforce the updated coverage threshold consistently.

### Description
- Update `COV_FAIL_UNDER` from "70" to "95" in `.github/workflows/ci.yml`, `pr-quality-comment.yml`, `quality.yml`, and `release.yml` to tighten the coverage gate. 
- Add `tests/test_maintenance_utils.py` containing `test_run_cmd_returns_completed_process` which exercises `run_cmd`. 
- Add `tests/test_notify_core_extra.py` with tests for entrypoint adapter discovery, adapter map merging, and `notify.main` behaviors. 
- Add `tests/test_notify_plugins_extra.py` and `tests/test_ops_cli_extra.py` covering plugin adapters and `ops` CLI functions and edge cases.

### Testing
- Ran `pytest` which executed the new test modules and all tests passed. 
- Ran the quality gate locally with `bash quality.sh cov` to validate the coverage measurement and it passed. 
- Confirmed the CI workflow files were updated so remote runs will enforce the new `COV_FAIL_UNDER` value.

------