### PR TITLE
feat(gate): add baseline --profile release

### DIFF
--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -66,8 +66,9 @@ def _stable_json(data: dict[str, object]) -> str:
     return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n"
 
 
-def _baseline_snapshot_path(root: Path) -> Path:
-    return root / ".sdetkit" / "gate.fast.snapshot.json"
+def _baseline_snapshot_path(root: Path, profile: str) -> Path:
+    name = "gate.release.snapshot.json" if profile == "release" else "gate.fast.snapshot.json"
+    return root / ".sdetkit" / name
 
 
 def _read_text(path: Path) -> str:
@@ -438,13 +439,16 @@ def main(argv: list[str] | None = None) -> int:
         bp.add_argument("--path", default=None)
         bp.add_argument("--diff", action="store_true")
         bp.add_argument("--diff-context", type=int, default=3)
+        bp.add_argument("--profile", choices=["fast", "release"], default="fast")
         ns, extra = bp.parse_known_args(args0[1:])
         if extra and extra[0] == "--":
             extra = extra[1:]
 
         root = Path.cwd()
         snap = (
-            Path(ns.path) if isinstance(ns.path, str) and ns.path else _baseline_snapshot_path(root)
+            Path(ns.path)
+            if isinstance(ns.path, str) and ns.path
+            else _baseline_snapshot_path(root, ns.profile)
         )
         if not snap.is_absolute():
             snap = root / snap
@@ -455,7 +459,7 @@ def main(argv: list[str] | None = None) -> int:
 
         buf = io.StringIO()
         with redirect_stdout(buf):
-            rc_fast = main(["fast", "--format", "json"] + list(extra))
+            rc_fast = main([ns.profile, "--format", "json"] + list(extra))
         cur_text = buf.getvalue()
         if rc_fast != 0:
             return rc_fast
@@ -466,7 +470,7 @@ def main(argv: list[str] | None = None) -> int:
             cur_obj = None
 
         if isinstance(cur_obj, dict):
-            norm = _normalize_gate_payload(cur_obj)
+            norm = _normalize_gate_payload(cur_obj) if ns.profile == "fast" else cur_obj
             cur_text = _stable_json(norm)
 
         if ns.action == "write":

--- a/tests/test_gate_baseline.py
+++ b/tests/test_gate_baseline.py
@@ -81,3 +81,12 @@ def test_gate_baseline_check_includes_diff_when_requested(
     assert "snapshot drift detected" in data["snapshot_diff_summary"]
     assert isinstance(data.get("snapshot_diff"), str)
     assert data["snapshot_diff"].startswith("--- snapshot\n+++ current\n")
+
+
+def test_gate_baseline_release_profile_writes_release_snapshot(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = gate.main(["baseline", "write", "--profile", "release", "--", "--dry-run"])
+    assert rc == 0
+    snap = tmp_path / ".sdetkit" / "gate.release.snapshot.json"
+    assert snap.exists()
+    json.loads(snap.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

* Add `--profile fast|release` to `sdetkit gate baseline` so release readiness can be snapshotted deterministically.
* Store release snapshot at `.sdetkit/gate.release.snapshot.json` (fast remains `.sdetkit/gate.fast.snapshot.json`).

## Why

* Release readiness is now baseline-able like other gates, preventing silent drift and enabling CI-friendly regression detection.

## How

* Extend baseline arg parsing with `--profile` (default `fast`).
* Route baseline generation to `gate fast` or `gate release` depending on profile.
* Keep normalization behavior: normalize `fast` output as before; `release` output is already deterministic so it is stored directly.
* Add a focused pytest to assert the release snapshot path and JSON validity.

## Risk assessment

* Risk level: low
* Primary risk area: baseline CLI behavior (arg parsing / snapshot path selection)

## Test evidence

* Commands run:

  * `python -m pytest -q tests/test_gate_baseline.py`
  * `python -m sdetkit gate fast`
  * `python -m sdetkit baseline check --format json`
* Attach key output snippets/artifacts:

  * `tests/test_gate_baseline.py` now includes `test_gate_baseline_release_profile_writes_release_snapshot`
  * Release baseline snapshot path: `.sdetkit/gate.release.snapshot.json`

## Rollback plan

* If this causes regressions, revert commit(s):

  * `b8ece57` (`feat(gate): add baseline --profile release`)
* Mitigation while rollback executes:

  * Continue using existing `gate baseline` (fast profile) with no flags (default behavior unchanged)

## Triage and ownership

* Reviewer owner: (assign)
* Target merge window: (set)

## Checklist

* [x] Tests added/updated
* [ ] `bash ci.sh` passes
* [ ] `bash quality.sh` passes
* [ ] Docs updated (if needed)
* [ ] Issue links / acceptance criteria mapped
* [ ] Premium guideline reference reviewed: `docs/premium-quality-gate.md`
