### PR TITLE
ci: opt-in network lane + ci.sh flag + fix badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+    inputs:
+      run_network_tests:
+        description: "Run tests marked @pytest.mark.network (opt-in; default is offline-only)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -64,8 +70,13 @@ jobs:
       - name: Install project + dev/test extras
         run: python -m pip install -e .[dev,test]
 
-      - name: Canonical fast gate
+      - name: Canonical fast gate (offline default)
+        if: ${{ github.event.inputs.run_network_tests != 'true' }}
         run: bash ci.sh quick --skip-docs
+
+      - name: Canonical fast gate (with network tests)
+        if: ${{ github.event.inputs.run_network_tests == 'true' }}
+        run: bash ci.sh quick --skip-docs --run-network
 
   ci-demo-60s:
     name: 60-second CI demo artifact

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SDETKit
 
-![CI](https://github.com/DevS69/DevS69-sdetkit/actions/workflows/ci.yml/badge.svg?branch=main)
-![Quality](https://github.com/DevS69/DevS69-sdetkit/actions/workflows/quality.yml/badge.svg?branch=main)
-![Security](https://github.com/DevS69/DevS69-sdetkit/actions/workflows/security.yml/badge.svg?branch=main)
-![Repo Audit](https://github.com/DevS69/DevS69-sdetkit/actions/workflows/repo-audit.yml/badge.svg?branch=main)
-![Pages](https://github.com/DevS69/DevS69-sdetkit/actions/workflows/pages.yml/badge.svg?branch=main)
+![CI](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml/badge.svg?branch=main)
+![Quality](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/quality.yml/badge.svg?branch=main)
+![Security](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/security.yml/badge.svg?branch=main)
+![Repo Audit](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/repo-audit.yml/badge.svg?branch=main)
+![Pages](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/pages.yml/badge.svg?branch=main)
 
 SDETKit is a production-oriented SDET + DevOps toolkit for auditing repositories, running deterministic API checks, enforcing policy gates, and generating release/readiness evidence. It is designed for team adoption: stable outputs, explicit exit codes, CI-friendly commands, and safety-minded defaults.
 
@@ -34,7 +34,9 @@ Optional extras:
   - `python -m sdetkit apiget --help`
   - `python -m sdetkit cassette-get --help`
 
-- Run the full local quality gate (same as CI):
+- Run the fast CI-equivalent gate:
+  - `bash ci.sh quick --skip-docs`
+- Run the full local quality gate:
   - `bash quality.sh all`
 
 ## DevOps Quickstart
@@ -99,6 +101,9 @@ SDETKit aims to be safe by default:
 ## CI usage
 
 Recommended CI entrypoint (single reproducible command):
+
+Opt-in network tests:
+- `bash ci.sh quick --skip-docs --run-network`
 - `bash ci.sh quick --skip-docs`
 
 This runs the same fast checks CI relies on (format/lint/type/tests) while keeping docs builds opt-in.

--- a/ci.sh
+++ b/ci.sh
@@ -22,12 +22,14 @@ mode="${1:-all}"
 shift || true
 
 skip_docs=0
+run_network=0
 for arg in "$@"; do
   case "$arg" in
     --skip-docs) skip_docs=1 ;;
+    --run-network) run_network=1 ;;
     *)
       echo "unknown option: $arg" >&2
-      echo "usage: $0 {all|quick} [--skip-docs]" >&2
+      echo "usage: $0 {all|quick} [--skip-docs] [--run-network]" >&2
       exit 2
       ;;
   esac
@@ -52,6 +54,10 @@ run_types() {
 }
 
 run_tests() {
+  if [[ "$run_network" -eq 1 ]]; then
+    python3 -m pytest -q -o addopts=
+    return 0
+  fi
   python3 -m pytest -q
 }
 
@@ -81,7 +87,7 @@ case "$mode" in
     run_docs
     ;;
   *)
-    echo "usage: $0 {all|quick} [--skip-docs]" >&2
+    echo "usage: $0 {all|quick} [--skip-docs] [--run-network]" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
* Adds opt-in network tests via `workflow_dispatch` input `run_network_tests` (default remains offline).
* Extends `ci.sh` with `--run-network` to include `@pytest.mark.network` tests by overriding pytest `addopts`.
* Fixes README workflow badges to point at the correct repo (`sherif69-sa/DevS69-sdetkit`) and clarifies that CI-equivalent gate is `bash ci.sh quick --skip-docs`.

**Verification (local):**

* `python -m ruff format .`
* `python -m ruff check .`
* `python -m mypy src`
* `python -m pytest -q`
* `python -m sdetkit gate fast`
* `python -m sdetkit baseline check --format json`
* `bash ci.sh quick --skip-docs`
* `bash ci.sh quick --skip-docs --run-network`
* `bash ci.sh all --skip-docs`

**Files changed:**

* `ci.sh`
* `.github/workflows/ci.yml`
* `README.md`