### PR TITLE
quality: make test use gate fast; add full-test target

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ Optional extras:
 
 - Run the fast CI-equivalent gate:
   - `bash ci.sh quick --skip-docs`
-- Run the full local quality gate:
-  - `bash quality.sh all`
+- Run the coverage quality gate (CI/release lane):
+  - `bash quality.sh cov`
+- Run the full test suite (opt-in):
+  - `bash quality.sh full-test`
 
 ## DevOps Quickstart
 
@@ -128,8 +130,10 @@ Tip: pair `security scan --format sarif` (for code scanning upload) with `securi
 - Bootstrap the pinned dev toolchain:
   - `bash scripts/bootstrap.sh`
   - `source .venv/bin/activate`
-- Run the local quality gate before opening a PR:
-  - `bash quality.sh all`
+- Run the coverage quality gate before opening a PR:
+  - `bash quality.sh cov`
+- Optionally run the full test suite:
+  - `bash quality.sh full-test`
 
 ## Closeout lanes (Days 72-76)
 

--- a/quality.sh
+++ b/quality.sh
@@ -33,6 +33,8 @@ need_cmd() {
 run_fmt()     { need_cmd ruff; python -m ruff format .; }
 run_lint()    { need_cmd ruff; python -m ruff check .; }
 run_type()    { need_cmd mypy; python -m mypy --config-file pyproject.toml src; }
+run_gate_fast() { python -m sdetkit gate fast; }
+run_full_test() { need_cmd pytest; python -m pytest -q -o addopts=; }
 run_test()    { need_cmd pytest; python -m pytest; }
 run_cov()     { need_cmd pytest; python -m pytest --cov=sdetkit --cov-report=term-missing --cov-fail-under="$cov_fail_under"; }
 run_mut()     { need_cmd mutmut; mutmut run; }
@@ -42,8 +44,9 @@ case "$mode" in
   fmt) run_fmt ;;
   lint) run_lint ;;
   type) run_type ;;
-  test) run_test ;;
+  test) run_gate_fast ;;
   cov) run_cov ;;
+  full-test) run_full_test ;;
   mut) run_mut ;;
   muthtml) run_muthtml ;;
   all)
@@ -54,7 +57,7 @@ case "$mode" in
     run_cov
     ;;
   *)
-    echo "Usage: bash quality.sh {all|fmt|lint|type|test|cov|mut|muthtml}" >&2
+    echo "Usage: bash quality.sh {all|fmt|lint|type|test|full-test|cov|mut|muthtml}" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
* Summary: `quality.sh test` now runs `sdetkit gate fast` (fast, deterministic). Added `quality.sh full-test` for opt-in full suite.
* Why: reduces drift vs `ci.sh`/CI and keeps default path fast; full suite remains opt-in.
* How: small change in `quality.sh` dispatch + README updates.
* Risk: low (no CI workflow depended on `quality.sh test`; coverage lane `quality.sh cov` unchanged).
* Tests: `bash quality.sh test` and `bash quality.sh cov` (you already ran both successfully).