### PR TITLE
test: boost coverage for docs-nav + reliability pack helpers

### DIFF
--- a/src/sdetkit/docs_navigation.py
+++ b/src/sdetkit/docs_navigation.py
@@ -85,7 +85,10 @@ def _replace_or_append_block(
     start = text.find(start_marker)
     end = text.find(end_marker, start) if start >= 0 else -1
     if start >= 0 and end >= 0:
-        updated = text[:start] + block + text[end + len(end_marker) :]
+        tail = text[end + len(end_marker) :]
+        if block.endswith("\n") and tail.startswith("\n"):
+            tail = tail[1:]
+        updated = text[:start] + block + tail
         return updated, updated != text
     updated = text.rstrip() + ("\n\n" if text.strip() else "") + block
     return updated, updated != text

--- a/tests/test_docs_navigation.py
+++ b/tests/test_docs_navigation.py
@@ -64,3 +64,44 @@ def test_main_cli_dispatches_docs_navigation(capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "Day 11 docs navigation tune-up" in out
+
+
+def test_docs_navigation_extract_quick_jump_missing_end_returns_empty():
+    text = f"hello {docs_navigation._QUICK_JUMP_START} still-open"
+    assert docs_navigation._extract_quick_jump(text) == ""
+
+
+def test_docs_navigation_write_defaults_noop_when_already_clean(tmp_path):
+    (tmp_path / "docs").mkdir(parents=True)
+    (tmp_path / "docs/index.md").write_text("# Documentation Home\n", encoding="utf-8")
+
+    first = docs_navigation._write_defaults(tmp_path)
+    assert first == ["docs/index.md"]
+
+    second = docs_navigation._write_defaults(tmp_path)
+    assert second == []
+
+
+def test_docs_navigation_markdown_output_file_written(tmp_path, capsys):
+    (tmp_path / "docs").mkdir(parents=True)
+    content = (
+        "# Documentation Home\n\n"
+        + docs_navigation._DAY11_QUICK_JUMP_BLOCK
+        + "\n\n"
+        + docs_navigation._DAY11_SECTION_HEADER
+        + "\n\n"
+        + docs_navigation._DAY11_JOURNEYS_BLOCK
+        + "\n"
+    )
+    (tmp_path / "docs/index.md").write_text(content, encoding="utf-8")
+
+    out_path = tmp_path / "out.md"
+    rc = docs_navigation.main(
+        ["--root", str(tmp_path), "--format", "markdown", "--output", str(out_path), "--strict"]
+    )
+    assert rc == 0
+
+    written = out_path.read_text(encoding="utf-8")
+    assert "# Day 11 docs navigation tune-up" in written
+    assert "## Missing docs navigation content" in written
+    assert "- none" in written

--- a/tests/test_reliability_evidence_pack.py
+++ b/tests/test_reliability_evidence_pack.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from sdetkit import cli
 from sdetkit import reliability_evidence_pack as rep
@@ -141,3 +144,134 @@ def test_day18_cli_dispatch(tmp_path: Path, capsys) -> None:
     assert rc == 0
     out = capsys.readouterr().out
     assert "Day 18 reliability evidence pack" in out
+
+
+def test_reliability_pack_load_json_requires_object(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ValueError) as e:
+        rep._load_json(str(p))
+    assert "must contain a JSON object" in str(e.value)
+
+
+def test_reliability_pack_require_keys_reports_missing_key() -> None:
+    with pytest.raises(ValueError) as e:
+        rep._require_keys({}, ("score",), "x")
+    assert "missing required key: score" in str(e.value)
+
+
+def test_reliability_pack_normalize_execution_summary_alt_schema_zero_total() -> None:
+    out = rep._normalize_execution_summary(
+        {"passed_commands": 0, "total_commands": 0, "failed_commands": 0},
+        "alt",
+    )
+    assert out["score"] == 0.0
+    assert out["strict"] is True
+    assert out["checks_total"] == 0.0
+
+
+def test_reliability_pack_normalize_execution_summary_rejects_unknown_schema() -> None:
+    with pytest.raises(ValueError) as e:
+        rep._normalize_execution_summary({"x": 1}, "bad")
+    assert "bad summary must include" in str(e.value)
+
+
+def test_reliability_pack_execute_commands_timeout_records_error(monkeypatch) -> None:
+    def boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["x"], timeout=1, output="out", stderr="err")
+
+    monkeypatch.setattr(rep.subprocess, "run", boom)
+    rows = rep._execute_commands(["python -c 'print(1)'"], timeout_sec=1)
+    assert rows[0]["returncode"] == 124
+    assert rows[0]["ok"] is False
+    assert "timed out after" in rows[0]["error"]
+
+
+def test_reliability_pack_main_returns_2_on_missing_inputs(tmp_path: Path, capsys) -> None:
+    # Missing day15/day16/day17 files should be caught and return rc=2.
+    rc = rep.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day15-summary",
+            "missing15.json",
+            "--day16-summary",
+            "missing16.json",
+            "--day17-summary",
+            "missing17.json",
+            "--format",
+            "text",
+        ]
+    )
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert out.strip() != ""
+
+
+def test_reliability_pack_main_markdown_writes_output_file(tmp_path: Path) -> None:
+    day15, day16, day17 = _write_inputs(tmp_path)
+    _write_page(tmp_path)
+
+    out_path = tmp_path / "pack.md"
+    rc = rep.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day15-summary",
+            str(day15.relative_to(tmp_path)),
+            "--day16-summary",
+            str(day16.relative_to(tmp_path)),
+            "--day17-summary",
+            str(day17.relative_to(tmp_path)),
+            "--format",
+            "markdown",
+            "--output",
+            str(out_path.relative_to(tmp_path)),
+        ]
+    )
+    assert rc == 0
+    assert out_path.exists()
+    assert "Day 18 reliability evidence pack" in out_path.read_text(encoding="utf-8")
+
+
+def test_reliability_pack_strict_fails_when_page_missing_and_score_low(
+    tmp_path: Path, capsys
+) -> None:
+    # Create inputs that produce a very low reliability_score and a page missing required content.
+    day15 = tmp_path / "day15.json"
+    day16 = tmp_path / "day16.json"
+    day17 = tmp_path / "day17.json"
+    day15.write_text(
+        '{"score": 0.0, "strict": true, "checks_passed": 0, "checks_total": 10}\n', encoding="utf-8"
+    )
+    day16.write_text(
+        '{"score": 0.0, "strict": true, "checks_passed": 0, "checks_total": 10}\n', encoding="utf-8"
+    )
+    day17.write_text(
+        '{"name":"day17-quality-contribution-delta","quality":{"stability_score":0.0},"contributions":{"velocity_score":0.0},"strict_failures":[]}\n',
+        encoding="utf-8",
+    )
+    # Write a page that is missing the required header/sections/commands.
+    (tmp_path / "docs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "docs/integrations-reliability-evidence-pack.md").write_text(
+        "# empty\n", encoding="utf-8"
+    )
+
+    rc = rep.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day15-summary",
+            str(day15.relative_to(tmp_path)),
+            "--day16-summary",
+            str(day16.relative_to(tmp_path)),
+            "--day17-summary",
+            str(day17.relative_to(tmp_path)),
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["strict_failures"]


### PR DESCRIPTION
## Summary
- Coverage wave for `docs-nav` + `reliability-evidence-pack` helpers.
- Makes `docs-nav --write-defaults` idempotent (second run becomes a no-op).

## Why
- Increase confidence/coverage on error + edge paths without changing user-facing CLI contracts.
- Avoid noisy rewrites of `docs/index.md` when content is already in the desired shape.

## How
- Add targeted tests for:
  - `docs_navigation`: quick-jump parsing edge case + `--write-defaults` idempotence behavior.
  - `reliability_evidence_pack`: helper validation errors, alternate schema normalization, timeout path, strict failure aggregation, and output modes.
- Small behavior fix: `_replace_or_append_block(...)` now avoids rewriting when the block is already present.

## Risk assessment
- Risk level: low
- Primary risk area: docs-nav write-defaults behavior (now stable/idempotent).

## Test evidence
- Commands run:
  - `python -m ruff format src/sdetkit/docs_navigation.py tests/test_docs_navigation.py tests/test_reliability_evidence_pack.py`
  - `python -m ruff check src/sdetkit/docs_navigation.py tests/test_docs_navigation.py tests/test_reliability_evidence_pack.py`
  - `python -m pytest -q tests/test_docs_navigation.py tests/test_reliability_evidence_pack.py`

## Rollback plan
- Revert commit(s): `77413b5`
- Mitigation while rollback executes: none needed (non-breaking change; tests-only + idempotence tweak).

## Checklist
- [x] Tests added/updated
- [x] Docs updated (not required for this wave)
