### PR TITLE
test: cover production-readiness text/markdown output paths

### DIFF
--- a/tests/test_production_readiness_extra.py
+++ b/tests/test_production_readiness_extra.py
@@ -22,3 +22,27 @@ def test_main_emit_pack_and_strict_failure(tmp_path: Path, capsys) -> None:
     assert payload["summary"]["strict_pass"] is False
     assert (out / "production-readiness-summary.json").exists()
     assert (out / "production-readiness-report.md").exists()
+
+
+def test_render_text_includes_check_status_lines(tmp_path: Path) -> None:
+    payload = pr.build_production_readiness_summary(tmp_path)
+
+    text = pr._render_text(payload)
+
+    assert text.startswith("production-readiness\n")
+    assert "checks:" in text
+    assert "- [FAIL] governance_core_docs" in text
+
+
+def test_main_markdown_and_text_output_modes(tmp_path: Path, capsys) -> None:
+    markdown_rc = pr.main(["--root", str(tmp_path), "--format", "markdown"])
+    markdown_out = capsys.readouterr().out
+
+    assert markdown_rc == 0
+    assert markdown_out.startswith("# Production readiness report")
+
+    text_rc = pr.main(["--root", str(tmp_path), "--format", "text"])
+    text_out = capsys.readouterr().out
+
+    assert text_rc == 0
+    assert text_out.startswith("production-readiness")


### PR DESCRIPTION
### Motivation
- Improve real line and branch coverage for the `production_readiness` module by exercising text and markdown rendering paths that were previously untested.

### Description
- Added focused tests in `tests/test_production_readiness_extra.py` to exercise `_render_text(...)` output and CLI `main(...)` branches for `--format markdown` and `--format text`.
- The new tests assert presence of summary lines, failed-check formatting (e.g. `- [FAIL] governance_core_docs`), and that `main()` returns `0` for non-strict runs and emits the expected output formats.
- The change is a single test-file update that broadens coverage around rendering and output-selection logic for `sdetkit.production_readiness`.

### Testing
- Ran `pytest -q tests/test_production_readiness.py tests/test_production_readiness_extra.py` and all tests passed (`6 passed`).
- Ran coverage targeted to the module with `pytest -q ... --cov=sdetkit.production_readiness --cov-report=term-missing` and `src/sdetkit/production_readiness.py` reported `100%` coverage.
- Existing repository test run shown earlier completed successfully (full suite run producing `1292 passed, 3 deselected`).

------