### PR TITLE
Add product strategy and release-confidence quickstart; update README and mkdocs nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ SDETKit is designed as an **execution layer for trusted delivery**:
 - **Readiness by default**: quality, security, and release controls in one workflow.
 - **Adoption-focused UX**: clear command groups, practical docs, and role-based paths.
 
+## Product direction (next 30 days)
+
+To evolve this repository into a focused product, we are prioritizing one primary use-case:
+
+- **Release Confidence Engine for SDET/DevOps teams**
+- Goal: provide deterministic, repeatable evidence that a repository is safe to ship.
+
+Start with the focused strategy checklist:
+
+- `docs/product-strategy.md`
+
+Fast path to run the "release confidence" workflow:
+
+```bash
+bash ci.sh quick --skip-docs
+bash quality.sh cov
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+python -m sdetkit gate release
+```
+
 ## Installation
 
 ### Runtime install

--- a/docs/product-strategy.md
+++ b/docs/product-strategy.md
@@ -1,0 +1,65 @@
+# Product Strategy: Make SDETKit a Real Tool
+
+## Primary wedge
+
+**SDETKit v1 focus:** become a **Release Confidence Engine** for SDET and DevOps teams.
+
+### Problem
+Teams often run quality, security, and release checks in disconnected tools, which creates
+unclear ship/no-ship decisions and weak auditability.
+
+### Outcome
+Given a repository, SDETKit should produce deterministic evidence that answers:
+
+- Is this build safe to ship now?
+- If not, what failed and why?
+- What artifact can be shared with engineering leadership?
+
+## Hero workflow (ship-ready lane)
+
+Use this sequence as the default v1 story:
+
+```bash
+bash ci.sh quick --skip-docs
+bash quality.sh cov
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+python -m sdetkit gate release
+```
+
+## 30-day execution plan
+
+### Week 1 — positioning + onboarding
+
+- Keep one primary persona in all docs: SDET/DevOps release owner.
+- Add one single-page quickstart for the hero workflow.
+- Define 3 measurable success metrics.
+
+### Week 2 — product UX hardening
+
+- Add opinionated command presets (`quick`, `safe`, `release`) in docs and CLI help.
+- Reduce decision points in first-run experience.
+- Validate deterministic outputs and exit codes in tests.
+
+### Week 3 — proof of value
+
+- Publish two example scenarios (startup team + platform team).
+- Include expected outputs and pass/fail interpretation.
+- Add one reproducible release evidence artifact example.
+
+### Week 4 — trust and adoption
+
+- Add release narrative template tied to generated evidence.
+- Document CI/CD integration copy-paste snippets by role.
+- Prepare v1 scope freeze criteria and non-goals.
+
+## Success metrics
+
+- **Time to first successful release lane:** under 10 minutes from install.
+- **Deterministic rerun consistency:** same inputs produce same pass/fail outputs.
+- **Adoption signal:** repeated weekly usage of the hero workflow in target repos.
+
+## What we will not optimize yet
+
+- Broad feature expansion outside release-confidence scope.
+- Persona-specific deep customization before core workflow stability.
+- Complex integrations that reduce determinism or increase setup friction.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
       - Plugins, rule packs, and fix-audit: plugins-and-fix.md
       - PR automation for audit auto-fixes: pr-automation.md
   - Strategy:
+      - Product strategy (release confidence): product-strategy.md
       - Enterprise + regulated workflow: use-cases-enterprise-regulated.md
       - Startup + small-team workflow: use-cases-startup-small-team.md
       - Production S-class tier blueprint for the next 90-day boost: production-s-class-90-day-boost.md


### PR DESCRIPTION
### Motivation

- Provide a focused 30-day product direction to pivot the repository toward a "Release Confidence Engine" for SDET/DevOps teams.
- Make it easy for users to run a deterministic hero workflow that produces repeatable evidence for ship/no-ship decisions.

### Description

- Adds a new product strategy document at `docs/product-strategy.md` that outlines the primary wedge, a 30-day plan, success metrics, and the hero workflow.
- Updates `README.md` to include a "Product direction (next 30 days)" section and a fast-path quickstart with the recommended commands to run the release-confidence workflow (`bash ci.sh quick --skip-docs`, `bash quality.sh cov`, `python -m sdetkit security enforce ...`, `python -m sdetkit gate release`).
- Updates `mkdocs.yml` to include the new "Product strategy (release confidence)" page in the site navigation.

### Testing

- No automated tests were added or executed as part of this change.

------