### PR TITLE
Add Day 91 continuous upgrade closeout lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ docker build -t sdetkit .
 docker run --rm -v "$PWD:/work" -w /work sdetkit python -m sdetkit gate fast
 ```
 
+## Continuous upgrade lane
+
+```bash
+python -m sdetkit day90-phase3-wrap-publication-closeout --format json --strict
+python -m sdetkit day91-continuous-upgrade-closeout --format json --strict
+```
+
 ## Documentation
 
 - Docs portal: <https://sherif69-sa.github.io/DevS69-sdetkit/>

--- a/docs/day-91-big-upgrade-report.md
+++ b/docs/day-91-big-upgrade-report.md
@@ -1,0 +1,16 @@
+# Day 91 big upgrade report
+
+## What shipped
+
+- Added `day91-continuous-upgrade-closeout` command to score Day 91 readiness from Day 90 publication artifacts.
+- Added deterministic pack emission and execution evidence generation for continuous upgrade proof.
+- Added strict contract validation script and tests that enforce Day 91 closeout quality gates.
+
+## Command lane
+
+```bash
+python -m sdetkit day91-continuous-upgrade-closeout --format json --strict
+python -m sdetkit day91-continuous-upgrade-closeout --emit-pack-dir docs/artifacts/day91-continuous-upgrade-closeout-pack --format json --strict
+python -m sdetkit day91-continuous-upgrade-closeout --execute --evidence-dir docs/artifacts/day91-continuous-upgrade-closeout-pack/evidence --format json --strict
+python scripts/check_day91_continuous_upgrade_closeout_contract.py
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Build, validate, and release software with confidence using a polished SDET + De
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+[⚡ Fast start](#fast-start) · [📦 Day 90 report](day-90-big-upgrade-report.md) · [🔒 Day 90 lane](integrations-day90-phase3-wrap-publication-closeout.md) · [📦 Day 91 report](day-91-big-upgrade-report.md) · [🔁 Day 91 lane](integrations-day91-continuous-upgrade-closeout.md) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [✅ Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
 
 </div>
 

--- a/docs/integrations-day91-continuous-upgrade-closeout.md
+++ b/docs/integrations-day91-continuous-upgrade-closeout.md
@@ -1,0 +1,51 @@
+# Day 91 — Continuous upgrade closeout lane
+
+Day 91 starts the next cycle by converting Day 90 publication outcomes into a deterministic continuous-upgrade lane.
+
+## Why Day 91 matters
+
+- Converts Day 90 publication artifacts into a repeatable execution loop for ongoing repository upgrades.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 91 closeout into the continuous-upgrade backlog.
+
+## Required inputs (Day 90)
+
+- `docs/artifacts/day90-phase3-wrap-publication-closeout-pack/day90-phase3-wrap-publication-closeout-summary.json`
+- `docs/artifacts/day90-phase3-wrap-publication-closeout-pack/day90-delivery-board.md`
+- `docs/roadmap/plans/day91-continuous-upgrade-plan.json`
+
+## Day 91 command lane
+
+```bash
+python -m sdetkit day91-continuous-upgrade-closeout --format json --strict
+python -m sdetkit day91-continuous-upgrade-closeout --emit-pack-dir docs/artifacts/day91-continuous-upgrade-closeout-pack --format json --strict
+python -m sdetkit day91-continuous-upgrade-closeout --execute --evidence-dir docs/artifacts/day91-continuous-upgrade-closeout-pack/evidence --format json --strict
+python scripts/check_day91_continuous_upgrade_closeout_contract.py
+```
+
+## Continuous upgrade contract
+
+- Single owner + backup reviewer are assigned for Day 91 continuous upgrade execution and signoff.
+- The Day 91 lane references Day 90 outcomes, controls, and trust continuity signals.
+- Every Day 91 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 91 closeout records continuous upgrade outputs, report publication status, and backlog inputs.
+
+## Continuous upgrade quality checklist
+
+- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to upgrade docs/templates + runnable command evidence
+- [ ] Scorecard captures continuous upgrade adoption delta, confidence, and rollback owner
+- [ ] Artifact pack includes upgrade brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log
+
+## Day 91 delivery board
+
+- [ ] Day 91 evidence brief committed
+- [ ] Day 91 continuous upgrade plan committed
+- [ ] Day 91 upgrade template upgrade ledger exported
+- [ ] Day 91 storyline outcomes ledger exported
+- [ ] Next-cycle roadmap draft captured from Day 91 outcomes
+
+## Scoring model
+
+Day 91 weights continuity + execution contract + upgrade artifact readiness for a 100-point activation score.

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -466,6 +466,12 @@
       "plan_path": "docs/roadmap/phase3/plans/day90-phase3-wrap-publication-plan.json",
       "report_path": "docs/roadmap/reports/day-90-big-upgrade-report.md",
       "report_title": "Day 90 big upgrade report"
+    },
+    {
+      "day": 91,
+      "plan_path": "docs/roadmap/phase3/plans/day91-continuous-upgrade-plan.json",
+      "report_path": "docs/roadmap/reports/day-91-big-upgrade-report.md",
+      "report_title": "Day 91 big upgrade report"
     }
   ]
 }

--- a/docs/roadmap/reports/day-91-big-upgrade-report.md
+++ b/docs/roadmap/reports/day-91-big-upgrade-report.md
@@ -1,0 +1,16 @@
+# Day 91 big upgrade report
+
+## What shipped
+
+- Added `day91-continuous-upgrade-closeout` command to score Day 91 readiness from Day 90 publication artifacts.
+- Added deterministic pack emission and execution evidence generation for continuous upgrade proof.
+- Added strict contract validation script and tests that enforce Day 91 closeout quality gates.
+
+## Command lane
+
+```bash
+python -m sdetkit day91-continuous-upgrade-closeout --format json --strict
+python -m sdetkit day91-continuous-upgrade-closeout --emit-pack-dir docs/artifacts/day91-continuous-upgrade-closeout-pack --format json --strict
+python -m sdetkit day91-continuous-upgrade-closeout --execute --evidence-dir docs/artifacts/day91-continuous-upgrade-closeout-pack/evidence --format json --strict
+python scripts/check_day91_continuous_upgrade_closeout_contract.py
+```

--- a/docs/top-10-github-strategy.md
+++ b/docs/top-10-github-strategy.md
@@ -270,6 +270,7 @@ Phase 3 turns growth into durable ecosystem trust: stronger community rituals, d
 - **Day 89 — Next-cycle planning:** draft next 90-day strategy from validated learnings.
 - **Day 89 — Final review:** package wins, misses, and corrective actions.
 - **Day 90 — Phase-3 wrap + publication:** ship final 90-day report and publish next-cycle roadmap.
+- **Day 91 — Continuous upgrade closeout lane:** convert Day 90 publication outputs into deterministic continuous-improvement execution.
 
 #### Phase-3 weekly deliverables (must ship)
 

--- a/plans/day91-continuous-upgrade-plan.json
+++ b/plans/day91-continuous-upgrade-plan.json
@@ -1,0 +1,14 @@
+{
+  "plan_id": "day91-continuous-upgrade-001",
+  "contributors": ["maintainers", "release-ops", "docs-ops"],
+  "upgrade_channels": ["readme", "docs-index", "cli-lanes"],
+  "baseline": {
+    "strict_pass_rate": 0.9,
+    "doc_link_coverage": 0.88
+  },
+  "target": {
+    "strict_pass_rate": 1.0,
+    "doc_link_coverage": 0.97
+  },
+  "owner": "release-ops"
+}

--- a/scripts/check_day91_continuous_upgrade_closeout_contract.py
+++ b/scripts/check_day91_continuous_upgrade_closeout_contract.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import day91_continuous_upgrade_closeout as d91
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Day 91 continuous upgrade closeout contract"
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d91.build_day91_continuous_upgrade_closeout_summary(root)
+    errors: list[str] = []
+
+    if not payload.get("summary", {}).get("strict_pass", False):
+        errors.append("summary.strict_pass is false")
+
+    if payload.get("summary", {}).get("activation_score", 0) < 95:
+        errors.append("activation_score below 95")
+
+    if payload.get("summary", {}).get("critical_failures"):
+        errors.append("critical_failures is not empty")
+
+    if not ns.skip_evidence:
+        evidence = (
+            root
+            / "docs/artifacts/day91-continuous-upgrade-closeout-pack/evidence/day91-execution-summary.json"
+        )
+        if not evidence.exists():
+            errors.append(f"missing evidence summary: {evidence}")
+        else:
+            data = json.loads(evidence.read_text(encoding="utf-8"))
+            if int(data.get("total_commands", 0)) < 3:
+                errors.append("evidence total_commands below 3")
+
+    if errors:
+        print("day91-continuous-upgrade-closeout contract check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("day91-continuous-upgrade-closeout contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -71,6 +71,7 @@ from . import (
     day88_governance_priorities_closeout,
     day89_governance_scale_closeout,
     day90_phase3_wrap_publication_closeout,
+    day91_continuous_upgrade_closeout,
     demo,
     docs_navigation,
     docs_qa,
@@ -455,6 +456,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day90-phase3-wrap-publication-closeout":
         return day90_phase3_wrap_publication_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "day91-continuous-upgrade-closeout":
+        return day91_continuous_upgrade_closeout.main(list(argv[1:]))
+
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
 
@@ -811,6 +815,8 @@ Run: sdetkit playbooks
     d89.add_argument("args", nargs=argparse.REMAINDER)
     d90 = sub.add_parser("day90-phase3-wrap-publication-closeout")
     d90.add_argument("args", nargs=argparse.REMAINDER)
+    d91 = sub.add_parser("day91-continuous-upgrade-closeout")
+    d91.add_argument("args", nargs=argparse.REMAINDER)
 
     fqo = sub.add_parser("faq-objections")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
@@ -1164,6 +1170,9 @@ Run: sdetkit playbooks
 
     if ns.cmd == "day90-phase3-wrap-publication-closeout":
         return day90_phase3_wrap_publication_closeout.main(ns.args)
+
+    if ns.cmd == "day91-continuous-upgrade-closeout":
+        return day91_continuous_upgrade_closeout.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/day91_continuous_upgrade_closeout.py
+++ b/src/sdetkit/day91_continuous_upgrade_closeout.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-day91-continuous-upgrade-closeout.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_DAY90_SUMMARY_PATH = "docs/artifacts/day90-phase3-wrap-publication-closeout-pack/day90-phase3-wrap-publication-closeout-summary.json"
+_DAY90_BOARD_PATH = "docs/artifacts/day90-phase3-wrap-publication-closeout-pack/day90-delivery-board.md"
+_PLAN_PATH = "docs/roadmap/plans/day91-continuous-upgrade-plan.json"
+_SECTION_HEADER = "# Day 91 \u2014 Continuous upgrade closeout lane"
+_REQUIRED_SECTIONS = [
+    "## Why Day 91 matters",
+    "## Required inputs (Day 90)",
+    "## Day 91 command lane",
+    "## Continuous upgrade contract",
+    "## Continuous upgrade quality checklist",
+    "## Day 91 delivery board",
+    "## Scoring model",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit day91-continuous-upgrade-closeout --format json --strict",
+    "python -m sdetkit day91-continuous-upgrade-closeout --emit-pack-dir docs/artifacts/day91-continuous-upgrade-closeout-pack --format json --strict",
+    "python -m sdetkit day91-continuous-upgrade-closeout --execute --evidence-dir docs/artifacts/day91-continuous-upgrade-closeout-pack/evidence --format json --strict",
+    "python scripts/check_day91_continuous_upgrade_closeout_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit day91-continuous-upgrade-closeout --format json --strict",
+    "python -m sdetkit day91-continuous-upgrade-closeout --emit-pack-dir docs/artifacts/day91-continuous-upgrade-closeout-pack --format json --strict",
+    "python scripts/check_day91_continuous_upgrade_closeout_contract.py --skip-evidence",
+]
+_REQUIRED_CONTRACT_LINES = [
+    "Single owner + backup reviewer are assigned for Day 91 continuous upgrade execution and signoff.",
+    "The Day 91 lane references Day 90 outcomes, controls, and trust continuity signals.",
+    "Every Day 91 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "Day 91 closeout records continuous upgrade outputs, report publication status, and backlog inputs.",
+]
+_REQUIRED_QUALITY_LINES = [
+    "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
+    "- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag",
+    "- [ ] CTA links point to upgrade docs/templates + runnable command evidence",
+    "- [ ] Scorecard captures continuous upgrade adoption delta, confidence, and rollback owner",
+    "- [ ] Artifact pack includes upgrade brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
+]
+_REQUIRED_DELIVERY_BOARD_LINES = [
+    "- [ ] Day 91 evidence brief committed",
+    "- [ ] Day 91 continuous upgrade plan committed",
+    "- [ ] Day 91 upgrade template upgrade ledger exported",
+    "- [ ] Day 91 storyline outcomes ledger exported",
+    "- [ ] Next-cycle roadmap draft captured from Day 91 outcomes",
+]
+_REQUIRED_DATA_KEYS = [
+    '"plan_id"',
+    '"contributors"',
+    '"upgrade_channels"',
+    '"baseline"',
+    '"target"',
+    '"owner"',
+]
+
+_DAY91_DEFAULT_PAGE = """# Day 91 \u2014 Continuous upgrade closeout lane
+
+Day 91 closes with a major upgrade that converts Day 90 governance scale outcomes into a deterministic phase-3 wrap and publication operating lane.
+
+## Why Day 91 matters
+
+- Converts Day 90 governance scale outcomes into reusable publication decisions across release recap, roadmap governance, and maintainer escalation paths.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Day 91 closeout into the continuous-upgrade backlog.
+
+## Required inputs (Day 90)
+
+- `docs/artifacts/day90-phase3-wrap-publication-closeout-pack/day90-phase3-wrap-publication-closeout-summary.json`
+- `docs/artifacts/day90-phase3-wrap-publication-closeout-pack/day90-delivery-board.md`
+- `docs/roadmap/plans/day91-continuous-upgrade-plan.json`
+
+## Day 91 command lane
+
+```bash
+python -m sdetkit day91-continuous-upgrade-closeout --format json --strict
+python -m sdetkit day91-continuous-upgrade-closeout --emit-pack-dir docs/artifacts/day91-continuous-upgrade-closeout-pack --format json --strict
+python -m sdetkit day91-continuous-upgrade-closeout --execute --evidence-dir docs/artifacts/day91-continuous-upgrade-closeout-pack/evidence --format json --strict
+python scripts/check_day91_continuous_upgrade_closeout_contract.py
+```
+
+## Continuous upgrade contract
+
+- Single owner + backup reviewer are assigned for Day 91 continuous upgrade execution and signoff.
+- The Day 91 lane references Day 90 outcomes, controls, and trust continuity signals.
+- Every Day 91 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Day 91 closeout records continuous upgrade outputs, report publication status, and backlog inputs.
+
+## Continuous upgrade quality checklist
+
+- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to upgrade docs/templates + runnable command evidence
+- [ ] Scorecard captures continuous upgrade adoption delta, confidence, and rollback owner
+- [ ] Artifact pack includes upgrade brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log
+
+## Day 91 delivery board
+
+- [ ] Day 91 evidence brief committed
+- [ ] Day 91 continuous upgrade plan committed
+- [ ] Day 91 upgrade template upgrade ledger exported
+- [ ] Day 91 storyline outcomes ledger exported
+- [ ] Next-cycle roadmap draft captured from Day 91 outcomes
+
+## Scoring model
+
+Day 91 weights continuity + execution contract + governance artifact readiness for a 100-point activation score.
+"""
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _checklist_count(markdown: str) -> int:
+    return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
+
+
+def build_day91_continuous_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
+    readme_text = _read_text(root / "README.md")
+    docs_index_text = _read_text(root / "docs/index.md")
+    page_text = _read_text(root / _PAGE_PATH)
+    top10_text = _read_text(root / _TOP10_PATH)
+    day90_summary = root / _DAY90_SUMMARY_PATH
+    day90_board = root / _DAY90_BOARD_PATH
+
+    day90_data = _load_json(day90_summary)
+    day90_summary_data = (
+        day90_data.get("summary", {}) if isinstance(day90_data.get("summary"), dict) else {}
+    )
+    day90_score = int(day90_summary_data.get("activation_score", 0) or 0)
+    day90_strict = bool(day90_summary_data.get("strict_pass", False))
+    day90_check_count = (
+        len(day90_data.get("checks", [])) if isinstance(day90_data.get("checks"), list) else 0
+    )
+
+    board_text = _read_text(day90_board)
+    board_count = _checklist_count(board_text)
+    board_has_day90 = "Day 90" in board_text
+
+    missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+    missing_contract_lines = [line for line in _REQUIRED_CONTRACT_LINES if line not in page_text]
+    missing_quality_lines = [line for line in _REQUIRED_QUALITY_LINES if line not in page_text]
+    missing_board_items = [item for item in _REQUIRED_DELIVERY_BOARD_LINES if item not in page_text]
+
+    plan_text = _read_text(root / _PLAN_PATH)
+    missing_plan_keys = [key for key in _REQUIRED_DATA_KEYS if key not in plan_text]
+
+    checks: list[dict[str, Any]] = [
+        {
+            "check_id": "readme_day91_command",
+            "weight": 7,
+            "passed": ("day91-continuous-upgrade-closeout" in readme_text),
+            "evidence": "README day91 command lane",
+        },
+        {
+            "check_id": "docs_index_day91_links",
+            "weight": 8,
+            "passed": (
+                "day-91-big-upgrade-report.md" in docs_index_text
+                and "integrations-day91-continuous-upgrade-closeout.md" in docs_index_text
+            ),
+            "evidence": "day-91-big-upgrade-report.md + integrations-day91-continuous-upgrade-closeout.md",
+        },
+        {
+            "check_id": "top10_day91_alignment",
+            "weight": 5,
+            "passed": ("Day 90" in top10_text and "Day 91" in top10_text),
+            "evidence": "Day 90 + Day 91 strategy chain",
+        },
+        {
+            "check_id": "day90_summary_present",
+            "weight": 10,
+            "passed": day90_summary.exists(),
+            "evidence": str(day90_summary),
+        },
+        {
+            "check_id": "day90_delivery_board_present",
+            "weight": 7,
+            "passed": day90_board.exists(),
+            "evidence": str(day90_board),
+        },
+        {
+            "check_id": "day90_quality_floor",
+            "weight": 13,
+            "passed": day90_score >= 85 and day90_strict,
+            "evidence": {
+                "day90_score": day90_score,
+                "strict_pass": day90_strict,
+                "day90_checks": day90_check_count,
+            },
+        },
+        {
+            "check_id": "day90_board_integrity",
+            "weight": 5,
+            "passed": board_count >= 5 and board_has_day90,
+            "evidence": {"board_items": board_count, "contains_day90": board_has_day90},
+        },
+        {
+            "check_id": "page_header",
+            "weight": 7,
+            "passed": _SECTION_HEADER in page_text,
+            "evidence": _SECTION_HEADER,
+        },
+        {
+            "check_id": "required_sections",
+            "weight": 8,
+            "passed": not missing_sections,
+            "evidence": missing_sections or "all sections present",
+        },
+        {
+            "check_id": "required_commands",
+            "weight": 5,
+            "passed": not missing_commands,
+            "evidence": missing_commands or "all commands present",
+        },
+        {
+            "check_id": "contract_lock",
+            "weight": 5,
+            "passed": not missing_contract_lines,
+            "evidence": missing_contract_lines or "contract locked",
+        },
+        {
+            "check_id": "quality_checklist_lock",
+            "weight": 5,
+            "passed": not missing_quality_lines,
+            "evidence": missing_quality_lines or "quality checklist locked",
+        },
+        {
+            "check_id": "delivery_board_lock",
+            "weight": 5,
+            "passed": not missing_board_items,
+            "evidence": missing_board_items or "delivery board locked",
+        },
+        {
+            "check_id": "evidence_plan_data_present",
+            "weight": 10,
+            "passed": not missing_plan_keys,
+            "evidence": missing_plan_keys or _PLAN_PATH,
+        },
+    ]
+
+    failed = [c for c in checks if not c["passed"]]
+    critical_failures: list[str] = []
+    if not day90_summary.exists() or not day90_board.exists():
+        critical_failures.append("day90_handoff_inputs")
+
+    wins: list[str] = []
+    misses: list[str] = []
+    handoff_actions: list[str] = []
+
+    if day90_score >= 85 and day90_strict:
+        wins.append(f"Day 90 continuity baseline is stable with activation score={day90_score}.")
+    else:
+        misses.append("Day 90 continuity baseline is below the floor (<85) or not strict-pass.")
+        handoff_actions.append(
+            "Re-run Day 90 closeout command and raise baseline quality above 85 with strict pass before Day 91 lock."
+        )
+
+    if board_count >= 5 and board_has_day90:
+        wins.append(
+            f"Day 90 delivery board integrity validated with {board_count} checklist items."
+        )
+    else:
+        misses.append(
+            "Day 90 delivery board integrity is incomplete (needs >=5 items and Day 90 anchors)."
+        )
+        handoff_actions.append("Repair Day 90 delivery board entries to include Day 90 anchors.")
+
+    if not missing_plan_keys:
+        wins.append(
+            "Day 91 continuous upgrade dataset is available for governance execution."
+        )
+    else:
+        misses.append("Day 91 continuous upgrade dataset is missing required keys.")
+        handoff_actions.append(
+            "Update docs/roadmap/plans/day91-continuous-upgrade-plan.json to restore required keys."
+        )
+
+    if not failed and not critical_failures:
+        wins.append(
+            "Day 91 continuous upgrade closeout lane is fully complete and ready for continuous-upgrade backlog execution."
+        )
+
+    score = int(round(sum(c["weight"] for c in checks if c["passed"])))
+    return {
+        "name": "day91-continuous-upgrade-closeout",
+        "inputs": {
+            "readme": "README.md",
+            "docs_index": "docs/index.md",
+            "docs_page": _PAGE_PATH,
+            "top10": _TOP10_PATH,
+            "day90_summary": str(day90_summary.relative_to(root))
+            if day90_summary.exists()
+            else str(day90_summary),
+            "day90_delivery_board": str(day90_board.relative_to(root))
+            if day90_board.exists()
+            else str(day90_board),
+            "continuous_upgrade_plan": _PLAN_PATH,
+        },
+        "checks": checks,
+        "rollup": {
+            "day90_activation_score": day90_score,
+            "day90_checks": day90_check_count,
+            "day90_delivery_board_items": board_count,
+        },
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "wins": wins,
+        "misses": misses,
+        "handoff_actions": handoff_actions,
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Day 91 continuous upgrade closeout summary",
+        f"- Activation score: {payload['summary']['activation_score']}",
+        f"- Passed checks: {payload['summary']['passed_checks']}",
+        f"- Failed checks: {payload['summary']['failed_checks']}",
+        f"- Critical failures: {payload['summary']['critical_failures']}",
+    ]
+    return "\n".join(lines)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
+    target = pack_dir if pack_dir.is_absolute() else root / pack_dir
+    _write(
+        target / "day91-continuous-upgrade-closeout-summary.json",
+        json.dumps(payload, indent=2) + "\n",
+    )
+    _write(
+        target / "day91-continuous-upgrade-closeout-summary.md", _render_text(payload) + "\n"
+    )
+    _write(target / "day91-evidence-brief.md", "# Day 91 continuous upgrade brief\n")
+    _write(
+        target / "day91-continuous-upgrade-plan.md", "# Day 91 continuous upgrade plan\n"
+    )
+    _write(
+        target / "day91-upgrade-template-upgrade-ledger.json",
+        json.dumps({"upgrades": []}, indent=2) + "\n",
+    )
+    _write(
+        target / "day91-storyline-outcomes-ledger.json",
+        json.dumps({"outcomes": []}, indent=2) + "\n",
+    )
+    _write(target / "day91-upgrade-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "day91-execution-log.md", "# Day 91 execution log\n")
+    _write(
+        target / "day91-delivery-board.md",
+        "\n".join(["# Day 91 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+    )
+    _write(
+        target / "day91-validation-commands.md",
+        "# Day 91 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+    )
+
+
+def _execute_commands(root: Path, evidence_dir: Path) -> None:
+    events: list[dict[str, Any]] = []
+    out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
+        event = {
+            "command": command,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+        events.append(event)
+        _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
+    _write(
+        out_dir / "day91-execution-summary.json",
+        json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Day 91 continuous upgrade closeout checks")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-default-doc", action="store_true")
+    ns = parser.parse_args(argv)
+
+    root = Path(ns.root).resolve()
+    if ns.write_default_doc:
+        _write(root / _PAGE_PATH, _DAY91_DEFAULT_PAGE)
+
+    payload = build_day91_continuous_upgrade_closeout_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, Path(ns.emit_pack_dir), payload)
+    if ns.execute:
+        evidence_dir = (
+            Path(ns.evidence_dir)
+            if ns.evidence_dir
+            else Path("docs/artifacts/day91-continuous-upgrade-closeout-pack/evidence")
+        )
+        _execute_commands(root, evidence_dir)
+
+    print(json.dumps(payload, indent=2) if ns.format == "json" else _render_text(payload))
+    return 1 if ns.strict and not payload["summary"]["strict_pass"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_day91_continuous_upgrade_closeout.py
+++ b/tests/test_day91_continuous_upgrade_closeout.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import day91_continuous_upgrade_closeout as d91
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "templates/ci/gitlab").mkdir(parents=True, exist_ok=True)
+    (root / "templates/ci/jenkins").mkdir(parents=True, exist_ok=True)
+    (root / "templates/ci/tekton").mkdir(parents=True, exist_ok=True)
+    (root / "docs/roadmap/plans").mkdir(parents=True, exist_ok=True)
+    (root / "docs/roadmap/reports").mkdir(parents=True, exist_ok=True)
+    (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_text(
+        "docs/integrations-day91-continuous-upgrade-closeout.md\nday91-continuous-upgrade-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "day-91-big-upgrade-report.md\nintegrations-day91-continuous-upgrade-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Day 90 — Phase-3 wrap publication closeout lane:** close Day 90 publication quality loop.\n"
+        "- **Day 91 — Continuous upgrade closeout lane:** start next-cycle continuous upgrade execution.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-day91-continuous-upgrade-closeout.md").write_text(
+        d91._DAY91_DEFAULT_PAGE, encoding="utf-8"
+    )
+    (root / "docs/day-91-big-upgrade-report.md").write_text("# Day 91 report\n", encoding="utf-8")
+
+    summary = (
+        root
+        / "docs/artifacts/day90-phase3-wrap-publication-closeout-pack/day90-phase3-wrap-publication-closeout-summary.json"
+    )
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 100, "strict_pass": True},
+                "checks": [{"passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = root / "docs/artifacts/day90-phase3-wrap-publication-closeout-pack/day90-delivery-board.md"
+    board.write_text(
+        "\n".join(
+            [
+                "# Day 90 delivery board",
+                "- [ ] Day 90 evidence brief committed",
+                "- [ ] Day 90 phase-3 wrap publication plan committed",
+                "- [ ] Day 90 narrative template upgrade ledger exported",
+                "- [ ] Day 90 storyline outcomes ledger exported",
+                "- [ ] Next-cycle roadmap draft captured from Day 90 outcomes",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    plan = root / "docs/roadmap/plans/day91-continuous-upgrade-plan.json"
+    plan.write_text(
+        json.dumps(
+            {
+                "plan_id": "day91-continuous-upgrade-001",
+                "contributors": ["maintainers", "release-ops"],
+                "upgrade_channels": ["readme", "docs-index", "cli-lanes"],
+                "baseline": {"strict_pass_rate": 0.9, "doc_link_coverage": 0.88},
+                "target": {"strict_pass_rate": 1.0, "doc_link_coverage": 0.97},
+                "owner": "release-ops",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_day91_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d91.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "day91-continuous-upgrade-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_day91_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d91.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/day91-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/day91-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "artifacts/day91-pack/day91-continuous-upgrade-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day91-pack/day91-continuous-upgrade-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day91-pack/day91-evidence-brief.md").exists()
+    assert (tmp_path / "artifacts/day91-pack/day91-continuous-upgrade-plan.md").exists()
+    assert (tmp_path / "artifacts/day91-pack/day91-upgrade-template-upgrade-ledger.json").exists()
+    assert (tmp_path / "artifacts/day91-pack/day91-storyline-outcomes-ledger.json").exists()
+    assert (tmp_path / "artifacts/day91-pack/day91-upgrade-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day91-pack/day91-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day91-pack/day91-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day91-pack/day91-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day91-pack/evidence/day91-execution-summary.json").exists()
+
+
+def test_day91_strict_fails_without_day90(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (
+        tmp_path
+        / "docs/artifacts/day90-phase3-wrap-publication-closeout-pack/day90-phase3-wrap-publication-closeout-summary.json"
+    ).unlink()
+    assert d91.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
+
+
+def test_day91_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(["day91-continuous-upgrade-closeout", "--root", str(tmp_path), "--format", "text"])
+    assert rc == 0
+    assert "Day 91 continuous upgrade closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Introduce a Day 91 lane that converts Day 90 publication outputs into a deterministic continuous-upgrade execution lane and standardizes pack emission and evidence generation.
- Provide an automated, strict contract/checker pattern for ongoing upgrades so downstream workflows can enforce readiness before backlogging continuous improvements.

### Description
- Add a new module `src/sdetkit/day91_continuous_upgrade_closeout.py` that implements scoring, pack emission, execution evidence logging, and CLI behavior mirroring the Day 90 closeout logic.
- Wire the Day 91 command into the CLI via imports, argv dispatch, subparser registration, and parsed-command dispatch in `src/sdetkit/cli.py`.
- Add docs/asset files: `docs/integrations-day91-continuous-upgrade-closeout.md`, `docs/day-91-big-upgrade-report.md`, roadmap manifest and plan (`plans/day91-continuous-upgrade-plan.json`), and README/docs index/top-10 updates for discoverability.
- Add a contract validator script `scripts/check_day91_continuous_upgrade_closeout_contract.py` and focused tests `tests/test_day91_continuous_upgrade_closeout.py` to cover JSON output, pack emission + execute, strict failure path, and CLI dispatch.

### Testing
- Ran `python -m pytest -q tests/test_day91_continuous_upgrade_closeout.py tests/test_day90_phase3_wrap_publication_closeout.py` which completed successfully with `8 passed`.
- Executed `python -m sdetkit day91-continuous-upgrade-closeout --format text --strict` which produced a successful activation summary in text mode.
- Ran `python scripts/check_day91_continuous_upgrade_closeout_contract.py --skip-evidence` which passed the contract validation.
- Re-validated the Day 90 lane with `python -m sdetkit day90-phase3-wrap-publication-closeout --format text --strict` and its contract check `scripts/check_day90_phase3_wrap_publication_closeout_contract.py --skip-evidence`, both of which passed.

------