### PR TITLE
Fix CLI help listings and Day91/enterprise strict-check regressions

### DIFF
--- a/docs/use-cases-enterprise-regulated.md
+++ b/docs/use-cases-enterprise-regulated.md
@@ -14,7 +14,7 @@ Use this sequence to establish an enterprise guardrail baseline:
 
 ```bash
 python -m sdetkit repo audit . --profile enterprise --format json
-python -m sdetkit security check --root . --baseline tools/security.baseline.json --format text
+python -m sdetkit security report --format text
 python -m sdetkit policy snapshot --output .sdetkit/day13-policy-snapshot.json
 python -m pytest -q tests/test_enterprise_use_case.py tests/test_cli_help_lists_subcommands.py
 python scripts/check_day13_enterprise_use_case_contract.py

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -527,16 +527,25 @@ def main(argv: Sequence[str] | None = None) -> int:
 Command groups:
 
   Core workflows:
+    kv
+    apiget
     doctor
+    patch
+    cassette-get
     repo
+    dev
     gate
     security
     evidence
+    maintenance
+    agent
 
   Extensions:
     ci
     report
+    proof
     docs-qa
+    docs-nav
     policy
 
   Playbooks:
@@ -553,6 +562,9 @@ Command groups:
     gitlab-ci-quickstart
     quality-contribution-delta
     reliability-evidence-pack
+    release-readiness-board
+    release-narrative
+    trust-signal-upgrade
     faq-objections
     community-activation
     external-contribution-push

--- a/src/sdetkit/day91_continuous_upgrade_closeout.py
+++ b/src/sdetkit/day91_continuous_upgrade_closeout.py
@@ -63,9 +63,6 @@ _REQUIRED_DATA_KEYS = [
     "baseline",
     "target",
     "owner",
-    "rollback_owner",
-    "confidence_floor",
-    "cadence_days",
 ]
 
 _DAY91_DEFAULT_PAGE = """# Day 91 \u2014 Continuous upgrade closeout lane
@@ -167,10 +164,15 @@ def _validate_plan_contract(
                 )
 
     owner_issues: list[str] = []
-    for owner_field in ("owner", "rollback_owner"):
-        value = plan_data.get(owner_field)
-        if not isinstance(value, str) or not value.strip():
-            owner_issues.append(f"{owner_field}: missing owner assignment")
+    owner_value = plan_data.get("owner")
+    if not isinstance(owner_value, str) or not owner_value.strip():
+        owner_issues.append("owner: missing owner assignment")
+
+    rollback_owner = plan_data.get("rollback_owner")
+    if rollback_owner is not None and (
+        not isinstance(rollback_owner, str) or not rollback_owner.strip()
+    ):
+        owner_issues.append("rollback_owner: missing owner assignment")
 
     hygiene_issues: list[str] = []
     contributors = plan_data.get("contributors")
@@ -185,11 +187,11 @@ def _validate_plan_contract(
     elif not all(isinstance(item, str) and item.strip() for item in channels):
         hygiene_issues.append("upgrade_channels: every channel must be a non-empty string")
 
-    confidence_floor = plan_data.get("confidence_floor")
+    confidence_floor = plan_data.get("confidence_floor", 0.8)
     if not isinstance(confidence_floor, (int, float)) or not (0 <= confidence_floor <= 1):
         hygiene_issues.append("confidence_floor: must be a number between 0 and 1")
 
-    cadence_days = plan_data.get("cadence_days")
+    cadence_days = plan_data.get("cadence_days", 7)
     if not isinstance(cadence_days, int) or cadence_days <= 0:
         hygiene_issues.append("cadence_days: must be a positive integer")
 


### PR DESCRIPTION
### Motivation
- Restore expected CLI help output so the top-level `sdetkit --help` text lists subcommands used by tooling and tests. 
- Preserve backward compatibility for Day 91 plan validation so existing plan fixtures and emitted packs don't fail strict checks. 
- Align enterprise use-case documentation to the command that the strict checks expect.

### Description
- Updated the help epilog in `src/sdetkit/cli.py` to include missing top-level entries such as `kv`, `apiget`, `patch`, `cassette-get`, `dev`, `maintenance`, `agent`, `proof`, `docs-nav`, `release-readiness-board`, `release-narrative`, and `trust-signal-upgrade`. 
- Relaxed and clarified Day 91 plan validation in `src/sdetkit/day91_continuous_upgrade_closeout.py` by requiring `owner` while making `rollback_owner` optional unless present, removing `confidence_floor`/`cadence_days` from the required key list, and providing defaults for `confidence_floor` (`0.8`) and `cadence_days` (`7`) during hygiene checks. 
- Updated `docs/use-cases-enterprise-regulated.md` to use `python -m sdetkit security report --format text` so the enterprise baseline doc matches the expected strict-check command.

### Testing
- Ran the previously failing test subset with `pytest -q tests/test_cli_help_lists_subcommands.py::test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_proof_docs_qa_weekly_review_first_contribution_contributor_funnel_triage_templates_and_docs_nav_and_startup_and_enterprise_and_github_actions_quickstart_use_case tests/test_day91_continuous_upgrade_closeout.py::test_day91_json tests/test_day91_continuous_upgrade_closeout.py::test_day91_emit_pack_and_execute tests/test_enterprise_use_case.py::test_enterprise_use_case_json_and_strict_success` and all tests passed (`4 passed`).

------