### PR TITLE
Add explicit permissions to day64 advanced workflow

### DIFF
--- a/.github/workflows/day64-advanced-github-actions-reference.yml
+++ b/.github/workflows/day64-advanced-github-actions-reference.yml
@@ -12,6 +12,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate (${{ matrix.os }} / py${{ matrix.python-version }})


### PR DESCRIPTION
### Motivation
- Ensure the workflow declares least-privilege token access so `actions/checkout` and CI fetches do not fail in constrained environments.

### Description
- Added a top-level `permissions` block with `contents: read` to `.github/workflows/day64-advanced-github-actions-reference.yml`.

### Testing
- Parsed the updated workflow with `yaml.safe_load()` (PyYAML) to confirm valid YAML and inspected `git diff` to confirm the change; both checks succeeded.

------