### PR TITLE
fix(quality): ensure pre-commit is installed before linting

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install -r requirements-test.txt -r requirements-docs.txt
-          python -m pip install pre-commit==4.3.0
+          python -m pip install pre-commit==4.5.1
       - name: Install (deps)
         run: |
           python -m pip install -e .
@@ -39,6 +39,7 @@ jobs:
           python -m sdetkit.doctor --ascii
       - name: Lint
         run: |
+          python -m pip install pre-commit==4.5.1
           python -m pre_commit run -a
 
       - name: Tests


### PR DESCRIPTION
### Motivation
- Prevent the CI lint step from failing with `No module named pre_commit` and align the workflow with the repository's pinned `pre-commit` version.

### Description
- Updated `.github/workflows/quality.yml` to install `pre-commit==4.5.1` in the `Install` step and added a defensive `python -m pip install pre-commit==4.5.1` just before running `python -m pre_commit run -a` in the `Lint` step.

### Testing
- Ran `python -m pre_commit run --files .github/workflows/quality.yml` which passed, and ran `python -m pip install pre-commit==4.5.1 && python -m pre_commit --version` which returned `pre-commit 4.5.1` successfully.

------