### PR TITLE
fix(ci): install pre-commit via editable dev extras in quality workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,19 +27,14 @@ jobs:
             requirements-test.txt
             requirements-docs.txt
 
-      - name: Install
+      - name: Install project + quality tooling
         run: |
-          python -m pip install -r requirements-test.txt -r requirements-docs.txt
-          python -m pip install pre-commit==4.5.1
-      - name: Install (deps)
-        run: |
-          python -m pip install -e .
+          python -m pip install -e .[dev,test,docs]
       - name: Doctor (ASCII)
         run: |
           python -m sdetkit.doctor --ascii
       - name: Lint
         run: |
-          python -m pip install pre-commit==4.5.1
           python -m pre_commit run -a
 
       - name: Tests


### PR DESCRIPTION
### Motivation
- The `Lint` step in the `quality` workflow failed with `No module named pre_commit` because `pre-commit` was not guaranteed to be installed before lint runs.
- Consolidate dependency installation to ensure all quality tooling (including `pre-commit`) is present and to remove redundant install commands.

### Description
- Replace separate installs with a single step that runs `python -m pip install -e .[dev,test,docs]` in `.github/workflows/quality.yml` so `pre-commit` and other dev/test/docs extras are available.
- Remove the redundant `python -m pip install pre-commit==4.5.1` lines and keep the lint invocation as `python -m pre_commit run -a`.

### Testing
- Ran `python -m pip install -e .[dev,test,docs]` and the install completed successfully.
- Ran `python -m pre_commit --version` which returned the expected `pre-commit` version.
- Ran `python -m pre_commit run -a` and all configured hooks passed.

------