### PR TITLE
productize onboarding surface and contract checks

### DIFF
--- a/docs/artifacts/day1-onboarding-sample.md
+++ b/docs/artifacts/day1-onboarding-sample.md
@@ -5,4 +5,33 @@
 | Security / compliance lead | `sdetkit security --format markdown` | Apply policy controls from `docs/security.md` and `docs/policy-and-baselines.md`. |
 | Engineering manager / tech lead | `sdetkit doctor --format markdown` | Standardize team workflows using `docs/automation-os.md` and `docs/repo-tour.md`. |
 
-Quick start: [Repo audit quick start](../repo-audit.md#quick-start)
+## Platform setup snippets
+
+### Linux (bash)
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements-test.txt -e .
+python -m sdetkit doctor --format text
+```
+
+### macOS (zsh/bash)
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements-test.txt -e .
+python -m sdetkit doctor --format text
+```
+
+### Windows (PowerShell)
+
+```bash
+py -3 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements-test.txt -e .
+python -m sdetkit doctor --format text
+```
+
+Quick start: [Docs fast start](../index.md#fast-start)

--- a/scripts/check_onboarding_contract.py
+++ b/scripts/check_onboarding_contract.py
@@ -1,58 +1,65 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 
-README = Path("README.md")
-REQUIRED_SNIPPETS = [
-    "## 🔥 Day 1 ultra upgrade pack",
-    "sdetkit doctor --format markdown",
-    "sdetkit repo audit --format markdown",
-    "sdetkit security --format markdown",
-    "docs/day-1-ultra-upgrade-report.md",
+ARTIFACT = Path("docs/artifacts/day1-onboarding-sample.md")
+REPORT = Path("docs/day-1-ultra-upgrade-report.md")
+
+REQUIRED_ARTIFACT_SNIPPETS = [
+    "| Role | First command | Next action |",
+    "SDET / QA engineer",
+    "Platform / DevOps engineer",
+    "Security / compliance lead",
+    "Engineering manager / tech lead",
+    "Quick start:",
 ]
+
+REQUIRED_REPORT_SNIPPETS = [
+    "`src/sdetkit/onboarding.py`",
+    "`tests/test_onboarding_cli.py`",
+    "`scripts/check_onboarding_contract.py`",
+    "`docs/artifacts/day1-onboarding-sample.md`",
+    "`python -m sdetkit onboarding --format markdown --output docs/artifacts/day1-onboarding-sample.md`",
+    "`python scripts/check_onboarding_contract.py`",
+]
+
 REQUIRED_DOC_PATHS = [
+    "docs/doctor.md",
     "docs/repo-audit.md",
     "docs/github-action.md",
     "docs/security.md",
     "docs/policy-and-baselines.md",
     "docs/automation-os.md",
-    "docs/day-1-ultra-upgrade-report.md",
+    "docs/repo-tour.md",
 ]
 
 
-def _day1_section(text: str) -> str:
-    start = text.find("## 🔥 Day 1 ultra upgrade pack")
-    if start == -1:
-        return ""
-    remainder = text[start:]
-    m = re.search(r"\n## ", remainder[1:])
-    if not m:
-        return remainder
-    return remainder[: m.start() + 1]
-
-
 def main() -> int:
-    if not README.exists():
-        print("README.md missing", file=sys.stderr)
-        return 2
-
-    text = README.read_text(encoding="utf-8")
-    section = _day1_section(text)
     errors: list[str] = []
 
-    for snippet in REQUIRED_SNIPPETS:
-        if snippet not in text:
-            errors.append(f"missing snippet: {snippet}")
+    if not ARTIFACT.exists():
+        errors.append(f"missing artifact: {ARTIFACT}")
+        artifact_text = ""
+    else:
+        artifact_text = ARTIFACT.read_text(encoding="utf-8")
 
-    if not section:
-        errors.append("missing Day 1 ultra section")
+    if not REPORT.exists():
+        errors.append(f"missing report: {REPORT}")
+        report_text = ""
+    else:
+        report_text = REPORT.read_text(encoding="utf-8")
+
+    for snippet in REQUIRED_ARTIFACT_SNIPPETS:
+        if snippet not in artifact_text:
+            errors.append(f"missing artifact snippet: {snippet}")
+
+    for snippet in REQUIRED_REPORT_SNIPPETS:
+        if snippet not in report_text:
+            errors.append(f"missing report snippet: {snippet}")
 
     for rel_path in REQUIRED_DOC_PATHS:
-        if rel_path not in section:
-            errors.append(f"missing Day 1 link: {rel_path}")
         if not Path(rel_path).exists():
             errors.append(f"missing docs link target: {rel_path}")
 

--- a/src/sdetkit/onboarding.py
+++ b/src/sdetkit/onboarding.py
@@ -82,7 +82,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--platform",
         choices=["all", *_PLATFORM_SETUP.keys()],
         default="all",
-        help="Platform-specific setup snippets for Day 5 onboarding.",
+        help="Platform-specific setup snippets to print.",
     )
     p.add_argument(
         "--output",
@@ -104,7 +104,9 @@ def _as_json(role: str, platform: str) -> str:
         payload = {name: details for name, details in _ROLE_PLAYBOOK.items()}
     else:
         payload = {role: _ROLE_PLAYBOOK[role]}
-    payload["day5_platform_setup"] = _platform_payload(platform)
+    setup = _platform_payload(platform)
+    payload["platform_setup"] = setup
+    payload["day5_platform_setup"] = setup
     return json.dumps(payload, indent=2, sort_keys=True)
 
 
@@ -117,7 +119,7 @@ def _as_markdown(role: str, platform: str) -> str:
             f"| {details['label']} | `{details['first_command']}` | {details['next_action']} |"
         )
     rows.append("")
-    rows.append("## Day 5 platform onboarding snippets")
+    rows.append("## Platform setup snippets")
     rows.append("")
     for key, details in _PLATFORM_SETUP.items():
         if platform != "all" and platform != key:
@@ -128,12 +130,12 @@ def _as_markdown(role: str, platform: str) -> str:
         rows.extend(details["commands"])
         rows.append("```")
         rows.append("")
-    rows.append("Quick start: [README quick start](../README.md#quick-start)")
+    rows.append("Quick start: [Docs fast start](../index.md#fast-start)")
     return "\n".join(rows)
 
 
 def _as_text(role: str, platform: str) -> str:
-    lines = ["Day 1 onboarding paths", ""]
+    lines = ["Onboarding paths", ""]
     for key, details in _ROLE_PLAYBOOK.items():
         if role != "all" and role != key:
             continue
@@ -142,7 +144,7 @@ def _as_text(role: str, platform: str) -> str:
         lines.append(f"  next : {details['next_action']}")
         lines.append(f"  docs : {', '.join(details['docs'])}")
         lines.append("")
-    lines.extend(["Day 5 platform onboarding snippets", ""])
+    lines.extend(["Platform setup snippets", ""])
     for key, details in _PLATFORM_SETUP.items():
         if platform != "all" and platform != key:
             continue
@@ -150,7 +152,7 @@ def _as_text(role: str, platform: str) -> str:
         for cmd in details["commands"]:
             lines.append(f"  {cmd}")
         lines.append("")
-    lines.append("Start here: README quick start -> #quick-start")
+    lines.append("Start here: docs/index.md -> Fast start")
     return "\n".join(lines)
 
 

--- a/tests/test_onboarding_cli.py
+++ b/tests/test_onboarding_cli.py
@@ -7,12 +7,12 @@ def test_onboarding_default_text_lists_all_roles(capsys):
     rc = onboarding.main([])
     assert rc == 0
     out = capsys.readouterr().out
-    assert "Day 1 onboarding paths" in out
+    assert "Onboarding paths" in out
     assert "SDET / QA engineer" in out
     assert "Platform / DevOps engineer" in out
     assert "Security / compliance lead" in out
     assert "Engineering manager / tech lead" in out
-    assert "Day 5 platform onboarding snippets" in out
+    assert "Platform setup snippets" in out
 
 
 def test_onboarding_role_markdown_focuses_single_role(capsys):
@@ -30,7 +30,9 @@ def test_onboarding_json_is_machine_readable(capsys):
     data = json.loads(capsys.readouterr().out)
     assert "security" in data
     assert data["security"]["first_command"] == "sdetkit security --format markdown"
-    assert "windows" in data["day5_platform_setup"]
+    assert "platform_setup" in data
+    assert "windows" in data["platform_setup"]
+    assert data["platform_setup"] == data["day5_platform_setup"]
 
 
 def test_onboarding_platform_filter_renders_selected_os(capsys):


### PR DESCRIPTION
## Summary
- remove remaining day-branded wording from the public `onboarding` output
- keep JSON backward compatibility by preserving `day5_platform_setup` and adding `platform_setup`
- realign `check_onboarding_contract.py` with the current repo layout and generated onboarding artifact
- regenerate `docs/artifacts/day1-onboarding-sample.md`

## Validation
- `python -m pytest tests/test_onboarding_cli.py -q`
- `python -m sdetkit onboarding --format markdown --output docs/artifacts/day1-onboarding-sample.md`
- `python scripts/check_onboarding_contract.py`