### PR TITLE
productize demo lane wording and docs

### DIFF
--- a/docs/artifacts/day2-demo-sample.md
+++ b/docs/artifacts/day2-demo-sample.md
@@ -1,4 +1,4 @@
-# Day 2 demo path (target: ~60 seconds)
+# Demo path (target: ~60 seconds)
 
 | Step | Command | Expected output snippets | Outcome |
 |---|---|---|---|
@@ -20,10 +20,10 @@
 - Target: `60.0s`
 - Within target: `yes`
 
-## Closeout hints
+## Demo tips
 
-- Use --execute when recording a live Day 2 walkthrough so each step is validated.
-- Use --format markdown --output docs/artifacts/day2-demo-closeout.md to save a shareable run artifact.
+- Use --execute when recording a live product demo so each step is validated.
+- Use --format markdown --output demo.md to save a shareable run artifact.
 - If a snippet check fails, rerun a single command manually and compare output with the expected markers.
 
-Related docs: [Repo audit quick start](../repo-audit.md#quick-start), [repo audit](../repo-audit.md).
+Related docs: [Docs fast start](../index.md#fast-start), [repo audit](../repo-audit.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,17 +77,17 @@ See: day-1-ultra-upgrade-report.md and day-5-ultra-upgrade-report.md
 
 ## demo
 
-Renders a Day 2 copy/paste walkthrough for fast product demos.
+Renders a copy/paste workflow for fast, shareable product demos.
 
 Examples:
 
 - `sdetkit demo --execute --format text`
-- `sdetkit demo --execute --format markdown --output docs/artifacts/day2-demo-sample.md`
+- `sdetkit demo --execute --format markdown --output demo.md`
 - `sdetkit demo --format json`
 
 Useful flags: `--execute`, `--timeout-seconds`, `--fail-fast`, `--target-seconds`.
 
-See: day-2-ultra-upgrade-report.md
+See: day-2-ultra-upgrade-report.md (legacy history).
 
 
 ## proof

--- a/src/sdetkit/demo.py
+++ b/src/sdetkit/demo.py
@@ -40,8 +40,8 @@ _DEMO_FLOW = [
 ]
 
 _HINTS = [
-    "Use --execute when recording a live Day 2 walkthrough so each step is validated.",
-    "Use --format markdown --output docs/artifacts/day2-demo-closeout.md to save a shareable run artifact.",
+    "Use --execute when recording a live product demo so each step is validated.",
+    "Use --format markdown --output demo.md to save a shareable run artifact.",
     "If a snippet check fails, rerun a single command manually and compare output with the expected markers.",
 ]
 
@@ -153,7 +153,7 @@ def _execution_summary(
 
 
 def _as_text(execution_results: list[dict[str, object]], target_seconds: float) -> str:
-    lines = ["Day 2 demo path (target: ~60 seconds)", ""]
+    lines = ["Demo path (target: ~60 seconds)", ""]
     for item in _DEMO_FLOW:
         lines.append(f"[{item['step']}]")
         lines.append(f"  run     : {item['command']}")
@@ -180,7 +180,7 @@ def _as_text(execution_results: list[dict[str, object]], target_seconds: float) 
         )
         lines.append("")
 
-    lines.append("Closeout hints")
+    lines.append("Demo tips")
     for hint in _HINTS:
         lines.append(f"- {hint}")
     return "\n".join(lines)
@@ -188,7 +188,7 @@ def _as_text(execution_results: list[dict[str, object]], target_seconds: float) 
 
 def _as_markdown(execution_results: list[dict[str, object]], target_seconds: float) -> str:
     rows = [
-        "# Day 2 demo path (target: ~60 seconds)",
+        "# Demo path (target: ~60 seconds)",
         "",
         "| Step | Command | Expected output snippets | Outcome |",
         "|---|---|---|---|",
@@ -225,11 +225,11 @@ def _as_markdown(execution_results: list[dict[str, object]], target_seconds: flo
             ]
         )
 
-    rows.extend(["", "## Closeout hints", ""])
+    rows.extend(["", "## Demo tips", ""])
     rows.extend(f"- {hint}" for hint in _HINTS)
     rows.append("")
     rows.append(
-        "Related docs: [README quick start](../README.md#quick-start), [repo audit](repo-audit.md)."
+        "Related docs: [Docs fast start](../index.md#fast-start), [repo audit](../repo-audit.md)."
     )
     return "\n".join(rows)
 
@@ -237,7 +237,7 @@ def _as_markdown(execution_results: list[dict[str, object]], target_seconds: flo
 def _as_json(execution_results: list[dict[str, object]], target_seconds: float) -> str:
     return json.dumps(
         {
-            "name": "day2-demo-path",
+            "name": "demo-path",
             "steps": _DEMO_FLOW,
             "execution": execution_results,
             "sla": _execution_summary(execution_results, target_seconds),

--- a/tests/test_demo_cli.py
+++ b/tests/test_demo_cli.py
@@ -7,11 +7,11 @@ def test_demo_default_text_contains_all_steps(capsys):
     rc = demo.main([])
     assert rc == 0
     out = capsys.readouterr().out
-    assert "Day 2 demo path" in out
+    assert "Demo path" in out
     assert "Health check" in out
     assert "Repository audit" in out
     assert "Security baseline" in out
-    assert "Closeout hints" in out
+    assert "Demo tips" in out
 
 
 def test_demo_markdown_has_copy_paste_commands(capsys):
@@ -20,14 +20,14 @@ def test_demo_markdown_has_copy_paste_commands(capsys):
     out = capsys.readouterr().out
     assert "| Step | Command | Expected output snippets | Outcome |" in out
     assert "python -m sdetkit doctor --format text" in out
-    assert "## Closeout hints" in out
+    assert "## Demo tips" in out
 
 
 def test_demo_json_is_machine_readable(capsys):
     rc = demo.main(["--format", "json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["name"] == "day2-demo-path"
+    assert payload["name"] == "demo-path"
     assert len(payload["steps"]) == 3
     assert payload["execution"] == []
     assert payload["sla"] == {}
@@ -37,7 +37,7 @@ def test_demo_json_is_machine_readable(capsys):
 def test_cli_dispatches_demo(capsys):
     rc = cli.main(["demo", "--format", "text"])
     assert rc == 0
-    assert "Closeout hints" in capsys.readouterr().out
+    assert "Demo tips" in capsys.readouterr().out
 
 
 def test_demo_writes_output_file(tmp_path, capsys):
@@ -46,7 +46,7 @@ def test_demo_writes_output_file(tmp_path, capsys):
     assert rc == 0
     stdout = capsys.readouterr().out
     written = out_file.read_text(encoding="utf-8")
-    assert "# Day 2 demo path" in written
+    assert "# Demo path" in written
     assert written.rstrip("\n") == stdout.rstrip("\n")
 
 


### PR DESCRIPTION
## Summary
- remove remaining day-branded wording from the public `demo` output
- rename demo-facing labels from “Day 2 demo path” / “Closeout hints” to product-first wording
- update demo JSON metadata from `day2-demo-path` to `demo-path`
- align `docs/cli.md` and `docs/artifacts/day2-demo-sample.md` with the canonical public `demo` lane

## Validation
- `python -m pytest tests/test_demo_cli.py -q`
- `python -m sdetkit gate fast --root . --format json --out /tmp/gate-fast-day02.json`

## Notes
- `python -m sdetkit gate release --format json --out /tmp/gate-release-day02.json` failed on `doctor_release`
- `playbooks validate --recommended` and `gate fast` were green inside the release profile