### PR TITLE
Register day96 CLI command and refresh roadmap manifest

### DIFF
--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -486,10 +486,20 @@
       "report_title": "Day 93 big upgrade report"
     },
     {
+      "day": 94,
+      "plan_path": "docs/roadmap/phase3/plans/day94-continuous-upgrade-cycle4-plan.json"
+    },
+    {
       "day": 95,
       "plan_path": "docs/roadmap/phase3/plans/day95-continuous-upgrade-cycle5-plan.json",
       "report_path": "docs/roadmap/reports/day-95-big-upgrade-report.md",
       "report_title": "Day 95 big upgrade report"
+    },
+    {
+      "day": 96,
+      "plan_path": "docs/roadmap/phase3/plans/day96-continuous-upgrade-cycle6-plan.json",
+      "report_path": "docs/roadmap/reports/day-96-big-upgrade-report.md",
+      "report_title": "Day 96 big upgrade report"
     },
     {
       "day": 97,

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -76,6 +76,7 @@ from . import (
     day93_continuous_upgrade_cycle3_closeout,
     day94_continuous_upgrade_cycle4_closeout,
     day95_continuous_upgrade_cycle5_closeout,
+    day96_continuous_upgrade_cycle6_closeout,
     day97_continuous_upgrade_cycle7_closeout,
     demo,
     docs_navigation,
@@ -474,6 +475,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return day94_continuous_upgrade_cycle4_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day95-continuous-upgrade-cycle5-closeout":
         return day95_continuous_upgrade_cycle5_closeout.main(list(argv[1:]))
+    if argv and argv[0] == "day96-continuous-upgrade-cycle6-closeout":
+        return day96_continuous_upgrade_cycle6_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day97-continuous-upgrade-cycle7-closeout":
         return day97_continuous_upgrade_cycle7_closeout.main(list(argv[1:]))
 
@@ -841,6 +844,8 @@ Run: sdetkit playbooks
     d94.add_argument("args", nargs=argparse.REMAINDER)
     d95 = sub.add_parser("day95-continuous-upgrade-cycle5-closeout")
     d95.add_argument("args", nargs=argparse.REMAINDER)
+    d96 = sub.add_parser("day96-continuous-upgrade-cycle6-closeout")
+    d96.add_argument("args", nargs=argparse.REMAINDER)
     d97 = sub.add_parser("day97-continuous-upgrade-cycle7-closeout")
     d97.add_argument("args", nargs=argparse.REMAINDER)
 


### PR DESCRIPTION
### Motivation
- The `day96-continuous-upgrade-cycle6-closeout` playbook was not wired into the CLI so invoking it failed and CI tests reported a stale roadmap manifest.
- Regenerating the roadmap manifest is required to satisfy the manifest freshness check used by tests.

### Description
- Add runtime dispatch and register the `day96-continuous-upgrade-cycle6-closeout` subcommand in `src/sdetkit/cli.py` so the command is accepted and dispatched at runtime (`day96_continuous_upgrade_cycle6_closeout` import, parser entry, and dispatch branch). 
- Add the argparse subparser `day96-continuous-upgrade-cycle6-closeout` so it appears to the CLI and can accept `args` (argparse.REMAINDER).
- Regenerate `docs/roadmap/manifest.json` via the roadmap tooling to include the Day 96 plan/report entry by running `python -m sdetkit.roadmap_manifest write`.

### Testing
- Ran `python -m sdetkit.roadmap_manifest write` to update the manifest and confirm the file was written successfully.
- Ran the failing tests with `pytest -q tests/test_day96_continuous_upgrade_cycle6_closeout.py::test_day96_emit_pack_and_execute tests/test_day96_continuous_upgrade_cycle6_closeout.py::test_day96_cli_dispatch tests/test_roadmap_manifest_tooling.py::test_roadmap_manifest_is_fresh` and all three tests passed (3 passed).

------