### PR TITLE
Productize day18 reliability evidence pack docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -344,7 +344,7 @@ Useful flags: `--root`, `--current-signals-file`, `--previous-signals-file`, `--
 See: day-17-ultra-upgrade-report.md (legacy history).
 ## reliability-evidence-pack
 
-Builds Day 18 reliability evidence by combining Day 15 GitHub execution logs, Day 16 GitLab execution logs, and Day 17 quality/contribution delta summary.
+Builds a reliability evidence report by combining Day 15, Day 16, and Day 17 evidence inputs into one closeout view.
 
 Examples:
 
@@ -353,19 +353,21 @@ Examples:
 - `sdetkit reliability-evidence-pack --write-defaults --format json --strict`
 - `sdetkit reliability-evidence-pack --emit-pack-dir docs/artifacts/day18-reliability-pack --format json --strict`
 - `sdetkit reliability-evidence-pack --execute --evidence-dir docs/artifacts/day18-reliability-pack/evidence --format json --strict`
-- `sdetkit reliability-evidence-pack --format markdown --output docs/artifacts/day18-reliability-evidence-pack-sample.md`
+- `sdetkit reliability-evidence-pack --format markdown --output reliability-evidence-report.md`
 
 Useful flags: `--root`, `--day15-summary`, `--day16-summary`, `--day17-summary`, `--min-reliability-score`, `--write-defaults`, `--emit-pack-dir`, `--execute`, `--evidence-dir`, `--timeout-sec`, `--strict`, `--format`, `--output`.
 
-`--write-defaults` writes a hardened Day 18 integration page if missing/incomplete, then validates it.
+`--day15-summary`, `--day16-summary`, and `--day17-summary` point to the execution and delta JSON inputs used to build the report.
 
-`--emit-pack-dir` writes a Day 18 pack containing reliability summary JSON, scorecard markdown, closeout checklist markdown, and a validation commands file.
+`--write-defaults` writes or repairs the default Day 18 integration page before validation.
 
-`--execute` runs the Day 18 command chain and emits an execution summary plus per-command logs for closeout evidence.
+`--emit-pack-dir` writes a reliability evidence pack bundle containing summary JSON, scorecard markdown, closeout checklist markdown, and validation commands.
 
-`--strict` returns non-zero if Day 18 required docs sections/commands are missing, strict gates are not green across Day 15/16/17 inputs, or reliability score falls below `--min-reliability-score`.
+`--execute` runs the Day 18 validation commands and writes execution logs into `--evidence-dir`.
 
-See: day-18-ultra-upgrade-report.md
+`--strict` returns non-zero when required docs content is missing, upstream strict gates are not all green, the reliability score falls below `--min-reliability-score`, or execute mode detects failed commands.
+
+See: day-18-ultra-upgrade-report.md (legacy history).
 
 ## patch
 


### PR DESCRIPTION
## Summary
- productize the Day 18 `reliability-evidence-pack` CLI docs section
- update wording to describe the report-oriented output and input files
- refresh markdown output example path and strict/execute/help text

## Validation
- `python -m py_compile src/sdetkit/reliability_evidence_pack.py tests/test_reliability_evidence_pack.py`
- `python -m pytest -q tests/test_reliability_evidence_pack.py`