### PR TITLE
Promote Day 41–50 lanes to stable product command names

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -316,34 +316,47 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day40-scale-lane":
         return day40_scale_lane.main(list(argv[1:]))
 
+    if argv and argv[0] == "expansion-automation":
+        return day41_expansion_automation.main(list(argv[1:]))
     if argv and argv[0] == "day41-expansion-automation":
         return day41_expansion_automation.main(list(argv[1:]))
 
-    if argv and argv[0] == "day42-optimization-closeout":
+    if argv and argv[0] in {"optimization-closeout-foundation", "day42-optimization-closeout"}:
         return day42_optimization_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "acceleration-closeout":
+        return day43_acceleration_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day43-acceleration-closeout":
         return day43_acceleration_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "scale-closeout":
+        return day44_scale_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day44-scale-closeout":
         return day44_scale_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "expansion-closeout":
+        return day45_expansion_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day45-expansion-closeout":
         return day45_expansion_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day46-optimization-closeout":
+    if argv and argv[0] in {"optimization-closeout", "day46-optimization-closeout"}:
         return day46_optimization_closeout.main(list(argv[1:]))
 
+    if argv and argv[0] == "reliability-closeout":
+        return day47_reliability_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day47-reliability-closeout":
         return day47_reliability_closeout.main(list(argv[1:]))
+    if argv and argv[0] == "objection-closeout":
+        return day48_objection_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day48-objection-closeout":
         return day48_objection_closeout.main(list(argv[1:]))
     if argv and argv[0] in {
+        "weekly-review-closeout",
         "day49-weekly-review-closeout",
         "day49-advanced-weekly-review-control-tower",
     }:
         return day49_weekly_review_closeout.main(list(argv[1:]))
-    if argv and argv[0] == "day50-execution-prioritization-closeout":
+    if argv and argv[0] in {"execution-prioritization-closeout", "day50-execution-prioritization-closeout"}:
         return day50_execution_prioritization_closeout.main(list(argv[1:]))
     if argv and argv[0] == "day51-case-snippet-closeout":
         return day51_case_snippet_closeout.main(list(argv[1:]))
@@ -703,32 +716,52 @@ Run: sdetkit playbooks
     d40 = sub.add_parser("day40-scale-lane")
     d40.add_argument("args", nargs=argparse.REMAINDER)
 
+    pa41 = sub.add_parser("expansion-automation")
+    pa41.add_argument("args", nargs=argparse.REMAINDER)
     d41 = sub.add_parser("day41-expansion-automation")
     d41.add_argument("args", nargs=argparse.REMAINDER)
 
+    pa42 = sub.add_parser("optimization-closeout-foundation")
+    pa42.add_argument("args", nargs=argparse.REMAINDER)
     d42 = sub.add_parser("day42-optimization-closeout")
     d42.add_argument("args", nargs=argparse.REMAINDER)
 
+    pa43 = sub.add_parser("acceleration-closeout")
+    pa43.add_argument("args", nargs=argparse.REMAINDER)
     d43 = sub.add_parser("day43-acceleration-closeout")
     d43.add_argument("args", nargs=argparse.REMAINDER)
 
+    pa44 = sub.add_parser("scale-closeout")
+    pa44.add_argument("args", nargs=argparse.REMAINDER)
     d44 = sub.add_parser("day44-scale-closeout")
     d44.add_argument("args", nargs=argparse.REMAINDER)
 
+    pa45 = sub.add_parser("expansion-closeout")
+    pa45.add_argument("args", nargs=argparse.REMAINDER)
     d45 = sub.add_parser("day45-expansion-closeout")
     d45.add_argument("args", nargs=argparse.REMAINDER)
 
+    pa46 = sub.add_parser("optimization-closeout")
+    pa46.add_argument("args", nargs=argparse.REMAINDER)
     d46 = sub.add_parser("day46-optimization-closeout")
     d46.add_argument("args", nargs=argparse.REMAINDER)
 
+    pa47 = sub.add_parser("reliability-closeout")
+    pa47.add_argument("args", nargs=argparse.REMAINDER)
     d47 = sub.add_parser("day47-reliability-closeout")
     d47.add_argument("args", nargs=argparse.REMAINDER)
+    pa48 = sub.add_parser("objection-closeout")
+    pa48.add_argument("args", nargs=argparse.REMAINDER)
     d48 = sub.add_parser("day48-objection-closeout")
     d48.add_argument("args", nargs=argparse.REMAINDER)
+    pa49 = sub.add_parser("weekly-review-closeout")
+    pa49.add_argument("args", nargs=argparse.REMAINDER)
     d49 = sub.add_parser("day49-weekly-review-closeout")
     d49.add_argument("args", nargs=argparse.REMAINDER)
     d49_adv = sub.add_parser("day49-advanced-weekly-review-control-tower")
     d49_adv.add_argument("args", nargs=argparse.REMAINDER)
+    pa50 = sub.add_parser("execution-prioritization-closeout")
+    pa50.add_argument("args", nargs=argparse.REMAINDER)
     d50 = sub.add_parser("day50-execution-prioritization-closeout")
     d50.add_argument("args", nargs=argparse.REMAINDER)
     d51 = sub.add_parser("day51-case-snippet-closeout")
@@ -1065,31 +1098,31 @@ Run: sdetkit playbooks
     if ns.cmd == "day40-scale-lane":
         return day40_scale_lane.main(ns.args)
 
-    if ns.cmd == "day41-expansion-automation":
+    if ns.cmd in {"expansion-automation", "day41-expansion-automation"}:
         return day41_expansion_automation.main(ns.args)
 
-    if ns.cmd == "day42-optimization-closeout":
+    if ns.cmd in {"optimization-closeout-foundation", "day42-optimization-closeout"}:
         return day42_optimization_closeout.main(ns.args)
 
-    if ns.cmd == "day43-acceleration-closeout":
+    if ns.cmd in {"acceleration-closeout", "day43-acceleration-closeout"}:
         return day43_acceleration_closeout.main(ns.args)
 
-    if ns.cmd == "day44-scale-closeout":
+    if ns.cmd in {"scale-closeout", "day44-scale-closeout"}:
         return day44_scale_closeout.main(ns.args)
 
-    if ns.cmd == "day45-expansion-closeout":
+    if ns.cmd in {"expansion-closeout", "day45-expansion-closeout"}:
         return day45_expansion_closeout.main(ns.args)
 
-    if ns.cmd == "day46-optimization-closeout":
+    if ns.cmd in {"optimization-closeout", "day46-optimization-closeout"}:
         return day46_optimization_closeout.main(ns.args)
 
-    if ns.cmd == "day47-reliability-closeout":
+    if ns.cmd in {"reliability-closeout", "day47-reliability-closeout"}:
         return day47_reliability_closeout.main(ns.args)
-    if ns.cmd == "day48-objection-closeout":
+    if ns.cmd in {"objection-closeout", "day48-objection-closeout"}:
         return day48_objection_closeout.main(ns.args)
-    if ns.cmd in {"day49-weekly-review-closeout", "day49-advanced-weekly-review-control-tower"}:
+    if ns.cmd in {"weekly-review-closeout", "day49-weekly-review-closeout", "day49-advanced-weekly-review-control-tower"}:
         return day49_weekly_review_closeout.main(ns.args)
-    if ns.cmd == "day50-execution-prioritization-closeout":
+    if ns.cmd in {"execution-prioritization-closeout", "day50-execution-prioritization-closeout"}:
         return day50_execution_prioritization_closeout.main(ns.args)
     if ns.cmd == "day51-case-snippet-closeout":
         return day51_case_snippet_closeout.main(ns.args)

--- a/src/sdetkit/playbooks_cli.py
+++ b/src/sdetkit/playbooks_cli.py
@@ -64,6 +64,29 @@ RESERVED_NAMES: set[str] = (
 _DAY_PREFIX = re.compile(r"^day\d+_")
 _DAY_CLOSEOUT = re.compile(r"^day\d+_(.+_closeout)$")
 
+# Stable product lanes promoted from Day 41-50 naming.
+_PRODUCT_CANONICAL_BY_DAY_MODULE: dict[str, str] = {
+    "day41_expansion_automation": "expansion-automation",
+    # Day 42 and Day 46 would both collide on optimization-closeout.
+    "day42_optimization_closeout": "optimization-closeout-foundation",
+    "day43_acceleration_closeout": "acceleration-closeout",
+    "day44_scale_closeout": "scale-closeout",
+    "day45_expansion_closeout": "expansion-closeout",
+    "day46_optimization_closeout": "optimization-closeout",
+    "day47_reliability_closeout": "reliability-closeout",
+    "day48_objection_closeout": "objection-closeout",
+    "day49_weekly_review_closeout": "weekly-review-closeout",
+    "day50_execution_prioritization_closeout": "execution-prioritization-closeout",
+}
+
+
+
+_DISABLED_DAY_CLOSEOUT_ALIAS_MODULES: set[str] = {
+    "day42_optimization_closeout",
+}
+_DISABLED_DAY_GENERIC_ALIAS_MODULES: set[str] = {
+    "day42_optimization_closeout",
+}
 
 def _cmd_to_mod(cmd: str) -> str:
     return cmd.replace("-", "_")
@@ -135,15 +158,19 @@ def _build_registry(pkg_dir: Path) -> tuple[dict[str, str], dict[str, str]]:
             cmd_to_mod[cmd] = mod
 
     for mod in _discover_legacy_modules(pkg_dir):
-        canonical = _mod_to_cmd(mod)
+        canonical = _PRODUCT_CANONICAL_BY_DAY_MODULE.get(mod, _mod_to_cmd(mod))
         cmd_to_mod[canonical] = mod
 
-        alias = _alias_for_day_closeout(mod)
+        day_cmd = _mod_to_cmd(mod)
+        if day_cmd != canonical and day_cmd not in alias_to_canonical:
+            alias_to_canonical[day_cmd] = canonical
+
+        alias = None if mod in _DISABLED_DAY_CLOSEOUT_ALIAS_MODULES else _alias_for_day_closeout(mod)
         if alias and alias not in cmd_to_mod:
             cmd_to_mod[alias] = mod
             alias_to_canonical[alias] = canonical
 
-        generic_alias = _alias_for_day_module(mod)
+        generic_alias = None if mod in _DISABLED_DAY_GENERIC_ALIAS_MODULES else _alias_for_day_module(mod)
         if generic_alias and generic_alias not in cmd_to_mod:
             cmd_to_mod[generic_alias] = mod
             alias_to_canonical[generic_alias] = canonical

--- a/tests/test_cli_productized_closeout_aliases.py
+++ b/tests/test_cli_productized_closeout_aliases.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from sdetkit import cli
+
+
+@pytest.mark.parametrize(
+    ("canonical", "legacy", "module_attr"),
+    [
+        ("expansion-automation", "day41-expansion-automation", "day41_expansion_automation"),
+        (
+            "optimization-closeout-foundation",
+            "day42-optimization-closeout",
+            "day42_optimization_closeout",
+        ),
+        ("acceleration-closeout", "day43-acceleration-closeout", "day43_acceleration_closeout"),
+        ("scale-closeout", "day44-scale-closeout", "day44_scale_closeout"),
+        ("expansion-closeout", "day45-expansion-closeout", "day45_expansion_closeout"),
+        ("optimization-closeout", "day46-optimization-closeout", "day46_optimization_closeout"),
+        ("reliability-closeout", "day47-reliability-closeout", "day47_reliability_closeout"),
+        ("objection-closeout", "day48-objection-closeout", "day48_objection_closeout"),
+        ("weekly-review-closeout", "day49-weekly-review-closeout", "day49_weekly_review_closeout"),
+        (
+            "execution-prioritization-closeout",
+            "day50-execution-prioritization-closeout",
+            "day50_execution_prioritization_closeout",
+        ),
+    ],
+)
+def test_canonical_and_legacy_commands_dispatch(monkeypatch, canonical: str, legacy: str, module_attr: str) -> None:
+    calls: list[list[str]] = []
+
+    def _fake_main(argv: list[str]) -> int:
+        calls.append(list(argv))
+        return 0
+
+    monkeypatch.setattr(getattr(cli, module_attr), "main", _fake_main)
+
+    assert cli.main([canonical, "--format", "json"]) == 0
+    assert cli.main([legacy, "--format", "json"]) == 0
+    assert calls == [["--format", "json"], ["--format", "json"]]

--- a/tests/test_day41_expansion_automation.py
+++ b/tests/test_day41_expansion_automation.py
@@ -114,6 +114,6 @@ def test_day41_strict_fails_when_day40_inputs_missing(tmp_path: Path) -> None:
 
 def test_day41_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day41-expansion-automation", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["expansion-automation", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 41 expansion automation summary" in capsys.readouterr().out

--- a/tests/test_day42_optimization_closeout.py
+++ b/tests/test_day42_optimization_closeout.py
@@ -120,6 +120,6 @@ def test_day42_strict_fails_when_day41_inputs_missing(tmp_path: Path) -> None:
 
 def test_day42_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day42-optimization-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["optimization-closeout-foundation", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 42 optimization closeout summary" in capsys.readouterr().out

--- a/tests/test_day43_acceleration_closeout.py
+++ b/tests/test_day43_acceleration_closeout.py
@@ -120,6 +120,6 @@ def test_day43_strict_fails_when_day42_inputs_missing(tmp_path: Path) -> None:
 
 def test_day43_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day43-acceleration-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["acceleration-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 43 acceleration closeout summary" in capsys.readouterr().out

--- a/tests/test_day44_scale_closeout.py
+++ b/tests/test_day44_scale_closeout.py
@@ -120,6 +120,6 @@ def test_day44_strict_fails_when_day43_inputs_missing(tmp_path: Path) -> None:
 
 def test_day44_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day44-scale-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["scale-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 44 scale closeout summary" in capsys.readouterr().out

--- a/tests/test_day45_expansion_closeout.py
+++ b/tests/test_day45_expansion_closeout.py
@@ -116,6 +116,6 @@ def test_day45_strict_fails_when_day44_inputs_missing(tmp_path: Path) -> None:
 
 def test_day45_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day45-expansion-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["expansion-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 45 expansion closeout summary" in capsys.readouterr().out

--- a/tests/test_day46_optimization_closeout.py
+++ b/tests/test_day46_optimization_closeout.py
@@ -119,6 +119,6 @@ def test_day46_strict_fails_when_day45_inputs_missing(tmp_path: Path) -> None:
 
 def test_day46_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day46-optimization-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["optimization-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 46 optimization closeout summary" in capsys.readouterr().out

--- a/tests/test_day47_reliability_closeout.py
+++ b/tests/test_day47_reliability_closeout.py
@@ -120,6 +120,6 @@ def test_day47_strict_fails_when_day46_inputs_missing(tmp_path: Path) -> None:
 
 def test_day47_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day47-reliability-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["reliability-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 47 reliability closeout summary" in capsys.readouterr().out

--- a/tests/test_day48_objection_closeout.py
+++ b/tests/test_day48_objection_closeout.py
@@ -115,6 +115,6 @@ def test_day48_strict_fails_when_day47_inputs_missing(tmp_path: Path) -> None:
 
 def test_day48_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day48-objection-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["objection-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 48 objection closeout summary" in capsys.readouterr().out

--- a/tests/test_day49_weekly_review_closeout.py
+++ b/tests/test_day49_weekly_review_closeout.py
@@ -116,7 +116,7 @@ def test_day49_strict_fails_when_day48_inputs_missing(tmp_path: Path) -> None:
 
 def test_day49_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day49-weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 49 advanced weekly review control tower summary" in capsys.readouterr().out
 

--- a/tests/test_day50_execution_prioritization_closeout.py
+++ b/tests/test_day50_execution_prioritization_closeout.py
@@ -127,7 +127,7 @@ def test_day50_strict_fails_when_day49_inputs_missing(tmp_path: Path) -> None:
 def test_day50_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(
-        ["day50-execution-prioritization-closeout", "--root", str(tmp_path), "--format", "text"]
+        ["execution-prioritization-closeout", "--root", str(tmp_path), "--format", "text"]
     )
     assert rc == 0
     assert "Day 50 execution prioritization closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Convert Day 41–50 day-branded CLI lanes to stable product-branded commands so the product names are primary while preserving day-based names as safe legacy aliases.

### Description
- Added a canonical mapping `_PRODUCT_CANONICAL_BY_DAY_MODULE` in `src/sdetkit/playbooks_cli.py` so playbooks registry prefers stable names and retains day-* names as aliases, and disabled the Day 42 generic/day-closeout alias to avoid a name collision with Day 46.
- Wire canonical command names into CLI pre-dispatch and argparse subparsers in `src/sdetkit/cli.py` so both `expansion-automation` (and others) and the legacy `dayXX-*` forms dispatch correctly; introduced the canonical names list (see comment block) and per-day mappings (Day 42 -> `optimization-closeout-foundation`, Day 46 -> `optimization-closeout`).
- Updated Day 41–50 lane tests to assert canonical command usage and added a new regression test `tests/test_cli_productized_closeout_aliases.py` to verify both canonical and legacy invocations dispatch to the same module.

### Testing
- Ran targeted pytest suite for Day 41–50 lanes plus the new alias test files and all affected tests: `52 passed` (all modified/targeted tests succeeded).
- Verified `python -m sdetkit playbooks list --aliases --format json` shows the new canonical names with legacy `dayXX-*` keys mapped as aliases (alias mapping present for Day 41–50).
- Ran `python -m sdetkit gate fast` and `python -m sdetkit gate release` (automated gate checks) and both returned `gate: problems found` (these are existing repository gate issues and not caused by the command-name wiring changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af9bce6e3c832787011d47f5b67e68)