### PR TITLE
Productize Day 51–60 closeout lanes with stable canonical commands

### DIFF
--- a/docs/integrations-day51-case-snippet-closeout.md
+++ b/docs/integrations-day51-case-snippet-closeout.md
@@ -1,4 +1,4 @@
-# Day 51 — Case snippet closeout lane
+# Case Snippet Closeout lane (Legacy: Day 51)
 
 Day 51 closes with a major case-snippet upgrade that converts Day 50 execution-prioritization evidence into a deterministic release-storytelling lane.
 
@@ -13,12 +13,12 @@ Day 51 closes with a major case-snippet upgrade that converts Day 50 execution-p
 - `docs/artifacts/day50-execution-prioritization-closeout-pack/day50-execution-prioritization-closeout-summary.json`
 - `docs/artifacts/day50-execution-prioritization-closeout-pack/day50-delivery-board.md`
 
-## Day 51 command lane
+## Case Snippet Closeout command lane
 
 ```bash
-python -m sdetkit day51-case-snippet-closeout --format json --strict
-python -m sdetkit day51-case-snippet-closeout --emit-pack-dir docs/artifacts/day51-case-snippet-closeout-pack --format json --strict
-python -m sdetkit day51-case-snippet-closeout --execute --evidence-dir docs/artifacts/day51-case-snippet-closeout-pack/evidence --format json --strict
+python -m sdetkit case-snippet-closeout --format json --strict
+python -m sdetkit case-snippet-closeout --emit-pack-dir docs/artifacts/day51-case-snippet-closeout-pack --format json --strict
+python -m sdetkit case-snippet-closeout --execute --evidence-dir docs/artifacts/day51-case-snippet-closeout-pack/evidence --format json --strict
 python scripts/check_day51_case_snippet_closeout_contract.py
 ```
 

--- a/docs/integrations-day52-narrative-closeout.md
+++ b/docs/integrations-day52-narrative-closeout.md
@@ -1,4 +1,4 @@
-# Day 52 — Narrative closeout lane
+# Narrative Closeout lane (Legacy: Day 52)
 
 Day 52 closes with a major narrative upgrade that converts Day 51 case-snippet evidence into a deterministic release-storytelling lane.
 
@@ -13,12 +13,12 @@ Day 52 closes with a major narrative upgrade that converts Day 51 case-snippet e
 - `docs/artifacts/day51-case-snippet-closeout-pack/day51-case-snippet-closeout-summary.json`
 - `docs/artifacts/day51-case-snippet-closeout-pack/day51-delivery-board.md`
 
-## Day 52 command lane
+## Narrative Closeout command lane
 
 ```bash
-python -m sdetkit day52-narrative-closeout --format json --strict
-python -m sdetkit day52-narrative-closeout --emit-pack-dir docs/artifacts/day52-narrative-closeout-pack --format json --strict
-python -m sdetkit day52-narrative-closeout --execute --evidence-dir docs/artifacts/day52-narrative-closeout-pack/evidence --format json --strict
+python -m sdetkit narrative-closeout --format json --strict
+python -m sdetkit narrative-closeout --emit-pack-dir docs/artifacts/day52-narrative-closeout-pack --format json --strict
+python -m sdetkit narrative-closeout --execute --evidence-dir docs/artifacts/day52-narrative-closeout-pack/evidence --format json --strict
 python scripts/check_day52_narrative_closeout_contract.py
 ```
 

--- a/docs/integrations-day53-docs-loop-closeout.md
+++ b/docs/integrations-day53-docs-loop-closeout.md
@@ -1,4 +1,4 @@
-# Day 53 — Docs loop optimization closeout lane
+# Docs Loop Closeout lane (Legacy: Day 53)
 
 Day 53 closes with a major docs loop optimization upgrade that converts Day 52 narrative evidence into deterministic cross-link execution across demos, playbooks, and CLI docs.
 
@@ -13,12 +13,12 @@ Day 53 closes with a major docs loop optimization upgrade that converts Day 52 n
 - `docs/artifacts/day52-narrative-closeout-pack/day52-narrative-closeout-summary.json`
 - `docs/artifacts/day52-narrative-closeout-pack/day52-delivery-board.md`
 
-## Day 53 command lane
+## Docs Loop Closeout command lane
 
 ```bash
-python -m sdetkit day53-docs-loop-closeout --format json --strict
-python -m sdetkit day53-docs-loop-closeout --emit-pack-dir docs/artifacts/day53-docs-loop-closeout-pack --format json --strict
-python -m sdetkit day53-docs-loop-closeout --execute --evidence-dir docs/artifacts/day53-docs-loop-closeout-pack/evidence --format json --strict
+python -m sdetkit docs-loop-closeout --format json --strict
+python -m sdetkit docs-loop-closeout --emit-pack-dir docs/artifacts/day53-docs-loop-closeout-pack --format json --strict
+python -m sdetkit docs-loop-closeout --execute --evidence-dir docs/artifacts/day53-docs-loop-closeout-pack/evidence --format json --strict
 python scripts/check_day53_docs_loop_closeout_contract.py
 ```
 

--- a/docs/integrations-day55-contributor-activation-closeout.md
+++ b/docs/integrations-day55-contributor-activation-closeout.md
@@ -1,4 +1,4 @@
-# Day 55 — Contributor activation closeout lane
+# Contributor Activation Closeout lane (Legacy: Day 55)
 
 Day 55 closes with a major contributor activation upgrade that turns Day 53 docs-loop evidence into a deterministic contributor follow-through lane.
 
@@ -13,12 +13,12 @@ Day 55 closes with a major contributor activation upgrade that turns Day 53 docs
 - `docs/artifacts/day53-docs-loop-closeout-pack/day53-docs-loop-closeout-summary.json`
 - `docs/artifacts/day53-docs-loop-closeout-pack/day53-delivery-board.md`
 
-## Day 55 command lane
+## Contributor Activation Closeout command lane
 
 ```bash
-python -m sdetkit day55-contributor-activation-closeout --format json --strict
-python -m sdetkit day55-contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict
-python -m sdetkit day55-contributor-activation-closeout --execute --evidence-dir docs/artifacts/day55-contributor-activation-closeout-pack/evidence --format json --strict
+python -m sdetkit contributor-activation-closeout --format json --strict
+python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict
+python -m sdetkit contributor-activation-closeout --execute --evidence-dir docs/artifacts/day55-contributor-activation-closeout-pack/evidence --format json --strict
 python scripts/check_day55_contributor_activation_closeout_contract.py
 ```
 

--- a/docs/integrations-day56-stabilization-closeout.md
+++ b/docs/integrations-day56-stabilization-closeout.md
@@ -1,4 +1,4 @@
-# Day 56 — Stabilization closeout lane
+# Stabilization Closeout lane (Legacy: Day 56)
 
 Day 56 closes with a major stabilization upgrade that turns Day 55 contributor-activation outcomes into deterministic KPI recovery and follow-through.
 
@@ -13,12 +13,12 @@ Day 56 closes with a major stabilization upgrade that turns Day 55 contributor-a
 - `docs/artifacts/day55-contributor-activation-closeout-pack/day55-contributor-activation-closeout-summary.json`
 - `docs/artifacts/day55-contributor-activation-closeout-pack/day55-delivery-board.md`
 
-## Day 56 command lane
+## Stabilization Closeout command lane
 
 ```bash
-python -m sdetkit day56-stabilization-closeout --format json --strict
-python -m sdetkit day56-stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict
-python -m sdetkit day56-stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict
+python -m sdetkit stabilization-closeout --format json --strict
+python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict
+python -m sdetkit stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict
 python scripts/check_day56_stabilization_closeout_contract.py
 ```
 

--- a/docs/integrations-day57-kpi-deep-audit-closeout.md
+++ b/docs/integrations-day57-kpi-deep-audit-closeout.md
@@ -1,4 +1,4 @@
-# Day 57 — KPI deep audit closeout lane
+# KPI Deep Audit Closeout lane (Legacy: Day 57)
 
 Day 57 closes with a major KPI deep-audit upgrade that turns Day 56 stabilization outcomes into deterministic trendline governance.
 
@@ -13,12 +13,12 @@ Day 57 closes with a major KPI deep-audit upgrade that turns Day 56 stabilizatio
 - `docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json`
 - `docs/artifacts/day56-stabilization-closeout-pack/day56-delivery-board.md`
 
-## Day 57 command lane
+## KPI Deep Audit Closeout command lane
 
 ```bash
-python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict
-python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict
-python -m sdetkit day57-kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict
 python scripts/check_day57_kpi_deep_audit_closeout_contract.py
 ```
 

--- a/docs/integrations-day58-phase2-hardening-closeout.md
+++ b/docs/integrations-day58-phase2-hardening-closeout.md
@@ -1,4 +1,4 @@
-# Day 58 — Phase-2 hardening closeout lane
+# Phase 2 Hardening Closeout lane (Legacy: Day 58)
 
 Day 58 closes with a major Phase-2 hardening upgrade that turns Day 57 KPI deep-audit outcomes into deterministic execution hardening governance.
 
@@ -13,12 +13,12 @@ Day 58 closes with a major Phase-2 hardening upgrade that turns Day 57 KPI deep-
 - `docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-kpi-deep-audit-closeout-summary.json`
 - `docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-delivery-board.md`
 
-## Day 58 command lane
+## Phase 2 Hardening Closeout command lane
 
 ```bash
-python -m sdetkit day58-phase2-hardening-closeout --format json --strict
-python -m sdetkit day58-phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict
-python -m sdetkit day58-phase2-hardening-closeout --execute --evidence-dir docs/artifacts/day58-phase2-hardening-closeout-pack/evidence --format json --strict
+python -m sdetkit phase2-hardening-closeout --format json --strict
+python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict
+python -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/day58-phase2-hardening-closeout-pack/evidence --format json --strict
 python scripts/check_day58_phase2_hardening_closeout_contract.py
 ```
 

--- a/docs/integrations-day59-phase3-preplan-closeout.md
+++ b/docs/integrations-day59-phase3-preplan-closeout.md
@@ -1,4 +1,4 @@
-# Day 59 — Phase-3 pre-plan closeout lane
+# Phase3 Preplan Closeout lane (Legacy: Day 59)
 
 Day 59 closes with a major Phase-3 pre-plan upgrade that turns Day 58 hardening outcomes into deterministic Day 60 execution priorities.
 
@@ -13,12 +13,12 @@ Day 59 closes with a major Phase-3 pre-plan upgrade that turns Day 58 hardening 
 - `docs/artifacts/day58-phase2-hardening-closeout-pack/day58-phase2-hardening-closeout-summary.json`
 - `docs/artifacts/day58-phase2-hardening-closeout-pack/day58-delivery-board.md`
 
-## Day 59 command lane
+## Phase3 Preplan Closeout command lane
 
 ```bash
-python -m sdetkit day59-phase3-preplan-closeout --format json --strict
-python -m sdetkit day59-phase3-preplan-closeout --emit-pack-dir docs/artifacts/day59-phase3-preplan-closeout-pack --format json --strict
-python -m sdetkit day59-phase3-preplan-closeout --execute --evidence-dir docs/artifacts/day59-phase3-preplan-closeout-pack/evidence --format json --strict
+python -m sdetkit phase3-preplan-closeout --format json --strict
+python -m sdetkit phase3-preplan-closeout --emit-pack-dir docs/artifacts/day59-phase3-preplan-closeout-pack --format json --strict
+python -m sdetkit phase3-preplan-closeout --execute --evidence-dir docs/artifacts/day59-phase3-preplan-closeout-pack/evidence --format json --strict
 python scripts/check_day59_phase3_preplan_closeout_contract.py
 ```
 

--- a/docs/integrations-day60-phase2-wrap-handoff-closeout.md
+++ b/docs/integrations-day60-phase2-wrap-handoff-closeout.md
@@ -1,4 +1,4 @@
-# Day 60 — Phase-2 wrap + handoff closeout lane
+# Phase 2 Wrap Handoff Closeout lane (Legacy: Day 60)
 
 Day 60 closes with a major Phase-2 wrap + handoff upgrade that turns Day 59 pre-plan outcomes into deterministic Day 61 execution priorities.
 
@@ -13,12 +13,12 @@ Day 60 closes with a major Phase-2 wrap + handoff upgrade that turns Day 59 pre-
 - `docs/artifacts/day59-phase3-preplan-closeout-pack/day59-phase3-preplan-closeout-summary.json`
 - `docs/artifacts/day59-phase3-preplan-closeout-pack/day59-delivery-board.md`
 
-## Day 60 command lane
+## Phase 2 Wrap Handoff Closeout command lane
 
 ```bash
-python -m sdetkit day60-phase2-wrap-handoff-closeout --format json --strict
-python -m sdetkit day60-phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack --format json --strict
-python -m sdetkit day60-phase2-wrap-handoff-closeout --execute --evidence-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack/evidence --format json --strict
+python -m sdetkit phase2-wrap-handoff-closeout --format json --strict
+python -m sdetkit phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack --format json --strict
+python -m sdetkit phase2-wrap-handoff-closeout --execute --evidence-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack/evidence --format json --strict
 python scripts/check_day60_phase2_wrap_handoff_closeout_contract.py
 ```
 

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -356,30 +356,36 @@ def main(argv: Sequence[str] | None = None) -> int:
         "day49-advanced-weekly-review-control-tower",
     }:
         return day49_weekly_review_closeout.main(list(argv[1:]))
-    if argv and argv[0] in {"execution-prioritization-closeout", "day50-execution-prioritization-closeout"}:
+    if argv and argv[0] in {
+        "execution-prioritization-closeout",
+        "day50-execution-prioritization-closeout",
+    }:
         return day50_execution_prioritization_closeout.main(list(argv[1:]))
-    if argv and argv[0] == "day51-case-snippet-closeout":
+    if argv and argv[0] in {"case-snippet-closeout", "day51-case-snippet-closeout"}:
         return day51_case_snippet_closeout.main(list(argv[1:]))
-    if argv and argv[0] == "day52-narrative-closeout":
+    if argv and argv[0] in {"narrative-closeout", "day52-narrative-closeout"}:
         return day52_narrative_closeout.main(list(argv[1:]))
-    if argv and argv[0] == "day53-docs-loop-closeout":
+    if argv and argv[0] in {"docs-loop-closeout", "day53-docs-loop-closeout"}:
         return day53_docs_loop_closeout.main(list(argv[1:]))
-    if argv and argv[0] == "day55-contributor-activation-closeout":
+    if argv and argv[0] in {
+        "contributor-activation-closeout",
+        "day55-contributor-activation-closeout",
+    }:
         return day55_contributor_activation_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day56-stabilization-closeout":
+    if argv and argv[0] in {"stabilization-closeout", "day56-stabilization-closeout"}:
         return day56_stabilization_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day57-kpi-deep-audit-closeout":
+    if argv and argv[0] in {"kpi-deep-audit-closeout", "day57-kpi-deep-audit-closeout"}:
         return day57_kpi_deep_audit_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day58-phase2-hardening-closeout":
+    if argv and argv[0] in {"phase2-hardening-closeout", "day58-phase2-hardening-closeout"}:
         return day58_phase2_hardening_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day59-phase3-preplan-closeout":
+    if argv and argv[0] in {"phase3-preplan-closeout", "day59-phase3-preplan-closeout"}:
         return day59_phase3_preplan_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day60-phase2-wrap-handoff-closeout":
+    if argv and argv[0] in {"phase2-wrap-handoff-closeout", "day60-phase2-wrap-handoff-closeout"}:
         return day60_phase2_wrap_handoff_closeout.main(list(argv[1:]))
 
     if argv and argv[0] == "day61-phase3-kickoff-closeout":
@@ -764,26 +770,47 @@ Run: sdetkit playbooks
     pa50.add_argument("args", nargs=argparse.REMAINDER)
     d50 = sub.add_parser("day50-execution-prioritization-closeout")
     d50.add_argument("args", nargs=argparse.REMAINDER)
+    p51 = sub.add_parser("case-snippet-closeout")
+    p51.add_argument("args", nargs=argparse.REMAINDER)
     d51 = sub.add_parser("day51-case-snippet-closeout")
     d51.add_argument("args", nargs=argparse.REMAINDER)
+    p52 = sub.add_parser("narrative-closeout")
+    p52.add_argument("args", nargs=argparse.REMAINDER)
     d52 = sub.add_parser("day52-narrative-closeout")
     d52.add_argument("args", nargs=argparse.REMAINDER)
 
+    p53 = sub.add_parser("docs-loop-closeout")
+    p53.add_argument("args", nargs=argparse.REMAINDER)
     d53 = sub.add_parser("day53-docs-loop-closeout")
     d53.add_argument("args", nargs=argparse.REMAINDER)
 
+    p55 = sub.add_parser("contributor-activation-closeout")
+    p55.add_argument("args", nargs=argparse.REMAINDER)
     d55 = sub.add_parser("day55-contributor-activation-closeout")
     d55.add_argument("args", nargs=argparse.REMAINDER)
 
+    p56 = sub.add_parser("stabilization-closeout")
+    p56.add_argument("args", nargs=argparse.REMAINDER)
     d56 = sub.add_parser("day56-stabilization-closeout")
     d56.add_argument("args", nargs=argparse.REMAINDER)
 
+    p57 = sub.add_parser("kpi-deep-audit-closeout")
+    p57.add_argument("args", nargs=argparse.REMAINDER)
     d57 = sub.add_parser("day57-kpi-deep-audit-closeout")
     d57.add_argument("args", nargs=argparse.REMAINDER)
 
+    p58 = sub.add_parser("phase2-hardening-closeout")
+    p58.add_argument("args", nargs=argparse.REMAINDER)
+    d58 = sub.add_parser("day58-phase2-hardening-closeout")
+    d58.add_argument("args", nargs=argparse.REMAINDER)
+
+    p59 = sub.add_parser("phase3-preplan-closeout")
+    p59.add_argument("args", nargs=argparse.REMAINDER)
     d59 = sub.add_parser("day59-phase3-preplan-closeout")
     d59.add_argument("args", nargs=argparse.REMAINDER)
 
+    p60 = sub.add_parser("phase2-wrap-handoff-closeout")
+    p60.add_argument("args", nargs=argparse.REMAINDER)
     d60 = sub.add_parser("day60-phase2-wrap-handoff-closeout")
     d60.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -1120,29 +1147,36 @@ Run: sdetkit playbooks
         return day47_reliability_closeout.main(ns.args)
     if ns.cmd in {"objection-closeout", "day48-objection-closeout"}:
         return day48_objection_closeout.main(ns.args)
-    if ns.cmd in {"weekly-review-closeout", "day49-weekly-review-closeout", "day49-advanced-weekly-review-control-tower"}:
+    if ns.cmd in {
+        "weekly-review-closeout",
+        "day49-weekly-review-closeout",
+        "day49-advanced-weekly-review-control-tower",
+    }:
         return day49_weekly_review_closeout.main(ns.args)
     if ns.cmd in {"execution-prioritization-closeout", "day50-execution-prioritization-closeout"}:
         return day50_execution_prioritization_closeout.main(ns.args)
-    if ns.cmd == "day51-case-snippet-closeout":
+    if ns.cmd in {"case-snippet-closeout", "day51-case-snippet-closeout"}:
         return day51_case_snippet_closeout.main(ns.args)
-    if ns.cmd == "day52-narrative-closeout":
+    if ns.cmd in {"narrative-closeout", "day52-narrative-closeout"}:
         return day52_narrative_closeout.main(ns.args)
-    if ns.cmd == "day53-docs-loop-closeout":
+    if ns.cmd in {"docs-loop-closeout", "day53-docs-loop-closeout"}:
         return day53_docs_loop_closeout.main(ns.args)
-    if ns.cmd == "day55-contributor-activation-closeout":
+    if ns.cmd in {"contributor-activation-closeout", "day55-contributor-activation-closeout"}:
         return day55_contributor_activation_closeout.main(ns.args)
 
-    if ns.cmd == "day56-stabilization-closeout":
+    if ns.cmd in {"stabilization-closeout", "day56-stabilization-closeout"}:
         return day56_stabilization_closeout.main(ns.args)
 
-    if ns.cmd == "day57-kpi-deep-audit-closeout":
+    if ns.cmd in {"kpi-deep-audit-closeout", "day57-kpi-deep-audit-closeout"}:
         return day57_kpi_deep_audit_closeout.main(ns.args)
 
-    if ns.cmd == "day59-phase3-preplan-closeout":
+    if ns.cmd in {"phase2-hardening-closeout", "day58-phase2-hardening-closeout"}:
+        return day58_phase2_hardening_closeout.main(ns.args)
+
+    if ns.cmd in {"phase3-preplan-closeout", "day59-phase3-preplan-closeout"}:
         return day59_phase3_preplan_closeout.main(ns.args)
 
-    if ns.cmd == "day60-phase2-wrap-handoff-closeout":
+    if ns.cmd in {"phase2-wrap-handoff-closeout", "day60-phase2-wrap-handoff-closeout"}:
         return day60_phase2_wrap_handoff_closeout.main(ns.args)
 
     if ns.cmd == "day61-phase3-kickoff-closeout":

--- a/src/sdetkit/day51_case_snippet_closeout.py
+++ b/src/sdetkit/day51_case_snippet_closeout.py
@@ -25,14 +25,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day51-case-snippet-closeout --format json --strict",
-    "python -m sdetkit day51-case-snippet-closeout --emit-pack-dir docs/artifacts/day51-case-snippet-closeout-pack --format json --strict",
-    "python -m sdetkit day51-case-snippet-closeout --execute --evidence-dir docs/artifacts/day51-case-snippet-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit case-snippet-closeout --format json --strict",
+    "python -m sdetkit case-snippet-closeout --emit-pack-dir docs/artifacts/day51-case-snippet-closeout-pack --format json --strict",
+    "python -m sdetkit case-snippet-closeout --execute --evidence-dir docs/artifacts/day51-case-snippet-closeout-pack/evidence --format json --strict",
     "python scripts/check_day51_case_snippet_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day51-case-snippet-closeout --format json --strict",
-    "python -m sdetkit day51-case-snippet-closeout --emit-pack-dir docs/artifacts/day51-case-snippet-closeout-pack --format json --strict",
+    "python -m sdetkit case-snippet-closeout --format json --strict",
+    "python -m sdetkit case-snippet-closeout --emit-pack-dir docs/artifacts/day51-case-snippet-closeout-pack --format json --strict",
     "python scripts/check_day51_case_snippet_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -74,9 +74,9 @@ Day 51 closes with a major case-snippet upgrade that converts Day 50 execution-p
 ## Day 51 command lane
 
 ```bash
-python -m sdetkit day51-case-snippet-closeout --format json --strict
-python -m sdetkit day51-case-snippet-closeout --emit-pack-dir docs/artifacts/day51-case-snippet-closeout-pack --format json --strict
-python -m sdetkit day51-case-snippet-closeout --execute --evidence-dir docs/artifacts/day51-case-snippet-closeout-pack/evidence --format json --strict
+python -m sdetkit case-snippet-closeout --format json --strict
+python -m sdetkit case-snippet-closeout --emit-pack-dir docs/artifacts/day51-case-snippet-closeout-pack --format json --strict
+python -m sdetkit case-snippet-closeout --execute --evidence-dir docs/artifacts/day51-case-snippet-closeout-pack/evidence --format json --strict
 python scripts/check_day51_case_snippet_closeout_contract.py
 ```
 
@@ -325,7 +325,7 @@ def build_day51_case_snippet_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     return {
-        "name": "day51-case-snippet-closeout",
+        "name": "case-snippet-closeout",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -359,7 +359,7 @@ def build_day51_case_snippet_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 51 case snippet closeout summary",
+        "Case Snippet Closeout summary (legacy: Day 51)",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -396,7 +396,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(
         target / "day51-proof-map.csv",
         "stream,owner,backup,review_window,docs_cta,command_cta,kpi_target,risk_flag\n"
-        "case-snippet-floor,qa-lead,docs-owner,2026-03-19T10:00:00Z,docs/integrations-day51-case-snippet-closeout.md,python -m sdetkit day51-case-snippet-closeout --format json --strict,failed-checks:0,narrative-drift\n",
+        "case-snippet-floor,qa-lead,docs-owner,2026-03-19T10:00:00Z,docs/integrations-day51-case-snippet-closeout.md,python -m sdetkit case-snippet-closeout --format json --strict,failed-checks:0,narrative-drift\n",
     )
     _write(
         target / "day51-case-snippet-kpi-scorecard.json",
@@ -454,7 +454,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Day 51 case snippet closeout checks")
+    parser = argparse.ArgumentParser(
+        description="Case Snippet Closeout checks (legacy alias: day51-case-snippet-closeout)"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day52_narrative_closeout.py
+++ b/src/sdetkit/day52_narrative_closeout.py
@@ -25,14 +25,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day52-narrative-closeout --format json --strict",
-    "python -m sdetkit day52-narrative-closeout --emit-pack-dir docs/artifacts/day52-narrative-closeout-pack --format json --strict",
-    "python -m sdetkit day52-narrative-closeout --execute --evidence-dir docs/artifacts/day52-narrative-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit narrative-closeout --format json --strict",
+    "python -m sdetkit narrative-closeout --emit-pack-dir docs/artifacts/day52-narrative-closeout-pack --format json --strict",
+    "python -m sdetkit narrative-closeout --execute --evidence-dir docs/artifacts/day52-narrative-closeout-pack/evidence --format json --strict",
     "python scripts/check_day52_narrative_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day52-narrative-closeout --format json --strict",
-    "python -m sdetkit day52-narrative-closeout --emit-pack-dir docs/artifacts/day52-narrative-closeout-pack --format json --strict",
+    "python -m sdetkit narrative-closeout --format json --strict",
+    "python -m sdetkit narrative-closeout --emit-pack-dir docs/artifacts/day52-narrative-closeout-pack --format json --strict",
     "python scripts/check_day52_narrative_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -74,9 +74,9 @@ Day 52 closes with a major narrative upgrade that converts Day 51 case-snippet e
 ## Day 52 command lane
 
 ```bash
-python -m sdetkit day52-narrative-closeout --format json --strict
-python -m sdetkit day52-narrative-closeout --emit-pack-dir docs/artifacts/day52-narrative-closeout-pack --format json --strict
-python -m sdetkit day52-narrative-closeout --execute --evidence-dir docs/artifacts/day52-narrative-closeout-pack/evidence --format json --strict
+python -m sdetkit narrative-closeout --format json --strict
+python -m sdetkit narrative-closeout --emit-pack-dir docs/artifacts/day52-narrative-closeout-pack --format json --strict
+python -m sdetkit narrative-closeout --execute --evidence-dir docs/artifacts/day52-narrative-closeout-pack/evidence --format json --strict
 python scripts/check_day52_narrative_closeout_contract.py
 ```
 
@@ -325,7 +325,7 @@ def build_day52_narrative_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     return {
-        "name": "day52-narrative-closeout",
+        "name": "narrative-closeout",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -359,7 +359,7 @@ def build_day52_narrative_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 52 narrative closeout summary",
+        "Narrative Closeout summary (legacy: Day 52)",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -394,7 +394,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(
         target / "day52-proof-map.csv",
         "stream,owner,backup,review_window,docs_cta,command_cta,kpi_target,risk_flag\n"
-        "narrative-floor,qa-lead,docs-owner,2026-03-19T10:00:00Z,docs/integrations-day52-narrative-closeout.md,python -m sdetkit day52-narrative-closeout --format json --strict,failed-checks:0,narrative-drift\n",
+        "narrative-floor,qa-lead,docs-owner,2026-03-19T10:00:00Z,docs/integrations-day52-narrative-closeout.md,python -m sdetkit narrative-closeout --format json --strict,failed-checks:0,narrative-drift\n",
     )
     _write(
         target / "day52-narrative-kpi-scorecard.json",
@@ -452,7 +452,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Day 52 narrative closeout checks")
+    parser = argparse.ArgumentParser(
+        description="Narrative Closeout checks (legacy alias: day52-narrative-closeout)"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day53_docs_loop_closeout.py
+++ b/src/sdetkit/day53_docs_loop_closeout.py
@@ -25,14 +25,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day53-docs-loop-closeout --format json --strict",
-    "python -m sdetkit day53-docs-loop-closeout --emit-pack-dir docs/artifacts/day53-docs-loop-closeout-pack --format json --strict",
-    "python -m sdetkit day53-docs-loop-closeout --execute --evidence-dir docs/artifacts/day53-docs-loop-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit docs-loop-closeout --format json --strict",
+    "python -m sdetkit docs-loop-closeout --emit-pack-dir docs/artifacts/day53-docs-loop-closeout-pack --format json --strict",
+    "python -m sdetkit docs-loop-closeout --execute --evidence-dir docs/artifacts/day53-docs-loop-closeout-pack/evidence --format json --strict",
     "python scripts/check_day53_docs_loop_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day53-docs-loop-closeout --format json --strict",
-    "python -m sdetkit day53-docs-loop-closeout --emit-pack-dir docs/artifacts/day53-docs-loop-closeout-pack --format json --strict",
+    "python -m sdetkit docs-loop-closeout --format json --strict",
+    "python -m sdetkit docs-loop-closeout --emit-pack-dir docs/artifacts/day53-docs-loop-closeout-pack --format json --strict",
     "python scripts/check_day53_docs_loop_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -74,9 +74,9 @@ Day 53 closes with a major docs loop optimization upgrade that converts Day 52 n
 ## Day 53 command lane
 
 ```bash
-python -m sdetkit day53-docs-loop-closeout --format json --strict
-python -m sdetkit day53-docs-loop-closeout --emit-pack-dir docs/artifacts/day53-docs-loop-closeout-pack --format json --strict
-python -m sdetkit day53-docs-loop-closeout --execute --evidence-dir docs/artifacts/day53-docs-loop-closeout-pack/evidence --format json --strict
+python -m sdetkit docs-loop-closeout --format json --strict
+python -m sdetkit docs-loop-closeout --emit-pack-dir docs/artifacts/day53-docs-loop-closeout-pack --format json --strict
+python -m sdetkit docs-loop-closeout --execute --evidence-dir docs/artifacts/day53-docs-loop-closeout-pack/evidence --format json --strict
 python scripts/check_day53_docs_loop_closeout_contract.py
 ```
 
@@ -325,7 +325,7 @@ def build_day53_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     return {
-        "name": "day53-docs-loop-closeout",
+        "name": "docs-loop-closeout",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -359,7 +359,7 @@ def build_day53_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 53 docs-loop closeout summary",
+        "Docs Loop Closeout summary (legacy: Day 53)",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -394,7 +394,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(
         target / "day53-cross-link-map.csv",
         "stream,owner,backup,review_window,docs_cta,command_cta,kpi_target,risk_flag\n"
-        "docs-loop-floor,qa-lead,docs-owner,2026-03-20T10:00:00Z,docs/integrations-day53-docs-loop-closeout.md,python -m sdetkit day53-docs-loop-closeout --format json --strict,failed-checks:0,link-drift\n",
+        "docs-loop-floor,qa-lead,docs-owner,2026-03-20T10:00:00Z,docs/integrations-day53-docs-loop-closeout.md,python -m sdetkit docs-loop-closeout --format json --strict,failed-checks:0,link-drift\n",
     )
     _write(
         target / "day53-docs-loop-kpi-scorecard.json",
@@ -452,7 +452,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Day 53 docs-loop closeout checks")
+    parser = argparse.ArgumentParser(
+        description="Docs Loop Closeout checks (legacy alias: day53-docs-loop-closeout)"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day55_contributor_activation_closeout.py
+++ b/src/sdetkit/day55_contributor_activation_closeout.py
@@ -25,14 +25,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day55-contributor-activation-closeout --format json --strict",
-    "python -m sdetkit day55-contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict",
-    "python -m sdetkit day55-contributor-activation-closeout --execute --evidence-dir docs/artifacts/day55-contributor-activation-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit contributor-activation-closeout --format json --strict",
+    "python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict",
+    "python -m sdetkit contributor-activation-closeout --execute --evidence-dir docs/artifacts/day55-contributor-activation-closeout-pack/evidence --format json --strict",
     "python scripts/check_day55_contributor_activation_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day55-contributor-activation-closeout --format json --strict",
-    "python -m sdetkit day55-contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict",
+    "python -m sdetkit contributor-activation-closeout --format json --strict",
+    "python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict",
     "python scripts/check_day55_contributor_activation_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -74,9 +74,9 @@ Day 55 closes with a major contributor activation upgrade that turns Day 53 docs
 ## Day 55 command lane
 
 ```bash
-python -m sdetkit day55-contributor-activation-closeout --format json --strict
-python -m sdetkit day55-contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict
-python -m sdetkit day55-contributor-activation-closeout --execute --evidence-dir docs/artifacts/day55-contributor-activation-closeout-pack/evidence --format json --strict
+python -m sdetkit contributor-activation-closeout --format json --strict
+python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict
+python -m sdetkit contributor-activation-closeout --execute --evidence-dir docs/artifacts/day55-contributor-activation-closeout-pack/evidence --format json --strict
 python scripts/check_day55_contributor_activation_closeout_contract.py
 ```
 
@@ -315,7 +315,7 @@ def build_day55_contributor_activation_closeout_summary(root: Path) -> dict[str,
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day55-contributor-activation-closeout",
+        "name": "contributor-activation-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -349,7 +349,7 @@ def build_day55_contributor_activation_closeout_summary(root: Path) -> dict[str,
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 55 contributor activation closeout summary",
+        "Contributor Activation Closeout summary (legacy: Day 55)",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -415,7 +415,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 55 contributor activation closeout checks")
+    parser = argparse.ArgumentParser(
+        description="Contributor Activation Closeout checks (legacy alias: day55-contributor-activation-closeout)"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day56_stabilization_closeout.py
+++ b/src/sdetkit/day56_stabilization_closeout.py
@@ -25,14 +25,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day56-stabilization-closeout --format json --strict",
-    "python -m sdetkit day56-stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict",
-    "python -m sdetkit day56-stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit stabilization-closeout --format json --strict",
+    "python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict",
+    "python -m sdetkit stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict",
     "python scripts/check_day56_stabilization_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day56-stabilization-closeout --format json --strict",
-    "python -m sdetkit day56-stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict",
+    "python -m sdetkit stabilization-closeout --format json --strict",
+    "python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict",
     "python scripts/check_day56_stabilization_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -74,9 +74,9 @@ Day 56 closes with a major stabilization upgrade that turns Day 55 contributor-a
 ## Day 56 command lane
 
 ```bash
-python -m sdetkit day56-stabilization-closeout --format json --strict
-python -m sdetkit day56-stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict
-python -m sdetkit day56-stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict
+python -m sdetkit stabilization-closeout --format json --strict
+python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict
+python -m sdetkit stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict
 python scripts/check_day56_stabilization_closeout_contract.py
 ```
 
@@ -315,7 +315,7 @@ def build_day56_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
 
     score = int(round(sum(c["weight"] for c in checks if bool(c["passed"]))))
     return {
-        "name": "day56-stabilization-closeout",
+        "name": "stabilization-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -349,7 +349,7 @@ def build_day56_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 56 stabilization closeout summary",
+        "Stabilization Closeout summary (legacy: Day 56)",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -409,7 +409,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 56 stabilization closeout checks")
+    parser = argparse.ArgumentParser(
+        description="Stabilization Closeout checks (legacy alias: day56-stabilization-closeout)"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day57_kpi_deep_audit_closeout.py
+++ b/src/sdetkit/day57_kpi_deep_audit_closeout.py
@@ -25,14 +25,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict",
-    "python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict",
-    "python -m sdetkit day57-kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit kpi-deep-audit-closeout --format json --strict",
+    "python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict",
+    "python -m sdetkit kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict",
     "python scripts/check_day57_kpi_deep_audit_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict",
-    "python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict",
+    "python -m sdetkit kpi-deep-audit-closeout --format json --strict",
+    "python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict",
     "python scripts/check_day57_kpi_deep_audit_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -74,9 +74,9 @@ Day 57 closes with a major KPI deep-audit upgrade that turns Day 56 stabilizatio
 ## Day 57 command lane
 
 ```bash
-python -m sdetkit day57-kpi-deep-audit-closeout --format json --strict
-python -m sdetkit day57-kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict
-python -m sdetkit day57-kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict
 python scripts/check_day57_kpi_deep_audit_closeout_contract.py
 ```
 
@@ -308,7 +308,7 @@ def build_day57_kpi_deep_audit_closeout_summary(root: Path) -> dict[str, Any]:
 
     score = int(round(sum(c["weight"] for c in checks if bool(c["passed"]))))
     return {
-        "name": "day57-kpi-deep-audit-closeout",
+        "name": "kpi-deep-audit-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -342,7 +342,7 @@ def build_day57_kpi_deep_audit_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 57 KPI deep-audit closeout summary",
+        "KPI Deep Audit Closeout summary (legacy: Day 57)",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -400,7 +400,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 57 KPI deep audit closeout checks")
+    parser = argparse.ArgumentParser(
+        description="KPI Deep Audit Closeout checks (legacy alias: day57-kpi-deep-audit-closeout)"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day58_phase2_hardening_closeout.py
+++ b/src/sdetkit/day58_phase2_hardening_closeout.py
@@ -25,14 +25,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day58-phase2-hardening-closeout --format json --strict",
-    "python -m sdetkit day58-phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict",
-    "python -m sdetkit day58-phase2-hardening-closeout --execute --evidence-dir docs/artifacts/day58-phase2-hardening-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit phase2-hardening-closeout --format json --strict",
+    "python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict",
+    "python -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/day58-phase2-hardening-closeout-pack/evidence --format json --strict",
     "python scripts/check_day58_phase2_hardening_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day58-phase2-hardening-closeout --format json --strict",
-    "python -m sdetkit day58-phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict",
+    "python -m sdetkit phase2-hardening-closeout --format json --strict",
+    "python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict",
     "python scripts/check_day58_phase2_hardening_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -74,9 +74,9 @@ Day 58 closes with a major Phase-2 hardening upgrade that turns Day 57 KPI deep-
 ## Day 58 command lane
 
 ```bash
-python -m sdetkit day58-phase2-hardening-closeout --format json --strict
-python -m sdetkit day58-phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict
-python -m sdetkit day58-phase2-hardening-closeout --execute --evidence-dir docs/artifacts/day58-phase2-hardening-closeout-pack/evidence --format json --strict
+python -m sdetkit phase2-hardening-closeout --format json --strict
+python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict
+python -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/day58-phase2-hardening-closeout-pack/evidence --format json --strict
 python scripts/check_day58_phase2_hardening_closeout_contract.py
 ```
 
@@ -308,7 +308,7 @@ def build_day58_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
 
     score = int(round(sum(c["weight"] for c in checks if bool(c["passed"]))))
     return {
-        "name": "day58-phase2-hardening-closeout",
+        "name": "phase2-hardening-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -342,7 +342,7 @@ def build_day58_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 58 Phase-2 hardening closeout summary",
+        "Phase 2 Hardening Closeout summary (legacy: Day 58)",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -401,7 +401,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 58 Phase-2 hardening closeout checks")
+    parser = argparse.ArgumentParser(
+        description="Phase 2 Hardening Closeout checks (legacy alias: day58-phase2-hardening-closeout)"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day59_phase3_preplan_closeout.py
+++ b/src/sdetkit/day59_phase3_preplan_closeout.py
@@ -23,14 +23,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day59-phase3-preplan-closeout --format json --strict",
-    "python -m sdetkit day59-phase3-preplan-closeout --emit-pack-dir docs/artifacts/day59-phase3-preplan-closeout-pack --format json --strict",
-    "python -m sdetkit day59-phase3-preplan-closeout --execute --evidence-dir docs/artifacts/day59-phase3-preplan-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit phase3-preplan-closeout --format json --strict",
+    "python -m sdetkit phase3-preplan-closeout --emit-pack-dir docs/artifacts/day59-phase3-preplan-closeout-pack --format json --strict",
+    "python -m sdetkit phase3-preplan-closeout --execute --evidence-dir docs/artifacts/day59-phase3-preplan-closeout-pack/evidence --format json --strict",
     "python scripts/check_day59_phase3_preplan_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day59-phase3-preplan-closeout --format json --strict",
-    "python -m sdetkit day59-phase3-preplan-closeout --emit-pack-dir docs/artifacts/day59-phase3-preplan-closeout-pack --format json --strict",
+    "python -m sdetkit phase3-preplan-closeout --format json --strict",
+    "python -m sdetkit phase3-preplan-closeout --emit-pack-dir docs/artifacts/day59-phase3-preplan-closeout-pack --format json --strict",
     "python scripts/check_day59_phase3_preplan_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -72,9 +72,9 @@ Day 59 closes with a major Phase-3 pre-plan upgrade that turns Day 58 hardening 
 ## Day 59 command lane
 
 ```bash
-python -m sdetkit day59-phase3-preplan-closeout --format json --strict
-python -m sdetkit day59-phase3-preplan-closeout --emit-pack-dir docs/artifacts/day59-phase3-preplan-closeout-pack --format json --strict
-python -m sdetkit day59-phase3-preplan-closeout --execute --evidence-dir docs/artifacts/day59-phase3-preplan-closeout-pack/evidence --format json --strict
+python -m sdetkit phase3-preplan-closeout --format json --strict
+python -m sdetkit phase3-preplan-closeout --emit-pack-dir docs/artifacts/day59-phase3-preplan-closeout-pack --format json --strict
+python -m sdetkit phase3-preplan-closeout --execute --evidence-dir docs/artifacts/day59-phase3-preplan-closeout-pack/evidence --format json --strict
 python scripts/check_day59_phase3_preplan_closeout_contract.py
 ```
 
@@ -297,7 +297,7 @@ def build_day59_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day59-phase3-preplan-closeout",
+        "name": "phase3-preplan-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -331,7 +331,7 @@ def build_day59_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 59 Phase-3 pre-plan closeout summary",
+        "Phase3 Preplan Closeout summary (legacy: Day 59)",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -389,7 +389,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 59 Phase-3 pre-plan closeout checks")
+    parser = argparse.ArgumentParser(
+        description="Phase3 Preplan Closeout checks (legacy alias: day59-phase3-preplan-closeout)"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day60_phase2_wrap_handoff_closeout.py
+++ b/src/sdetkit/day60_phase2_wrap_handoff_closeout.py
@@ -25,14 +25,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day60-phase2-wrap-handoff-closeout --format json --strict",
-    "python -m sdetkit day60-phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack --format json --strict",
-    "python -m sdetkit day60-phase2-wrap-handoff-closeout --execute --evidence-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit phase2-wrap-handoff-closeout --format json --strict",
+    "python -m sdetkit phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack --format json --strict",
+    "python -m sdetkit phase2-wrap-handoff-closeout --execute --evidence-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack/evidence --format json --strict",
     "python scripts/check_day60_phase2_wrap_handoff_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day60-phase2-wrap-handoff-closeout --format json --strict",
-    "python -m sdetkit day60-phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack --format json --strict",
+    "python -m sdetkit phase2-wrap-handoff-closeout --format json --strict",
+    "python -m sdetkit phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack --format json --strict",
     "python scripts/check_day60_phase2_wrap_handoff_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -74,9 +74,9 @@ Day 60 closes with a major Phase-2 wrap + handoff upgrade that turns Day 59 pre-
 ## Day 60 command lane
 
 ```bash
-python -m sdetkit day60-phase2-wrap-handoff-closeout --format json --strict
-python -m sdetkit day60-phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack --format json --strict
-python -m sdetkit day60-phase2-wrap-handoff-closeout --execute --evidence-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack/evidence --format json --strict
+python -m sdetkit phase2-wrap-handoff-closeout --format json --strict
+python -m sdetkit phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack --format json --strict
+python -m sdetkit phase2-wrap-handoff-closeout --execute --evidence-dir docs/artifacts/day60-phase2-wrap-handoff-closeout-pack/evidence --format json --strict
 python scripts/check_day60_phase2_wrap_handoff_closeout_contract.py
 ```
 
@@ -301,7 +301,7 @@ def build_day60_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, An
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day60-phase2-wrap-handoff-closeout",
+        "name": "phase2-wrap-handoff-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -335,7 +335,7 @@ def build_day60_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, An
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 60 Phase-2 wrap + handoff closeout summary",
+        "Phase 2 Wrap Handoff Closeout summary (legacy: Day 60)",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -394,7 +394,9 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 60 Phase-2 wrap + handoff closeout checks")
+    parser = argparse.ArgumentParser(
+        description="Phase 2 Wrap Handoff Closeout checks (legacy alias: day60-phase2-wrap-handoff-closeout)"
+    )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/tests/test_day51_case_snippet_closeout.py
+++ b/tests/test_day51_case_snippet_closeout.py
@@ -78,7 +78,7 @@ def test_day51_case_snippet_closeout_json(tmp_path: Path, capsys) -> None:
     rc = d51.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day51-case-snippet-closeout"
+    assert out["name"] == "case-snippet-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -122,6 +122,6 @@ def test_day51_strict_fails_when_day50_inputs_missing(tmp_path: Path) -> None:
 
 def test_day51_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day51-case-snippet-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["case-snippet-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 51 case snippet closeout summary" in capsys.readouterr().out
+    assert "Case Snippet Closeout summary" in capsys.readouterr().out

--- a/tests/test_day52_narrative_closeout.py
+++ b/tests/test_day52_narrative_closeout.py
@@ -76,7 +76,7 @@ def test_day52_narrative_closeout_json(tmp_path: Path, capsys) -> None:
     rc = d52.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day52-narrative-closeout"
+    assert out["name"] == "narrative-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -120,6 +120,6 @@ def test_day52_strict_fails_when_day51_inputs_missing(tmp_path: Path) -> None:
 
 def test_day52_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day52-narrative-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["narrative-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 52 narrative closeout summary" in capsys.readouterr().out
+    assert "Narrative Closeout summary" in capsys.readouterr().out

--- a/tests/test_day53_docs_loop_closeout.py
+++ b/tests/test_day53_docs_loop_closeout.py
@@ -75,7 +75,7 @@ def test_day53_docs_loop_closeout_json(tmp_path: Path, capsys) -> None:
     rc = d53.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day53-docs-loop-closeout"
+    assert out["name"] == "docs-loop-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -119,6 +119,6 @@ def test_day53_strict_fails_when_day52_inputs_missing(tmp_path: Path) -> None:
 
 def test_day53_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day53-docs-loop-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["docs-loop-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 53 docs-loop closeout summary" in capsys.readouterr().out
+    assert "Docs Loop Closeout summary" in capsys.readouterr().out

--- a/tests/test_day55_contributor_activation_closeout.py
+++ b/tests/test_day55_contributor_activation_closeout.py
@@ -75,7 +75,7 @@ def test_day55_json(tmp_path: Path, capsys) -> None:
     rc = d55.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day55-contributor-activation-closeout"
+    assert out["name"] == "contributor-activation-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -128,4 +128,4 @@ def test_day55_cli_dispatch(tmp_path: Path, capsys) -> None:
         ["day55-contributor-activation-closeout", "--root", str(tmp_path), "--format", "text"]
     )
     assert rc == 0
-    assert "Day 55 contributor activation closeout summary" in capsys.readouterr().out
+    assert "Contributor Activation Closeout summary" in capsys.readouterr().out

--- a/tests/test_day56_stabilization_closeout.py
+++ b/tests/test_day56_stabilization_closeout.py
@@ -78,7 +78,7 @@ def test_day56_json(tmp_path: Path, capsys) -> None:
     rc = d56.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day56-stabilization-closeout"
+    assert out["name"] == "stabilization-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -121,6 +121,6 @@ def test_day56_strict_fails_without_day55(tmp_path: Path) -> None:
 
 def test_day56_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day56-stabilization-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["stabilization-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 56 stabilization closeout summary" in capsys.readouterr().out
+    assert "Stabilization Closeout summary" in capsys.readouterr().out

--- a/tests/test_day57_kpi_deep_audit_closeout.py
+++ b/tests/test_day57_kpi_deep_audit_closeout.py
@@ -76,7 +76,7 @@ def test_day57_json(tmp_path: Path, capsys) -> None:
     rc = d57.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day57-kpi-deep-audit-closeout"
+    assert out["name"] == "kpi-deep-audit-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -119,6 +119,6 @@ def test_day57_strict_fails_without_day56(tmp_path: Path) -> None:
 
 def test_day57_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day57-kpi-deep-audit-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["kpi-deep-audit-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 57 KPI deep-audit closeout summary" in capsys.readouterr().out
+    assert "KPI Deep Audit Closeout summary" in capsys.readouterr().out

--- a/tests/test_day58_phase2_hardening_closeout.py
+++ b/tests/test_day58_phase2_hardening_closeout.py
@@ -76,7 +76,7 @@ def test_day58_json(tmp_path: Path, capsys) -> None:
     rc = d58.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day58-phase2-hardening-closeout"
+    assert out["name"] == "phase2-hardening-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -119,6 +119,6 @@ def test_day58_strict_fails_without_day57(tmp_path: Path) -> None:
 
 def test_day58_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day58-phase2-hardening-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["phase2-hardening-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 58 Phase-2 hardening closeout summary" in capsys.readouterr().out
+    assert "Phase 2 Hardening Closeout summary" in capsys.readouterr().out

--- a/tests/test_day59_phase3_preplan_closeout.py
+++ b/tests/test_day59_phase3_preplan_closeout.py
@@ -76,7 +76,7 @@ def test_day59_json(tmp_path: Path, capsys) -> None:
     rc = d59.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day59-phase3-preplan-closeout"
+    assert out["name"] == "phase3-preplan-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -119,6 +119,6 @@ def test_day59_strict_fails_without_day58(tmp_path: Path) -> None:
 
 def test_day59_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day59-phase3-preplan-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["phase3-preplan-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 59 Phase-3 pre-plan closeout summary" in capsys.readouterr().out
+    assert "Phase3 Preplan Closeout summary" in capsys.readouterr().out

--- a/tests/test_day60_phase2_wrap_handoff_closeout.py
+++ b/tests/test_day60_phase2_wrap_handoff_closeout.py
@@ -76,7 +76,7 @@ def test_day60_json(tmp_path: Path, capsys) -> None:
     rc = d60.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day60-phase2-wrap-handoff-closeout"
+    assert out["name"] == "phase2-wrap-handoff-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -127,4 +127,4 @@ def test_day60_cli_dispatch(tmp_path: Path, capsys) -> None:
         ["day60-phase2-wrap-handoff-closeout", "--root", str(tmp_path), "--format", "text"]
     )
     assert rc == 0
-    assert "Day 60 Phase-2 wrap + handoff closeout summary" in capsys.readouterr().out
+    assert "Phase 2 Wrap Handoff Closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Make the stable product-branded lane names the primary public commands for Days 51–53 and 55–60 while preserving the Day-XX commands as safe legacy aliases. 
- Surface the product intent and remove dated-first discoverability while preserving evidence, pack layout, and behavior for CI/docs/testing.
- Treat Day 54 as ambiguous and avoid forcing any rename because no concrete Day 54 lane implementation exists in the codebase.

### Description
- Updated the CLI to accept canonical product names and preserve day-branded names as aliases by adding new parser entries and dispatch checks in `src/sdetkit/cli.py` (e.g., `case-snippet-closeout` alongside `day51-case-snippet-closeout`).
- Modified each affected lane module under `src/sdetkit/` to emit the canonical `name` value, use canonical command examples, and update help/description text to indicate a legacy day alias (e.g., `Case Snippet Closeout checks (legacy alias: day51-case-snippet-closeout)`).
- Updated documentation pages under `docs/` for the targeted lanes to prefer product-branded titles and command-lane sections while adding `(Legacy: Day XX)` framing and switching examples to canonical commands.
- Adjusted tests in `tests/` to assert the canonical `name` and canonical CLI dispatch and to continue exercising legacy alias dispatch where relevant; no behavioral change to outputs or artifact layout was made.

### Testing
- Ran help checks for both canonical and legacy commands for all targeted lanes (invoked `python -m sdetkit <canonical>` and `python -m sdetkit <legacy>`); both entrypoints responded (help output collected).
- Executed targeted unit tests `pytest -q` for the modified lanes: `tests/test_day51_*.py` ... `tests/test_day60_*.py` which resulted in `36 passed` (all targeted tests passed).
- Ran repository gate checks: `python -m sdetkit gate fast` and `python -m sdetkit gate release` were executed; `gate fast` reported an existing `ruff_format` issue and `gate release` failed on `doctor_release` and nested `gate_fast` steps that reflect repo-level release checks rather than lane regressions.
- Ran `ruff format` on the modified files (reformatted 10 files) as part of validation; formatting changes were applied but repo-level gate formatting expectations still surfaced in `gate fast` output.

------