### PR TITLE
Productize Day 71–80 lanes: make stable names primary and keep dayXX aliases

### DIFF
--- a/docs/day-71-big-upgrade-report.md
+++ b/docs/day-71-big-upgrade-report.md
@@ -6,7 +6,7 @@ Close Day 71 with a high-signal case-study prep lane that converts Day 70 output
 
 ## What shipped
 
-- New `day71-case-study-prep3-closeout` CLI lane with strict scoring and Day 70 continuity validation.
+- New `case-study-prep3-closeout` CLI lane with strict scoring and Day 70 continuity validation.
 - New Day 71 integration guide with command lane, contract lock, quality checklist, and delivery board.
 - New Day 71 contract checker script for CI and local execution gating.
 - New case-study artifact pack outputs for narrative, controls logging, KPI scoring, and execution evidence.
@@ -15,9 +15,9 @@ Close Day 71 with a high-signal case-study prep lane that converts Day 70 output
 ## Validation flow
 
 ```bash
-python -m sdetkit day71-case-study-prep3-closeout --format json --strict
-python -m sdetkit day71-case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict
-python -m sdetkit day71-case-study-prep3-closeout --execute --evidence-dir docs/artifacts/day71-case-study-prep3-closeout-pack/evidence --format json --strict
+python -m sdetkit case-study-prep3-closeout --format json --strict
+python -m sdetkit case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict
+python -m sdetkit case-study-prep3-closeout --execute --evidence-dir docs/artifacts/day71-case-study-prep3-closeout-pack/evidence --format json --strict
 python scripts/check_day71_case_study_prep3_closeout_contract.py
 ```
 

--- a/docs/day-72-big-upgrade-report.md
+++ b/docs/day-72-big-upgrade-report.md
@@ -6,7 +6,7 @@ Close Day 72 with a high-signal case-study prep #4 lane that upgrades Day 71 esc
 
 ## What shipped
 
-- New `day72-case-study-prep4-closeout` CLI lane with strict scoring and Day 71 continuity validation.
+- New `case-study-prep4-closeout` CLI lane with strict scoring and Day 71 continuity validation.
 - New Day 72 integration guide with command lane, contract lock, quality checklist, and delivery board.
 - New Day 72 contract checker script for CI and local execution gating.
 - New publication-quality artifact pack outputs for narrative, controls logging, KPI scoring, and execution evidence.
@@ -15,9 +15,9 @@ Close Day 72 with a high-signal case-study prep #4 lane that upgrades Day 71 esc
 ## Validation flow
 
 ```bash
-python -m sdetkit day72-case-study-prep4-closeout --format json --strict
-python -m sdetkit day72-case-study-prep4-closeout --emit-pack-dir docs/artifacts/day72-case-study-prep4-closeout-pack --format json --strict
-python -m sdetkit day72-case-study-prep4-closeout --execute --evidence-dir docs/artifacts/day72-case-study-prep4-closeout-pack/evidence --format json --strict
+python -m sdetkit case-study-prep4-closeout --format json --strict
+python -m sdetkit case-study-prep4-closeout --emit-pack-dir docs/artifacts/day72-case-study-prep4-closeout-pack --format json --strict
+python -m sdetkit case-study-prep4-closeout --execute --evidence-dir docs/artifacts/day72-case-study-prep4-closeout-pack/evidence --format json --strict
 python scripts/check_day72_case_study_prep4_closeout_contract.py
 ```
 

--- a/docs/day-73-big-upgrade-report.md
+++ b/docs/day-73-big-upgrade-report.md
@@ -6,7 +6,7 @@ Close Day 73 with a high-signal case-study launch lane that upgrades Day 72 publ
 
 ## What shipped
 
-- New `day73-case-study-launch-closeout` CLI lane with strict scoring and Day 72 continuity validation.
+- New `case-study-launch-closeout` CLI lane with strict scoring and Day 72 continuity validation.
 - New Day 73 integration guide with command lane, contract lock, quality checklist, and delivery board.
 - New Day 73 contract checker script for CI and local execution gating.
 - New published-case-study artifact pack outputs for narrative, controls logging, KPI scoring, and execution evidence.
@@ -15,9 +15,9 @@ Close Day 73 with a high-signal case-study launch lane that upgrades Day 72 publ
 ## Validation flow
 
 ```bash
-python -m sdetkit day73-case-study-launch-closeout --format json --strict
-python -m sdetkit day73-case-study-launch-closeout --emit-pack-dir docs/artifacts/day73-case-study-launch-closeout-pack --format json --strict
-python -m sdetkit day73-case-study-launch-closeout --execute --evidence-dir docs/artifacts/day73-case-study-launch-closeout-pack/evidence --format json --strict
+python -m sdetkit case-study-launch-closeout --format json --strict
+python -m sdetkit case-study-launch-closeout --emit-pack-dir docs/artifacts/day73-case-study-launch-closeout-pack --format json --strict
+python -m sdetkit case-study-launch-closeout --execute --evidence-dir docs/artifacts/day73-case-study-launch-closeout-pack/evidence --format json --strict
 python scripts/check_day73_case_study_launch_closeout_contract.py
 ```
 

--- a/docs/day-74-big-upgrade-report.md
+++ b/docs/day-74-big-upgrade-report.md
@@ -6,7 +6,7 @@ Close Day 74 with a high-signal distribution scaling lane that upgrades Day 73 p
 
 ### What shipped
 
-- New `day74-distribution-scaling-closeout` CLI lane with strict scoring and Day 73 continuity validation.
+- New `distribution-scaling-closeout` CLI lane with strict scoring and Day 73 continuity validation.
 - New Day 74 integration guide with command lane, contract lock, quality checklist, and delivery board.
 - New Day 74 contract checker script for CI and local execution gating.
 - New `docs/roadmap/plans/day74-distribution-scaling-plan.json` baseline dataset scaffold for Day 74 distribution execution planning.
@@ -14,9 +14,9 @@ Close Day 74 with a high-signal distribution scaling lane that upgrades Day 73 p
 ### Command lane
 
 ```bash
-python -m sdetkit day74-distribution-scaling-closeout --format json --strict
-python -m sdetkit day74-distribution-scaling-closeout --emit-pack-dir docs/artifacts/day74-distribution-scaling-closeout-pack --format json --strict
-python -m sdetkit day74-distribution-scaling-closeout --execute --evidence-dir docs/artifacts/day74-distribution-scaling-closeout-pack/evidence --format json --strict
+python -m sdetkit distribution-scaling-closeout --format json --strict
+python -m sdetkit distribution-scaling-closeout --emit-pack-dir docs/artifacts/day74-distribution-scaling-closeout-pack --format json --strict
+python -m sdetkit distribution-scaling-closeout --execute --evidence-dir docs/artifacts/day74-distribution-scaling-closeout-pack/evidence --format json --strict
 python scripts/check_day74_distribution_scaling_closeout_contract.py
 ```
 

--- a/docs/day-75-big-upgrade-report.md
+++ b/docs/day-75-big-upgrade-report.md
@@ -6,7 +6,7 @@ Close Day 75 with a high-signal trust-assets refresh lane that upgrades Day 74 d
 
 ### What shipped
 
-- New `day75-trust-assets-refresh-closeout` CLI lane with strict scoring and Day 74 continuity validation.
+- New `trust-assets-refresh-closeout` CLI lane with strict scoring and Day 74 continuity validation.
 - New Day 75 integration guide with command lane, contract lock, quality checklist, and delivery board.
 - New Day 75 contract checker script for CI and local execution gating.
 - New `docs/roadmap/plans/day75-trust-assets-refresh-plan.json` baseline dataset scaffold for trust refresh execution planning.
@@ -14,9 +14,9 @@ Close Day 75 with a high-signal trust-assets refresh lane that upgrades Day 74 d
 ### Command lane
 
 ```bash
-python -m sdetkit day75-trust-assets-refresh-closeout --format json --strict
-python -m sdetkit day75-trust-assets-refresh-closeout --emit-pack-dir docs/artifacts/day75-trust-assets-refresh-closeout-pack --format json --strict
-python -m sdetkit day75-trust-assets-refresh-closeout --execute --evidence-dir docs/artifacts/day75-trust-assets-refresh-closeout-pack/evidence --format json --strict
+python -m sdetkit trust-assets-refresh-closeout --format json --strict
+python -m sdetkit trust-assets-refresh-closeout --emit-pack-dir docs/artifacts/day75-trust-assets-refresh-closeout-pack --format json --strict
+python -m sdetkit trust-assets-refresh-closeout --execute --evidence-dir docs/artifacts/day75-trust-assets-refresh-closeout-pack/evidence --format json --strict
 python scripts/check_day75_trust_assets_refresh_closeout_contract.py
 ```
 

--- a/docs/day-76-big-upgrade-report.md
+++ b/docs/day-76-big-upgrade-report.md
@@ -6,7 +6,7 @@ Close Day 76 with a high-signal contributor-recognition lane that upgrades Day 7
 
 ### What shipped
 
-- New `day76-contributor-recognition-closeout` CLI lane with strict scoring and Day 75 continuity validation.
+- New `contributor-recognition-closeout` CLI lane with strict scoring and Day 75 continuity validation.
 - New Day 76 integration guide with command lane, contract lock, quality checklist, and delivery board.
 - New Day 76 contract checker script for CI and local execution gating.
 - New `docs/roadmap/plans/day76-contributor-recognition-plan.json` baseline dataset scaffold for recognition execution planning.
@@ -14,9 +14,9 @@ Close Day 76 with a high-signal contributor-recognition lane that upgrades Day 7
 ### Command lane
 
 ```bash
-python -m sdetkit day76-contributor-recognition-closeout --format json --strict
-python -m sdetkit day76-contributor-recognition-closeout --emit-pack-dir docs/artifacts/day76-contributor-recognition-closeout-pack --format json --strict
-python -m sdetkit day76-contributor-recognition-closeout --execute --evidence-dir docs/artifacts/day76-contributor-recognition-closeout-pack/evidence --format json --strict
+python -m sdetkit contributor-recognition-closeout --format json --strict
+python -m sdetkit contributor-recognition-closeout --emit-pack-dir docs/artifacts/day76-contributor-recognition-closeout-pack --format json --strict
+python -m sdetkit contributor-recognition-closeout --execute --evidence-dir docs/artifacts/day76-contributor-recognition-closeout-pack/evidence --format json --strict
 python scripts/check_day76_contributor_recognition_closeout_contract.py
 ```
 

--- a/docs/day-77-big-upgrade-report.md
+++ b/docs/day-77-big-upgrade-report.md
@@ -6,7 +6,7 @@ Close Day 77 with a high-signal community-touchpoint lane that upgrades Day 76 c
 
 ### What shipped
 
-- New `day77-community-touchpoint-closeout` CLI lane with strict scoring and Day 76 continuity validation.
+- New `community-touchpoint-closeout` CLI lane with strict scoring and Day 76 continuity validation.
 - New Day 77 integration guide with command lane, contract lock, quality checklist, and delivery board.
 - New Day 77 contract checker script for CI and local execution gating.
 - New `docs/roadmap/plans/day77-community-touchpoint-plan.json` baseline dataset scaffold for touchpoint execution planning.
@@ -14,9 +14,9 @@ Close Day 77 with a high-signal community-touchpoint lane that upgrades Day 76 c
 ### Command lane
 
 ```bash
-python -m sdetkit day77-community-touchpoint-closeout --format json --strict
-python -m sdetkit day77-community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict
-python -m sdetkit day77-community-touchpoint-closeout --execute --evidence-dir docs/artifacts/day77-community-touchpoint-closeout-pack/evidence --format json --strict
+python -m sdetkit community-touchpoint-closeout --format json --strict
+python -m sdetkit community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict
+python -m sdetkit community-touchpoint-closeout --execute --evidence-dir docs/artifacts/day77-community-touchpoint-closeout-pack/evidence --format json --strict
 python scripts/check_day77_community_touchpoint_closeout_contract.py
 ```
 

--- a/docs/day-78-big-upgrade-report.md
+++ b/docs/day-78-big-upgrade-report.md
@@ -6,7 +6,7 @@ Close Day 78 with a high-signal ecosystem-priorities lane that upgrades Day 77 c
 
 ### What shipped
 
-- New `day78-ecosystem-priorities-closeout` CLI lane with strict scoring and Day 77 continuity validation.
+- New `ecosystem-priorities-closeout` CLI lane with strict scoring and Day 77 continuity validation.
 - New Day 78 integration guide with command lane, contract lock, quality checklist, and delivery board.
 - New Day 78 contract checker script for CI and local execution gating.
 - New `docs/roadmap/plans/day78-ecosystem-priorities-plan.json` baseline dataset scaffold for ecosystem execution planning.
@@ -14,9 +14,9 @@ Close Day 78 with a high-signal ecosystem-priorities lane that upgrades Day 77 c
 ### Command lane
 
 ```bash
-python -m sdetkit day78-ecosystem-priorities-closeout --format json --strict
-python -m sdetkit day78-ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict
-python -m sdetkit day78-ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack/evidence --format json --strict
+python -m sdetkit ecosystem-priorities-closeout --format json --strict
+python -m sdetkit ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict
+python -m sdetkit ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack/evidence --format json --strict
 python scripts/check_day78_ecosystem_priorities_closeout_contract.py
 ```
 

--- a/docs/day-79-big-upgrade-report.md
+++ b/docs/day-79-big-upgrade-report.md
@@ -4,7 +4,7 @@ Day 79 delivers a closeout-grade scale upgrade lane that promotes Day 78 ecosyst
 
 ## What shipped
 
-- New command: `python -m sdetkit day79-scale-upgrade-closeout`.
+- New command: `python -m sdetkit scale-upgrade-closeout`.
 - New integration guide: `docs/integrations-day79-scale-upgrade-closeout.md`.
 - New contract checker: `python scripts/check_day79_scale_upgrade_closeout_contract.py`.
 - New artifact schema emitted via `--emit-pack-dir` and deterministic evidence via `--execute`.

--- a/docs/integrations-day71-case-study-prep3-closeout.md
+++ b/docs/integrations-day71-case-study-prep3-closeout.md
@@ -1,4 +1,6 @@
-# Day 71 — Case-study prep #3 closeout lane
+# Case Study Prep3 Closeout
+
+> Legacy mapping: Day 71 remains as history/compatibility alias `day71-case-study-prep3-closeout`. Use `python -m sdetkit case-study-prep3-closeout` as the stable command.
 
 Day 71 closes with a major upgrade that turns Day 70 integration outputs into a measurable escalation-quality case-study prep pack.
 
@@ -17,9 +19,9 @@ Day 71 closes with a major upgrade that turns Day 70 integration outputs into a 
 ## Day 71 command lane
 
 ```bash
-python -m sdetkit day71-case-study-prep3-closeout --format json --strict
-python -m sdetkit day71-case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict
-python -m sdetkit day71-case-study-prep3-closeout --execute --evidence-dir docs/artifacts/day71-case-study-prep3-closeout-pack/evidence --format json --strict
+python -m sdetkit case-study-prep3-closeout --format json --strict
+python -m sdetkit case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict
+python -m sdetkit case-study-prep3-closeout --execute --evidence-dir docs/artifacts/day71-case-study-prep3-closeout-pack/evidence --format json --strict
 python scripts/check_day71_case_study_prep3_closeout_contract.py
 ```
 

--- a/docs/integrations-day72-case-study-prep4-closeout.md
+++ b/docs/integrations-day72-case-study-prep4-closeout.md
@@ -1,4 +1,6 @@
-# Day 72 — Case-study prep #4 closeout lane
+# Case Study Prep4 Closeout
+
+> Legacy mapping: Day 72 remains as history/compatibility alias `day72-case-study-prep4-closeout`. Use `python -m sdetkit case-study-prep4-closeout` as the stable command.
 
 Day 72 closes with a major upgrade that turns Day 71 escalation-quality outputs into a measurable publication-quality case-study launch pack.
 

--- a/docs/integrations-day73-case-study-launch-closeout.md
+++ b/docs/integrations-day73-case-study-launch-closeout.md
@@ -1,4 +1,6 @@
-# Day 73 — Case-study launch closeout lane
+# Case Study Launch Closeout
+
+> Legacy mapping: Day 73 remains as history/compatibility alias `day73-case-study-launch-closeout`. Use `python -m sdetkit case-study-launch-closeout` as the stable command.
 
 Day 73 closes with a major upgrade that turns Day 72 publication-quality prep into a published case-study launch pack with rollout safeguards.
 

--- a/docs/integrations-day74-distribution-scaling-closeout.md
+++ b/docs/integrations-day74-distribution-scaling-closeout.md
@@ -1,4 +1,6 @@
-# Day 74 — Distribution scaling closeout lane
+# Distribution Scaling Closeout
+
+> Legacy mapping: Day 74 remains as history/compatibility alias `day74-distribution-scaling-closeout`. Use `python -m sdetkit distribution-scaling-closeout` as the stable command.
 
 Day 74 closes with a major upgrade that turns Day 73 published case-study outcomes into a scalable distribution execution pack with governance safeguards.
 

--- a/docs/integrations-day75-trust-assets-refresh-closeout.md
+++ b/docs/integrations-day75-trust-assets-refresh-closeout.md
@@ -1,4 +1,6 @@
-# Day 75 — Trust assets refresh closeout lane
+# Trust Assets Refresh Closeout
+
+> Legacy mapping: Day 75 remains as history/compatibility alias `day75-trust-assets-refresh-closeout`. Use `python -m sdetkit trust-assets-refresh-closeout` as the stable command.
 
 Day 75 closes with a major upgrade that turns Day 74 distribution outcomes into a governance-grade trust refresh execution pack.
 

--- a/docs/integrations-day76-contributor-recognition-closeout.md
+++ b/docs/integrations-day76-contributor-recognition-closeout.md
@@ -1,4 +1,6 @@
-# Day 76 — Contributor recognition closeout lane
+# Contributor Recognition Closeout
+
+> Legacy mapping: Day 76 remains as history/compatibility alias `day76-contributor-recognition-closeout`. Use `python -m sdetkit contributor-recognition-closeout` as the stable command.
 
 Day 76 closes with a major upgrade that converts Day 75 trust refresh outcomes into a contributor-recognition execution pack.
 

--- a/docs/integrations-day77-community-touchpoint-closeout.md
+++ b/docs/integrations-day77-community-touchpoint-closeout.md
@@ -1,4 +1,6 @@
-# Day 77 — Community touchpoint closeout lane
+# Community Touchpoint Closeout
+
+> Legacy mapping: Day 77 remains as history/compatibility alias `day77-community-touchpoint-closeout`. Use `python -m sdetkit community-touchpoint-closeout` as the stable command.
 
 Day 77 closes with a major upgrade that converts Day 76 contributor-recognition outcomes into a community-touchpoint execution pack.
 
@@ -17,9 +19,9 @@ Day 77 closes with a major upgrade that converts Day 76 contributor-recognition 
 ## Day 77 command lane
 
 ```bash
-python -m sdetkit day77-community-touchpoint-closeout --format json --strict
-python -m sdetkit day77-community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict
-python -m sdetkit day77-community-touchpoint-closeout --execute --evidence-dir docs/artifacts/day77-community-touchpoint-closeout-pack/evidence --format json --strict
+python -m sdetkit community-touchpoint-closeout --format json --strict
+python -m sdetkit community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict
+python -m sdetkit community-touchpoint-closeout --execute --evidence-dir docs/artifacts/day77-community-touchpoint-closeout-pack/evidence --format json --strict
 python scripts/check_day77_community_touchpoint_closeout_contract.py
 ```
 

--- a/docs/integrations-day78-ecosystem-priorities-closeout.md
+++ b/docs/integrations-day78-ecosystem-priorities-closeout.md
@@ -1,4 +1,6 @@
-# Day 78 — Ecosystem priorities closeout lane
+# Ecosystem Priorities Closeout
+
+> Legacy mapping: Day 78 remains as history/compatibility alias `day78-ecosystem-priorities-closeout`. Use `python -m sdetkit ecosystem-priorities-closeout` as the stable command.
 
 Day 78 closes with a major upgrade that converts Day 77 community-touchpoint outcomes into an ecosystem-priorities execution pack.
 
@@ -17,9 +19,9 @@ Day 78 closes with a major upgrade that converts Day 77 community-touchpoint out
 ## Day 78 command lane
 
 ```bash
-python -m sdetkit day78-ecosystem-priorities-closeout --format json --strict
-python -m sdetkit day78-ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict
-python -m sdetkit day78-ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack/evidence --format json --strict
+python -m sdetkit ecosystem-priorities-closeout --format json --strict
+python -m sdetkit ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict
+python -m sdetkit ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack/evidence --format json --strict
 python scripts/check_day78_ecosystem_priorities_closeout_contract.py
 ```
 

--- a/docs/integrations-day79-scale-upgrade-closeout.md
+++ b/docs/integrations-day79-scale-upgrade-closeout.md
@@ -1,4 +1,6 @@
-# Day 79 — Scale upgrade closeout lane
+# Scale Upgrade Closeout
+
+> Legacy mapping: Day 79 remains as history/compatibility alias `day79-scale-upgrade-closeout`. Use `python -m sdetkit scale-upgrade-closeout` as the stable command.
 
 Day 79 closes with a major upgrade that converts Day 78 ecosystem priorities into an enterprise-scale onboarding execution pack.
 
@@ -17,9 +19,9 @@ Day 79 closes with a major upgrade that converts Day 78 ecosystem priorities int
 ## Day 79 command lane
 
 ```bash
-python -m sdetkit day79-scale-upgrade-closeout --format json --strict
-python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict
-python -m sdetkit day79-scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict
+python -m sdetkit scale-upgrade-closeout --format json --strict
+python -m sdetkit scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict
+python -m sdetkit scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict
 python scripts/check_day79_scale_upgrade_closeout_contract.py
 ```
 

--- a/docs/integrations-day80-partner-outreach-closeout.md
+++ b/docs/integrations-day80-partner-outreach-closeout.md
@@ -1,4 +1,6 @@
-# Day 80 — Partner outreach closeout lane
+# Partner Outreach Closeout
+
+> Legacy mapping: Day 80 remains as history/compatibility alias `day80-partner-outreach-closeout`. Use `python -m sdetkit partner-outreach-closeout` as the stable command.
 
 Day 80 closes with a major upgrade that converts Day 79 scale outcomes into a partner-outreach execution pack.
 
@@ -17,9 +19,9 @@ Day 80 closes with a major upgrade that converts Day 79 scale outcomes into a pa
 ## Day 80 command lane
 
 ```bash
-python -m sdetkit day80-partner-outreach-closeout --format json --strict
-python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict
-python -m sdetkit day80-partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict
+python -m sdetkit partner-outreach-closeout --format json --strict
+python -m sdetkit partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict
+python -m sdetkit partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict
 python scripts/check_day80_partner_outreach_closeout_contract.py
 ```
 

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -418,37 +418,37 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "day70-case-study-prep2-closeout":
         return day70_case_study_prep2_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day71-case-study-prep3-closeout":
+    if argv and argv[0] in {"case-study-prep3-closeout", "day71-case-study-prep3-closeout"}:
         return day71_case_study_prep3_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] in {"day72-case-study-prep4-closeout", "case-study-prep4-closeout"}:
+    if argv and argv[0] in {"case-study-prep4-closeout", "day72-case-study-prep4-closeout"}:
         return day72_case_study_prep4_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] in {"day73-case-study-launch-closeout", "case-study-launch-closeout"}:
+    if argv and argv[0] in {"case-study-launch-closeout", "day73-case-study-launch-closeout"}:
         return day73_case_study_launch_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] in {"day74-distribution-scaling-closeout", "distribution-scaling-closeout"}:
+    if argv and argv[0] in {"distribution-scaling-closeout", "day74-distribution-scaling-closeout"}:
         return day74_distribution_scaling_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] in {"day75-trust-assets-refresh-closeout", "trust-assets-refresh-closeout"}:
+    if argv and argv[0] in {"trust-assets-refresh-closeout", "day75-trust-assets-refresh-closeout"}:
         return day75_trust_assets_refresh_closeout.main(list(argv[1:]))
 
     if argv and argv[0] in {
-        "day76-contributor-recognition-closeout",
         "contributor-recognition-closeout",
+        "day76-contributor-recognition-closeout",
     }:
         return day76_contributor_recognition_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day77-community-touchpoint-closeout":
+    if argv and argv[0] in {"community-touchpoint-closeout", "day77-community-touchpoint-closeout"}:
         return day77_community_touchpoint_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day78-ecosystem-priorities-closeout":
+    if argv and argv[0] in {"ecosystem-priorities-closeout", "day78-ecosystem-priorities-closeout"}:
         return day78_ecosystem_priorities_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day79-scale-upgrade-closeout":
+    if argv and argv[0] in {"scale-upgrade-closeout", "day79-scale-upgrade-closeout"}:
         return day79_scale_upgrade_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day80-partner-outreach-closeout":
+    if argv and argv[0] in {"partner-outreach-closeout", "day80-partner-outreach-closeout"}:
         return day80_partner_outreach_closeout.main(list(argv[1:]))
 
     if argv and argv[0] == "day81-growth-campaign-closeout":
@@ -843,36 +843,36 @@ Run: sdetkit playbooks
 
     d70 = sub.add_parser("day70-case-study-prep2-closeout")
     d70.add_argument("args", nargs=argparse.REMAINDER)
-    d71 = sub.add_parser("day71-case-study-prep3-closeout")
+    d71 = sub.add_parser("case-study-prep3-closeout", aliases=["day71-case-study-prep3-closeout"])
     d71.add_argument("args", nargs=argparse.REMAINDER)
     d72 = sub.add_parser("case-study-prep4-closeout", aliases=["day72-case-study-prep4-closeout"])
-    d72.set_defaults(cmd="day72-case-study-prep4-closeout")
+    d72.set_defaults(cmd="case-study-prep4-closeout")
     d72.add_argument("args", nargs=argparse.REMAINDER)
     d73 = sub.add_parser("case-study-launch-closeout", aliases=["day73-case-study-launch-closeout"])
-    d73.set_defaults(cmd="day73-case-study-launch-closeout")
+    d73.set_defaults(cmd="case-study-launch-closeout")
     d73.add_argument("args", nargs=argparse.REMAINDER)
     d74 = sub.add_parser(
         "distribution-scaling-closeout", aliases=["day74-distribution-scaling-closeout"]
     )
-    d74.set_defaults(cmd="day74-distribution-scaling-closeout")
+    d74.set_defaults(cmd="distribution-scaling-closeout")
     d74.add_argument("args", nargs=argparse.REMAINDER)
     d75 = sub.add_parser(
         "trust-assets-refresh-closeout", aliases=["day75-trust-assets-refresh-closeout"]
     )
-    d75.set_defaults(cmd="day75-trust-assets-refresh-closeout")
+    d75.set_defaults(cmd="trust-assets-refresh-closeout")
     d75.add_argument("args", nargs=argparse.REMAINDER)
     d76 = sub.add_parser(
         "contributor-recognition-closeout", aliases=["day76-contributor-recognition-closeout"]
     )
-    d76.set_defaults(cmd="day76-contributor-recognition-closeout")
+    d76.set_defaults(cmd="contributor-recognition-closeout")
     d76.add_argument("args", nargs=argparse.REMAINDER)
-    d77 = sub.add_parser("day77-community-touchpoint-closeout")
+    d77 = sub.add_parser("community-touchpoint-closeout", aliases=["day77-community-touchpoint-closeout"])
     d77.add_argument("args", nargs=argparse.REMAINDER)
-    d78 = sub.add_parser("day78-ecosystem-priorities-closeout")
+    d78 = sub.add_parser("ecosystem-priorities-closeout", aliases=["day78-ecosystem-priorities-closeout"])
     d78.add_argument("args", nargs=argparse.REMAINDER)
-    d79 = sub.add_parser("day79-scale-upgrade-closeout")
+    d79 = sub.add_parser("scale-upgrade-closeout", aliases=["day79-scale-upgrade-closeout"])
     d79.add_argument("args", nargs=argparse.REMAINDER)
-    d80 = sub.add_parser("day80-partner-outreach-closeout")
+    d80 = sub.add_parser("partner-outreach-closeout", aliases=["day80-partner-outreach-closeout"])
     d80.add_argument("args", nargs=argparse.REMAINDER)
     d81 = sub.add_parser("day81-growth-campaign-closeout")
     d81.add_argument("args", nargs=argparse.REMAINDER)
@@ -1209,34 +1209,34 @@ Run: sdetkit playbooks
     if ns.cmd == "day70-case-study-prep2-closeout":
         return day70_case_study_prep2_closeout.main(ns.args)
 
-    if ns.cmd == "day71-case-study-prep3-closeout":
+    if ns.cmd == "case-study-prep3-closeout":
         return day71_case_study_prep3_closeout.main(ns.args)
 
-    if ns.cmd == "day72-case-study-prep4-closeout":
+    if ns.cmd == "case-study-prep4-closeout":
         return day72_case_study_prep4_closeout.main(ns.args)
 
-    if ns.cmd == "day73-case-study-launch-closeout":
+    if ns.cmd == "case-study-launch-closeout":
         return day73_case_study_launch_closeout.main(ns.args)
 
-    if ns.cmd == "day74-distribution-scaling-closeout":
+    if ns.cmd == "distribution-scaling-closeout":
         return day74_distribution_scaling_closeout.main(ns.args)
 
-    if ns.cmd == "day75-trust-assets-refresh-closeout":
+    if ns.cmd == "trust-assets-refresh-closeout":
         return day75_trust_assets_refresh_closeout.main(ns.args)
 
-    if ns.cmd == "day76-contributor-recognition-closeout":
+    if ns.cmd == "contributor-recognition-closeout":
         return day76_contributor_recognition_closeout.main(ns.args)
 
-    if ns.cmd == "day77-community-touchpoint-closeout":
+    if ns.cmd == "community-touchpoint-closeout":
         return day77_community_touchpoint_closeout.main(ns.args)
 
-    if ns.cmd == "day78-ecosystem-priorities-closeout":
+    if ns.cmd == "ecosystem-priorities-closeout":
         return day78_ecosystem_priorities_closeout.main(ns.args)
 
-    if ns.cmd == "day79-scale-upgrade-closeout":
+    if ns.cmd == "scale-upgrade-closeout":
         return day79_scale_upgrade_closeout.main(ns.args)
 
-    if ns.cmd == "day80-partner-outreach-closeout":
+    if ns.cmd == "partner-outreach-closeout":
         return day80_partner_outreach_closeout.main(ns.args)
 
     if ns.cmd == "day81-growth-campaign-closeout":

--- a/src/sdetkit/day71_case_study_prep3_closeout.py
+++ b/src/sdetkit/day71_case_study_prep3_closeout.py
@@ -24,14 +24,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day71-case-study-prep3-closeout --format json --strict",
-    "python -m sdetkit day71-case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict",
-    "python -m sdetkit day71-case-study-prep3-closeout --execute --evidence-dir docs/artifacts/day71-case-study-prep3-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit case-study-prep3-closeout --format json --strict",
+    "python -m sdetkit case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict",
+    "python -m sdetkit case-study-prep3-closeout --execute --evidence-dir docs/artifacts/day71-case-study-prep3-closeout-pack/evidence --format json --strict",
     "python scripts/check_day71_case_study_prep3_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day71-case-study-prep3-closeout --format json --strict",
-    "python -m sdetkit day71-case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict",
+    "python -m sdetkit case-study-prep3-closeout --format json --strict",
+    "python -m sdetkit case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict",
     "python scripts/check_day71_case_study_prep3_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -82,9 +82,9 @@ Day 71 closes with a major upgrade that turns Day 70 integration outputs into a 
 ## Day 71 command lane
 
 ```bash
-python -m sdetkit day71-case-study-prep3-closeout --format json --strict
-python -m sdetkit day71-case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict
-python -m sdetkit day71-case-study-prep3-closeout --execute --evidence-dir docs/artifacts/day71-case-study-prep3-closeout-pack/evidence --format json --strict
+python -m sdetkit case-study-prep3-closeout --format json --strict
+python -m sdetkit case-study-prep3-closeout --emit-pack-dir docs/artifacts/day71-case-study-prep3-closeout-pack --format json --strict
+python -m sdetkit case-study-prep3-closeout --execute --evidence-dir docs/artifacts/day71-case-study-prep3-closeout-pack/evidence --format json --strict
 python scripts/check_day71_case_study_prep3_closeout_contract.py
 ```
 
@@ -174,7 +174,7 @@ def build_day71_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "readme_day71_command",
             "weight": 7,
-            "passed": ("day71-case-study-prep3-closeout" in readme_text),
+            "passed": ("case-study-prep3-closeout" in readme_text),
             "evidence": "README day71 command lane",
         },
         {
@@ -310,7 +310,7 @@ def build_day71_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day71-case-study-prep3-closeout",
+        "name": "case-study-prep3-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -345,7 +345,7 @@ def build_day71_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 71 case-study prep #3 closeout summary",
+        "Case Study Prep3 Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -405,7 +405,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 71 case-study prep #3 closeout checks")
+    parser = argparse.ArgumentParser(description="Case Study Prep3 Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day72_case_study_prep4_closeout.py
+++ b/src/sdetkit/day72_case_study_prep4_closeout.py
@@ -176,7 +176,7 @@ def build_day72_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
             "weight": 7,
             "passed": (
                 "case-study-prep4-closeout" in readme_text
-                or "day72-case-study-prep4-closeout" in readme_text
+                or "case-study-prep4-closeout" in readme_text
             ),
             "evidence": "README day72 command lane",
         },
@@ -313,7 +313,7 @@ def build_day72_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day72-case-study-prep4-closeout",
+        "name": "case-study-prep4-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -348,7 +348,7 @@ def build_day72_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 72 case-study prep #4 closeout summary",
+        "Case Study Prep4 Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -408,7 +408,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 72 case-study prep #4 closeout checks")
+    parser = argparse.ArgumentParser(description="Case Study Prep4 Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day73_case_study_launch_closeout.py
+++ b/src/sdetkit/day73_case_study_launch_closeout.py
@@ -176,7 +176,7 @@ def build_day73_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]
             "weight": 7,
             "passed": (
                 "case-study-launch-closeout" in readme_text
-                or "day73-case-study-launch-closeout" in readme_text
+                or "case-study-launch-closeout" in readme_text
             ),
             "evidence": "README day73 command lane",
         },
@@ -311,7 +311,7 @@ def build_day73_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day73-case-study-launch-closeout",
+        "name": "case-study-launch-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -346,7 +346,7 @@ def build_day73_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 73 case-study launch closeout summary",
+        "Case Study Launch Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -406,7 +406,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 73 case-study launch closeout checks")
+    parser = argparse.ArgumentParser(description="Case Study Launch Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day74_distribution_scaling_closeout.py
+++ b/src/sdetkit/day74_distribution_scaling_closeout.py
@@ -176,7 +176,7 @@ def build_day74_distribution_scaling_closeout_summary(root: Path) -> dict[str, A
             "weight": 7,
             "passed": (
                 "distribution-scaling-closeout" in readme_text
-                or "day74-distribution-scaling-closeout" in readme_text
+                or "distribution-scaling-closeout" in readme_text
             ),
             "evidence": "README day74 command lane",
         },
@@ -311,7 +311,7 @@ def build_day74_distribution_scaling_closeout_summary(root: Path) -> dict[str, A
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day74-distribution-scaling-closeout",
+        "name": "distribution-scaling-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -346,7 +346,7 @@ def build_day74_distribution_scaling_closeout_summary(root: Path) -> dict[str, A
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 74 distribution scaling closeout summary",
+        "Distribution Scaling Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -408,7 +408,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 74 distribution scaling closeout checks")
+    parser = argparse.ArgumentParser(description="Distribution Scaling Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day75_trust_assets_refresh_closeout.py
+++ b/src/sdetkit/day75_trust_assets_refresh_closeout.py
@@ -175,7 +175,7 @@ def build_day75_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, A
             "weight": 7,
             "passed": (
                 "trust-assets-refresh-closeout" in readme_text
-                or "day75-trust-assets-refresh-closeout" in readme_text
+                or "trust-assets-refresh-closeout" in readme_text
             ),
             "evidence": "README day75 command lane",
         },
@@ -310,7 +310,7 @@ def build_day75_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, A
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day75-trust-assets-refresh-closeout",
+        "name": "trust-assets-refresh-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -345,7 +345,7 @@ def build_day75_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, A
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 75 trust assets refresh closeout summary",
+        "Trust Assets Refresh Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -405,7 +405,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 75 trust assets refresh closeout checks")
+    parser = argparse.ArgumentParser(description="Trust Assets Refresh Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day76_contributor_recognition_closeout.py
+++ b/src/sdetkit/day76_contributor_recognition_closeout.py
@@ -175,7 +175,7 @@ def build_day76_contributor_recognition_closeout_summary(root: Path) -> dict[str
             "weight": 7,
             "passed": (
                 "contributor-recognition-closeout" in readme_text
-                or "day76-contributor-recognition-closeout" in readme_text
+                or "contributor-recognition-closeout" in readme_text
             ),
             "evidence": "README day76 command lane",
         },
@@ -310,7 +310,7 @@ def build_day76_contributor_recognition_closeout_summary(root: Path) -> dict[str
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day76-contributor-recognition-closeout",
+        "name": "contributor-recognition-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -345,7 +345,7 @@ def build_day76_contributor_recognition_closeout_summary(root: Path) -> dict[str
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 76 contributor recognition closeout summary",
+        "Contributor Recognition Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -414,7 +414,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 76 contributor recognition closeout checks")
+    parser = argparse.ArgumentParser(description="Contributor Recognition Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day77_community_touchpoint_closeout.py
+++ b/src/sdetkit/day77_community_touchpoint_closeout.py
@@ -26,14 +26,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day77-community-touchpoint-closeout --format json --strict",
-    "python -m sdetkit day77-community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict",
-    "python -m sdetkit day77-community-touchpoint-closeout --execute --evidence-dir docs/artifacts/day77-community-touchpoint-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit community-touchpoint-closeout --format json --strict",
+    "python -m sdetkit community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict",
+    "python -m sdetkit community-touchpoint-closeout --execute --evidence-dir docs/artifacts/day77-community-touchpoint-closeout-pack/evidence --format json --strict",
     "python scripts/check_day77_community_touchpoint_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day77-community-touchpoint-closeout --format json --strict",
-    "python -m sdetkit day77-community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict",
+    "python -m sdetkit community-touchpoint-closeout --format json --strict",
+    "python -m sdetkit community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict",
     "python scripts/check_day77_community_touchpoint_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -84,9 +84,9 @@ Day 77 closes with a major upgrade that converts Day 76 contributor-recognition 
 ## Day 77 command lane
 
 ```bash
-python -m sdetkit day77-community-touchpoint-closeout --format json --strict
-python -m sdetkit day77-community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict
-python -m sdetkit day77-community-touchpoint-closeout --execute --evidence-dir docs/artifacts/day77-community-touchpoint-closeout-pack/evidence --format json --strict
+python -m sdetkit community-touchpoint-closeout --format json --strict
+python -m sdetkit community-touchpoint-closeout --emit-pack-dir docs/artifacts/day77-community-touchpoint-closeout-pack --format json --strict
+python -m sdetkit community-touchpoint-closeout --execute --evidence-dir docs/artifacts/day77-community-touchpoint-closeout-pack/evidence --format json --strict
 python scripts/check_day77_community_touchpoint_closeout_contract.py
 ```
 
@@ -173,7 +173,7 @@ def build_day77_community_touchpoint_closeout_summary(root: Path) -> dict[str, A
         {
             "check_id": "readme_day77_command",
             "weight": 7,
-            "passed": ("day77-community-touchpoint-closeout" in readme_text),
+            "passed": ("community-touchpoint-closeout" in readme_text),
             "evidence": "README day77 command lane",
         },
         {
@@ -307,7 +307,7 @@ def build_day77_community_touchpoint_closeout_summary(root: Path) -> dict[str, A
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day77-community-touchpoint-closeout",
+        "name": "community-touchpoint-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -342,7 +342,7 @@ def build_day77_community_touchpoint_closeout_summary(root: Path) -> dict[str, A
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 77 community touchpoint closeout summary",
+        "Community Touchpoint Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -407,7 +407,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 77 community touchpoint closeout checks")
+    parser = argparse.ArgumentParser(description="Community Touchpoint Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day78_ecosystem_priorities_closeout.py
+++ b/src/sdetkit/day78_ecosystem_priorities_closeout.py
@@ -26,14 +26,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day78-ecosystem-priorities-closeout --format json --strict",
-    "python -m sdetkit day78-ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict",
-    "python -m sdetkit day78-ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit ecosystem-priorities-closeout --format json --strict",
+    "python -m sdetkit ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict",
+    "python -m sdetkit ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack/evidence --format json --strict",
     "python scripts/check_day78_ecosystem_priorities_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day78-ecosystem-priorities-closeout --format json --strict",
-    "python -m sdetkit day78-ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict",
+    "python -m sdetkit ecosystem-priorities-closeout --format json --strict",
+    "python -m sdetkit ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict",
     "python scripts/check_day78_ecosystem_priorities_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -84,9 +84,9 @@ Day 78 closes with a major upgrade that converts Day 77 community-touchpoint out
 ## Day 78 command lane
 
 ```bash
-python -m sdetkit day78-ecosystem-priorities-closeout --format json --strict
-python -m sdetkit day78-ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict
-python -m sdetkit day78-ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack/evidence --format json --strict
+python -m sdetkit ecosystem-priorities-closeout --format json --strict
+python -m sdetkit ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack --format json --strict
+python -m sdetkit ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/day78-ecosystem-priorities-closeout-pack/evidence --format json --strict
 python scripts/check_day78_ecosystem_priorities_closeout_contract.py
 ```
 
@@ -173,7 +173,7 @@ def build_day78_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, A
         {
             "check_id": "readme_day78_command",
             "weight": 7,
-            "passed": ("day78-ecosystem-priorities-closeout" in readme_text),
+            "passed": ("ecosystem-priorities-closeout" in readme_text),
             "evidence": "README day78 command lane",
         },
         {
@@ -305,7 +305,7 @@ def build_day78_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, A
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day78-ecosystem-priorities-closeout",
+        "name": "ecosystem-priorities-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -340,7 +340,7 @@ def build_day78_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, A
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 78 ecosystem priorities closeout summary",
+        "Ecosystem Priorities Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -403,7 +403,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 78 ecosystem priorities closeout checks")
+    parser = argparse.ArgumentParser(description="Ecosystem Priorities Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day79_scale_upgrade_closeout.py
+++ b/src/sdetkit/day79_scale_upgrade_closeout.py
@@ -26,14 +26,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day79-scale-upgrade-closeout --format json --strict",
-    "python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict",
-    "python -m sdetkit day79-scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit scale-upgrade-closeout --format json --strict",
+    "python -m sdetkit scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict",
+    "python -m sdetkit scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict",
     "python scripts/check_day79_scale_upgrade_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day79-scale-upgrade-closeout --format json --strict",
-    "python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict",
+    "python -m sdetkit scale-upgrade-closeout --format json --strict",
+    "python -m sdetkit scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict",
     "python scripts/check_day79_scale_upgrade_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -84,9 +84,9 @@ Day 79 closes with a major upgrade that converts Day 78 ecosystem priorities int
 ## Day 79 command lane
 
 ```bash
-python -m sdetkit day79-scale-upgrade-closeout --format json --strict
-python -m sdetkit day79-scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict
-python -m sdetkit day79-scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict
+python -m sdetkit scale-upgrade-closeout --format json --strict
+python -m sdetkit scale-upgrade-closeout --emit-pack-dir docs/artifacts/day79-scale-upgrade-closeout-pack --format json --strict
+python -m sdetkit scale-upgrade-closeout --execute --evidence-dir docs/artifacts/day79-scale-upgrade-closeout-pack/evidence --format json --strict
 python scripts/check_day79_scale_upgrade_closeout_contract.py
 ```
 
@@ -171,7 +171,7 @@ def build_day79_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "readme_day79_command",
             "weight": 7,
-            "passed": ("day79-scale-upgrade-closeout" in readme_text),
+            "passed": ("scale-upgrade-closeout" in readme_text),
             "evidence": "README day79 command lane",
         },
         {
@@ -303,7 +303,7 @@ def build_day79_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day79-scale-upgrade-closeout",
+        "name": "scale-upgrade-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -338,7 +338,7 @@ def build_day79_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 79 scale upgrade closeout summary",
+        "Scale Upgrade Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -402,7 +402,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 79 scale upgrade closeout checks")
+    parser = argparse.ArgumentParser(description="Scale Upgrade Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/day80_partner_outreach_closeout.py
+++ b/src/sdetkit/day80_partner_outreach_closeout.py
@@ -26,14 +26,14 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day80-partner-outreach-closeout --format json --strict",
-    "python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict",
-    "python -m sdetkit day80-partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit partner-outreach-closeout --format json --strict",
+    "python -m sdetkit partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict",
+    "python -m sdetkit partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict",
     "python scripts/check_day80_partner_outreach_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day80-partner-outreach-closeout --format json --strict",
-    "python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict",
+    "python -m sdetkit partner-outreach-closeout --format json --strict",
+    "python -m sdetkit partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict",
     "python scripts/check_day80_partner_outreach_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -84,9 +84,9 @@ Day 80 closes with a major upgrade that converts Day 79 scale outcomes into a pa
 ## Day 80 command lane
 
 ```bash
-python -m sdetkit day80-partner-outreach-closeout --format json --strict
-python -m sdetkit day80-partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict
-python -m sdetkit day80-partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict
+python -m sdetkit partner-outreach-closeout --format json --strict
+python -m sdetkit partner-outreach-closeout --emit-pack-dir docs/artifacts/day80-partner-outreach-closeout-pack --format json --strict
+python -m sdetkit partner-outreach-closeout --execute --evidence-dir docs/artifacts/day80-partner-outreach-closeout-pack/evidence --format json --strict
 python scripts/check_day80_partner_outreach_closeout_contract.py
 ```
 
@@ -177,7 +177,7 @@ def build_day80_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "readme_day80_command",
             "weight": 7,
-            "passed": ("day80-partner-outreach-closeout" in readme_text),
+            "passed": ("partner-outreach-closeout" in readme_text),
             "evidence": "README day80 command lane",
         },
         {
@@ -309,7 +309,7 @@ def build_day80_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     return {
-        "name": "day80-partner-outreach-closeout",
+        "name": "partner-outreach-closeout",
         "inputs": {
             "readme": "README.md",
             "docs_index": "docs/index.md",
@@ -344,7 +344,7 @@ def build_day80_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 80 partner outreach closeout summary",
+        "Partner Outreach Closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -407,7 +407,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Day 80 partner outreach closeout checks")
+    parser = argparse.ArgumentParser(description="Partner Outreach Closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/tests/test_day71_case_study_prep3_closeout.py
+++ b/tests/test_day71_case_study_prep3_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-day71-case-study-prep3-closeout.md\nday71-case-study-prep3-closeout\n",
+        "docs/integrations-day71-case-study-prep3-closeout.md\ncase-study-prep3-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -92,7 +92,7 @@ def test_day71_json(tmp_path: Path, capsys) -> None:
     rc = d71.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day71-case-study-prep3-closeout"
+    assert out["name"] == "case-study-prep3-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -136,6 +136,6 @@ def test_day71_strict_fails_without_day70(tmp_path: Path) -> None:
 
 def test_day71_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day71-case-study-prep3-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["case-study-prep3-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 71 case-study prep #3 closeout summary" in capsys.readouterr().out
+    assert "Case Study Prep3 Closeout summary" in capsys.readouterr().out

--- a/tests/test_day72_case_study_prep4_closeout.py
+++ b/tests/test_day72_case_study_prep4_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-day72-case-study-prep4-closeout.md\nday72-case-study-prep4-closeout\n",
+        "docs/integrations-day72-case-study-prep4-closeout.md\ncase-study-prep4-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -92,7 +92,7 @@ def test_day72_json(tmp_path: Path, capsys) -> None:
     rc = d72.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day72-case-study-prep4-closeout"
+    assert out["name"] == "case-study-prep4-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -136,6 +136,6 @@ def test_day72_strict_fails_without_day71(tmp_path: Path) -> None:
 
 def test_day72_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day72-case-study-prep4-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["case-study-prep4-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 72 case-study prep #4 closeout summary" in capsys.readouterr().out
+    assert "Case Study Prep4 Closeout summary" in capsys.readouterr().out

--- a/tests/test_day73_case_study_launch_closeout.py
+++ b/tests/test_day73_case_study_launch_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-day73-case-study-launch-closeout.md\nday73-case-study-launch-closeout\n",
+        "docs/integrations-day73-case-study-launch-closeout.md\ncase-study-launch-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -92,7 +92,7 @@ def test_day73_json(tmp_path: Path, capsys) -> None:
     rc = d73.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day73-case-study-launch-closeout"
+    assert out["name"] == "case-study-launch-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -138,6 +138,6 @@ def test_day73_strict_fails_without_day72(tmp_path: Path) -> None:
 
 def test_day73_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day73-case-study-launch-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["case-study-launch-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 73 case-study launch closeout summary" in capsys.readouterr().out
+    assert "Case Study Launch Closeout summary" in capsys.readouterr().out

--- a/tests/test_day74_distribution_scaling_closeout.py
+++ b/tests/test_day74_distribution_scaling_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-day74-distribution-scaling-closeout.md\nday74-distribution-scaling-closeout\n",
+        "docs/integrations-day74-distribution-scaling-closeout.md\ndistribution-scaling-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -92,7 +92,7 @@ def test_day74_json(tmp_path: Path, capsys) -> None:
     rc = d74.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day74-distribution-scaling-closeout"
+    assert out["name"] == "distribution-scaling-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -141,7 +141,7 @@ def test_day74_strict_fails_without_day73(tmp_path: Path) -> None:
 def test_day74_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(
-        ["day74-distribution-scaling-closeout", "--root", str(tmp_path), "--format", "text"]
+        ["distribution-scaling-closeout", "--root", str(tmp_path), "--format", "text"]
     )
     assert rc == 0
-    assert "Day 74 distribution scaling closeout summary" in capsys.readouterr().out
+    assert "Distribution Scaling Closeout summary" in capsys.readouterr().out

--- a/tests/test_day75_trust_assets_refresh_closeout.py
+++ b/tests/test_day75_trust_assets_refresh_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-day75-trust-assets-refresh-closeout.md\nday75-trust-assets-refresh-closeout\n",
+        "docs/integrations-day75-trust-assets-refresh-closeout.md\ntrust-assets-refresh-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -92,7 +92,7 @@ def test_day75_json(tmp_path: Path, capsys) -> None:
     rc = d75.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day75-trust-assets-refresh-closeout"
+    assert out["name"] == "trust-assets-refresh-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -141,7 +141,7 @@ def test_day75_strict_fails_without_day74(tmp_path: Path) -> None:
 def test_day75_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(
-        ["day75-trust-assets-refresh-closeout", "--root", str(tmp_path), "--format", "text"]
+        ["trust-assets-refresh-closeout", "--root", str(tmp_path), "--format", "text"]
     )
     assert rc == 0
-    assert "Day 75 trust assets refresh closeout summary" in capsys.readouterr().out
+    assert "Trust Assets Refresh Closeout summary" in capsys.readouterr().out

--- a/tests/test_day76_contributor_recognition_closeout.py
+++ b/tests/test_day76_contributor_recognition_closeout.py
@@ -65,7 +65,7 @@ def test_day76_json(tmp_path: Path, capsys) -> None:
     rc = d76.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day76-contributor-recognition-closeout"
+    assert out["name"] == "contributor-recognition-closeout"
     assert out["summary"]["strict_pass"] is True
 
 
@@ -106,4 +106,4 @@ def test_day76_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["contributor-recognition-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 76 contributor recognition closeout summary" in capsys.readouterr().out
+    assert "Contributor Recognition Closeout summary" in capsys.readouterr().out

--- a/tests/test_day77_community_touchpoint_closeout.py
+++ b/tests/test_day77_community_touchpoint_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-day77-community-touchpoint-closeout.md\nday77-community-touchpoint-closeout\n",
+        "docs/integrations-day77-community-touchpoint-closeout.md\ncommunity-touchpoint-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -94,7 +94,7 @@ def test_day77_json(tmp_path: Path, capsys) -> None:
     rc = d77.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day77-community-touchpoint-closeout"
+    assert out["name"] == "community-touchpoint-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -143,7 +143,7 @@ def test_day77_strict_fails_without_day76(tmp_path: Path) -> None:
 def test_day77_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(
-        ["day77-community-touchpoint-closeout", "--root", str(tmp_path), "--format", "text"]
+        ["community-touchpoint-closeout", "--root", str(tmp_path), "--format", "text"]
     )
     assert rc == 0
-    assert "Day 77 community touchpoint closeout summary" in capsys.readouterr().out
+    assert "Community Touchpoint Closeout summary" in capsys.readouterr().out

--- a/tests/test_day78_ecosystem_priorities_closeout.py
+++ b/tests/test_day78_ecosystem_priorities_closeout.py
@@ -11,7 +11,7 @@ def _seed_repo(root: Path) -> None:
     (root / "docs/roadmap/plans").mkdir(parents=True, exist_ok=True)
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-day78-ecosystem-priorities-closeout.md\nday78-ecosystem-priorities-closeout\n",
+        "docs/integrations-day78-ecosystem-priorities-closeout.md\necosystem-priorities-closeout\n",
         encoding="utf-8",
     )
     (root / "docs/index.md").write_text(
@@ -65,7 +65,7 @@ def test_day78_json(tmp_path: Path, capsys) -> None:
     rc = d78.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day78-ecosystem-priorities-closeout"
+    assert out["name"] == "ecosystem-priorities-closeout"
     assert out["summary"]["strict_pass"] is True
 
 
@@ -105,7 +105,7 @@ def test_day78_strict_fails_without_day77_summary(tmp_path: Path) -> None:
 def test_day78_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(
-        ["day78-ecosystem-priorities-closeout", "--root", str(tmp_path), "--format", "text"]
+        ["ecosystem-priorities-closeout", "--root", str(tmp_path), "--format", "text"]
     )
     assert rc == 0
-    assert "Day 78 ecosystem priorities closeout summary" in capsys.readouterr().out
+    assert "Ecosystem Priorities Closeout summary" in capsys.readouterr().out

--- a/tests/test_day79_scale_upgrade_closeout.py
+++ b/tests/test_day79_scale_upgrade_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-day79-scale-upgrade-closeout.md\nday79-scale-upgrade-closeout\n",
+        "docs/integrations-day79-scale-upgrade-closeout.md\nscale-upgrade-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -92,7 +92,7 @@ def test_day79_json(tmp_path: Path, capsys) -> None:
     rc = d79.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day79-scale-upgrade-closeout"
+    assert out["name"] == "scale-upgrade-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -136,6 +136,6 @@ def test_day79_strict_fails_without_day78(tmp_path: Path) -> None:
 
 def test_day79_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day79-scale-upgrade-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["scale-upgrade-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 79 scale upgrade closeout summary" in capsys.readouterr().out
+    assert "Scale Upgrade Closeout summary" in capsys.readouterr().out

--- a/tests/test_day80_partner_outreach_closeout.py
+++ b/tests/test_day80_partner_outreach_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-day80-partner-outreach-closeout.md\nday80-partner-outreach-closeout\n",
+        "docs/integrations-day80-partner-outreach-closeout.md\npartner-outreach-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -92,7 +92,7 @@ def test_day80_json(tmp_path: Path, capsys) -> None:
     rc = d80.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day80-partner-outreach-closeout"
+    assert out["name"] == "partner-outreach-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -136,6 +136,6 @@ def test_day80_strict_fails_without_day79(tmp_path: Path) -> None:
 
 def test_day80_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day80-partner-outreach-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["partner-outreach-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 80 partner outreach closeout summary" in capsys.readouterr().out
+    assert "Partner Outreach Closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Move Day 71–80 CLI lanes from day-branded public names to stable product-branded canonical names while preserving the original day-based commands as safe compatibility aliases. 
- Ensure docs, help text, and tests present the stable command surface without changing lane behavior or artifact names.

### Description
- Updated CLI dispatch and subparser registration so the canonical names (e.g. `case-study-prep3-closeout` … `partner-outreach-closeout`) are primary while each `dayXX-*` name is an alias accepted in argv and subparsers. 
- Updated the 10 lane modules (Day 71–80) to use product-branded `name` values, parser descriptions, and text-summary headers while keeping all artifact/pack filenames and docs dependency paths unchanged. 
- Updated integration docs and big-upgrade reports to prefer canonical commands and inserted a short legacy-mapping note on each integration page to surface the `dayXX-*` alias. 
- Updated the 10 targeted tests to invoke the canonical commands and to assert product-branded summaries/names while preserving artifact existence checks.

### Testing
- Ran targeted unit tests for Day 71–80: `pytest -q tests/test_day71_case_study_prep3_closeout.py ... tests/test_day80_partner_outreach_closeout.py`, and all tests passed (40 passed). 
- Verified canonical and legacy help/alias behavior with `python -m sdetkit case-study-prep3-closeout --help` through `python -m sdetkit partner-outreach-closeout --help` and also `python -m sdetkit day71-case-study-prep3-closeout --help` through `python -m sdetkit day80-partner-outreach-closeout --help`, which completed successfully. 
- Ran `python -m sdetkit gate fast --root .` and `python -m sdetkit gate release --root .` which returned `gate: problems found`, matching repository baseline issues not caused by this rename-focused change. 
- Focused change set only affects CLI names, help text, docs, and tests for these lanes and preserves runtime artifact filenames and pack outputs to avoid behavioral drift.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afa364075c8327b17d50c398ea5381)