### PR TITLE
docs: add troubleshooting for sqlite-utils empty-column schema inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Ready-to-use guide: `docs/ready-to-use.md`
 
 For full docs UX, open: <https://sherif69-sa.github.io/DevS69-sdetkit/>.
 
+Troubleshooting note for sqlite-utils schema inference edge-cases: `docs/sqlite-utils-empty-column-troubleshooting.md`
+
 ## Role-based starting paths
 
 | Role | Start here | Why |

--- a/docs/sqlite-utils-empty-column-troubleshooting.md
+++ b/docs/sqlite-utils-empty-column-troubleshooting.md
@@ -1,0 +1,52 @@
+# sqlite-utils `--schema` and empty CSV text columns
+
+When a CSV column is entirely empty (`""`/missing values for every row), SQLite type inference may classify that column as `INTEGER` when using `sqlite-utils memory <file.csv> --schema`.
+
+Example input:
+
+```csv
+id,name
+1,
+2,
+```
+
+Potential output:
+
+```sql
+CREATE TABLE "empty_names" (
+   "id" INTEGER,
+   "name" INTEGER
+);
+```
+
+## Why this happens
+
+Type inference relies on sampled values. If a column never contains a non-empty string value, there is no evidence that the column should be `TEXT`, so it can fall back to a numeric/`INTEGER` affinity.
+
+## Practical workarounds
+
+- Seed at least one non-empty value in that column before inferring schema.
+- Create the table with an explicit schema (`name TEXT`) and import into it.
+- Post-process generated DDL and coerce selected columns to `TEXT` when your domain requires textual affinity.
+
+## Regression harness snippet
+
+```python
+import pathlib
+from click.testing import CliRunner
+from sqlite_utils import cli
+
+runner = CliRunner()
+
+with runner.isolated_filesystem():
+    tmp = pathlib.Path(".")
+    empty_csv = tmp / "empty_names.csv"
+    empty_csv.write_text("id,name\n1,\n2,\n", "utf-8")
+
+    result = runner.invoke(
+        cli.cli,
+        ["memory", str(empty_csv), "--schema"],
+        catch_exceptions=False,
+    )
+    print(result.output)
+```


### PR DESCRIPTION
### Motivation
- Document `sqlite-utils memory --schema` behavior when a CSV text column is entirely empty because SQLite type inference can classify such columns as `INTEGER`, which is surprising to users.

### Description
- Add `docs/sqlite-utils-empty-column-troubleshooting.md` that explains the issue, lists practical mitigations, includes a reproducible Python `CliRunner` harness, and link the note from the `README.md` quick docs section.

### Testing
- Ran `pytest -q tests/test_sqlite_scalar.py`, which succeeded with `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afaa9b7b4083278b73a7ab22786711)