### PR TITLE
Productize day-branded lanes in docs and CLI while preserving legacy aliases

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -738,7 +738,7 @@ Examples:
 - `sdetkit gate release --dry-run --format json`
 - `sdetkit gate release --format json`
 - `sdetkit gate release --playbooks-legacy --format json`
-- `sdetkit gate release --playbook-name day28-weekly-review --playbook-name day29-phase1-hardening --format json`
+- `sdetkit gate release --playbook-name weekly-review-lane --playbook-name phase1-hardening --format json`
 
 Useful flags (`gate fast`): `--root`, `--format`, `--out`/`--output`, `--strict`, `--fix`, `--fix-only`, `--list-steps`, `--only`, `--skip`, `--no-doctor`, `--no-ci-templates`, `--no-ruff`, `--no-mypy`, `--no-pytest`, `--mypy-args`, `--pytest-args`, `--full-pytest`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,25 @@ Build, validate, and release software with confidence using a polished SDET + De
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [📦 Legacy Day 90 report](day-90-big-upgrade-report.md) · [🔒 Phase3 Wrap Publication Closeout lane](integrations-day90-phase3-wrap-publication-closeout.md) · [📦 Legacy Day 91 report](day-91-big-upgrade-report.md) · [🔁 Continuous Upgrade Closeout lane](integrations-day91-continuous-upgrade-closeout.md) · [📦 Legacy Day 92 report](day-92-big-upgrade-report.md) · [🔁 Continuous Upgrade Cycle 2 Closeout lane](integrations-day92-continuous-upgrade-cycle2-closeout.md) · [📦 Legacy Day 93 report](day-93-big-upgrade-report.md) · [🔁 Continuous Upgrade Cycle3 Closeout lane](integrations-day93-continuous-upgrade-cycle3-closeout.md) · [📦 Legacy Day 94 report](day-94-big-upgrade-report.md) · [🔁 Continuous Upgrade Cycle 4 lane](integrations-day94-continuous-upgrade-cycle4-closeout.md) · [📦 Legacy Day 95 report](day-95-big-upgrade-report.md) · [🔁 Continuous Upgrade Cycle 5 lane](integrations-day95-continuous-upgrade-cycle5-closeout.md) · [📦 Legacy Day 97 report](day-97-big-upgrade-report.md) · [🔁 Continuous Upgrade Cycle 7 lane](integrations-day97-continuous-upgrade-cycle7-closeout.md) · [🚀 Phase-1 daily plan](top-10-github-strategy.md#phase-1-days-1-30-positioning-conversion-daily-execution) · [✅ Legacy Day 10 ultra report](day-10-ultra-upgrade-report.md) · [🧭 Legacy Day 11 ultra report](day-11-ultra-upgrade-report.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md)
+[⚡ Fast start](#fast-start) · [🔒 Phase 3 Wrap Publication Closeout](integrations-day90-phase3-wrap-publication-closeout.md) · [🔁 Continuous Upgrade Closeout](integrations-day91-continuous-upgrade-closeout.md) · [🔁 Continuous Upgrade Cycle 2 Closeout](integrations-day92-continuous-upgrade-cycle2-closeout.md) · [🔁 Continuous Upgrade Cycle 3 Closeout](integrations-day93-continuous-upgrade-cycle3-closeout.md) · [🔁 Continuous Upgrade Cycle 4 Closeout](integrations-day94-continuous-upgrade-cycle4-closeout.md) · [🔁 Continuous Upgrade Cycle 5 Closeout](integrations-day95-continuous-upgrade-cycle5-closeout.md) · [🔁 Continuous Upgrade Cycle 7 Closeout](integrations-day97-continuous-upgrade-cycle7-closeout.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy day reports](#legacy-day-reports)
 
 </div>
 
-## Docs navigation upgrades (legacy: Day 11)
+## Docs navigation upgrades (legacy Day 11 initiative)
+
+## Legacy day reports
+
+Historical day reports remain available for audit/history traceability:
+
+- [Day 90 report](day-90-big-upgrade-report.md)
+- [Day 91 report](day-91-big-upgrade-report.md)
+- [Day 92 report](day-92-big-upgrade-report.md)
+- [Day 93 report](day-93-big-upgrade-report.md)
+- [Day 94 report](day-94-big-upgrade-report.md)
+- [Day 95 report](day-95-big-upgrade-report.md)
+- [Day 97 report](day-97-big-upgrade-report.md)
+- [Day 10 ultra report](day-10-ultra-upgrade-report.md)
+- [Day 11 ultra report](day-11-ultra-upgrade-report.md)
 
 ### Top journeys
 

--- a/docs/integrations-day29-phase1-hardening.md
+++ b/docs/integrations-day29-phase1-hardening.md
@@ -18,9 +18,9 @@ Day 29 closes Phase-1 by hardening top entry pages, removing stale guidance, and
 ## Day 29 command lane
 
 ```bash
-python -m sdetkit day29-phase1-hardening --format json --strict
-python -m sdetkit day29-phase1-hardening --emit-pack-dir docs/artifacts/day29-hardening-pack --format json --strict
-python -m sdetkit day29-phase1-hardening --execute --evidence-dir docs/artifacts/day29-hardening-pack/evidence --format json --strict
+python -m sdetkit phase1-hardening --format json --strict
+python -m sdetkit phase1-hardening --emit-pack-dir docs/artifacts/day29-hardening-pack --format json --strict
+python -m sdetkit phase1-hardening --execute --evidence-dir docs/artifacts/day29-hardening-pack/evidence --format json --strict
 python scripts/check_day29_phase1_hardening_contract.py
 ```
 

--- a/docs/integrations-day30-phase1-wrap.md
+++ b/docs/integrations-day30-phase1-wrap.md
@@ -17,9 +17,9 @@ Day 30 closes Phase-1 with a hard evidence wrap-up and locks the first Phase-2 e
 ## Day 30 command lane
 
 ```bash
-python -m sdetkit day30-phase1-wrap --format json --strict
-python -m sdetkit day30-phase1-wrap --emit-pack-dir docs/artifacts/day30-wrap-pack --format json --strict
-python -m sdetkit day30-phase1-wrap --execute --evidence-dir docs/artifacts/day30-wrap-pack/evidence --format json --strict
+python -m sdetkit phase1-wrap --format json --strict
+python -m sdetkit phase1-wrap --emit-pack-dir docs/artifacts/day30-wrap-pack --format json --strict
+python -m sdetkit phase1-wrap --execute --evidence-dir docs/artifacts/day30-wrap-pack/evidence --format json --strict
 python scripts/check_day30_phase1_wrap_contract.py
 ```
 

--- a/docs/integrations-day31-phase2-kickoff.md
+++ b/docs/integrations-day31-phase2-kickoff.md
@@ -16,9 +16,9 @@ Day 31 starts Phase-2 with a measurable baseline carried over from Day 30 and a 
 ## Day 31 command lane
 
 ```bash
-python -m sdetkit day31-phase2-kickoff --format json --strict
-python -m sdetkit day31-phase2-kickoff --emit-pack-dir docs/artifacts/day31-phase2-pack --format json --strict
-python -m sdetkit day31-phase2-kickoff --execute --evidence-dir docs/artifacts/day31-phase2-pack/evidence --format json --strict
+python -m sdetkit phase2-kickoff --format json --strict
+python -m sdetkit phase2-kickoff --emit-pack-dir docs/artifacts/day31-phase2-pack --format json --strict
+python -m sdetkit phase2-kickoff --execute --evidence-dir docs/artifacts/day31-phase2-pack/evidence --format json --strict
 python scripts/check_day31_phase2_kickoff_contract.py
 ```
 

--- a/docs/integrations-day32-release-cadence.md
+++ b/docs/integrations-day32-release-cadence.md
@@ -16,9 +16,9 @@ Day 32 converts Day 31 baseline goals into a repeatable release operating cadenc
 ## Day 32 command lane
 
 ```bash
-python -m sdetkit day32-release-cadence --format json --strict
-python -m sdetkit day32-release-cadence --emit-pack-dir docs/artifacts/day32-release-cadence-pack --format json --strict
-python -m sdetkit day32-release-cadence --execute --evidence-dir docs/artifacts/day32-release-cadence-pack/evidence --format json --strict
+python -m sdetkit release-cadence --format json --strict
+python -m sdetkit release-cadence --emit-pack-dir docs/artifacts/day32-release-cadence-pack --format json --strict
+python -m sdetkit release-cadence --execute --evidence-dir docs/artifacts/day32-release-cadence-pack/evidence --format json --strict
 python scripts/check_day32_release_cadence_contract.py
 ```
 

--- a/docs/integrations-day33-demo-asset.md
+++ b/docs/integrations-day33-demo-asset.md
@@ -16,9 +16,9 @@ Day 33 closes the first distribution-ready demo asset, turning Day 32 release re
 ## Day 33 command lane
 
 ```bash
-python -m sdetkit day33-demo-asset --format json --strict
-python -m sdetkit day33-demo-asset --emit-pack-dir docs/artifacts/day33-demo-asset-pack --format json --strict
-python -m sdetkit day33-demo-asset --execute --evidence-dir docs/artifacts/day33-demo-asset-pack/evidence --format json --strict
+python -m sdetkit demo-asset --format json --strict
+python -m sdetkit demo-asset --emit-pack-dir docs/artifacts/day33-demo-asset-pack --format json --strict
+python -m sdetkit demo-asset --execute --evidence-dir docs/artifacts/day33-demo-asset-pack/evidence --format json --strict
 python scripts/check_day33_demo_asset_contract.py
 ```
 

--- a/docs/integrations-day34-demo-asset2.md
+++ b/docs/integrations-day34-demo-asset2.md
@@ -16,9 +16,9 @@ Day 34 closes the second distribution-ready demo asset by translating repository
 ## Day 34 command lane
 
 ```bash
-python -m sdetkit day34-demo-asset2 --format json --strict
-python -m sdetkit day34-demo-asset2 --emit-pack-dir docs/artifacts/day34-demo-asset2-pack --format json --strict
-python -m sdetkit day34-demo-asset2 --execute --evidence-dir docs/artifacts/day34-demo-asset2-pack/evidence --format json --strict
+python -m sdetkit demo-asset2 --format json --strict
+python -m sdetkit demo-asset2 --emit-pack-dir docs/artifacts/day34-demo-asset2-pack --format json --strict
+python -m sdetkit demo-asset2 --execute --evidence-dir docs/artifacts/day34-demo-asset2-pack/evidence --format json --strict
 python scripts/check_day34_demo_asset2_contract.py
 ```
 

--- a/docs/integrations-day35-kpi-instrumentation.md
+++ b/docs/integrations-day35-kpi-instrumentation.md
@@ -16,9 +16,9 @@ Day 35 closes the week with a hardened KPI operating loop that ties growth narra
 ## Day 35 command lane
 
 ```bash
-python -m sdetkit day35-kpi-instrumentation --format json --strict
-python -m sdetkit day35-kpi-instrumentation --emit-pack-dir docs/artifacts/day35-kpi-instrumentation-pack --format json --strict
-python -m sdetkit day35-kpi-instrumentation --execute --evidence-dir docs/artifacts/day35-kpi-instrumentation-pack/evidence --format json --strict
+python -m sdetkit kpi-instrumentation --format json --strict
+python -m sdetkit kpi-instrumentation --emit-pack-dir docs/artifacts/day35-kpi-instrumentation-pack --format json --strict
+python -m sdetkit kpi-instrumentation --execute --evidence-dir docs/artifacts/day35-kpi-instrumentation-pack/evidence --format json --strict
 python scripts/check_day35_kpi_instrumentation_contract.py
 ```
 

--- a/docs/integrations-day36-distribution-closeout.md
+++ b/docs/integrations-day36-distribution-closeout.md
@@ -16,9 +16,9 @@ Day 36 closes the distribution lane by converting the Day 35 KPI story into chan
 ## Day 36 command lane
 
 ```bash
-python -m sdetkit day36-distribution-closeout --format json --strict
-python -m sdetkit day36-distribution-closeout --emit-pack-dir docs/artifacts/day36-distribution-closeout-pack --format json --strict
-python -m sdetkit day36-distribution-closeout --execute --evidence-dir docs/artifacts/day36-distribution-closeout-pack/evidence --format json --strict
+python -m sdetkit distribution-closeout --format json --strict
+python -m sdetkit distribution-closeout --emit-pack-dir docs/artifacts/day36-distribution-closeout-pack --format json --strict
+python -m sdetkit distribution-closeout --execute --evidence-dir docs/artifacts/day36-distribution-closeout-pack/evidence --format json --strict
 python scripts/check_day36_distribution_closeout_contract.py
 ```
 

--- a/docs/integrations-day37-experiment-lane.md
+++ b/docs/integrations-day37-experiment-lane.md
@@ -16,9 +16,9 @@ Day 37 turns Day 36 distribution misses into controlled experiments with strict 
 ## Day 37 command lane
 
 ```bash
-python -m sdetkit day37-experiment-lane --format json --strict
-python -m sdetkit day37-experiment-lane --emit-pack-dir docs/artifacts/day37-experiment-lane-pack --format json --strict
-python -m sdetkit day37-experiment-lane --execute --evidence-dir docs/artifacts/day37-experiment-lane-pack/evidence --format json --strict
+python -m sdetkit experiment-lane --format json --strict
+python -m sdetkit experiment-lane --emit-pack-dir docs/artifacts/day37-experiment-lane-pack --format json --strict
+python -m sdetkit experiment-lane --execute --evidence-dir docs/artifacts/day37-experiment-lane-pack/evidence --format json --strict
 python scripts/check_day37_experiment_lane_contract.py
 ```
 

--- a/docs/integrations-day38-distribution-batch.md
+++ b/docs/integrations-day38-distribution-batch.md
@@ -16,9 +16,9 @@ Day 38 publishes a coordinated distribution batch that operationalizes Day 37 ex
 ## Day 38 command lane
 
 ```bash
-python -m sdetkit day38-distribution-batch --format json --strict
-python -m sdetkit day38-distribution-batch --emit-pack-dir docs/artifacts/day38-distribution-batch-pack --format json --strict
-python -m sdetkit day38-distribution-batch --execute --evidence-dir docs/artifacts/day38-distribution-batch-pack/evidence --format json --strict
+python -m sdetkit distribution-batch --format json --strict
+python -m sdetkit distribution-batch --emit-pack-dir docs/artifacts/day38-distribution-batch-pack --format json --strict
+python -m sdetkit distribution-batch --execute --evidence-dir docs/artifacts/day38-distribution-batch-pack/evidence --format json --strict
 python scripts/check_day38_distribution_batch_contract.py
 ```
 

--- a/docs/integrations-day39-playbook-post.md
+++ b/docs/integrations-day39-playbook-post.md
@@ -16,9 +16,9 @@ Day 39 publishes playbook post #1 that converts Day 38 distribution evidence int
 ## Day 39 command lane
 
 ```bash
-python -m sdetkit day39-playbook-post --format json --strict
-python -m sdetkit day39-playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict
-python -m sdetkit day39-playbook-post --execute --evidence-dir docs/artifacts/day39-playbook-post-pack/evidence --format json --strict
+python -m sdetkit playbook-post --format json --strict
+python -m sdetkit playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict
+python -m sdetkit playbook-post --execute --evidence-dir docs/artifacts/day39-playbook-post-pack/evidence --format json --strict
 python scripts/check_day39_playbook_post_contract.py
 ```
 

--- a/docs/integrations-day40-scale-lane.md
+++ b/docs/integrations-day40-scale-lane.md
@@ -16,9 +16,9 @@ Day 40 closes the lane with a scale-oriented upgrade that converts Day 39 public
 ## Day 40 command lane
 
 ```bash
-python -m sdetkit day40-scale-lane --format json --strict
-python -m sdetkit day40-scale-lane --emit-pack-dir docs/artifacts/day40-scale-lane-pack --format json --strict
-python -m sdetkit day40-scale-lane --execute --evidence-dir docs/artifacts/day40-scale-lane-pack/evidence --format json --strict
+python -m sdetkit scale-lane --format json --strict
+python -m sdetkit scale-lane --emit-pack-dir docs/artifacts/day40-scale-lane-pack --format json --strict
+python -m sdetkit scale-lane --execute --evidence-dir docs/artifacts/day40-scale-lane-pack/evidence --format json --strict
 python scripts/check_day40_scale_lane_contract.py
 ```
 

--- a/docs/integrations-day41-expansion-automation.md
+++ b/docs/integrations-day41-expansion-automation.md
@@ -16,9 +16,9 @@ Day 41 closes the lane with a major upgrade that converts Day 40 scale outcomes 
 ## Day 41 command lane
 
 ```bash
-python -m sdetkit day41-expansion-automation --format json --strict
-python -m sdetkit day41-expansion-automation --emit-pack-dir docs/artifacts/day41-expansion-automation-pack --format json --strict
-python -m sdetkit day41-expansion-automation --execute --evidence-dir docs/artifacts/day41-expansion-automation-pack/evidence --format json --strict
+python -m sdetkit expansion-automation --format json --strict
+python -m sdetkit expansion-automation --emit-pack-dir docs/artifacts/day41-expansion-automation-pack --format json --strict
+python -m sdetkit expansion-automation --execute --evidence-dir docs/artifacts/day41-expansion-automation-pack/evidence --format json --strict
 python scripts/check_day41_expansion_automation_contract.py
 ```
 

--- a/docs/integrations-day42-optimization-closeout.md
+++ b/docs/integrations-day42-optimization-closeout.md
@@ -16,9 +16,9 @@ Day 42 closes the lane with a major optimization upgrade that converts Day 41 ex
 ## Day 42 command lane
 
 ```bash
-python -m sdetkit day42-optimization-closeout --format json --strict
-python -m sdetkit day42-optimization-closeout --emit-pack-dir docs/artifacts/day42-optimization-closeout-pack --format json --strict
-python -m sdetkit day42-optimization-closeout --execute --evidence-dir docs/artifacts/day42-optimization-closeout-pack/evidence --format json --strict
+python -m sdetkit optimization-closeout-foundation --format json --strict
+python -m sdetkit optimization-closeout-foundation --emit-pack-dir docs/artifacts/day42-optimization-closeout-pack --format json --strict
+python -m sdetkit optimization-closeout-foundation --execute --evidence-dir docs/artifacts/day42-optimization-closeout-pack/evidence --format json --strict
 python scripts/check_day42_optimization_closeout_contract.py
 ```
 

--- a/docs/integrations-day43-acceleration-closeout.md
+++ b/docs/integrations-day43-acceleration-closeout.md
@@ -16,9 +16,9 @@ Day 43 closes with a major acceleration upgrade that converts Day 42 optimizatio
 ## Day 43 command lane
 
 ```bash
-python -m sdetkit day43-acceleration-closeout --format json --strict
-python -m sdetkit day43-acceleration-closeout --emit-pack-dir docs/artifacts/day43-acceleration-closeout-pack --format json --strict
-python -m sdetkit day43-acceleration-closeout --execute --evidence-dir docs/artifacts/day43-acceleration-closeout-pack/evidence --format json --strict
+python -m sdetkit acceleration-closeout --format json --strict
+python -m sdetkit acceleration-closeout --emit-pack-dir docs/artifacts/day43-acceleration-closeout-pack --format json --strict
+python -m sdetkit acceleration-closeout --execute --evidence-dir docs/artifacts/day43-acceleration-closeout-pack/evidence --format json --strict
 python scripts/check_day43_acceleration_closeout_contract.py
 ```
 

--- a/docs/integrations-day44-scale-closeout.md
+++ b/docs/integrations-day44-scale-closeout.md
@@ -16,9 +16,9 @@ Day 44 closes with a big scale upgrade that converts Day 43 acceleration evidenc
 ## Day 44 command lane
 
 ```bash
-python -m sdetkit day44-scale-closeout --format json --strict
-python -m sdetkit day44-scale-closeout --emit-pack-dir docs/artifacts/day44-scale-closeout-pack --format json --strict
-python -m sdetkit day44-scale-closeout --execute --evidence-dir docs/artifacts/day44-scale-closeout-pack/evidence --format json --strict
+python -m sdetkit scale-closeout --format json --strict
+python -m sdetkit scale-closeout --emit-pack-dir docs/artifacts/day44-scale-closeout-pack --format json --strict
+python -m sdetkit scale-closeout --execute --evidence-dir docs/artifacts/day44-scale-closeout-pack/evidence --format json --strict
 python scripts/check_day44_scale_closeout_contract.py
 ```
 

--- a/docs/integrations-day45-expansion-closeout.md
+++ b/docs/integrations-day45-expansion-closeout.md
@@ -16,9 +16,9 @@ Day 45 closes with a major expansion upgrade that converts Day 44 scale evidence
 ## Day 45 command lane
 
 ```bash
-python -m sdetkit day45-expansion-closeout --format json --strict
-python -m sdetkit day45-expansion-closeout --emit-pack-dir docs/artifacts/day45-expansion-closeout-pack --format json --strict
-python -m sdetkit day45-expansion-closeout --execute --evidence-dir docs/artifacts/day45-expansion-closeout-pack/evidence --format json --strict
+python -m sdetkit expansion-closeout --format json --strict
+python -m sdetkit expansion-closeout --emit-pack-dir docs/artifacts/day45-expansion-closeout-pack --format json --strict
+python -m sdetkit expansion-closeout --execute --evidence-dir docs/artifacts/day45-expansion-closeout-pack/evidence --format json --strict
 python scripts/check_day45_expansion_closeout_contract.py
 ```
 

--- a/docs/integrations-day46-optimization-closeout.md
+++ b/docs/integrations-day46-optimization-closeout.md
@@ -16,9 +16,9 @@ Day 46 closes with a major optimization upgrade that converts Day 45 expansion e
 ## Day 46 command lane
 
 ```bash
-python -m sdetkit day46-optimization-closeout --format json --strict
-python -m sdetkit day46-optimization-closeout --emit-pack-dir docs/artifacts/day46-optimization-closeout-pack --format json --strict
-python -m sdetkit day46-optimization-closeout --execute --evidence-dir docs/artifacts/day46-optimization-closeout-pack/evidence --format json --strict
+python -m sdetkit optimization-closeout --format json --strict
+python -m sdetkit optimization-closeout --emit-pack-dir docs/artifacts/day46-optimization-closeout-pack --format json --strict
+python -m sdetkit optimization-closeout --execute --evidence-dir docs/artifacts/day46-optimization-closeout-pack/evidence --format json --strict
 python scripts/check_day46_optimization_closeout_contract.py
 ```
 

--- a/docs/integrations-day47-reliability-closeout.md
+++ b/docs/integrations-day47-reliability-closeout.md
@@ -16,9 +16,9 @@ Day 47 closes with a major reliability upgrade that converts Day 46 optimization
 ## Day 47 command lane
 
 ```bash
-python -m sdetkit day47-reliability-closeout --format json --strict
-python -m sdetkit day47-reliability-closeout --emit-pack-dir docs/artifacts/day47-reliability-closeout-pack --format json --strict
-python -m sdetkit day47-reliability-closeout --execute --evidence-dir docs/artifacts/day47-reliability-closeout-pack/evidence --format json --strict
+python -m sdetkit reliability-closeout --format json --strict
+python -m sdetkit reliability-closeout --emit-pack-dir docs/artifacts/day47-reliability-closeout-pack --format json --strict
+python -m sdetkit reliability-closeout --execute --evidence-dir docs/artifacts/day47-reliability-closeout-pack/evidence --format json --strict
 python scripts/check_day47_reliability_closeout_contract.py
 ```
 

--- a/docs/integrations-day48-objection-closeout.md
+++ b/docs/integrations-day48-objection-closeout.md
@@ -16,9 +16,9 @@ Day 48 closes with a major objection-handling upgrade that converts Day 47 relia
 ## Day 48 command lane
 
 ```bash
-python -m sdetkit day48-objection-closeout --format json --strict
-python -m sdetkit day48-objection-closeout --emit-pack-dir docs/artifacts/day48-objection-closeout-pack --format json --strict
-python -m sdetkit day48-objection-closeout --execute --evidence-dir docs/artifacts/day48-objection-closeout-pack/evidence --format json --strict
+python -m sdetkit objection-closeout --format json --strict
+python -m sdetkit objection-closeout --emit-pack-dir docs/artifacts/day48-objection-closeout-pack --format json --strict
+python -m sdetkit objection-closeout --execute --evidence-dir docs/artifacts/day48-objection-closeout-pack/evidence --format json --strict
 python scripts/check_day48_objection_closeout_contract.py
 ```
 

--- a/docs/integrations-day49-weekly-review-closeout.md
+++ b/docs/integrations-day49-weekly-review-closeout.md
@@ -16,9 +16,9 @@ Day 49 closes with a major weekly-review upgrade that converts Day 48 objection 
 ## Day 49 command lane
 
 ```bash
-python -m sdetkit day49-weekly-review-closeout --format json --strict
-python -m sdetkit day49-weekly-review-closeout --emit-pack-dir docs/artifacts/day49-weekly-review-closeout-pack --format json --strict
-python -m sdetkit day49-weekly-review-closeout --execute --evidence-dir docs/artifacts/day49-weekly-review-closeout-pack/evidence --format json --strict
+python -m sdetkit weekly-review-closeout --format json --strict
+python -m sdetkit weekly-review-closeout --emit-pack-dir docs/artifacts/day49-weekly-review-closeout-pack --format json --strict
+python -m sdetkit weekly-review-closeout --execute --evidence-dir docs/artifacts/day49-weekly-review-closeout-pack/evidence --format json --strict
 python scripts/check_day49_weekly_review_closeout_contract.py
 ```
 

--- a/docs/integrations-day50-execution-prioritization-closeout.md
+++ b/docs/integrations-day50-execution-prioritization-closeout.md
@@ -16,9 +16,9 @@ Day 50 closes with a major execution-prioritization upgrade that converts Day 49
 ## Day 50 command lane
 
 ```bash
-python -m sdetkit day50-execution-prioritization-closeout --format json --strict
-python -m sdetkit day50-execution-prioritization-closeout --emit-pack-dir docs/artifacts/day50-execution-prioritization-closeout-pack --format json --strict
-python -m sdetkit day50-execution-prioritization-closeout --execute --evidence-dir docs/artifacts/day50-execution-prioritization-closeout-pack/evidence --format json --strict
+python -m sdetkit execution-prioritization-closeout --format json --strict
+python -m sdetkit execution-prioritization-closeout --emit-pack-dir docs/artifacts/day50-execution-prioritization-closeout-pack --format json --strict
+python -m sdetkit execution-prioritization-closeout --execute --evidence-dir docs/artifacts/day50-execution-prioritization-closeout-pack/evidence --format json --strict
 python scripts/check_day50_execution_prioritization_closeout_contract.py
 ```
 

--- a/examples/ci/gitlab/day66-advanced-reference.yml
+++ b/examples/ci/gitlab/day66-advanced-reference.yml
@@ -34,14 +34,14 @@ integration-matrix:
   script:
     - bash scripts/bootstrap.sh
     - . .venv/bin/activate
-    - python -m sdetkit day66-integration-expansion2-closeout --format json --strict
+    - python -m sdetkit integration-expansion2-closeout --format json --strict
 
 package-evidence:
   stage: package
   script:
     - bash scripts/bootstrap.sh
     - . .venv/bin/activate
-    - python -m sdetkit day66-integration-expansion2-closeout --emit-pack-dir docs/artifacts/day66-integration-expansion2-closeout-pack --format json --strict
+    - python -m sdetkit integration-expansion2-closeout --emit-pack-dir docs/artifacts/day66-integration-expansion2-closeout-pack --format json --strict
     - python scripts/check_day66_integration_expansion2_closeout_contract.py --skip-evidence
     - bash security.sh
   artifacts:

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -283,43 +283,43 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "kpi-audit":
         return kpi_audit.main(list(argv[1:]))
 
-    if argv and argv[0] == "day28-weekly-review":
+    if argv and argv[0] in {"weekly-review-lane", "day28-weekly-review"}:
         return day28_weekly_review.main(list(argv[1:]))
 
-    if argv and argv[0] == "day29-phase1-hardening":
+    if argv and argv[0] in {"phase1-hardening", "day29-phase1-hardening"}:
         return day29_phase1_hardening.main(list(argv[1:]))
 
-    if argv and argv[0] == "day30-phase1-wrap":
+    if argv and argv[0] in {"phase1-wrap", "day30-phase1-wrap"}:
         return day30_phase1_wrap.main(list(argv[1:]))
 
-    if argv and argv[0] == "day31-phase2-kickoff":
+    if argv and argv[0] in {"phase2-kickoff", "day31-phase2-kickoff"}:
         return day31_phase2_kickoff.main(list(argv[1:]))
 
-    if argv and argv[0] == "day32-release-cadence":
+    if argv and argv[0] in {"release-cadence", "day32-release-cadence"}:
         return day32_release_cadence.main(list(argv[1:]))
 
-    if argv and argv[0] == "day33-demo-asset":
+    if argv and argv[0] in {"demo-asset", "day33-demo-asset"}:
         return day33_demo_asset.main(list(argv[1:]))
 
-    if argv and argv[0] == "day34-demo-asset2":
+    if argv and argv[0] in {"demo-asset2", "day34-demo-asset2"}:
         return day34_demo_asset2.main(list(argv[1:]))
 
-    if argv and argv[0] == "day35-kpi-instrumentation":
+    if argv and argv[0] in {"kpi-instrumentation", "day35-kpi-instrumentation"}:
         return day35_kpi_instrumentation.main(list(argv[1:]))
 
-    if argv and argv[0] == "day36-distribution-closeout":
+    if argv and argv[0] in {"distribution-closeout", "day36-distribution-closeout"}:
         return day36_distribution_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] == "day37-experiment-lane":
+    if argv and argv[0] in {"experiment-lane", "day37-experiment-lane"}:
         return day37_experiment_lane.main(list(argv[1:]))
 
-    if argv and argv[0] == "day38-distribution-batch":
+    if argv and argv[0] in {"distribution-batch", "day38-distribution-batch"}:
         return day38_distribution_batch.main(list(argv[1:]))
 
-    if argv and argv[0] == "day39-playbook-post":
+    if argv and argv[0] in {"playbook-post", "day39-playbook-post"}:
         return day39_playbook_post.main(list(argv[1:]))
 
-    if argv and argv[0] == "day40-scale-lane":
+    if argv and argv[0] in {"scale-lane", "day40-scale-lane"}:
         return day40_scale_lane.main(list(argv[1:]))
 
     if argv and argv[0] == "expansion-automation":
@@ -412,7 +412,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     }:
         return day64_integration_expansion_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] in {"day65-weekly-review-closeout"}:
+    if argv and argv[0] in {"weekly-review-closeout-cycle2", "day65-weekly-review-closeout"}:
         return day65_weekly_review_closeout.main(list(argv[1:]))
 
     if argv and argv[0] in {
@@ -731,43 +731,56 @@ Run: sdetkit playbooks
     kpa = sub.add_parser("kpi-audit")
     kpa.add_argument("args", nargs=argparse.REMAINDER)
 
-    dwr = sub.add_parser("day28-weekly-review")
+    dwr = sub.add_parser("weekly-review-lane", aliases=["day28-weekly-review"])
+    dwr.set_defaults(cmd="weekly-review-lane")
     dwr.add_argument("args", nargs=argparse.REMAINDER)
 
-    d29 = sub.add_parser("day29-phase1-hardening")
+    d29 = sub.add_parser("phase1-hardening", aliases=["day29-phase1-hardening"])
+    d29.set_defaults(cmd="phase1-hardening")
     d29.add_argument("args", nargs=argparse.REMAINDER)
 
-    d30 = sub.add_parser("day30-phase1-wrap")
+    d30 = sub.add_parser("phase1-wrap", aliases=["day30-phase1-wrap"])
+    d30.set_defaults(cmd="phase1-wrap")
     d30.add_argument("args", nargs=argparse.REMAINDER)
 
-    d31 = sub.add_parser("day31-phase2-kickoff")
+    d31 = sub.add_parser("phase2-kickoff", aliases=["day31-phase2-kickoff"])
+    d31.set_defaults(cmd="phase2-kickoff")
     d31.add_argument("args", nargs=argparse.REMAINDER)
 
-    d32 = sub.add_parser("day32-release-cadence")
+    d32 = sub.add_parser("release-cadence", aliases=["day32-release-cadence"])
+    d32.set_defaults(cmd="release-cadence")
     d32.add_argument("args", nargs=argparse.REMAINDER)
 
-    d33 = sub.add_parser("day33-demo-asset")
+    d33 = sub.add_parser("demo-asset", aliases=["day33-demo-asset"])
+    d33.set_defaults(cmd="demo-asset")
     d33.add_argument("args", nargs=argparse.REMAINDER)
 
-    d34 = sub.add_parser("day34-demo-asset2")
+    d34 = sub.add_parser("demo-asset2", aliases=["day34-demo-asset2"])
+    d34.set_defaults(cmd="demo-asset2")
     d34.add_argument("args", nargs=argparse.REMAINDER)
 
-    d35 = sub.add_parser("day35-kpi-instrumentation")
+    d35 = sub.add_parser("kpi-instrumentation", aliases=["day35-kpi-instrumentation"])
+    d35.set_defaults(cmd="kpi-instrumentation")
     d35.add_argument("args", nargs=argparse.REMAINDER)
 
-    d36 = sub.add_parser("day36-distribution-closeout")
+    d36 = sub.add_parser("distribution-closeout", aliases=["day36-distribution-closeout"])
+    d36.set_defaults(cmd="distribution-closeout")
     d36.add_argument("args", nargs=argparse.REMAINDER)
 
-    d37 = sub.add_parser("day37-experiment-lane")
+    d37 = sub.add_parser("experiment-lane", aliases=["day37-experiment-lane"])
+    d37.set_defaults(cmd="experiment-lane")
     d37.add_argument("args", nargs=argparse.REMAINDER)
 
-    d38 = sub.add_parser("day38-distribution-batch")
+    d38 = sub.add_parser("distribution-batch", aliases=["day38-distribution-batch"])
+    d38.set_defaults(cmd="distribution-batch")
     d38.add_argument("args", nargs=argparse.REMAINDER)
 
-    d39 = sub.add_parser("day39-playbook-post")
+    d39 = sub.add_parser("playbook-post", aliases=["day39-playbook-post"])
+    d39.set_defaults(cmd="playbook-post")
     d39.add_argument("args", nargs=argparse.REMAINDER)
 
-    d40 = sub.add_parser("day40-scale-lane")
+    d40 = sub.add_parser("scale-lane", aliases=["day40-scale-lane"])
+    d40.set_defaults(cmd="scale-lane")
     d40.add_argument("args", nargs=argparse.REMAINDER)
 
     pa41 = sub.add_parser("expansion-automation")
@@ -882,8 +895,8 @@ Run: sdetkit playbooks
     d64.set_defaults(cmd="integration-expansion-closeout")
     d64.add_argument("args", nargs=argparse.REMAINDER)
 
-    d65 = sub.add_parser("day65-weekly-review-closeout")
-    d65.set_defaults(cmd="day65-weekly-review-closeout")
+    d65 = sub.add_parser("weekly-review-closeout-cycle2", aliases=["day65-weekly-review-closeout"])
+    d65.set_defaults(cmd="weekly-review-closeout-cycle2")
     d65.add_argument("args", nargs=argparse.REMAINDER)
 
     d66 = sub.add_parser(
@@ -912,6 +925,7 @@ Run: sdetkit playbooks
     d70.set_defaults(cmd="case-study-prep2-closeout")
     d70.add_argument("args", nargs=argparse.REMAINDER)
     d71 = sub.add_parser("case-study-prep3-closeout", aliases=["day71-case-study-prep3-closeout"])
+    d71.set_defaults(cmd="case-study-prep3-closeout")
     d71.add_argument("args", nargs=argparse.REMAINDER)
     d72 = sub.add_parser("case-study-prep4-closeout", aliases=["day72-case-study-prep4-closeout"])
     d72.set_defaults(cmd="case-study-prep4-closeout")
@@ -947,63 +961,63 @@ Run: sdetkit playbooks
     d80 = sub.add_parser("partner-outreach-closeout", aliases=["day80-partner-outreach-closeout"])
     d80.add_argument("args", nargs=argparse.REMAINDER)
     d81 = sub.add_parser("growth-campaign-closeout", aliases=["day81-growth-campaign-closeout"])
-    d81.set_defaults(cmd="day81-growth-campaign-closeout")
+    d81.set_defaults(cmd="growth-campaign-closeout")
     d81.add_argument("args", nargs=argparse.REMAINDER)
     d82 = sub.add_parser(
         "integration-feedback-closeout", aliases=["day82-integration-feedback-closeout"]
     )
-    d82.set_defaults(cmd="day82-integration-feedback-closeout")
+    d82.set_defaults(cmd="integration-feedback-closeout")
     d82.add_argument("args", nargs=argparse.REMAINDER)
     d83 = sub.add_parser(
         "trust-faq-expansion-closeout", aliases=["day83-trust-faq-expansion-closeout"]
     )
-    d83.set_defaults(cmd="day83-trust-faq-expansion-closeout")
+    d83.set_defaults(cmd="trust-faq-expansion-closeout")
     d83.add_argument("args", nargs=argparse.REMAINDER)
     d84 = sub.add_parser(
         "evidence-narrative-closeout", aliases=["day84-evidence-narrative-closeout"]
     )
-    d84.set_defaults(cmd="day84-evidence-narrative-closeout")
+    d84.set_defaults(cmd="evidence-narrative-closeout")
     d84.add_argument("args", nargs=argparse.REMAINDER)
     d85 = sub.add_parser(
         "release-prioritization-closeout", aliases=["day85-release-prioritization-closeout"]
     )
-    d85.set_defaults(cmd="day85-release-prioritization-closeout")
+    d85.set_defaults(cmd="release-prioritization-closeout")
     d85.add_argument("args", nargs=argparse.REMAINDER)
     d86 = sub.add_parser("launch-readiness-closeout", aliases=["day86-launch-readiness-closeout"])
-    d86.set_defaults(cmd="day86-launch-readiness-closeout")
+    d86.set_defaults(cmd="launch-readiness-closeout")
     d86.add_argument("args", nargs=argparse.REMAINDER)
     d87 = sub.add_parser(
         "governance-handoff-closeout", aliases=["day87-governance-handoff-closeout"]
     )
-    d87.set_defaults(cmd="day87-governance-handoff-closeout")
+    d87.set_defaults(cmd="governance-handoff-closeout")
     d87.add_argument("args", nargs=argparse.REMAINDER)
     d88 = sub.add_parser(
         "governance-priorities-closeout", aliases=["day88-governance-priorities-closeout"]
     )
-    d88.set_defaults(cmd="day88-governance-priorities-closeout")
+    d88.set_defaults(cmd="governance-priorities-closeout")
     d88.add_argument("args", nargs=argparse.REMAINDER)
     d89 = sub.add_parser("governance-scale-closeout", aliases=["day89-governance-scale-closeout"])
-    d89.set_defaults(cmd="day89-governance-scale-closeout")
+    d89.set_defaults(cmd="governance-scale-closeout")
     d89.add_argument("args", nargs=argparse.REMAINDER)
     d90 = sub.add_parser(
         "phase3-wrap-publication-closeout", aliases=["day90-phase3-wrap-publication-closeout"]
     )
-    d90.set_defaults(cmd="day90-phase3-wrap-publication-closeout")
+    d90.set_defaults(cmd="phase3-wrap-publication-closeout")
     d90.add_argument("args", nargs=argparse.REMAINDER)
     d91 = sub.add_parser(
         "continuous-upgrade-closeout", aliases=["day91-continuous-upgrade-closeout"]
     )
-    d91.set_defaults(cmd="day91-continuous-upgrade-closeout")
+    d91.set_defaults(cmd="continuous-upgrade-closeout")
     d91.add_argument("args", nargs=argparse.REMAINDER)
     d92 = sub.add_parser(
         "continuous-upgrade-cycle2-closeout", aliases=["day92-continuous-upgrade-cycle2-closeout"]
     )
-    d92.set_defaults(cmd="day92-continuous-upgrade-cycle2-closeout")
+    d92.set_defaults(cmd="continuous-upgrade-cycle2-closeout")
     d92.add_argument("args", nargs=argparse.REMAINDER)
     d93 = sub.add_parser(
         "continuous-upgrade-cycle3-closeout", aliases=["day93-continuous-upgrade-cycle3-closeout"]
     )
-    d93.set_defaults(cmd="day93-continuous-upgrade-cycle3-closeout")
+    d93.set_defaults(cmd="continuous-upgrade-cycle3-closeout")
     d93.add_argument("args", nargs=argparse.REMAINDER)
     d94 = sub.add_parser(
         "continuous-upgrade-cycle4-closeout", aliases=["day94-continuous-upgrade-cycle4-closeout"]

--- a/src/sdetkit/playbooks_cli.py
+++ b/src/sdetkit/playbooks_cli.py
@@ -66,6 +66,7 @@ _DAY_CLOSEOUT = re.compile(r"^day\d+_(.+_closeout)$")
 
 # Stable product lanes promoted from Day 41-50 naming.
 _PRODUCT_CANONICAL_BY_DAY_MODULE: dict[str, str] = {
+    "day28_weekly_review": "weekly-review-lane",
     "day41_expansion_automation": "expansion-automation",
     # Day 42 and Day 46 would both collide on optimization-closeout.
     "day42_optimization_closeout": "optimization-closeout-foundation",
@@ -77,6 +78,7 @@ _PRODUCT_CANONICAL_BY_DAY_MODULE: dict[str, str] = {
     "day48_objection_closeout": "objection-closeout",
     "day49_weekly_review_closeout": "weekly-review-closeout",
     "day50_execution_prioritization_closeout": "execution-prioritization-closeout",
+    "day65_weekly_review_closeout": "weekly-review-closeout-cycle2",
 }
 
 

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -72,6 +72,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
 
     j = _json.loads(r3.stdout)
     assert "playbooks" in j
+    assert "phase1-hardening" in j["playbooks"]
     assert "day29-phase1-hardening" in j["playbooks"]
     r2 = subprocess.run(
         [sys.executable, "-m", "sdetkit", "playbooks"],
@@ -80,9 +81,10 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     )
     assert r2.returncode == 0
     out2 = r2.stdout
-    assert "day29-phase1-hardening" in out2
-    assert "day30-phase1-wrap" in out2
-    assert "day44-scale-closeout" in out2
+    assert "phase1-hardening" in out2
+    assert "phase1-wrap" in out2
+    assert "scale-closeout" in out2
+    assert "day29-phase1-hardening -> phase1-hardening" in out2
     assert "Run: sdetkit playbooks run <name>" in out2
 
 

--- a/tests/test_cli_productized_closeout_aliases.py
+++ b/tests/test_cli_productized_closeout_aliases.py
@@ -28,7 +28,9 @@ from sdetkit import cli
         ),
     ],
 )
-def test_canonical_and_legacy_commands_dispatch(monkeypatch, canonical: str, legacy: str, module_attr: str) -> None:
+def test_canonical_and_legacy_commands_dispatch(
+    monkeypatch, canonical: str, legacy: str, module_attr: str
+) -> None:
     calls: list[list[str]] = []
 
     def _fake_main(argv: list[str]) -> int:

--- a/tests/test_cli_sdetkit.py
+++ b/tests/test_cli_sdetkit.py
@@ -155,3 +155,19 @@ def test_apigetcli_help():
     )
     assert p.returncode == 0
     assert "usage:" in p.stdout
+
+
+def test_product_lane_alias_resolves_to_canonical(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["day29-phase1-hardening", "--help"])
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "Day 29 phase-1 hardening scorer" in out
+
+
+def test_product_lane_canonical_help_is_available(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["phase1-hardening", "--help"])
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "usage:" in out

--- a/tests/test_day61_phase3_kickoff_closeout.py
+++ b/tests/test_day61_phase3_kickoff_closeout.py
@@ -121,6 +121,8 @@ def test_day61_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase3-kickoff-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    alias_rc = cli.main(["day61-phase3-kickoff-closeout", "--root", str(tmp_path), "--format", "text"])
+    alias_rc = cli.main(
+        ["day61-phase3-kickoff-closeout", "--root", str(tmp_path), "--format", "text"]
+    )
     assert alias_rc == 0
     assert "Phase3 Kickoff Closeout summary" in capsys.readouterr().out

--- a/tests/test_day62_community_program_closeout.py
+++ b/tests/test_day62_community_program_closeout.py
@@ -125,6 +125,8 @@ def test_day62_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["community-program-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    alias_rc = cli.main(["day62-community-program-closeout", "--root", str(tmp_path), "--format", "text"])
+    alias_rc = cli.main(
+        ["day62-community-program-closeout", "--root", str(tmp_path), "--format", "text"]
+    )
     assert alias_rc == 0
     assert "Community Program Closeout summary" in capsys.readouterr().out

--- a/tests/test_day65_weekly_review_closeout.py
+++ b/tests/test_day65_weekly_review_closeout.py
@@ -128,6 +128,8 @@ def test_day65_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    alias_rc = cli.main(["day65-weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
+    alias_rc = cli.main(
+        ["day65-weekly-review-closeout", "--root", str(tmp_path), "--format", "text"]
+    )
     assert alias_rc == 0
     assert "Weekly Review Closeout summary" in capsys.readouterr().out

--- a/tests/test_day68_integration_expansion4_closeout.py
+++ b/tests/test_day68_integration_expansion4_closeout.py
@@ -114,8 +114,6 @@ def test_day68_strict_fails_without_day67_summary(tmp_path: Path) -> None:
 
 def test_day68_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["integration-expansion4-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["integration-expansion4-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Integration Expansion4 Closeout summary" in capsys.readouterr().out

--- a/tests/test_day69_case_study_prep1_closeout.py
+++ b/tests/test_day69_case_study_prep1_closeout.py
@@ -115,6 +115,8 @@ def test_day69_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["case-study-prep1-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    alias_rc = cli.main(["day69-case-study-prep1-closeout", "--root", str(tmp_path), "--format", "text"])
+    alias_rc = cli.main(
+        ["day69-case-study-prep1-closeout", "--root", str(tmp_path), "--format", "text"]
+    )
     assert alias_rc == 0
     assert "Case Study Prep1 Closeout summary" in capsys.readouterr().out

--- a/tests/test_day70_case_study_prep2_closeout.py
+++ b/tests/test_day70_case_study_prep2_closeout.py
@@ -103,6 +103,8 @@ def test_day70_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["case-study-prep2-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    alias_rc = cli.main(["day70-case-study-prep2-closeout", "--root", str(tmp_path), "--format", "text"])
+    alias_rc = cli.main(
+        ["day70-case-study-prep2-closeout", "--root", str(tmp_path), "--format", "text"]
+    )
     assert alias_rc == 0
     assert "Case Study Prep 2 Closeout summary" in capsys.readouterr().out

--- a/tests/test_day74_distribution_scaling_closeout.py
+++ b/tests/test_day74_distribution_scaling_closeout.py
@@ -140,8 +140,6 @@ def test_day74_strict_fails_without_day73(tmp_path: Path) -> None:
 
 def test_day74_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["distribution-scaling-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["distribution-scaling-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Distribution Scaling Closeout summary" in capsys.readouterr().out

--- a/tests/test_day75_trust_assets_refresh_closeout.py
+++ b/tests/test_day75_trust_assets_refresh_closeout.py
@@ -140,8 +140,6 @@ def test_day75_strict_fails_without_day74(tmp_path: Path) -> None:
 
 def test_day75_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["trust-assets-refresh-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["trust-assets-refresh-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Trust Assets Refresh Closeout summary" in capsys.readouterr().out

--- a/tests/test_day77_community_touchpoint_closeout.py
+++ b/tests/test_day77_community_touchpoint_closeout.py
@@ -142,8 +142,6 @@ def test_day77_strict_fails_without_day76(tmp_path: Path) -> None:
 
 def test_day77_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["community-touchpoint-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["community-touchpoint-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Community Touchpoint Closeout summary" in capsys.readouterr().out

--- a/tests/test_day78_ecosystem_priorities_closeout.py
+++ b/tests/test_day78_ecosystem_priorities_closeout.py
@@ -104,8 +104,6 @@ def test_day78_strict_fails_without_day77_summary(tmp_path: Path) -> None:
 
 def test_day78_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["ecosystem-priorities-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["ecosystem-priorities-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Ecosystem Priorities Closeout summary" in capsys.readouterr().out

--- a/tests/test_day82_integration_feedback_closeout.py
+++ b/tests/test_day82_integration_feedback_closeout.py
@@ -141,8 +141,6 @@ def test_day82_strict_fails_without_day81(tmp_path: Path) -> None:
 
 def test_day82_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["integration-feedback-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["integration-feedback-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 82 integration feedback closeout summary" in capsys.readouterr().out

--- a/tests/test_day83_trust_faq_expansion_closeout.py
+++ b/tests/test_day83_trust_faq_expansion_closeout.py
@@ -141,8 +141,6 @@ def test_day83_strict_fails_without_day82(tmp_path: Path) -> None:
 
 def test_day83_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["trust-faq-expansion-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["trust-faq-expansion-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 83 trust FAQ expansion closeout summary" in capsys.readouterr().out

--- a/tests/test_day84_evidence_narrative_closeout.py
+++ b/tests/test_day84_evidence_narrative_closeout.py
@@ -139,8 +139,6 @@ def test_day84_strict_fails_without_day83(tmp_path: Path) -> None:
 
 def test_day84_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["evidence-narrative-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["evidence-narrative-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 84 evidence narrative closeout summary" in capsys.readouterr().out

--- a/tests/test_day85_release_prioritization_closeout.py
+++ b/tests/test_day85_release_prioritization_closeout.py
@@ -141,8 +141,6 @@ def test_day85_strict_fails_without_day84(tmp_path: Path) -> None:
 
 def test_day85_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["release-prioritization-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["release-prioritization-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 85 release prioritization closeout summary" in capsys.readouterr().out

--- a/tests/test_day87_governance_handoff_closeout.py
+++ b/tests/test_day87_governance_handoff_closeout.py
@@ -139,8 +139,6 @@ def test_day87_strict_fails_without_day86(tmp_path: Path) -> None:
 
 def test_day87_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["governance-handoff-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["governance-handoff-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 87 governance handoff closeout summary" in capsys.readouterr().out

--- a/tests/test_day88_governance_priorities_closeout.py
+++ b/tests/test_day88_governance_priorities_closeout.py
@@ -141,8 +141,6 @@ def test_day88_strict_fails_without_day87(tmp_path: Path) -> None:
 
 def test_day88_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["governance-priorities-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["governance-priorities-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 88 governance priorities closeout summary" in capsys.readouterr().out

--- a/tests/test_day90_phase3_wrap_publication_closeout.py
+++ b/tests/test_day90_phase3_wrap_publication_closeout.py
@@ -141,8 +141,6 @@ def test_day90_strict_fails_without_day89(tmp_path: Path) -> None:
 
 def test_day90_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["phase3-wrap-publication-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["phase3-wrap-publication-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 90 phase-3 wrap publication closeout summary" in capsys.readouterr().out

--- a/tests/test_day91_continuous_upgrade_closeout.py
+++ b/tests/test_day91_continuous_upgrade_closeout.py
@@ -169,8 +169,6 @@ def test_day91_strict_fails_without_day90(tmp_path: Path) -> None:
 
 def test_day91_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["continuous-upgrade-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["continuous-upgrade-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 91 continuous upgrade closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Replace day-branded public UX with stable product lane names for Day 01–97 families where safe to do so, while keeping day-prefixed commands as legacy aliases. 
- Surface stable, discoverable commands in onboarding, README/docs index, CLI help, examples and playbook listings to reduce dated onboarding friction. 
- Preserve historical reports and compatibility for audits and migration traceability. 

### Description
- Promote product-primary command names in the CLI dispatch and parsers (e.g. `phase1-hardening`, `release-cadence`, `demo-asset`, `weekly-review-lane`, `weekly-review-closeout-cycle2`), and preserve day-prefixed names as aliases in `src/sdetkit/cli.py`. 
- Update playbook registry canonical mapping (`src/sdetkit/playbooks_cli.py`) to map day modules to stable names (e.g. `day28_weekly_review -> weekly-review-lane`, `day65_weekly_review_closeout -> weekly-review-closeout-cycle2`). 
- Productize public docs and examples by making stable commands primary in `docs/index.md`, `docs/cli.md`, integration docs under `docs/integrations-day*.md` (Day 29–50 cohort and related files), and the GitLab CI example `examples/ci/gitlab/day66-advanced-reference.yml`, while adding an explicit legacy day reports section. 
- Adjust and extend tests to assert product-primary names while retaining alias behavior (tests under `tests/` updated), and apply formatting fixes (`ruff format`) where required to keep gates green. 

### Testing
- Ran targeted unit tests: `pytest -q tests/test_cli_help_lists_subcommands.py tests/test_cli_sdetkit.py tests/test_playbooks_validate.py` and all selected tests passed (`21 passed`). 
- Ran wider test subset used during gating (multiple `pytest` targets touched by `gate fast`) and resolved formatter failures by running `ruff format` on affected test files until `ruff --check tests` returned clean. 
- Executed CLI smoke checks: `python -m sdetkit --help`, `python -m sdetkit phase1-hardening --help`, and `python -m sdetkit day29-phase1-hardening --help` which produced the expected help outputs (canonical and alias behavior validated). 
- Ran release and fast gates: `python -m sdetkit gate fast --root . --format json --out /tmp/gate-fast-productization.json` and `python -m sdetkit gate release --root . --format json --out /tmp/gate-release-productization.json` and both gates completed successfully after the formatting fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afb28c4e988327822c21b7bb314709)