### PR TITLE
Productize day-branded lanes: remove day aliases from playbooks and de-brand docs/tests

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -688,17 +688,11 @@ Builds an expansion-automation report by combining upstream scale-lane handoff a
 Examples:
 
 - `sdetkit expansion-automation --format text`
-- `sdetkit day41-expansion-automation --format text` (legacy alias)
 - `sdetkit expansion-automation --format json --strict`
-- `sdetkit day41-expansion-automation --format json --strict` (legacy alias)
 - `sdetkit expansion-automation --write-defaults --format json --strict`
-- `sdetkit day41-expansion-automation --write-defaults --format json --strict` (legacy alias)
 - `sdetkit expansion-automation --emit-pack-dir docs/artifacts/expansion-automation-pack --format json --strict`
-- `sdetkit day41-expansion-automation --emit-pack-dir docs/artifacts/expansion-automation-pack --format json --strict` (legacy alias)
 - `sdetkit expansion-automation --execute --evidence-dir docs/artifacts/expansion-automation-pack/evidence --format json --strict`
-- `sdetkit day41-expansion-automation --execute --evidence-dir docs/artifacts/expansion-automation-pack/evidence --format json --strict` (legacy alias)
 - `sdetkit expansion-automation --format markdown --output expansion-automation-report.md`
-- `sdetkit day41-expansion-automation --format markdown --output expansion-automation-report.md` (legacy alias)
 
 Useful flags: `--root`, `--format`, `--output`, `--strict`, `--emit-pack-dir`, `--execute`, `--evidence-dir`, `--write-defaults`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Build, validate, and release software with confidence using a polished SDET + De
 
 </div>
 
-## Docs navigation upgrades (legacy Day 11 initiative)
+## Docs navigation upgrades (legacy docs navigation initiative)
 
 ## Legacy day reports
 

--- a/docs/integrations-case-study-prep1-closeout.md
+++ b/docs/integrations-case-study-prep1-closeout.md
@@ -1,6 +1,5 @@
-# Case Study Prep1 Closeout (Legacy Day 69) — Case-study prep #1 closeout lane
+# Case Study Prep1 Closeout (legacy) — Case-study prep #1 closeout lane
 
-> Legacy alias: `day69-case-study-prep1-closeout` remains supported; prefer `case-study-prep1-closeout` in active usage.
 
 Day 69 closes with a major upgrade that turns Day 68 integration outputs into a measurable reliability case-study prep pack.
 
@@ -16,7 +15,7 @@ Day 69 closes with a major upgrade that turns Day 68 integration outputs into a 
 - `docs/artifacts/day68-integration-expansion4-closeout-pack/day68-delivery-board.md`
 - `docs/roadmap/plans/reliability-case-study.json`
 
-## Case Study Prep1 Closeout command lane (Legacy Day 69)
+## Case Study Prep1 Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit case-study-prep1-closeout --format json --strict
@@ -40,7 +39,7 @@ python scripts/check_day69_case_study_prep1_closeout_contract.py
 - [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner
 - [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log
 
-## Case Study Prep1 Closeout delivery board (Legacy Day 69)
+## Case Study Prep1 Closeout delivery board (legacy)
 
 - [ ] Day 69 integration brief committed
 - [ ] Day 69 reliability case-study narrative published

--- a/docs/integrations-case-study-prep2-closeout.md
+++ b/docs/integrations-case-study-prep2-closeout.md
@@ -1,6 +1,5 @@
-# Case Study Prep 2 Closeout (Legacy Day 70) — Case-study prep #2 closeout lane
+# Case Study Prep 2 Closeout (legacy) — Case-study prep #2 closeout lane
 
-> Legacy alias: `day70-case-study-prep2-closeout` remains supported; prefer `case-study-prep2-closeout` in active usage.
 
 Day 70 closes with a major upgrade that turns Day 69 integration outputs into a measurable triage-speed case-study prep pack.
 
@@ -16,7 +15,7 @@ Day 70 closes with a major upgrade that turns Day 69 integration outputs into a 
 - `docs/artifacts/day69-case-study-prep1-closeout-pack/day69-delivery-board.md`
 - `docs/roadmap/plans/triage-speed-case-study.json`
 
-## Case Study Prep 2 Closeout command lane (Legacy Day 70)
+## Case Study Prep 2 Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit case-study-prep2-closeout --format json --strict
@@ -40,7 +39,7 @@ python scripts/check_day70_case_study_prep2_closeout_contract.py
 - [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner
 - [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log
 
-## Case Study Prep 2 Closeout delivery board (Legacy Day 70)
+## Case Study Prep 2 Closeout delivery board (legacy)
 
 - [ ] Day 70 integration brief committed
 - [ ] Day 70 triage-speed case-study narrative published

--- a/docs/integrations-community-program-closeout.md
+++ b/docs/integrations-community-program-closeout.md
@@ -1,6 +1,5 @@
-# Community Program Closeout (Legacy Day 62) — Community program setup closeout lane
+# Community Program Closeout (legacy) — Community program setup closeout lane
 
-> Legacy alias: `day62-community-program-closeout` remains supported; prefer `community-program-closeout` in active usage.
 
 Day 62 ships a major community-program upgrade that converts Day 61 kickoff evidence into a strict baseline for office-hours, participation, and moderation execution.
 
@@ -15,7 +14,7 @@ Day 62 ships a major community-program upgrade that converts Day 61 kickoff evid
 - `docs/artifacts/day61-phase3-kickoff-closeout-pack/day61-phase3-kickoff-closeout-summary.json`
 - `docs/artifacts/day61-phase3-kickoff-closeout-pack/day61-delivery-board.md`
 
-## Community Program Closeout command lane (Legacy Day 62)
+## Community Program Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit community-program-closeout --format json --strict
@@ -39,7 +38,7 @@ python scripts/check_day62_community_program_closeout_contract.py
 - [ ] Scorecard captures attendance target, response SLA, trust incidents, confidence, and recovery owner
 - [ ] Artifact pack includes launch brief, participation policy, moderation runbook, and execution log
 
-## Community Program Closeout delivery board (Legacy Day 62)
+## Community Program Closeout delivery board (legacy)
 
 - [ ] Day 62 community launch brief committed
 - [ ] Day 62 office-hours cadence published

--- a/docs/integrations-continuous-upgrade-closeout.md
+++ b/docs/integrations-continuous-upgrade-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit continuous-upgrade-closeout --execute --evidence-dir docs/arti
 python scripts/check_day91_continuous_upgrade_closeout_contract.py
 ```
 
-Legacy alias: `day91-continuous-upgrade-closeout` remains supported for compatibility.
 
 ## Continuous upgrade contract
 

--- a/docs/integrations-continuous-upgrade-cycle2-closeout.md
+++ b/docs/integrations-continuous-upgrade-cycle2-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit continuous-upgrade-cycle2-closeout --execute --evidence-dir do
 python scripts/check_day92_continuous_upgrade_cycle2_closeout_contract.py
 ```
 
-Legacy alias: `day92-continuous-upgrade-cycle2-closeout` remains supported for compatibility.
 
 ## Continuous upgrade contract
 

--- a/docs/integrations-continuous-upgrade-cycle3-closeout.md
+++ b/docs/integrations-continuous-upgrade-cycle3-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit continuous-upgrade-cycle3-closeout --execute --evidence-dir do
 python scripts/check_day93_continuous_upgrade_cycle3_closeout_contract.py
 ```
 
-Legacy alias: `day93-continuous-upgrade-cycle3-closeout` remains supported for compatibility.
 
 ## Continuous upgrade contract
 

--- a/docs/integrations-continuous-upgrade-cycle4-closeout.md
+++ b/docs/integrations-continuous-upgrade-cycle4-closeout.md
@@ -18,7 +18,7 @@ Day 94 starts the next cycle by converting Day 93 publication outcomes into a de
 
 ```bash
 python -m sdetkit continuous-upgrade-cycle4-closeout --format json --strict
-python -m sdetkit day94-continuous-upgrade-cycle4-closeout --format json --strict  # legacy alias
+python -m sdetkit continuous-upgrade-cycle4-closeout --format json --strict  # legacy alias
 python -m sdetkit continuous-upgrade-cycle4-closeout --emit-pack-dir docs/artifacts/day94-continuous-upgrade-cycle4-closeout-pack --format json --strict
 python -m sdetkit continuous-upgrade-cycle4-closeout --execute --evidence-dir docs/artifacts/day94-continuous-upgrade-cycle4-closeout-pack/evidence --format json --strict
 python scripts/check_day94_continuous_upgrade_cycle4_closeout_contract.py
@@ -26,7 +26,7 @@ python scripts/check_day94_continuous_upgrade_cycle4_closeout_contract.py
 
 ## Continuous upgrade contract
 
-- Single owner + backup reviewer are assigned for continuous-upgrade execution and signoff (legacy Day 94).
+- Single owner + backup reviewer are assigned for continuous-upgrade execution and signoff (legacy).
 - The Day 94 lane references Day 93 outcomes, controls, and trust continuity signals.
 - Every Day 94 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Day 94 closeout records continuous upgrade outputs, report publication status, and backlog inputs.

--- a/docs/integrations-continuous-upgrade-cycle5-closeout.md
+++ b/docs/integrations-continuous-upgrade-cycle5-closeout.md
@@ -18,7 +18,7 @@ Day 95 starts the next cycle by converting Day 94 publication outcomes into a de
 
 ```bash
 python -m sdetkit continuous-upgrade-cycle5-closeout --format json --strict
-python -m sdetkit day95-continuous-upgrade-cycle5-closeout --format json --strict  # legacy alias
+python -m sdetkit continuous-upgrade-cycle5-closeout --format json --strict  # legacy alias
 python -m sdetkit continuous-upgrade-cycle5-closeout --emit-pack-dir docs/artifacts/day95-continuous-upgrade-cycle5-closeout-pack --format json --strict
 python -m sdetkit continuous-upgrade-cycle5-closeout --execute --evidence-dir docs/artifacts/day95-continuous-upgrade-cycle5-closeout-pack/evidence --format json --strict
 python scripts/check_day95_continuous_upgrade_cycle5_closeout_contract.py
@@ -26,7 +26,7 @@ python scripts/check_day95_continuous_upgrade_cycle5_closeout_contract.py
 
 ## Continuous upgrade contract
 
-- Single owner + backup reviewer are assigned for continuous-upgrade execution and signoff (legacy Day 95).
+- Single owner + backup reviewer are assigned for continuous-upgrade execution and signoff (legacy).
 - The Day 95 lane references Day 94 outcomes, controls, and trust continuity signals.
 - Every Day 95 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Day 95 closeout records continuous upgrade outputs, report publication status, and backlog inputs.

--- a/docs/integrations-continuous-upgrade-cycle6-closeout.md
+++ b/docs/integrations-continuous-upgrade-cycle6-closeout.md
@@ -18,7 +18,7 @@ Continuous Upgrade Cycle 6 continues the next-cycle motion by converting prior c
 
 ```bash
 python -m sdetkit continuous-upgrade-cycle6-closeout --format json --strict
-python -m sdetkit day96-continuous-upgrade-cycle6-closeout --format json --strict  # legacy alias
+python -m sdetkit continuous-upgrade-cycle6-closeout --format json --strict  # legacy alias
 python -m sdetkit continuous-upgrade-cycle6-closeout --emit-pack-dir docs/artifacts/day96-continuous-upgrade-cycle6-closeout-pack --format json --strict
 python -m sdetkit continuous-upgrade-cycle6-closeout --execute --evidence-dir docs/artifacts/day96-continuous-upgrade-cycle6-closeout-pack/evidence --format json --strict
 python scripts/check_day96_continuous_upgrade_cycle6_closeout_contract.py
@@ -26,7 +26,7 @@ python scripts/check_day96_continuous_upgrade_cycle6_closeout_contract.py
 
 ## Continuous upgrade contract
 
-- Single owner + backup reviewer are assigned for continuous-upgrade execution and signoff (legacy Day 96).
+- Single owner + backup reviewer are assigned for continuous-upgrade execution and signoff (legacy).
 - The Day 96 lane references Day 95 outcomes, controls, and trust continuity signals.
 - Every Day 96 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Day 96 closeout records continuous upgrade outputs, report publication status, and backlog inputs.

--- a/docs/integrations-continuous-upgrade-cycle7-closeout.md
+++ b/docs/integrations-continuous-upgrade-cycle7-closeout.md
@@ -18,7 +18,7 @@ Continuous Upgrade Cycle 7 continues the next-cycle motion by converting prior c
 
 ```bash
 python -m sdetkit continuous-upgrade-cycle7-closeout --format json --strict
-python -m sdetkit day97-continuous-upgrade-cycle7-closeout --format json --strict  # legacy alias
+python -m sdetkit continuous-upgrade-cycle7-closeout --format json --strict  # legacy alias
 python -m sdetkit continuous-upgrade-cycle7-closeout --emit-pack-dir docs/artifacts/day97-continuous-upgrade-cycle7-closeout-pack --format json --strict
 python -m sdetkit continuous-upgrade-cycle7-closeout --execute --evidence-dir docs/artifacts/day97-continuous-upgrade-cycle7-closeout-pack/evidence --format json --strict
 python scripts/check_day97_continuous_upgrade_cycle7_closeout_contract.py
@@ -26,7 +26,7 @@ python scripts/check_day97_continuous_upgrade_cycle7_closeout_contract.py
 
 ## Continuous upgrade contract
 
-- Single owner + backup reviewer are assigned for continuous-upgrade execution and signoff (legacy Day 97).
+- Single owner + backup reviewer are assigned for continuous-upgrade execution and signoff (legacy).
 - The Day 97 lane references Day 95 outcomes, controls, and trust continuity signals.
 - Every Day 97 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Day 97 closeout records continuous upgrade outputs, report publication status, and backlog inputs.

--- a/docs/integrations-evidence-narrative-closeout.md
+++ b/docs/integrations-evidence-narrative-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit evidence-narrative-closeout --execute --evidence-dir docs/arti
 python scripts/check_day84_evidence_narrative_closeout_contract.py
 ```
 
-Legacy alias: `day84-evidence-narrative-closeout` remains supported for compatibility.
 
 ## Evidence narrative contract
 

--- a/docs/integrations-governance-handoff-closeout.md
+++ b/docs/integrations-governance-handoff-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit governance-handoff-closeout --execute --evidence-dir docs/arti
 python scripts/check_day87_governance_handoff_closeout_contract.py
 ```
 
-Legacy alias: `day87-governance-handoff-closeout` remains supported for compatibility.
 
 ## Governance handoff contract
 

--- a/docs/integrations-governance-priorities-closeout.md
+++ b/docs/integrations-governance-priorities-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit governance-priorities-closeout --execute --evidence-dir docs/a
 python scripts/check_day88_governance_priorities_closeout_contract.py
 ```
 
-Legacy alias: `day88-governance-priorities-closeout` remains supported for compatibility.
 
 ## Governance priorities contract
 

--- a/docs/integrations-governance-scale-closeout.md
+++ b/docs/integrations-governance-scale-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit governance-scale-closeout --execute --evidence-dir docs/artifa
 python scripts/check_day89_governance_scale_closeout_contract.py
 ```
 
-Legacy alias: `day89-governance-scale-closeout` remains supported for compatibility.
 
 ## Governance scale contract
 

--- a/docs/integrations-growth-campaign-closeout.md
+++ b/docs/integrations-growth-campaign-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit growth-campaign-closeout --execute --evidence-dir docs/artifac
 python scripts/check_day81_growth_campaign_closeout_contract.py
 ```
 
-Legacy alias: `day81-growth-campaign-closeout` remains supported for compatibility.
 
 ## Growth campaign contract
 

--- a/docs/integrations-integration-expansion-closeout.md
+++ b/docs/integrations-integration-expansion-closeout.md
@@ -1,6 +1,5 @@
-# Integration Expansion Closeout (Legacy Day 64) — Integration expansion #1 closeout lane
+# Integration Expansion Closeout (legacy) — Integration expansion #1 closeout lane
 
-> Legacy alias: `day64-integration-expansion-closeout` remains supported; prefer `integration-expansion-closeout` in active usage.
 
 Day 64 closes with a major integration upgrade that turns Day 63 onboarding momentum into an advanced GitHub Actions reference workflow with deterministic CI controls.
 
@@ -15,7 +14,7 @@ Day 64 closes with a major integration upgrade that turns Day 63 onboarding mome
 - `docs/artifacts/day63-onboarding-activation-closeout-pack/day63-onboarding-activation-closeout-summary.json`
 - `docs/artifacts/day63-onboarding-activation-closeout-pack/day63-delivery-board.md`
 
-## Integration Expansion Closeout command lane (Legacy Day 64)
+## Integration Expansion Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit integration-expansion-closeout --format json --strict
@@ -39,7 +38,7 @@ python scripts/check_day64_integration_expansion_closeout_contract.py
 - [ ] Scorecard captures workflow pass-rate, median runtime, cache hit-rate, confidence, and recovery owner
 - [ ] Artifact pack includes integration brief, workflow blueprint, matrix plan, KPI scorecard, and execution log
 
-## Integration Expansion Closeout delivery board (Legacy Day 64)
+## Integration Expansion Closeout delivery board (legacy)
 
 - [ ] Day 64 integration brief committed
 - [ ] Day 64 advanced workflow blueprint published

--- a/docs/integrations-integration-expansion2-closeout.md
+++ b/docs/integrations-integration-expansion2-closeout.md
@@ -1,6 +1,5 @@
-# Integration Expansion 2 Closeout (Legacy Day 66) — Integration expansion #2 closeout lane
+# Integration Expansion 2 Closeout (legacy) — Integration expansion #2 closeout lane
 
-> Legacy alias: `day66-integration-expansion2-closeout` remains supported; prefer `integration-expansion2-closeout` in active usage.
 
 Day 66 closes with a major integration upgrade that converts Day 65 weekly review outcomes into an advanced GitLab CI reference pipeline.
 
@@ -16,7 +15,7 @@ Day 66 closes with a major integration upgrade that converts Day 65 weekly revie
 - `docs/artifacts/day65-weekly-review-closeout-pack/day65-delivery-board.md`
 - `templates/ci/gitlab/day66-advanced-reference.yml`
 
-## Integration Expansion 2 Closeout command lane (Legacy Day 66)
+## Integration Expansion 2 Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit integration-expansion2-closeout --format json --strict
@@ -40,7 +39,7 @@ python scripts/check_day66_integration_expansion2_closeout_contract.py
 - [ ] Scorecard captures pipeline pass-rate, median runtime, cache efficiency, confidence, and recovery owner
 - [ ] Artifact pack includes integration brief, pipeline blueprint, matrix plan, KPI scorecard, and execution log
 
-## Integration Expansion 2 Closeout delivery board (Legacy Day 66)
+## Integration Expansion 2 Closeout delivery board (legacy)
 
 - [ ] Day 66 integration brief committed
 - [ ] Day 66 advanced GitLab pipeline blueprint published

--- a/docs/integrations-integration-expansion3-closeout.md
+++ b/docs/integrations-integration-expansion3-closeout.md
@@ -1,6 +1,5 @@
-# Integration Expansion3 Closeout (Legacy Day 67) — Integration expansion #3 closeout lane
+# Integration Expansion3 Closeout (legacy) — Integration expansion #3 closeout lane
 
-> Legacy alias: `day67-integration-expansion3-closeout` remains supported; prefer `integration-expansion3-closeout` in active usage.
 
 Day 67 closes with a major integration upgrade that converts Day 66 integration outputs into an advanced Jenkins reference pipeline.
 
@@ -16,7 +15,7 @@ Day 67 closes with a major integration upgrade that converts Day 66 integration 
 - `docs/artifacts/day66-integration-expansion2-closeout-pack/day66-delivery-board.md`
 - `templates/ci/jenkins/day67-advanced-reference.Jenkinsfile`
 
-## Integration Expansion3 Closeout command lane (Legacy Day 67)
+## Integration Expansion3 Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit integration-expansion3-closeout --format json --strict
@@ -40,7 +39,7 @@ python scripts/check_day67_integration_expansion3_closeout_contract.py
 - [ ] Scorecard captures pipeline pass-rate, median runtime, cache efficiency, confidence, and recovery owner
 - [ ] Artifact pack includes integration brief, Jenkins blueprint, matrix plan, KPI scorecard, and execution log
 
-## Integration Expansion3 Closeout delivery board (Legacy Day 67)
+## Integration Expansion3 Closeout delivery board (legacy)
 
 - [ ] Day 67 integration brief committed
 - [ ] Day 67 advanced Jenkins pipeline blueprint published

--- a/docs/integrations-integration-expansion4-closeout.md
+++ b/docs/integrations-integration-expansion4-closeout.md
@@ -1,6 +1,5 @@
-# Integration Expansion4 Closeout (Legacy Day 68) — Integration expansion #4 closeout lane
+# Integration Expansion4 Closeout (legacy) — Integration expansion #4 closeout lane
 
-> Legacy alias: `day68-integration-expansion4-closeout` remains supported; prefer `integration-expansion4-closeout` in active usage.
 
 Day 68 closes with a major integration upgrade that converts Day 67 outputs into a self-hosted enterprise Tekton reference.
 
@@ -16,7 +15,7 @@ Day 68 closes with a major integration upgrade that converts Day 67 outputs into
 - `docs/artifacts/day67-integration-expansion3-closeout-pack/day67-delivery-board.md`
 - `templates/ci/tekton/day68-self-hosted-reference.yaml`
 
-## Integration Expansion4 Closeout command lane (Legacy Day 68)
+## Integration Expansion4 Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit integration-expansion4-closeout --format json --strict
@@ -40,7 +39,7 @@ python scripts/check_day68_integration_expansion4_closeout_contract.py
 - [ ] Scorecard captures pipeline pass-rate, median runtime, queue saturation, confidence, and recovery owner
 - [ ] Artifact pack includes integration brief, self-hosted blueprint, policy plan, KPI scorecard, and execution log
 
-## Integration Expansion4 Closeout delivery board (Legacy Day 68)
+## Integration Expansion4 Closeout delivery board (legacy)
 
 - [ ] Day 68 integration brief committed
 - [ ] Day 68 self-hosted enterprise pipeline blueprint published

--- a/docs/integrations-integration-feedback-closeout.md
+++ b/docs/integrations-integration-feedback-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit integration-feedback-closeout --execute --evidence-dir docs/ar
 python scripts/check_day82_integration_feedback_closeout_contract.py
 ```
 
-Legacy alias: `day82-integration-feedback-closeout` remains supported for compatibility.
 
 ## Integration feedback contract
 

--- a/docs/integrations-launch-readiness-closeout.md
+++ b/docs/integrations-launch-readiness-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit launch-readiness-closeout --execute --evidence-dir docs/artifa
 python scripts/check_day86_launch_readiness_closeout_contract.py
 ```
 
-Legacy alias: `day86-launch-readiness-closeout` remains supported for compatibility.
 
 ## Launch readiness contract
 

--- a/docs/integrations-onboarding-activation-closeout.md
+++ b/docs/integrations-onboarding-activation-closeout.md
@@ -1,6 +1,5 @@
-# Onboarding Activation Closeout (Legacy Day 63) — Contributor onboarding activation closeout lane
+# Onboarding Activation Closeout (legacy) — Contributor onboarding activation closeout lane
 
-> Legacy alias: `day63-onboarding-activation-closeout` remains supported; prefer `onboarding-activation-closeout` in active usage.
 
 Day 63 closes with a major onboarding activation upgrade that turns Day 62 community operations evidence into deterministic contributor activation, ownership handoffs, and roadmap voting execution.
 
@@ -15,7 +14,7 @@ Day 63 closes with a major onboarding activation upgrade that turns Day 62 commu
 - `docs/artifacts/day62-community-program-closeout-pack/day62-community-program-closeout-summary.json`
 - `docs/artifacts/day62-community-program-closeout-pack/day62-delivery-board.md`
 
-## Onboarding Activation Closeout command lane (Legacy Day 63)
+## Onboarding Activation Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit onboarding-activation-closeout --format json --strict
@@ -39,7 +38,7 @@ python scripts/check_day63_onboarding_activation_closeout_contract.py
 - [ ] Scorecard captures activation conversion, mentor SLA, roadmap-vote participation, confidence, and recovery owner
 - [ ] Artifact pack includes onboarding brief, orientation script, ownership matrix, roadmap-vote brief, and execution log
 
-## Onboarding Activation Closeout delivery board (Legacy Day 63)
+## Onboarding Activation Closeout delivery board (legacy)
 
 - [ ] Day 63 onboarding launch brief committed
 - [ ] Day 63 orientation script + ownership matrix published

--- a/docs/integrations-phase3-kickoff-closeout.md
+++ b/docs/integrations-phase3-kickoff-closeout.md
@@ -1,6 +1,5 @@
-# Phase3 Kickoff Closeout (Legacy Day 61) — Phase-3 kickoff execution closeout lane
+# Phase3 Kickoff Closeout (legacy) — Phase-3 kickoff execution closeout lane
 
-> Legacy alias: `day61-phase3-kickoff-closeout` remains supported; prefer `phase3-kickoff-closeout` in active usage.
 
 Day 61 ships a major Phase-3 kickoff upgrade that converts Day 60 wrap evidence into a strict baseline for ecosystem + trust execution.
 
@@ -15,7 +14,7 @@ Day 61 ships a major Phase-3 kickoff upgrade that converts Day 60 wrap evidence 
 - `docs/artifacts/day60-phase2-wrap-handoff-closeout-pack/day60-phase2-wrap-handoff-closeout-summary.json`
 - `docs/artifacts/day60-phase2-wrap-handoff-closeout-pack/day60-delivery-board.md`
 
-## Phase3 Kickoff Closeout command lane (Legacy Day 61)
+## Phase3 Kickoff Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit phase3-kickoff-closeout --format json --strict
@@ -39,7 +38,7 @@ python scripts/check_day61_phase3_kickoff_closeout_contract.py
 - [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each trust KPI
 - [ ] Artifact pack includes kickoff brief, trust ledger, KPI scorecard, and execution log
 
-## Phase3 Kickoff Closeout delivery board (Legacy Day 61)
+## Phase3 Kickoff Closeout delivery board (legacy)
 
 - [ ] Day 61 Phase-3 kickoff brief committed
 - [ ] Day 61 kickoff reviewed with owner + backup

--- a/docs/integrations-phase3-wrap-publication-closeout.md
+++ b/docs/integrations-phase3-wrap-publication-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit phase3-wrap-publication-closeout --execute --evidence-dir docs
 python scripts/check_day90_phase3_wrap_publication_closeout_contract.py
 ```
 
-Legacy alias: `day90-phase3-wrap-publication-closeout` remains supported for compatibility.
 
 ## Phase-3 wrap publication contract
 

--- a/docs/integrations-release-prioritization-closeout.md
+++ b/docs/integrations-release-prioritization-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit release-prioritization-closeout --execute --evidence-dir docs/
 python scripts/check_day85_release_prioritization_closeout_contract.py
 ```
 
-Legacy alias: `day85-release-prioritization-closeout` remains supported for compatibility.
 
 ## Release prioritization contract
 

--- a/docs/integrations-trust-faq-expansion-closeout.md
+++ b/docs/integrations-trust-faq-expansion-closeout.md
@@ -23,7 +23,6 @@ python -m sdetkit trust-faq-expansion-closeout --execute --evidence-dir docs/art
 python scripts/check_day83_trust_faq_expansion_closeout_contract.py
 ```
 
-Legacy alias: `day83-trust-faq-expansion-closeout` remains supported for compatibility.
 
 ## Trust FAQ expansion contract
 

--- a/docs/integrations-weekly-review-closeout-cycle2.md
+++ b/docs/integrations-weekly-review-closeout-cycle2.md
@@ -1,4 +1,4 @@
-# Weekly Review Closeout (Legacy Day 65) — Weekly review #9 closeout lane
+# Weekly Review Closeout (legacy) — Weekly review #9 closeout lane
 
 > Legacy alias: `weekly-review-closeout-cycle2` remains supported; prefer `weekly-review-closeout` in active usage.
 
@@ -16,7 +16,7 @@ Day 65 closes with a major weekly review upgrade that converts Day 64 integratio
 - `docs/artifacts/day64-integration-expansion-closeout-pack/day64-delivery-board.md`
 - `.github/workflows/day64-advanced-github-actions-reference.yml`
 
-## Weekly Review Closeout command lane (Legacy Day 65)
+## Weekly Review Closeout command lane (legacy)
 
 ```bash
 python -m sdetkit weekly-review-closeout --format json --strict
@@ -40,7 +40,7 @@ python scripts/check_day65_weekly_review_closeout_contract.py
 - [ ] Scorecard captures pass-rate trend, reliability incidents, contributor signal quality, and recovery owner
 - [ ] Artifact pack includes weekly brief, KPI dashboard, decision register, risk ledger, and execution log
 
-## Weekly Review Closeout delivery board (Legacy Day 65)
+## Weekly Review Closeout delivery board (legacy)
 
 - [ ] Day 65 weekly brief committed
 - [ ] Day 65 KPI dashboard snapshot exported

--- a/docs/integrations-weekly-review.md
+++ b/docs/integrations-weekly-review.md
@@ -17,9 +17,9 @@ Day 28 closes the weekly growth loop by consolidating Day 25-27 outcomes into wi
 ## Closeout checklist
 
 ```bash
-python -m sdetkit day28-weekly-review --format json --strict
-python -m sdetkit day28-weekly-review --emit-pack-dir docs/artifacts/day28-weekly-pack --format json --strict
-python -m sdetkit day28-weekly-review --execute --evidence-dir docs/artifacts/day28-weekly-pack/evidence --format json --strict
+python -m sdetkit weekly-review --format json --strict
+python -m sdetkit weekly-review --emit-pack-dir docs/artifacts/day28-weekly-pack --format json --strict
+python -m sdetkit weekly-review --execute --evidence-dir docs/artifacts/day28-weekly-pack/evidence --format json --strict
 python scripts/check_day28_weekly_review_contract.py
 ```
 

--- a/src/sdetkit/playbooks_cli.py
+++ b/src/sdetkit/playbooks_cli.py
@@ -169,27 +169,6 @@ def _build_registry(pkg_dir: Path) -> tuple[dict[str, str], dict[str, str]]:
 
         cmd_to_mod[canonical] = mod
 
-        day_cmd = _mod_to_cmd(mod)
-        if day_cmd != canonical:
-            if day_cmd not in cmd_to_mod:
-                cmd_to_mod[day_cmd] = mod
-            if day_cmd not in alias_to_canonical:
-                alias_to_canonical[day_cmd] = canonical
-
-        alias = (
-            None if mod in _DISABLED_DAY_CLOSEOUT_ALIAS_MODULES else _alias_for_day_closeout(mod)
-        )
-        if alias and alias not in cmd_to_mod:
-            cmd_to_mod[alias] = mod
-            alias_to_canonical[alias] = canonical
-
-        generic_alias = (
-            None if mod in _DISABLED_DAY_GENERIC_ALIAS_MODULES else _alias_for_day_module(mod)
-        )
-        if generic_alias and generic_alias not in cmd_to_mod:
-            cmd_to_mod[generic_alias] = mod
-            alias_to_canonical[generic_alias] = canonical
-
     return cmd_to_mod, alias_to_canonical
 
 

--- a/tests/test_cli_sdetkit.py
+++ b/tests/test_cli_sdetkit.py
@@ -159,7 +159,7 @@ def test_apigetcli_help():
 
 def test_product_lane_alias_resolves_to_canonical(capsys):
     with pytest.raises(SystemExit) as excinfo:
-        cli.main(["day29-phase1-hardening", "--help"])
+        cli.main(["phase1-hardening", "--help"])
     assert excinfo.value.code == 0
     out = capsys.readouterr().out
     assert "Day 29 phase-1 hardening scorer" in out

--- a/tests/test_demo_asset.py
+++ b/tests/test_demo_asset.py
@@ -121,6 +121,6 @@ def test_day33_strict_fails_when_day32_board_is_not_ready(tmp_path: Path) -> Non
 
 def test_day33_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day33-demo-asset", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["demo-asset", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 33 demo asset summary" in capsys.readouterr().out

--- a/tests/test_demo_asset2.py
+++ b/tests/test_demo_asset2.py
@@ -121,6 +121,6 @@ def test_day34_strict_fails_when_day33_board_is_not_ready(tmp_path: Path) -> Non
 
 def test_day34_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day34-demo-asset2", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["demo-asset2", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 34 demo asset #2 summary" in capsys.readouterr().out

--- a/tests/test_distribution_batch.py
+++ b/tests/test_distribution_batch.py
@@ -125,6 +125,6 @@ def test_day38_strict_fails_when_day37_board_is_not_ready(tmp_path: Path) -> Non
 
 def test_day38_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day38-distribution-batch", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["distribution-batch", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 38 distribution batch summary" in capsys.readouterr().out

--- a/tests/test_distribution_closeout.py
+++ b/tests/test_distribution_closeout.py
@@ -128,6 +128,6 @@ def test_day36_strict_fails_when_day35_board_is_not_ready(tmp_path: Path) -> Non
 
 def test_day36_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day36-distribution-closeout", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["distribution-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 36 community distribution summary" in capsys.readouterr().out

--- a/tests/test_experiment_lane.py
+++ b/tests/test_experiment_lane.py
@@ -129,6 +129,6 @@ def test_day37_strict_fails_when_day36_board_is_not_ready(tmp_path: Path) -> Non
 
 def test_day37_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day37-experiment-lane", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["experiment-lane", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 37 experiment lane summary" in capsys.readouterr().out

--- a/tests/test_kpi_instrumentation.py
+++ b/tests/test_kpi_instrumentation.py
@@ -121,6 +121,6 @@ def test_day35_strict_fails_when_day34_board_is_not_ready(tmp_path: Path) -> Non
 
 def test_day35_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day35-kpi-instrumentation", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["kpi-instrumentation", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 35 KPI instrumentation summary" in capsys.readouterr().out

--- a/tests/test_phase1_hardening.py
+++ b/tests/test_phase1_hardening.py
@@ -86,6 +86,6 @@ def test_day29_strict_fails_when_sections_missing(tmp_path: Path) -> None:
 
 def test_day29_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day29-phase1-hardening", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["phase1-hardening", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 29 phase-1 hardening summary" in capsys.readouterr().out

--- a/tests/test_phase1_wrap.py
+++ b/tests/test_phase1_wrap.py
@@ -92,6 +92,6 @@ def test_day30_strict_fails_when_inputs_missing(tmp_path: Path) -> None:
 
 def test_day30_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day30-phase1-wrap", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["phase1-wrap", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 30 phase-1 wrap summary" in capsys.readouterr().out

--- a/tests/test_phase2_kickoff.py
+++ b/tests/test_phase2_kickoff.py
@@ -123,6 +123,6 @@ def test_day31_strict_fails_when_backlog_is_not_phase2_ready(tmp_path: Path) -> 
 
 def test_day31_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day31-phase2-kickoff", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["phase2-kickoff", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 31 phase-2 kickoff summary" in capsys.readouterr().out

--- a/tests/test_playbook_post.py
+++ b/tests/test_playbook_post.py
@@ -119,6 +119,6 @@ def test_day39_strict_fails_when_day38_inputs_missing(tmp_path: Path) -> None:
 
 def test_day39_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day39-playbook-post", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["playbook-post", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 39 playbook post summary" in capsys.readouterr().out

--- a/tests/test_release_cadence.py
+++ b/tests/test_release_cadence.py
@@ -121,6 +121,6 @@ def test_day32_strict_fails_when_day31_board_is_not_ready(tmp_path: Path) -> Non
 
 def test_day32_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day32-release-cadence", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["release-cadence", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 32 release cadence summary" in capsys.readouterr().out

--- a/tests/test_scale_lane.py
+++ b/tests/test_scale_lane.py
@@ -112,6 +112,6 @@ def test_day40_strict_fails_when_day39_inputs_missing(tmp_path: Path) -> None:
 
 def test_day40_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day40-scale-lane", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["scale-lane", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 40 scale lane summary" in capsys.readouterr().out

--- a/tests/test_weekly_review_lane.py
+++ b/tests/test_weekly_review_lane.py
@@ -95,6 +95,6 @@ def test_day28_strict_fails_when_sections_missing(tmp_path: Path) -> None:
 
 def test_day28_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(["day28-weekly-review", "--root", str(tmp_path), "--format", "text"])
+    rc = cli.main(["weekly-review-lane", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 28 weekly review summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation

- Remove day-number branding from public surfaces so product-facing command names and docs are dayless while preserving historical artifacts where appropriate. 
- Stop auto-exposing day-prefixed CLI aliases in playbook discovery so the playbooks listing and registry surface only stable product names. 
- Align tests, examples, and help text with the dayless command names to avoid confusing legacy alias exposure. 

### Description

- Stop exposing `dayNN-*` aliases from the playbooks registry by removing alias population logic in `_build_registry` in `src/sdetkit/playbooks_cli.py`. 
- Update integration and CLI docs to use dayless command examples (e.g., replace `python -m sdetkit day28-weekly-review` with `python -m sdetkit weekly-review`) and collapse duplicate legacy alias lines in `docs/cli.md` and many `docs/integrations-*.md` files. 
- Reframe headings and legacy labels that read `Legacy Day NN` to neutral `(legacy)` wording in integration docs (for example `docs/integrations-*.md`) while keeping artifact filepaths intact as historical references. 
- Update test call sites and CLI-dispatch expectations to use product-first command names (e.g., tests invoking `day33-demo-asset` now call `demo-asset`) and adjust `tests/test_cli_sdetkit.py` help assertions accordingly. 

### Testing

- Ran the test suite slices covering CLI and affected lanes with `pytest`, resulting in full green for the exercised tests: `71 passed` in the main run. 
- Verified small focused suites multiple times: `pytest tests/test_cli_sdetkit.py tests/test_weekly_review_lane.py` passed (15 passed), and the broader set of lane tests passed (56 passed) in follow-ups. 
- Confirmed CLI help and specific lane help render without errors using `python -m sdetkit --help`, `python -m sdetkit weekly-review-lane --help`, and `python -m sdetkit phase3-wrap-publication-closeout --help`. 
- Ran the project gates: `python -m sdetkit gate fast --root . --format json --out /tmp/gate-fast-productization.json` succeeded (fast gate OK), and `python -m sdetkit gate release --root . --format json --out /tmp/gate-release-productization.json` failed due to a pre-existing `doctor_release` check unrelated to the alias removal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afb958163c8327b36c9f4a6e1faf49)