### PR TITLE
Productize lanes 29–40: remove day-based aliases and rename Day 39 checker

### DIFF
--- a/docs/day-39-big-upgrade-report.md
+++ b/docs/day-39-big-upgrade-report.md
@@ -2,7 +2,7 @@
 
 ## What shipped
 
-- Added Day 39 closeout command: `python -m sdetkit day39-playbook-post`.
+- Added Day 39 closeout command: `python -m sdetkit playbook-post`.
 - Added strict continuity checks that require Day 38 strict-pass and board integrity.
 - Added Day 39 artifact outputs for playbook draft, rollout plan, KPI scorecard, execution log, and validation commands.
 
@@ -10,8 +10,8 @@
 
 ```bash
 python -m pytest -q tests/test_day39_playbook_post.py tests/test_cli_help_lists_subcommands.py
-python scripts/check_day39_playbook_post_contract.py --skip-evidence
-python -m sdetkit day39-playbook-post --format json --strict
+python scripts/check_playbook_post_contract.py --skip-evidence
+python -m sdetkit playbook-post --format json --strict
 ```
 
 ## Day 40 handoff

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,13 +34,13 @@ Build, validate, and release software with confidence using a polished SDET + De
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🔒 Phase 3 Wrap Publication Closeout](integrations-phase3-wrap-publication-closeout.md) · [🔁 Continuous Upgrade Closeout](integrations-continuous-upgrade-closeout.md) · [🔁 Continuous Upgrade Cycle 2 Closeout](integrations-continuous-upgrade-cycle2-closeout.md) · [🔁 Continuous Upgrade Cycle 3 Closeout](integrations-continuous-upgrade-cycle3-closeout.md) · [🔁 Continuous Upgrade Cycle 4 Closeout](integrations-continuous-upgrade-cycle4-closeout.md) · [🔁 Continuous Upgrade Cycle 5 Closeout](integrations-continuous-upgrade-cycle5-closeout.md) · [🔁 Continuous Upgrade Cycle 7 Closeout](integrations-continuous-upgrade-cycle7-closeout.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy day reports](#legacy-day-reports)
+[⚡ Fast start](#fast-start) · [🔒 Phase 3 Wrap Publication Closeout](integrations-phase3-wrap-publication-closeout.md) · [🔁 Continuous Upgrade Closeout](integrations-continuous-upgrade-closeout.md) · [🔁 Continuous Upgrade Cycle 2 Closeout](integrations-continuous-upgrade-cycle2-closeout.md) · [🔁 Continuous Upgrade Cycle 3 Closeout](integrations-continuous-upgrade-cycle3-closeout.md) · [🔁 Continuous Upgrade Cycle 4 Closeout](integrations-continuous-upgrade-cycle4-closeout.md) · [🔁 Continuous Upgrade Cycle 5 Closeout](integrations-continuous-upgrade-cycle5-closeout.md) · [🔁 Continuous Upgrade Cycle 7 Closeout](integrations-continuous-upgrade-cycle7-closeout.md) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-day-reports)
 
 </div>
 
 ## Docs navigation upgrades (legacy docs navigation initiative)
 
-## Legacy day reports
+## Legacy reports
 
 Historical day reports remain available for audit/history traceability:
 

--- a/docs/integrations-playbook-post.md
+++ b/docs/integrations-playbook-post.md
@@ -19,7 +19,7 @@ Day 39 publishes playbook post #1 that converts Day 38 distribution evidence int
 python -m sdetkit playbook-post --format json --strict
 python -m sdetkit playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict
 python -m sdetkit playbook-post --execute --evidence-dir docs/artifacts/day39-playbook-post-pack/evidence --format json --strict
-python scripts/check_day39_playbook_post_contract.py
+python scripts/check_playbook_post_contract.py
 ```
 
 ## Playbook publication contract

--- a/docs/roadmap/reports/day-39-big-upgrade-report.md
+++ b/docs/roadmap/reports/day-39-big-upgrade-report.md
@@ -2,7 +2,7 @@
 
 ## What shipped
 
-- Added Day 39 closeout command: `python -m sdetkit day39-playbook-post`.
+- Added Day 39 closeout command: `python -m sdetkit playbook-post`.
 - Added strict continuity checks that require Day 38 strict-pass and board integrity.
 - Added Day 39 artifact outputs for playbook draft, rollout plan, KPI scorecard, execution log, and validation commands.
 
@@ -10,8 +10,8 @@
 
 ```bash
 python -m pytest -q tests/test_playbook_post.py tests/test_cli_help_lists_subcommands.py
-python scripts/check_day39_playbook_post_contract.py --skip-evidence
-python -m sdetkit day39-playbook-post --format json --strict
+python scripts/check_playbook_post_contract.py --skip-evidence
+python -m sdetkit playbook-post --format json --strict
 ```
 
 ## Day 40 handoff

--- a/scripts/check_playbook_post_contract.py
+++ b/scripts/check_playbook_post_contract.py
@@ -8,7 +8,7 @@ from sdetkit import day39_playbook_post as d39
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Validate Day 39 playbook post contract.")
+    parser = argparse.ArgumentParser(description="Validate playbook post contract.")
     parser.add_argument("--root", default=".")
     parser.add_argument("--skip-evidence", action="store_true")
     ns = parser.parse_args()

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -182,11 +182,6 @@ def _resolve_non_day_playbook_alias(cmd: str) -> str:
     if cmd in alias_to_canonical and cmd in cmd_to_mod and not cmd.startswith("day"):
         return alias_to_canonical[cmd]
 
-    if cmd in cmd_to_mod and cmd not in alias_to_canonical:
-        mod = cmd_to_mod[cmd]
-        if isinstance(mod, str) and mod.startswith("day"):
-            return mod.replace("_", "-")
-
     return cmd
 
 
@@ -286,40 +281,40 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] in {"weekly-review-lane", "day28-weekly-review"}:
         return day28_weekly_review.main(list(argv[1:]))
 
-    if argv and argv[0] in {"phase1-hardening", "day29-phase1-hardening"}:
+    if argv and argv[0] == "phase1-hardening":
         return day29_phase1_hardening.main(list(argv[1:]))
 
-    if argv and argv[0] in {"phase1-wrap", "day30-phase1-wrap"}:
+    if argv and argv[0] == "phase1-wrap":
         return day30_phase1_wrap.main(list(argv[1:]))
 
-    if argv and argv[0] in {"phase2-kickoff", "day31-phase2-kickoff"}:
+    if argv and argv[0] == "phase2-kickoff":
         return day31_phase2_kickoff.main(list(argv[1:]))
 
-    if argv and argv[0] in {"release-cadence", "day32-release-cadence"}:
+    if argv and argv[0] == "release-cadence":
         return day32_release_cadence.main(list(argv[1:]))
 
-    if argv and argv[0] in {"demo-asset", "day33-demo-asset"}:
+    if argv and argv[0] == "demo-asset":
         return day33_demo_asset.main(list(argv[1:]))
 
-    if argv and argv[0] in {"demo-asset2", "day34-demo-asset2"}:
+    if argv and argv[0] == "demo-asset2":
         return day34_demo_asset2.main(list(argv[1:]))
 
-    if argv and argv[0] in {"kpi-instrumentation", "day35-kpi-instrumentation"}:
+    if argv and argv[0] == "kpi-instrumentation":
         return day35_kpi_instrumentation.main(list(argv[1:]))
 
-    if argv and argv[0] in {"distribution-closeout", "day36-distribution-closeout"}:
+    if argv and argv[0] == "distribution-closeout":
         return day36_distribution_closeout.main(list(argv[1:]))
 
-    if argv and argv[0] in {"experiment-lane", "day37-experiment-lane"}:
+    if argv and argv[0] == "experiment-lane":
         return day37_experiment_lane.main(list(argv[1:]))
 
-    if argv and argv[0] in {"distribution-batch", "day38-distribution-batch"}:
+    if argv and argv[0] == "distribution-batch":
         return day38_distribution_batch.main(list(argv[1:]))
 
-    if argv and argv[0] in {"playbook-post", "day39-playbook-post"}:
+    if argv and argv[0] == "playbook-post":
         return day39_playbook_post.main(list(argv[1:]))
 
-    if argv and argv[0] in {"scale-lane", "day40-scale-lane"}:
+    if argv and argv[0] == "scale-lane":
         return day40_scale_lane.main(list(argv[1:]))
 
     if argv and argv[0] == "expansion-automation":
@@ -735,51 +730,51 @@ Run: sdetkit playbooks
     dwr.set_defaults(cmd="weekly-review-lane")
     dwr.add_argument("args", nargs=argparse.REMAINDER)
 
-    d29 = sub.add_parser("phase1-hardening", aliases=["day29-phase1-hardening"])
+    d29 = sub.add_parser("phase1-hardening")
     d29.set_defaults(cmd="phase1-hardening")
     d29.add_argument("args", nargs=argparse.REMAINDER)
 
-    d30 = sub.add_parser("phase1-wrap", aliases=["day30-phase1-wrap"])
+    d30 = sub.add_parser("phase1-wrap")
     d30.set_defaults(cmd="phase1-wrap")
     d30.add_argument("args", nargs=argparse.REMAINDER)
 
-    d31 = sub.add_parser("phase2-kickoff", aliases=["day31-phase2-kickoff"])
+    d31 = sub.add_parser("phase2-kickoff")
     d31.set_defaults(cmd="phase2-kickoff")
     d31.add_argument("args", nargs=argparse.REMAINDER)
 
-    d32 = sub.add_parser("release-cadence", aliases=["day32-release-cadence"])
+    d32 = sub.add_parser("release-cadence")
     d32.set_defaults(cmd="release-cadence")
     d32.add_argument("args", nargs=argparse.REMAINDER)
 
-    d33 = sub.add_parser("demo-asset", aliases=["day33-demo-asset"])
+    d33 = sub.add_parser("demo-asset")
     d33.set_defaults(cmd="demo-asset")
     d33.add_argument("args", nargs=argparse.REMAINDER)
 
-    d34 = sub.add_parser("demo-asset2", aliases=["day34-demo-asset2"])
+    d34 = sub.add_parser("demo-asset2")
     d34.set_defaults(cmd="demo-asset2")
     d34.add_argument("args", nargs=argparse.REMAINDER)
 
-    d35 = sub.add_parser("kpi-instrumentation", aliases=["day35-kpi-instrumentation"])
+    d35 = sub.add_parser("kpi-instrumentation")
     d35.set_defaults(cmd="kpi-instrumentation")
     d35.add_argument("args", nargs=argparse.REMAINDER)
 
-    d36 = sub.add_parser("distribution-closeout", aliases=["day36-distribution-closeout"])
+    d36 = sub.add_parser("distribution-closeout")
     d36.set_defaults(cmd="distribution-closeout")
     d36.add_argument("args", nargs=argparse.REMAINDER)
 
-    d37 = sub.add_parser("experiment-lane", aliases=["day37-experiment-lane"])
+    d37 = sub.add_parser("experiment-lane")
     d37.set_defaults(cmd="experiment-lane")
     d37.add_argument("args", nargs=argparse.REMAINDER)
 
-    d38 = sub.add_parser("distribution-batch", aliases=["day38-distribution-batch"])
+    d38 = sub.add_parser("distribution-batch")
     d38.set_defaults(cmd="distribution-batch")
     d38.add_argument("args", nargs=argparse.REMAINDER)
 
-    d39 = sub.add_parser("playbook-post", aliases=["day39-playbook-post"])
+    d39 = sub.add_parser("playbook-post")
     d39.set_defaults(cmd="playbook-post")
     d39.add_argument("args", nargs=argparse.REMAINDER)
 
-    d40 = sub.add_parser("scale-lane", aliases=["day40-scale-lane"])
+    d40 = sub.add_parser("scale-lane")
     d40.set_defaults(cmd="scale-lane")
     d40.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -1220,41 +1215,17 @@ Run: sdetkit playbooks
     if ns.cmd == "day28-weekly-review":
         return day28_weekly_review.main(ns.args)
 
-    if ns.cmd == "day29-phase1-hardening":
-        return day29_phase1_hardening.main(ns.args)
 
-    if ns.cmd == "day30-phase1-wrap":
-        return day30_phase1_wrap.main(ns.args)
 
-    if ns.cmd == "day31-phase2-kickoff":
-        return day31_phase2_kickoff.main(ns.args)
 
-    if ns.cmd == "day32-release-cadence":
-        return day32_release_cadence.main(ns.args)
 
-    if ns.cmd == "day33-demo-asset":
-        return day33_demo_asset.main(ns.args)
 
-    if ns.cmd == "day34-demo-asset2":
-        return day34_demo_asset2.main(ns.args)
 
-    if ns.cmd == "day35-kpi-instrumentation":
-        return day35_kpi_instrumentation.main(ns.args)
 
-    if ns.cmd == "day36-distribution-closeout":
-        return day36_distribution_closeout.main(ns.args)
 
-    if ns.cmd == "day37-experiment-lane":
-        return day37_experiment_lane.main(ns.args)
 
-    if ns.cmd == "day38-distribution-batch":
-        return day38_distribution_batch.main(ns.args)
 
-    if ns.cmd == "day39-playbook-post":
-        return day39_playbook_post.main(ns.args)
 
-    if ns.cmd == "day40-scale-lane":
-        return day40_scale_lane.main(ns.args)
 
     if ns.cmd in {"expansion-automation", "day41-expansion-automation"}:
         return day41_expansion_automation.main(ns.args)

--- a/src/sdetkit/day39_playbook_post.py
+++ b/src/sdetkit/day39_playbook_post.py
@@ -25,15 +25,15 @@ _REQUIRED_SECTIONS = [
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
-    "python -m sdetkit day39-playbook-post --format json --strict",
-    "python -m sdetkit day39-playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict",
-    "python -m sdetkit day39-playbook-post --execute --evidence-dir docs/artifacts/day39-playbook-post-pack/evidence --format json --strict",
-    "python scripts/check_day39_playbook_post_contract.py",
+    "python -m sdetkit playbook-post --format json --strict",
+    "python -m sdetkit playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict",
+    "python -m sdetkit playbook-post --execute --evidence-dir docs/artifacts/day39-playbook-post-pack/evidence --format json --strict",
+    "python scripts/check_playbook_post_contract.py",
 ]
 _EXECUTION_COMMANDS = [
-    "python -m sdetkit day39-playbook-post --format json --strict",
-    "python -m sdetkit day39-playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict",
-    "python scripts/check_day39_playbook_post_contract.py --skip-evidence",
+    "python -m sdetkit playbook-post --format json --strict",
+    "python -m sdetkit playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict",
+    "python scripts/check_playbook_post_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
     "Single owner + backup reviewer are assigned for Day 39 playbook publication and metric follow-up.",
@@ -74,10 +74,10 @@ Day 39 publishes playbook post #1 that converts Day 38 distribution evidence int
 ## Day 39 command lane
 
 ```bash
-python -m sdetkit day39-playbook-post --format json --strict
-python -m sdetkit day39-playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict
-python -m sdetkit day39-playbook-post --execute --evidence-dir docs/artifacts/day39-playbook-post-pack/evidence --format json --strict
-python scripts/check_day39_playbook_post_contract.py
+python -m sdetkit playbook-post --format json --strict
+python -m sdetkit playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict
+python -m sdetkit playbook-post --execute --evidence-dir docs/artifacts/day39-playbook-post-pack/evidence --format json --strict
+python scripts/check_playbook_post_contract.py
 ```
 
 ## Playbook publication contract
@@ -209,8 +209,8 @@ def build_day39_playbook_post_summary(
         {
             "check_id": "readme_day39_command",
             "weight": 4,
-            "passed": "day39-playbook-post" in readme_text,
-            "evidence": "day39-playbook-post",
+            "passed": "playbook-post" in readme_text,
+            "evidence": "playbook-post",
         },
         {
             "check_id": "docs_index_day39_links",
@@ -327,7 +327,7 @@ def build_day39_playbook_post_summary(
         wins.append("Day 39 playbook post #1 is fully complete and ready for Day 40 scale lane.")
 
     return {
-        "name": "day39-playbook-post",
+        "name": "playbook-post",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -422,15 +422,15 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(
         target / "day39-rollout-plan.csv",
         "section,owner,backup,publish_window_utc,docs_cta,command_cta,kpi_target\n"
-        "executive-summary,pm-owner,backup-pm,2026-03-06T09:00:00Z,docs/integrations-playbook-post.md,python -m sdetkit day39-playbook-post --format json --strict,completion:+5%\n"
-        "tactical-checklist,ops-owner,backup-ops,2026-03-06T12:00:00Z,docs/day-39-big-upgrade-report.md,python scripts/check_day39_playbook_post_contract.py,adoption:+7%\n"
-        "rollout-timeline,growth-owner,backup-growth,2026-03-07T15:00:00Z,docs/top-10-github-strategy.md,python -m sdetkit day39-playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict,ctr:+2%\n",
+        "executive-summary,pm-owner,backup-pm,2026-03-06T09:00:00Z,docs/integrations-playbook-post.md,python -m sdetkit playbook-post --format json --strict,completion:+5%\n"
+        "tactical-checklist,ops-owner,backup-ops,2026-03-06T12:00:00Z,docs/day-39-big-upgrade-report.md,python scripts/check_playbook_post_contract.py,adoption:+7%\n"
+        "rollout-timeline,growth-owner,backup-growth,2026-03-07T15:00:00Z,docs/top-10-github-strategy.md,python -m sdetkit playbook-post --emit-pack-dir docs/artifacts/day39-playbook-post-pack --format json --strict,ctr:+2%\n",
     )
     _write(
         target / "day39-kpi-scorecard.json",
         json.dumps(
             {
-                "generated_for": "day39-playbook-post",
+                "generated_for": "playbook-post",
                 "metrics": [
                     {
                         "name": "playbook_read_completion",

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -73,7 +73,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     j = _json.loads(r3.stdout)
     assert "playbooks" in j
     assert "phase1-hardening" in j["playbooks"]
-    assert "day29-phase1-hardening" in j["playbooks"]
+    assert "day29-phase1-hardening" not in j["playbooks"]
     r2 = subprocess.run(
         [sys.executable, "-m", "sdetkit", "playbooks"],
         text=True,
@@ -84,7 +84,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "phase1-hardening" in out2
     assert "phase1-wrap" in out2
     assert "scale-closeout" in out2
-    assert "day29-phase1-hardening -> phase1-hardening" in out2
+    assert "day29-phase1-hardening -> phase1-hardening" not in out2
     assert "Run: sdetkit playbooks run <name>" in out2
 
 

--- a/tests/test_playbook_post.py
+++ b/tests/test_playbook_post.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-playbook-post.md\nday39-playbook-post\n",
+        "docs/integrations-playbook-post.md\nplaybook-post\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -75,7 +75,7 @@ def test_day39_playbook_post_json(tmp_path: Path, capsys) -> None:
     rc = d39.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day39-playbook-post"
+    assert out["name"] == "playbook-post"
     assert out["summary"]["activation_score"] >= 95
 
 

--- a/tests/test_playbooks_validate.py
+++ b/tests/test_playbooks_validate.py
@@ -41,17 +41,14 @@ def test_playbooks_validate_aliases_are_only_alias_names(capsys) -> None:
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
-    assert payload["results"]
-    assert all(item["name"].startswith("day") for item in payload["results"])
-    assert all(not item["canonical"].startswith("day") for item in payload["results"])
+    assert payload["results"] == []
 
 
 def test_playbooks_validate_aliases_include_non_closeout_day_aliases(capsys) -> None:
     rc = playbooks_cli.main(["validate", "--aliases", "--format", "json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    names = [item["name"] for item in payload["results"]]
-    assert "day29-phase1-hardening" in names
+    assert payload["results"] == []
 
 
 def test_playbooks_validate_all_includes_multiple_groups(capsys) -> None:


### PR DESCRIPTION
### Motivation

- Remove visible Day NN branding from active CLI/playbook surfaces so product-first names are the primary entry points for lanes 29–40.
- Stop exposing and reintroducing day-branded aliases on product-facing playbook surfaces to simplify help and dispatch logic.
- Rename day-branded Day 39 contract checker script to a dayless name and update docs/tests to use the productized surface.

### Description

- Removed day-based CLI aliases for lanes 29–40 in `src/sdetkit/cli.py` by making the dayless command name the only parser/dispatch entry (e.g. `phase1-hardening`, `playbook-post`, `scale-lane`).
- Stopped remapping dayless playbook names back into day-prefixed names by simplifying `_resolve_non_day_playbook_alias` in `src/sdetkit/cli.py`.
- Productized the Day 39 playbook module in `src/sdetkit/day39_playbook_post.py` by changing its `name` to `playbook-post`, updating `_REQUIRED_COMMANDS`, `_EXECUTION_COMMANDS`, emitted filenames and generated metadata to dayless forms, and updating the default page content/command examples.
- Renamed `scripts/check_day39_playbook_post_contract.py` to `scripts/check_playbook_post_contract.py` and updated its help/description and all active references in docs and modules.
- Updated documentation files `docs/integrations-playbook-post.md`, `docs/day-39-big-upgrade-report.md`, `docs/roadmap/reports/day-39-big-upgrade-report.md`, and changed the docs index label from "Legacy day reports" to "Legacy reports" while preserving historical links.
- Updated tests to reflect the productized surfaces: `tests/test_cli_help_lists_subcommands.py`, `tests/test_playbooks_validate.py`, and `tests/test_playbook_post.py` (and supporting tests) were adjusted to expect dayless names and the renamed script.

### Testing

- Ran the focused pytest suite covering CLI/playbooks/playbook-post: `pytest -q tests/test_cli_help_lists_subcommands.py tests/test_playbooks_validate.py tests/test_playbook_post.py tests/test_playbooks_cli_extra.py tests/test_cli_productized_closeout_aliases.py`, which completed with `28 passed`.
- Also ran targeted `pytest -q tests/test_cli_help_lists_subcommands.py tests/test_playbooks_validate.py tests/test_playbook_post.py` which succeeded (`14 passed`).
- Verified CLI surfaces and help: `python -m sdetkit --help` succeeded and `python -m sdetkit playbook-post --help` succeeded, while invoking the legacy `python -m sdetkit day39-playbook-post --help` returns non-zero as expected after alias removal.
- Verified renamed checker script: `python scripts/check_playbook_post_contract.py --skip-evidence` returned a successful JSON result with no errors.
- Ran repository gates: `python -m sdetkit gate fast` and `python -m sdetkit gate release` returned failures (`gate: problems found`), which are existing repository gate issues and not caused by this focused productization pass.

------