### PR TITLE
packaging: strengthen distribution metadata and validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,14 +126,16 @@ jobs:
 
       - name: Install packaging tooling
         run: |
-          python -m pip install -e .[dev]
-          python -m pip install build==1.2.2.post1 twine==6.1.0
+          python -m pip install -e .[dev,packaging]
 
       - name: Build distributions
         run: python -m build
 
       - name: Twine check
         run: python -m twine check dist/*
+
+      - name: Wheel contents check
+        run: python -m check_wheel_contents --ignore W009 dist/*.whl
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,7 @@ jobs:
           COV_FAIL_UNDER: "95"
         run: |
           set -euo pipefail
-          python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .
-          python -m pip install build==1.2.2.post1 twine==6.1.0
+          python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .[packaging]
           bash quality.sh cov
 
       - name: Build dist
@@ -78,6 +77,7 @@ jobs:
           set -euo pipefail
           python -m build
           python -m twine check dist/*
+          python -m check_wheel_contents --ignore W009 dist/*.whl
 
       - name: Wheel smoke test
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # --- dev targets (bootstrap) ---
 
-.PHONY: venv install test cov lint fmt type docs-serve docs-build
+.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate
 
 venv:
 	@test -x .venv/bin/python || python3 -m venv .venv
@@ -28,3 +28,7 @@ docs-serve: install
 
 docs-build: install
 	@bash -lc '. .venv/bin/activate && mkdocs build'
+
+
+package-validate: venv
+	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python -m pip install -e .[packaging] && rm -rf dist build && python -m build && python -m twine check dist/* && python -m check_wheel_contents --ignore W009 dist/*.whl && python -m venv .venv-smoke && . .venv-smoke/bin/activate && python -m pip install --force-reinstall dist/*.whl && sdetkit --help'

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ python -m pip install .[dev]
 python -m pip install .[test]
 ```
 
+```bash
+python -m pip install .[packaging]
+```
+
+### Build distributable artifacts
+
+```bash
+python -m pip install .[packaging]
+rm -rf dist build
+python -m build
+```
+
+### Validate package artifacts (local release gate)
+
+```bash
+make package-validate
+```
+
+This validates wheel/sdist build, metadata (`twine check`), wheel contents, and a smoke install of the built wheel (`sdetkit --help`).
+
+> Current posture: repository is prepared for artifact build and validation; public PyPI publication depends on release workflow credentials/secrets and is not claimed as generally available from this README.
+
 ## 2-minute quickstart
 
 ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,12 +20,18 @@ Release tags must be `vX.Y.Z` and must match the package version. `CHANGELOG.md`
 2. Create a release tag `vX.Y.Z`.
 3. Run release validation locally:
    - `python -m sdetkit doctor --release --format md`
+   - `make package-validate`
+
+   Equivalent manual commands:
+   - `python -m pip install .[packaging]`
+   - `rm -rf dist build`
    - `python -m build`
    - `python -m twine check dist/*`
-   - `python -m pip install dist/*.whl`
+   - `python -m check_wheel_contents --ignore W009 dist/*.whl`
+   - `python -m pip install --force-reinstall dist/*.whl`
    - `sdetkit --help`
 4. Push the tag.
 5. Confirm GitHub Release workflow passed and artifacts are attached.
-6. Confirm publish job uploaded to PyPI.
+6. Confirm publish job uploaded to PyPI (only when `PYPI_API_TOKEN` is configured in repository secrets).
 7. Verify Dependency Audit workflow is green for the release commit/tag.
 8. (Optional) Generate and archive SBOM (`.github/workflows/sbom.yml`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,10 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/sherif69-sa/DevS69-sdetkit"
 Repository = "https://github.com/sherif69-sa/DevS69-sdetkit"
-Documentation = "https://github.com/sherif69-sa/DevS69-sdetkit/tree/main/docs"
+Documentation = "https://sherif69-sa.github.io/DevS69-sdetkit/"
 Issues = "https://github.com/sherif69-sa/DevS69-sdetkit/issues"
 Changelog = "https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CHANGELOG.md"
+"Release Process" = "https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/RELEASE.md"
 
 [project.optional-dependencies]
 dev = [
@@ -53,6 +54,11 @@ test = [
 docs = [
   "mkdocs==1.6.1",
   "mkdocs-material==9.7.5"
+]
+packaging = [
+  "build==1.4.0",
+  "check-wheel-contents==0.6.3",
+  "twine==6.2.0"
 ]
 telegram = [
   "python-telegram-bot>=21,<23"


### PR DESCRIPTION
### Motivation
- Harden the repository's packaging and distribution readiness so maintainers can build, validate, and smoke-test artifacts locally and in CI without changing product scope or CLI entrypoints.
- Make the documentation and CI release steps honest and practical about what is validated locally vs. what requires repository secrets to publish.

### Description
- Updated `pyproject.toml` project URLs to point `Documentation` to the published docs site and added a `Release Process` URL, and added a `packaging` optional dependency group containing `build`, `twine`, and `check-wheel-contents`.
- Added a repo-native validation target `make package-validate` in `Makefile` that builds sdist/wheel, runs `twine check`, runs `check_wheel_contents` (with an explicit ignore for an expected condition), and performs an isolated wheel smoke install followed by `sdetkit --help`.
- Improved user-facing docs by adding build and validation instructions to `README.md` and updating `RELEASE.md` to recommend `make package-validate` and document equivalent manual steps.
- Aligned CI and release workflows to install the `packaging` extras and perform wheel-content checks prior to upload (added `check_wheel_contents --ignore W009` usage in CI steps).
- Files changed: `pyproject.toml`, `Makefile`, `README.md`, `RELEASE.md`, `.github/workflows/ci.yml`, `.github/workflows/release.yml`.

### Testing
- Built artifacts: `python -m build` produced both sdist and wheel successfully and `python -m twine check dist/*` passed for both artifacts.
- Wheel contents validation: `python -m check_wheel_contents --ignore W009 dist/*.whl` passed after explicitly ignoring `W009` (the repository intentionally produces two top-level packages: `sdetkit` and a compatibility `sdkit` shim). 
- Full repo-native validation: `make package-validate` executed the end-to-end flow (install packaging tooling, remove old dist, build, `twine check`, `check_wheel_contents` with `--ignore W009`, isolated venv wheel install, then `sdetkit --help`) and completed successfully.
- Notes: an initial run surfaced `check-wheel-contents` W009 (dual top-level packages); the PR documents and intentionally ignores that code (W009) because the `sdkit` shim is a supported compatibility artifact.

------