### PR TITLE
Harden release workflow with metadata preflight, safer PyPI gating, and a maintainer preflight target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,12 @@ jobs:
             requirements-docs.txt
 
 
+      - name: Release metadata preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/release_preflight.py --tag "${{ steps.resolved.outputs.tag }}"
+
       - name: Verify tag matches package version
         shell: bash
         run: |
@@ -87,7 +93,7 @@ jobs:
           sdetkit --help
 
       - name: Publish to PyPI
-        if: ${{ env.PYPI_API_TOKEN != '' }}
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
         env:
           TWINE_USERNAME: __token__
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
@@ -97,6 +103,11 @@ jobs:
           set -euo pipefail
           python -m twine upload dist/*
 
+      - name: PyPI publish skipped (no PYPI_API_TOKEN configured)
+        if: ${{ secrets.PYPI_API_TOKEN == "" }}
+        shell: bash
+        run: |
+          echo "PyPI publish skipped: configure repository secret PYPI_API_TOKEN to enable upload."
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # --- dev targets (bootstrap) ---
 
-.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate
+.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight
 
 venv:
 	@test -x .venv/bin/python || python3 -m venv .venv
@@ -32,3 +32,7 @@ docs-build: install
 
 package-validate: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python -m pip install -e .[packaging] && rm -rf dist build && python -m build && python -m twine check dist/* && python -m check_wheel_contents --ignore W009 dist/*.whl && python -m venv .venv-smoke && . .venv-smoke/bin/activate && python -m pip install --force-reinstall dist/*.whl && sdetkit --help'
+
+
+release-preflight: venv
+	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .[packaging] && python scripts/release_preflight.py && python -m sdetkit doctor --release --skip clean_tree --format md && $(MAKE) package-validate'

--- a/README.md
+++ b/README.md
@@ -79,7 +79,15 @@ make package-validate
 
 This validates wheel/sdist build, metadata (`twine check`), wheel contents, and a smoke install of the built wheel (`sdetkit --help`).
 
-> Current posture: repository is prepared for artifact build and validation; public PyPI publication depends on release workflow credentials/secrets and is not claimed as generally available from this README.
+### Maintainer release preflight
+
+```bash
+make release-preflight
+```
+
+This is the recommended local release check before creating/pushing a release tag. It validates release metadata (`pyproject.toml`, `CHANGELOG.md`, optional tag format), runs `doctor --release`, and validates build artifacts.
+
+> Current posture: repository is prepared for artifact build and release execution validation; public PyPI publication depends on `PYPI_API_TOKEN` configuration and successful workflow execution, and is not claimed as generally available from this README.
 
 ## 2-minute quickstart
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,27 +11,55 @@ Release tags must be `vX.Y.Z` and must match the package version. `CHANGELOG.md`
 - `0.x`: fast iteration is allowed, but the patch-spec schema stays versioned (`spec_version`).
 - `1.0+`: patch spec is stable; incompatible changes require a new schema version and deprecation window.
 
-## Checklist
+## Release preconditions (before any tag push)
 
-1. Ensure release metadata is finalized for the version in `pyproject.toml`:
-   - `pyproject.toml` version
-   - matching heading in `CHANGELOG.md`
-   - any embedded fallback `tool_version` values used in reports/templates
-2. Create a release tag `vX.Y.Z`.
-3. Run release validation locally:
-   - `python -m sdetkit doctor --release --format md`
-   - `make package-validate`
+- Repository secret `PYPI_API_TOKEN` must be configured to enable PyPI upload.
+- If `PYPI_API_TOKEN` is not configured, the release workflow still builds artifacts and creates a GitHub Release, but PyPI upload is skipped.
+- The release workflow requires:
+  - `pyproject.toml` `[project].version`
+  - matching heading in `CHANGELOG.md`
+  - tag in the form `vX.Y.Z` that matches version
 
-   Equivalent manual commands:
-   - `python -m pip install .[packaging]`
-   - `rm -rf dist build`
-   - `python -m build`
-   - `python -m twine check dist/*`
-   - `python -m check_wheel_contents --ignore W009 dist/*.whl`
-   - `python -m pip install --force-reinstall dist/*.whl`
-   - `sdetkit --help`
-4. Push the tag.
-5. Confirm GitHub Release workflow passed and artifacts are attached.
-6. Confirm publish job uploaded to PyPI (only when `PYPI_API_TOKEN` is configured in repository secrets).
-7. Verify Dependency Audit workflow is green for the release commit/tag.
-8. (Optional) Generate and archive SBOM (`.github/workflows/sbom.yml`).
+## Maintainer path (first public release)
+
+1. Finalize release metadata for the target version:
+   - update `[project].version` in `pyproject.toml`
+   - add matching heading in `CHANGELOG.md`
+2. Run local preflight (single command):
+
+   ```bash
+   make release-preflight
+   ```
+
+   This runs release metadata validation, `doctor --release --skip clean_tree`, artifact build validation, and wheel smoke install.
+3. Create and push the tag:
+
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+4. Watch `.github/workflows/release.yml` complete.
+5. Verify outcomes:
+   - GitHub Release exists and includes `dist/*` artifacts.
+   - PyPI upload occurred only if `PYPI_API_TOKEN` secret is configured.
+   - Dependency/security workflows are green for the same commit/tag.
+
+## Workflow triggers
+
+- **Tag push**: automatic for tags matching `v*.*.*`.
+- **Manual dispatch**: `workflow_dispatch` with an existing `tag` input.
+
+The workflow performs:
+1. release metadata preflight (`scripts/release_preflight.py`)
+2. tag/version consistency check (`scripts/check_release_tag_version.py`)
+3. quality gates + coverage
+4. artifact build + metadata checks + wheel smoke test
+5. conditional PyPI upload
+6. provenance attestation + GitHub Release creation
+
+## What not to claim before publish is real
+
+Do not claim public PyPI availability until:
+- the release workflow succeeded,
+- the PyPI upload step ran (not skipped), and
+- install from PyPI is verified externally.

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+def _load_version(pyproject_path: Path) -> str:
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    version = project.get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError("pyproject.toml missing [project].version")
+    return version.strip()
+
+
+def _normalize_tag(tag: str) -> str:
+    normalized = tag.strip()
+    if normalized.startswith("refs/tags/"):
+        normalized = normalized[len("refs/tags/") :]
+    return normalized
+
+
+def _validate_tag(tag: str, version: str) -> None:
+    normalized = _normalize_tag(tag)
+    if not re.fullmatch(r"v\d+\.\d+\.\d+", normalized):
+        raise ValueError(f"release tag must look like vX.Y.Z (got: {tag})")
+    if normalized[1:] != version:
+        raise ValueError(f"release tag {normalized} does not match pyproject version {version}")
+
+
+def _validate_changelog(changelog_path: Path, version: str) -> None:
+    text = changelog_path.read_text(encoding="utf-8")
+    pattern = re.compile(rf"^##\s+\[?v?{re.escape(version)}\]?\s*$", re.MULTILINE)
+    if not pattern.search(text):
+        raise ValueError(
+            "CHANGELOG.md missing release heading for version "
+            f"{version} (expected: `## [{version}]` or `## v{version}`)"
+        )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Validate release preflight metadata.")
+    parser.add_argument("--tag", help="Release tag to validate (example: v1.0.2)")
+    parser.add_argument("--pyproject", default="pyproject.toml")
+    parser.add_argument("--changelog", default="CHANGELOG.md")
+    args = parser.parse_args(argv[1:])
+
+    pyproject = Path(args.pyproject)
+    changelog = Path(args.changelog)
+
+    try:
+        version = _load_version(pyproject)
+        _validate_changelog(changelog, version)
+        if args.tag:
+            _validate_tag(args.tag, version)
+    except (FileNotFoundError, tomllib.TOMLDecodeError, ValueError) as exc:
+        print(f"release preflight failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"release preflight ok: version={version}")
+    if args.tag:
+        print(f"release preflight ok: tag={_normalize_tag(args.tag)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/release_preflight.py").resolve()
+
+
+def _write_baseline(root: Path, version: str = "1.2.3") -> tuple[Path, Path]:
+    pyproject = root / "pyproject.toml"
+    changelog = root / "CHANGELOG.md"
+    pyproject.write_text(f"[project]\nname='x'\nversion='{version}'\n", encoding="utf-8")
+    changelog.write_text(f"## Unreleased\n\n## [{version}]\n- note\n", encoding="utf-8")
+    return pyproject, changelog
+
+
+def _run(pyproject: Path, changelog: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--pyproject",
+            str(pyproject),
+            "--changelog",
+            str(changelog),
+            *args,
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_release_preflight_ok_with_tag(tmp_path: Path) -> None:
+    pyproject, changelog = _write_baseline(tmp_path)
+    proc = _run(pyproject, changelog, "--tag", "v1.2.3")
+    assert proc.returncode == 0
+
+
+def test_release_preflight_fails_on_bad_tag_format(tmp_path: Path) -> None:
+    pyproject, changelog = _write_baseline(tmp_path)
+    proc = _run(pyproject, changelog, "--tag", "1.2.3")
+    assert proc.returncode == 1
+
+
+def test_release_preflight_fails_without_changelog_heading(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    changelog = tmp_path / "CHANGELOG.md"
+    pyproject.write_text("[project]\nname='x'\nversion='1.2.3'\n", encoding="utf-8")
+    changelog.write_text("## Unreleased\n", encoding="utf-8")
+    proc = _run(pyproject, changelog)
+    assert proc.returncode == 1


### PR DESCRIPTION
### Motivation

- Close the gap between artifact build validation and a safe first public publish by surfacing and blocking common metadata/tag issues early. 
- Make PyPI publish behavior and secret preconditions explicit so maintainers understand when uploads will be attempted or skipped. 
- Provide a single, repository-native local preflight command to reduce human error before tagging and pushing a first release. 

### Description

- Added `scripts/release_preflight.py` to validate `[project].version` in `pyproject.toml`, require a matching heading in `CHANGELOG.md`, and optionally validate `vX.Y.Z` tag format and version match. 
- Wired the preflight into the release CI by running `scripts/release_preflight.py --tag` before tag/version checks and quality/build steps in `.github/workflows/release.yml`. 
- Made the PyPI publish gate explicit by checking `secrets.PYPI_API_TOKEN` (instead of an env-context check) and added a clear "PyPI publish skipped" step when the secret is absent. 
- Added `make release-preflight` which installs required deps, runs the preflight, runs `doctor --release --skip clean_tree`, then runs `package-validate` (build, twine check, wheel contents, smoke install). 
- Updated `RELEASE.md` and `README.md` to document preconditions, the maintainer path for a first-public release, and to avoid claiming PyPI availability until a real upload occurs. 
- Added `tests/test_release_preflight.py` with focused integration-style tests for the preflight validator (happy path, bad tag format, missing changelog heading). 

### Testing

- Ran `python scripts/release_preflight.py --tag v1.0.2` which printed `release preflight ok: version=1.0.2` and `release preflight ok: tag=v1.0.2` (exit 0). 
- Ran `pytest -q tests/test_release_preflight.py` which returned `3 passed` (exit 0). 
- Executed `make release-preflight` locally which performed metadata preflight, `doctor --release --skip clean_tree`, full artifact build and validation (`python -m build`, `twine check`, `check_wheel_contents`), and a wheel smoke install; the target completed successfully.

------