### PR TITLE
Promote ready_to_use release-confidence workflow in README/docs and use `security enforce` in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,36 +6,64 @@
 ![Repo Audit](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/repo-audit.yml/badge.svg?branch=main)
 ![Pages](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/pages.yml/badge.svg?branch=main)
 
-Production-ready SDET + DevOps toolkit for deterministic diagnostics, API validation, policy gates, and release evidence.
+SDETKit helps **SDET, QA, and DevOps teams prove release confidence** with deterministic local/CI checks and audit-friendly evidence.
 
-## Product vision
+## The one thing this repo is best at
 
-SDETKit is designed as an **execution layer for trusted delivery**:
+SDETKit is centered on one flagship workflow: **release confidence gating**.
 
-- **Reliability first**: deterministic outputs, explicit exit codes, CI-safe behavior.
-- **Readiness by default**: quality, security, and release controls in one workflow.
-- **Adoption-focused UX**: clear command groups, practical docs, and role-based paths.
-
-## Product direction (next 30 days)
-
-To evolve this repository into a focused product, we are prioritizing one primary use-case:
-
-- **Release Confidence Engine for SDET/DevOps teams**
-- Goal: provide deterministic, repeatable evidence that a repository is safe to ship.
-
-Start with the focused strategy checklist:
-
-- `docs/product-strategy.md`
-- `docs/global-production-transformation-playbook.md`
-
-Fast path to run the "release confidence" workflow:
+Run one command sequence to answer: _"Is this repository ready to ship?"_
 
 ```bash
-bash ci.sh quick --skip-docs
-bash quality.sh cov
-python -m sdetkit security check --root . --baseline tools/security.baseline.json --format json
-python -m sdetkit gate release
+bash scripts/ready_to_use.sh release
 ```
+
+This runs environment bootstrap + CI quick lane + coverage + security enforcement + release gate in a repeatable flow.
+
+---
+
+## Start here (first 5 minutes)
+
+### 1) Run the fastest path
+
+```bash
+bash scripts/ready_to_use.sh quick
+```
+
+### 2) What to expect
+
+- Bootstraps a local virtual environment.
+- Verifies the CLI is healthy.
+- Runs `ci.sh quick --skip-docs`.
+- Prints a clear status and next step.
+
+### 3) Value proof
+
+If this command finishes, you have a working local gate path that mirrors CI expectations and gives deterministic pass/fail output.
+
+### 4) Next command
+
+```bash
+bash scripts/ready_to_use.sh release
+```
+
+Use release mode when you want a stricter go/no-go decision before a release.
+
+Ready-to-use guide: `docs/ready-to-use.md`
+
+---
+
+## Who this is for
+
+- **SDET / QA** teams that need reproducible quality gates.
+- **DevOps / platform** teams that want policy-aware release checks in CI.
+- **Maintainers** who need machine-readable evidence for release decisions.
+
+## What you get
+
+- Deterministic command behavior and CI-safe exit codes.
+- A structured release-confidence workflow instead of ad-hoc scripts.
+- Evidence-oriented outputs for review, governance, and handoffs.
 
 ## Installation
 
@@ -57,97 +85,35 @@ source .venv/bin/activate
 ```bash
 python -m pip install .[dev]
 python -m pip install .[test]
-```
-
-```bash
 python -m pip install .[packaging]
 ```
 
-### Build distributable artifacts
+## Flagship workflow (manual form)
 
-```bash
-python -m pip install .[packaging]
-rm -rf dist build
-python -m build
-```
-
-### Validate package artifacts (local release gate)
-
-```bash
-make package-validate
-```
-
-This validates wheel/sdist build, metadata (`twine check`), wheel contents, and a smoke install of the built wheel (`sdetkit --help`).
-
-### Maintainer release preflight
-
-```bash
-make release-preflight
-```
-
-This is the recommended local release check before creating/pushing a release tag. It validates release metadata (`pyproject.toml`, `CHANGELOG.md`, optional tag format), runs `doctor --release`, and validates build artifacts.
-
-> Current posture: repository is prepared for artifact build and release execution validation; public PyPI publication depends on `PYPI_API_TOKEN` configuration and successful workflow execution, and is not claimed as generally available from this README.
-
-## 2-minute quickstart
-
-```bash
-bash scripts/ready_to_use.sh quick
-```
-
-Manual equivalent:
-
-```bash
-python -m sdetkit --help
-python -m sdetkit doctor --help
-bash ci.sh quick --skip-docs
-```
-
-Ready-to-use guide: `docs/ready-to-use.md`
-
-For full docs UX, open: <https://sherif69-sa.github.io/DevS69-sdetkit/>.
-
-Troubleshooting note for sqlite-utils schema inference edge-cases: `docs/sqlite-utils-empty-column-troubleshooting.md`
-
-## Role-based starting paths
-
-| Role | Start here | Why |
-| --- | --- | --- |
-| SDET / QA | `python -m sdetkit doctor --help` | Validate local/repo health quickly. |
-| DevOps / Platform | `python -m sdetkit gate fast` | Run CI-equivalent quality lane locally. |
-| Security / Governance | `python -m sdetkit security --help` | Apply policy and budget controls deterministically. |
-| Maintainers | `python -m sdetkit evidence --help` | Generate and review release evidence artifacts. |
-
-## Readiness model
-
-Use this sequence for a release-ready posture:
+If you want the release-confidence workflow step-by-step:
 
 ```bash
 bash ci.sh quick --skip-docs
 bash quality.sh cov
-python -m sdetkit security check --root . --baseline tools/security.baseline.json --format json
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
 python -m sdetkit gate release
 ```
 
-## UX-focused command architecture
-
-Core domains:
-
-- `doctor`: repository and environment diagnostics
-- `repo`: repository audit + reporting
-- `apiget` / `cassette-get`: deterministic API checks and replays
-- `security`: policy/security workflows and budget enforcement
-- `report`: deterministic report generation
-- `ops` / `notify`: operations and communication automation
-- `docs-qa` / `docs-nav`: docs health and navigation integrity
-- `evidence` / `roadmap`: governance and planning support
-
-List all commands:
+## Explore core commands
 
 ```bash
 python -m sdetkit --help
 python -m sdetkit playbooks
 ```
+
+Command domains include `doctor`, `repo`, `security`, `evidence`, `report`, and `ops`.
+
+## Docs and contributor entry points
+
+- Docs portal: <https://sherif69-sa.github.io/DevS69-sdetkit/>
+- Quickstart doc: `docs/ready-to-use.md`
+- Contributing guide: `CONTRIBUTING.md`
+- First contribution command: `python -m sdetkit first-contribution --format text --strict`
 
 ## CI/CD integration
 
@@ -162,7 +128,7 @@ python -m sdetkit playbooks
 
 ### Jenkins
 
-See `examples/ci/jenkins/` (for example `jenkins-advanced-reference.Jenkinsfile`).
+See `examples/ci/jenkins/`.
 
 ### Docker
 
@@ -171,33 +137,9 @@ docker build -t sdetkit .
 docker run --rm -v "$PWD:/work" -w /work sdetkit python -m sdetkit gate fast
 ```
 
-## Continuous upgrade lane
+## Release posture note
 
-```bash
-python -m sdetkit phase3-wrap-publication-closeout --format json --strict
-python -m sdetkit continuous-upgrade-closeout --format json --strict
-python -m sdetkit continuous-upgrade-cycle2-closeout --format json --strict
-python -m sdetkit continuous-upgrade-cycle3-closeout --format json --strict
-python -m sdetkit continuous-upgrade-cycle4-closeout --format json --strict
-python -m sdetkit continuous-upgrade-cycle5-closeout --format json --strict
-python -m sdetkit continuous-upgrade-cycle7-closeout --format json --strict
-```
-
-## Documentation
-
-- Docs portal: <https://sherif69-sa.github.io/DevS69-sdetkit/>
-- Local build: `mkdocs build -s`
-- Determinism checklist: `docs/determinism-checklist.md`
-
-## Contributing
-
-```bash
-bash scripts/bootstrap.sh
-source .venv/bin/activate
-bash quality.sh cov
-```
-
-Before opening a PR, prefer running `bash quality.sh full-test` when feasible.
+This repository is prepared for artifact build and release validation. Public PyPI publication depends on `PYPI_API_TOKEN` configuration and successful workflow execution; this README does not claim generally available PyPI distribution by default.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,193 +2,69 @@
 
 <div class="hero-badges" markdown>
 
+<span class="pill">Release-confidence focused</span>
 <span class="pill">Deterministic by design</span>
-<span class="pill">CI-ready workflows</span>
-<span class="pill">Audit-friendly evidence</span>
+<span class="pill">Audit-friendly outputs</span>
 
 </div>
 
 # DevS69 SDETKit
 
-Build, validate, and release software with confidence using a polished SDET + DevOps toolkit that keeps quality, security, and traceability aligned from local runs to production pipelines.
+SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need a repeatable answer to: **"is this repo ready to ship?"**
 
 <div class="hero-actions" markdown>
 
-[Get started](#fast-start){ .md-button .md-button--primary }
-[Open command reference](cli.md){ .md-button }
-[See release evidence](evidence.md){ .md-button }
-
-</div>
-
-<div class="hero-stats" markdown>
-
-- **Single toolkit** for quality + security + release readiness
-- **Deterministic output** with CI-safe exit codes and repeatability
-- **Actionable docs** for SDETs, DevOps, and engineering leads
+[Start in 5 minutes](#start-in-5-minutes){ .md-button .md-button--primary }
+[Open quickstart](ready-to-use.md){ .md-button }
+[See evidence commands](evidence.md){ .md-button }
 
 </div>
 
 </div>
 
+## Start in 5 minutes
 
+Run the flagship workflow:
 
-<div class="quick-jump" markdown>
-
-[⚡ Fast start](#fast-start) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-reports)
-
-</div>
-
-## Docs navigation upgrades (legacy docs navigation initiative)
-
-## Legacy reports
-
-Historical day reports remain available for audit/history traceability:
-
-- Day 90 report (stored under excluded historical artifacts)
-- Day 91 report (stored under excluded historical artifacts)
-- Day 92 report (stored under excluded historical artifacts)
-- Day 93 report (stored under excluded historical artifacts)
-- Day 94 report (stored under excluded historical artifacts)
-- Day 95 report (stored under excluded historical artifacts)
-- Day 97 report (stored under excluded historical artifacts)
-- Day 10 ultra report (stored under excluded historical artifacts)
-- Day 11 ultra report (stored under excluded historical artifacts)
-
-### Top journeys
-
-- Run first command in under 60 seconds
-- Validate docs links and anchors before publishing
-- Ship a first contribution with deterministic quality gates
-
-## Platform architecture at a glance
-
-```mermaid
-flowchart LR
-    A[Code + Policy Inputs] --> B[Doctor + Audit]
-    B --> C[CI Quick / Full Lanes]
-    C --> D[Security + Quality Gates]
-    D --> E[Evidence Pack + Reports]
-    E --> F[Release Decision]
-
-    style B fill:#3b82f633,stroke:#3b82f6
-    style D fill:#14b8a633,stroke:#14b8a6
-    style E fill:#a855f733,stroke:#a855f7
+```bash
+bash scripts/ready_to_use.sh quick
 ```
 
-## Why teams choose SDETKit
+Then run the stricter release gate:
 
-<div class="grid cards feature-grid" markdown>
+```bash
+bash scripts/ready_to_use.sh release
+```
 
-- [**Repository diagnostics**](doctor.md)
-  Continuously detect hygiene, policy, and reliability gaps with clear remediation guidance.
+### What happens
 
-- [**Deterministic API validation**](api.md)
-  Run and replay checks with cassettes for reproducible, low-flake test behavior.
+1. Bootstrap a local environment.
+2. Validate CLI health.
+3. Run CI-style checks.
+4. (Release mode) enforce security policy budgets and run the release gate.
 
-- [**Policy + security enforcement**](security-gate.md)
-  Enforce release budgets and quality constraints before they turn into production risk.
+### What proves value quickly
 
-- [**Release evidence packs**](evidence.md)
-  Produce machine-readable artifacts for audits, governance reviews, and handoffs.
+You get deterministic pass/fail output and a clear go/no-go signal you can reuse in local and CI workflows.
 
-- [**Patch-safe workflows**](patch-harness.md)
-  Apply controlled updates with validations that reduce merge and rollback risk.
+## Flagship workflow (manual form)
 
-- [**Production readiness controls**](production-readiness.md)
-  Standardize CI lanes, quality gates, and release decisions with confidence.
+```bash
+bash ci.sh quick --skip-docs
+bash quality.sh cov
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+python -m sdetkit gate release
+```
 
-</div>
+## Who should start where
 
-## Delivery flow (arranged by outcome)
+- **SDET / QA:** [Doctor](doctor.md) and [CLI](cli.md)
+- **DevOps / platform:** [Production readiness](production-readiness.md) and [Security gate](security-gate.md)
+- **Maintainers:** [Evidence](evidence.md) and [Releasing](releasing.md)
 
-<div class="process-grid" markdown>
+## Next steps
 
-<div class="process-step" markdown>
-
-### 1) Diagnose
-Run repository health checks and baseline policy posture.
-
-`python -m sdetkit doctor --help`
-
-</div>
-
-<div class="process-step" markdown>
-
-### 2) Validate
-Execute deterministic test and API verification workflows.
-
-`bash ci.sh quick --skip-docs`
-
-</div>
-
-<div class="process-step" markdown>
-
-### 3) Enforce
-Apply quality and security budgets as go/no-go release controls.
-
-`python -m sdetkit security enforce --help`
-
-</div>
-
-<div class="process-step" markdown>
-
-### 4) Evidence
-Generate artifacts to support traceable release approvals.
-
-`python -m sdetkit evidence --help`
-
-</div>
-
-</div>
-
-## Fast start
-
-=== "Local setup"
-
-    ```bash
-    python3 -m venv .venv
-    ./.venv/bin/python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .
-    bash ci.sh quick --skip-docs
-    ```
-
-=== "CI-style path"
-
-    ```bash
-    bash ci.sh quick
-    bash quality.sh cov
-    python -m sdetkit security check --root . --baseline tools/security.baseline.json --format json
-    ```
-
-!!! tip "10-minute onboarding path"
-    Follow this sequence for the fastest adoption: **CLI help** → **Doctor** → **Gate fast** → **Evidence export**.
-
-## Role-based jump points
-
-<div class="grid cards" markdown>
-
-- **SDET / QA engineers**
-  Start with [CLI](cli.md), [Doctor](doctor.md), and [API](api.md).
-
-- **Platform / DevOps teams**
-  Start with [Production readiness](production-readiness.md), [Security gate](security-gate.md), and [Patch harness](patch-harness.md).
-
-- **Tech leads / maintainers**
-  Start with [Repo tour](repo-tour.md), [Project structure](project-structure.md), and [Design](design.md).
-
-</div>
-
-## Readiness scorecard
-
-| Area | Outcome target | Primary command |
-| --- | --- | --- |
-| Quality | CI-equivalent checks are green and reproducible | `bash ci.sh quick --skip-docs` |
-| Coverage | Coverage gate meets release threshold | `bash quality.sh cov` |
-| Security | Policy budgets are enforced with zero drift | `python -m sdetkit security check --root . --baseline tools/security.baseline.json --format json` |
-| Evidence | Artifacts are generated and stored for review | `python -m sdetkit evidence --help` |
-
-## Continue exploring
-
+- [Ready-to-use quickstart](ready-to-use.md)
 - [Repo tour](repo-tour.md)
 - [Contributing](contributing.md)
-- [Security policy](security.md)
-- [Releasing](releasing.md)
+- [Full command reference](cli.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -24,7 +24,7 @@ bash scripts/ready_to_use.sh release
 In addition to the fast start, this mode runs:
 
 - `bash quality.sh cov`
-- `python -m sdetkit security check --root . --baseline tools/security.baseline.json --format json`
+- `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`
 - `python -m sdetkit gate release`
 
 Use this when you need production-quality release evidence.

--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 SCRIPT = Path("scripts/release_preflight.py").resolve()
 
 


### PR DESCRIPTION
### Motivation

- Re-focus the repository docs and README around a single flagship "release confidence" workflow that provides a repeatable go/no-go path for local and CI usage.
- Make the fastest onboarding path explicit by promoting `scripts/ready_to_use.sh` as the primary quickstart and runtime bootstrap command.
- Replace an older `security check` quickstart step with the stricter policy enforcement invocation to align the quickstart with release-grade validation.

### Description

- Rewrote `README.md` to center on the release-confidence workflow, replace multiple ad-hoc commands with the `scripts/ready_to_use.sh quick` and `scripts/ready_to_use.sh release` flows, and simplify installation/startup instructions.
- Updated `docs/index.md` to highlight the one-command quickstart, describe what the ready-to-use flow does, and surface the manual flagship sequence for `gate release` and the stricter security enforcement step.
- Updated `docs/ready-to-use.md` to document the `quick` and `release` modes and switch the release-mode security step from `python -m sdetkit security check` to `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`.
- Minor test file formatting change in `tests/test_release_preflight.py` (trimming an extra blank line); no behavior changes to the test itself.

### Testing

- Ran the automated test suite with `pytest -q`, including `tests/test_release_preflight.py`, and the tests completed successfully.

------
