### PR TITLE
Add release-confidence example scenarios and docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ Use release mode when you want a stricter go/no-go decision before a release.
 
 Ready-to-use guide: `docs/ready-to-use.md`
 
+## Proof by scenario
+
+Want concrete examples before adopting?
+
+- See **3 realistic release-confidence scenarios** in `docs/examples.md`.
+- Each scenario includes: situation, command, representative output, and maintainer next action.
+
+```bash
+# quick confidence lane
+bash scripts/ready_to_use.sh quick
+
+# strict release lane
+bash scripts/ready_to_use.sh release
+```
+
 ---
 
 ## Who this is for

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,97 @@
+# Release-confidence examples
+
+These examples are short proof scenarios you can run (or compare against) to understand what SDETKit's flagship workflow looks like in practice.
+
+## Scenario 1: "Is this repo basically healthy?" (quick confidence pass)
+
+**Situation**
+
+You just cloned the repo and want a fast confidence signal before deeper checks.
+
+**Command**
+
+```bash
+bash scripts/ready_to_use.sh quick
+```
+
+**Representative output**
+
+```text
+[3/4] Running CI quick lane...
+ok: repo layout invariants hold
+gate fast: OK
+[OK] doctor (...) rc=0
+[OK] ci_templates (...) rc=0
+[OK] ruff (...) rc=0
+[OK] mypy (...) rc=0
+[OK] pytest (...) rc=0
+[4/4] Quick mode complete.
+Repository is ready to use.
+```
+
+**Maintainer next action**
+
+Move to strict release mode when you need a higher-trust go/no-go decision.
+
+---
+
+## Scenario 2: "What blocks release?" (strict release gate fails)
+
+**Situation**
+
+You want release-level confidence. The gate should fail loudly if release prerequisites are not met.
+
+**Command**
+
+```bash
+python -m sdetkit gate release
+```
+
+**Representative output**
+
+```text
+gate: problems found
+gate release: FAIL
+[FAIL] doctor_release rc=2
+[OK] playbooks_validate rc=0
+[OK] gate_fast rc=0
+failed_steps:
+- doctor_release
+```
+
+**Maintainer next action**
+
+Run the failing check directly, fix the issue, and rerun the release gate.
+
+```bash
+python -m sdetkit doctor --release --format json
+```
+
+---
+
+## Scenario 3: "Tune policy strictness" (security budget as release control)
+
+**Situation**
+
+You need to enforce security findings budgets in a transparent, machine-readable way.
+
+**Commands**
+
+```bash
+# strict: fail if any info/warn/error findings appear
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+
+# less strict: allow informational findings while keeping 0 errors/warnings
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 200
+```
+
+**Representative output**
+
+```json
+{"counts":{"error":0,"info":131,"total":131,"warn":0},"ok":false,"exceeded":[{"metric":"info","count":131,"limit":0}]}
+{"counts":{"error":0,"info":131,"total":131,"warn":0},"ok":true,"exceeded":[]}
+```
+
+**Maintainer next action**
+
+Set thresholds per branch/stage (for example, stricter on release branches, looser on feature branches), then enforce the selected policy in CI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 
 [Start in 5 minutes](#start-in-5-minutes){ .md-button .md-button--primary }
 [Open quickstart](ready-to-use.md){ .md-button }
+[See examples](examples.md){ .md-button }
 [See evidence commands](evidence.md){ .md-button }
 
 </div>
@@ -65,6 +66,7 @@ python -m sdetkit gate release
 ## Next steps
 
 - [Ready-to-use quickstart](ready-to-use.md)
+- [Release-confidence examples](examples.md)
 - [Repo tour](repo-tour.md)
 - [Contributing](contributing.md)
 - [Full command reference](cli.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ extra_javascript:
 nav:
   - Home: index.md
   - Quickstart: ready-to-use.md
+  - Examples: examples.md
   - Foundation:
       - AgentOS cookbook: agentos-cookbook.md
       - AgentOS foundation: agentos-foundation.md


### PR DESCRIPTION
### Motivation

- Provide a compact, high-trust proof layer so new users can quickly see realistic outcomes of the repo's flagship release-confidence workflow instead of only high-level positioning. 
- Surface concrete next actions and representative outputs to build trust and reduce initial discovery friction for maintainers evaluating the tool.

### Description

- Add a new proof page `docs/examples.md` with three realistic scenarios: quick confidence pass (`scripts/ready_to_use.sh quick`), strict release-gate failure/triage (`sdetkit gate release`), and security-budget tuning (`sdetkit security enforce`), each including situation, command, representative output, and maintainer next action. 
- Add a short "Proof by scenario" section to `README.md` linking to the new examples page and surfacing the quick/release commands. 
- Improve discoverability by adding an Examples CTA and a "Release-confidence examples" next-step link in `docs/index.md` and registering `examples.md` in `mkdocs.yml` navigation. 

### Testing

- `bash scripts/bootstrap.sh` ran successfully and installed the editable package. 
- `bash scripts/ready_to_use.sh quick` ran successfully and produced a healthy quick lane (`gate fast: OK`, doctor/ruff/mypy/pytest OK). 
- `bash scripts/ready_to_use.sh release` executed the strict release lane and produced an intentional failure in the strict path (release gate reported `FAIL` and two automated tests failed during the run), which is recorded as the realistic blocked-release example. 
- `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0` ran and returned `ok: false` due to exceeded info findings, and with `--max-info 200` returned `ok: true`, demonstrating both fail/pass policy outcomes. 
- `python -m sdetkit gate fast` succeeded while `python -m sdetkit gate release` failed due to `doctor_release` issues (non-zero exit), and `python -m sdetkit doctor --release --format json` produced JSON diagnostics (clean_tree failed due to uncommitted changes). 
- `mkdocs build` completed successfully to validate docs integration.

Files changed: `README.md`, `docs/examples.md` (new), `docs/index.md`, and `mkdocs.yml`.

------