### PR TITLE
Harden first-public-release verification: add post-publish plan & make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # --- dev targets (bootstrap) ---
 
-.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight
+.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan
 
 venv:
 	@test -x .venv/bin/python || python3 -m venv .venv
@@ -36,3 +36,7 @@ package-validate: venv
 
 release-preflight: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .[packaging] && python scripts/release_preflight.py && python -m sdetkit doctor --release --skip clean_tree --format md && $(MAKE) package-validate'
+
+
+release-verify-plan: venv
+	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python scripts/release_verify_post_publish.py --plan'

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ docker run --rm -v "$PWD:/work" -w /work sdetkit python -m sdetkit gate fast
 
 This repository is prepared for artifact build and release validation. Public PyPI publication depends on `PYPI_API_TOKEN` configuration and successful workflow execution; this README does not claim generally available PyPI distribution by default.
 
+For first-public-release and post-release external verification steps, follow `RELEASE.md` and `docs/releasing.md`.
+
 ## License
 
 Distributed under the Apache-2.0 license. See `LICENSE` and `ENTERPRISE_OFFERINGS.md`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,14 +32,22 @@ Release tags must be `vX.Y.Z` and must match the package version. `CHANGELOG.md`
    ```
 
    This runs release metadata validation, `doctor --release --skip clean_tree`, artifact build validation, and wheel smoke install.
-3. Create and push the tag:
+3. Generate post-release verification plan and confirm package install string before tagging:
+
+   ```bash
+   make release-verify-plan
+   python scripts/release_verify_post_publish.py --assert-install-string
+   ```
+
+   This validates the canonical external install target (`pip install sdetkit==<version>`) and prints a deterministic verification plan maintainers can execute after publish.
+4. Create and push the tag:
 
    ```bash
    git tag vX.Y.Z
    git push origin vX.Y.Z
    ```
-4. Watch `.github/workflows/release.yml` complete.
-5. Verify outcomes:
+5. Watch `.github/workflows/release.yml` complete.
+6. Verify outcomes:
    - GitHub Release exists and includes `dist/*` artifacts.
    - PyPI upload occurred only if `PYPI_API_TOKEN` secret is configured.
    - Dependency/security workflows are green for the same commit/tag.
@@ -63,3 +71,39 @@ Do not claim public PyPI availability until:
 - the release workflow succeeded,
 - the PyPI upload step ran (not skipped), and
 - install from PyPI is verified externally.
+
+## Post-release verification (external-user perspective)
+
+Run these in a clean shell after the release workflow shows a successful PyPI upload:
+
+```bash
+python -m venv .venv-release-verify
+. .venv-release-verify/bin/activate
+python -m pip install -U pip
+python -m pip install sdetkit==X.Y.Z
+python -m sdetkit --help
+python -m pip show sdetkit
+```
+
+Success means:
+- `pip install` resolves from default PyPI index without private index overrides.
+- `python -m sdetkit --help` exits 0 and prints CLI usage.
+- `pip show sdetkit` reports the expected version (`X.Y.Z`).
+
+Also confirm:
+- GitHub Release page for `vX.Y.Z` is present with generated notes and `dist/*` artifacts.
+- PyPI project/version page exists and files include wheel + source tarball.
+- The release workflow job includes a successful **Publish to PyPI** step (not skipped).
+
+Only after all checks pass is it safe to claim public availability.
+
+## Optional risk-reduction rehearsal (TestPyPI)
+
+If maintainers want a dry run before the first real publish, run from local `dist/*` against TestPyPI manually with a separate token:
+
+```bash
+python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple sdetkit==X.Y.Z
+```
+
+This repository does not auto-publish to TestPyPI in CI; this path is an optional rehearsal only.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,7 +27,21 @@ Current baseline release: **v1.0.2**.
 4. Commit changes and open/merge a PR.
 5. Create and push a signed tag: `vX.Y.Z`.
 6. Confirm GitHub Actions release workflow succeeded.
-7. Confirm artifacts were published to PyPI.
+7. Confirm artifacts were published to PyPI (workflow step must be successful, not skipped).
+8. Run external-user verification in a clean virtual environment:
+
+   ```bash
+   python -m venv .venv-release-verify
+   . .venv-release-verify/bin/activate
+   python -m pip install -U pip
+   python -m pip install sdetkit==X.Y.Z
+   python -m sdetkit --help
+   python -m pip show sdetkit
+   ```
+
+9. Confirm index/release pages:
+   - `https://pypi.org/project/sdetkit/X.Y.Z/` is reachable.
+   - GitHub Release for `vX.Y.Z` includes dist artifacts.
 
 ## CI release safeguards
 
@@ -46,3 +60,16 @@ Publishing is handled by GitHub Actions in `.github/workflows/release.yml`.
 - On tag push `v*.*.*`, artifacts are built and uploaded.
 - Upload uses the configured `PYPI_API_TOKEN` secret.
 - If no token is configured, packaging checks still run and release artifacts are generated.
+
+
+## Optional TestPyPI rehearsal
+
+Before first real publish, maintainers can rehearse upload/install manually:
+
+```bash
+python -m build
+python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple sdetkit==X.Y.Z
+```
+
+This is optional and not wired to the default release workflow.

--- a/scripts/release_verify_post_publish.py
+++ b/scripts/release_verify_post_publish.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+def _project_meta(pyproject: Path) -> tuple[str, str]:
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    name = str(project.get("name", "")).strip()
+    version = str(project.get("version", "")).strip()
+    if not name or not version:
+        raise ValueError("pyproject.toml missing [project].name or [project].version")
+    return name, version
+
+
+def _run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def _plan(name: str, version: str) -> dict[str, object]:
+    return {
+        "package": name,
+        "version": version,
+        "verification": {
+            "external_install": [
+                f"python -m venv .venv-release-verify && . .venv-release-verify/bin/activate",
+                "python -m pip install -U pip",
+                f"python -m pip install {name}=={version}",
+                "python -m sdetkit --help",
+                f"python -m pip show {name}",
+            ],
+            "index_checks": [
+                f"PyPI project page exists: https://pypi.org/project/{name}/{version}/",
+                f"PyPI files tab shows both sdist + wheel for {version}",
+                "GitHub Release exists for matching tag and contains dist artifacts",
+            ],
+            "success_signals": [
+                "pip install resolves from PyPI without --index-url overrides",
+                "CLI help command exits 0",
+                "pip show reports expected version",
+                "Release workflow includes successful Publish to PyPI step",
+            ],
+        },
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a deterministic post-publish verification plan for maintainers."
+    )
+    parser.add_argument("--pyproject", default="pyproject.toml")
+    parser.add_argument("--plan", action="store_true", help="Print JSON verification plan.")
+    parser.add_argument(
+        "--assert-install-string",
+        action="store_true",
+        help="Fail if `pip install <name>==<version>` syntax generation is invalid.",
+    )
+    args = parser.parse_args(argv[1:])
+
+    try:
+        name, version = _project_meta(Path(args.pyproject))
+    except (FileNotFoundError, tomllib.TOMLDecodeError, ValueError) as exc:
+        print(f"post-release verification prep failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.assert_install_string:
+        cmd = [sys.executable, "-m", "pip", "--version"]
+        _ = _run(cmd)
+        install_string = f"{name}=={version}"
+        if " " in install_string.strip():
+            print("post-release verification prep failed: invalid install string", file=sys.stderr)
+            return 1
+        print(f"post-release verification prep ok: install string `{install_string}`")
+
+    if args.plan:
+        print(json.dumps(_plan(name, version), indent=2))
+
+    if not args.plan and not args.assert_install_string:
+        print(f"post-release verification prep ok: package={name} version={version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
### Motivation
- Close the gap between “release workflow exists” and a confident first public publish by giving maintainers a deterministic pre-tag validation and a clear post-release verification runbook. 
- Keep the release workflow unchanged while providing small, high-leverage tools and docs so maintainers can rehearse and verify external installability before claiming public availability.

### Description
- Add a maintainer-facing helper `scripts/release_verify_post_publish.py` that reads `pyproject.toml`, emits a JSON post-publish verification plan, and can assert the canonical install string (`pip install <name>==<version>`).
- Add `make release-verify-plan` to the `Makefile` to generate the verification plan from a single command in a maintainer environment.
- Strengthen release guidance by updating `RELEASE.md` and `docs/releasing.md` with an explicit pre-tag verification step, a concrete post-release external-user verification checklist (clean venv install + CLI check + index/GitHub Release page checks), and optional TestPyPI rehearsal notes.
- Add a small README pointer to the release docs so maintainers can find the new verification path without implying the package is already live.

### Testing
- Ran `python scripts/release_verify_post_publish.py --plan` and it printed a package/version-aware JSON plan (package `sdetkit`, version `1.0.2`), which succeeded.
- Ran `python scripts/release_verify_post_publish.py --assert-install-string` and it printed `post-release verification prep ok: install string \\`sdetkit==1.0.2\\``, which succeeded.
- Ran metadata preflight with `python scripts/release_preflight.py` and it returned `release preflight ok: version=1.0.2`.
- Executed `make release-verify-plan` and `make release-preflight`, and the `release-preflight` flow completed locally including editable install, build, `twine` checks, `check_wheel_contents`, wheel smoke install, and a successful `sdetkit --help` CLI check; all automated steps succeeded in this environment.

------