### PR TITLE
docs: streamline first-time contributor onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Questions / discussion
     url: https://github.com/sherif69-sa/DevS69-sdetkit/discussions
     about: Please ask and answer questions here.
+  - name: First contribution quickstart
+    url: https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/docs/first-contribution-quickstart.md
+    about: New contributor? Start here for setup, validation, and first PR scope.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,47 +10,58 @@ Thanks for helping improve **sdetkit**.
 
 ---
 
-## 0) Day 10 first-contribution checklist
+## Start here (first external contribution)
 
-Use this guided path from local clone to first merged PR:
+If this is your first PR to this repository, use this shortest safe path:
 
-- [ ] Fork the repository and clone your fork locally.
-- [ ] Create and activate a virtual environment.
-- [ ] Install editable dependencies for dev/test/docs.
-- [ ] Create a branch named `feat/<topic>` or `fix/<topic>`.
-- [ ] Run focused tests for changed modules before committing.
-- [ ] Run full quality gates (`pre-commit`, `quality.sh`, docs build) before opening a PR.
-- [ ] Open a PR using the repository template and include test evidence.
+1. **Set up locally**
+   ```bash
+   bash scripts/bootstrap.sh
+   source .venv/bin/activate
+   ```
+2. **Choose one small contribution type** from [Starter contribution types](#starter-contribution-types).
+3. **Make one focused change** and keep the PR scope small.
+4. **Validate before push**:
+   ```bash
+   python -m pre_commit run -a
+   bash quality.sh cov
+   ```
+5. **Open a PR** using `.github/PULL_REQUEST_TEMPLATE.md` and include the commands you ran.
 
-Recommended shell sequence:
+For a condensed version, see `docs/first-contribution-quickstart.md`.
+
+## Starter contribution types
+
+Use these when you want a realistic first PR without deep project context:
+
+- **Docs/example improvements**: clarify command wording, tighten examples, or fix broken internal doc links in `docs/` and `README.md`.
+- **Small tests**: add or extend targeted tests under `tests/` for existing CLI behavior.
+- **Lint/type hygiene fixes**: fix Ruff or mypy findings without changing behavior.
+- **Workflow/docs polish**: improve contributor/developer docs or issue-template clarity.
+- **CLI/docs alignment**: update docs when command names/options drift from actual CLI output.
+
+If you are unsure where to start, run:
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -e .[dev,test,docs]
-pre-commit run -a
-bash quality.sh cov
-mkdocs build
+python -m sdetkit first-contribution --format text --strict
 ```
 
-## Contribution flow
+## Where to find starter work
 
-1. Fork and create a focused branch.
-2. Implement changes with tests and documentation as needed.
-3. Run local quality gates.
-4. Open a pull request with clear context and impact.
+- Look for open issues labelled **`good first issue`**, **`documentation`**, **`tests`**, or **`needs-triage`**.
+- If no issue fits, open a small scoped feature request (use `.github/ISSUE_TEMPLATE/feature_request.yml`) and mention it is a first contribution.
+- Prefer changes that can be reviewed in one pass and validated with existing commands.
 
-## 1) Local development setup
+## Local development setup
 
 ```bash
-cd ~/DevS69-sdetkit
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install -U pip
 python -m pip install -e .[dev,test,docs]
 ```
 
-## 2) Enable pre-commit hooks
+## Enable pre-commit hooks
 
 ```bash
 pre-commit install
@@ -58,7 +69,7 @@ python -m ruff format --check .
 python -m pre_commit run -a
 ```
 
-## 3) Run quality gates locally
+## Validate changes before opening a PR
 
 Use the same commands expected by CI:
 
@@ -71,33 +82,31 @@ python -m twine check dist/*
 mkdocs build
 ```
 
-## 4) Common day-to-day commands
+For docs-only updates, run at least:
 
 ```bash
-ruff format .
-ruff check .
-mypy src
-pytest -q
+python -m pre_commit run -a
+mkdocs build
 ```
 
-## 5) Pull request checklist
+## Pull request checklist
 
 Reference: [docs/premium-quality-gate.md](docs/premium-quality-gate.md)
 
-- [ ] `pre-commit run -a` passes.
-- [ ] `bash quality.sh cov` passes.
-- [ ] `python -m build` and `python -m twine check dist/*` pass.
+- [ ] `python -m pre_commit run -a` passes.
+- [ ] `bash quality.sh cov` passes (or explain why not run).
+- [ ] `python -m build` and `python -m twine check dist/*` pass for packaging-impacting changes.
 - [ ] `mkdocs build` passes for docs changes.
 - [ ] `CHANGELOG.md` updated if behavior changed.
 
-## 6) Commit guidance
+## Commit guidance
 
 - Keep commits focused and easy to review.
 - Include tests for behavior changes.
 - Prefer typed public APIs and clear error messages.
 - Write commit messages that describe **what changed** and **why**.
 
-## 7) PR quality tips (recommended)
+## PR quality tips (recommended)
 
 - Add before/after snippets for docs UX changes.
 - Mention affected commands/workflows.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,19 @@ Command domains include `doctor`, `repo`, `security`, `evidence`, `report`, and 
 - Docs portal: <https://sherif69-sa.github.io/DevS69-sdetkit/>
 - Quickstart doc: `docs/ready-to-use.md`
 - Contributing guide: `CONTRIBUTING.md`
+- First-time contributor quickstart: `docs/first-contribution-quickstart.md`
 - First contribution command: `python -m sdetkit first-contribution --format text --strict`
+
+## New contributors: fastest safe first PR
+
+If you already ran `bash scripts/ready_to_use.sh quick`, use this path to make a first contribution quickly.
+
+1. Read `docs/first-contribution-quickstart.md` and pick a small contribution type.
+2. Set up your environment with `bash scripts/bootstrap.sh`.
+3. Make one focused change (docs/example, test, lint fix, or CLI/docs alignment).
+4. Run `python -m pre_commit run -a` and `bash quality.sh cov` before opening a PR.
+
+If you cannot find a starter issue, open a scoped proposal using the Feature request template and state that it is a first contribution.
 
 ## CI/CD integration
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,27 +1,21 @@
 # Contributing
 
-Use the repository root guide (`CONTRIBUTING.md`) for the full contributor workflow.
+For the complete workflow, use the repository guide: [`CONTRIBUTING.md`](https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CONTRIBUTING.md).
 
-## Day 10 first-contribution checklist
+If this is your first external PR, start here first: [First contribution quickstart](first-contribution-quickstart.md).
 
-Generate a guided checklist from clone to PR:
+## Generate the Day 10 checklist
 
 ```bash
-sdetkit first-contribution --format text --strict
-sdetkit first-contribution --write-defaults --format json --strict
-sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md
+python -m sdetkit first-contribution --format text --strict
+python -m sdetkit first-contribution --write-defaults --format json --strict
+python -m sdetkit first-contribution --format markdown --output docs/artifacts/day10-first-contribution-checklist-sample.md
 ```
 
-Quick start:
+## Baseline contributor validation commands
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -U pip
-bash scripts/bootstrap.sh
-. .venv/bin/activate
-pre-commit install
-pre-commit run -a
+python -m pre_commit run -a
 bash quality.sh cov
 mkdocs build
 ```

--- a/docs/first-contribution-quickstart.md
+++ b/docs/first-contribution-quickstart.md
@@ -1,0 +1,72 @@
+# First contribution quickstart
+
+This page is for first-time external contributors who want a small, safe PR.
+
+## 1) Local setup (fast path)
+
+```bash
+bash scripts/bootstrap.sh
+source .venv/bin/activate
+```
+
+If you prefer manual setup:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
+python -m pip install -e .[dev,test,docs]
+```
+
+## 2) Pick a realistic first contribution type
+
+Choose one:
+
+1. **Docs/example polish** (`README.md`, `docs/`)
+   - Clarify command wording.
+   - Fix broken or confusing internal links.
+   - Improve examples to match current CLI behavior.
+2. **Targeted tests** (`tests/`)
+   - Add one focused test for existing command behavior.
+   - Extend an existing test file with an edge case.
+3. **Lint/type small fixes** (`src/`, `tests/`)
+   - Resolve Ruff/mypy findings without behavior changes.
+4. **CLI/docs alignment**
+   - Update docs when command names/options/output changed.
+
+## 3) Validate locally before opening a PR
+
+Run minimum checks:
+
+```bash
+python -m pre_commit run -a
+bash quality.sh cov
+```
+
+For docs-only changes:
+
+```bash
+python -m pre_commit run -a
+mkdocs build
+```
+
+## 4) Open your PR
+
+- Use the PR template: `.github/PULL_REQUEST_TEMPLATE.md`.
+- Include exact commands you ran and key output.
+- Keep scope small so review can complete quickly.
+
+## 5) Need help finding starter work?
+
+- Search issues for labels like `good first issue`, `documentation`, `tests`, and `needs-triage`.
+- If nothing fits, open a scoped proposal with `.github/ISSUE_TEMPLATE/feature_request.yml` and mention it is your first contribution.
+
+## Optional helper command
+
+Generate the repository checklist:
+
+```bash
+python -m sdetkit first-contribution --format text --strict
+```
+
+For the complete workflow, see [Contributing](contributing.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,5 +68,6 @@ python -m sdetkit gate release
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Release-confidence examples](examples.md)
 - [Repo tour](repo-tour.md)
+- [First contribution quickstart](first-contribution-quickstart.md)
 - [Contributing](contributing.md)
 - [Full command reference](cli.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
       - Security code scanning follow-ups: security-code-scanning-followups.md
   - Platform & Governance:
       - AgentOS productization blueprint: enterprise-productization-blueprint.md
+      - First contribution quickstart: first-contribution-quickstart.md
       - Contributing: contributing.md
       - Design notes: design.md
       - Governance and org packs: governance-and-org-packs.md


### PR DESCRIPTION
### Motivation

- Make the public path from "this looks useful" to "I can contribute" explicit and easy to follow for first-time external contributors. 
- Reduce friction by giving a smallest-safe-first-PR recipe, concrete starter contribution types, and a discoverable quickstart from README/docs. 

### Description

- Add `docs/first-contribution-quickstart.md` with a short setup flow, realistic first-task categories, minimal local validation commands, and PR expectations. 
- Surface the quickstart in the public entry points by updating `README.md`, `docs/index.md`, `docs/contributing.md`, and `mkdocs.yml` navigation. 
- Refocus `CONTRIBUTING.md` to lead with a concise first-external-contributor path and concrete starter contribution types. 
- Improve discoverability for newcomers by adding a contact link in `.github/ISSUE_TEMPLATE/config.yml` that points to the quickstart. 

### Testing

- Ran targeted pre-commit checks on changed files with `python -m pre_commit run --files README.md CONTRIBUTING.md docs/index.md docs/contributing.md docs/first-contribution-quickstart.md .github/ISSUE_TEMPLATE/config.yml mkdocs.yml` and the hooks passed for the modified files. 
- Re-ran `python -m pre_commit run --files docs/contributing.md` to validate doc-specific hooks and it passed. 
- Built the docs with `mkdocs build` and the site built successfully (the environment emitted a Material/MkDocs 2.0 compatibility warning which is an external tooling message, not a regression from this change).

------