### PR TITLE
Add lightweight public release verification records and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ docker run --rm -v "$PWD:/work" -w /work sdetkit python -m sdetkit gate fast
 This repository is prepared for artifact build and release validation. Public PyPI publication depends on `PYPI_API_TOKEN` configuration and successful workflow execution; this README does not claim generally available PyPI distribution by default.
 
 For first-public-release and post-release external verification steps, follow `RELEASE.md` and `docs/releasing.md`.
+After real releases are verified externally, see `docs/release-verification.md` for published evidence records.
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,6 +97,19 @@ Also confirm:
 
 Only after all checks pass is it safe to claim public availability.
 
+## Record public verification evidence
+
+After completing external-user verification for a real release, add a short record to `docs/release-verification.md` using the page template.
+
+Keep entries factual and minimal:
+- exact released version
+- exact install and validation commands run
+- verifier environment (OS, Python, pip)
+- success signals + links (PyPI version page and GitHub Release)
+- support path if users cannot install
+
+Do not add a verification entry unless the release was actually published and validated externally.
+
 ## Optional risk-reduction rehearsal (TestPyPI)
 
 If maintainers want a dry run before the first real publish, run from local `dist/*` against TestPyPI manually with a separate token:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Track release-level updates, notable features, and operational changes in the pr
 
 - Repository changelog: [CHANGELOG.md](https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CHANGELOG.md)
 - Release guide: [Releasing](releasing.md)
+- Public release install verification records: [Release verification](release-verification.md)
 - Quality and release controls: [Production readiness](production-readiness.md)
 
 !!! tip "Recommended release flow"

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,0 +1,59 @@
+# Public release verification records
+
+This page is the repository's **post-release credibility log**.
+
+Use it only for real, completed verification runs after a tag is published and the release workflow succeeds. Do not pre-fill this page with hypothetical results.
+
+## Status
+
+No public release verification record has been added yet.
+
+When the first successful external install verification is completed, add an entry in the format below.
+
+## Minimal evidence format (copy for each released version)
+
+```md
+### vX.Y.Z — YYYY-MM-DD
+
+- Package/version verified: `sdetkit==X.Y.Z`
+- Verifier: <maintainer-handle>
+- Environment:
+  - OS: <e.g., Ubuntu 24.04>
+  - Python: <e.g., 3.11.11>
+  - Installer: <e.g., pip 25.0>
+
+Install and verification commands run:
+
+```bash
+python -m venv .venv-release-verify
+. .venv-release-verify/bin/activate
+python -m pip install -U pip
+python -m pip install sdetkit==X.Y.Z
+python -m sdetkit --help
+python -m pip show sdetkit
+```
+
+Success signals captured:
+
+- `pip install` resolved from default PyPI index.
+- `python -m sdetkit --help` exited 0.
+- `python -m pip show sdetkit` reported `Version: X.Y.Z`.
+- PyPI page: <https://pypi.org/project/sdetkit/X.Y.Z/> reachable.
+- GitHub Release: <release-url> contains expected artifacts.
+
+Failure/support path:
+
+- If install fails, open a bug using the issue tracker and include OS, Python, pip version, full install output, and command history.
+```
+
+## Evidence quality bar (lightweight)
+
+Each entry should include only the essentials external users care about:
+
+1. Exact released package version.
+2. Exact install command.
+3. Environment details (OS/Python/pip).
+4. One post-install command proving usability (`python -m sdetkit --help`).
+5. Plain success signals and where to report failures.
+
+This keeps verification credible without adding heavy release bureaucracy.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -62,6 +62,19 @@ Publishing is handled by GitHub Actions in `.github/workflows/release.yml`.
 - If no token is configured, packaging checks still run and release artifacts are generated.
 
 
+## Record public verification evidence
+
+After completing external-user verification for a real release, add a short record to `docs/release-verification.md` using the page template.
+
+Keep entries factual and minimal:
+- exact released version
+- exact install and validation commands run
+- verifier environment (OS, Python, pip)
+- success signals + links (PyPI version page and GitHub Release)
+- support path if users cannot install
+
+Do not add a verification entry unless the release was actually published and validated externally.
+
 ## Optional TestPyPI rehearsal
 
 Before first real publish, maintainers can rehearse upload/install manually:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - Monorepo + multi-project support: monorepo-projects.md
       - Project structure: project-structure.md
       - Releasing sdetkit: releasing.md
+      - Public release verification records: release-verification.md
       - Changelog: changelog.md
       - Roadmap: roadmap.md
       - Repo tour (visual orientation): repo-tour.md


### PR DESCRIPTION
### Motivation

- The repository already documents pre-release checks and post-publish verification steps but lacked a single, discoverable place to publish actual, per-release external-install verification evidence. 
- The goal is a minimal, truthful credibility layer that lets maintainers record real verification results (no claims or fake evidence) and makes them easy for external users to find and assess.

### Description

- Add `docs/release-verification.md`, a short public evidence log that includes a clear placeholder status and a copyable per-release evidence template with fields for package/version, environment, exact install/validation commands, success signals, and a failure/support path. 
- Add guidance pointers instructing maintainers to use the evidence page in `RELEASE.md` and `docs/releasing.md`, update the `README.md` release posture note to point to the new page, and add the page to the docs nav by updating `mkdocs.yml`. 
- Add a short link to the new page in `docs/changelog.md` so release reviewers can find published verification records quickly.

### Testing

- Ran `python scripts/release_verify_post_publish.py --assert-install-string --plan` which returned `post-release verification prep ok: install string sdetkit==1.0.2` and printed the JSON verification plan for `sdetkit` version `1.0.2`, demonstrating the repo helper aligns with the new documentation. 
- Ran `mkdocs build` which completed successfully (build output completed and site generated) with only an upstream informational warning from the Material theme. 
- Based on the added docs and the validation above, the repository is now ready to record and surface real public-release verification evidence after the first live publish without implying availability before verification.

------