### PR TITLE
Add starter-work inventory and maintainer hygiene to improve first-contributor discoverability

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,3 +9,7 @@ contact_links:
   - name: First contribution quickstart
     url: https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/docs/first-contribution-quickstart.md
     about: New contributor? Start here for setup, validation, and first PR scope.
+
+  - name: Starter work inventory
+    url: https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/docs/starter-work-inventory.md
+    about: Concrete first-contribution categories mapped to this repository.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -52,6 +52,28 @@ body:
     validations:
       required: true
 
+
+  - type: checkboxes
+    id: contributor-path
+    attributes:
+      label: Contribution path
+      description: Mark this if you are proposing starter-sized work.
+      options:
+        - label: This is scoped as a first contribution (small, reviewable in one PR).
+          required: false
+
+  - type: textarea
+    id: starter-scope
+    attributes:
+      label: Starter scope (for small contributions)
+      description: If this is first-contribution sized, describe a narrow scope and touched areas.
+      placeholder: |
+        - Expected size: one workflow or small file group
+        - Planned files/areas:
+        - Out of scope:
+    validations:
+      required: false
+
   - type: textarea
     id: alternatives
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ If this is your first PR to this repository, use this shortest safe path:
 5. **Open a PR** using `.github/PULL_REQUEST_TEMPLATE.md` and include the commands you ran.
 
 For a condensed version, see `docs/first-contribution-quickstart.md`.
+For concrete, repo-grounded starter categories, use `docs/starter-work-inventory.md`.
 
 ## Starter contribution types
 
@@ -48,9 +49,17 @@ python -m sdetkit first-contribution --format text --strict
 
 ## Where to find starter work
 
-- Look for open issues labelled **`good first issue`**, **`documentation`**, **`tests`**, or **`needs-triage`**.
-- If no issue fits, open a small scoped feature request (use `.github/ISSUE_TEMPLATE/feature_request.yml`) and mention it is a first contribution.
+- Look for open issues labelled **`good first issue`**, **`help wanted`**, **`documentation`**, **`tests`**, or **`needs-triage`**.
+- If no issue fits, pick a safe path from `docs/starter-work-inventory.md`.
+- Open a small scoped feature request (use `.github/ISSUE_TEMPLATE/feature_request.yml`) and mark it as first-contribution sized.
 - Prefer changes that can be reviewed in one pass and validated with existing commands.
+
+### Starter-label expectations
+
+- **`good first issue`**: scoped to one workflow/file group, clear acceptance criteria, no deep architecture context required.
+- **`help wanted`**: useful but may require more context; still includes explicit acceptance criteria.
+- **`documentation` / `tests`**: indicate domain so contributors can filter by skill.
+- **`needs-triage`**: intake state only; move to specific labels after maintainers confirm scope.
 
 ## Local development setup
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Command domains include `doctor`, `repo`, `security`, `evidence`, `report`, and 
 - Quickstart doc: `docs/ready-to-use.md`
 - Contributing guide: `CONTRIBUTING.md`
 - First-time contributor quickstart: `docs/first-contribution-quickstart.md`
+- Starter work inventory: `docs/starter-work-inventory.md`
+- Maintainer starter-issue hygiene: `docs/maintainer-starter-issue-hygiene.md`
 - First contribution command: `python -m sdetkit first-contribution --format text --strict`
 
 ## New contributors: fastest safe first PR
@@ -136,11 +138,12 @@ Command domains include `doctor`, `repo`, `security`, `evidence`, `report`, and 
 If you already ran `bash scripts/ready_to_use.sh quick`, use this path to make a first contribution quickly.
 
 1. Read `docs/first-contribution-quickstart.md` and pick a small contribution type.
-2. Set up your environment with `bash scripts/bootstrap.sh`.
-3. Make one focused change (docs/example, test, lint fix, or CLI/docs alignment).
-4. Run `python -m pre_commit run -a` and `bash quality.sh cov` before opening a PR.
+2. Check `docs/starter-work-inventory.md` for concrete starter categories tied to this repo.
+3. Set up your environment with `bash scripts/bootstrap.sh`.
+4. Make one focused change (docs/example, test, lint fix, or CLI/docs alignment).
+5. Run `python -m pre_commit run -a` and `bash quality.sh cov` before opening a PR.
 
-If you cannot find a starter issue, open a scoped proposal using the Feature request template and state that it is a first contribution.
+If you cannot find a starter issue, use `docs/starter-work-inventory.md` and open a scoped proposal with the Feature request template, noting it is a first contribution.
 
 ## CI/CD integration
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,6 +3,8 @@
 For the complete workflow, use the repository guide: [`CONTRIBUTING.md`](https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CONTRIBUTING.md).
 
 If this is your first external PR, start here first: [First contribution quickstart](first-contribution-quickstart.md).
+For real starter task categories, use [Starter work inventory](starter-work-inventory.md).
+Maintainers curating newcomer-ready issues can use [Maintainer starter-issue hygiene](maintainer-starter-issue-hygiene.md).
 
 ## Generate the Day 10 checklist
 

--- a/docs/first-contribution-quickstart.md
+++ b/docs/first-contribution-quickstart.md
@@ -20,7 +20,7 @@ python -m pip install -e .[dev,test,docs]
 
 ## 2) Pick a realistic first contribution type
 
-Choose one:
+Use `docs/starter-work-inventory.md` for concrete categories mapped to this repo, then choose one:
 
 1. **Docs/example polish** (`README.md`, `docs/`)
    - Clarify command wording.
@@ -58,8 +58,9 @@ mkdocs build
 
 ## 5) Need help finding starter work?
 
-- Search issues for labels like `good first issue`, `documentation`, `tests`, and `needs-triage`.
-- If nothing fits, open a scoped proposal with `.github/ISSUE_TEMPLATE/feature_request.yml` and mention it is your first contribution.
+- Search issues for labels like `good first issue`, `help wanted`, `documentation`, `tests`, and `needs-triage`.
+- If nothing fits, choose a safe category from `docs/starter-work-inventory.md`.
+- Open a scoped proposal with `.github/ISSUE_TEMPLATE/feature_request.yml` and mention it is your first contribution.
 
 ## Optional helper command
 

--- a/docs/maintainer-starter-issue-hygiene.md
+++ b/docs/maintainer-starter-issue-hygiene.md
@@ -1,0 +1,38 @@
+# Maintainer starter-issue hygiene
+
+Use this lightweight checklist to keep starter work real and usable for first-time contributors.
+
+## Curate issues with conversion in mind
+
+For each issue you mark `good first issue`:
+
+- Keep scope narrow (one workflow, one command family, or a small doc/test area).
+- Add objective acceptance criteria (what must be true to close it).
+- Link to exact files/commands contributors should start from.
+- Confirm it can be validated with existing repo checks.
+
+If any item is missing, use `help wanted` until scope is tightened.
+
+## Labeling rules of thumb
+
+- Use **`good first issue`** only when context burden is low.
+- Use **`help wanted`** for valuable tasks that still need project context.
+- Add domain labels (for example: `documentation`, `tests`) to improve filtering.
+- Remove **`needs-triage`** once scope/labels are confirmed.
+
+## Keep issue quality lightweight
+
+When creating or grooming starter work, avoid process bloat:
+
+- No placeholder/fake tasks.
+- No broad epics for first-timers.
+- No extra templates/checklists beyond what this repo already uses.
+
+## Fallback when issue queue is thin
+
+If there are few open starter issues, direct contributors to:
+
+- `docs/starter-work-inventory.md` for safe contribution categories.
+- `.github/ISSUE_TEMPLATE/feature_request.yml` for scoped proposals.
+
+This maintains a truthful contribution path without pretending there is a large maintained backlog.

--- a/docs/starter-work-inventory.md
+++ b/docs/starter-work-inventory.md
@@ -1,0 +1,57 @@
+# Starter work inventory
+
+Use this page when you want a **real first contribution** without guessing where to start.
+
+## How to use this inventory
+
+1. Pick one contribution type below.
+2. Keep it reviewable in one PR (usually a few files, no broad refactors).
+3. Run the minimum checks listed in [First contribution quickstart](first-contribution-quickstart.md).
+
+If you want to coordinate first, open a scoped proposal with `.github/ISSUE_TEMPLATE/feature_request.yml` and mark it as first-contribution sized.
+
+## Starter contribution categories
+
+### 1) Docs and examples alignment
+
+**Good fit when:** command behavior has drifted from docs, or examples are hard to follow.
+
+- Sync command flags/output between `README.md`, `docs/ready-to-use.md`, and `docs/cli.md`.
+- Fix broken internal documentation links in `docs/`.
+- Improve short “what to run next” guidance after quickstart steps.
+
+### 2) Small, focused tests
+
+**Good fit when:** behavior exists but one edge case is not covered.
+
+- Add one targeted test in an existing `tests/test_*.py` file.
+- Add a regression test for a command already documented in `docs/cli.md`.
+- Improve assertion clarity (inputs/expected outputs) without changing product behavior.
+
+### 3) Lint/type hygiene fixes
+
+**Good fit when:** Ruff/mypy reports a localized issue.
+
+- Resolve one lint warning in `src/` or `tests/` without behavior changes.
+- Tighten a type annotation where return/input types are already implied by code.
+
+### 4) Contributor-flow polish
+
+**Good fit when:** contributor docs/templates are inconsistent.
+
+- Align wording across `README.md`, `CONTRIBUTING.md`, and `docs/first-contribution-quickstart.md`.
+- Improve issue-template prompts so maintainers get reproducible context faster.
+
+## If no starter issue is available
+
+You can still contribute safely:
+
+1. Choose one category above.
+2. Open a feature request with:
+   - a narrow problem statement,
+   - one-file or one-workflow scope,
+   - objective acceptance criteria,
+   - note that it is intended as a first contribution.
+3. Wait for maintainer confirmation before implementing.
+
+This keeps the contribution path real without creating placeholder/fake issues.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,8 @@ nav:
   - Platform & Governance:
       - AgentOS productization blueprint: enterprise-productization-blueprint.md
       - First contribution quickstart: first-contribution-quickstart.md
+      - Starter work inventory: starter-work-inventory.md
+      - Maintainer starter-issue hygiene: maintainer-starter-issue-hygiene.md
       - Contributing: contributing.md
       - Design notes: design.md
       - Governance and org packs: governance-and-org-packs.md


### PR DESCRIPTION
### Motivation
- Close the gap between contributor onboarding docs and actionable starter work by providing concrete, repo-grounded starter categories. 
- Make it straightforward for newcomers to find realistic, small contributions without inventing fake issues or adding heavy process. 
- Keep maintainer burden low by giving a brief hygiene checklist to help convert intake into reviewable `good first issue` tasks.

### Description
- Add `docs/starter-work-inventory.md` containing concrete starter contribution categories (docs/examples alignment, small tests, lint/type fixes, contributor-flow polish) and a truthful fallback for when no starter issue exists. 
- Add `docs/maintainer-starter-issue-hygiene.md` with a lightweight checklist and label expectations to help maintainers curate high-conversion `good first issue` tasks. 
- Improve discoverability by linking the new pages from `README.md`, `CONTRIBUTING.md`, `docs/first-contribution-quickstart.md`, and `docs/contributing.md`, and add them to the MkDocs navigation (`mkdocs.yml`). 
- Improve issue-entry UX by adding a contact link to `.github/ISSUE_TEMPLATE/config.yml` and extending `.github/ISSUE_TEMPLATE/feature_request.yml` with optional fields to mark and describe first-contribution-sized proposals.

### Testing
- Ran `python -m pre_commit run -a`; hooks auto-fixed one ruff formatting issue and the full run passed. (Passed)
- Ran `python -m pre_commit run --files README.md CONTRIBUTING.md docs/contributing.md docs/first-contribution-quickstart.md docs/starter-work-inventory.md docs/maintainer-starter-issue-hygiene.md .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/feature_request.yml mkdocs.yml`; all configured hooks passed. (Passed)
- Ran `mkdocs build` to validate site changes; site built successfully (build completed with a non-blocking MkDocs Material warning). (Passed)

------