### PR TITLE
Add adopter-focused guide and link it into README and site navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Use release mode when you want a stricter go/no-go decision before a release.
 
 Ready-to-use guide: `docs/ready-to-use.md`
 
+## Adopt in your own repository (external integration)
+
+If you want to use SDETKit in a different repository, use the adopter-focused guide:
+
+- `docs/adoption.md`
+- Includes copy-paste local + CI integration patterns.
+- Shows a progressive path from lightweight `gate fast` to stricter release gating.
+
 ## Proof by scenario
 
 Want concrete examples before adopting?
@@ -147,14 +155,11 @@ If you cannot find a starter issue, use `docs/starter-work-inventory.md` and ope
 
 ## CI/CD integration
 
-### GitHub Actions
+For teams adopting SDETKit in another repository, start with:
 
-```yaml
-- name: Install
-  run: python -m pip install .[dev,test]
-- name: CI gate
-  run: bash ci.sh quick --skip-docs
-```
+- `docs/adoption.md` for copy-paste local and GitHub Actions workflows.
+- First gate: `python -m sdetkit gate fast`
+- Stricter rollout: security budgets + `python -m sdetkit gate release`
 
 ### Jenkins
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,0 +1,128 @@
+# Adopt SDETKit in your repository
+
+This page is for teams using SDETKit **outside this repository**.
+
+It gives you a safe, copy-paste path from first run to stricter CI enforcement.
+
+## What to install
+
+Until public package release is completed, install from GitHub:
+
+```bash
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+```
+
+For CI and local development parity:
+
+```bash
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git#egg=sdetkit[dev,test]"
+```
+
+## Start small: local quick confidence
+
+Run this first in your own repository root:
+
+```bash
+python -m sdetkit gate fast
+```
+
+This is a **signal-producing gate**, not a guaranteed-green onboarding command.
+
+- Exit code `0`: your current repo state passes the fast checks.
+- Non-zero exit code: one or more checks failed (for example lint/tests/type checks), which is expected if your repo is not yet aligned with the gate.
+
+Why this is the right first command:
+
+- Fast pass/fail signal with deterministic output.
+- Minimal integration overhead.
+- Good confidence before adding stricter gates.
+
+If it fails, treat the output as your integration backlog: fix the first failing check, then rerun.
+
+If you want a machine-readable artifact immediately:
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+```
+
+## Add a lightweight CI gate (copy/paste)
+
+Use this minimal GitHub Actions workflow in your repository.
+
+```yaml
+name: sdetkit-fast-gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  fast-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install SDETKit
+        run: python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+      - name: Run fast gate
+        run: python -m sdetkit gate fast
+```
+
+## Graduate to stricter release gating
+
+After fast gate is stable in your repo, add stricter checks:
+
+```bash
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+python -m sdetkit gate release
+```
+
+Suggested rollout:
+
+1. **Week 1**: local + CI `gate fast` only.
+2. **Week 2**: add security budgets in CI (start with a non-zero `--max-info` if needed).
+3. **Week 3+**: enforce `gate release` for release branches/tags.
+
+## CI pattern: fast on PR, strict on release branches
+
+```yaml
+name: sdetkit-progressive-gating
+
+on:
+  pull_request:
+  push:
+    branches: [main, release/**]
+
+jobs:
+  sdetkit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+      - name: Always run fast gate
+        run: python -m sdetkit gate fast
+      - name: Strict release gate
+        if: startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+          python -m sdetkit gate release
+```
+
+## Command choices at a glance
+
+- Run first: `python -m sdetkit gate fast`
+- CI minimum: `python -m sdetkit gate fast`
+- Strict path: `python -m sdetkit security enforce ...` + `python -m sdetkit gate release`
+- Evidence artifact: `python -m sdetkit gate fast --format json --stable-json --out ...`
+
+## Related docs
+
+- [Ready-to-use quickstart](ready-to-use.md)
+- [Release-confidence examples](examples.md)
+- [Production readiness command](production-readiness.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,6 +2,8 @@
 
 These examples are short proof scenarios you can run (or compare against) to understand what SDETKit's flagship workflow looks like in practice.
 
+For copy-paste integration in an external repository, see [Adopt SDETKit in your repository](adoption.md).
+
 ## Scenario 1: "Is this repo basically healthy?" (quick confidence pass)
 
 **Situation**

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 
 [Start in 5 minutes](#start-in-5-minutes){ .md-button .md-button--primary }
 [Open quickstart](ready-to-use.md){ .md-button }
+[Adopt in your repo](adoption.md){ .md-button }
 [See examples](examples.md){ .md-button }
 [See evidence commands](evidence.md){ .md-button }
 
@@ -66,6 +67,7 @@ python -m sdetkit gate release
 ## Next steps
 
 - [Ready-to-use quickstart](ready-to-use.md)
+- [Adopt in your repository](adoption.md)
 - [Release-confidence examples](examples.md)
 - [Repo tour](repo-tour.md)
 - [First contribution quickstart](first-contribution-quickstart.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -41,3 +41,13 @@ Use this when you need production-quality release evidence.
 - Read strategy context:
   - `docs/product-strategy.md`
   - `docs/global-production-transformation-playbook.md`
+
+## Using this in another repository
+
+If you are integrating SDETKit into an external repo (not this one), use [Adopt SDETKit in your repository](adoption.md).
+
+That guide includes:
+
+- Installation from GitHub
+- Copy-paste GitHub Actions workflows
+- A staged path from `gate fast` to stricter release gating

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ extra_javascript:
 nav:
   - Home: index.md
   - Quickstart: ready-to-use.md
+  - Adopt in your repository: adoption.md
   - Examples: examples.md
   - Foundation:
       - AgentOS cookbook: agentos-cookbook.md


### PR DESCRIPTION
### Motivation

- Provide a clear, copy-paste path for teams that want to adopt SDETKit in an external repository so they can integrate quickly and progressively. 
- Surface the adopter guidance in the main README and site navigation so it is discoverable from the project home and quickstart pages.

### Description

- Add a new `docs/adoption.md` document with install instructions, a `gate fast` quickstart, CI/GitHub Actions copy-paste examples, and a staged rollout path to `gate release` and security enforcement. 
- Update `README.md` to include an "Adopt in your own repository (external integration)" section and point to `docs/adoption.md` instead of inline CI snippets. 
- Add links to the adoption guide from `docs/index.md`, `docs/examples.md`, and `docs/ready-to-use.md` to improve discoverability. 
- Register the new page in `mkdocs.yml` navigation so the site includes "Adopt in your repository" in the docs site menu.

### Testing

- No automated tests were modified or executed as part of this documentation-only change.

------
