### PR TITLE
docs: add compact adoption troubleshooting guidance for first-failure triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Ready-to-use guide: `docs/ready-to-use.md`
 If you want to use SDETKit in a different repository, use the adopter-focused guide:
 
 - `docs/adoption.md`
+- `docs/adoption-troubleshooting.md` for first-failure triage (what failed, what it means, what to do next).
 - Includes copy-paste local + CI integration patterns.
 - Shows a progressive path from lightweight `gate fast` to stricter release gating.
 

--- a/docs/adoption-troubleshooting.md
+++ b/docs/adoption-troubleshooting.md
@@ -1,0 +1,90 @@
+# Adoption troubleshooting (external repositories)
+
+Use this page when you are integrating SDETKit into **your own repo** and a command fails.
+
+The goal is to decide quickly:
+
+- Is this failure expected during onboarding?
+- Should you fix code issues now, loosen policy temporarily, or run a lighter command?
+- What is the next sensible adoption step?
+
+## Quick command intent map
+
+| Command | Primary purpose | Typical onboarding outcome |
+| --- | --- | --- |
+| `python -m sdetkit gate fast` | Fast repo-health signal (doctor + templates + lint + type + tests) | Often fails at first; use failures as adoption backlog |
+| `python -m sdetkit security enforce ...` | Enforce security finding budgets | Strict limits commonly fail until thresholds are tuned |
+| `python -m sdetkit gate release` | Stricter release go/no-go gate | Usually fails until `gate fast` and policy prerequisites are stable |
+
+## Troubleshooting matrix
+
+| What you see | Usually means | What to do next | Stay lightweight vs tighten later |
+| --- | --- | --- | --- |
+| `gate fast: FAIL` with a failed step like `ruff`, `mypy`, or `pytest` | SDETKit is working and surfaced real quality debt in your repo | Run the failing tool directly, fix one issue class, rerun `gate fast` | Keep using `gate fast` on PRs until it is consistently green |
+| `security enforce` exits non-zero with `"ok": false` and `exceeded` for `info`/`warn`/`error` | Your current findings are above configured budgets | Keep `--max-error 0 --max-warn 0`, raise `--max-info` to current baseline, then ratchet down over time | Start with realistic budgets, then tighten per release cycle |
+| `gate release: FAIL` with failed steps such as `doctor_release` and/or `gate_fast` | Release prerequisites are not yet satisfied (for example clean-tree/release checks or fast-gate failures) | Read `failed_steps`, run the failed checks directly, and clear them in order | Keep release gate for release branches/tags until fast gate and release prerequisites are consistently green |
+| `bash scripts/ready_to_use.sh quick` prints CI lane issues but exits `0` | Quick mode is onboarding-friendly and does not block on CI quick lane failure | Treat printed failing checks as backlog; use direct commands in your repo for enforcement | Use quick mode for first-day setup, not as merge policy |
+
+## Grounded examples from this repository
+
+These are representative outputs from real runs in this repo.
+
+### 1) `gate fast` failed on lint (`ruff`)
+
+```text
+gate: problems found
+gate fast: FAIL
+[OK] doctor (...) rc=0
+[OK] ci_templates (...) rc=0
+[FAIL] ruff (...) rc=1
+[OK] mypy (...) rc=0
+[OK] pytest (...) rc=0
+failed_steps:
+- ruff
+```
+
+Next step:
+
+```bash
+ruff check .
+```
+
+### 2) strict security budget failed, relaxed budget passed
+
+```bash
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+```
+
+```json
+{"counts":{"error":0,"info":131,"total":131,"warn":0},"ok":false,"exceeded":[{"metric":"info","count":131,"limit":0}]}
+```
+
+```bash
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 200
+```
+
+```json
+{"counts":{"error":0,"info":131,"total":131,"warn":0},"ok":true,"exceeded":[]}
+```
+
+### 3) `gate release` failed on release prerequisites
+
+```text
+gate: problems found
+gate release: FAIL
+[FAIL] doctor_release rc=2
+[OK] playbooks_validate rc=0
+[FAIL] gate_fast rc=2
+failed_steps:
+- doctor_release
+- gate_fast
+```
+
+## Progressive adoption decisions
+
+1. **First integration:** run `gate fast` locally and in PR CI.
+2. **If it fails:** fix the first failing step category (lint/type/tests), not everything at once.
+3. **Then add security budgets:** keep errors/warnings strict, set `--max-info` to a temporary baseline.
+4. **Finally enforce release gate:** apply on release branches/tags once fast gate is reliable.
+
+If you want the full copy-paste integration workflow, go back to [adoption.md](adoption.md).

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -45,6 +45,14 @@ If you want a machine-readable artifact immediately:
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
 ```
 
+## If a command fails on first adoption
+
+Before changing your pipeline, check the focused troubleshooting matrix:
+
+- [Adoption troubleshooting](adoption-troubleshooting.md)
+- Covers common `gate fast`, `security enforce`, and `gate release` failures.
+- Helps decide whether to fix quality debt now, tune a threshold temporarily, or stay on a lighter command.
+
 ## Add a lightweight CI gate (copy/paste)
 
 Use this minimal GitHub Actions workflow in your repository.
@@ -123,6 +131,7 @@ jobs:
 
 ## Related docs
 
+- [Adoption troubleshooting](adoption-troubleshooting.md)
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Release-confidence examples](examples.md)
 - [Production readiness command](production-readiness.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 [Start in 5 minutes](#start-in-5-minutes){ .md-button .md-button--primary }
 [Open quickstart](ready-to-use.md){ .md-button }
 [Adopt in your repo](adoption.md){ .md-button }
+[Adoption troubleshooting](adoption-troubleshooting.md){ .md-button }
 [See examples](examples.md){ .md-button }
 [See evidence commands](evidence.md){ .md-button }
 
@@ -68,6 +69,7 @@ python -m sdetkit gate release
 
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Adopt in your repository](adoption.md)
+- [Adoption troubleshooting](adoption-troubleshooting.md)
 - [Release-confidence examples](examples.md)
 - [Repo tour](repo-tour.md)
 - [First contribution quickstart](first-contribution-quickstart.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - Home: index.md
   - Quickstart: ready-to-use.md
   - Adopt in your repository: adoption.md
+  - Adoption troubleshooting: adoption-troubleshooting.md
   - Examples: examples.md
   - Foundation:
       - AgentOS cookbook: agentos-cookbook.md


### PR DESCRIPTION
### Motivation

- External adopters often reach a clear value proposition but drop off on the first failing run; this adds a concise, high-signal triage layer to reduce that friction. 
- Keep guidance focused on the real-first-adoption path (fast gate → security budgets → release gate) and help teams decide whether to fix code, relax thresholds temporarily, or use a lighter command. 

### Description

- Add a new troubleshooting page `docs/adoption-troubleshooting.md` with a compact intent map, a 4-column troubleshooting matrix (what you see / what it means / what to do next / when to tighten later), and grounded examples from real runs. 
- Surface the page from the adopter flow by updating `docs/adoption.md`, add a hero/next-steps link in `docs/index.md`, list it in `mkdocs.yml` navigation, and add a pointer in `README.md` for discoverability. 
- Keep changes narrowly scoped to onboarding/troubleshooting docs and discoverability only; no behavioural or feature changes were made. 

### Testing

- Bootstrapped the environment with `bash scripts/bootstrap.sh` which completed successfully. 
- Verified fast-gate behaviour with `source .venv/bin/activate && python -m sdetkit gate fast`, which failed on `ruff` as expected and was used as a representative example. 
- Validated security budget behaviour with `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0` which failed, and `... --max-info 200` which passed. 
- Ran `python -m sdetkit gate release` which failed on release prerequisites (used to illustrate progressive adoption), and inspected `python -m sdetkit doctor --release --format json` which showed a `clean_tree` failure. 
- Built the docs with `mkdocs build -s` which completed successfully.

------
