### PR TITLE
docs: add compact remediation cookbook for first adoption failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Ready-to-use guide: `docs/ready-to-use.md`
 
 ## Adopt in your own repository (external integration)
 
+Focused remediation playbooks: `docs/remediation-cookbook.md`
+
 If you want to use SDETKit in a different repository, use the adopter-focused guide:
 
 - `docs/adoption.md`

--- a/docs/adoption-troubleshooting.md
+++ b/docs/adoption-troubleshooting.md
@@ -16,6 +16,12 @@ The goal is to decide quickly:
 | `python -m sdetkit security enforce ...` | Enforce security finding budgets | Strict limits commonly fail until thresholds are tuned |
 | `python -m sdetkit gate release` | Stricter release go/no-go gate | Usually fails until `gate fast` and policy prerequisites are stable |
 
+## Copy-paste remediation playbooks
+
+If you already know what failed and just want the exact next commands, use:
+
+- [Remediation cookbook](remediation-cookbook.md)
+
 ## Troubleshooting matrix
 
 | What you see | Usually means | What to do next | Stay lightweight vs tighten later |

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -50,7 +50,7 @@ python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.js
 Before changing your pipeline, check the focused troubleshooting matrix:
 
 - [Adoption troubleshooting](adoption-troubleshooting.md)
-- Covers common `gate fast`, `security enforce`, and `gate release` failures.
+- [Remediation cookbook](remediation-cookbook.md) for copy-paste next-step playbooks after common failures.
 - Helps decide whether to fix quality debt now, tune a threshold temporarily, or stay on a lighter command.
 
 ## Add a lightweight CI gate (copy/paste)
@@ -132,6 +132,7 @@ jobs:
 ## Related docs
 
 - [Adoption troubleshooting](adoption-troubleshooting.md)
+- [Remediation cookbook](remediation-cookbook.md)
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Release-confidence examples](examples.md)
 - [Production readiness command](production-readiness.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -51,3 +51,5 @@ That guide includes:
 - Installation from GitHub
 - Copy-paste GitHub Actions workflows
 - A staged path from `gate fast` to stricter release gating
+
+If quick or release checks fail in an external adoption flow, use the [remediation cookbook](remediation-cookbook.md) for copy-paste next steps.

--- a/docs/remediation-cookbook.md
+++ b/docs/remediation-cookbook.md
@@ -1,0 +1,189 @@
+# Remediation cookbook (first-failure playbooks)
+
+Use this page after your **first failed SDETKit command** in an external repository.
+
+It is intentionally compact: identify the failed step, run the safest next command, fix one class of issue, rerun.
+
+## 0) Start with machine-readable failure output
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+cat build/gate-fast.json
+```
+
+Why: `failed_steps` tells you exactly which playbook to use next.
+
+---
+
+## 1) `gate fast` failed on `ruff`
+
+**What failed**
+
+`gate fast: FAIL` and `failed_steps` includes `ruff` or `ruff_format`.
+
+**Likely meaning**
+
+Your repo has lint and/or formatting debt. This is common on first adoption.
+
+**Safest next commands**
+
+```bash
+# inspect only
+python -m ruff check .
+python -m ruff format --check .
+
+# optional minimal auto-fix pass
+python -m sdetkit gate fast --only ruff,ruff_format --fix
+```
+
+**Smallest fix path**
+
+1. Run `ruff check` to see exact rule IDs/files.
+2. Apply small fixes (or scoped `--fix`) and review the diff.
+3. Rerun `python -m sdetkit gate fast`.
+
+**Stay lightweight vs tighten later**
+
+- Lightweight now: keep `gate fast` as the PR gate while you reduce lint debt.
+- Tighten later: move to release gating only after `gate fast` is consistently green.
+
+---
+
+## 2) `gate fast` failed on `mypy`
+
+**What failed**
+
+`gate fast: FAIL` and `failed_steps` includes `mypy`.
+
+**Likely meaning**
+
+Type errors were found in the checked target (default: `src`).
+
+**Safest next commands**
+
+```bash
+# rerun exactly what gate fast runs by default
+python -m mypy src
+
+# narrow while adopting (example)
+python -m sdetkit gate fast --only mypy --mypy-args "src/your_package"
+```
+
+**Smallest fix path**
+
+1. Fix one error class at a time (for example missing annotations or incompatible return types).
+2. Rerun `python -m mypy ...` until clean.
+3. Rerun full `python -m sdetkit gate fast`.
+
+**Stay lightweight vs tighten later**
+
+- Lightweight now: scope mypy to the package you are actively stabilizing.
+- Tighten later: expand back to full `src` coverage.
+
+---
+
+## 3) `gate fast` failed on `pytest`
+
+**What failed**
+
+`gate fast: FAIL` and `failed_steps` includes `pytest`.
+
+**Likely meaning**
+
+Tests failed in the fast lane's default subset.
+
+**Safest next commands**
+
+```bash
+# run default fast subset
+python -m sdetkit gate fast --only pytest
+
+# or run your own focused subset while triaging
+python -m sdetkit gate fast --only pytest --pytest-args "-q tests/path_or_file.py"
+```
+
+**Smallest fix path**
+
+1. Isolate one failing test module/class.
+2. Fix deterministic failures first (assertions, setup, fixtures).
+3. Rerun focused pytest, then rerun full `gate fast`.
+
+**Stay lightweight vs tighten later**
+
+- Lightweight now: keep PR enforcement on fast gate.
+- Tighten later: use `--full-pytest` in stricter stages once flakiness is under control.
+
+---
+
+## 4) `security enforce` failed due to strict thresholds
+
+**What failed**
+
+`"ok": false` and `exceeded` shows counts over configured limits.
+
+**Likely meaning**
+
+Policy is stricter than your current baseline (often `info` findings first).
+
+**Safest next commands**
+
+```bash
+# strict check
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+
+# temporary adoption budget (example)
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 200
+```
+
+**Smallest fix path**
+
+1. Keep `--max-error 0 --max-warn 0` (do not normalize serious findings).
+2. Set `--max-info` close to current baseline.
+3. Ratchet `--max-info` down on a schedule.
+
+**Stay lightweight vs tighten later**
+
+- Lightweight now: realistic info budget to avoid blocking all adoption.
+- Tighten later: progressively lower budget until strict target is feasible.
+
+---
+
+## 5) `gate release` / `doctor --release` failed
+
+**What failed**
+
+`gate release: FAIL` and `failed_steps` includes `doctor_release`, `playbooks_validate`, or `gate_fast`.
+
+**Likely meaning**
+
+Release prerequisites are not met yet (often because fast gate is not green).
+
+**Safest next commands**
+
+```bash
+# inspect release prerequisites directly
+python -m sdetkit doctor --release --format json
+
+# inspect release gate breakdown
+python -m sdetkit gate release --format json --out build/gate-release.json
+cat build/gate-release.json
+```
+
+**Smallest fix path**
+
+1. Read `failed_steps` and clear them in order.
+2. If `gate_fast` failed, fix that before retrying release gate.
+3. Re-run release gate after prerequisites pass.
+
+**Stay lightweight vs tighten later**
+
+- Lightweight now: enforce only `gate fast` on PRs.
+- Tighten later: apply `gate release` on release branches/tags.
+
+---
+
+## Guardrails (important)
+
+- These playbooks are triage paths, not auto-fix guarantees.
+- If the target repository has real code/test/security debt, the correct action is to fix the repository.
+- Threshold tuning is for staged adoption, not permanent masking of failures.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
   - Quickstart: ready-to-use.md
   - Adopt in your repository: adoption.md
   - Adoption troubleshooting: adoption-troubleshooting.md
+  - Remediation cookbook: remediation-cookbook.md
   - Examples: examples.md
   - Foundation:
       - AgentOS cookbook: agentos-cookbook.md


### PR DESCRIPTION
### Motivation
- External adopters can already see what failed but need a compact, copy‑paste layer that answers “what exact step should I try next?” after a first failure. 
- Focus remediation on the smallest high‑impact failure classes (`ruff`, `mypy`, `pytest`, `security enforce` thresholds, and `gate release` prerequisites) so teams can make incremental progress without broad policy changes. 
- Keep guidance honest and narrowly scoped to docs and discoverability without touching command behavior or CI pipelines.

### Description
- Add a focused remediation page `docs/remediation-cookbook.md` with short playbooks for the five common first-failure classes and explicit guardrails against masking real repo debt. 
- Surface the cookbook from adoption and quickstart surfaces by updating `docs/adoption.md`, `docs/adoption-troubleshooting.md`, `docs/ready-to-use.md`, and `README.md` so adopters find copy‑paste next steps quickly. 
- Add the page to the documentation navigation by updating `mkdocs.yml`. 
- No runtime/CLI code, CI workflow, or production behavior was changed; changes are limited to documentation and discoverability only.

### Testing
- Verified CLI command help to ensure flags used in playbooks exist with `python -m sdetkit gate fast --help`, `python -m sdetkit security enforce --help`, `python -m sdetkit gate release --help`, and `python -m sdetkit doctor --help` (all returned usage output). 
- Reproduced a representative `gate fast` failure and captured machine-readable output with `python -m sdetkit gate fast --format json --stable-json --out /tmp/gate-fast.json` which returned a non-zero exit and `failed_steps: ["ruff"]`. 
- Confirmed the ruff remediation path by running `python -m ruff check .` (observed a lint finding) and validated the optional fix path by running the gated-only command `python -m sdetkit gate fast --only ruff,ruff_format --fix` conceptually in docs (commands and flags are supported). 
- Validated security threshold playbook by running `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0` (failed with `ok:false` and `info` exceeded) and `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 200` (succeeded). 
- Validated release gating guidance with `python -m sdetkit gate release --format json --out /tmp/gate-release.json` which returned a non-zero exit and `failed_steps: ["gate_fast"]`, and confirmed narrowing runs `python -m sdetkit gate fast --only pytest` and `python -m sdetkit gate fast --only mypy --mypy-args "src/sdetkit"` succeeded (rc=0) to show the playbook narrowing is supported.

------