### PR TITLE
Improve CI gate/release artifact visibility with focused JSON diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,22 @@ jobs:
         if: ${{ github.event.inputs.run_network_tests == 'true' }}
         run: bash ci.sh quick --skip-docs --run-network --artifact-dir build
 
-      - name: Upload gate-fast artifact
+      - name: Collect security threshold diagnostics (non-blocking)
+        if: always()
+        continue-on-error: true
+        run: |
+          mkdir -p build
+          python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
+
+      - name: Upload CI gate diagnostics
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: gate-fast
-          path: build/gate-fast.json
+          name: ci-gate-diagnostics
+          path: |
+            build/gate-fast.json
+            build/security-enforce.json
+          retention-days: 14
           if-no-files-found: warn
 
   ci-demo-60s:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python scripts/release_preflight.py --tag "${{ steps.resolved.outputs.tag }}"
+          mkdir -p build
+          python scripts/release_preflight.py --tag "${{ steps.resolved.outputs.tag }}" --format json --out build/release-preflight.json
 
       - name: Verify tag matches package version
         shell: bash
@@ -123,3 +124,12 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             dist/*
+
+      - name: Upload release diagnostics
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: release-diagnostics
+          path: build/release-preflight.json
+          retention-days: 30
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ For teams adopting SDETKit in another repository, start with:
 - First gate: `python -m sdetkit gate fast`
 - Stricter rollout: security budgets + `python -m sdetkit gate release`
 
+For CI failure triage in this repository's GitHub Actions runs, inspect uploaded artifacts:
+
+- `ci-gate-diagnostics` (`build/gate-fast.json`, `build/security-enforce.json`)
+- `release-diagnostics` (`build/release-preflight.json`)
+
+This keeps `failed_steps` and policy threshold outcomes easy to inspect without depending only on log scrolling.
+
 ### Jenkins
 
 See `examples/ci/jenkins/`.

--- a/docs/adoption-troubleshooting.md
+++ b/docs/adoption-troubleshooting.md
@@ -22,6 +22,13 @@ If you already know what failed and just want the exact next commands, use:
 
 - [Remediation cookbook](remediation-cookbook.md)
 
+If you are diagnosing a failed GitHub Actions run, download CI artifacts first:
+
+- `ci-gate-diagnostics` (contains `build/gate-fast.json` and `build/security-enforce.json`)
+- `release-diagnostics` (contains `build/release-preflight.json`)
+
+These files make `failed_steps` and threshold outcomes inspectable without scrolling long logs.
+
 ## Troubleshooting matrix
 
 | What you see | Usually means | What to do next | Stay lightweight vs tighten later |

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -129,6 +129,24 @@ jobs:
 - Strict path: `python -m sdetkit security enforce ...` + `python -m sdetkit gate release`
 - Evidence artifact: `python -m sdetkit gate fast --format json --stable-json --out ...`
 
+## GitHub Actions artifact visibility (this repository pattern)
+
+When a CI gate fails, keep machine-readable outputs in predictable files and upload only the highest-signal diagnostics:
+
+- `build/gate-fast.json` → includes `failed_steps` for fast-gate triage.
+- `build/security-enforce.json` → shows threshold outcomes (`ok`, `counts`, `exceeded`).
+- `build/release-preflight.json` → shows release metadata preflight status (`ok`, `version`, `tag`).
+
+In GitHub Actions, these are uploaded as:
+
+- `ci-gate-diagnostics` (CI workflow)
+- `release-diagnostics` (Release workflow)
+
+Use those artifacts first, then follow:
+
+- [Adoption troubleshooting](adoption-troubleshooting.md)
+- [Remediation cookbook](remediation-cookbook.md)
+
 ## Related docs
 
 - [Adoption troubleshooting](adoption-troubleshooting.md)

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 import tomllib
@@ -46,7 +47,13 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--tag", help="Release tag to validate (example: v1.0.2)")
     parser.add_argument("--pyproject", default="pyproject.toml")
     parser.add_argument("--changelog", default="CHANGELOG.md")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--out", help="Optional path for JSON output (requires --format json)")
     args = parser.parse_args(argv[1:])
+
+    if args.out and args.format != "json":
+        print("release preflight failed: --out requires --format json", file=sys.stderr)
+        return 2
 
     pyproject = Path(args.pyproject)
     changelog = Path(args.changelog)
@@ -59,6 +66,24 @@ def main(argv: list[str]) -> int:
     except (FileNotFoundError, tomllib.TOMLDecodeError, ValueError) as exc:
         print(f"release preflight failed: {exc}", file=sys.stderr)
         return 1
+
+    payload = {
+        "ok": True,
+        "version": version,
+        "tag": _normalize_tag(args.tag) if args.tag else None,
+        "pyproject": str(pyproject),
+        "changelog": str(changelog),
+    }
+
+    if args.format == "json":
+        text = json.dumps(payload, indent=2, sort_keys=True)
+        if args.out:
+            out_path = Path(args.out)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(f"{text}\n", encoding="utf-8")
+        else:
+            print(text)
+        return 0
 
     print(f"release preflight ok: version={version}")
     if args.tag:


### PR DESCRIPTION
### Motivation

- Preserve the highest-signal machine-readable outputs from failing CI gates so adopters can triage without long log searches. 
- Fast gate already emits `build/gate-fast.json` but security threshold and release preflight outputs were not consistently uploaded as artifacts. 
- Provide predictable artifact paths and light discoverability docs while keeping the change small and non-invasive. 

### Description

- CI fast lane (`.github/workflows/ci.yml`) now runs a non-blocking `python -m sdetkit security enforce --format json ... --out build/security-enforce.json` and uploads a consolidated artifact `ci-gate-diagnostics` containing `build/gate-fast.json` and `build/security-enforce.json` with `retention-days: 14`. 
- Release workflow (`.github/workflows/release.yml`) now runs `scripts/release_preflight.py` with `--format json --out build/release-preflight.json` and uploads it as `release-diagnostics` with `retention-days: 30`. 
- `scripts/release_preflight.py` gained `--format {text,json}` and `--out` support, emits a stable JSON payload when requested, and creates parent directories for the output path while preserving existing text-mode behavior. 
- Documentation updates: `docs/adoption.md`, `docs/adoption-troubleshooting.md`, and `README.md` include compact guidance pointing to artifact names/paths (`build/gate-fast.json`, `build/security-enforce.json`, `build/release-preflight.json`) and the corresponding GitHub Actions artifact names. 

### Testing

- Ran `python scripts/release_preflight.py --format json --out build/release-preflight.json` to produce `build/release-preflight.json` and the command succeeded. 
- Verified JSON formatting with `python -m json.tool build/release-preflight.json` and inspected pretty output successfully. 
- Compiled the modified script with `python -m compileall scripts/release_preflight.py` to validate syntax and it succeeded. 
- Confirmed workflow changes and docs references via greps and a small assertion script that validated `ci-gate-diagnostics` and `release-diagnostics` are present in the respective workflows, and all checks passed.

------