### PR TITLE
docs: map CI/release diagnostics artifacts to next remediation actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ For CI failure triage in this repository's GitHub Actions runs, inspect uploaded
 
 This keeps `failed_steps` and policy threshold outcomes easy to inspect without depending only on log scrolling.
 
+For an immediate "downloaded artifact -> next fix step" path, start at the **Artifact-to-action map** in `docs/adoption-troubleshooting.md`.
+
 ### Jenkins
 
 See `examples/ci/jenkins/`.

--- a/docs/adoption-troubleshooting.md
+++ b/docs/adoption-troubleshooting.md
@@ -29,6 +29,21 @@ If you are diagnosing a failed GitHub Actions run, download CI artifacts first:
 
 These files make `failed_steps` and threshold outcomes inspectable without scrolling long logs.
 
+## Artifact-to-action map (open this first after download)
+
+Use this table when you already downloaded artifacts and want the fastest next step.
+
+| Downloaded artifact | File to open first | Fields/signals to inspect first | Usually means | Go next |
+| --- | --- | --- | --- | --- |
+| `ci-gate-diagnostics` | `build/gate-fast.json` | `ok`, `failed_steps`, then `steps[]` entries (`id`, `ok`, `rc`) | Fast CI lane failed in one or more concrete checks (lint/type/tests/doctor/templates) | This page's matrix below, then [Remediation cookbook](remediation-cookbook.md#1-gate-fast-failed-on-ruff) section matching the first failed step |
+| `ci-gate-diagnostics` | `build/security-enforce.json` | `ok`, `counts`, `exceeded`, `limits` | Security threshold check is above current configured budget (commonly `info`) | [Remediation cookbook: security enforce failed due to strict thresholds](remediation-cookbook.md#4-security-enforce-failed-due-to-strict-thresholds) |
+| `release-diagnostics` | `build/release-preflight.json` | `ok`, `version`, `tag`, `pyproject`, `changelog` | Release metadata preflight passed for the resolved tag/version/changelog files | If later release steps fail, continue with release workflow logs and [Remediation cookbook: gate release / doctor --release failed](remediation-cookbook.md#5-gate-release--doctor---release-failed) |
+
+Practical order for `ci-gate-diagnostics`:
+
+1. Open `build/gate-fast.json` first (actionable `failed_steps` list).
+2. Then open `build/security-enforce.json` (budget posture: `counts` vs `limits`).
+
 ## Troubleshooting matrix
 
 | What you see | Usually means | What to do next | Stay lightweight vs tighten later |

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -49,7 +49,7 @@ python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.js
 
 Before changing your pipeline, check the focused troubleshooting matrix:
 
-- [Adoption troubleshooting](adoption-troubleshooting.md)
+- [Adoption troubleshooting](adoption-troubleshooting.md) (start with the **Artifact-to-action map** section if you downloaded CI artifacts).
 - [Remediation cookbook](remediation-cookbook.md) for copy-paste next-step playbooks after common failures.
 - Helps decide whether to fix quality debt now, tune a threshold temporarily, or stay on a lighter command.
 

--- a/docs/remediation-cookbook.md
+++ b/docs/remediation-cookbook.md
@@ -4,6 +4,8 @@ Use this page after your **first failed SDETKit command** in an external reposit
 
 It is intentionally compact: identify the failed step, run the safest next command, fix one class of issue, rerun.
 
+If you came from a downloaded GitHub Actions artifact, first map file -> next section in [Adoption troubleshooting](adoption-troubleshooting.md#artifact-to-action-map-open-this-first-after-download), then use the matching playbook here.
+
 ## 0) Start with machine-readable failure output
 
 ```bash


### PR DESCRIPTION
### Motivation
- Close the tiny but high-friction gap between "artifact downloaded" and "what do I open first / what matters" by giving users a compact, actionable map from CI/reported artifacts to the exact JSON file, the fields to inspect first, and the next remediation doc to follow.

### Description
- Add an **Artifact-to-action map** to `docs/adoption-troubleshooting.md` that lists `ci-gate-diagnostics` → `build/gate-fast.json` / `build/security-enforce.json` and `release-diagnostics` → `build/release-preflight.json`, the key fields to inspect (for example `failed_steps`, `ok`, `counts`, `exceeded`, `version`, `tag`), and the recommended next doc/playbook to consult.
- Add lightweight discoverability links so adopters are directed to the new artifact map from `docs/adoption.md`, `docs/remediation-cookbook.md`, and `README.md` without changing CI behavior or artifact formats.

### Testing
- Generated and inspected representative artifacts with: `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`, `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json`, and `python scripts/release_preflight.py --tag v1.0.2 --format json --out build/release-preflight.json`, and confirmed the expected JSON keys and contents were present.
- Verified workflow artifact names/paths and upload steps by scanning `.github/workflows/ci.yml` and `.github/workflows/release.yml`; confirmed docs refer to real files and fields (commands returned expected non-zero/zero RCs in this repo state).

------
