### PR TITLE
Docs: emphasize release-confidence core path and surface core commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@
 ![Repo Audit](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/repo-audit.yml/badge.svg?branch=main)
 ![Pages](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/pages.yml/badge.svg?branch=main)
 
-SDETKit helps **SDET, QA, and DevOps teams prove release confidence** with deterministic local/CI checks and audit-friendly evidence.
+SDETKit helps teams **prove release confidence** with deterministic checks and audit-friendly evidence.
+
+## What this is (10-second version)
+
+SDETKit is a release-confidence toolkit.
+
+It gives teams one repeatable answer to: **"Is this repository ready to ship?"**
+
+If you want one command path from quick confidence to a strict release gate (with evidence you can review later), start here.
 
 ## The one thing this repo is best at
 
@@ -24,7 +32,7 @@ This runs environment bootstrap + CI quick lane + coverage + security enforcemen
 
 ## Start here (first 5 minutes)
 
-### 1) Run the fastest path
+### 1) Run the fastest path (quick confidence)
 
 ```bash
 bash scripts/ready_to_use.sh quick
@@ -41,7 +49,7 @@ bash scripts/ready_to_use.sh quick
 
 If this command finishes, you have a working local gate path that mirrors CI expectations and gives deterministic pass/fail output.
 
-### 4) Next command
+### 4) Move to strict release gate
 
 ```bash
 bash scripts/ready_to_use.sh release
@@ -50,6 +58,18 @@ bash scripts/ready_to_use.sh release
 Use release mode when you want a stricter go/no-go decision before a release.
 
 Ready-to-use guide: `docs/ready-to-use.md`
+
+Release-confidence overview: `docs/release-confidence.md`
+
+## Core path (local and CI)
+
+Use this progression:
+
+1. **Quick confidence:** `bash scripts/ready_to_use.sh quick`
+2. **Strict release gate:** `bash scripts/ready_to_use.sh release`
+3. **Adopt in external repo:** `docs/adoption.md`
+
+This keeps the journey focused on release confidence first, then rollout.
 
 ## Adopt in your own repository (external integration)
 
@@ -125,7 +145,19 @@ python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --ma
 python -m sdetkit gate release
 ```
 
-## Explore core commands
+## Explore commands (core first)
+
+### Core release-confidence commands
+
+```bash
+bash scripts/ready_to_use.sh quick
+bash scripts/ready_to_use.sh release
+python -m sdetkit gate fast
+python -m sdetkit gate release
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+```
+
+### Broader toolkit commands
 
 ```bash
 python -m sdetkit --help

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,4 +1,14 @@
 # CLI
+
+## Start with these core release-confidence commands
+
+- `bash scripts/ready_to_use.sh quick`
+- `bash scripts/ready_to_use.sh release`
+- `sdetkit gate fast`
+- `sdetkit gate release`
+- `sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`
+
+## Broader command catalog
 - `sdetkit baseline write`
 - `sdetkit baseline check`
 - `sdetkit baseline check --format json`

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,9 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 
 <div class="hero-actions" markdown>
 
-[Start in 5 minutes](#start-in-5-minutes){ .md-button .md-button--primary }
+[Start in 5 minutes](#fast-start){ .md-button .md-button--primary }
 [Open quickstart](ready-to-use.md){ .md-button }
+[Release confidence story](release-confidence.md){ .md-button }
 [Adopt in your repo](adoption.md){ .md-button }
 [Adoption troubleshooting](adoption-troubleshooting.md){ .md-button }
 [See examples](examples.md){ .md-button }
@@ -25,7 +26,7 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 
 </div>
 
-## Start in 5 minutes
+## Fast start
 
 Run the flagship workflow:
 
@@ -49,6 +50,14 @@ bash scripts/ready_to_use.sh release
 ### What proves value quickly
 
 You get deterministic pass/fail output and a clear go/no-go signal you can reuse in local and CI workflows.
+
+## Core path
+
+Use this sequence to keep rollout focused:
+
+1. **Quick confidence** via `bash scripts/ready_to_use.sh quick`
+2. **Strict release gate** via `bash scripts/ready_to_use.sh release`
+3. **External adoption** via [adoption.md](adoption.md)
 
 ## Flagship workflow (manual form)
 
@@ -75,3 +84,24 @@ python -m sdetkit gate release
 - [First contribution quickstart](first-contribution-quickstart.md)
 - [Contributing](contributing.md)
 - [Full command reference](cli.md)
+
+<div class="quick-jump" markdown>
+
+### Top journeys
+
+- Run first command in under 60 seconds
+- Validate docs links and anchors before publishing
+- Ship a first contribution with deterministic quality gates
+
+- [⚡ Fast start](#fast-start)
+- [🛠 CLI commands](cli.md)
+- [🩺 Doctor checks](doctor.md)
+- [🤝 Contribute](contributing.md)
+- [🧭 Repo tour](repo-tour.md)
+- [📦 Legacy reports](#legacy-reports)
+
+</div>
+
+## Legacy reports
+
+Historical day-by-day upgrade reports remain available for audit trails and prior initiative context.

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -1,8 +1,8 @@
 # Ready-to-use setup (start working in minutes)
 
-Use this guide when you want a practical, production-focused start without learning the entire repository first.
+Use this guide when you want a practical start to release confidence without learning the entire repository first.
 
-## Fast start (recommended)
+## Fast start (recommended, under 5 minutes)
 
 ```bash
 bash scripts/ready_to_use.sh quick
@@ -36,11 +36,17 @@ Use this when you need production-quality release evidence.
 
 ## Next actions after setup
 
+Follow the core path:
+
+1. `bash scripts/ready_to_use.sh quick`
+2. `bash scripts/ready_to_use.sh release`
+3. Adopt in another repository with [adoption.md](adoption.md)
+
+Then explore broader commands if needed:
+
 - Explore command groups: `python -m sdetkit --help`
 - See playbooks: `python -m sdetkit playbooks`
-- Read strategy context:
-  - `docs/product-strategy.md`
-  - `docs/global-production-transformation-playbook.md`
+- Read release-confidence narrative: [release-confidence.md](release-confidence.md)
 
 ## Using this in another repository
 

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -1,0 +1,54 @@
+# Release confidence with SDETKit
+
+SDETKit exists for one primary outcome: help teams make a release decision with deterministic checks and audit-friendly evidence.
+
+## Core idea
+
+Use one repeatable command path to answer:
+
+**"Is this repository ready to ship?"**
+
+## Why this instead of separate tools
+
+Many teams already run linting, tests, and scanners. The gap is usually release decision clarity.
+
+SDETKit focuses that gap by combining:
+
+- deterministic gate commands with stable exit behavior
+- strict release policies (`gate release`, security budgets)
+- evidence-oriented outputs for post-run review
+
+This turns scattered checks into a consistent go/no-go workflow.
+
+## The core path
+
+For new users and adopters, use this sequence:
+
+1. **Quick confidence**
+
+   ```bash
+   bash scripts/ready_to_use.sh quick
+   ```
+
+2. **Strict release gate**
+
+   ```bash
+   bash scripts/ready_to_use.sh release
+   ```
+
+3. **Adopt in external repository**
+
+   Follow [adoption.md](adoption.md) for copy-paste rollout in CI and local workflows.
+
+## Who gets the most value
+
+- SDET/QA teams needing deterministic pass/fail gates
+- Platform/DevOps teams enforcing policy-aware release checks in CI
+- Maintainers who need audit-friendly artifacts for release review
+
+## Start here
+
+- Quickstart: [ready-to-use.md](ready-to-use.md)
+- External rollout: [adoption.md](adoption.md)
+- First-failure triage: [adoption-troubleshooting.md](adoption-troubleshooting.md)
+- Practical scenarios: [examples.md](examples.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: DevS69 SDETKit
-site_description: Production-ready SDET + DevOps toolkit with deterministic quality, security, and release workflows.
+site_description: Release-confidence toolkit with deterministic checks and audit-friendly evidence.
 site_url: https://sherif69-sa.github.io/DevS69-sdetkit/
 repo_name: sherif69-sa/DevS69-sdetkit
 repo_url: https://github.com/sherif69-sa/DevS69-sdetkit
@@ -83,6 +83,7 @@ extra_javascript:
 nav:
   - Home: index.md
   - Quickstart: ready-to-use.md
+  - Release confidence: release-confidence.md
   - Adopt in your repository: adoption.md
   - Adoption troubleshooting: adoption-troubleshooting.md
   - Remediation cookbook: remediation-cookbook.md


### PR DESCRIPTION
### Motivation
- Clarify and tighten the project messaging to emphasize the repo's primary outcome: a repeatable "release confidence" path. 
- Make the core user journey and commands easier to discover for new users and adopters. 
- Add a focused narrative page that explains the release-confidence concept and links to fast/strict workflows.

### Description
- Reworked `README.md` to simplify the intro, highlight the one-command release-confidence flow, and surface the quick and release paths. 
- Added `docs/release-confidence.md` as a new explanatory page that documents the core idea, value, and recommended sequence (`bash scripts/ready_to_use.sh quick` then `bash scripts/ready_to_use.sh release`). 
- Updated docs pages (`docs/cli.md`, `docs/index.md`, `docs/ready-to-use.md`) to show the core commands up-front, refine headings, add a quick-jump/core-path section, and adjust copy for consistency. 
- Updated `mkdocs.yml` to include the new page in the navigation and to revise the `site_description`.

### Testing
- Built the documentation site locally with `mkdocs build` to validate the updated pages and navigation, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0f95a2fec832790e64494d44d4359)