### PR TITLE
docs: fix broken anchor link to remediation cookbook

### DIFF
--- a/docs/adoption-troubleshooting.md
+++ b/docs/adoption-troubleshooting.md
@@ -37,7 +37,7 @@ Use this table when you already downloaded artifacts and want the fastest next s
 | --- | --- | --- | --- | --- |
 | `ci-gate-diagnostics` | `build/gate-fast.json` | `ok`, `failed_steps`, then `steps[]` entries (`id`, `ok`, `rc`) | Fast CI lane failed in one or more concrete checks (lint/type/tests/doctor/templates) | This page's matrix below, then [Remediation cookbook](remediation-cookbook.md#1-gate-fast-failed-on-ruff) section matching the first failed step |
 | `ci-gate-diagnostics` | `build/security-enforce.json` | `ok`, `counts`, `exceeded`, `limits` | Security threshold check is above current configured budget (commonly `info`) | [Remediation cookbook: security enforce failed due to strict thresholds](remediation-cookbook.md#4-security-enforce-failed-due-to-strict-thresholds) |
-| `release-diagnostics` | `build/release-preflight.json` | `ok`, `version`, `tag`, `pyproject`, `changelog` | Release metadata preflight passed for the resolved tag/version/changelog files | If later release steps fail, continue with release workflow logs and [Remediation cookbook: gate release / doctor --release failed](remediation-cookbook.md#5-gate-release--doctor---release-failed) |
+| `release-diagnostics` | `build/release-preflight.json` | `ok`, `version`, `tag`, `pyproject`, `changelog` | Release metadata preflight passed for the resolved tag/version/changelog files | If later release steps fail, continue with release workflow logs and [Remediation cookbook: gate release / doctor --release failed](remediation-cookbook.md#5-gate-release-doctor-release-failed) |
 
 Practical order for `ci-gate-diagnostics`:
 


### PR DESCRIPTION
### Motivation
- Resolve a known docs QA failure where `docs/adoption-troubleshooting.md` contained a broken internal anchor link to the release remediation section so docs validation is trustworthy again.

### Description
- Edited `docs/adoption-troubleshooting.md` to update the remediation-cookbook link fragment from `#5-gate-release--doctor---release-failed` to the actual generated slug `#5-gate-release-doctor-release-failed`, touching only that single link and no other content.

### Testing
- Ran `python -m sdetkit docs-qa --format text` and it passed (no issues reported).
- Ran `python -m sdetkit docs-nav --format text` and it passed (navigation score 100.0).
- Ran `mkdocs build --strict` and the site built successfully (the Material theme warning is informational and did not cause failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1012c56a88327aeeb64406e90f5ae)