### PR TITLE
docs: add recommended baseline CI flow for team adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ python -m pip install .[packaging]
 For teams adopting SDETKit in another repository, start with:
 
 - `docs/adoption.md` for copy-paste local and GitHub Actions workflows.
+- `docs/recommended-ci-flow.md` for the recommended baseline CI shape (PR fast feedback, stricter `main`, release-oriented checks).
 - First gate: `python -m sdetkit gate fast`
 - Stricter rollout: security budgets + `python -m sdetkit gate release`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ python -m sdetkit gate release
 
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Adopt in your repository](adoption.md)
+- [Recommended CI flow (baseline)](recommended-ci-flow.md)
 - [Example adoption flow](example-adoption-flow.md)
 - [Adoption troubleshooting](adoption-troubleshooting.md)
 - [Release-confidence examples](examples.md)

--- a/docs/recommended-ci-flow.md
+++ b/docs/recommended-ci-flow.md
@@ -1,0 +1,173 @@
+# Recommended CI flow for team adoption
+
+This page is the **recommended baseline** for operationalizing SDETKit in GitHub Actions with minimal friction.
+
+It is intentionally small and derived from this repository's current CI/release patterns in:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `docs/adoption.md`
+
+## Recommended shape
+
+Use three stages:
+
+1. **Pull requests (fast feedback):** block on `gate fast`; always upload fast diagnostics.
+2. **`main` branch (stricter confidence):** keep fast gate, then run security thresholds + full quality/docs checks.
+3. **Release tags (release-oriented):** run release preflight + build validation + wheel smoke before publish.
+
+This gives teams quick PR signal, stronger merge confidence, and explicit release controls without forcing strict release checks on every feature branch.
+
+## Minimal baseline workflow (GitHub Actions)
+
+```yaml
+name: sdetkit-recommended-baseline
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+
+jobs:
+  pr-and-main:
+    if: github.ref_type != 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install project + CI extras
+        run: python -m pip install -e .[dev,test,docs]
+
+      # Fast PR-safe gate (also emits JSON when artifact-dir is set)
+      - name: Fast gate
+        run: bash ci.sh quick --skip-docs --artifact-dir build
+
+      # Keep threshold evidence even when gate fails
+      - name: Security diagnostics (non-blocking)
+        if: always()
+        continue-on-error: true
+        run: python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
+
+      # Tighten only on main
+      - name: Main branch stricter checks
+        if: github.ref == 'refs/heads/main'
+        env:
+          COV_FAIL_UNDER: "95"
+        run: |
+          python -m pre_commit run -a
+          bash quality.sh cov
+          NO_MKDOCS_2_WARNING=1 python -m mkdocs build
+
+      - name: Upload CI diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-gate-diagnostics
+          path: |
+            build/gate-fast.json
+            build/security-enforce.json
+          if-no-files-found: warn
+
+  release:
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install release tooling
+        run: python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .[packaging]
+      - name: Release preflight + package validation
+        run: |
+          mkdir -p build
+          python scripts/release_preflight.py --tag "${GITHUB_REF_NAME}" --format json --out build/release-preflight.json
+          python scripts/check_release_tag_version.py "${GITHUB_REF_NAME}"
+          python -m build
+          python -m twine check dist/*
+          python -m check_wheel_contents --ignore W009 dist/*.whl
+          python -m pip install --force-reinstall dist/*.whl
+          sdetkit --help
+      - name: Upload release diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-diagnostics
+          path: build/release-preflight.json
+          if-no-files-found: warn
+```
+
+## Stage-by-stage command recommendations
+
+### Pull requests (fast feedback)
+
+- `bash ci.sh quick --skip-docs --artifact-dir build`
+- `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json` (non-blocking diagnostics)
+
+Why: fast and deterministic contributor signal, with triage-ready JSON artifacts.
+
+### `main` branch (stricter checks)
+
+Keep PR commands, then add:
+
+- `python -m pre_commit run -a`
+- `bash quality.sh cov`
+- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build`
+
+Why: stronger confidence on integrated code without slowing every PR.
+
+### Release-oriented workflow (tags)
+
+- `python scripts/release_preflight.py --tag "${GITHUB_REF_NAME}" --format json --out build/release-preflight.json`
+- `python scripts/check_release_tag_version.py "${GITHUB_REF_NAME}"`
+- `python -m build`
+- `python -m twine check dist/*`
+- `python -m check_wheel_contents --ignore W009 dist/*.whl`
+- `python -m pip install --force-reinstall dist/*.whl && sdetkit --help`
+
+Why: explicit release metadata validation + package integrity + installability proof.
+
+## Artifacts to preserve
+
+For CI failure triage and release reviews, keep:
+
+- `build/gate-fast.json` (fast lane failed step details)
+- `build/security-enforce.json` (threshold counts/exceeded budgets)
+- `build/release-preflight.json` (release metadata status)
+
+Recommended upload names:
+
+- `ci-gate-diagnostics`
+- `release-diagnostics`
+
+## Progressive adoption path
+
+1. **Week 1:** PR-only `gate fast` with diagnostics upload.
+2. **Week 2:** Add security threshold diagnostics, then enforce stricter thresholds once noise is reduced.
+3. **Week 3+:** Apply stricter `main` checks (coverage/docs/pre-commit).
+4. **Release maturity:** Add tag-triggered release preflight + package validation.
+
+This sequencing avoids "all-at-once" CI pain while still moving toward deterministic release confidence.
+
+## When checks fail
+
+- **Fast gate failed:** open `build/gate-fast.json`; fix the first failing step before broad refactors.
+- **Security threshold exceeded:** open `build/security-enforce.json`; either remediate findings or temporarily tune thresholds with an explicit follow-up issue.
+- **Release preflight failed:** open `build/release-preflight.json`; fix tag/version metadata mismatch first.
+
+For remediation playbooks, use:
+
+- `docs/adoption-troubleshooting.md`
+- `docs/remediation-cookbook.md`
+
+## Keep it lighter for smaller repositories
+
+If your repo is small or early-stage, keep only:
+
+- PR: `python -m sdetkit gate fast`
+- Optional JSON artifact: `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`
+
+Delay coverage/doc/release packaging jobs until the fast lane is stable and trusted by the team.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
   - Quickstart: ready-to-use.md
   - Release confidence: release-confidence.md
   - Adopt in your repository: adoption.md
+  - Recommended CI flow (baseline): recommended-ci-flow.md
   - Example adoption flow: example-adoption-flow.md
   - Evidence showcase: evidence-showcase.md
   - Adoption troubleshooting: adoption-troubleshooting.md


### PR DESCRIPTION
### Motivation

- Provide one concise, copy‑pasteable CI example that shows a practical, minimal, and credible way teams should adopt SDETKit in GitHub Actions. 
- Keep scope focused on a single recommended path derived from the repository's existing CI and release patterns, avoiding broad multi‑provider guidance.

### Description

- Added `docs/recommended-ci-flow.md` containing a short GitHub Actions YAML baseline and stage-by-stage recommendations (PR fast feedback, stricter `main`, and tag‑triggered release checks). 
- Documented which commands to run in each stage and which artifacts to preserve (`build/gate-fast.json`, `build/security-enforce.json`, `build/release-preflight.json`) and provided a progressive adoption path and failure remediation pointers. 
- Added discoverability links to `README.md`, `docs/index.md`, and `mkdocs.yml` so the new guide is visible in the docs site navigation. 
- The example is explicitly described as a recommended baseline and is derived from `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `docs/adoption.md` to stay aligned with existing repo behaviour.

### Testing

- Verified CLI and script commands used in the doc: `python -m sdetkit --help`, `python scripts/release_preflight.py --help`, `python scripts/check_release_tag_version.py v1.0.2`, `python -m sdetkit security enforce --help`, `python -m pre_commit --version`, `python -m build --version`, `python -m twine --version`, `python -m check_wheel_contents --help`, `python -m pip install -e .[packaging]` and `sdetkit --help` after wheel install; all succeeded for the help/version checks and packaging helpers. 
- Ran repo documentation checks: `python -m sdetkit docs-qa --format text` and `NO_MKDOCS_2_WARNING=1 python -m mkdocs build`; both passed and the site built (mkdocs reported the new page exists but was not in nav until updated). 
- Executed the in‑repo CI quick command `bash ci.sh quick --skip-docs --artifact-dir build`; the command is valid and produced diagnostics but the run failed due to existing lint failures (`ruff` / `ruff_format`) in the repository (reported as `gate fast: FAIL` and `failed_steps: - ruff - ruff_format`). 
- Note: `bash ci.sh quick` failure is a validation of the example commands against the current repo state and not caused by the documentation change; the doc documents how to triage such failures and which artifacts to consult.

------