### PR TITLE
docs: add capstone decision guide for evaluator fit and adoption path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Most repositories accumulate separate scripts and tools, but the release decisio
 
 Choose the path that matches where you are now:
 
+### 0) Decide if SDETKit is a fit
+
+- Decision guide: `docs/decision-guide.md`
+
 ### 1) Evaluate a repository quickly
 
 ```bash
@@ -57,6 +61,7 @@ Comparison and proof details: `docs/why-not-just-tools.md`
 
 ## How to navigate SDETKit
 
+- Decision guide (fit + path + stop point): `docs/decision-guide.md`
 - Adoption walkthrough: `docs/example-adoption-flow.md`
 - Real artifact output showcase: `docs/evidence-showcase.md`
 - Command taxonomy: `docs/command-taxonomy.md`

--- a/docs/decision-guide.md
+++ b/docs/decision-guide.md
@@ -1,0 +1,99 @@
+# Is SDETKit right for your repo? (Decision Guide)
+
+Use this page to make a fast, technical decision: **fit, first path, and stop point**.
+
+SDETKit is a layered **release-confidence and engineering-operations toolkit**. It is strongest when you need deterministic checks, reusable evidence, and a repeatable operator workflow across local and CI usage.
+
+## 1) Good-fit profile
+
+SDETKit is usually a good fit when at least one of these is true:
+
+| Repo/team profile | Why SDETKit fits |
+| --- | --- |
+| Solo maintainer on a growing repo | You want one repeatable command path instead of remembering scattered scripts and tool flags. |
+| Repo owner improving release confidence | You need a clearer go/no-go signal than ad hoc interpretation of multiple tool outputs. |
+| QA/SDET/reliability-minded team | You want deterministic, policy-aware checks and consistent evidence artifacts for triage/audits. |
+| Team standardizing checks/evidence/CI | You want the same operator workflow locally and in CI, with machine-readable outputs. |
+| Advanced operator with broader workflow needs | You want access to a larger command surface (`doctor`, `repo`, `security`, `evidence`, `report`, `ops`) beyond a single gate command. |
+
+## 2) When SDETKit is probably *not* worth it
+
+SDETKit may be unnecessary if:
+
+- Your repo is very small/simple and release risk is low.
+- You only want raw underlying tools and prefer to wire everything manually.
+- Your team is not willing to adopt an opinionated workflow and shared command conventions.
+- You are not ready for a broader command surface beyond a minimal one-off check.
+
+If these apply, run only the lightweight path first (below), then stop unless you see clear repeatability or release-confidence gaps.
+
+## 3) Choose your entry path
+
+Pick one path based on what you need to answer first.
+
+| If you need to... | Start here | Then go to |
+| --- | --- | --- |
+| Evaluate quickly | `bash scripts/ready_to_use.sh quick` | [Ready-to-use quickstart](ready-to-use.md) |
+| Inspect proof/artifacts before adopting | [Evidence showcase](evidence-showcase.md) | [Release confidence](release-confidence.md) |
+| Understand capability breadth | [Command taxonomy](command-taxonomy.md) | [CLI reference](cli.md) |
+| Adopt in CI with low risk | [Recommended CI flow](recommended-ci-flow.md) | [Adoption guide](adoption.md) |
+| Go deeper into broader workflows | [Example adoption flow](example-adoption-flow.md) | [Ops control plane](ops.md) + [Evidence pack](evidence.md) |
+
+## 4) Manual scattered workflow vs SDETKit workflow
+
+A fair comparison for evaluator teams:
+
+| Dimension | Manual scattered workflow | SDETKit workflow |
+| --- | --- | --- |
+| Command execution | Multiple tools/scripts, order depends on operator memory | Shared command lanes (`quick`, `release`) and CLI gates |
+| Output consistency | Mixed formats and ad hoc interpretation | Deterministic pass/fail plus structured evidence outputs |
+| Triage speed | Context spread across logs and tool-specific outputs | Standardized command path and artifact-oriented troubleshooting |
+| CI portability | Each repo reinvents wiring | Reusable adoption path and recommended CI baseline |
+| Repeatability | Varies by engineer and repo maturity | Higher consistency through a defined operator experience |
+| Trade-off | Maximum flexibility, more coordination overhead | More opinionated model, broader surface area to learn |
+
+SDETKit does **not** replace every underlying tool; it standardizes how they are orchestrated and interpreted for release-confidence decisions.
+
+## 5) First-time evaluator: do this first, second, third
+
+1. **Run a quick evaluation**
+   ```bash
+   bash scripts/ready_to_use.sh quick
+   ```
+2. **Run the stricter release-confidence lane**
+   ```bash
+   bash scripts/ready_to_use.sh release
+   ```
+3. **Choose adoption depth**
+   - Lightweight CI rollout: [Recommended CI flow](recommended-ci-flow.md)
+   - Broader operator workflow: [Example adoption flow](example-adoption-flow.md)
+
+## 6) Proof checklist before adopting
+
+Before standardizing on SDETKit, inspect these pages:
+
+- [Release-confidence model and lanes](release-confidence.md)
+- [System-value comparison: why not just separate tools?](why-not-just-tools.md)
+- [Representative adoption walkthrough](example-adoption-flow.md)
+- [Evidence/artifact showcase](evidence-showcase.md)
+- [Capability map and command taxonomy](command-taxonomy.md)
+- [Recommended CI baseline](recommended-ci-flow.md)
+- [CLI command reference](cli.md)
+
+This sequence is intentional: decision model -> proof -> adoption route -> command depth.
+
+## 7) “Stop here” point (lightweight path)
+
+Stop after the lightweight path if all of the following are true:
+
+- `quick` and `release` already match your confidence needs,
+- you do not need broader operator domains right now,
+- and your team is not yet ready to standardize the full command surface.
+
+In that case, keep using:
+
+- `bash scripts/ready_to_use.sh quick`
+- `bash scripts/ready_to_use.sh release`
+- [Recommended CI flow](recommended-ci-flow.md)
+
+Return to broader docs only when coordination overhead, triage inconsistency, or evidence/governance needs increase.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 <div class="hero-actions" markdown>
 
 [Start in 5 minutes](#fast-start){ .md-button .md-button--primary }
+[Decision guide](decision-guide.md){ .md-button }
 [Open quickstart](ready-to-use.md){ .md-button }
 [Release confidence story](release-confidence.md){ .md-button }
 [Adopt in your repo](adoption.md){ .md-button }
@@ -76,6 +77,7 @@ python -m sdetkit gate release
 
 ## Next steps
 
+- [Decision guide: is SDETKit right for you?](decision-guide.md)
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Adopt in your repository](adoption.md)
 - [Recommended CI flow (baseline)](recommended-ci-flow.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ extra_javascript:
 
 nav:
   - Home: index.md
+  - Decision guide: decision-guide.md
   - Quickstart: ready-to-use.md
   - Release confidence: release-confidence.md
   - Adopt in your repository: adoption.md


### PR DESCRIPTION
### Motivation

- Provide a single capstone decision page that helps a skeptical engineer quickly decide if SDETKit is a fit, which first path to take, and when to stop using only the lightweight path. 
- Tie together existing proof assets (release-confidence, evidence, command taxonomy, adoption flow, recommended CI) without changing code behavior or command names.
- Preserve a technically honest orientation by calling out fit vs non-fit scenarios and routing evaluators to real proofs and commands.

### Description

- Add `docs/decision-guide.md` as the new capstone decision/evaluator page covering fit profile, non-fit boundaries, entry-path matrix, manual-vs-SDETKit comparison, a 3-step first evaluator path, proof checklist, and a clear stop point. 
- Wire the new page into discovery surfaces by adding a `Decision guide` hero button and next-step link in `docs/index.md`, adding a top-level nav entry in `mkdocs.yml`, and adding routing references in `README.md`. 
- Keep changes intentionally small and discovery-focused with no behavioral changes to scripts or commands, and no renames/removals of existing commands. 
- Targeted routing emphasizes existing assets: `docs/release-confidence.md`, `docs/evidence-showcase.md`, `docs/command-taxonomy.md`, `docs/example-adoption-flow.md`, and `scripts/ready_to_use.sh` (`quick`/`release`) and `python -m sdetkit gate release` usage.

### Testing

- Ran `python -m mkdocs build --strict` which completed successfully (build succeeded; a pre-existing Material-for-MkDocs 2.0 warning was emitted). 
- Verified internal links referenced from `docs/decision-guide.md` resolve to existing files using a small link-check script, with no missing targets. 
- Verified referenced commands and paths exist by grepping for `bash scripts/ready_to_use.sh quick`, `bash scripts/ready_to_use.sh release`, and `python -m sdetkit gate release` across `scripts`, `docs`, and `README.md`. 
- Confirmed no code or command behavior was modified and documentation changes are limited to the new guide and minimal routing updates in `README.md`, `docs/index.md`, and `mkdocs.yml`.

------