### PR TITLE
Add productization boundary audit and target taxonomy map

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Comparison and proof details: `docs/why-not-just-tools.md`
 - External repository adoption: `docs/adoption.md`
 - Troubleshooting first failures: `docs/adoption-troubleshooting.md`
 - Scenario-based proof examples: `docs/examples.md`
+- Product boundary audit and taxonomy plan: `docs/productization-map.md`
 
 Docs portal: <https://sherif69-sa.github.io/DevS69-sdetkit/>
 

--- a/docs/productization-map.md
+++ b/docs/productization-map.md
@@ -1,0 +1,194 @@
+# Productization map: release confidence / shipping readiness
+
+## Purpose
+
+This document is a **product-boundary audit** of the current repository and a concrete map for evolving SDETKit into a globally adoptable product centered on one flagship promise:
+
+> **Release confidence / shipping readiness for software teams.**
+
+This is an inspection and planning artifact. It does **not** propose broad refactors or functionality removal.
+
+## 1) Current-state audit
+
+## Repository shape (what exists today)
+
+- Runtime package code sits in `src/sdetkit/` with a very broad command surface routed by `src/sdetkit/cli.py`.
+- The top-level UX is already release-confidence oriented in `README.md` (`ready_to_use.sh quick` and `ready_to_use.sh release`).
+- Documentation is extensive (`docs/`), but currently mixes:
+  - core user journeys,
+  - reference docs,
+  - integration guides,
+  - a large archive of day-based reports and closeout pages.
+- `scripts/` includes both core workflows (`ready_to_use.sh`, `check.sh`, `bootstrap.sh`) and many day-specific contract checks.
+
+## Package and command surface observations
+
+## Stable/public-facing feeling areas
+
+These appear closest to stable product surface:
+
+- Core release flow:
+  - `gate`, `doctor`, `security`, `evidence`
+  - wrapper script `scripts/ready_to_use.sh` with `quick` and `release` lanes.
+- Supporting operational surface:
+  - `repo`, `ci`, `maintenance`, `policy`, `report`, `production-readiness`.
+- Practical utility commands with clear contracts:
+  - `kv`, `apiget`, `patch`, `cassette-get`.
+
+## Confusing/overlapping/internal-feeling areas
+
+- Very large set of day/closeout command modules in `src/sdetkit/` (for example `day28_*` through `day97_*` and many `*_closeout` modules).
+- CLI has to hide many commands from main help, which is itself a signal that product boundaries are still blurred.
+- Docs navigation includes strong flagship pages plus a very large historical/report corpus in the same visible namespace.
+- Command naming has overlap in places (`weekly-review`, `weekly-review-lane`, cycle-specific closeouts), which can feel incubator-like to external adopters.
+
+## 2) Classification of current contents (core / integrations / playbooks / experimental)
+
+Classification is based on current repository contents and naming patterns.
+
+## Core
+
+**Definition:** mandatory, high-confidence paths directly tied to release confidence / shipping readiness.
+
+- Runtime commands and modules:
+  - `gate`, `doctor`, `security`, `evidence`, `production_readiness`, `repo`, `ci`, `policy`, `report`.
+- Wrapper workflows:
+  - `scripts/ready_to_use.sh`, `ci.sh`, `quality.sh`, `security.sh`, `scripts/check.sh`.
+- Primary docs:
+  - `README.md`, `docs/index.md`, `docs/ready-to-use.md`, `docs/release-confidence.md`, `docs/decision-guide.md`, `docs/recommended-ci-flow.md`, `docs/adoption.md`, `docs/adoption-troubleshooting.md`.
+
+## Integrations
+
+**Definition:** ecosystem connectors and platform-specific interoperability that extend the core.
+
+- CLI/module areas:
+  - `agent/*`, `notify`, `notify_plugins`, `plugin_system`, `plugins`, `github_actions_quickstart`, `gitlab_ci_quickstart`, `n8n` docs, omnichannel/bridge docs.
+- Packaging extras and entry points indicating external systems:
+  - optional dependencies for Telegram and WhatsApp.
+- Example integration assets:
+  - `examples/ci/*`, template-related CI docs/pages.
+
+## Playbooks
+
+**Definition:** guided rollout/use-case workflows for adoption and organizational execution.
+
+- Named playbook modules:
+  - `onboarding`, `weekly_review`, `demo`, `proof`, `first_contribution`, `contributor_funnel`, `triage_templates`, `startup_use_case`, `enterprise_use_case`.
+- Rollout-oriented narrative modules:
+  - `release_narrative`, `release_readiness_board`, `reliability_evidence_pack`, `quality_contribution_delta`, `faq_objections`, `community_activation`, `external_contribution_push`, `kpi_audit`.
+- Playbook discovery/routing:
+  - `playbooks_cli.py`, `sdetkit playbooks`.
+
+## Experimental
+
+**Definition:** incubator/history-heavy surfaces that are useful but should not define first-time product identity.
+
+- Most `dayNN_*` and `*_closeout` modules in `src/sdetkit/`.
+- Day-based contract scripts in `scripts/check_day*.py` and cycle-specific closeout checks.
+- Large archive of day-based docs and integration closeout pages in `docs/`.
+- Long-tail command aliases and hidden command behavior currently needed to keep main help usable.
+
+## 3) Public/stable vs unclear boundary statement
+
+## Treat as public/stable now
+
+- `sdetkit gate ...`
+- `sdetkit doctor ...`
+- `sdetkit security ...`
+- `sdetkit evidence ...`
+- `sdetkit repo ...`
+- `sdetkit ci ...`
+- `scripts/ready_to_use.sh quick|release`
+
+## Treat as "advanced but supported"
+
+- `policy`, `report`, `maintenance`, `ops`, `notify`, `agent`, integration quickstarts.
+
+## Treat as incubator/legacy lane (explicit opt-in)
+
+- Day/cycle/closeout command family and matching day-report documentation.
+- Campaign-style command names where scope is phase-specific rather than evergreen.
+
+## 4) Proposed target taxonomy (for future productization)
+
+Keep implementation mostly where it is for now, but define a target taxonomy to guide future incremental changes.
+
+## Runtime package taxonomy (target)
+
+```text
+sdetkit/
+  core/           # release gate, doctor, security, evidence, readiness contracts
+  integrations/   # CI providers, chat/notify adapters, external connectors, plugin adapters
+  playbooks/      # guided onboarding, rollout, adoption, governance playbooks
+  experimental/   # incubator lanes, day/cycle closeouts, unstable aliases
+  cli/            # user-facing command routing (thin), help profiles, command visibility policy
+```
+
+Notes:
+- This is a target map, not a migration request in this PR.
+- Existing modules can be progressively wrapped/aliased into this taxonomy over multiple small PRs.
+
+## CLI taxonomy (target)
+
+Top-level command groups should converge toward:
+
+1. `sdetkit core ...` (or continue top-level aliases) for release-confidence essentials.
+2. `sdetkit integrations ...` for external systems/platform connectors.
+3. `sdetkit playbooks ...` for guided outcomes.
+4. `sdetkit experimental ...` for explicit incubator access.
+
+Maintain backwards compatibility by keeping existing commands as aliases during transition.
+
+## 5) Proposed docs information architecture (few top-level journeys)
+
+Recommended top-level docs journeys:
+
+1. **Start here (5 minutes)**
+   - Quick confidence, release gate, and first pass/fail interpretation.
+2. **Adopt in CI/CD**
+   - GitHub/GitLab/Jenkins templates, rollout order, troubleshooting.
+3. **Operate at scale**
+   - Evidence packs, policy, reporting, governance patterns.
+4. **Integrations**
+   - Notifications, agent/automation bridges, plugin adapters.
+5. **Playbooks**
+   - Outcome-based guided lanes (onboarding, contribution, reliability narratives, etc.).
+6. **Experimental / archive**
+   - Day/cycle closeout history and incubator commands, clearly marked as non-primary.
+
+Practical IA rule:
+- Keep only journeys 1-4 prominently in README and docs landing pages.
+- Link playbooks as guided optional paths.
+- Keep experimental/archive content accessible but visually de-emphasized.
+
+## 6) Recommended follow-up sequence (next PRs)
+
+1. **Boundary declaration PR**
+   - Add a concise "stability levels" doc and link it from README + docs index.
+2. **CLI discoverability PR**
+   - Introduce clearer help grouping that labels commands as Core / Integrations / Playbooks / Experimental.
+3. **Docs IA PR**
+   - Reorganize MkDocs nav to foreground 3-5 flagship journeys and move day/cycle history under archive sections.
+4. **Compatibility PR**
+   - Add explicit alias/compatibility matrix for legacy day/closeout commands.
+5. **Incremental module convergence PRs**
+   - Move only a few modules at a time toward target taxonomy with tests and deprecation notes.
+
+## 7) Key risks and ambiguities
+
+- **Risk: product identity dilution.** The breadth of commands and day-history artifacts can overshadow the flagship release-confidence promise.
+- **Risk: accidental breaking change.** Aggressive command cleanup could break existing automation that depends on legacy names.
+- **Risk: docs overload for first-time users.** Too many equally prominent pages slows adoption.
+- **Ambiguity: long-term status of day/closeout modules.** Need maintainers to decide: archive-only, supported-long-tail, or scheduled deprecation.
+- **Ambiguity: naming end-state.** Whether to keep flat top-level commands forever or migrate to grouped command namespaces with aliases.
+
+## 8) Decision checkpoints for maintainers
+
+Before implementation-heavy refactors, explicitly decide:
+
+1. Which commands are "public/stable" with compatibility guarantees.
+2. Which commands are "supported/advanced" without long-term frozen interfaces.
+3. Which commands are "experimental/incubator" and may change quickly.
+4. Documentation SLA for each tier (full docs vs brief reference vs archive-only).
+
+Those decisions will reduce future refactor risk and let SDETKit scale as a product with a clearer boundary contract.


### PR DESCRIPTION
### Motivation

- Clarify the repository's product boundary so the project can be evolved deliberately around the flagship promise: "release confidence / shipping readiness for software teams." 
- Provide a low-risk, reviewable planning artifact to guide incremental productization without changing runtime behavior.

### Description

- Add `docs/productization-map.md` which contains a current-state audit, a classification into `core` / `integrations` / `playbooks` / `experimental`, a proposed target runtime/CLI taxonomy, a recommended docs information architecture, follow-up sequence, and key risks and decision checkpoints. 
- Small README improvement that adds a navigation link to `docs/productization-map.md` so the productization plan is discoverable from the main entrypoint. 
- No functional code changes, no removals, and no large refactors are included in this change.

### Testing

- Ran the CLI help sanity check with `python -m sdetkit --help`, which executed successfully and produced the expected top-level help output. 
- No unit tests or behavioral changes were introduced or required by this documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1beea7ad48327b858d86dbd5ef397)