### PR TITLE
docs: add stability-levels policy and align README/docs/CLI wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,21 @@ Comparison and proof details: `docs/why-not-just-tools.md`
 - External repository adoption: `docs/adoption.md`
 - Troubleshooting first failures: `docs/adoption-troubleshooting.md`
 - Scenario-based proof examples: `docs/examples.md`
+- Stability levels (current policy): `docs/stability-levels.md`
 - Product boundary audit and taxonomy plan: `docs/productization-map.md`
 
 Docs portal: <https://sherif69-sa.github.io/DevS69-sdetkit/>
+
+## Stability levels (current policy)
+
+SDETKit uses four user-facing stability levels: **Stable/Core**, **Integrations**, **Playbooks**, and **Experimental**.
+
+- Start production rollout with **Stable/Core** release-confidence flows.
+- Add **Integrations** after validating platform-specific behavior.
+- Use **Playbooks** for guided adoption and operational lanes.
+- Treat **Experimental** lanes (including day/closeout families) as opt-in transition-era or advanced flows.
+
+Policy doc: `docs/stability-levels.md`
 
 ## Core commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,17 @@ python -m sdetkit gate release
 - **DevOps / platform:** [Production readiness](production-readiness.md) and [Security gate](security-gate.md)
 - **Maintainers:** [Evidence](evidence.md) and [Releasing](releasing.md)
 
+## Stability levels
+
+SDETKit documents command and workflow maturity with four levels: **Stable/Core**, **Integrations**, **Playbooks**, and **Experimental**.
+
+- **Stable/Core** is the default production path for release confidence and shipping readiness.
+- **Integrations** extend core workflows into CI, notifications, and external systems.
+- **Playbooks** provide guided rollout lanes for adoption and operating practice.
+- **Experimental** includes transition-era/advanced day and closeout lanes; keep as opt-in with validation.
+
+Read the policy: [stability-levels.md](stability-levels.md)
+
 ## Next steps
 
 - [Decision guide: is SDETKit right for you?](decision-guide.md)
@@ -110,4 +121,4 @@ python -m sdetkit gate release
 
 ## Legacy reports
 
-Historical day-by-day upgrade reports remain available for audit trails and prior initiative context.
+Historical day-by-day upgrade reports remain available as transition-era context for audit trails and prior initiatives.

--- a/docs/stability-levels.md
+++ b/docs/stability-levels.md
@@ -1,0 +1,55 @@
+# Stability levels (current policy)
+
+SDETKit's flagship promise remains:
+
+> **Release confidence / shipping readiness for software teams.**
+
+This page defines the current stability labels used across docs and CLI help. It is intended to set clear expectations without changing existing commands or workflows.
+
+## Stable/Core
+
+- **Intended audience:** teams making day-to-day go/no-go release decisions.
+- **Expected stability:** highest stability in this repository; this is the default starting path.
+- **Support expectations:** prioritized for maintenance, docs clarity, and regression prevention.
+- **Backward compatibility:** best-effort compatibility is expected for normal usage; changes should be deliberate and clearly documented.
+- **How to use in production:** safe as the primary production lane for release confidence checks.
+
+Typical examples include `gate`, `doctor`, `security`, `evidence`, and `scripts/ready_to_use.sh quick|release`.
+
+## Integrations
+
+- **Intended audience:** teams connecting SDETKit to CI platforms, notifications, plugins, or external automation.
+- **Expected stability:** stable for practical adoption, with occasional environment-specific adjustments.
+- **Support expectations:** maintained and documented, but behavior can depend on third-party systems.
+- **Backward compatibility:** best-effort compatibility with clear migration notes when interfaces evolve.
+- **How to use in production:** recommended when integration points are validated in your own environment.
+
+## Playbooks
+
+- **Intended audience:** teams adopting guided rollout lanes (onboarding, contribution, reliability storytelling, governance execution).
+- **Expected stability:** generally usable and supported, but more iterative than core gate commands.
+- **Support expectations:** maintained as practical guidance with incremental improvements.
+- **Backward compatibility:** command availability is expected, while workflows and narrative output can evolve.
+- **How to use in production:** use for operational rollout and enablement, alongside stable/core release gates.
+
+## Experimental
+
+- **Intended audience:** advanced users and maintainers exploring incubator lanes or historical day/closeout flows.
+- **Expected stability:** lower stability and faster iteration; not the first stop for new adopters.
+- **Support expectations:** best-effort maintenance; focus is learning, transition support, and preserving historical value.
+- **Backward compatibility:** may change more quickly, though breaking changes should still be communicated where practical.
+- **How to use in production:** treat as opt-in and validate locally/in CI before relying on it for critical release decisions.
+
+This includes many day/cycle/closeout lanes. They remain available as transition-era and advanced playbook material, not removed.
+
+## Usage guidance
+
+1. Start with **Stable/Core** for release confidence and shipping readiness decisions.
+2. Add **Integrations** to embed checks into your delivery systems.
+3. Use **Playbooks** for guided adoption and organizational rollout.
+4. Use **Experimental** lanes intentionally, with explicit validation.
+
+See also:
+
+- [Productization map](productization-map.md)
+- [Capability map and command taxonomy](command-taxonomy.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - CI Contract: ci-contract.md
       - CLI: cli.md
       - Capability map and command taxonomy: command-taxonomy.md
+  - Stability levels (current policy): stability-levels.md
   - Live Views:
       - 🕹️ DevS69 Command HUD — Live Detail View: command-hud-live.md
       - 🔄 DevS69 Diff-to-Decision — Live Detail View: diff-flow-live.md

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -207,8 +207,10 @@ def _add_passthrough_subcommand(
 
 def _build_root_parser() -> tuple[argparse.ArgumentParser, object]:
     help_description = """\
-SDETKit helps teams prove release confidence with deterministic checks and
-audit-friendly evidence.
+SDETKit helps teams prove release confidence / shipping readiness with
+deterministic checks and audit-friendly evidence.
+
+Stability levels: Stable/Core, Integrations, Playbooks, Experimental.
 
 Start here:
   1) Quick confidence: sdetkit gate fast
@@ -235,10 +237,10 @@ Command groups:
     maintenance         Repo maintenance automation.
     agent               Agent workflow helpers.
 
-  Advanced and extensions:
+  Integrations and extensions:
     ci, report, proof, docs-qa, docs-nav, policy, ops, notify, roadmap
 
-  Playbook highlights:
+  Playbook highlights (supported, iterative):
     onboarding, weekly-review, demo, first-contribution, contributor-funnel,
     triage-templates, startup-use-case, enterprise-use-case,
     github-actions-quickstart, gitlab-ci-quickstart, quality-contribution-delta,
@@ -248,6 +250,8 @@ Command groups:
 
 Run: sdetkit playbooks
   to list additional playbook flows hidden from the main --help output.
+
+Note: many day/closeout lanes are still available as transition-era experimental flows.
 """
 
     p = argparse.ArgumentParser(


### PR DESCRIPTION
### Motivation
- Provide a concise, repo-specific stability-level policy to make product boundaries explicit while preserving the existing flagship promise: "release confidence / shipping readiness for software teams." 
- Align top-level user-facing language so docs, site navigation, and CLI help use the same stability taxonomy without touching command behavior or doing broad refactors.

### Description
- Add new policy doc `docs/stability-levels.md` that defines the four levels: **Stable/Core**, **Integrations**, **Playbooks**, and **Experimental**, and documents audience, expected stability, support, compatibility, and production guidance. 
- Update `README.md` to surface the new policy in navigation and include a short `Stability levels (current policy)` summary for quick discoverability. 
- Update `docs/index.md` to add a matching `Stability levels` section and soften legacy wording to label day/closeout material as transition-era context. 
- Update `mkdocs.yml` to include the new page in the top-level navigation and update `src/sdetkit/cli.py` help text to mention the four stability labels and explicitly note that day/closeout lanes remain available as transition-era/experimental flows, with no change to command routing or behavior.

### Testing
- Ran `python -m sdetkit --help` to validate the updated root help text and command listing, and it succeeded. 
- Ran `mkdocs build -q` to validate docs build after nav changes, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1c4ec32708327a4dc807f15409251)