### PR TITLE
Improve CLI/docs discoverability by labeling command groups with stability levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ bash scripts/ready_to_use.sh release
 
 - Representative adopter walkthrough: `docs/example-adoption-flow.md`
 - Full command map: `docs/command-taxonomy.md`
+- Stability-aware command inventory: `docs/command-surface.md`
 - CLI command reference: `docs/cli.md`
 
 ## Who this is for

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,6 +3,7 @@
 ## Start with these core release-confidence commands
 
 Need a fast model of where commands belong before diving into the full list? See [Capability map and command taxonomy](command-taxonomy.md).
+For a stability-aware entrypoint and command inventory, see [command-surface.md](command-surface.md).
 
 Use this primary path first:
 

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -1,0 +1,95 @@
+# Command surface inventory (stability-aware)
+
+SDETKit's flagship identity remains:
+
+> **Release confidence / shipping readiness for software teams.**
+
+This page is a discoverability map for the current CLI surface. It does not remove or rename commands, and it follows the stability policy in [stability-levels.md](stability-levels.md) plus boundaries from [productization-map.md](productization-map.md).
+
+## Start here (first-time adopters)
+
+Use this order first:
+
+1. **[Stable/Core] Quick confidence**: `sdetkit gate fast`
+2. **[Stable/Core] Strict release gate**: `sdetkit gate release`
+3. **[Stable/Core] Readiness diagnostics**: `sdetkit doctor --all --json`
+4. **[Stable/Core] Security enforcement**: `sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`
+5. **[Playbooks] Guided rollout discovery**: `sdetkit playbooks`
+
+Wrapper equivalents:
+
+- `bash scripts/ready_to_use.sh quick`
+- `bash scripts/ready_to_use.sh release`
+
+## Current top-level command inventory by stability level
+
+This is a major-group inventory for navigation clarity (not an exhaustive subcommand reference).
+
+### Stable/Core
+
+Primary release-confidence and shipping-readiness path:
+
+- `gate`
+- `doctor`
+- `security`
+- `evidence`
+- `playbooks` (as discovery entrypoint)
+
+Core engineering workflow support with stable day-to-day utility:
+
+- `repo`, `dev`, `maintenance`
+- `ci`, `policy`, `report`
+- `kv`, `apiget`, `cassette-get`, `patch`
+
+## Integrations
+
+Environment-dependent integration and control-plane families:
+
+- `ops`
+- `notify`
+- `agent`
+- Platform workflow playbooks such as `github-actions-quickstart` and `gitlab-ci-quickstart` (via `sdetkit playbooks`)
+
+## Playbooks
+
+Guided adoption and execution flows (supported, iterative):
+
+- `onboarding`, `onboarding-time-upgrade`
+- `weekly-review`, `first-contribution`, `contributor-funnel`, `triage-templates`
+- `startup-use-case`, `enterprise-use-case`
+- `demo`, `proof`
+- `quality-contribution-delta`, `reliability-evidence-pack`
+- `faq-objections`, `community-activation`, `external-contribution-push`, `kpi-audit`
+
+Use `sdetkit playbooks` to discover the full current catalog.
+
+## Experimental
+
+Transition-era/advanced lanes retained for compatibility and specialized programs:
+
+- many `dayNN-*` command families
+- many `*-closeout` lanes
+- cycle closeout families (for example `continuous-upgrade-cycleX-closeout`)
+
+These remain available intentionally, but are not the first stop for new adopters.
+
+## Transition-era command families (how to treat them)
+
+- Treat `dayNN-*` and `*-closeout` as **opt-in experimental lanes**.
+- Prefer Stable/Core commands for go/no-go release decisions.
+- Use Experimental flows when you explicitly need historical, campaign, or program-phase workflows.
+- Validate these lanes in your own CI/environment before relying on them for critical release decisions.
+
+## Practical navigation rules
+
+- If uncertain, start in **Stable/Core**.
+- Add **Integrations** when embedding SDETKit into delivery systems.
+- Use **Playbooks** for guided rollout and adoption programs.
+- Use **Experimental** lanes intentionally and with explicit validation.
+
+## Related references
+
+- [CLI reference](cli.md)
+- [Capability map and command taxonomy](command-taxonomy.md)
+- [Stability levels (current policy)](stability-levels.md)
+- [Productization map](productization-map.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,7 @@ Read the policy: [stability-levels.md](stability-levels.md)
 - [Contributing](contributing.md)
 - [Full command reference](cli.md)
 - [Capability map and command taxonomy](command-taxonomy.md)
+- [Command surface inventory (stability-aware)](command-surface.md)
 
 <div class="quick-jump" markdown>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
       - Automation templates engine: automation-templates-engine.md
       - CI Contract: ci-contract.md
       - CLI: cli.md
+      - Command surface inventory (stability-aware): command-surface.md
       - Capability map and command taxonomy: command-taxonomy.md
   - Stability levels (current policy): stability-levels.md
   - Live Views:

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -213,22 +213,22 @@ deterministic checks and audit-friendly evidence.
 Stability levels: Stable/Core, Integrations, Playbooks, Experimental.
 
 Start here:
-  1) Quick confidence: sdetkit gate fast
-  2) Strict release gate: sdetkit gate release
-  3) External adoption/rollout: sdetkit playbooks
+  1) [Stable/Core] Quick confidence: sdetkit gate fast
+  2) [Stable/Core] Strict release gate: sdetkit gate release
+  3) [Playbooks] Guided rollout: sdetkit playbooks
 """
 
     help_epilog = """\
 Command groups:
 
-  Core release confidence:
+  Stable/Core release confidence:
     gate                Quick confidence and strict release gate entry points.
     doctor              Deterministic health checks for repo/release readiness.
     security            Security policy checks and enforcement.
     evidence            Generate audit-friendly evidence artifacts.
     playbooks           Discover and run guided rollout/adoption flows.
 
-  Core engineering workflows:
+  Stable/Core engineering workflows:
     kv                  Parse key=value input to JSON.
     apiget              Deterministic API capture with cassette support.
     patch               Apply controlled text patches.
@@ -237,10 +237,10 @@ Command groups:
     maintenance         Repo maintenance automation.
     agent               Agent workflow helpers.
 
-  Integrations and extensions:
+  Integrations (environment-dependent extensions):
     ci, report, proof, docs-qa, docs-nav, policy, ops, notify, roadmap
 
-  Playbook highlights (supported, iterative):
+  Playbooks (guided adoption lanes):
     onboarding, weekly-review, demo, first-contribution, contributor-funnel,
     triage-templates, startup-use-case, enterprise-use-case,
     github-actions-quickstart, gitlab-ci-quickstart, quality-contribution-delta,
@@ -251,7 +251,7 @@ Command groups:
 Run: sdetkit playbooks
   to list additional playbook flows hidden from the main --help output.
 
-Note: many day/closeout lanes are still available as transition-era experimental flows.
+Experimental note: many day/closeout lanes remain available as transition-era flows.
 """
 
     p = argparse.ArgumentParser(

--- a/src/sdetkit/playbooks_cli.py
+++ b/src/sdetkit/playbooks_cli.py
@@ -279,7 +279,7 @@ def _print_text(payload: dict[str, object]) -> None:
     else:
         print("  (none)")
     print("")
-    print("Incubator workflows:")
+    print("Experimental (transition-era) workflows:")
     if isinstance(legacy, list) and legacy:
         for n in legacy:
             print(f"  {n}")
@@ -419,14 +419,14 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     p = argparse.ArgumentParser(
         prog="sdetkit playbooks",
-        description="Discover, run, and validate recommended playbooks and incubator workflows.",
+        description="Discover, run, and validate playbooks across Playbooks and Experimental (transition-era) lanes.",
     )
     sub = p.add_subparsers(dest="cmd", required=True)
 
     listp = sub.add_parser(
         "list",
-        help="List recommended playbooks, incubator workflows, and aliases.",
-        description="List recommended playbooks, incubator workflows, and aliases.",
+        help="List recommended playbooks, Experimental workflows, and aliases.",
+        description="List recommended playbooks, Experimental workflows, and aliases.",
     )
     listp.add_argument("--format", choices=["text", "json"], default="text")
     g = listp.add_mutually_exclusive_group()


### PR DESCRIPTION
### Motivation

- Make the top-level CLI/docs surfaces easier for first-time users to navigate by surfacing repository stability semantics already defined in `docs/stability-levels.md` and `docs/productization-map.md`.
- Emphasize the flagship release-confidence path (quick → release gates, diagnostics, security) while keeping playbooks and experimental/legacy lanes discoverable but de-emphasized.
- Keep the change small, reversible, and purely documentation/help-text oriented to avoid behavioral risk.

### Description

- Added a new stability-aware inventory document `docs/command-surface.md` that lists major top-level command families and classifies them as Stable/Core, Integrations, Playbooks, or Experimental. 
- Updated root CLI help copy in `src/sdetkit/cli.py` to add stability tags in the `Start here` lines and to relabel the help-group headings to reflect stability-aware language. 
- Updated `src/sdetkit/playbooks_cli.py` output and parser descriptions to call legacy/hidden lanes “Experimental (transition-era) workflows” and align wording with the stability policy. 
- Surface the new inventory by adding links to `README.md`, `docs/index.md`, `docs/cli.md`, and `mkdocs.yml` (nav), with no changes to command routing, aliases, or runtime behavior.

### Testing

- Ran `python -m sdetkit --help` to validate updated root help output and it completed successfully. 
- Ran `python -m sdetkit playbooks` and `python -m sdetkit playbooks --help` to validate playbooks text and parser descriptions and both completed successfully. 
- Ran `python -m sdetkit playbooks list --format json` to verify the playbooks catalog output and it produced the expected JSON summary. 
- Ran `mkdocs build -q` to validate site generation; the build completed (a theme warning was emitted but did not block the build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1c65634288327890d0e3a5c230de3)