### PR TITLE
Add public command-surface contract and wire CLI help to consume it

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -87,6 +87,18 @@ These remain available intentionally, but are not the first stop for new adopter
 - Use **Playbooks** for guided rollout and adoption programs.
 - Use **Experimental** lanes intentionally and with explicit validation.
 
+## Public surface contract (source of truth)
+
+The major command-family contract is defined in:
+
+- `src/sdetkit/public_surface_contract.py`
+
+Maintainer guidance:
+
+- Keep this contract focused on **major top-level families only** (not every subcommand).
+- Update this contract first when a family-level productization decision changes (role, stability tier, first-time recommendation, or transition-era/legacy posture).
+- Keep CLI/docs discoverability text aligned by sourcing summary text from this contract where practical.
+
 ## Related references
 
 - [CLI reference](cli.md)

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -114,6 +114,7 @@ from . import (
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
 from .security_gate import main as security_main
+from .public_surface_contract import render_root_help_groups
 
 
 def _tool_version() -> str:
@@ -218,41 +219,7 @@ Start here:
   3) [Playbooks] Guided rollout: sdetkit playbooks
 """
 
-    help_epilog = """\
-Command groups:
-
-  Stable/Core release confidence:
-    gate                Quick confidence and strict release gate entry points.
-    doctor              Deterministic health checks for repo/release readiness.
-    security            Security policy checks and enforcement.
-    evidence            Generate audit-friendly evidence artifacts.
-    playbooks           Discover and run guided rollout/adoption flows.
-
-  Stable/Core engineering workflows:
-    kv                  Parse key=value input to JSON.
-    apiget              Deterministic API capture with cassette support.
-    patch               Apply controlled text patches.
-    repo / dev          Repo automation workflows and dev shortcuts.
-    cassette-get        Deterministic HTTP capture/replay helper.
-    maintenance         Repo maintenance automation.
-    agent               Agent workflow helpers.
-
-  Integrations (environment-dependent extensions):
-    ci, report, proof, docs-qa, docs-nav, policy, ops, notify, roadmap
-
-  Playbooks (guided adoption lanes):
-    onboarding, weekly-review, demo, first-contribution, contributor-funnel,
-    triage-templates, startup-use-case, enterprise-use-case,
-    github-actions-quickstart, gitlab-ci-quickstart, quality-contribution-delta,
-    reliability-evidence-pack, release-readiness-board, release-narrative,
-    trust-signal-upgrade, faq-objections, community-activation,
-    external-contribution-push, kpi-audit
-
-Run: sdetkit playbooks
-  to list additional playbook flows hidden from the main --help output.
-
-Experimental note: many day/closeout lanes remain available as transition-era flows.
-"""
+    help_epilog = render_root_help_groups()
 
     p = argparse.ArgumentParser(
         prog="sdetkit",

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CommandFamilyContract:
+    """Repo-specific contract for major public command families.
+
+    This contract is intentionally small and only covers top-level families.
+    It is used for discoverability surfaces (CLI/docs) during productization.
+    """
+
+    name: str
+    role: str
+    stability_tier: str
+    first_time_recommended: bool
+    transition_legacy_oriented: bool
+    top_level_commands: tuple[str, ...]
+
+
+PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
+    CommandFamilyContract(
+        name="stable-core-release-confidence",
+        role="Primary release-confidence and shipping-readiness go/no-go path.",
+        stability_tier="Stable/Core",
+        first_time_recommended=True,
+        transition_legacy_oriented=False,
+        top_level_commands=("gate", "doctor", "security", "evidence", "playbooks"),
+    ),
+    CommandFamilyContract(
+        name="stable-core-engineering-workflows",
+        role="Stable day-to-day engineering and repository utility workflows.",
+        stability_tier="Stable/Core",
+        first_time_recommended=True,
+        transition_legacy_oriented=False,
+        top_level_commands=(
+            "repo",
+            "dev",
+            "maintenance",
+            "ci",
+            "policy",
+            "report",
+            "kv",
+            "apiget",
+            "cassette-get",
+            "patch",
+        ),
+    ),
+    CommandFamilyContract(
+        name="integrations",
+        role="Environment-dependent connectors and delivery-system extensions.",
+        stability_tier="Integrations",
+        first_time_recommended=False,
+        transition_legacy_oriented=False,
+        top_level_commands=("ops", "notify", "agent", "docs-qa", "docs-nav", "roadmap"),
+    ),
+    CommandFamilyContract(
+        name="playbooks",
+        role="Guided adoption and rollout lanes for operational outcomes.",
+        stability_tier="Playbooks",
+        first_time_recommended=True,
+        transition_legacy_oriented=False,
+        top_level_commands=(
+            "onboarding",
+            "weekly-review",
+            "first-contribution",
+            "contributor-funnel",
+            "triage-templates",
+            "startup-use-case",
+            "enterprise-use-case",
+            "demo",
+            "proof",
+            "quality-contribution-delta",
+            "reliability-evidence-pack",
+            "release-readiness-board",
+            "release-narrative",
+            "trust-signal-upgrade",
+            "faq-objections",
+            "community-activation",
+            "external-contribution-push",
+            "kpi-audit",
+            "github-actions-quickstart",
+            "gitlab-ci-quickstart",
+        ),
+    ),
+    CommandFamilyContract(
+        name="experimental-transition-lanes",
+        role="Transition-era and legacy-oriented lanes retained for compatibility.",
+        stability_tier="Experimental",
+        first_time_recommended=False,
+        transition_legacy_oriented=True,
+        top_level_commands=("dayNN-*", "*-closeout", "continuous-upgrade-cycleX-closeout"),
+    ),
+)
+
+
+def render_root_help_groups() -> str:
+    """Render concise command-family guidance for root CLI help text."""
+    lines = ["Command groups:", ""]
+    for family in PUBLIC_SURFACE_CONTRACT:
+        name = family.name.replace("-", " ")
+        lines.append(
+            f"  {name} [{family.stability_tier}]"
+            f" (first-time: {'yes' if family.first_time_recommended else 'no'};"
+            f" transition-era: {'yes' if family.transition_legacy_oriented else 'no'}):"
+        )
+        lines.append(f"    {family.role}")
+        lines.append(f"    {', '.join(family.top_level_commands)}")
+        lines.append("")
+    lines.append("Run: sdetkit playbooks")
+    lines.append("  to list additional playbook flows hidden from the main --help output.")
+    return "\n".join(lines)


### PR DESCRIPTION
### Motivation
- Create a single, small, maintainable source-of-truth for the repository's major top-level command families to aid productization and docs consistency. 
- Surface family-level metadata (role, stability tier, recommendation, legacy posture) without changing any command behavior or structure.
- Make root CLI help and docs easier to keep in sync with product decisions about which families are Stable / Integrations / Playbooks / Experimental.

### Description
- Add a lightweight Python contract module `src/sdetkit/public_surface_contract.py` that defines a frozen `CommandFamilyContract` dataclass and a `PUBLIC_SURFACE_CONTRACT` tuple of family records. 
- Add a small renderer `render_root_help_groups()` in the same module to produce concise command-family guidance for CLI help. 
- Wire the root CLI help epilog in `src/sdetkit/cli.py` to use `render_root_help_groups()` instead of the previous hard-coded block, preserving all command routing and aliases. 
- Add a short maintainer note to `docs/command-surface.md` pointing to `src/sdetkit/public_surface_contract.py` and advising how to use/update the contract (family-level only, not exhaustive per-subcommand modeling).

### Testing
- Ran targeted automated tests: `python -m pytest -q tests/test_entrypoints_smoke.py tests/test_cli_help_lists_subcommands.py tests/test_cli_sdetkit.py`, and all tests passed. 
- Ran `python -m pytest -q tests/test_cli_help_lists_subcommands.py` to validate CLI help content specifically, and it passed.
- No runtime behavior or command execution code was changed, so existing integration/command tests continue to exercise the same paths.

Files changed: `src/sdetkit/public_surface_contract.py` (new), `src/sdetkit/cli.py` (help epilog wiring), `docs/command-surface.md` (maintainer guidance).

How the contract is represented: a small Python metadata module with a frozen dataclass and an explicit tuple of family entries (`PUBLIC_SURFACE_CONTRACT`), chosen for easy in-repo reuse from code and help text.

User-facing surfaces updated: root `sdetkit --help` epilog is now generated from the contract and `docs/command-surface.md` includes a pointer to the contract as the source-of-truth for family-level decisions.

Why this is safe to merge: no commands, aliases, or routing behavior were added, removed, or modified; the change centralizes metadata and only affects help text generation and a docs pointer.

Recommended next PR: add an optional docs table or generated snippet sourced from `PUBLIC_SURFACE_CONTRACT` so docs pages and CLI help remain in sync while still avoiding behavioral changes.

Assumptions / tradeoffs: chosen a Python module (not YAML/JSON) so the contract can be directly reused in code without extra parsing, and intentionally limited scope to major top-level families only to keep the PR small and reviewable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1c8689d8483278906df80162edccd)