### PR TITLE
docs: add contract-backed command-family table and first-time starting points

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -6,15 +6,36 @@ SDETKit's flagship identity remains:
 
 This page is a discoverability map for the current CLI surface. It does not remove or rename commands, and it follows the stability policy in [stability-levels.md](stability-levels.md) plus boundaries from [productization-map.md](productization-map.md).
 
-## Start here (first-time adopters)
+## Command-family contract snapshot
 
-Use this order first:
+This compact table is sourced from `src/sdetkit/public_surface_contract.py` and covers major command families only.
 
-1. **[Stable/Core] Quick confidence**: `sdetkit gate fast`
-2. **[Stable/Core] Strict release gate**: `sdetkit gate release`
-3. **[Stable/Core] Readiness diagnostics**: `sdetkit doctor --all --json`
-4. **[Stable/Core] Security enforcement**: `sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`
-5. **[Playbooks] Guided rollout discovery**: `sdetkit playbooks`
+<!-- BEGIN:PUBLIC_SURFACE_CONTRACT_TABLE -->
+
+| Command family | Purpose | Stability tier | First-time adopter default? | Transition-era / legacy-oriented? |
+|---|---|---|---|---|
+| `stable-core-release-confidence` | Primary release-confidence and shipping-readiness go/no-go path. | Stable/Core | Yes | No |
+| `stable-core-engineering-workflows` | Stable day-to-day engineering and repository utility workflows. | Stable/Core | Yes | No |
+| `integrations` | Environment-dependent connectors and delivery-system extensions. | Integrations | No | No |
+| `playbooks` | Guided adoption and rollout lanes for operational outcomes. | Playbooks | Yes | No |
+| `experimental-transition-lanes` | Transition-era and legacy-oriented lanes retained for compatibility. | Experimental | No | Yes |
+
+<!-- END:PUBLIC_SURFACE_CONTRACT_TABLE -->
+
+Maintainer sync:
+
+- Regenerate this table with `python tools/render_public_surface_contract_table.py`.
+- Use `python tools/render_public_surface_contract_table.py --check` in CI/pre-commit to keep docs and contract aligned.
+
+## Recommended starting points (first-time adopters)
+
+For release confidence and shipping readiness, start with the core path first:
+
+1. **Quick confidence gate (Stable/Core):** `sdetkit gate fast`
+2. **Strict release gate (Stable/Core):** `sdetkit gate release`
+3. **Readiness diagnostics (Stable/Core):** `sdetkit doctor --all --json`
+4. **Security enforcement (Stable/Core):** `sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`
+5. **Guided rollout catalog (Playbooks):** `sdetkit playbooks`
 
 Wrapper equivalents:
 

--- a/tools/render_public_surface_contract_table.py
+++ b/tools/render_public_surface_contract_table.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from sdetkit.public_surface_contract import PUBLIC_SURFACE_CONTRACT
+
+BEGIN = "<!-- BEGIN:PUBLIC_SURFACE_CONTRACT_TABLE -->"
+END = "<!-- END:PUBLIC_SURFACE_CONTRACT_TABLE -->"
+
+
+def _yes_no(value: bool) -> str:
+    return "Yes" if value else "No"
+
+
+def render_table() -> str:
+    lines = [
+        "| Command family | Purpose | Stability tier | First-time adopter default? | Transition-era / legacy-oriented? |",
+        "|---|---|---|---|---|",
+    ]
+    for family in PUBLIC_SURFACE_CONTRACT:
+        lines.append(
+            "| "
+            f"`{family.name}`"
+            f" | {family.role}"
+            f" | {family.stability_tier}"
+            f" | {_yes_no(family.first_time_recommended)}"
+            f" | {_yes_no(family.transition_legacy_oriented)}"
+            " |"
+        )
+    return "\n".join(lines)
+
+
+def sync_doc(doc_path: Path) -> bool:
+    content = doc_path.read_text(encoding="utf-8")
+    if BEGIN not in content or END not in content:
+        raise ValueError(f"Missing markers in {doc_path}")
+    start = content.index(BEGIN) + len(BEGIN)
+    end = content.index(END)
+    rendered = "\n\n" + render_table() + "\n\n"
+    updated = content[:start] + rendered + content[end:]
+    changed = updated != content
+    if changed:
+        doc_path.write_text(updated, encoding="utf-8")
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Render and sync the public surface contract command-family table."
+    )
+    parser.add_argument(
+        "--doc",
+        default="docs/command-surface.md",
+        help="Markdown doc containing BEGIN/END markers for the contract table.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the table is out of sync.",
+    )
+    args = parser.parse_args()
+
+    changed = sync_doc(ROOT / args.doc)
+    if args.check and changed:
+        print(f"{args.doc} is out of sync with PUBLIC_SURFACE_CONTRACT.")
+        return 1
+    if changed:
+        print(f"Updated {args.doc} from PUBLIC_SURFACE_CONTRACT.")
+    else:
+        print(f"{args.doc} already matches PUBLIC_SURFACE_CONTRACT.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Use the existing `PUBLIC_SURFACE_CONTRACT` as the single source of truth to reduce duplication and keep command-family guidance consistent between CLI help and docs. 
- Provide a compact, machine-syncable command-family summary and a clear first-time adopter path to foreground the core release-confidence workflows. 
- Keep the change small, reviewable, and behavior-neutral (docs + a tiny helper only). 

### Description
- Add a contract-backed command-family table to `docs/command-surface.md` enclosed by explicit markers so the table can be regenerated from `src/sdetkit/public_surface_contract.py`. 
- Add a tiny helper script `tools/render_public_surface_contract_table.py` that imports `PUBLIC_SURFACE_CONTRACT`, renders the markdown table, injects it between `<!-- BEGIN:PUBLIC_SURFACE_CONTRACT_TABLE -->` / `<!-- END:PUBLIC_SURFACE_CONTRACT_TABLE -->`, and supports `--check` for CI. 
- Add a concise `Recommended starting points (first-time adopters)` section that highlights the core release-confidence path: `sdetkit gate fast`, `sdetkit gate release`, `sdetkit doctor --all --json`, `sdetkit security enforce ...`, and `sdetkit playbooks`. 
- Document the maintainer sync workflow in the docs with commands to regenerate (`python tools/render_public_surface_contract_table.py`) and to assert alignment in CI (`python tools/render_public_surface_contract_table.py --check`). 

### Testing
- Ran the renderer locally with `python tools/render_public_surface_contract_table.py` and `python tools/render_public_surface_contract_table.py --check`, which reported the docs already matched the contract. 
- Executed unit tests with `python -m pytest tests/test_cli_sdetkit.py -q` and observed `11 passed`. 
- No CLI behavior or package layout changes were introduced, so existing CLI tests remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1cbabb37c83278898a86f3c500afa)