### PR TITLE
docs: foreground core release-confidence journeys in navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ SDETKit is a layered **release-confidence and engineering-operations toolkit**. 
 
 Most repositories accumulate separate scripts and tools, but the release decision still depends on manual interpretation. SDETKit provides a consistent command path from quick confidence to strict release gating, with machine-readable evidence and CI-safe outcomes.
 
-## Start here
+## Start here: core release-confidence path
 
-Choose the path that matches where you are now:
+If you're new to SDETKit, start with the **Stable/Core** shipping-readiness path first:
 
 ### 0) Decide if SDETKit is a fit
 
@@ -40,12 +40,21 @@ bash scripts/ready_to_use.sh release
 - Use before release decisions.
 - Overview: `docs/release-confidence.md`
 
-### 3) Understand the broader system and command surface
+### 3) Expand deliberately after core gates are working
 
+- Command-family contract and starting defaults: `docs/command-surface.md`
+- Capability map and command taxonomy: `docs/command-taxonomy.md`
+- Full CLI command reference: `docs/cli.md`
 - Representative adopter walkthrough: `docs/example-adoption-flow.md`
-- Full command map: `docs/command-taxonomy.md`
-- Stability-aware command inventory: `docs/command-surface.md`
-- CLI command reference: `docs/cli.md`
+
+## Recommended expansion order
+
+Keep first-time rollout focused to avoid identity drift:
+
+1. **Stable/Core:** run `quick` then `release` and confirm deterministic go/no-go output.
+2. **Integrations:** wire core checks into CI/platform flows after local confidence is established.
+3. **Playbooks:** add guided rollout/adoption lanes for team operating rhythms.
+4. **Experimental (transition-era):** use day/closeout material only when intentionally needed.
 
 ## Who this is for
 
@@ -73,6 +82,10 @@ Comparison and proof details: `docs/why-not-just-tools.md`
 - Scenario-based proof examples: `docs/examples.md`
 - Stability levels (current policy): `docs/stability-levels.md`
 - Product boundary audit and taxonomy plan: `docs/productization-map.md`
+
+### Secondary and transition-era material
+
+Historical day/closeout pages remain available for compatibility, audit trails, and specialized programs. They are intentionally **not** the primary onboarding path for first-time adopters.
 
 Docs portal: <https://sherif69-sa.github.io/DevS69-sdetkit/>
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-## Start with these core release-confidence commands
+## Start here: Stable/Core command path
 
 Need a fast model of where commands belong before diving into the full list? See [Capability map and command taxonomy](command-taxonomy.md).
 For a stability-aware entrypoint and command inventory, see [command-surface.md](command-surface.md).
@@ -16,6 +16,15 @@ Related script wrappers:
 - `bash scripts/ready_to_use.sh quick`
 - `bash scripts/ready_to_use.sh release`
 - `sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`
+
+
+## Recommended expansion after core
+
+After the core gates are reliable in your environment:
+
+1. Add **Integrations** for CI/platform embedding (for example `ci`, `ops`, `notify`, `agent`).
+2. Add **Playbooks** for guided rollout using `sdetkit playbooks`.
+3. Use transition-era `dayNN-*` / `*-closeout` lanes only as explicit Experimental opt-in paths.
 
 ## Broader command catalog
 - `sdetkit baseline write`

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,8 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 [Release confidence story](release-confidence.md){ .md-button }
 [Adopt in your repo](adoption.md){ .md-button }
 [Adoption troubleshooting](adoption-troubleshooting.md){ .md-button }
+[See integrations](github-action.md){ .md-button }
+[See playbooks](global-production-transformation-playbook.md){ .md-button }
 [See examples](examples.md){ .md-button }
 [See evidence commands](evidence.md){ .md-button }
 
@@ -27,7 +29,9 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 
 </div>
 
-## Fast start
+<a id="fast-start"></a>
+
+## Start here: Stable/Core release-confidence path
 
 Run the flagship workflow:
 
@@ -52,7 +56,7 @@ bash scripts/ready_to_use.sh release
 
 You get deterministic pass/fail output and a clear go/no-go signal you can reuse in local and CI workflows.
 
-## Core path
+## Core path (recommended first-time sequence)
 
 Use this sequence to keep rollout focused:
 
@@ -69,11 +73,11 @@ python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --ma
 python -m sdetkit gate release
 ```
 
-## Who should start where
+## Where integrations and playbooks fit
 
-- **SDET / QA:** [Doctor](doctor.md) and [CLI](cli.md)
-- **DevOps / platform:** [Production readiness](production-readiness.md) and [Security gate](security-gate.md)
-- **Maintainers:** [Evidence](evidence.md) and [Releasing](releasing.md)
+- **Integrations (after core gates):** [GitHub Action](github-action.md), [Recommended CI flow](recommended-ci-flow.md), and [Adopt in your repository](adoption.md).
+- **Playbooks (guided rollout):** [Global production transformation playbook](global-production-transformation-playbook.md), [First contribution quickstart](first-contribution-quickstart.md), and [Release-confidence examples](examples.md).
+- **Reference depth:** [CLI](cli.md), [Command surface inventory](command-surface.md), and [Capability map](command-taxonomy.md).
 
 ## Stability levels
 
@@ -86,22 +90,19 @@ SDETKit documents command and workflow maturity with four levels: **Stable/Core*
 
 Read the policy: [stability-levels.md](stability-levels.md)
 
-## Next steps
+## Next steps (ordered by default path)
 
 - [Decision guide: is SDETKit right for you?](decision-guide.md)
 - [Ready-to-use quickstart](ready-to-use.md)
+- [Release confidence model and lanes](release-confidence.md)
 - [Adopt in your repository](adoption.md)
 - [Recommended CI flow (baseline)](recommended-ci-flow.md)
-- [Example adoption flow](example-adoption-flow.md)
-- [Adoption troubleshooting](adoption-troubleshooting.md)
+- [Global production transformation playbook](global-production-transformation-playbook.md)
 - [Release-confidence examples](examples.md)
-- [Why not just separate tools? (system value)](why-not-just-tools.md)
-- [Repo tour](repo-tour.md)
-- [First contribution quickstart](first-contribution-quickstart.md)
-- [Contributing](contributing.md)
 - [Full command reference](cli.md)
-- [Capability map and command taxonomy](command-taxonomy.md)
 - [Command surface inventory (stability-aware)](command-surface.md)
+- [Capability map and command taxonomy](command-taxonomy.md)
+- [Transition-era historical reports (secondary)](#legacy-reports)
 
 <div class="quick-jump" markdown>
 
@@ -116,10 +117,10 @@ Read the policy: [stability-levels.md](stability-levels.md)
 - [🩺 Doctor checks](doctor.md)
 - [🤝 Contribute](contributing.md)
 - [🧭 Repo tour](repo-tour.md)
-- [📦 Legacy reports](#legacy-reports)
+- [📦 Transition-era reports (secondary)](#legacy-reports)
 
 </div>
 
 ## Legacy reports
 
-Historical day-by-day upgrade reports remain available as transition-era context for audit trails and prior initiatives.
+Historical day-by-day upgrade reports remain available as transition-era context for audit trails and prior initiatives. They are intentionally secondary to the Stable/Core release-confidence journey.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,33 +82,41 @@ extra_javascript:
 
 nav:
   - Home: index.md
-  - Decision guide: decision-guide.md
-  - Quickstart: ready-to-use.md
-  - Release confidence: release-confidence.md
-  - Adopt in your repository: adoption.md
-  - Recommended CI flow (baseline): recommended-ci-flow.md
-  - Example adoption flow: example-adoption-flow.md
-  - Evidence showcase: evidence-showcase.md
-  - Adoption troubleshooting: adoption-troubleshooting.md
-  - Remediation cookbook: remediation-cookbook.md
-  - Examples: examples.md
-  - Foundation:
-      - AgentOS cookbook: agentos-cookbook.md
-      - AgentOS foundation: agentos-foundation.md
+  - Start here:
+      - Decision guide: decision-guide.md
+      - Quickstart: ready-to-use.md
+      - Release confidence: release-confidence.md
+      - CLI (core-first entrypoint): cli.md
+      - Command surface inventory (stability-aware): command-surface.md
+      - Capability map and command taxonomy: command-taxonomy.md
+      - Stability levels (current policy): stability-levels.md
+  - Core release-confidence journeys:
+      - Adopt in your repository: adoption.md
+      - Recommended CI flow (baseline): recommended-ci-flow.md
+      - Example adoption flow: example-adoption-flow.md
+      - Adoption troubleshooting: adoption-troubleshooting.md
+      - Remediation cookbook: remediation-cookbook.md
+      - Evidence showcase: evidence-showcase.md
+      - Examples: examples.md
+  - Integrations (after core path):
+      - "GitHub Action: sdetkit repo audit": github-action.md
+      - IDE + pre-commit integration: ide-and-precommit.md
+      - n8n Integration (PR Webhook Automation): n8n.md
+      - Omnichannel + MCP bridge: omnichannel-mcp-bridge.md
+      - Plugins: plugins.md
+      - Plugins, rule packs, and fix-audit: plugins-and-fix.md
+      - PR automation for audit auto-fixes: pr-automation.md
+  - Playbooks (guided rollout):
+      - Global production transformation playbook: global-production-transformation-playbook.md
+      - First contribution quickstart: first-contribution-quickstart.md
+      - Starter work inventory: starter-work-inventory.md
+      - Maintainer starter-issue hygiene: maintainer-starter-issue-hygiene.md
+      - Contributing: contributing.md
+  - Reference and operations:
       - API: api.md
       - Automation OS: automation-os.md
       - Automation templates engine: automation-templates-engine.md
       - CI Contract: ci-contract.md
-      - CLI: cli.md
-      - Command surface inventory (stability-aware): command-surface.md
-      - Capability map and command taxonomy: command-taxonomy.md
-  - Stability levels (current policy): stability-levels.md
-  - Live Views:
-      - 🕹️ DevS69 Command HUD — Live Detail View: command-hud-live.md
-      - 🔄 DevS69 Diff-to-Decision — Live Detail View: diff-flow-live.md
-      - 🗺️ DevS69 Repo Map — Live Detail View: repo-map-live.md
-      - DevS69 Visual HUD Showcase: hud-showcase.md
-  - Core Operations:
       - Doctor: doctor.md
       - Evidence Pack: evidence.md
       - Ops Control Plane: ops.md
@@ -119,7 +127,6 @@ nav:
       - Repo init: repo-init.md
       - Tool server: tool-server.md
       - sqlite-utils empty-column troubleshooting: sqlite-utils-empty-column-troubleshooting.md
-  - Security & Quality:
       - Determinism checklist: determinism-checklist.md
       - Determinism contract: determinism-contract.md
       - Policy and baselines (sdetkit repo audit): policy-and-baselines.md
@@ -131,38 +138,36 @@ nav:
       - Security suite (Phase 10): security-suite.md
       - Security hardening: security.md
       - Security code scanning follow-ups: security-code-scanning-followups.md
-  - Platform & Governance:
+  - Platform & governance:
+      - AgentOS cookbook: agentos-cookbook.md
+      - AgentOS foundation: agentos-foundation.md
       - AgentOS productization blueprint: enterprise-productization-blueprint.md
-      - First contribution quickstart: first-contribution-quickstart.md
-      - Starter work inventory: starter-work-inventory.md
-      - Maintainer starter-issue hygiene: maintainer-starter-issue-hygiene.md
-      - Contributing: contributing.md
       - Design notes: design.md
       - Governance and org packs: governance-and-org-packs.md
       - License: license.md
       - Monorepo + multi-project support: monorepo-projects.md
+      - Productization map: productization-map.md
       - Project structure: project-structure.md
       - Releasing sdetkit: releasing.md
       - Public release verification records: release-verification.md
       - Changelog: changelog.md
       - Roadmap: roadmap.md
       - Repo tour (visual orientation): repo-tour.md
-  - Ecosystem & Integrations:
-      - "GitHub Action: sdetkit repo audit": github-action.md
-      - IDE + pre-commit integration: ide-and-precommit.md
-      - n8n Integration (PR Webhook Automation): n8n.md
-      - Omnichannel + MCP bridge: omnichannel-mcp-bridge.md
-      - Plugins: plugins.md
-      - Plugins, rule packs, and fix-audit: plugins-and-fix.md
-      - PR automation for audit auto-fixes: pr-automation.md
   - Strategy:
       - Why not just separate tools? (system value): why-not-just-tools.md
       - Product strategy (release confidence): product-strategy.md
-      - Global production transformation playbook: global-production-transformation-playbook.md
       - Enterprise + regulated workflow: use-cases-enterprise-regulated.md
       - Startup + small-team workflow: use-cases-startup-small-team.md
       - Production S-class tier blueprint for the next 90-day boost: production-s-class-90-day-boost.md
       - Top-10 GitHub Strategy for DevS69 sdetkit: top-10-github-strategy.md
+  - Live Views:
+      - 🕹️ DevS69 Command HUD — Live Detail View: command-hud-live.md
+      - 🔄 DevS69 Diff-to-Decision — Live Detail View: diff-flow-live.md
+      - 🗺️ DevS69 Repo Map — Live Detail View: repo-map-live.md
+      - DevS69 Visual HUD Showcase: hud-showcase.md
+  - Transition-era and historical archive (secondary):
+      - Stability policy for Experimental lanes: stability-levels.md
+      - Productization boundary map: productization-map.md
 
 exclude_docs: |
   artifacts/**


### PR DESCRIPTION
### Motivation
- Clarify the repository's flagship identity as "release confidence / shipping readiness" by making the Stable/Core paths the obvious first stop for new users.
- Reduce product-identity noise caused by many transition-era/day/closeout pages by making them discoverable but explicitly secondary.
- Preserve all existing content while improving first-time orientation and recommended expansion order.

### Description
- Reframe top-level onboarding text in `README.md` to present a clear Stable/Core start path (`quick` → `release`) and an explicit expansion order (Stable/Core → Integrations → Playbooks → Experimental).
- Update docs landing (`docs/index.md`) to foreground the Stable/Core release-confidence journey, add a clear section on where integrations and playbooks fit, and mark legacy day/closeout reports as secondary.
- Update CLI landing (`docs/cli.md`) to present a core-first command path and a short “recommended expansion after core” guidance aligned to stability tiers.
- Reorder and regroup MkDocs navigation in `mkdocs.yml` so the primary discovery sequence becomes: Start here → Core release-confidence journeys → Integrations → Playbooks → Reference/Operations → Transition-era/archive (secondary).

### Testing
- Ran a script to verify that every `mkdocs.yml` nav target exists, and the check returned `OK`.
- Built the site with `mkdocs build --strict` (fixed a missing anchor then rebuilt) and the build completed successfully.
- Served the site with `mkdocs serve` and captured a visual smoke-check screenshot using Playwright to validate the updated docs landing, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1cce1296083278664bd48ac53711d)