### PR TITLE
Improve packaging/install/release-readiness docs and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,25 +126,54 @@ python -m sdetkit playbooks
 
 ## Installation
 
-### Runtime install
+SDETKit currently supports two explicit install paths:
+
+- **From source (this repository)** for contributors/maintainers.
+- **From GitHub URL** for external adopters until PyPI publication is verified.
+
+### From source (local clone)
 
 ```bash
 python -m pip install .
 ```
 
-### Developer install (recommended)
+### From GitHub (external repository adoption)
+
+```bash
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+```
+
+### Developer install (recommended in this repo)
 
 ```bash
 bash scripts/bootstrap.sh
 source .venv/bin/activate
 ```
 
-### Optional extras
+### Optional extras (choose only what you need)
+
+| Extra | Installs | Use when |
+|---|---|---|
+| `dev` | linting, typing, packaging helper tooling | You are contributing to this repository. |
+| `test` | pytest and test helpers | You need to run/extend tests. |
+| `docs` | mkdocs + theme | You need to build docs locally. |
+| `packaging` | build/twine/wheel validation tooling | You are validating release artifacts. |
+| `telegram` | telegram notifier dependency | You need Telegram notifier integration. |
+| `whatsapp` | Twilio notifier dependency | You need WhatsApp notifier integration. |
 
 ```bash
 python -m pip install .[dev]
 python -m pip install .[test]
+python -m pip install .[docs]
 python -m pip install .[packaging]
+python -m pip install .[telegram]
+python -m pip install .[whatsapp]
+```
+
+You can combine extras as needed, for example:
+
+```bash
+python -m pip install .[dev,test,docs]
 ```
 
 ## CI/CD integration

--- a/docs/packaging-readiness-audit.md
+++ b/docs/packaging-readiness-audit.md
@@ -1,0 +1,49 @@
+# Packaging / install / release-readiness audit
+
+This audit captures **small, safe** productization improvements focused on adoption friction for outside users.
+
+## Scope reviewed
+
+- Package metadata in `pyproject.toml`
+- Install guidance in `README.md`
+- External-adoption install guidance in `docs/adoption.md`
+- Release/versioning discoverability in `RELEASE.md`, `docs/releasing.md`, and changelog navigation
+
+## What is already good
+
+- Build backend and metadata are modern (`setuptools` + PEP 621 layout).
+- CLI entry points are explicitly declared for `sdetkit`, `sdkit`, `kvcli`, and `apigetcli`.
+- Semantic versioning and release tag/version matching are clearly documented.
+- Release flow already includes build validation, twine checks, and wheel smoke testing.
+- Changelog and release verification docs already exist and are linked from docs navigation.
+
+## Friction points identified
+
+1. **Install-method ambiguity for new adopters**
+   - README previously focused on local `pip install .` without clearly separating local clone vs external adoption paths.
+2. **Optional dependency discoverability was too thin**
+   - Extras were listed as commands but not explained by purpose (required vs optional intent).
+3. **Release discoverability from package metadata could be improved**
+   - `pyproject.toml` URLs included changelog and release process, but not direct GitHub Releases page.
+
+## Improvements made in this PR
+
+- Added a direct **Releases** URL in package metadata (`[project.urls]`) for better discovery in package index metadata surfaces.
+- Clarified README installation section to explicitly distinguish:
+  - local/source install,
+  - GitHub install for external adoption,
+  - developer bootstrap path.
+- Added an extras guidance table in README describing when to use each extra (`dev`, `test`, `docs`, `packaging`, `telegram`, `whatsapp`) and example combined install.
+
+## Deferred for later PRs
+
+- Publishing policy automation details beyond current docs (kept current flow unchanged).
+- Potential future PyPI-first install guidance switch (only after confirmed public release availability and verification records).
+- Any dependency or build-system restructuring.
+
+## Safety notes
+
+- No runtime behavior or command surface changed.
+- No dependency versions changed.
+- No packaging build flow changed.
+- Changes are documentation/metadata only, so risk is low and review scope is small.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
       - Productization map: productization-map.md
       - Project structure: project-structure.md
       - Releasing sdetkit: releasing.md
+      - Packaging/install/release-readiness audit: packaging-readiness-audit.md
       - Public release verification records: release-verification.md
       - Changelog: changelog.md
       - Roadmap: roadmap.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ Homepage = "https://github.com/sherif69-sa/DevS69-sdetkit"
 Repository = "https://github.com/sherif69-sa/DevS69-sdetkit"
 Documentation = "https://sherif69-sa.github.io/DevS69-sdetkit/"
 Issues = "https://github.com/sherif69-sa/DevS69-sdetkit/issues"
+Releases = "https://github.com/sherif69-sa/DevS69-sdetkit/releases"
 Changelog = "https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CHANGELOG.md"
 "Release Process" = "https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/RELEASE.md"
 


### PR DESCRIPTION
### Motivation

- Reduce first-time adopter friction by making install paths and optional extras explicit and discoverable. 
- Improve release discoverability in package metadata so index/UIs can link directly to GitHub Releases. 
- Provide a small, reviewable audit that documents current state and low-risk next steps for packaging readiness.

### Description

- Add a direct `Releases` URL under `[project.urls]` in `pyproject.toml` to surface the GitHub Releases page. 
- Clarify the `README.md` installation section by explicitly separating `From source` (local clone), `From GitHub` (external adopters), and the developer bootstrap flow. 
- Document optional extras in `README.md` with a purpose-oriented table for `dev`, `test`, `docs`, `packaging`, `telegram`, and `whatsapp`, and show a combined-extras example. 
- Add `docs/packaging-readiness-audit.md` capturing the review scope, identified friction points, what was improved, and deferred items, and register it in `mkdocs.yml` navigation. 
- All edits are metadata/docs-only and do not change runtime behavior, dependencies, packaging build flow, or public CLI surface.

### Testing

- Built artifacts successfully with `python -m build`, producing a source tarball and wheel without errors. 
- Ran packaging checks with `python -m twine check dist/*`, and both wheel and sdist passed. 
- No test code was modified and existing test suites were not altered by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1cf1a71588327aa54ead659fb4e3d)