### PR TITLE
docs: tighten first-run install verification and onboarding path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Most repositories accumulate separate scripts and tools, but the release decisio
 
 If you're new to SDETKit, start with the **Stable/Core** shipping-readiness path first:
 
+- Install first: see [Installation](#installation)
+- Verify install in under 60 seconds: see [Verify your install](#verify-your-install)
+- Then run the core path below (`quick` → `release`)
+
 ### 0) Decide if SDETKit is a fit
 
 - Decision guide: `docs/decision-guide.md`
@@ -175,6 +179,45 @@ You can combine extras as needed, for example:
 ```bash
 python -m pip install .[dev,test,docs]
 ```
+
+## Verify your install
+
+Run this short check immediately after installation:
+
+```bash
+python -m sdetkit --help
+python -m sdetkit gate --help
+```
+
+Expected result: both commands print usage/help text and exit successfully.
+
+Then run the first real release-confidence signal:
+
+```bash
+bash scripts/ready_to_use.sh quick
+```
+
+If you installed SDETKit in another repository (without this repo's scripts), use:
+
+```bash
+python -m sdetkit gate fast
+```
+
+## Recommended first 10 minutes
+
+1. Install SDETKit (local clone or GitHub URL).
+2. Verify CLI availability with `python -m sdetkit --help`.
+3. Run quick confidence: `bash scripts/ready_to_use.sh quick` (or `python -m sdetkit gate fast` in external repos).
+4. Run strict release checks: `bash scripts/ready_to_use.sh release`.
+5. Review command families in `docs/cli.md` and staged rollout guidance in `docs/adoption.md`.
+
+What works without optional extras:
+
+- Core gate commands (`gate fast`, `gate release`)
+- Security budget enforcement (`security enforce`)
+- Stable/Core quickstart wrapper (`scripts/ready_to_use.sh` in this repository)
+
+Optional extras are only for specialized workflows (contributing, docs authoring, packaging validation, notifier integrations).
 
 ## CI/CD integration
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -18,6 +18,13 @@ For CI and local development parity:
 python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git#egg=sdetkit[dev,test]"
 ```
 
+Verify CLI wiring before running gates:
+
+```bash
+python -m sdetkit --help
+python -m sdetkit gate --help
+```
+
 ## Start small: local quick confidence
 
 Run this first in your own repository root:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,9 +7,10 @@ For a stability-aware entrypoint and command inventory, see [command-surface.md]
 
 Use this primary path first:
 
-1. **Quick confidence:** `sdetkit gate fast`
-2. **Strict release gate:** `sdetkit gate release`
-3. **External adoption/rollout:** `sdetkit playbooks`
+1. **Verify CLI install:** `sdetkit --help` then `sdetkit gate --help`
+2. **Quick confidence:** `sdetkit gate fast`
+3. **Strict release gate:** `sdetkit gate release`
+4. **External adoption/rollout:** follow [adoption.md](adoption.md)
 
 Related script wrappers:
 
@@ -17,6 +18,8 @@ Related script wrappers:
 - `bash scripts/ready_to_use.sh release`
 - `sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`
 
+
+For a script-first onboarding path, see [ready-to-use.md](ready-to-use.md).
 
 ## Recommended expansion after core
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,9 +29,15 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 
 </div>
 
-<a id="fast-start"></a>
+## Fast start
 
-## Start here: Stable/Core release-confidence path
+### Start here: Stable/Core release-confidence path
+
+New to SDETKit? Use this order for the first run:
+
+1. Install SDETKit from source or GitHub URL (see [ready-to-use.md](ready-to-use.md)).
+2. Verify CLI availability (see [Verify your install](ready-to-use.md#verify-your-install)).
+3. Run the flagship workflow below (`quick` then `release`).
 
 Run the flagship workflow:
 
@@ -62,7 +68,8 @@ Use this sequence to keep rollout focused:
 
 1. **Quick confidence** via `bash scripts/ready_to_use.sh quick`
 2. **Strict release gate** via `bash scripts/ready_to_use.sh release`
-3. **External adoption** via [adoption.md](adoption.md)
+3. **Discover core commands** via [cli.md](cli.md)
+4. **External adoption** via [adoption.md](adoption.md)
 
 ## Flagship workflow (manual form)
 
@@ -114,6 +121,7 @@ Read the policy: [stability-levels.md](stability-levels.md)
 
 - [⚡ Fast start](#fast-start)
 - [🛠 CLI commands](cli.md)
+- [✅ Verify install first](ready-to-use.md#verify-your-install)
 - [🩺 Doctor checks](doctor.md)
 - [🤝 Contribute](contributing.md)
 - [🧭 Repo tour](repo-tour.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -2,6 +2,26 @@
 
 Use this guide when you want a practical start to release confidence without learning the entire repository first.
 
+## Install SDETKit
+
+Choose the path that matches your context:
+
+- In this repository (local clone): `python -m pip install .`
+- In an external repository: `python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"`
+
+Optional extras (`dev`, `test`, `docs`, `packaging`, `telegram`, `whatsapp`) are not required for the core release-confidence path.
+
+## Verify your install
+
+Run this right after installation:
+
+```bash
+python -m sdetkit --help
+python -m sdetkit gate --help
+```
+
+Expected result: both commands print help text and exit with code `0`.
+
 ## Fast start (recommended, under 5 minutes)
 
 ```bash
@@ -14,6 +34,12 @@ What this does:
 2. Verifies the SDETKit CLI is available.
 3. Runs the CI quick lane.
 4. Leaves you with a working repo and a clear next step.
+
+If you are in another repository (without this repo's helper scripts), use:
+
+```bash
+python -m sdetkit gate fast
+```
 
 ## Full release-confidence start
 
@@ -33,6 +59,15 @@ Use this when you need production-quality release evidence.
 
 - Exit code `0`: setup/checks completed successfully.
 - Non-zero exit code: setup or checks failed; review the command output and fix the first failing step.
+
+## Recommended first 10 minutes
+
+1. Install SDETKit.
+2. Verify install with `python -m sdetkit --help`.
+3. Run quick confidence (`bash scripts/ready_to_use.sh quick` or `python -m sdetkit gate fast`).
+4. Run strict release checks (`bash scripts/ready_to_use.sh release` or security-enforce + `gate release`).
+5. Use [cli.md](cli.md) to discover core command families.
+6. Use [adoption.md](adoption.md) to roll the same path into CI.
 
 ## Next actions after setup
 


### PR DESCRIPTION
### Motivation

- Reduce first-run friction by giving new users a short, concrete install → verify → run sequence so they can prove the toolkit works within minutes. 
- Make it explicit what works without optional extras and clarify the difference between the in-repo script wrappers and the direct CLI commands used in external adopters.

### Description

- Added a concise "Verify your install" section with immediate commands (`python -m sdetkit --help` and `python -m sdetkit gate --help`) and an explicit first real signal (`bash scripts/ready_to_use.sh quick`) to the project README (`README.md`).
- Added a "Recommended first 10 minutes" checklist and clarified what functionality works without optional extras in `README.md` and `docs/ready-to-use.md`.
- Tightened cross-links and the first-run ordering on the docs home (`docs/index.md`) and strengthened the CLI entrypoint guidance in `docs/cli.md` to place verification as step 1 for new users.
- Added an explicit verify step to external adoption guidance in `docs/adoption.md` and fixed a docs anchor/quick-start anchor to satisfy `docs-qa`.
- Files changed: `README.md`, `docs/index.md`, `docs/ready-to-use.md`, `docs/cli.md`, and `docs/adoption.md`; no code, packaging, or behavior changes were made.

### Testing

- Ran `python -m sdetkit --help` and confirmed the CLI printed usage and exited successfully.
- Ran `python -m sdetkit gate --help` and confirmed subcommand help printed and exited successfully.
- Ran the repository docs QA via `python -m sdetkit docs-qa --format text` and resolved an anchor issue, after which `docs-qa` reported pass.
- All automated checks exercised locally passed (CLI help and docs QA passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1d0e20c888327b5509cfa6e8028d4)