### PR TITLE
docs: add compact first-failure triage guide for core release-confidence path

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Comparison and proof details: `docs/why-not-just-tools.md`
 - CLI docs: `docs/cli.md`
 - External repository adoption: `docs/adoption.md`
 - Troubleshooting first failures: `docs/adoption-troubleshooting.md`
+- Compact first-failure triage (core path): `docs/first-failure-triage.md`
 - Scenario-based proof examples: `docs/examples.md`
 - Stability levels (current policy): `docs/stability-levels.md`
 - Product boundary audit and taxonomy plan: `docs/productization-map.md`

--- a/docs/adoption-troubleshooting.md
+++ b/docs/adoption-troubleshooting.md
@@ -8,6 +8,8 @@ The goal is to decide quickly:
 - Should you fix code issues now, loosen policy temporarily, or run a lighter command?
 - What is the next sensible adoption step?
 
+For a shorter fix-first path across the core commands, start with [First-failure triage](first-failure-triage.md).
+
 ## Quick command intent map
 
 | Command | Primary purpose | Typical onboarding outcome |

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -56,6 +56,7 @@ python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.js
 
 Before changing your pipeline, check the focused troubleshooting matrix:
 
+- [First-failure triage](first-failure-triage.md) for the compact fix-first path across `gate fast` -> `security enforce` -> `gate release`.
 - [Adoption troubleshooting](adoption-troubleshooting.md) (start with the **Artifact-to-action map** section if you downloaded CI artifacts).
 - [Remediation cookbook](remediation-cookbook.md) for copy-paste next-step playbooks after common failures.
 - Helps decide whether to fix quality debt now, tune a threshold temporarily, or stay on a lighter command.
@@ -156,6 +157,7 @@ Use those artifacts first, then follow:
 
 ## Related docs
 
+- [First-failure triage](first-failure-triage.md)
 - [Adoption troubleshooting](adoption-troubleshooting.md)
 - [Remediation cookbook](remediation-cookbook.md)
 - [Ready-to-use quickstart](ready-to-use.md)

--- a/docs/first-failure-triage.md
+++ b/docs/first-failure-triage.md
@@ -1,0 +1,39 @@
+# First-failure triage (core release-confidence path)
+
+Use this page right after your **first failed core run** (`gate fast`, `security enforce`, or `gate release`).
+
+Goal: recover quickly, fix the right thing first, and avoid guessing.
+
+## 60-second decision path
+
+1. Run (or open) `gate fast` output first.
+2. Fix the **first failed quality step** (`ruff` / `mypy` / `pytest`) before moving to stricter gates.
+3. Run `security enforce` after `gate fast` is stable; tune only `--max-info` temporarily if needed.
+4. Run `gate release` after fast gate + security posture are stable.
+5. Use `doctor --release` when release prerequisites are unclear.
+
+## Fix-first matrix
+
+| What failed? | Check first | Fix before moving on | Run next |
+| --- | --- | --- | --- |
+| `python -m sdetkit gate fast` | `failed_steps` in terminal output or `build/gate-fast.json` | The first failing step category (usually `ruff`, `mypy`, or `pytest`) | Rerun `python -m sdetkit gate fast` |
+| `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0` | `ok`, `counts`, `exceeded`, `limits` in JSON output | Keep `--max-error 0 --max-warn 0`; if onboarding, set a temporary realistic `--max-info` baseline and plan ratcheting down | Rerun `security enforce`, then continue to `gate release` |
+| `python -m sdetkit gate release` | `failed_steps` (commonly `doctor_release` or `gate_fast`) | Clear upstream failures in order; if `gate_fast` appears, fix that first | Run `python -m sdetkit doctor --release --format json`, then rerun `gate release` |
+
+## When to use each command
+
+- **Use `gate fast`** for first-line triage and day-to-day PR confidence.
+- **Use `doctor --release`** when `gate release` fails and you need release-prerequisite detail.
+- **Use `security enforce`** to evaluate policy budgets (`error`/`warn`/`info`) after quality checks are under control.
+
+## Minimal triage order (recommended)
+
+1. `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`
+2. Fix first failing quality step and rerun `python -m sdetkit gate fast`
+3. `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`
+4. `python -m sdetkit gate release --format json --out build/release-preflight.json`
+
+If you need expanded playbooks after this compact pass, continue with:
+
+- [Adoption troubleshooting](adoption-troubleshooting.md)
+- [Remediation cookbook](remediation-cookbook.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 [Release confidence story](release-confidence.md){ .md-button }
 [Adopt in your repo](adoption.md){ .md-button }
 [Adoption troubleshooting](adoption-troubleshooting.md){ .md-button }
+[First-failure triage](first-failure-triage.md){ .md-button }
 [See integrations](github-action.md){ .md-button }
 [See playbooks](global-production-transformation-playbook.md){ .md-button }
 [See examples](examples.md){ .md-button }

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -93,4 +93,4 @@ That guide includes:
 - Copy-paste GitHub Actions workflows
 - A staged path from `gate fast` to stricter release gating
 
-If quick or release checks fail in an external adoption flow, use the [remediation cookbook](remediation-cookbook.md) for copy-paste next steps.
+If quick or release checks fail, start with [First-failure triage](first-failure-triage.md), then use the [remediation cookbook](remediation-cookbook.md) for copy-paste next steps.

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -50,5 +50,6 @@ For new users and adopters, use this sequence:
 
 - Quickstart: [ready-to-use.md](ready-to-use.md)
 - External rollout: [adoption.md](adoption.md)
-- First-failure triage: [adoption-troubleshooting.md](adoption-troubleshooting.md)
+- First-failure triage (compact): [first-failure-triage.md](first-failure-triage.md)
+- Expanded troubleshooting: [adoption-troubleshooting.md](adoption-troubleshooting.md)
 - Practical scenarios: [examples.md](examples.md)


### PR DESCRIPTION
### Motivation
- New adopters often hit a non-obvious first failure when running the core path (`gate fast`, `security enforce`, `gate release`) and need a short, repo-specific triage path to recover quickly. 
- Keep onboarding focused and reduce confusion by prescribing a small, fix-first decision flow without changing any command behavior or package layout. 
- The change must be safe and docs-only so adopters can act immediately without runtime risk.

### Description
- Add a new compact triage page `docs/first-failure-triage.md` that contains a 60‑second decision path, a fix‑first matrix for the three core commands, guidance for when to use `doctor --release`, and a minimal recommended command order. 
- Prioritizes the most-likely first failures: `gate fast` (first failing quality step such as `ruff`/`mypy`/`pytest`), `security enforce` (strict `info` budgets), and `gate release` (upstream prerequisite failures like `doctor_release` or `gate_fast`). 
- Add small cross-links from core onboarding documents to surface the compact triage guide in context, updating `README.md`, `docs/ready-to-use.md`, `docs/adoption.md`, `docs/release-confidence.md`, `docs/index.md`, and `docs/adoption-troubleshooting.md`. 
- All changes are documentation-only and preserve existing commands, workflows, packaging, and dependencies.

### Testing
- Verified presence and content of the new page with `sed`/file prints and confirmed cross-links using `rg` to search for `first-failure-triage` and related anchors, with results matching expectations. 
- Confirmed the edited docs render locations were updated by inspecting the modified file excerpts (commands used: `sed -n`, `nl -ba`) and reviewed the diffs. 
- Performed repository checks (`git status --short`) and committed the changes with a descriptive message, verifying a clean commit that contains the intended files. 
- No runtime or behavioral tests were required because this is a docs-only change and no code or dependency changes were made.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1d397724c8327b937740cd86a9bca)