### PR TITLE
docs: add realistic adoption scenarios and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ bash scripts/ready_to_use.sh release
 - Capability map and command taxonomy: `docs/command-taxonomy.md`
 - Full CLI command reference: `docs/cli.md`
 - Representative adopter walkthrough: `docs/example-adoption-flow.md`
+- Scenario-based adoption examples: `docs/adoption-examples.md`
 
 ## Recommended expansion order
 
@@ -77,6 +78,7 @@ Comparison and proof details: `docs/why-not-just-tools.md`
 
 - Decision guide (fit + path + stop point): `docs/decision-guide.md`
 - Adoption walkthrough: `docs/example-adoption-flow.md`
+- Adoption scenarios: `docs/adoption-examples.md`
 - Real artifact output showcase: `docs/evidence-showcase.md`
 - Command taxonomy: `docs/command-taxonomy.md`
 - Release-confidence model and lanes: `docs/release-confidence.md`
@@ -224,6 +226,7 @@ Optional extras are only for specialized workflows (contributing, docs authoring
 For teams adopting SDETKit in another repository, start with:
 
 - `docs/adoption.md` for copy-paste local and GitHub Actions workflows.
+- `docs/adoption-examples.md` for practical rollout shapes by team/repo context.
 - `docs/recommended-ci-flow.md` for the recommended baseline CI shape (PR fast feedback, stricter `main`, release-oriented checks).
 - First gate: `python -m sdetkit gate fast`
 - Stricter rollout: security budgets + `python -m sdetkit gate release`

--- a/docs/adoption-examples.md
+++ b/docs/adoption-examples.md
@@ -1,0 +1,112 @@
+# Adoption examples: practical first rollout shapes
+
+These examples are intentionally small and realistic.
+
+They use the existing Stable/Core command path for **release confidence / shipping readiness** and avoid unsupported integrations or "big bang" rollouts.
+
+## 1) Solo maintainer with a small Python repository
+
+**Who this is for**
+
+- One maintainer (or very small team) running a Python package/service repo.
+- You want a quick, repeatable ship/no-ship signal without heavy CI redesign.
+
+**Starting goal**
+
+- Get a deterministic baseline signal locally, then mirror it in CI.
+
+**Recommended first commands**
+
+```bash
+python -m sdetkit gate fast
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+```
+
+**Add next after initial success**
+
+- Add a minimal CI job that runs `python -m sdetkit gate fast` on pull requests.
+- Use [adoption-troubleshooting.md](adoption-troubleshooting.md) and [remediation-cookbook.md](remediation-cookbook.md) if the first failures expose cleanup work.
+
+**What not to do yet (common overreach)**
+
+- Do not start with strict zero-budget security enforcement if the repo has known debt.
+- Do not add multiple new gates at once before `gate fast` is consistently green.
+
+## 2) Team tightening release checks in an existing service repo
+
+**Who this is for**
+
+- A team with an existing CI pipeline that already runs tests/lint, but no clear release gate.
+
+**Starting goal**
+
+- Keep PR feedback fast, and add a stricter release branch path for higher shipping confidence.
+
+**Recommended first commands**
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+```
+
+Use the staged rollout from [adoption.md](adoption.md) and the branch strategy in [recommended-ci-flow.md](recommended-ci-flow.md).
+
+**Add next after initial success**
+
+- Upload `build/*.json` as CI artifacts so reviewers can triage failures from structured output.
+- Move strict checks to release branches first, then expand scope once flakiness and debt are reduced.
+
+**What not to do yet (common overreach)**
+
+- Do not block every branch on the strictest path on day one.
+- Do not treat first strict failures as tool issues; route them as release-readiness backlog.
+
+## 3) Repo starting with core path first, then expanding into integrations/playbooks
+
+**Who this is for**
+
+- Teams new to SDETKit that want to avoid premature adoption of advanced lanes.
+
+**Starting goal**
+
+- Prove value quickly with the flagship core path, then layer integrations/playbooks intentionally.
+
+**Recommended first commands**
+
+In this repository:
+
+```bash
+bash scripts/ready_to_use.sh quick
+bash scripts/ready_to_use.sh release
+```
+
+In an external repository:
+
+```bash
+python -m sdetkit gate fast
+python -m sdetkit gate release
+```
+
+**Add next after initial success**
+
+- Add CI automation using [github-action.md](github-action.md) or [adoption.md](adoption.md).
+- Add guided operational rollout with a focused playbook only after core gates are routine (see [examples.md](examples.md)).
+
+**What not to do yet (common overreach)**
+
+- Do not start from historical or specialized integration pages before core commands are understood.
+- Do not expand into multiple playbooks simultaneously without a stable core gate baseline.
+
+## Quick decision aid
+
+- Need fastest first proof in a single repo: start with Scenario 1.
+- Need branch-aware release tightening in team CI: start with Scenario 2.
+- Need phased adoption from core into broader SDETKit usage: start with Scenario 3.
+
+## Related docs
+
+- [Ready-to-use setup](ready-to-use.md)
+- [Adopt SDETKit in your repository](adoption.md)
+- [Example adoption flow](example-adoption-flow.md)
+- [Recommended CI flow](recommended-ci-flow.md)

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -158,6 +158,7 @@ Use those artifacts first, then follow:
 
 - [Adoption troubleshooting](adoption-troubleshooting.md)
 - [Remediation cookbook](remediation-cookbook.md)
+- [Adoption examples](adoption-examples.md)
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Release-confidence examples](examples.md)
 - [Production readiness command](production-readiness.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 [Open quickstart](ready-to-use.md){ .md-button }
 [Release confidence story](release-confidence.md){ .md-button }
 [Adopt in your repo](adoption.md){ .md-button }
+[Adoption examples](adoption-examples.md){ .md-button }
 [Adoption troubleshooting](adoption-troubleshooting.md){ .md-button }
 [See integrations](github-action.md){ .md-button }
 [See playbooks](global-production-transformation-playbook.md){ .md-button }
@@ -70,6 +71,7 @@ Use this sequence to keep rollout focused:
 2. **Strict release gate** via `bash scripts/ready_to_use.sh release`
 3. **Discover core commands** via [cli.md](cli.md)
 4. **External adoption** via [adoption.md](adoption.md)
+5. **Pick a rollout scenario** via [adoption-examples.md](adoption-examples.md)
 
 ## Flagship workflow (manual form)
 

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -68,6 +68,7 @@ Use this when you need production-quality release evidence.
 4. Run strict release checks (`bash scripts/ready_to_use.sh release` or security-enforce + `gate release`).
 5. Use [cli.md](cli.md) to discover core command families.
 6. Use [adoption.md](adoption.md) to roll the same path into CI.
+7. Pick a realistic rollout shape in [adoption-examples.md](adoption-examples.md).
 
 ## Next actions after setup
 
@@ -92,5 +93,6 @@ That guide includes:
 - Installation from GitHub
 - Copy-paste GitHub Actions workflows
 - A staged path from `gate fast` to stricter release gating
+- Scenario-based rollout examples in [adoption-examples.md](adoption-examples.md)
 
 If quick or release checks fail in an external adoption flow, use the [remediation cookbook](remediation-cookbook.md) for copy-paste next steps.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - Adopt in your repository: adoption.md
       - Recommended CI flow (baseline): recommended-ci-flow.md
       - Example adoption flow: example-adoption-flow.md
+      - Adoption examples: adoption-examples.md
       - Adoption troubleshooting: adoption-troubleshooting.md
       - Remediation cookbook: remediation-cookbook.md
       - Evidence showcase: evidence-showcase.md


### PR DESCRIPTION
### Motivation

- Provide small, realistic adoption examples that show how different users and repo types can start using the toolkit while remaining aligned to the product direction of “release confidence / shipping readiness.”
- Make scenario guidance easy to discover from the primary onboarding and adoption pages so operators pick a practical path instead of guessing rollout scope.
- Keep this change strictly docs-only to avoid touching behavior, commands, packaging, dependencies, or release flow.

### Description

- Added a new page `docs/adoption-examples.md` containing three concise scenarios: (1) solo maintainer / small Python repo, (2) team tightening release checks in an existing service repo, and (3) core-path-first rollout that later expands into integrations/playbooks.
- Scenarios are grounded in existing, documented commands such as `python -m sdetkit gate fast`, `python -m sdetkit gate release`, `python -m sdetkit security enforce`, and `bash scripts/ready_to_use.sh`, and include who it’s for, starting goal, recommended first commands, next steps, and common overreach to avoid.
- Added discoverability cross-links from `docs/adoption.md`, `docs/index.md`, `docs/ready-to-use.md`, `README.md`, and the site navigation in `mkdocs.yml` so scenario guidance is surfaced in onboarding and CI guidance.
- All edits are additive and navigational; no code paths, commands, dependencies, or release flows were changed.

### Testing

- Built the docs with `mkdocs build -q` and the build completed successfully (a Material/MkDocs upstream informational warning was emitted and is unrelated to these changes).
- Verified cross-links exist by searching changed docs for `adoption-examples.md` and confirming updates in `README.md`, `docs/adoption.md`, `docs/index.md`, `docs/ready-to-use.md`, and `mkdocs.yml`.
- No unit tests or runtime code were modified, so no behavioral tests were required or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1d59ea6fc8327bb328f930c876b52)