### PR TITLE
docs: add compact choose-your-path adoption guide

### DIFF
--- a/docs/adoption-examples.md
+++ b/docs/adoption-examples.md
@@ -2,6 +2,8 @@
 
 These examples are intentionally small and realistic.
 
+Need a quick self-selection shortcut first? Start with [Choose your path](choose-your-path.md).
+
 They use the existing Stable/Core command path for **release confidence / shipping readiness** and avoid unsupported integrations or "big bang" rollouts.
 
 ## 1) Solo maintainer with a small Python repository
@@ -110,3 +112,4 @@ python -m sdetkit gate release
 - [Adopt SDETKit in your repository](adoption.md)
 - [Example adoption flow](example-adoption-flow.md)
 - [Recommended CI flow](recommended-ci-flow.md)
+- [Choose your path](choose-your-path.md)

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -4,6 +4,8 @@ This page is for teams using SDETKit **outside this repository**.
 
 It gives you a safe, copy-paste path from first run to stricter CI enforcement.
 
+Need help choosing rollout order first? Use the compact [Choose your path guide](choose-your-path.md).
+
 ## What to install
 
 Until public package release is completed, install from GitHub:
@@ -159,6 +161,7 @@ Use those artifacts first, then follow:
 - [Adoption troubleshooting](adoption-troubleshooting.md)
 - [Remediation cookbook](remediation-cookbook.md)
 - [Adoption examples](adoption-examples.md)
+- [Choose your path](choose-your-path.md)
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Release-confidence examples](examples.md)
 - [Production readiness command](production-readiness.md)

--- a/docs/choose-your-path.md
+++ b/docs/choose-your-path.md
@@ -1,0 +1,35 @@
+# Choose your path: compact adoption and rollout guide
+
+Use this page to quickly pick the safest first rollout path for your repository.
+
+The default product direction stays the same: **release confidence / shipping readiness for software teams**.
+
+## If this sounds like you, start here
+
+| Repo situation | Choose this path | First command(s) | Add next | Postpone for now |
+| --- | --- | --- | --- | --- |
+| Small or clean repo, want fast signal in minutes | **Path A — Fast signal first** | `python -m sdetkit gate fast` | Add CI `gate fast` on PRs and pushes; keep JSON output for triage (`--format json --stable-json --out build/gate-fast.json`). | Strict zero-budget enforcement and release gating on every branch. |
+| Existing repo already has CI, but quality/security discipline is uneven | **Path B — Stabilize baseline, then tighten** | `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json` | Fix top recurring failures, upload `build/*.json` artifacts, then add `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0` on release branches first. | Blocking all branches immediately with strict security + release checks. |
+| Team wants stricter release confidence before broader expansion | **Path C — Release confidence first** | `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0` then `python -m sdetkit gate release` | Keep `gate fast` on PRs, keep strict checks on release branches/tags, and standardize artifact review in release decisions. | Expanding into broader integrations/playbooks before strict release path is routine. |
+
+## Minimal rollout order (safe default)
+
+1. Start with **Path A** for first signal.
+2. Move to **Path B** when recurring failures and uneven discipline appear.
+3. Apply **Path C** when release decisions need stricter, auditable confidence.
+
+## Command set used in all paths
+
+These are the same existing, supported commands already used in adoption docs:
+
+- `python -m sdetkit gate fast`
+- `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0`
+- `python -m sdetkit gate release`
+
+## Next reading
+
+- [Adopt SDETKit in your repository](adoption.md)
+- [Adoption examples](adoption-examples.md)
+- [Ready-to-use setup](ready-to-use.md)
+- [Recommended CI flow](recommended-ci-flow.md)
+- [Decision guide (fit assessment)](decision-guide.md)

--- a/docs/decision-guide.md
+++ b/docs/decision-guide.md
@@ -2,6 +2,8 @@
 
 Use this page to make a fast, technical decision: **fit, first path, and stop point**.
 
+If you already know SDETKit is a fit and only need rollout selection, use [Choose your path](choose-your-path.md).
+
 SDETKit is a layered **release-confidence and engineering-operations toolkit**. It is strongest when you need deterministic checks, reusable evidence, and a repeatable operator workflow across local and CI usage.
 
 ## 1) Good-fit profile

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 
 [Start in 5 minutes](#fast-start){ .md-button .md-button--primary }
 [Decision guide](decision-guide.md){ .md-button }
+[Choose your path](choose-your-path.md){ .md-button }
 [Open quickstart](ready-to-use.md){ .md-button }
 [Release confidence story](release-confidence.md){ .md-button }
 [Adopt in your repo](adoption.md){ .md-button }
@@ -71,7 +72,8 @@ Use this sequence to keep rollout focused:
 2. **Strict release gate** via `bash scripts/ready_to_use.sh release`
 3. **Discover core commands** via [cli.md](cli.md)
 4. **External adoption** via [adoption.md](adoption.md)
-5. **Pick a rollout scenario** via [adoption-examples.md](adoption-examples.md)
+5. **Pick a rollout scenario** via [choose-your-path.md](choose-your-path.md)
+6. **See full scenarios** via [adoption-examples.md](adoption-examples.md)
 
 ## Flagship workflow (manual form)
 
@@ -102,6 +104,7 @@ Read the policy: [stability-levels.md](stability-levels.md)
 ## Next steps (ordered by default path)
 
 - [Decision guide: is SDETKit right for you?](decision-guide.md)
+- [Choose your path: compact rollout self-selection](choose-your-path.md)
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Release confidence model and lanes](release-confidence.md)
 - [Adopt in your repository](adoption.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -2,6 +2,8 @@
 
 Use this guide when you want a practical start to release confidence without learning the entire repository first.
 
+If you need a 30-second rollout self-selection first, use [Choose your path](choose-your-path.md).
+
 ## Install SDETKit
 
 Choose the path that matches your context:
@@ -69,6 +71,7 @@ Use this when you need production-quality release evidence.
 5. Use [cli.md](cli.md) to discover core command families.
 6. Use [adoption.md](adoption.md) to roll the same path into CI.
 7. Pick a realistic rollout shape in [adoption-examples.md](adoption-examples.md).
+8. Use [choose-your-path.md](choose-your-path.md) when deciding rollout order across teams.
 
 ## Next actions after setup
 


### PR DESCRIPTION
### Motivation
- Help first-time adopters self-select the right rollout/adoption path quickly without reading multiple pages. 
- Provide a compact, repo-specific decision aid that complements existing onboarding and example pages while keeping the flagship direction: release confidence / shipping readiness. 
- Keep the change docs-only and safe: no behavioral, command, dependency, package, or release-flow changes.

### Description
- Added a new compact guide at `docs/choose-your-path.md` that presents three practical paths (Fast signal, Stabilize then tighten, Release confidence first) with when to choose, first command(s), next steps, and what to postpone. 
- Cross-linked the new guide from these onboarding entry points: `docs/adoption.md`, `docs/adoption-examples.md`, `docs/ready-to-use.md`, `docs/index.md`, and `docs/decision-guide.md`. 
- Reused only existing supported commands in the guide (`python -m sdetkit gate fast`, `python -m sdetkit security enforce ...`, `python -m sdetkit gate release`) and documented a safe minimal rollout order (Path A → B → C). 
- All edits are additive to documentation only; no new workflows or unsupported modes were introduced.

### Testing
- Ran `git diff --check` to verify no whitespace or diff issues and it returned clean results (success). 
- Verified working tree and staged changes with `git status --short` and confirmed the new/modified files were present (success). 
- Render / content sanity checks performed by outputting files with `nl`/`sed` to confirm the new page and cross-links appear in `docs/choose-your-path.md`, `docs/adoption.md`, `docs/adoption-examples.md`, `docs/ready-to-use.md`, `docs/index.md`, and `docs/decision-guide.md` (success). 
- Committed changes with message `docs: add compact choose-your-path adoption guide` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1d752e2908327941d6ace7ccb4905)