### PR TITLE
docs: add compact first-run sample outputs and evidence snippets

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -4,6 +4,8 @@ This page is for teams using SDETKit **outside this repository**.
 
 It gives you a safe, copy-paste path from first run to stricter CI enforcement.
 
+Want to preview realistic command and artifact snippets first? See [Sample outputs](sample-outputs.md).
+
 Need help choosing rollout order first? Use the compact [Choose your path guide](choose-your-path.md).
 
 ## What to install

--- a/docs/choose-your-path.md
+++ b/docs/choose-your-path.md
@@ -32,4 +32,5 @@ These are the same existing, supported commands already used in adoption docs:
 - [Adoption examples](adoption-examples.md)
 - [Ready-to-use setup](ready-to-use.md)
 - [Recommended CI flow](recommended-ci-flow.md)
+- [Sample outputs (what first runs look like)](sample-outputs.md)
 - [Decision guide (fit assessment)](decision-guide.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -99,3 +99,5 @@ That guide includes:
 - Scenario-based rollout examples in [adoption-examples.md](adoption-examples.md)
 
 If quick or release checks fail, start with [First-failure triage](first-failure-triage.md), then use the [remediation cookbook](remediation-cookbook.md) for copy-paste next steps.
+
+If you want compact, realistic output examples before your first run, see [Sample outputs](sample-outputs.md).

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -53,3 +53,4 @@ For new users and adopters, use this sequence:
 - First-failure triage (compact): [first-failure-triage.md](first-failure-triage.md)
 - Expanded troubleshooting: [adoption-troubleshooting.md](adoption-troubleshooting.md)
 - Practical scenarios: [examples.md](examples.md)
+- Compact representative outputs: [sample-outputs.md](sample-outputs.md)

--- a/docs/sample-outputs.md
+++ b/docs/sample-outputs.md
@@ -1,0 +1,105 @@
+# Sample outputs (representative first-run evidence)
+
+Use this page to quickly see what a **realistic first run** can look like on the Stable/Core path.
+
+These snippets are **representative/illustrative** and based on documented outputs already used in this repository (not customer production screenshots).
+
+## 1) Quick confidence run: `gate fast` succeeds
+
+**Command**
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+```
+
+**Illustrative output snippet (pass shape)**
+
+```json
+{
+  "failed_steps": [],
+  "ok": true,
+  "profile": "fast"
+}
+```
+
+**What to notice**
+
+- `ok: true` and empty `failed_steps` means the fast gate is green.
+- `profile: "fast"` confirms this is the quick-confidence lane artifact.
+
+**What to do next**
+
+- Keep `gate fast` on PRs.
+- Add strict security enforcement next on release branches:
+
+```bash
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
+```
+
+## 2) First strict security run: budget fails
+
+**Command**
+
+```bash
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
+```
+
+**Representative output snippet**
+
+```json
+{"counts":{"error":0,"info":131,"total":131,"warn":0},"ok":false,"exceeded":[{"metric":"info","count":131,"limit":0}]}
+```
+
+**What to notice**
+
+- `ok: false` with `exceeded` tells you exactly which budget blocked the gate.
+- In first adoption, this is common and expected when `--max-info 0` is too strict for current baseline.
+
+**What to do next**
+
+- Keep `--max-error 0 --max-warn 0` strict.
+- Set a temporary realistic `--max-info` baseline and ratchet down:
+
+```bash
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 200
+```
+
+## 3) Release-confidence evidence artifact: release readiness summary
+
+**Command path**
+
+```bash
+python -m sdetkit gate release --format json --out build/release-preflight.json
+```
+
+**Representative evidence snippet**
+
+```json
+{
+  "name": "day19-release-readiness-board",
+  "summary": {
+    "gate_status": "pass",
+    "release_score": 96.56,
+    "strict_all_green": true
+  },
+  "strict_failures": []
+}
+```
+
+**What to notice**
+
+- A compact summary can be used as release-review evidence (`gate_status`, score, strict-failure list).
+- `strict_failures: []` indicates no strict blockers in this sample.
+
+**What to do next**
+
+- Upload release JSON artifacts in CI and link them in release decisions.
+- If release fails, triage in order: `failed_steps` -> `doctor --release` -> rerun `gate release`.
+
+## Related guides
+
+- [Ready-to-use setup](ready-to-use.md)
+- [Adopt SDETKit in your repository](adoption.md)
+- [Release confidence with SDETKit](release-confidence.md)
+- [First-failure triage](first-failure-triage.md)
+- [Evidence showcase](evidence-showcase.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Example adoption flow: example-adoption-flow.md
       - Adoption examples: adoption-examples.md
       - Adoption troubleshooting: adoption-troubleshooting.md
+      - Sample outputs (first-run evidence): sample-outputs.md
       - Remediation cookbook: remediation-cookbook.md
       - Evidence showcase: evidence-showcase.md
       - Examples: examples.md


### PR DESCRIPTION
### Motivation

- Provide first-time adopters compact, realistic examples of artifacts and terminal output so they know what a successful or first-failure run looks like. 
- Improve trust and reduce onboarding friction by surfacing high-signal snippets for the core Stable/Core path without changing behavior or commands. 
- Keep the change small and low-risk by making it docs-only and grounded in existing commands and artifacts.

### Description

- Add `docs/sample-outputs.md` containing three concise representative examples: a `gate fast` pass shape, a `security enforce` budget failure (and follow-up command), and a `gate release` release-readiness summary. 
- Add discoverability cross-links from `docs/adoption.md`, `docs/ready-to-use.md`, `docs/release-confidence.md`, and `docs/choose-your-path.md`. 
- Add the new page to navigation in `mkdocs.yml` under Core release-confidence journeys. 
- No runtime code, command behavior, packaging, dependency, or CI/release flow changes; purely documentation edits.

### Testing

- Ran site build with `mkdocs build -q`, which completed successfully. 
- Verified the docs files were staged and committed and inspected the commit with `git show` to confirm the changes were included. 
- Confirmed the new page is referenced from onboarding/core-path docs and added to navigation in `mkdocs.yml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1dafa2e248327b9d7c40ce29a8d02)