### PR TITLE
docs: add compact CI artifact walkthrough for reviewer/operator triage

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,5 +1,7 @@
 # Adopt SDETKit in your repository
 
+For a compact reviewer/operator artifact decode after CI runs, use [CI artifact walkthrough](ci-artifact-walkthrough.md).
+
 This page is for teams using SDETKit **outside this repository**.
 
 It gives you a safe, copy-paste path from first run to stricter CI enforcement.

--- a/docs/ci-artifact-walkthrough.md
+++ b/docs/ci-artifact-walkthrough.md
@@ -1,0 +1,27 @@
+# CI artifact walkthrough (core release-confidence path)
+
+Use this page when a CI run is finished and you need the fastest **artifact-first** review path.
+
+Grounded in this repository's documented workflow/artifacts:
+
+- `ci-gate-diagnostics` upload bundle (`build/gate-fast.json`, `build/security-enforce.json`)
+- `release-diagnostics` upload bundle (`build/release-preflight.json`)
+
+For full troubleshooting depth, continue to [adoption-troubleshooting.md](adoption-troubleshooting.md).
+
+## Artifact-to-action map
+
+| Artifact/file | What it represents | Look here first | If healthy, do this next | If failure/risk, do this next |
+| --- | --- | --- | --- | --- |
+| `build/gate-fast.json` | Fast PR-safe gate result (`gate fast`) and first failing step list | `ok`, then `failed_steps` (first item), then matching `steps[]` entry (`id`, `rc`) | Keep PR flow unchanged; move to `build/security-enforce.json` for threshold posture. | Fix the first failed step category (lint/type/tests/doctor/templates), rerun fast gate, then re-check artifact. |
+| `build/security-enforce.json` | Security budget enforcement result (`security enforce`) with current counts vs limits | `ok`, `counts`, `exceeded`, `limits` | Keep current thresholds; proceed with stricter `main`/release checks. | Remediate findings or temporarily tune budget with explicit follow-up to ratchet down. |
+| `build/release-preflight.json` | Release metadata preflight state used in tag/release workflows | `ok`, `version`, `tag`, `pyproject`, `changelog` (and summary fields when present) | Continue to package validation/publish flow for the same tag. | Fix tag/version/changelog mismatch first, rerun preflight, then continue release checks. |
+
+## Recommended review order
+
+1. Download artifacts from the workflow run: `ci-gate-diagnostics` and (for tag builds) `release-diagnostics`.
+2. Open `build/gate-fast.json` first for fastest actionable failure.
+3. Open `build/security-enforce.json` second for policy/budget posture.
+4. On release/tag runs, open `build/release-preflight.json` before checking later packaging logs.
+
+This order keeps review focused on deterministic go/no-go evidence before log-deep-dives.

--- a/docs/recommended-ci-flow.md
+++ b/docs/recommended-ci-flow.md
@@ -2,6 +2,8 @@
 
 This page is the **recommended baseline** for operationalizing SDETKit in GitHub Actions with minimal friction.
 
+For a compact reviewer/operator read path over CI artifacts, see [CI artifact walkthrough](ci-artifact-walkthrough.md).
+
 It is intentionally small and derived from this repository's current CI/release patterns in:
 
 - `.github/workflows/ci.yml`

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -1,5 +1,7 @@
 # Release confidence with SDETKit
 
+Need a compact operator/reviewer decode of CI evidence files? Use the [CI artifact walkthrough](ci-artifact-walkthrough.md).
+
 SDETKit exists for one primary outcome: help teams make a release decision with deterministic checks and audit-friendly evidence.
 
 ## Core idea

--- a/docs/sample-outputs.md
+++ b/docs/sample-outputs.md
@@ -1,5 +1,7 @@
 # Sample outputs (representative first-run evidence)
 
+Need a compact “what this artifact means and what to do next” map? See [CI artifact walkthrough](ci-artifact-walkthrough.md).
+
 Use this page to quickly see what a **realistic first run** can look like on the Stable/Core path.
 
 These snippets are **representative/illustrative** and based on documented outputs already used in this repository (not customer production screenshots).


### PR DESCRIPTION
### Motivation

- Provide a short, operational artifact-first walkthrough so reviewers and operators can quickly interpret CI release-confidence outputs. 
- Surface the few highest-signal JSON artifacts already emitted by CI so teams can act without scanning long logs or changing any pipelines.

### Description

- Add a new compact walkthrough page `docs/ci-artifact-walkthrough.md` that maps `build/gate-fast.json`, `build/security-enforce.json`, and `build/release-preflight.json` to what they represent and the immediate next actions for healthy and failing states. 
- Cross-link the new walkthrough from the most relevant CI/docs pages: `docs/recommended-ci-flow.md`, `docs/release-confidence.md`, `docs/sample-outputs.md`, and `docs/adoption.md`. 
- Keep the change strictly docs-only and minimal, with no command, CI logic, package, dependency, or behavioral changes.

### Testing

- Verified references and presence of the new file with repository searches using `rg` to confirm the three artifact names and the new walkthrough links were found in the updated docs. 
- Previewed the new and updated files with `sed`/`nl` to ensure the artifact-to-action table and cross-links render as intended. 
- Confirmed the walkthrough includes the expected artifact names (`build/gate-fast.json`, `build/security-enforce.json`, `build/release-preflight.json`) and a clear recommended review order; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1df435eac8327bfebb6e0f7d57d39)