### PR TITLE
docs: add compact versioning and support posture policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Comparison and proof details: `docs/why-not-just-tools.md`
 - Compact first-failure triage (core path): `docs/first-failure-triage.md`
 - Scenario-based proof examples: `docs/examples.md`
 - Stability levels (current policy): `docs/stability-levels.md`
+- Versioning and support posture (current policy): `docs/versioning-and-support.md`
 - Product boundary audit and taxonomy plan: `docs/productization-map.md`
 
 ### Secondary and transition-era material
@@ -105,7 +106,7 @@ SDETKit uses four user-facing stability levels: **Stable/Core**, **Integrations*
 - Use **Playbooks** for guided adoption and operational lanes.
 - Treat **Experimental** lanes (including day/closeout families) as opt-in transition-era or advanced flows.
 
-Policy doc: `docs/stability-levels.md`
+Policy docs: `docs/stability-levels.md`, `docs/versioning-and-support.md`
 
 ## Core commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ SDETKit documents command and workflow maturity with four levels: **Stable/Core*
 - **Playbooks** provide guided rollout lanes for adoption and operating practice.
 - **Experimental** includes transition-era/advanced day and closeout lanes; keep as opt-in with validation.
 
-Read the policy: [stability-levels.md](stability-levels.md)
+Read the policies: [stability-levels.md](stability-levels.md) and [versioning-and-support.md](versioning-and-support.md)
 
 ## Next steps (ordered by default path)
 
@@ -108,6 +108,7 @@ Read the policy: [stability-levels.md](stability-levels.md)
 - [Choose your path: compact rollout self-selection](choose-your-path.md)
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Release confidence model and lanes](release-confidence.md)
+- [Versioning and support posture](versioning-and-support.md)
 - [Adopt in your repository](adoption.md)
 - [Recommended CI flow (baseline)](recommended-ci-flow.md)
 - [Global production transformation playbook](global-production-transformation-playbook.md)

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -56,3 +56,4 @@ For new users and adopters, use this sequence:
 - Expanded troubleshooting: [adoption-troubleshooting.md](adoption-troubleshooting.md)
 - Practical scenarios: [examples.md](examples.md)
 - Compact representative outputs: [sample-outputs.md](sample-outputs.md)
+- Versioning and support posture: [versioning-and-support.md](versioning-and-support.md)

--- a/docs/stability-levels.md
+++ b/docs/stability-levels.md
@@ -52,4 +52,5 @@ This includes many day/cycle/closeout lanes. They remain available as transition
 See also:
 
 - [Productization map](productization-map.md)
+- [Versioning and support posture](versioning-and-support.md)
 - [Capability map and command taxonomy](command-taxonomy.md)

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -1,0 +1,85 @@
+# Versioning and support posture (current policy)
+
+SDETKit's flagship promise remains:
+
+> **Release confidence / shipping readiness for software teams.**
+
+This page documents the **current** trust-and-governance posture for versions,
+compatibility, support, and deprecation. It is intentionally compact and avoids
+promises that are not yet operationally guaranteed.
+
+## Scope and intent
+
+- This is a **current policy** for users and maintainers.
+- It complements (not replaces) command docs, release workflow docs, and
+  stability-level guidance.
+- Where needed, this page uses terms like **intended direction** and
+  **best-effort** to stay honest about present-day guarantees.
+
+## Versioning expectations
+
+- SDETKit uses a semantic version format (`MAJOR.MINOR.PATCH`) as the current
+  release convention.
+- Current intent:
+  - `PATCH` for fixes/docs/internal non-breaking improvements.
+  - `MINOR` for backward-compatible feature growth.
+  - `MAJOR` for deliberate breaking changes.
+- Versioning is maintained with release process checks, but users should treat
+  this as a practical maintainer policy rather than a legal compatibility SLA.
+
+## Compatibility expectations
+
+- **Stable/Core** commands and workflows are the primary compatibility target.
+- Integrations and playbooks are supported with best-effort compatibility,
+  recognizing third-party/environment variability.
+- Experimental and transition-era lanes may evolve faster and should be
+  validated before production reliance.
+- Compatibility expectations are intentionally tied to stability tiers rather
+  than assuming all surfaces have the same change velocity.
+
+## Stability tiers and what they imply
+
+- **Stable/Core:** highest confidence for day-to-day release gating and shipping
+  readiness checks.
+- **Integrations:** suitable for production use after local/CI validation in
+  your environment.
+- **Playbooks:** supported and useful, but expected to iterate more than core
+  gates.
+- **Experimental:** opt-in, best-effort maintenance, and faster evolution.
+
+For tier definitions and rollout guidance, see
+[stability-levels.md](stability-levels.md).
+
+## Deprecation approach (current)
+
+- No blanket hard timeline is promised for all deprecations.
+- Preferred approach:
+  1. Mark direction clearly in docs/CLI help/changelog where practical.
+  2. Keep compatibility aliases/wrappers during transition windows when
+     feasible.
+  3. Remove or tighten behavior deliberately in a major version when impact is
+     material.
+- Some historical and transition-era commands remain intentionally available for
+  auditability and migration support.
+
+## What users should treat as stable vs evolving
+
+Treat as most stable for production rollout:
+
+- Core release-confidence flow (`quick` then `release`).
+- Core gate/security/doctor/evidence command families.
+- Published installation and release-validation docs.
+
+Treat as evolving (validate before broad dependence):
+
+- Environment-specific integration edges.
+- Guided playbook narratives and transition-era/day closeout lanes.
+- Newer or explicitly experimental command families.
+
+## Related references
+
+- [stability-levels.md](stability-levels.md)
+- [release-confidence.md](release-confidence.md)
+- [command-surface.md](command-surface.md)
+- [releasing.md](releasing.md)
+- [release-verification.md](release-verification.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - Command surface inventory (stability-aware): command-surface.md
       - Capability map and command taxonomy: command-taxonomy.md
       - Stability levels (current policy): stability-levels.md
+      - Versioning and support posture (current policy): versioning-and-support.md
   - Core release-confidence journeys:
       - Adopt in your repository: adoption.md
       - Recommended CI flow (baseline): recommended-ci-flow.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ Issues = "https://github.com/sherif69-sa/DevS69-sdetkit/issues"
 Releases = "https://github.com/sherif69-sa/DevS69-sdetkit/releases"
 Changelog = "https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CHANGELOG.md"
 "Release Process" = "https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/RELEASE.md"
+"Trust and Support Policy" = "https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/docs/versioning-and-support.md"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
### Motivation

- Provide a small, honest trust-and-governance layer that documents versioning, compatibility, stability tiers, deprecation approach, and what users should treat as stable vs evolving.  
- Keep the change low-risk and docs-only so maintenance expectations are explicit without altering behavior, commands, packaging, or release automation.  

### Description

- Added a compact policy page `docs/versioning-and-support.md` describing current policy, intended direction, and best-effort support posture.  
- Added low-risk cross-links to surface the policy from `README.md`, `docs/index.md`, `docs/stability-levels.md`, and `docs/release-confidence.md`.  
- Updated the site navigation in `mkdocs.yml` to include `versioning-and-support.md`.  
- Added a minimal discoverability entry `project.urls["Trust and Support Policy"]` to `pyproject.toml` (docs metadata only).  

### Testing

- Ran `python -m sdetkit --help` which succeeded and validated CLI help still prints (smoke check).  
- Ran `python scripts/check_day6_conversion_contract.py` which failed due to pre-existing repository contract/snippet expectations unrelated to these docs-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1e08dd1808327b92b74c2aab566bf)