### PR TITLE
docs: add integrations/extension boundary and release-changelog operational note

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Comparison and proof details: `docs/why-not-just-tools.md`
 - Scenario-based proof examples: `docs/examples.md`
 - Stability levels (current policy): `docs/stability-levels.md`
 - Versioning and support posture (current policy): `docs/versioning-and-support.md`
+- Integrations and extension boundary (current policy): `docs/integrations-and-extension-boundary.md`
 - Product boundary audit and taxonomy plan: `docs/productization-map.md`
 
 ### Secondary and transition-era material
@@ -107,6 +108,8 @@ SDETKit uses four user-facing stability levels: **Stable/Core**, **Integrations*
 - Treat **Experimental** lanes (including day/closeout families) as opt-in transition-era or advanced flows.
 
 Policy docs: `docs/stability-levels.md`, `docs/versioning-and-support.md`
+
+Boundary guidance: `docs/integrations-and-extension-boundary.md`
 
 ## Core commands
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -10,6 +10,8 @@ Want to preview realistic command and artifact snippets first? See [Sample outpu
 
 Need help choosing rollout order first? Use the compact [Choose your path guide](choose-your-path.md).
 
+For current ecosystem boundaries (what stays core vs integration vs playbook vs experimental), see [integrations-and-extension-boundary.md](integrations-and-extension-boundary.md).
+
 ## What to install
 
 Until public package release is completed, install from GitHub:

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ SDETKit is a release confidence toolkit for SDET, QA, and DevOps teams that need
 [Adoption troubleshooting](adoption-troubleshooting.md){ .md-button }
 [First-failure triage](first-failure-triage.md){ .md-button }
 [See integrations](github-action.md){ .md-button }
+[Extension boundary](integrations-and-extension-boundary.md){ .md-button }
 [See playbooks](global-production-transformation-playbook.md){ .md-button }
 [See examples](examples.md){ .md-button }
 [See evidence commands](evidence.md){ .md-button }
@@ -102,6 +103,8 @@ SDETKit documents command and workflow maturity with four levels: **Stable/Core*
 
 Read the policies: [stability-levels.md](stability-levels.md) and [versioning-and-support.md](versioning-and-support.md)
 
+Boundary guidance: [integrations-and-extension-boundary.md](integrations-and-extension-boundary.md)
+
 ## Next steps (ordered by default path)
 
 - [Decision guide: is SDETKit right for you?](decision-guide.md)
@@ -109,6 +112,7 @@ Read the policies: [stability-levels.md](stability-levels.md) and [versioning-an
 - [Ready-to-use quickstart](ready-to-use.md)
 - [Release confidence model and lanes](release-confidence.md)
 - [Versioning and support posture](versioning-and-support.md)
+- [Integrations and extension boundary](integrations-and-extension-boundary.md)
 - [Adopt in your repository](adoption.md)
 - [Recommended CI flow (baseline)](recommended-ci-flow.md)
 - [Global production transformation playbook](global-production-transformation-playbook.md)

--- a/docs/integrations-and-extension-boundary.md
+++ b/docs/integrations-and-extension-boundary.md
@@ -1,0 +1,99 @@
+# Integrations and extension boundary
+
+SDETKit's flagship identity remains:
+
+> **Release confidence / shipping readiness for software teams.**
+
+This page defines practical ecosystem boundaries so future growth stays useful without bloating the core.
+
+## Boundary model
+
+Use this mental model when deciding where commands, docs, and workflows should live:
+
+1. **Stable/Core** = default release-confidence path for most teams.
+2. **Integrations** = optional environment/platform wiring around core checks.
+3. **Playbooks** = guided rollout/adoption operating lanes.
+4. **Experimental / transition-era** = incubator or historical lanes kept available but secondary.
+
+For formal tier definitions, see [stability-levels.md](stability-levels.md) and [versioning-and-support.md](versioning-and-support.md).
+
+## What belongs in Stable/Core
+
+Put something in **Stable/Core** when it is broadly applicable to everyday shipping-readiness decisions:
+
+- Core gate/security/doctor/evidence workflows used across repository types.
+- Deterministic pass/fail or policy outputs relied on for go/no-go decisions.
+- Installation and first-run docs that all adopters need.
+
+Core should stay focused on the default path (`quick` then `release`) and should avoid platform- or vendor-specific assumptions.
+
+## What belongs in Integrations
+
+Put something in **Integrations** when it connects core signals into a specific delivery environment:
+
+- CI provider wiring, artifact upload conventions, and external notification paths.
+- Adopter-facing guidance for using SDETKit in another repository or platform.
+- Optional integrations that depend on third-party services or environment-specific credentials.
+
+Integrations should reuse Stable/Core command outputs rather than redefining core decision logic.
+
+## What belongs in Playbooks
+
+Put something in **Playbooks** when it guides how teams adopt or operate, instead of adding a new core decision primitive:
+
+- Rollout sequencing and team operating patterns.
+- Onboarding and contribution guidance.
+- Scenario- or organization-specific execution narratives.
+
+Playbooks may iterate faster than core command docs as long as they stay aligned with the current stability and support posture.
+
+## What remains Experimental / transition-era
+
+Keep material in **Experimental** (or explicitly transition-era) when it is:
+
+- New and not yet proven across multiple adoption contexts.
+- Historical day/cycle/closeout content preserved for auditability.
+- Advanced or niche lanes that are useful for some users but not core onboarding.
+
+Do not remove this content by default; keep it available but clearly secondary in high-traffic docs.
+
+## Optional dependencies and optional integrations
+
+SDETKit keeps optional dependencies as opt-in extras (`dev`, `test`, `docs`, `packaging`, `telegram`, `whatsapp`).
+
+Practical policy:
+
+- Stable/Core usage should not require optional integrations.
+- Optional extras should be documented with explicit "use when" context.
+- Integration-specific dependencies should stay isolated from default install paths.
+
+See installation guidance in [../README.md](../README.md) and [ready-to-use.md](ready-to-use.md).
+
+## How to add future integrations/extensions safely
+
+When proposing a new integration or extension surface:
+
+1. Prove value using existing Stable/Core outputs first.
+2. Keep the integration optional and environment-scoped.
+3. Document setup, failure modes, and rollback/disable path.
+4. Cross-link stability tier and versioning/support implications.
+5. Avoid adding hard dependencies to the default core install unless broadly required.
+
+## Maintainer guardrails (what to avoid)
+
+Maintainers should avoid:
+
+- Promoting niche/vendor-specific integrations into Stable/Core too early.
+- Treating experimental or transition-era lanes as stable compatibility promises.
+- Expanding optional surfaces without matching docs/policy updates.
+- Introducing new extension claims (for example, a formal plugin API promise) unless truly implemented and supported.
+
+If uncertain, keep new capability in Integrations or Experimental first, gather adoption evidence, then promote deliberately.
+
+## Related references
+
+- [stability-levels.md](stability-levels.md)
+- [versioning-and-support.md](versioning-and-support.md)
+- [command-surface.md](command-surface.md)
+- [adoption.md](adoption.md)
+- [recommended-ci-flow.md](recommended-ci-flow.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -86,6 +86,7 @@ Then explore broader commands if needed:
 - Explore command groups: `python -m sdetkit --help`
 - See playbooks: `python -m sdetkit playbooks`
 - Read release-confidence narrative: [release-confidence.md](release-confidence.md)
+- Understand ecosystem scope: [integrations-and-extension-boundary.md](integrations-and-extension-boundary.md)
 
 ## Using this in another repository
 

--- a/docs/recommended-ci-flow.md
+++ b/docs/recommended-ci-flow.md
@@ -10,6 +10,8 @@ It is intentionally small and derived from this repository's current CI/release 
 - `.github/workflows/release.yml`
 - `docs/adoption.md`
 
+For tier and scope boundaries, use [integrations-and-extension-boundary.md](integrations-and-extension-boundary.md).
+
 ## Recommended shape
 
 Use three stages:

--- a/docs/stability-levels.md
+++ b/docs/stability-levels.md
@@ -53,4 +53,5 @@ See also:
 
 - [Productization map](productization-map.md)
 - [Versioning and support posture](versioning-and-support.md)
+- [Integrations and extension boundary](integrations-and-extension-boundary.md)
 - [Capability map and command taxonomy](command-taxonomy.md)

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -76,9 +76,20 @@ Treat as evolving (validate before broad dependence):
 - Guided playbook narratives and transition-era/day closeout lanes.
 - Newer or explicitly experimental command families.
 
+## Maintainer operational note (release/changelog hygiene)
+
+When a change can affect compatibility expectations (command behavior, output shape, install path, or integration-facing interfaces), maintainers should make the impact explicit in release materials:
+
+1. Call out the affected stability tier (**Stable/Core**, **Integrations**, **Playbooks**, or **Experimental**).
+2. State whether the change is backward-compatible or transitionary.
+3. Keep `CHANGELOG.md` wording aligned with this page and [stability-levels.md](stability-levels.md).
+
+This keeps trust policy operational in everyday review and release decisions without adding heavy process overhead.
+
 ## Related references
 
 - [stability-levels.md](stability-levels.md)
+- [integrations-and-extension-boundary.md](integrations-and-extension-boundary.md)
 - [release-confidence.md](release-confidence.md)
 - [command-surface.md](command-surface.md)
 - [releasing.md](releasing.md)


### PR DESCRIPTION
### Motivation

- Finish the productization wave by closing the remaining docs gaps around ecosystem boundaries, integrations, and trust/versioning operationalization while keeping changes documentation-only.  
- Make onboarding and adoption surfaces consistent and easy to discover for users and maintainers without changing behavior or automation.  

### Description

- Add a compact new boundary page at `docs/integrations-and-extension-boundary.md` that defines what belongs in `Stable/Core`, `Integrations`, `Playbooks`, and `Experimental`, and documents optional dependency posture and maintainer guardrails.  
- Add a maintainer operational note to `docs/versioning-and-support.md` instructing maintainers to call out the affected stability tier, compatibility direction, and align `CHANGELOG.md` wording when changes affect compatibility expectations.  
- Small, disciplined consistency/cross-link sweep in high-traffic docs to surface the new guidance, updating `README.md`, `docs/index.md`, `docs/stability-levels.md`, `docs/ready-to-use.md`, `docs/adoption.md`, and `docs/recommended-ci-flow.md` with focused links and wording harmonization.  
- No behavioral changes, no CLI/package/CI/dependency modifications, and legacy/transition-era content preserved and marked secondary.  

### Testing

- Built the documentation site successfully with `python -m mkdocs build -q`, which completed without errors.  
- Verified repository docs presence and local file changes were staged and recorded (reviewable files include `README.md`, `docs/index.md`, `docs/stability-levels.md`, `docs/versioning-and-support.md`, `docs/ready-to-use.md`, `docs/adoption.md`, `docs/recommended-ci-flow.md`, and the new `docs/integrations-and-extension-boundary.md`).  
- No runtime or package tests were required because this is docs-only and intentionally avoids behavior or release automation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1e221d22883279e6a6e29b45fd3c9)