### PR TITLE
Fix quality-gate import ordering and align docs/playbooks UX text

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -136,7 +136,7 @@ Boundary guidance: [integrations-and-extension-boundary.md](integrations-and-ext
 - [🩺 Doctor checks](doctor.md)
 - [🤝 Contribute](contributing.md)
 - [🧭 Repo tour](repo-tour.md)
-- [📦 Transition-era reports (secondary)](#legacy-reports)
+- [📦 Legacy reports](#legacy-reports)
 
 </div>
 

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -113,8 +113,8 @@ from . import (
 )
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
-from .security_gate import main as security_main
 from .public_surface_contract import render_root_help_groups
+from .security_gate import main as security_main
 
 
 def _tool_version() -> str:

--- a/src/sdetkit/playbooks_cli.py
+++ b/src/sdetkit/playbooks_cli.py
@@ -419,14 +419,14 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     p = argparse.ArgumentParser(
         prog="sdetkit playbooks",
-        description="Discover, run, and validate playbooks across Playbooks and Experimental (transition-era) lanes.",
+        description="Discover, run, and validate recommended playbooks and incubator workflows.",
     )
     sub = p.add_subparsers(dest="cmd", required=True)
 
     listp = sub.add_parser(
         "list",
-        help="List recommended playbooks, Experimental workflows, and aliases.",
-        description="List recommended playbooks, Experimental workflows, and aliases.",
+        help="List recommended playbooks, incubator workflows, and aliases.",
+        description="List recommended playbooks, incubator workflows, and aliases.",
     )
     listp.add_argument("--format", choices=["text", "json"], default="text")
     g = listp.add_mutually_exclusive_group()

--- a/tools/render_public_surface_contract_table.py
+++ b/tools/render_public_surface_contract_table.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
 import sys
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
-
-from sdetkit.public_surface_contract import PUBLIC_SURFACE_CONTRACT
 
 BEGIN = "<!-- BEGIN:PUBLIC_SURFACE_CONTRACT_TABLE -->"
 END = "<!-- END:PUBLIC_SURFACE_CONTRACT_TABLE -->"
@@ -24,6 +22,8 @@ def render_table() -> str:
         "| Command family | Purpose | Stability tier | First-time adopter default? | Transition-era / legacy-oriented? |",
         "|---|---|---|---|---|",
     ]
+    from sdetkit.public_surface_contract import PUBLIC_SURFACE_CONTRACT
+
     for family in PUBLIC_SURFACE_CONTRACT:
         lines.append(
             "| "


### PR DESCRIPTION
### Motivation

- Resolve CI quality gate failures caused by import-order/E402 lint issues and failing UX-driven unit tests for docs navigation and playbooks help text.
- Ensure the productized help copy and docs quick-jump content match strict validation expectations used by the test suite.

### Description

- Reordered top-level imports in `src/sdetkit/cli.py` to satisfy import-order linting (Ruff I001).
- Localized the `PUBLIC_SURFACE_CONTRACT` import inside `render_table()` in `tools/render_public_surface_contract_table.py` to avoid module-level imports after runtime `sys.path` manipulation and resolve E402.
- Restored productized UX wording in `src/sdetkit/playbooks_cli.py` for the root `playbooks` command and the `playbooks list` subcommand to use "recommended playbooks and incubator workflows".
- Updated `docs/index.md` quick-jump link label to `[📦 Legacy reports](#legacy-reports)` so the strict docs navigation checks find the expected entry.

### Testing

- Ran `ruff check .` and the linter returned no remaining issues.
- Ran the focused tests with `python -m pytest -q tests/test_docs_navigation.py tests/test_playbooks_help_ux.py` and they passed (`14 passed`).
- Ran the full test suite with `python -m pytest -q` and it completed successfully (`1370 passed, 1 skipped, 3 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1e5381d788327b471b5fa823ff016)