### PR TITLE
Fix import-order lint in contract table render script

### DIFF
--- a/tools/render_public_surface_contract_table.py
+++ b/tools/render_public_surface_contract_table.py
@@ -17,14 +17,18 @@ def _yes_no(value: bool) -> str:
     return "Yes" if value else "No"
 
 
+def _public_surface_contract():
+    from sdetkit.public_surface_contract import PUBLIC_SURFACE_CONTRACT
+
+    return PUBLIC_SURFACE_CONTRACT
+
+
 def render_table() -> str:
     lines = [
         "| Command family | Purpose | Stability tier | First-time adopter default? | Transition-era / legacy-oriented? |",
         "|---|---|---|---|---|",
     ]
-    from sdetkit.public_surface_contract import PUBLIC_SURFACE_CONTRACT
-
-    for family in PUBLIC_SURFACE_CONTRACT:
+    for family in _public_surface_contract():
         lines.append(
             "| "
             f"`{family.name}`"


### PR DESCRIPTION
### Motivation
- Address a lint failure caused by a non-top-level import in `tools/render_public_surface_contract_table.py` so import-order and module-level import rules are satisfied.

### Description
- Add a small helper `def _public_surface_contract()` that performs `from sdetkit.public_surface_contract import PUBLIC_SURFACE_CONTRACT` and update `render_table()` to iterate over `_public_surface_contract()` instead of relying on an in-function import.

### Testing
- Ran `ruff check` and `python3 -m ruff format --check` for the modified files and executed `bash quality.sh ci`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1ea7b7f588327a31be64e4a960de9)