### PR TITLE
docs: separate core lanes from archive/history material

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -1,0 +1,22 @@
+# Archive and history
+
+This section preserves **historical, transition-era, and closeout material** that is still useful for deep context.
+
+> This is not the recommended starting point for new users.
+
+If you're new to SDETKit, start with:
+
+- [Start here (core path)](../ready-to-use.md)
+- [Team adoption lane](../adoption.md)
+- [CI and automation lane](../recommended-ci-flow.md)
+- [Advanced and reference lane](../cli.md)
+
+## What lives in this archive
+
+- Day-by-day upgrade reports (`day-*-*-report.md`)
+- Transition-era integration and closeout docs (`integrations-*-closeout.md`, phase handoff docs, and similar)
+- Chronological roadmap reports under [`roadmap/reports/`](../roadmap.md)
+
+## Archive map
+
+Use the [transition-era material map](transition-era-material.md) to jump to specific historical tracks.

--- a/docs/archive/transition-era-material.md
+++ b/docs/archive/transition-era-material.md
@@ -1,0 +1,38 @@
+# Transition-era material map
+
+Use this page to access historical docs without mixing them into the core onboarding journey.
+
+## Day-by-day reports
+
+The full day-by-day report history is preserved as top-level docs files and excluded from first-time navigation.
+
+- Pattern: `day-*-ultra-upgrade-report.md`
+- Pattern: `day-*-big-upgrade-report.md`
+
+## Transition and closeout documents
+
+Transition-era docs are preserved as top-level docs files and grouped by naming pattern:
+
+- `integrations-*-closeout.md`
+- `integrations-phase*.md`
+- `integrations-*-handoff-*.md`
+- `integrations-*-kickoff*.md`
+
+These files primarily document sequencing, historical rollout decisions, and closeout snapshots.
+
+## Roadmap report archive
+
+Chronological reports are retained in:
+
+- `docs/roadmap/reports/`
+
+Start from [Roadmap](../roadmap.md) for current direction, then use the report archive only for historical traceability.
+
+## Guidance
+
+For current product usage, use these lanes instead:
+
+1. [Start here (core path)](../ready-to-use.md)
+2. [Team adoption](../adoption.md)
+3. [CI and automation](../recommended-ci-flow.md)
+4. [Advanced and reference](../cli.md)

--- a/docs/choose-your-path.md
+++ b/docs/choose-your-path.md
@@ -24,10 +24,11 @@ Use this page to pick the safest rollout path after the core story is clear: **d
 2. Move to **Path B** when recurring failures and uneven discipline appear.
 3. Apply **Path C** when release approvals need strict, auditable confidence.
 
-## Next reading
+## Curated lanes after path selection
 
-- [Decision guide (fit assessment)](decision-guide.md)
-- [Ready-to-use setup](ready-to-use.md)
-- [Adopt SDETKit in your repository](adoption.md)
-- [Recommended CI flow](recommended-ci-flow.md)
-- [Evidence showcase](evidence-showcase.md)
+- **Beginner lane**: [Ready-to-use setup](ready-to-use.md), [Release confidence](release-confidence.md), [Doctor](doctor.md)
+- **Team adoption lane**: [Adopt SDETKit in your repository](adoption.md), [Example adoption flow](example-adoption-flow.md)
+- **CI lane**: [Recommended CI flow](recommended-ci-flow.md), [CI contract](ci-contract.md), [CI artifact walkthrough](ci-artifact-walkthrough.md)
+- **Advanced/extensions lane**: [CLI reference](cli.md), [API](api.md), [Plugins](plugins.md), [Tool server](tool-server.md)
+
+Need historical context or transition-era chronology? Use [Archive and history](archive/index.md) instead of starting with day-by-day or closeout docs.

--- a/docs/decision-guide.md
+++ b/docs/decision-guide.md
@@ -55,3 +55,15 @@ Stop after the lightweight path if:
 - and current evidence outputs satisfy release reviewers.
 
 Then keep using the core commands and return to broader docs only when integration or scale needs increase.
+
+
+## 6) Route into a curated lane
+
+After confirming fit, choose exactly one lane to avoid doc sprawl:
+
+- **Beginner/core lane**: [Ready-to-use quickstart](ready-to-use.md) → [Release confidence](release-confidence.md) → [Doctor](doctor.md)
+- **Team adoption lane**: [Adoption](adoption.md) → [Example adoption flow](example-adoption-flow.md)
+- **CI lane**: [Recommended CI flow](recommended-ci-flow.md) → [CI contract](ci-contract.md)
+- **Advanced/extensions lane**: [CLI reference](cli.md), [API](api.md), [Plugins](plugins.md), [Tool server](tool-server.md)
+
+Historical transition-era documents remain available in [Archive and history](archive/index.md) and are intentionally out of the first-time path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,11 +52,13 @@ SDETKit gives engineering teams **deterministic release-confidence checks and ev
 
 ## Continue after the core path
 
-- [Decision guide](decision-guide.md)
-- [Choose your path](choose-your-path.md)
-- [Adopt in your repository](adoption.md)
-- [Recommended CI flow](recommended-ci-flow.md)
+Pick one lane based on your immediate need:
 
-## Secondary and historical material
+- **Team adoption lane**: [Adopt in your repository](adoption.md)
+- **CI and automation lane**: [Recommended CI flow](recommended-ci-flow.md)
+- **Advanced/extensions lane**: [Advanced and reference](cli.md)
+- **Rollout routing help**: [Decision guide](decision-guide.md), [Choose your path](choose-your-path.md)
 
-Integrations, playbooks, taxonomy depth, and transition-era historical pages remain available in docs navigation for teams that need broader rollout patterns. They are intentionally discover-later, not first-run requirements.
+## Archive and historical context
+
+Historical transition-era and day-by-day closeout material is preserved in [Archive and history](archive/index.md). Start there only if you need legacy implementation context or chronology.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,22 +82,33 @@ extra_javascript:
 
 nav:
   - Home: index.md
-  - Core path:
+  - Start here (core path):
       - Install (quickstart): ready-to-use.md
       - Gate fast + gate release: release-confidence.md
       - Doctor checks: doctor.md
       - Evidence and reports: evidence-showcase.md
       - Decision guide: decision-guide.md
       - Choose your path: choose-your-path.md
-  - Adopt and scale:
+  - Team adoption:
       - Adopt in your repository: adoption.md
-      - Recommended CI flow (baseline): recommended-ci-flow.md
       - Example adoption flow: example-adoption-flow.md
       - Adoption examples: adoption-examples.md
       - Adoption troubleshooting: adoption-troubleshooting.md
+      - First contribution quickstart: first-contribution-quickstart.md
+      - Contributing: contributing.md
+      - Starter work inventory: starter-work-inventory.md
+      - Maintainer starter-issue hygiene: maintainer-starter-issue-hygiene.md
+  - CI and automation:
+      - Recommended CI flow (baseline): recommended-ci-flow.md
+      - CI contract: ci-contract.md
+      - CI artifact walkthrough: ci-artifact-walkthrough.md
+      - "GitHub Action: sdetkit repo audit": github-action.md
+      - PR automation for audit auto-fixes: pr-automation.md
+      - n8n integration (PR webhook automation): n8n.md
+      - Reporting and trends: reporting-and-trends.md
       - Sample outputs (first-run evidence): sample-outputs.md
       - Remediation cookbook: remediation-cookbook.md
-  - Command and reference:
+  - Advanced and reference:
       - CLI reference: cli.md
       - Command surface inventory: command-surface.md
       - Capability map and command taxonomy: command-taxonomy.md
@@ -114,20 +125,12 @@ nav:
       - Reporting and trends: reporting-and-trends.md
       - Ops Control Plane: ops.md
       - Tool server: tool-server.md
-  - Integrations and playbooks (discover later):
-      - "GitHub Action: sdetkit repo audit": github-action.md
       - IDE + pre-commit integration: ide-and-precommit.md
       - n8n Integration (PR Webhook Automation): n8n.md
       - Omnichannel + MCP bridge: omnichannel-mcp-bridge.md
       - Plugins: plugins.md
       - Plugins, rule packs, and fix-audit: plugins-and-fix.md
-      - PR automation for audit auto-fixes: pr-automation.md
       - Global production transformation playbook: global-production-transformation-playbook.md
-      - First contribution quickstart: first-contribution-quickstart.md
-      - Starter work inventory: starter-work-inventory.md
-      - Maintainer starter-issue hygiene: maintainer-starter-issue-hygiene.md
-      - Contributing: contributing.md
-  - Strategy and governance:
       - Why not just separate tools? (system value): why-not-just-tools.md
       - Product strategy (release confidence): product-strategy.md
       - Stability levels (current policy): stability-levels.md
@@ -143,14 +146,14 @@ nav:
       - Changelog: changelog.md
       - Roadmap: roadmap.md
       - License: license.md
-  - Live Views:
+  - Advanced live views:
       - 🕹️ DevS69 Command HUD — Live Detail View: command-hud-live.md
       - 🔄 DevS69 Diff-to-Decision — Live Detail View: diff-flow-live.md
       - 🗺️ DevS69 Repo Map — Live Detail View: repo-map-live.md
       - DevS69 Visual HUD Showcase: hud-showcase.md
-  - Transition-era and historical archive (secondary):
-      - Stability policy for Experimental lanes: stability-levels.md
-      - Productization boundary map: productization-map.md
+  - Archive and history:
+      - Archive overview: archive/index.md
+      - Transition-era material map: archive/transition-era-material.md
 
 exclude_docs: |
   artifacts/**


### PR DESCRIPTION
### Motivation

- Make the first-time docs experience product-first and opinionated so new visitors follow a single core adoption path instead of encountering transition-era material early. 
- Preserve deep historical and closeout material for traceability while removing it from the primary onboarding/navigation surface. 
- Provide explicit lanes (core, team adoption, CI, advanced) so users can pick one safe path and avoid doc sprawl.

### Description

- Reorganized the primary navigation in `mkdocs.yml` into product-led lanes: `Start here (core path)`, `Team adoption`, `CI and automation`, `Advanced and reference`, and `Archive and history`.
- Updated the homepage `docs/index.md` to keep the core path front-and-center and add a clear pointer to the new archive landing page `docs/archive/index.md`.
- Updated routing pages `docs/decision-guide.md` and `docs/choose-your-path.md` to route users into curated lanes (beginner/core, team adoption, CI, advanced/extensions) and to direct historical needs into the archive.
- Added `docs/archive/index.md` and `docs/archive/transition-era-material.md` as a labeled archive landing and map so transition-era/day-by-day/closeout docs remain accessible but discover-later; no code or CLI behavior was changed.

### Testing

- Ran `mkdocs build --strict` and the build completed successfully (site built to `site/`) with informational notes about some pages being deliberately excluded from the top-level nav.
- The build reported an informational reference to an excluded file (`integrations-and-extension-boundary.md`) and a list of docs present but not in the `nav`, which is expected given the archive/`exclude_docs` strategy and does not break the strict build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1f846e56483279ad36c1067f39bce)