### PR TITLE
docs: add concrete proof-of-value pages and README proof section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ SDETKit gives engineering teams **deterministic release-confidence checks and ev
 
 Most teams can run tools; fewer teams can make a repeatable release decision. SDETKit defines a core command path that produces deterministic pass/fail outcomes plus evidence-backed outputs you can trust in local runs and CI.
 
+## Proof of value (concrete, fast, honest)
+
+New here? Start with proof pages grounded in real SDETKit commands and artifact shapes:
+
+- **Blank repo to value in 60 seconds**: `docs/blank-repo-to-value-60-seconds.md`
+- **Before/after evidence example**: `docs/before-after-evidence-example.md`
+- **SDETKit vs ad hoc scripts and separate tools**: `docs/sdetkit-vs-ad-hoc.md`
+- **Team rollout scenario**: `docs/team-rollout-scenario.md`
+
+## See it in action
+
+Terminal demo GIF/video: **not yet checked in**.
+
+When available, place the asset at `docs/assets/sdetkit-terminal-demo.gif` and link/embed it here and in the docs home page.
+
 ## Start here (core adoption path)
 
 For first-time adoption, focus on these five hero paths only:

--- a/docs/before-after-evidence-example.md
+++ b/docs/before-after-evidence-example.md
@@ -1,0 +1,67 @@
+# Before/after evidence example
+
+This page shows what changes when a team moves from ad hoc terminal checks to SDETKit evidence artifacts.
+
+No fabricated customer claims, no synthetic benchmark numbers—just command output shape and review behavior.
+
+## Before: ad hoc checks and log-only evidence
+
+Typical flow in many repos:
+
+```bash
+ruff check .
+pytest -q
+bandit -q -r src
+```
+
+What often happens:
+
+- Different engineers run different sequences.
+- Logs are long and mixed; reviewers scroll to find root cause.
+- CI failures are hard to compare between runs.
+- Release decisions rely on screenshots or pasted snippets.
+
+## After: deterministic gates + structured evidence
+
+SDETKit flow:
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
+python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+```
+
+Evidence files produced:
+
+```text
+build/
+├── gate-fast.json
+├── security-enforce.json
+└── release-preflight.json
+```
+
+Representative real shapes documented in this repository:
+
+- `gate-fast.json` includes fields like `ok`, `profile`, `failed_steps`.
+- `security-enforce.json` includes `ok`, `counts`, `exceeded`.
+- `release-preflight.json` includes `ok`, `profile`, `failed_steps`.
+
+See exact examples in [Evidence showcase](evidence-showcase.md).
+
+## What this changes in practice
+
+| Decision step | Before (log-only) | After (SDETKit evidence) |
+| --- | --- | --- |
+| First triage move | Read mixed console output | Open JSON artifact and check `ok` + first failed key |
+| Policy traceability | Often implicit in scripts | Explicit thresholds in `security enforce` output |
+| CI review speed | Depends on who wrote scripts | Consistent artifact structure across runs |
+| Release handoff | Human summary in chat | Attach `build/*.json` as decision evidence |
+
+## Minimal review playbook
+
+1. Open `build/release-preflight.json`.
+2. If it references `gate_fast`, open `build/gate-fast.json`.
+3. If policy is failing, open `build/security-enforce.json` and inspect `exceeded`.
+4. Only then deep-dive into raw logs.
+
+This keeps release decisions deterministic and auditable without claiming perfect green runs.

--- a/docs/blank-repo-to-value-60-seconds.md
+++ b/docs/blank-repo-to-value-60-seconds.md
@@ -1,0 +1,72 @@
+# Blank repo to value in 60 seconds
+
+This is the fastest honest proof path for a new visitor evaluating SDETKit in a fresh repository.
+
+Goal: get a deterministic go/no-go signal plus machine-readable evidence in about a minute.
+
+## 60-second command flow
+
+```bash
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+python -m sdetkit --help
+python -m sdetkit doctor
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+```
+
+## What value you get immediately
+
+1. **Environment confidence** via `doctor` before debugging random CI failures.
+2. **Deterministic release-confidence checks** via `gate fast` and `gate release`.
+3. **Structured evidence artifacts** in `build/` that can be uploaded to CI.
+
+Expected artifact shape:
+
+```text
+build/
+├── gate-fast.json
+└── release-preflight.json
+```
+
+## How to read the first artifacts
+
+### `build/gate-fast.json`
+
+Look at:
+
+- `ok`
+- `failed_steps`
+- `profile`
+
+If `ok` is `false`, fix the first item in `failed_steps`, rerun, and repeat.
+
+### `build/release-preflight.json`
+
+Look at:
+
+- `ok`
+- `failed_steps`
+- `profile`
+
+If release preflight fails because `gate_fast` failed, start with `build/gate-fast.json` before reading long logs.
+
+## Copy this into CI after local success
+
+Start with PR checks:
+
+```bash
+python -m sdetkit gate fast
+```
+
+Then enforce stricter release checks on release branches:
+
+```bash
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
+python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+```
+
+## Related proof pages
+
+- [Before/after evidence example](before-after-evidence-example.md)
+- [SDETKit vs ad hoc scripts and separate tools](sdetkit-vs-ad-hoc.md)
+- [Team rollout scenario](team-rollout-scenario.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,13 @@ SDETKit gives engineering teams **deterministic release-confidence checks and ev
 - Evidence-backed outputs to support release approvals.
 - One core path that works locally first, then scales into CI.
 
+## Proof of value (start here)
+
+- **Blank repo to value in 60 seconds**: [Fast demo path](blank-repo-to-value-60-seconds.md)
+- **Concrete evidence transformation**: [Before/after evidence example](before-after-evidence-example.md)
+- **Comparison framing**: [SDETKit vs ad hoc scripts and separate tools](sdetkit-vs-ad-hoc.md)
+- **Team rollout view**: [Team rollout scenario](team-rollout-scenario.md)
+
 ## Continue after the core path
 
 Pick one lane based on your immediate need:

--- a/docs/sdetkit-vs-ad-hoc.md
+++ b/docs/sdetkit-vs-ad-hoc.md
@@ -1,0 +1,47 @@
+# SDETKit vs ad hoc scripts and separate tools
+
+Running separate tools is still valid. This comparison explains why teams adopt SDETKit when they need repeatable release decisions, not just command execution.
+
+## Short answer
+
+Ad hoc scripts optimize for local flexibility.
+SDETKit optimizes for deterministic gate semantics, structured evidence, and consistent rollout from local runs to CI.
+
+## Comparison grounded in current command surface
+
+| Dimension | Ad hoc scripts + separate tools | SDETKit path |
+| --- | --- | --- |
+| Command contract | Varies by repo/maintainer | Stable gate commands (`gate fast`, `gate release`, `doctor`, `security enforce`) |
+| Decision output | Mostly terminal logs | JSON artifacts (`build/gate-fast.json`, `build/security-enforce.json`, `build/release-preflight.json`) |
+| CI portability | Requires custom per-repo glue | Same core commands locally and in CI |
+| Triage behavior | Human interpretation of logs | Deterministic keys (`ok`, `failed_steps`, `counts`, `exceeded`) |
+| Adoption model | Tribal scripts and runbooks | Documented staged rollout (`adoption.md`, `recommended-ci-flow.md`) |
+
+## Where SDETKit adds value
+
+- **Consistency:** shared go/no-go semantics across contributors.
+- **Reproducibility:** same commands for local and CI checks.
+- **Evidence:** machine-readable artifacts suitable for review and audits.
+- **Governance:** explicit budget and gate thresholds.
+
+## Where ad hoc can still be enough
+
+- Very small repos with low release risk.
+- Single maintainer workflows where formal evidence is unnecessary.
+- Teams intentionally avoiding a standardized gate model.
+
+## Recommended evaluation recipe
+
+Run this in your repo and inspect artifacts before deciding:
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
+python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+```
+
+If this gives your team faster and clearer release decisions, adopt progressively; if not, keep your lighter ad hoc path.
+
+## Deep-dive reference
+
+For the longer system-value argument, see [Why not just run separate tools?](why-not-just-tools.md).

--- a/docs/team-rollout-scenario.md
+++ b/docs/team-rollout-scenario.md
@@ -1,0 +1,79 @@
+# Team rollout scenario (local trial → CI pilot → release gate)
+
+This is a recommended adoption flow based on SDETKit's current repository workflows and docs.
+
+It is a scenario, not a claim that a specific company already executed it.
+
+## Stage 0 — one engineer proves value locally (day 1)
+
+Commands:
+
+```bash
+python -m sdetkit doctor
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+```
+
+Exit criteria:
+
+- Team can run commands locally.
+- `build/gate-fast.json` exists and can be shared in a PR comment.
+
+## Stage 1 — CI pilot on pull requests (week 1)
+
+Add one CI job using:
+
+```bash
+python -m sdetkit gate fast
+```
+
+Exit criteria:
+
+- PRs consistently produce pass/fail results.
+- Engineers use `failed_steps` to triage first, logs second.
+
+## Stage 2 — introduce policy budgets (week 2)
+
+Add strict thresholds incrementally:
+
+```bash
+python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
+```
+
+If initial `--max-info 0` is too strict, set a temporary baseline and ratchet down over time.
+
+Exit criteria:
+
+- Security budget failures are explicit and reviewable in JSON.
+- Team agrees on ratchet plan and owners.
+
+## Stage 3 — release lane enforcement (week 3+)
+
+Enable release preflight in release branches/tags:
+
+```bash
+python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+```
+
+Exit criteria:
+
+- Release decisions reference `build/release-preflight.json` plus supporting gate artifacts.
+- Handoffs include artifact links instead of only terminal snippets.
+
+## Operating rhythm after rollout
+
+- **PR lane:** keep `gate fast` always on.
+- **Main/release lane:** enforce security budgets and `gate release`.
+- **Incident/failure triage:** use artifact-first flow from [CI artifact walkthrough](ci-artifact-walkthrough.md).
+
+## Anti-patterns to avoid
+
+- Enabling all strict thresholds at once without baseline discussion.
+- Treating first non-green run as tool failure instead of integration backlog.
+- Reviewing logs before reading structured artifacts.
+
+## Related rollout docs
+
+- [Adopt SDETKit in your repository](adoption.md)
+- [Recommended CI flow](recommended-ci-flow.md)
+- [Adoption troubleshooting](adoption-troubleshooting.md)
+- [CI artifact walkthrough](ci-artifact-walkthrough.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,9 +84,13 @@ nav:
   - Home: index.md
   - Start here (core path):
       - Install (quickstart): ready-to-use.md
+      - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
       - Gate fast + gate release: release-confidence.md
       - Doctor checks: doctor.md
       - Evidence and reports: evidence-showcase.md
+      - Before/after evidence example: before-after-evidence-example.md
+      - SDETKit vs ad hoc scripts and separate tools: sdetkit-vs-ad-hoc.md
+      - Team rollout scenario: team-rollout-scenario.md
       - Decision guide: decision-guide.md
       - Choose your path: choose-your-path.md
   - Team adoption:


### PR DESCRIPTION
### Motivation

- New visitors need fast, honest, and concrete proof that SDETKit produces useful, machine-readable evidence rather than just positioning text.
- The goal is to expose a minimal try-now path, a before/after evidence story, a clear comparison to ad hoc scripts, and a realistic team rollout scenario using only repository-supported outputs.

### Description

- Added four new proof-first docs: `docs/blank-repo-to-value-60-seconds.md`, `docs/before-after-evidence-example.md`, `docs/sdetkit-vs-ad-hoc.md`, and `docs/team-rollout-scenario.md`, each grounded in real `sdetkit` commands and `build/*.json` artifact shapes. 
- Updated the docs landing page `docs/index.md` to surface a dedicated "Proof of value" section linking the new pages and added a concise proof-of-value snippet near the top of `README.md` with links to the new pages and a clearly labeled placeholder for future terminal demo media at `docs/assets/sdetkit-terminal-demo.gif`.
- Incorporated the new pages into the curated nav by updating `mkdocs.yml` so the proof pages appear in the "Start here (core path)" lane.
- No behavior or Python code changes were made; all edits are documentation-only and use existing, demonstrable command flows and artifact examples from the repo.

### Testing

- Ran `mkdocs build --strict` and the documentation site build completed successfully with no strict-mode failures. 
- Verified local docs pages render and new nav entries are included in the generated site. 
- Note: terminal GIF/video media was intentionally not added; README and docs include a clear placeholder path (`docs/assets/sdetkit-terminal-demo.gif`) for future real capture and inclusion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1f9c65930832792d3f0bd88a5fbe1)