### PR TITLE
docs: unify canonical install path and simplify install/distribution story

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ Terminal demo GIF/video: **not yet checked in**.
 
 When available, place the asset at `docs/assets/sdetkit-terminal-demo.gif` and link/embed it here and in the docs home page.
 
+## Install in 10 seconds
+
+**Recommended (external users):**
+
+```bash
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+python -m sdetkit --help
+```
+
+Why this is the canonical path today:
+
+- It works in any repository without cloning this repo first.
+- It does not depend on repo-local helper scripts.
+- PyPI install is not yet verified/publicly recorded for this project.
+
+Secondary install options are in [docs/install.md](docs/install.md) (`pipx`, `uv tool install`, local source install for contributors).
+
 ## Start here (core adoption path)
 
 For first-time adoption, focus on these five hero paths only:
@@ -44,7 +61,7 @@ For first-time adoption, focus on these five hero paths only:
 ### 1) Install and verify
 
 ```bash
-python -m pip install .
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
 python -m sdetkit --help
 ```
 
@@ -97,29 +114,17 @@ Docs portal: <https://sherif69-sa.github.io/DevS69-sdetkit/>
 
 ## Installation
 
-SDETKit currently supports two explicit install paths:
+See the canonical install guide: [docs/install.md](docs/install.md).
 
-- **From source (this repository)** for contributors/maintainers.
-- **From GitHub URL** for external adopters until PyPI publication is verified.
+Quick reference:
 
-### From source (local clone)
+- **Recommended for first-time users:**
 
-```bash
-python -m pip install .
-```
+  ```bash
+  python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+  ```
 
-### From GitHub (external repository adoption)
-
-```bash
-python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
-```
-
-### Developer install (recommended in this repo)
-
-```bash
-bash scripts/bootstrap.sh
-source .venv/bin/activate
-```
+- **Alternatives:** `pipx`, `uv tool install`, or local source install (`python -m pip install .`) for contributors.
 
 ### Optional extras (choose only what you need)
 
@@ -158,13 +163,7 @@ python -m sdetkit gate --help
 
 Expected result: both commands print usage/help text and exit successfully.
 
-Then run the first real release-confidence signal:
-
-```bash
-bash scripts/ready_to_use.sh quick
-```
-
-If you installed SDETKit in another repository (without this repo's scripts), use:
+Then run the first real release-confidence signal in your own repository:
 
 ```bash
 python -m sdetkit gate fast
@@ -172,10 +171,10 @@ python -m sdetkit gate fast
 
 ## Recommended first 10 minutes
 
-1. Install SDETKit (local clone or GitHub URL).
+1. Install SDETKit (recommended: GitHub URL install).
 2. Verify CLI availability with `python -m sdetkit --help`.
-3. Run quick confidence: `bash scripts/ready_to_use.sh quick` (or `python -m sdetkit gate fast` in external repos).
-4. Run strict release checks: `bash scripts/ready_to_use.sh release`.
+3. Run quick confidence: `python -m sdetkit gate fast`.
+4. Run strict release checks: `python -m sdetkit gate release`.
 5. Review command families in `docs/cli.md` and staged rollout guidance in `docs/adoption.md`.
 
 What works without optional extras:

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -14,7 +14,9 @@ For current ecosystem boundaries (what stays core vs integration vs playbook vs 
 
 ## What to install
 
-Until public package release is completed, install from GitHub:
+For full install options (including `pipx` and `uv tool install`), see [Install SDETKit](install.md).
+
+Until public package release is completed, the recommended external install is from GitHub:
 
 ```bash
 python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ SDETKit gives engineering teams **deterministic release-confidence checks and ev
 
 <div class="hero-actions" markdown>
 
-[Install](ready-to-use.md){ .md-button .md-button--primary }
+[Install](install.md){ .md-button .md-button--primary }
 [Gate fast](release-confidence.md){ .md-button }
 [Gate release](release-confidence.md){ .md-button }
 [Doctor](doctor.md){ .md-button }
@@ -27,7 +27,7 @@ SDETKit gives engineering teams **deterministic release-confidence checks and ev
 ## Core path in 5 minutes
 
 1. **Install and verify**
-   - [Ready-to-use quickstart](ready-to-use.md)
+   - [Install guide](install.md)
 2. **Gate fast**
    ```bash
    python -m sdetkit gate fast

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,78 @@
+# Install SDETKit
+
+This page is the canonical install guide for external users.
+
+## Recommended install path (first-time users)
+
+Install directly from GitHub, then verify the CLI:
+
+```bash
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+python -m sdetkit --help
+```
+
+Why this is the recommended path now:
+
+- Works in any repository without cloning this project first.
+- Uses the same public source every team can access.
+- Does not rely on this repository's helper scripts.
+- Public PyPI install is not yet verified in this repository's release records.
+
+## Alternative install paths
+
+Use these only if they better fit your environment.
+
+### `pipx` (isolated CLI install)
+
+```bash
+pipx install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+pipx run sdetkit --help
+```
+
+### `uv tool install` (isolated tool install)
+
+```bash
+uv tool install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+uv tool run sdetkit --help
+```
+
+### Local source install (contributors in this repo)
+
+```bash
+python -m pip install .
+python -m sdetkit --help
+```
+
+## First run in an external repository
+
+From the root of the repository you want to gate:
+
+```bash
+python -m sdetkit gate fast
+python -m sdetkit gate release
+```
+
+Start with `gate fast`, then add `gate release` when you want stricter release-confidence checks.
+
+For rollout patterns and CI examples, continue with [Adopt SDETKit in your repository](adoption.md).
+
+## Development setup (this repository only)
+
+If you are contributing to SDETKit itself:
+
+```bash
+bash scripts/bootstrap.sh
+source .venv/bin/activate
+python -m pip install -e .[dev,test,docs]
+```
+
+This setup is for contributors/maintainers, not required for external adoption.
+
+## PyPI/public distribution posture
+
+SDETKit has release automation for build, wheel validation, optional PyPI publish, and provenance attestation in `.github/workflows/release.yml`.
+
+Until a release is publicly published and externally verified, the install recommendation remains GitHub URL install.
+
+- Maintainer release process summary: [Releasing sdetkit](releasing.md)
+- Public verification log: [release-verification.md](release-verification.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -1,4 +1,4 @@
-# Ready-to-use setup (start working in minutes)
+# Ready-to-use quickstart (after install)
 
 Use this guide when you want a practical start to release confidence without learning the entire repository first.
 
@@ -6,10 +6,11 @@ If you need a 30-second rollout self-selection first, use [Choose your path](cho
 
 ## Install SDETKit
 
-Choose the path that matches your context:
+Use the canonical install guide first: [install.md](install.md).
 
-- In this repository (local clone): `python -m pip install .`
-- In an external repository: `python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"`
+Recommended for external users:
+
+- `python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"`
 
 Optional extras (`dev`, `test`, `docs`, `packaging`, `telegram`, `whatsapp`) are not required for the core release-confidence path.
 
@@ -24,7 +25,7 @@ python -m sdetkit gate --help
 
 Expected result: both commands print help text and exit with code `0`.
 
-## Fast start (recommended, under 5 minutes)
+## Fast start (repository helper lane, optional)
 
 ```bash
 bash scripts/ready_to_use.sh quick
@@ -37,13 +38,13 @@ What this does:
 3. Runs the CI quick lane.
 4. Leaves you with a working repo and a clear next step.
 
-If you are in another repository (without this repo's helper scripts), use:
+For external repositories (without this repo's helper scripts), use this as the primary command:
 
 ```bash
 python -m sdetkit gate fast
 ```
 
-## Full release-confidence start
+## Full release-confidence start (repository helper lane, optional)
 
 ```bash
 bash scripts/ready_to_use.sh release
@@ -66,20 +67,23 @@ Use this when you need production-quality release evidence.
 
 1. Install SDETKit.
 2. Verify install with `python -m sdetkit --help`.
-3. Run quick confidence (`bash scripts/ready_to_use.sh quick` or `python -m sdetkit gate fast`).
-4. Run strict release checks (`bash scripts/ready_to_use.sh release` or security-enforce + `gate release`).
-5. Use [cli.md](cli.md) to discover core command families.
-6. Use [adoption.md](adoption.md) to roll the same path into CI.
-7. Pick a realistic rollout shape in [adoption-examples.md](adoption-examples.md).
-8. Use [choose-your-path.md](choose-your-path.md) when deciding rollout order across teams.
+3. Run quick confidence (`python -m sdetkit gate fast`).
+4. Run strict release checks (`python -m sdetkit gate release`).
+5. If you are working inside this repository, you can optionally use `scripts/ready_to_use.sh` wrappers.
+6. Use [cli.md](cli.md) to discover core command families.
+7. Use [adoption.md](adoption.md) to roll the same path into CI.
+8. Pick a realistic rollout shape in [adoption-examples.md](adoption-examples.md).
+9. Use [choose-your-path.md](choose-your-path.md) when deciding rollout order across teams.
 
 ## Next actions after setup
 
 Follow the core path:
 
-1. `bash scripts/ready_to_use.sh quick`
-2. `bash scripts/ready_to_use.sh release`
+1. `python -m sdetkit gate fast`
+2. `python -m sdetkit gate release`
 3. Adopt in another repository with [adoption.md](adoption.md)
+
+If you are inside this repository and prefer wrappers, you can run `bash scripts/ready_to_use.sh quick` and `bash scripts/ready_to_use.sh release`.
 
 Then explore broader commands if needed:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,8 @@ extra_javascript:
 nav:
   - Home: index.md
   - Start here (core path):
-      - Install (quickstart): ready-to-use.md
+      - Install: install.md
+      - Install quickstart: ready-to-use.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
       - Gate fast + gate release: release-confidence.md
       - Doctor checks: doctor.md


### PR DESCRIPTION
### Motivation

- Make the install and distribution story obvious and friction-free for external users by surfacing one clear, canonical install path up front.
- Ensure external adoption does not require cloning this repo or running repo-local helper scripts, and keep alternatives available but secondary.
- Be honest about public distribution posture by avoiding any claim that PyPI is verified until external verification exists.

### Description

- Add a canonical install page `docs/install.md` that recommends a single external-first command: `python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"` and documents `pipx`, `uv tool install`, and local source installs as alternatives.
- Surface the canonical path in the README (`README.md`), the docs homepage (`docs/index.md`), quickstart (`docs/ready-to-use.md`), and adoption guidance (`docs/adoption.md`) and normalize first-run commands to `python -m sdetkit gate fast` / `python -m sdetkit gate release` for external repos.
- Update `mkdocs.yml` to add `install.md` to the primary nav and keep the quickstart as the secondary entry; no runtime code changes were made.
- Files changed: `README.md`, `docs/install.md` (new), `docs/index.md`, `docs/ready-to-use.md`, `docs/adoption.md`, `mkdocs.yml`.

### Testing

- Ran `mkdocs build --strict` and the build completed successfully (warnings from theme noted but no strict-mode failures). 
- Verified PyPI package presence via a quick query to `https://pypi.org/pypi/sdetkit/json` which returned a 404, confirming the repository must continue to recommend the GitHub URL until an externally verified PyPI release exists.
- No code or packaging metadata was changed, so package/unit tests were not required for this documentation pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1fbf0034483278bc27cd7cfbb9aa4)