### PR TITLE
Retry maintenance tests_check once on transient pytest failure

### DIFF
--- a/src/sdetkit/maintenance/checks/tests_check.py
+++ b/src/sdetkit/maintenance/checks/tests_check.py
@@ -7,22 +7,46 @@ CHECK_NAME = "tests_check"
 
 
 def run(ctx: MaintenanceContext) -> CheckResult:
-    result = run_cmd([ctx.python_exe, "-m", "pytest", "-q"], cwd=ctx.repo_root)
-    ok = result.returncode == 0
-    return CheckResult(
-        ok=ok,
-        summary="pytest passed" if ok else "pytest reported failures",
-        details={
+    cmd = [ctx.python_exe, "-m", "pytest", "-q"]
+    result = run_cmd(cmd, cwd=ctx.repo_root)
+    rerun = None
+    if result.returncode != 0:
+        rerun = run_cmd(cmd, cwd=ctx.repo_root)
+
+    final = rerun if rerun is not None else result
+    ok = final.returncode == 0
+
+    details: dict[str, object] = {
+        "returncode": final.returncode,
+        "stdout": final.stdout,
+        "stderr": final.stderr,
+    }
+    if rerun is not None:
+        details["first_attempt"] = {
             "returncode": result.returncode,
             "stdout": result.stdout,
             "stderr": result.stderr,
-        },
+        }
+        details["retries"] = 1
+
+    return CheckResult(
+        ok=ok,
+        summary="pytest passed"
+        if rerun is None
+        else ("pytest passed after retry" if ok else "pytest reported failures"),
+        details=details,
         actions=[
             CheckAction(
                 id="run-tests",
                 title="Run pytest -q",
                 applied=False,
-                notes="Investigate failed tests before merge" if not ok else "",
+                notes="Investigate failed tests before merge"
+                if not ok
+                else (
+                    "Initial pytest run failed but retry passed; review flaky tests."
+                    if rerun is not None
+                    else ""
+                ),
             )
         ],
     )

--- a/tests/test_maintenance_cli.py
+++ b/tests/test_maintenance_cli.py
@@ -243,6 +243,35 @@ def test_custom_example_and_tests_check(monkeypatch, tmp_path: Path) -> None:
     assert failed.summary == "pytest reported failures"
 
 
+def test_tests_check_retries_once_when_first_run_fails(monkeypatch, tmp_path: Path) -> None:
+    ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe=sys.executable,
+        mode="full",
+        fix=False,
+        env={},
+        logger=object(),
+    )
+
+    calls = {"count": 0}
+
+    def _run_cmd(_cmd, cwd):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return SimpleNamespace(returncode=1, stdout="", stderr="flake")
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(tests_check, "run_cmd", _run_cmd)
+
+    result = tests_check.run(ctx)
+
+    assert result.ok is True
+    assert result.summary == "pytest passed after retry"
+    assert result.details["retries"] == 1
+    assert result.details["first_attempt"]["returncode"] == 1
+    assert calls["count"] == 2
+
+
 def test_render_markdown_escapes_table_breaking_content() -> None:
     report = {
         "ok": False,


### PR DESCRIPTION
### Motivation
- Reduce false-positive maintenance failures when `pytest -q` fails due to transient/flaky test runner issues by making the check more resilient.
- Preserve actionable diagnostics so maintainers can triage intermittent failures when a retry recovers.

### Description
- Update `src/sdetkit/maintenance/checks/tests_check.py` to run `pytest -q` and, on non-zero exit, automatically retry the same command one more time.
- Record first-attempt diagnostics under `details["first_attempt"]` and set `details["retries"] = 1` when a retry is used, and update the check `summary` and guidance `notes` to reflect a retry success or persistent failure.
- Add a unit test `test_tests_check_retries_once_when_first_run_fails` in `tests/test_maintenance_cli.py` that simulates a failing first run and a succeeding retry to validate the new behavior.

### Testing
- Ran the targeted unit tests with `pytest -q tests/test_maintenance_cli.py` and observed `22 passed` (including the new retry test). 
- Ran style checks with `python3 -m ruff check` and `python3 -m ruff format --check` on the modified files and they passed.
- Executed a full maintenance invocation (`python3 -m sdetkit maintenance --mode full --format json --out .sdetkit/out/maintenance.json`), noting that the `tests_check` behavior is exercised, while the overall premium gate remains failing due to an unrelated `clean_tree_check` (uncommitted docs changes) which must be committed/stashed to achieve a passing score.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b20b2422ac8327a185ceab2fc2b14d)