### PR TITLE
ci: enable GitHub Pages in configure-pages step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,8 @@ jobs:
           python -m pip install -r requirements-docs.txt -e .
 
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
+        with:
+          enablement: true
 
       - name: Build mkdocs site
         run: NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict


### PR DESCRIPTION
### Motivation
- The Pages workflow was failing with `Get Pages site failed` when Pages was not preconfigured, so the `actions/configure-pages` step must be allowed to enable Pages automatically.

### Description
- Add `with:
  enablement: true` to the `actions/configure-pages` step in `.github/workflows/pages.yml` to allow the action to enable GitHub Pages when needed.

### Testing
- Verified the workflow file diff with `git diff` and inspected `.github/workflows/pages.yml` to confirm the `enablement: true` insertion; checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b21a074bb0832784b22176190bc4ab)