### PR TITLE
Fix broken upload-artifact action pins in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload repo audit artifact
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: repo-audit-report
           path: report.json
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload CI gate diagnostics
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ci-gate-diagnostics
           path: |
@@ -117,7 +117,7 @@ jobs:
           python -m sdetkit demo --format json > build/ci-demo.json
 
       - name: Upload demo artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ci-demo-json
           path: build/ci-demo.json
@@ -148,7 +148,7 @@ jobs:
         run: python -m check_wheel_contents --ignore W009 dist/*.whl
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: dist
           path: dist/*

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload pip-audit artifact
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: pip-audit-report
           path: pip-audit-report.json

--- a/.github/workflows/enterprise-gate.yml
+++ b/.github/workflows/enterprise-gate.yml
@@ -43,7 +43,7 @@ jobs:
           python -c "import json; d=json.load(open('sdet_check.json','r',encoding='utf-8')); f=d.get('findings', []); (_ for _ in ()).throw(SystemExit(f'enterprise gate failed: findings={len(f)}')) if f else print('enterprise gate ok: findings=0')"
 
       - name: Upload report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sdet_check
           path: sdet_check.json

--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -54,7 +54,7 @@ jobs:
         run: bash scripts/maintenance_ci.sh "${{ inputs.mode }}" "${{ inputs.fix && 'true' || 'false' }}" artifacts/maintenance
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: maintenance-on-demand
           path: |

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload mutmut report
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: mutmut-${{ github.run_id }}
           path: artifacts

--- a/.github/workflows/premium-gate.yml
+++ b/.github/workflows/premium-gate.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload evidence pack
         if: always() && hashFiles('.sdetkit/out/evidence.zip') != ''
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: evidence-pack
           path: .sdetkit/out/evidence.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload release diagnostics
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: release-diagnostics
           path: build/release-preflight.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -28,7 +28,7 @@ jobs:
           cyclonedx-py environment -o sbom.cdx.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: sbom-cyclonedx
           path: sbom.cdx.json

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -32,7 +32,7 @@ jobs:
         run: bash scripts/maintenance_ci.sh full false artifacts/maintenance
 
       - name: Upload baseline artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: weekly-maintenance
           path: |
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload fix artifacts
         if: steps.decide_fix.outputs.run_fix == 'true'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: weekly-maintenance-fixed
           path: |


### PR DESCRIPTION
### Motivation
- Several CI and maintenance workflows were failing to download `actions/upload-artifact` due to an invalid pinned SHA, causing `401 Unauthorized` errors during action fetch. 
- Pinning to a known public SHA for the `v4.6.2` release restores reliable action resolution and workflow execution.

### Description
- Replaced the invalid `actions/upload-artifact` SHA `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` with the public `v4.6.2` SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` across affected workflows. 
- Updated inline version annotations/comments to reflect `# v4.6.2` where applicable so comments match the pinned revision. 
- Files updated include `.github/workflows/ci.yml`, `dependency-audit.yml`, `enterprise-gate.yml`, `maintenance-on-demand.yml`, `mutation-tests.yml`, `premium-gate.yml`, `release.yml`, `sbom.yml`, and `weekly-maintenance.yml`.

### Testing
- Verified the `v4.6.2` tag resolves to the public SHA using `git ls-remote https://github.com/actions/upload-artifact.git refs/tags/v4.6.2`, and found the expected SHA. 
- Located all usages with `rg -n "upload-artifact@" .github/workflows` and confirmed updates were applied to each occurrence. 
- Ran the replacement script and checked updated workflow files contain `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` and `# v4.6.2`. 
- Confirmed there are no remaining references to the broken SHA using `rg -n "bbbca2ddaa5d8feaa63e36b76fdaad77386f024f" .github/workflows` which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b22d461d7483279edb9adb65b988c1)