### PR TITLE
Introduce umbrella kits with Intelligence, Integration, and Forensics CLIs, docs, examples, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,15 @@ jobs:
           mkdir -p build
           python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
 
+      - name: Generate kit sample artifacts
+        if: always()
+        run: |
+          mkdir -p build
+          python -m sdetkit kits list --format json > build/kits.json
+          python -m sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json > build/intelligence-flake.json
+          python -m sdetkit integration check --profile examples/kits/integration/profile.json > build/integration-check.json
+          python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json > build/forensics-compare.json
+
       - name: Upload CI gate diagnostics
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -93,6 +102,10 @@ jobs:
           path: |
             build/gate-fast.json
             build/security-enforce.json
+            build/kits.json
+            build/intelligence-flake.json
+            build/integration-check.json
+            build/forensics-compare.json
           retention-days: 14
           if-no-files-found: warn
 
@@ -154,13 +167,17 @@ jobs:
           path: dist/*
 
   smoke-install:
-    name: Smoke install from built wheel
+    name: Smoke install from built wheel (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: package-validate
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Download dist artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/README.md
+++ b/README.md
@@ -1,233 +1,39 @@
 # DevS69 SDETKit
 
-![CI](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml/badge.svg?branch=main)
-![Quality](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/quality.yml/badge.svg?branch=main)
-![Security](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/security.yml/badge.svg?branch=main)
-![Repo Audit](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/repo-audit.yml/badge.svg?branch=main)
-![Pages](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/pages.yml/badge.svg?branch=main)
-![Docs Link Check](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/docs-link-check.yml/badge.svg?branch=main)
+SDETKit is an umbrella **SDET / QA / release confidence platform** with deterministic CLI workflows and machine-readable artifacts.
 
-SDETKit gives engineering teams **deterministic release-confidence checks and evidence** so shipping decisions are fast, consistent, and audit-ready.
+## Umbrella kits
 
-## Why this exists
+- **Release Confidence Kit** (`sdetkit release ...`): gate, doctor, security, repo audit, and evidence lanes.
+- **Test Intelligence Kit** (`sdetkit intelligence ...`): flake classification, deterministic env capture, changed-scope impact summary, and mutation governance.
+- **Integration Assurance Kit** (`sdetkit integration ...`): profile-driven environment/service readiness contracts.
+- **Failure Forensics Kit** (`sdetkit forensics ...`, experimental): run compare and deterministic repro bundle generation.
 
-Most teams can run tools; fewer teams can make a repeatable release decision. SDETKit defines a core command path that produces deterministic pass/fail outcomes plus evidence-backed outputs you can trust in local runs and CI.
-
-## Proof of value (concrete, fast, honest)
-
-New here? Start with proof pages grounded in real SDETKit commands and artifact shapes:
-
-- **Blank repo to value in 60 seconds**: `docs/blank-repo-to-value-60-seconds.md`
-- **Before/after evidence example**: `docs/before-after-evidence-example.md`
-- **SDETKit vs ad hoc scripts and separate tools**: `docs/sdetkit-vs-ad-hoc.md`
-- **Team rollout scenario**: `docs/team-rollout-scenario.md`
-
-## See it in action
-
-Terminal demo GIF/video: **not yet checked in**.
-
-When available, place the asset at `docs/assets/sdetkit-terminal-demo.gif` and link/embed it here and in the docs home page.
-
-## Install in 10 seconds
-
-**Recommended (external users):**
+List kits:
 
 ```bash
-python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
-python -m sdetkit --help
+python -m sdetkit kits list --format json
 ```
 
-Why this is the canonical path today:
-
-- It works in any repository without cloning this repo first.
-- It does not depend on repo-local helper scripts.
-- PyPI install is not yet verified/publicly recorded for this project.
-
-Secondary install options are in [docs/install.md](docs/install.md) (`pipx`, `uv tool install`, local source install for contributors).
-
-## Start here (core adoption path)
-
-For first-time adoption, focus on these five hero paths only:
-
-1. **Install** → [Installation](#installation)
-2. **Gate fast** → `python -m sdetkit gate fast`
-3. **Gate release** → `python -m sdetkit gate release`
-4. **Doctor** → `python -m sdetkit doctor`
-5. **Evidence / report output** → `python -m sdetkit evidence --help` and `python -m sdetkit report --help`
-
-### 0) Confirm product fit
-
-- Decision guide: `docs/decision-guide.md`
-
-### 1) Install and verify
+## Hero journeys (start here)
 
 ```bash
-python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
-python -m sdetkit --help
+python -m sdetkit release gate fast
+python -m sdetkit release gate release
+python -m sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json
+python -m sdetkit integration check --profile examples/kits/integration/profile.json
+python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json
 ```
 
-### 2) Run the core gates
+## Backward compatibility
 
-```bash
-python -m sdetkit gate fast
-python -m sdetkit gate release
-```
+Existing stable commands remain supported (`gate`, `doctor`, `security`, `repo`, `evidence`, `report`, etc.). Kit commands are additive product grouping aliases.
 
-### 3) Validate environment health and output evidence
+## Docs
 
-```bash
-python -m sdetkit doctor
-python -m sdetkit evidence --help
-python -m sdetkit report --help
-```
-
-## Core commands (copy/paste)
-
-```bash
-# Optional wrapper lane in this repository
-bash scripts/ready_to_use.sh quick
-bash scripts/ready_to_use.sh release
-
-# Core CLI gates
-python -m sdetkit gate fast
-python -m sdetkit gate release
-
-# Environment diagnostics
-python -m sdetkit doctor
-
-# Evidence and reporting surfaces
-python -m sdetkit evidence --help
-python -m sdetkit report --help
-```
-
-## Discover later (secondary)
-
-After the five hero paths are working, expand deliberately:
-
-- Release-confidence model: `docs/release-confidence.md`
-- CI rollout: `docs/recommended-ci-flow.md`, `docs/adoption.md`
-- Capability taxonomy and full CLI depth: `docs/command-taxonomy.md`, `docs/cli.md`
-- Integrations/playbooks/history: see docs portal navigation
-
-Historical and transition-era material remains available for compatibility and audit trails, but is intentionally secondary to core adoption.
-
-Docs portal: <https://sherif69-sa.github.io/DevS69-sdetkit/>
-
-## Installation
-
-See the canonical install guide: [docs/install.md](docs/install.md).
-
-Quick reference:
-
-- **Recommended for first-time users:**
-
-  ```bash
-  python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
-  ```
-
-- **Alternatives:** `pipx`, `uv tool install`, or local source install (`python -m pip install .`) for contributors.
-
-### Optional extras (choose only what you need)
-
-| Extra | Installs | Use when |
-|---|---|---|
-| `dev` | linting, typing, packaging helper tooling | You are contributing to this repository. |
-| `test` | pytest and test helpers | You need to run/extend tests. |
-| `docs` | mkdocs + theme | You need to build docs locally. |
-| `packaging` | build/twine/wheel validation tooling | You are validating release artifacts. |
-| `telegram` | telegram notifier dependency | You need Telegram notifier integration. |
-| `whatsapp` | Twilio notifier dependency | You need WhatsApp notifier integration. |
-
-```bash
-python -m pip install .[dev]
-python -m pip install .[test]
-python -m pip install .[docs]
-python -m pip install .[packaging]
-python -m pip install .[telegram]
-python -m pip install .[whatsapp]
-```
-
-You can combine extras as needed, for example:
-
-```bash
-python -m pip install .[dev,test,docs]
-```
-
-## Verify your install
-
-Run this short check immediately after installation:
-
-```bash
-python -m sdetkit --help
-python -m sdetkit gate --help
-```
-
-Expected result: both commands print usage/help text and exit successfully.
-
-Then run the first real release-confidence signal in your own repository:
-
-```bash
-python -m sdetkit gate fast
-```
-
-## Recommended first 10 minutes
-
-1. Install SDETKit (recommended: GitHub URL install).
-2. Verify CLI availability with `python -m sdetkit --help`.
-3. Run quick confidence: `python -m sdetkit gate fast`.
-4. Run strict release checks: `python -m sdetkit gate release`.
-5. Review command families in `docs/cli.md` and staged rollout guidance in `docs/adoption.md`.
-
-What works without optional extras:
-
-- Core gate commands (`gate fast`, `gate release`)
-- Security budget enforcement (`security enforce`)
-- Stable/Core quickstart wrapper (`scripts/ready_to_use.sh` in this repository)
-
-Optional extras are only for specialized workflows (contributing, docs authoring, packaging validation, notifier integrations).
-
-## CI/CD integration
-
-For teams adopting SDETKit in another repository, start with:
-
-- `docs/adoption.md` for copy-paste local and GitHub Actions workflows.
-- `docs/adoption-examples.md` for practical rollout shapes by team/repo context.
-- `docs/recommended-ci-flow.md` for the recommended baseline CI shape (PR fast feedback, stricter `main`, release-oriented checks).
-- First gate: `python -m sdetkit gate fast`
-- Stricter rollout: security budgets + `python -m sdetkit gate release`
-
-For CI failure triage in this repository's GitHub Actions runs, inspect uploaded artifacts:
-
-- `ci-gate-diagnostics` (`build/gate-fast.json`, `build/security-enforce.json`)
-- `release-diagnostics` (`build/release-preflight.json`)
-
-For an immediate "downloaded artifact -> next fix step" path, use the artifact-to-action map in `docs/adoption-troubleshooting.md`.
-
-### Jenkins
-
-See `examples/ci/jenkins/`.
-
-### Docker
-
-```bash
-docker build -t sdetkit .
-docker run --rm -v "$PWD:/work" -w /work sdetkit python -m sdetkit gate fast
-```
-
-## Contributor entry points
-
-- Contributing guide: `CONTRIBUTING.md`
-- First-time contributor quickstart: `docs/first-contribution-quickstart.md`
-- Starter work inventory: `docs/starter-work-inventory.md`
-- Maintainer starter-issue hygiene: `docs/maintainer-starter-issue-hygiene.md`
-- First contribution command: `python -m sdetkit first-contribution --format text --strict`
-
-## Release posture note
-
-This repository is prepared for artifact build and release validation. Public PyPI publication depends on `PYPI_API_TOKEN` configuration and successful workflow execution; this README does not claim generally available PyPI distribution by default.
-
-For first-public-release and post-release external verification steps, follow `RELEASE.md` and `docs/releasing.md`. After real releases are verified externally, see `docs/release-verification.md` for published evidence records.
-
-## License
-
-Distributed under the Apache-2.0 license. See `LICENSE` and `ENTERPRISE_OFFERINGS.md`.
+- Architecture note: `docs/architecture/umbrella-kits.md`
+- Kit pages:
+  - `docs/kits/release-confidence.md`
+  - `docs/kits/test-intelligence.md`
+  - `docs/kits/integration-assurance.md`
+  - `docs/kits/failure-forensics.md`

--- a/docs/architecture/umbrella-kits.md
+++ b/docs/architecture/umbrella-kits.md
@@ -1,0 +1,18 @@
+# Umbrella architecture: SDETKit kits
+
+SDETKit now exposes four explicit kits under one umbrella CLI:
+
+- **Release Confidence Kit** (`sdetkit release ...`): gate, doctor, security, evidence, repo readiness.
+- **Test Intelligence Kit** (`sdetkit intelligence ...`): flake classification, deterministic env capture, impact summaries, mutation governance checks.
+- **Integration Assurance Kit** (`sdetkit integration ...`): profile-driven environment checks and compatibility summaries.
+- **Failure Forensics Kit** (`sdetkit forensics ...`): run-to-run compare and deterministic repro bundle generation.
+
+## Product boundaries
+
+- **Stable/Core**: release, intelligence, integration, and existing direct commands (`gate`, `doctor`, `repo`, `security`, `evidence`).
+- **Experimental**: forensics bundle/compare lane is real and deterministic, but staged for expansion.
+- **Backward compatibility**: existing stable commands remain first-class; kit commands are additive grouping aliases.
+
+## Deterministic artifact contracts
+
+Every new kit command emits machine-readable JSON with `schema_version` and deterministic ordering.

--- a/docs/kits/failure-forensics.md
+++ b/docs/kits/failure-forensics.md
@@ -1,0 +1,20 @@
+# Failure Forensics Kit
+
+## Purpose
+Provide deterministic run comparison and minimal repro bundle packaging.
+
+## Inputs
+Two run JSON files (`report` schema) and optional extra evidence files.
+
+## Outputs/artifacts
+- `sdetkit.forensics.compare.v1`
+- `sdetkit.forensics.bundle.v1`
+
+## CI role
+Summarize regressions/resolutions and preserve reproducible failure bundles.
+
+## Example commands
+```bash
+sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json
+sdetkit forensics bundle --run examples/kits/forensics/run-b.json --output build/repro.zip
+```

--- a/docs/kits/integration-assurance.md
+++ b/docs/kits/integration-assurance.md
@@ -1,0 +1,20 @@
+# Integration Assurance Kit
+
+## Purpose
+Validate environment and service readiness contracts with offline-first deterministic checks.
+
+## Inputs
+Integration profile JSON (`required_env`, `required_files`, `services`).
+
+## Outputs/artifacts
+- `sdetkit.integration.profile-check.v1`
+- `sdetkit.integration.matrix.v1`
+
+## CI role
+Catch environment drift before integration test execution.
+
+## Example commands
+```bash
+sdetkit integration check --profile examples/kits/integration/profile.json
+sdetkit integration matrix --profile examples/kits/integration/profile.json
+```

--- a/docs/kits/release-confidence.md
+++ b/docs/kits/release-confidence.md
@@ -1,0 +1,21 @@
+# Release Confidence Kit
+
+## Purpose
+Provide deterministic release gating, diagnostics, and evidence outputs for release owners.
+
+## Inputs
+Repository source tree, policy/config files, and optional CI metadata.
+
+## Outputs
+Gate/doctor/security/evidence JSON/SARIF/manifests from existing stable commands.
+
+## CI role
+Primary merge and release confidence decision lane.
+
+## Hero commands
+```bash
+sdetkit release gate fast
+sdetkit release gate release
+sdetkit release doctor
+sdetkit release evidence --help
+```

--- a/docs/kits/test-intelligence.md
+++ b/docs/kits/test-intelligence.md
@@ -1,0 +1,25 @@
+# Test Intelligence Kit
+
+## Purpose
+Provide deterministic test-quality intelligence beyond simple lint/test wrappers.
+
+## Inputs
+- flake history JSON (`tests[].id`, `tests[].outcomes`)
+- changed file list + test map JSON
+- mutation governance policy JSON
+
+## Outputs/artifacts
+- `sdetkit.intelligence.flake.v1`
+- `sdetkit.intelligence.impact.v1`
+- `sdetkit.intelligence.env-capture.v1`
+- `sdetkit.intelligence.mutation-policy.v1`
+
+## CI role
+Flag flaky tests, scope impact-driven runs, and enforce mutation governance policy.
+
+## Example commands
+```bash
+sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json
+sdetkit intelligence impact summarize --changed examples/kits/intelligence/changed-files.txt --map examples/kits/intelligence/test-map.json
+sdetkit intelligence mutation-policy --policy examples/kits/intelligence/mutation-policy.json
+```

--- a/examples/kits/forensics/run-a.json
+++ b/examples/kits/forensics/run-a.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "sdetkit.audit.run.v1",
+  "profile": "default",
+  "packs": ["core"],
+  "fail_on": "none",
+  "findings": [
+    {
+      "fingerprint": "fp-auth",
+      "rule_id": "AUTH-001",
+      "severity": "warn",
+      "message": "weak token",
+      "path": "src/auth.py",
+      "line": 9,
+      "tags": [],
+      "pack": "core",
+      "fixable": false,
+      "suppressed": false,
+      "suppression_reason": null
+    }
+  ],
+  "aggregates": {"counts_by_severity": {"error": 0, "info": 0, "warn": 1}, "counts_suppressed": 0, "counts_fixable": 0},
+  "execution": {"incremental_used": false, "changed_file_count": 0}
+}

--- a/examples/kits/forensics/run-b.json
+++ b/examples/kits/forensics/run-b.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "sdetkit.audit.run.v1",
+  "profile": "default",
+  "packs": ["core"],
+  "fail_on": "none",
+  "findings": [
+    {
+      "fingerprint": "fp-auth",
+      "rule_id": "AUTH-001",
+      "severity": "error",
+      "message": "weak token",
+      "path": "src/auth.py",
+      "line": 9,
+      "tags": [],
+      "pack": "core",
+      "fixable": false,
+      "suppressed": false,
+      "suppression_reason": null
+    },
+    {
+      "fingerprint": "fp-cache",
+      "rule_id": "CACHE-002",
+      "severity": "warn",
+      "message": "cache fallback",
+      "path": "src/cache.py",
+      "line": 4,
+      "tags": [],
+      "pack": "core",
+      "fixable": true,
+      "suppressed": false,
+      "suppression_reason": null
+    }
+  ],
+  "aggregates": {"counts_by_severity": {"error": 1, "info": 0, "warn": 1}, "counts_suppressed": 0, "counts_fixable": 1},
+  "execution": {"incremental_used": false, "changed_file_count": 0}
+}

--- a/examples/kits/integration/profile.json
+++ b/examples/kits/integration/profile.json
@@ -1,0 +1,8 @@
+{
+  "name": "local-smoke",
+  "required_env": ["CI"],
+  "required_files": ["pyproject.toml"],
+  "services": [
+    {"name": "dummy-http", "port": 9, "expect": "closed"}
+  ]
+}

--- a/examples/kits/intelligence/changed-files.txt
+++ b/examples/kits/intelligence/changed-files.txt
@@ -1,0 +1,2 @@
+src/app/auth.py
+src/app/retry.py

--- a/examples/kits/intelligence/flake-history.json
+++ b/examples/kits/intelligence/flake-history.json
@@ -1,0 +1,6 @@
+{
+  "tests": [
+    {"id": "tests/test_api.py::test_retry", "outcomes": ["failed", "passed", "failed"]},
+    {"id": "tests/test_auth.py::test_login", "outcomes": ["passed", "passed"]}
+  ]
+}

--- a/examples/kits/intelligence/mutation-policy.json
+++ b/examples/kits/intelligence/mutation-policy.json
@@ -1,0 +1,6 @@
+{
+  "minimum_score": 70,
+  "observed_score": 78,
+  "owners": ["qa-lead"],
+  "justification": "Core branch protected by mutation score budget"
+}

--- a/examples/kits/intelligence/test-map.json
+++ b/examples/kits/intelligence/test-map.json
@@ -1,0 +1,4 @@
+{
+  "src/app/auth.py": ["tests/test_auth.py::test_login", "tests/test_auth.py::test_mfa"],
+  "src/app/retry.py": ["tests/test_api.py::test_retry"]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,12 @@ nav:
       - Release confidence (core commands): release-confidence.md
       - Doctor checks: doctor.md
       - Decision guide (is SDETKit a fit?): decision-guide.md
+  - Kits (umbrella):
+      - Umbrella architecture note: architecture/umbrella-kits.md
+      - Release Confidence Kit: kits/release-confidence.md
+      - Test Intelligence Kit: kits/test-intelligence.md
+      - Integration Assurance Kit: kits/integration-assurance.md
+      - Failure Forensics Kit: kits/failure-forensics.md
   - Team adoption:
       - Adopt in your repository (canonical): adoption.md
       - Team rollout scenario: team-rollout-scenario.md

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from collections.abc import Sequence
 from importlib import metadata
 
@@ -86,8 +87,12 @@ from . import (
     external_contribution_push,
     faq_objections,
     first_contribution,
+    forensics,
     github_actions_quickstart,
     gitlab_ci_quickstart,
+    integration,
+    intelligence,
+    kits,
     kpi_audit,
     kvcli,
     notify,
@@ -112,6 +117,7 @@ from . import (
     trust_signal_upgrade,
     weekly_review,
 )
+from . import gate as gate_cmd
 from .agent.cli import main as agent_main
 from .maintenance import main as maintenance_main
 from .public_surface_contract import render_root_help_groups
@@ -242,6 +248,14 @@ Start here:
         "playbooks",
         help="Discover and run adoption/rollout playbooks",
     )
+    _add_passthrough_subcommand(sub, "kits", help_text="List umbrella SDET kits")
+
+    _add_passthrough_subcommand(
+        sub, "release", help_text="Release Confidence Kit (gate/doctor/security/evidence)"
+    )
+    _add_passthrough_subcommand(sub, "intelligence", help_text="Test Intelligence Kit")
+    _add_passthrough_subcommand(sub, "integration", help_text="Integration Assurance Kit")
+    _add_passthrough_subcommand(sub, "forensics", help_text="Failure Forensics Kit")
     _add_passthrough_subcommand(sub, "kv", help_text="Parse key=value input into JSON")
 
     ag = sub.add_parser("apiget", help="Deterministic HTTP JSON fetch and replay helper")
@@ -1165,6 +1179,37 @@ def main(argv: Sequence[str] | None = None) -> int:
         _print_playbooks(sub)
 
         return 0
+
+    if ns.cmd == "kits":
+        return kits.main(ns.args)
+
+    if ns.cmd == "release":
+        if not ns.args:
+            sys.stderr.write("release error: expected subcommand (gate|doctor|security|evidence|repo)\n")
+            return 2
+        subcmd = ns.args[0]
+        rest = ns.args[1:]
+        if subcmd == "gate":
+            return gate_cmd.main(rest)
+        if subcmd == "doctor":
+            return doctor.main(rest)
+        if subcmd == "security":
+            return security_main(rest)
+        if subcmd == "evidence":
+            return evidence.main(rest)
+        if subcmd == "repo":
+            return repo.main(rest)
+        sys.stderr.write("release error: supported subcommands are gate|doctor|security|evidence|repo\n")
+        return 2
+
+    if ns.cmd == "intelligence":
+        return intelligence.main(ns.args)
+
+    if ns.cmd == "integration":
+        return integration.main(ns.args)
+
+    if ns.cmd == "forensics":
+        return forensics.main(ns.args)
 
     if ns.cmd == "kv":
         return kvcli.main(ns.args)

--- a/src/sdetkit/forensics.py
+++ b/src/sdetkit/forensics.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from .atomicio import canonical_json_bytes, canonical_json_dumps
+from .report import diff_runs, load_run_record
+from .security import SecurityError, safe_path
+
+
+def _compare(from_path: Path, to_path: Path) -> dict[str, Any]:
+    from_run = load_run_record(from_path)
+    to_run = load_run_record(to_path)
+    payload = diff_runs(from_run, to_run)
+    payload["schema_version"] = "sdetkit.forensics.compare.v1"
+    return payload
+
+
+def _bundle(run_path: Path, output_path: Path, include: list[str]) -> dict[str, Any]:
+    run = load_run_record(run_path)
+    manifest = {
+        "schema_version": "sdetkit.forensics.bundle-manifest.v1",
+        "run_sha256": hashlib.sha256(canonical_json_bytes(run)).hexdigest(),
+        "included_files": sorted(include),
+    }
+
+    with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        info = zipfile.ZipInfo("manifest.json")
+        info.date_time = (1980, 1, 1, 0, 0, 0)
+        info.compress_type = zipfile.ZIP_DEFLATED
+        zf.writestr(info, canonical_json_dumps(manifest))
+
+        run_info = zipfile.ZipInfo("run.json")
+        run_info.date_time = (1980, 1, 1, 0, 0, 0)
+        run_info.compress_type = zipfile.ZIP_DEFLATED
+        zf.writestr(run_info, canonical_json_dumps(run))
+
+        for file_name in sorted(include):
+            path = Path(file_name)
+            if not path.exists() or not path.is_file():
+                continue
+            data = path.read_bytes()
+            extra = zipfile.ZipInfo(f"extras/{path.name}")
+            extra.date_time = (1980, 1, 1, 0, 0, 0)
+            extra.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(extra, data)
+
+    return {
+        "schema_version": "sdetkit.forensics.bundle.v1",
+        "bundle": str(output_path),
+        "manifest": manifest,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="sdetkit forensics", description="Failure Forensics Kit")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    compare = sub.add_parser("compare", help="Compare two run records")
+    compare.add_argument("--from", dest="from_run", required=True)
+    compare.add_argument("--to", dest="to_run", required=True)
+    compare.add_argument("--fail-on", choices=["none", "warn", "error"], default="none")
+
+    bundle = sub.add_parser("bundle", help="Create deterministic repro/evidence bundle")
+    bundle.add_argument("--run", required=True)
+    bundle.add_argument("--output", required=True)
+    bundle.add_argument("--include", nargs="*", default=[])
+
+    ns = parser.parse_args(argv)
+    try:
+        if ns.cmd == "compare":
+            payload = _compare(
+                safe_path(Path.cwd(), ns.from_run, allow_absolute=True),
+                safe_path(Path.cwd(), ns.to_run, allow_absolute=True),
+            )
+            sys.stdout.write(canonical_json_dumps(payload))
+            new_error = [x for x in payload.get("new", []) if x.get("severity") == "error"]
+            new_warn = [x for x in payload.get("new", []) if x.get("severity") in {"warn", "error"}]
+            if ns.fail_on == "error" and new_error:
+                return 1
+            if ns.fail_on == "warn" and new_warn:
+                return 1
+            return 0
+
+        payload = _bundle(
+            safe_path(Path.cwd(), ns.run, allow_absolute=True),
+            safe_path(Path.cwd(), ns.output, allow_absolute=True),
+            list(ns.include),
+        )
+        sys.stdout.write(canonical_json_dumps(payload))
+        return 0
+    except (ValueError, OSError, SecurityError, json.JSONDecodeError) as exc:
+        sys.stderr.write(f"forensics error: {exc}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/integration.py
+++ b/src/sdetkit/integration.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+from pathlib import Path
+from typing import Any
+
+from .atomicio import canonical_json_dumps
+from .security import SecurityError, safe_path
+
+
+def _load_profile(path: Path) -> dict[str, Any]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(obj, dict):
+        raise ValueError("profile must be a JSON object")
+    return obj
+
+
+def _probe_tcp_localhost(port: int, timeout_s: float = 0.2) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout_s)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _evaluate(profile: dict[str, Any]) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+
+    for env_name in sorted(str(x) for x in profile.get("required_env", [])):
+        present = bool(os.environ.get(env_name, ""))
+        checks.append({"kind": "env", "name": env_name, "passed": present})
+
+    for rel_file in sorted(str(x) for x in profile.get("required_files", [])):
+        exists = Path(rel_file).exists()
+        checks.append({"kind": "file", "name": rel_file, "passed": exists})
+
+    services = profile.get("services", [])
+    if isinstance(services, list):
+        for svc in sorted((x for x in services if isinstance(x, dict)), key=lambda x: str(x.get("name"))):
+            name = str(svc.get("name", "service"))
+            port = int(svc.get("port", 0))
+            expect = str(svc.get("expect", "closed"))
+            if port <= 0:
+                checks.append({"kind": "service", "name": name, "passed": False, "reason": "invalid-port"})
+                continue
+            open_now = _probe_tcp_localhost(port)
+            passed = open_now if expect == "open" else (not open_now)
+            checks.append(
+                {
+                    "kind": "service",
+                    "name": name,
+                    "port": port,
+                    "expect": expect,
+                    "observed": "open" if open_now else "closed",
+                    "passed": passed,
+                }
+            )
+
+    checks.sort(key=lambda x: (str(x.get("kind", "")), str(x.get("name", ""))))
+    return {
+        "schema_version": "sdetkit.integration.profile-check.v1",
+        "profile_name": str(profile.get("name", "default")),
+        "checks": checks,
+        "summary": {
+            "total": len(checks),
+            "failed": sum(1 for x in checks if not bool(x.get("passed"))),
+            "passed": all(bool(x.get("passed")) for x in checks) if checks else True,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit integration", description="Integration Assurance Kit (offline-first)"
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    check = sub.add_parser("check", help="Evaluate environment readiness profile")
+    check.add_argument("--profile", required=True)
+    matrix = sub.add_parser("matrix", help="Print compatibility summary in JSON")
+    matrix.add_argument("--profile", required=True)
+    ns = parser.parse_args(argv)
+
+    try:
+        profile = _load_profile(safe_path(Path.cwd(), ns.profile, allow_absolute=True))
+        payload = _evaluate(profile)
+        if ns.cmd == "matrix":
+            payload["schema_version"] = "sdetkit.integration.matrix.v1"
+            payload["compatibility"] = {
+                "profile": payload["profile_name"],
+                "status": "compatible" if payload["summary"]["passed"] else "incompatible",
+            }
+    except (ValueError, OSError, SecurityError) as exc:
+        sys.stderr.write(f"integration error: {exc}\n")
+        return 2
+
+    sys.stdout.write(canonical_json_dumps(payload))
+    return 0 if payload["summary"]["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/intelligence.py
+++ b/src/sdetkit/intelligence.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Any
+
+from .atomicio import canonical_json_dumps
+from .security import SecurityError, safe_path
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _fingerprint(test_id: str, message: str) -> str:
+    return hashlib.sha256(f"{test_id}\n{message}".encode("utf-8")).hexdigest()[:16]
+
+
+def _cmd_flake_classify(history_path: Path, rerun_threshold: int) -> dict[str, Any]:
+    data = _load_json(history_path)
+    if not isinstance(data, dict) or not isinstance(data.get("tests"), list):
+        raise ValueError("history must be an object with a tests array")
+    out: list[dict[str, Any]] = []
+    for item in data["tests"]:
+        if not isinstance(item, dict):
+            continue
+        test_id = str(item.get("id", ""))
+        outcomes = [str(x) for x in item.get("outcomes", []) if isinstance(x, str)]
+        if not test_id or not outcomes:
+            continue
+        failures = sum(1 for x in outcomes if x == "failed")
+        passes = sum(1 for x in outcomes if x == "passed")
+        flaky = failures > 0 and passes > 0 and len(outcomes) >= rerun_threshold
+        classification = "flaky" if flaky else ("stable-failing" if failures else "stable-passing")
+        message = f"{classification}:{','.join(outcomes)}"
+        out.append(
+            {
+                "test_id": test_id,
+                "classification": classification,
+                "runs": len(outcomes),
+                "failures": failures,
+                "passes": passes,
+                "fingerprint": _fingerprint(test_id, message),
+            }
+        )
+    out.sort(key=lambda x: (x["classification"], x["test_id"], x["fingerprint"]))
+    return {
+        "schema_version": "sdetkit.intelligence.flake.v1",
+        "tests": out,
+        "summary": {
+            "flaky": sum(1 for x in out if x["classification"] == "flaky"),
+            "stable_failing": sum(1 for x in out if x["classification"] == "stable-failing"),
+            "stable_passing": sum(1 for x in out if x["classification"] == "stable-passing"),
+        },
+    }
+
+
+def _cmd_capture_env(seed: int | None) -> dict[str, Any]:
+    chosen_seed = seed if seed is not None else int(os.environ.get("SDETKIT_SEED", "1337"))
+    rng = random.Random(chosen_seed)
+    sampled = {
+        k: os.environ.get(k, "")
+        for k in sorted(["CI", "GITHUB_REF", "GITHUB_SHA", "PYTHONHASHSEED", "TZ"])  # deterministic
+    }
+    return {
+        "schema_version": "sdetkit.intelligence.env-capture.v1",
+        "seed": chosen_seed,
+        "derived_seed": rng.randint(0, 10_000_000),
+        "environment": sampled,
+    }
+
+
+def _cmd_impact(changed_path: Path, testmap_path: Path) -> dict[str, Any]:
+    changed = [
+        line.strip()
+        for line in changed_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    mapping = _load_json(testmap_path)
+    if not isinstance(mapping, dict):
+        raise ValueError("test map must be a json object")
+    impacted: set[str] = set()
+    reasons: list[dict[str, str]] = []
+    for file_path in sorted(changed):
+        tests = mapping.get(file_path, [])
+        if isinstance(tests, list):
+            for test_id in sorted(str(x) for x in tests):
+                impacted.add(test_id)
+                reasons.append({"changed_file": file_path, "test_id": test_id})
+    reasons.sort(key=lambda x: (x["test_id"], x["changed_file"]))
+    return {
+        "schema_version": "sdetkit.intelligence.impact.v1",
+        "changed_files": sorted(changed),
+        "impacted_tests": sorted(impacted),
+        "mapping_hits": reasons,
+    }
+
+
+def _cmd_mutation_policy(policy_path: Path) -> dict[str, Any]:
+    policy = _load_json(policy_path)
+    if not isinstance(policy, dict):
+        raise ValueError("policy file must be a json object")
+    threshold = float(policy.get("minimum_score", 0))
+    score = float(policy.get("observed_score", 0))
+    owners = policy.get("owners", [])
+    owner_ok = isinstance(owners, list) and len(owners) > 0
+    justification = str(policy.get("justification", "")).strip()
+    passed = score >= threshold and owner_ok and bool(justification)
+    return {
+        "schema_version": "sdetkit.intelligence.mutation-policy.v1",
+        "passed": passed,
+        "threshold": threshold,
+        "observed_score": score,
+        "owner_count": len(owners) if isinstance(owners, list) else 0,
+        "has_justification": bool(justification),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="sdetkit intelligence", description="Test Intelligence Kit")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    flake = sub.add_parser("flake", help="Flake classification from rerun history")
+    flake_sub = flake.add_subparsers(dest="subcmd", required=True)
+    classify = flake_sub.add_parser("classify")
+    classify.add_argument("--history", required=True)
+    classify.add_argument("--rerun-threshold", type=int, default=2)
+
+    cap = sub.add_parser("capture-env", help="Deterministic seed/environment capture")
+    cap.add_argument("--seed", type=int, default=None)
+
+    impact = sub.add_parser("impact", help="Changed-scope impacted test summary")
+    impact_sub = impact.add_subparsers(dest="subcmd", required=True)
+    summarize = impact_sub.add_parser("summarize")
+    summarize.add_argument("--changed", required=True)
+    summarize.add_argument("--map", required=True, dest="test_map")
+
+    mut = sub.add_parser("mutation-policy", help="Mutation governance evaluation")
+    mut.add_argument("--policy", required=True)
+
+    ns = parser.parse_args(argv)
+    try:
+        if ns.cmd == "flake" and ns.subcmd == "classify":
+            payload = _cmd_flake_classify(
+                safe_path(Path.cwd(), ns.history, allow_absolute=True), max(ns.rerun_threshold, 1)
+            )
+        elif ns.cmd == "capture-env":
+            payload = _cmd_capture_env(ns.seed)
+        elif ns.cmd == "impact" and ns.subcmd == "summarize":
+            payload = _cmd_impact(
+                safe_path(Path.cwd(), ns.changed, allow_absolute=True),
+                safe_path(Path.cwd(), ns.test_map, allow_absolute=True),
+            )
+        else:
+            payload = _cmd_mutation_policy(safe_path(Path.cwd(), ns.policy, allow_absolute=True))
+    except (ValueError, OSError, SecurityError) as exc:
+        sys.stderr.write(f"intelligence error: {exc}\n")
+        return 2
+
+    sys.stdout.write(canonical_json_dumps(payload))
+    if payload.get("passed") is False:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Final
+
+from .atomicio import canonical_json_dumps
+
+SCHEMA_VERSION: Final[str] = "sdetkit.kits.catalog.v1"
+
+_KITS: Final[list[dict[str, object]]] = [
+    {
+        "id": "release-confidence",
+        "stability": "stable",
+        "summary": "Gate, doctor, repo audit, security, evidence, and release readiness.",
+        "hero_commands": [
+            "sdetkit release gate fast",
+            "sdetkit release gate release",
+            "sdetkit release doctor",
+            "sdetkit release evidence",
+        ],
+    },
+    {
+        "id": "test-intelligence",
+        "stability": "stable",
+        "summary": "Flake classification, deterministic env capture, impact summaries, and governance hooks.",
+        "hero_commands": [
+            "sdetkit intelligence flake classify --history history.json",
+            "sdetkit intelligence impact summarize --changed changed.txt --map testmap.json",
+            "sdetkit intelligence capture-env",
+        ],
+    },
+    {
+        "id": "integration-assurance",
+        "stability": "stable",
+        "summary": "Offline-first service profile and environment readiness contracts.",
+        "hero_commands": [
+            "sdetkit integration check --profile integration-profile.json",
+            "sdetkit integration matrix --profile integration-profile.json",
+        ],
+    },
+    {
+        "id": "failure-forensics",
+        "stability": "experimental",
+        "summary": "Run comparison and deterministic repro bundle generation.",
+        "hero_commands": [
+            "sdetkit forensics compare --from old.json --to new.json",
+            "sdetkit forensics bundle --run run.json --output bundle.zip",
+        ],
+    },
+]
+
+
+def list_payload() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kits": sorted(_KITS, key=lambda item: str(item["id"])),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit kits",
+        description="Discover umbrella kit surfaces and stability lanes.",
+    )
+    parser.add_argument("action", nargs="?", default="list", choices=["list"])
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    ns = parser.parse_args(argv)
+
+    payload = list_payload()
+    if ns.format == "json":
+        sys.stdout.write(canonical_json_dumps(payload))
+        return 0
+
+    print("SDETKit umbrella kits")
+    for kit in payload["kits"]:
+        assert isinstance(kit, dict)
+        print(f"- {kit['id']} [{kit['stability']}]")
+        print(f"  {kit['summary']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kits_intelligence_integration_forensics.py
+++ b/tests/test_kits_intelligence_integration_forensics.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+
+def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "sdetkit", *args], text=True, capture_output=True, cwd=cwd
+    )
+
+
+def test_intelligence_flake_impact_and_mutation_policy_contracts() -> None:
+    flake = _run(
+        "intelligence",
+        "flake",
+        "classify",
+        "--history",
+        "examples/kits/intelligence/flake-history.json",
+    )
+    assert flake.returncode == 0
+    flake_json = json.loads(flake.stdout)
+    assert flake_json["schema_version"] == "sdetkit.intelligence.flake.v1"
+    assert flake_json["tests"][0]["fingerprint"]
+
+    impact = _run(
+        "intelligence",
+        "impact",
+        "summarize",
+        "--changed",
+        "examples/kits/intelligence/changed-files.txt",
+        "--map",
+        "examples/kits/intelligence/test-map.json",
+    )
+    assert impact.returncode == 0
+    impact_json = json.loads(impact.stdout)
+    assert impact_json["schema_version"] == "sdetkit.intelligence.impact.v1"
+    assert impact_json["impacted_tests"] == sorted(impact_json["impacted_tests"])
+
+    policy = _run(
+        "intelligence",
+        "mutation-policy",
+        "--policy",
+        "examples/kits/intelligence/mutation-policy.json",
+    )
+    assert policy.returncode == 0
+    policy_json = json.loads(policy.stdout)
+    assert policy_json["schema_version"] == "sdetkit.intelligence.mutation-policy.v1"
+    assert policy_json["passed"] is True
+
+
+def test_integration_and_forensics_contracts_and_bundle_determinism(tmp_path: Path) -> None:
+    integration = _run("integration", "check", "--profile", "examples/kits/integration/profile.json")
+    assert integration.returncode in {0, 1}
+    integration_json = json.loads(integration.stdout)
+    assert integration_json["schema_version"] == "sdetkit.integration.profile-check.v1"
+
+    compare = _run(
+        "forensics",
+        "compare",
+        "--from",
+        "examples/kits/forensics/run-a.json",
+        "--to",
+        "examples/kits/forensics/run-b.json",
+    )
+    assert compare.returncode == 0
+    cmp_json = json.loads(compare.stdout)
+    assert cmp_json["schema_version"] == "sdetkit.forensics.compare.v1"
+
+    out1 = tmp_path / "bundle1.zip"
+    out2 = tmp_path / "bundle2.zip"
+    cmd = [
+        "forensics",
+        "bundle",
+        "--run",
+        "examples/kits/forensics/run-b.json",
+        "--output",
+    ]
+    b1 = _run(*cmd, str(out1))
+    b2 = _run(*cmd, str(out2))
+    assert b1.returncode == b2.returncode == 0
+    assert out1.read_bytes() == out2.read_bytes()
+
+    with zipfile.ZipFile(out1) as zf:
+        names = sorted(zf.namelist())
+    assert names == ["manifest.json", "run.json"]

--- a/tests/test_kits_umbrella_cli.py
+++ b/tests/test_kits_umbrella_cli.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "-m", "sdetkit", *args], text=True, capture_output=True)
+
+
+def test_root_help_lists_new_umbrella_kits_commands() -> None:
+    result = _run("--help")
+    assert result.returncode == 0
+    assert "kits" in result.stdout
+    assert "release" in result.stdout
+    assert "intelligence" in result.stdout
+    assert "integration" in result.stdout
+    assert "forensics" in result.stdout
+
+
+def test_kits_list_json_schema_and_order() -> None:
+    result = _run("kits", "list", "--format", "json")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "sdetkit.kits.catalog.v1"
+    ids = [x["id"] for x in payload["kits"]]
+    assert ids == sorted(ids)
+    assert "release-confidence" in ids
+
+
+def test_release_alias_routes_to_gate_and_backcompat_gate_still_works() -> None:
+    a = _run("release", "gate", "--help")
+    b = _run("gate", "--help")
+    assert a.returncode == b.returncode == 0
+    assert "usage:" in a.stdout
+    assert "usage:" in b.stdout


### PR DESCRIPTION
### Motivation

- Group SDETKit capabilities under a clear umbrella taxonomy so the project reads as a modular product with distinct kits and hero journeys.
- Provide real, non‑toy capabilities for Test Intelligence, Integration Assurance, and Failure Forensics that emit deterministic, machine‑readable artifacts.
- Preserve backward compatibility by keeping existing stable commands and offering a `release` grouping alias that routes into current gate/doctor/security/evidence flows.
- Ensure new kit surfaces are accompanied by docs, example fixtures, and tests so public features are runnable and verifiable.

### Description

- Add `sdetkit kits` catalog (`src/sdetkit/kits.py`) exposing a deterministic JSON catalog and text listing of umbrella kits.
- Implement Test Intelligence (`src/sdetkit/intelligence.py`) with flake classification (rerun‑based), deterministic env capture, impacted‑test summaries, and a mutation governance check emitting stable schema versions.
- Implement Integration Assurance (`src/sdetkit/integration.py`) for offline‑first profile checks (env/files/services) and a compatibility matrix output, and Failure Forensics (`src/sdetkit/forensics.py`) for run‑to‑run diffs and deterministic repro bundle generation (fixed zip timestamps + canonical manifests).
- Wire new kit entry points into the root CLI (`src/sdetkit/cli.py`) including `kits`, `release` (compatibility grouping to existing gates/doctor/security/evidence/repo), `intelligence`, `integration`, and `forensics`, and add deterministic example fixtures and docs pages plus mkdocs navigation updates.
- Update CI to generate kit sample artifacts and expand smoke wheel install validation to Python 3.11 and 3.12, and add contract/determinism tests validating schemas, aliases, and bundle determinism.

### Testing

- Ran `pytest -q tests/test_kits_umbrella_cli.py tests/test_kits_intelligence_integration_forensics.py`, which completed successfully with all tests passing (`5 passed`).
- Verified Python sources compile with `python -m compileall -q src/sdetkit` with no errors.
- CI workflow updated to produce and upload kit artifacts (kit catalog, intelligence, integration, forensics sample outputs) as part of the existing gate diagnostics job.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3024c0270832794375d68741f55be)