### PR TITLE
Harden doctor, evidence, and policy command contracts

### DIFF
--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,66 +1,36 @@
 # Doctor
 
-`doctor` is a repo health command focused on practical, release-ready diagnostics.
+`doctor` is a deterministic readiness verifier for release confidence.
 
-Run it via:
+## Commands
 
-- `sdetkit doctor ...`
-- `python -m sdetkit doctor ...`
+- `sdetkit doctor --all --format json`
+- `sdetkit doctor --dev --ci --deps --clean-tree --repo --format md`
+- `sdetkit doctor --only pyproject --format json`
 
-Common usage:
+## Contract
 
-```bash
-sdetkit doctor --ascii
-sdetkit doctor --all
-sdetkit doctor --all --json
-```
+- JSON output includes `schema_version: sdetkit.doctor.v2`.
+- Stable check IDs and deterministic JSON ordering.
+- Explicit failure classification in JSON error payloads (for example: `plan_id_mismatch`).
+- Exit codes:
+  - `0`: all selected checks passed
+  - `2`: one or more selected checks failed, or contract mismatch in apply-plan flow
 
-## What it checks
+## Real-world depth
 
-- `--ascii`: scans `src/` and `tools/` for non-ASCII bytes.
-  - Skips `__pycache__/` and `.pyc` files.
-- `--ci`: verifies required workflow files exist and validates YAML with pre-commit `check-yaml`.
-- `--pre-commit`: validates pre-commit is installed and config is valid.
-- `--deps`: runs `pip check` to detect dependency issues.
-- `--clean-tree`: fails if `git status --porcelain` is not empty.
-- `--dev`: validates local dev setup including required tools and active virtual environment.
-- `--pyproject`: parses `pyproject.toml` early to catch TOML syntax issues before CI.
-- `--repo`: validates repo readiness (gate scripts exist, repo layout check script exists and passes, CI templates are present, and pre-commit includes ruff/ruff-format/mypy hooks).
+`doctor` checks production-relevant failure modes:
 
-Convenience flags:
+- toolchain availability and virtualenv posture
+- dependency graph consistency
+- repo cleanliness + release metadata
+- CI + governance file integrity
+- stdlib-shadowing and non-ASCII hygiene
 
-- `--all`: runs core checks in one command.
-- `--release`: release-oriented check pack (`--all` + pyproject validation).
+Each failing check includes actionable remediation (`fix`) and supporting evidence.
 
-## Dev UX highlights
+## Determinism
 
-For local delivery checks you can run:
-
-```bash
-sdetkit doctor --dev --ci --deps --clean-tree
-```
-
-This now warns clearly if no virtual environment is active and provides concrete remediation.
-
-## PR-ready output
-
-Use `--pr` to print a compact markdown report that can be pasted directly into a PR comment:
-
-```bash
-sdetkit doctor --dev --ci --deps --clean-tree --pr
-```
-
-Use `--json` when integrating with bots or custom automation.
-
-## Score and recommendations
-
-Every run computes a `score` (0–100) from enabled checks and generates actionable `recommendations`.
-
-- Human mode prints compact status + next steps.
-- PR mode prints concise markdown.
-- JSON mode includes `checks`, `score`, `recommendations`, and `ok`.
-
-## Output and exit codes
-
-- Exit code `0` means all enabled checks passed.
-- Non-zero means at least one enabled check failed.
+- Baseline snapshots are emitted with stable key ordering.
+- Check collections are explicitly ordered.
+- Snapshot diff output is normalized for reproducible CI gating.

--- a/docs/evidence.md
+++ b/docs/evidence.md
@@ -1,5 +1,42 @@
 # Evidence Pack
 
-`python3 -m sdetkit evidence pack --output .sdetkit/out/evidence.zip`
+`evidence` is an audit-grade artifact command surface with deterministic packaging and verification.
 
-The pack is deterministic and includes doctor output, repo audit JSON, security SARIF, SBOM, policy outputs, and manifest checksums.
+## Commands
+
+- `python3 -m sdetkit evidence pack --output .sdetkit/out/evidence.zip`
+- `python3 -m sdetkit evidence validate .sdetkit/out/evidence.zip --format json`
+- `python3 -m sdetkit evidence compare old.zip new.zip --format json`
+
+## Contract
+
+- JSON responses include `schema_version: sdetkit.evidence.v2`.
+- Deterministic zip ordering and fixed file timestamps are enforced.
+- `manifest.json` includes deterministic checksum list for every packed artifact.
+- Exit codes:
+  - `0`: success
+  - `2`: validation or input error
+
+## Real-world use
+
+1. Build evidence for release governance (`pack`).
+2. Validate integrity in CI before publishing (`validate`).
+3. Compare two evidence packs for drift during incident review (`compare`).
+
+## Sample artifacts
+
+- `.sdetkit/out/evidence.zip`
+- `.sdetkit/out/manifest.json`
+
+Example manifest excerpt:
+
+```json
+{
+  "schema_version": "sdetkit.evidence.v2",
+  "version": 2,
+  "redacted": false,
+  "files": [
+    {"path": "doctor.txt", "sha256": "..."}
+  ]
+}
+```

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -1,7 +1,42 @@
 # Policy-as-Code
 
+`policy` is a governance-grade regression control surface around security + hygiene drift.
+
+## Commands
+
 - `sdetkit policy snapshot --output .sdetkit/policies/baseline.json`
-- `sdetkit policy check --baseline .sdetkit/policies/baseline.json`
+- `sdetkit policy check --baseline .sdetkit/policies/baseline.json --format json`
 - `sdetkit policy diff --baseline .sdetkit/policies/baseline.json --format sarif`
 
-Exit codes: `0` clean, `1` regression, `2` usage/config error.
+## Contract
+
+- JSON responses include `schema_version: sdetkit.policy.v2`.
+- Exit codes:
+  - `0`: policy clean
+  - `1`: policy regressions
+  - `2`: usage/config/waiver validation error
+- Waiver support with required governance fields:
+  - `owner`
+  - `justification`
+  - `expires_on` (`YYYY-MM-DD`)
+- Unknown waiver types are rejected.
+
+## Waiver model
+
+Use `--waivers waivers.json` with:
+
+```json
+{
+  "waivers": [
+    {
+      "type": "security_rule_increase",
+      "rule_id": "SECRET_GENERIC",
+      "owner": "security-team",
+      "justification": "accepted temporary migration risk",
+      "expires_on": "2099-01-01"
+    }
+  ]
+}
+```
+
+Expired or malformed waivers fail fast with deterministic machine-readable errors.

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -35,6 +35,10 @@ CHECK_ORDER = [
     "ascii",
 ]
 
+SCHEMA_VERSION = "sdetkit.doctor.v2"
+EXIT_OK = 0
+EXIT_FAILED = 2
+
 SUPPORTED_POLICY_CHECKS = {
     "ascii",
     "stdlib_shadowing",
@@ -960,8 +964,9 @@ def main(argv: list[str] | None = None) -> int:
     if isinstance(getattr(ns, "apply_plan", None), str) and ns.apply_plan:
         if ns.apply_plan != plan.get("plan_id"):
             payload = {
+                "schema_version": SCHEMA_VERSION,
                 "ok": False,
-                "error": "plan_id_mismatch",
+                "error": {"code": "plan_id_mismatch", "message": "apply plan id does not match generated plan"},
                 "expected": plan.get("plan_id"),
                 "provided": ns.apply_plan,
                 "plan": plan,
@@ -971,7 +976,7 @@ def main(argv: list[str] | None = None) -> int:
                 Path(ns.out).write_text(rendered, encoding="utf-8")
             else:
                 sys.stdout.write(rendered)
-            return 2
+            return EXIT_FAILED
         plan_steps, plan_ok = _apply_plan(plan, root)
 
     if ns.all:
@@ -1016,6 +1021,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0 if data_treat_ok else 2
 
     data: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
         "python": _python_info(),
         "package": _package_info(),
         "checks": _baseline_checks(),
@@ -1408,7 +1414,7 @@ def main(argv: list[str] | None = None) -> int:
     if not gate_ok and not is_json:
         sys.stderr.write("doctor: problems found\n")
 
-    return 0 if gate_ok else 2
+    return EXIT_OK if gate_ok else EXIT_FAILED
 
 
 if __name__ == "__main__":

--- a/src/sdetkit/evidence.py
+++ b/src/sdetkit/evidence.py
@@ -7,10 +7,19 @@ import subprocess
 import sys
 import zipfile
 from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.evidence.v2"
+EXIT_OK = 0
+EXIT_INVALID = 2
 
 
 def _sha(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _stable_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, indent=2) + "\n"
 
 
 def _zip_deterministic(output: Path, files: list[Path], base: Path) -> None:
@@ -24,13 +33,13 @@ def _zip_deterministic(output: Path, files: list[Path], base: Path) -> None:
             zf.writestr(info, fp.read_bytes())
 
 
-def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(prog="sdetkit evidence")
-    sub = p.add_subparsers(dest="cmd", required=True)
-    pack = sub.add_parser("pack")
-    pack.add_argument("--output", default=".sdetkit/out/evidence.zip")
-    ns = p.parse_args(argv)
+def _load_manifest_from_zip(pack: Path) -> dict[str, Any]:
+    with zipfile.ZipFile(pack, "r") as zf:
+        payload = zf.read("manifest.json").decode("utf-8")
+    return json.loads(payload)
 
+
+def _pack(output: Path, *, redacted: bool) -> int:
     out_dir = Path(".sdetkit/out")
     out_dir.mkdir(parents=True, exist_ok=True)
     for name in [
@@ -48,7 +57,7 @@ def main(argv: list[str] | None = None) -> int:
             target.unlink()
 
     commands = [
-        (["python3", "-m", "sdetkit", "doctor", "--ascii"], out_dir / "doctor.txt"),
+        (["python3", "-m", "sdetkit", "doctor", "--ascii", "--format", "json"], out_dir / "doctor.txt"),
         (
             [
                 "python3",
@@ -130,17 +139,109 @@ def main(argv: list[str] | None = None) -> int:
     files = [
         p
         for p in out_dir.iterdir()
-        if p.is_file() and p.name != "manifest.json" and p.name != Path(ns.output).name
+        if p.is_file() and p.name != "manifest.json" and p.name != output.name
     ]
     manifest = {
-        "version": 1,
+        "schema_version": SCHEMA_VERSION,
+        "version": 2,
+        "redacted": redacted,
         "files": [{"path": p.name, "sha256": _sha(p)} for p in sorted(files, key=lambda i: i.name)],
     }
-    (out_dir / "manifest.json").write_text(
-        json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8"
-    )
+    (out_dir / "manifest.json").write_text(_stable_json(manifest), encoding="utf-8")
     files.append(out_dir / "manifest.json")
 
-    _zip_deterministic(Path(ns.output), files, out_dir)
-    sys.stdout.write(f"{ns.output}\n")
-    return 0
+    _zip_deterministic(output, files, out_dir)
+    sys.stdout.write(output.as_posix() + "\n")
+    return EXIT_OK
+
+
+def _validate(pack: Path, *, format: str) -> int:
+    if not pack.is_file():
+        payload = {"schema_version": SCHEMA_VERSION, "ok": False, "error": {"code": "pack_missing", "message": str(pack)}}
+        if format == "json":
+            sys.stdout.write(_stable_json(payload))
+        else:
+            sys.stdout.write(f"pack not found: {pack}\n")
+        return EXIT_INVALID
+
+    manifest = _load_manifest_from_zip(pack)
+    failures: list[dict[str, str]] = []
+    with zipfile.ZipFile(pack, "r") as zf:
+        names = sorted(zf.namelist())
+        for item in manifest.get("files", []):
+            p = item["path"]
+            if p not in names:
+                failures.append({"path": p, "code": "missing_file"})
+                continue
+            actual = hashlib.sha256(zf.read(p)).hexdigest()
+            if actual != item.get("sha256"):
+                failures.append({"path": p, "code": "checksum_mismatch"})
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "ok": not failures,
+        "pack": pack.as_posix(),
+        "failures": failures,
+    }
+    if format == "json":
+        sys.stdout.write(_stable_json(payload))
+    else:
+        if failures:
+            for f in failures:
+                sys.stdout.write(f"FAIL {f['code']}: {f['path']}\n")
+        else:
+            sys.stdout.write("OK evidence pack validated\n")
+    return EXIT_OK if not failures else EXIT_INVALID
+
+
+def _compare(left: Path, right: Path, *, format: str) -> int:
+    lmf = _load_manifest_from_zip(left)
+    rmf = _load_manifest_from_zip(right)
+    lmap = {i["path"]: i["sha256"] for i in lmf.get("files", [])}
+    rmap = {i["path"]: i["sha256"] for i in rmf.get("files", [])}
+    added = sorted(set(rmap) - set(lmap))
+    removed = sorted(set(lmap) - set(rmap))
+    changed = sorted(p for p in (set(lmap) & set(rmap)) if lmap[p] != rmap[p])
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "left": left.as_posix(),
+        "right": right.as_posix(),
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+        "ok": not (added or removed or changed),
+    }
+    if format == "json":
+        sys.stdout.write(_stable_json(payload))
+    else:
+        sys.stdout.write(f"added={len(added)} removed={len(removed)} changed={len(changed)}\n")
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="sdetkit evidence")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pack = sub.add_parser("pack")
+    pack.add_argument("--output", default=".sdetkit/out/evidence.zip")
+    pack.add_argument("--redacted", action="store_true", help="Mark pack as redacted in manifest provenance metadata.")
+
+    validate = sub.add_parser("validate")
+    validate.add_argument("pack")
+    validate.add_argument("--format", choices=["text", "json"], default="text")
+
+    compare = sub.add_parser("compare")
+    compare.add_argument("left")
+    compare.add_argument("right")
+    compare.add_argument("--format", choices=["text", "json"], default="text")
+
+    ns = p.parse_args(argv)
+    if ns.cmd == "pack":
+        return _pack(Path(ns.output), redacted=bool(ns.redacted))
+    if ns.cmd == "validate":
+        return _validate(Path(ns.pack), format=ns.format)
+    return _compare(Path(ns.left), Path(ns.right), format=ns.format)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/policy.py
+++ b/src/sdetkit/policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import json
 import sys
 from pathlib import Path
@@ -11,6 +12,22 @@ from .import_hazards import find_stdlib_shadowing
 from .repo import run_repo_audit
 from .security_gate import scan_repo
 
+SCHEMA_VERSION = "sdetkit.policy.v2"
+EXIT_OK = 0
+EXIT_REGRESSION = 1
+EXIT_USAGE = 2
+
+
+def _stable_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, indent=2) + "\n"
+
+
+def _error(code: str, message: str, *, detail: dict[str, Any] | None = None) -> dict[str, Any]:
+    out: dict[str, Any] = {"schema_version": SCHEMA_VERSION, "error": {"code": code, "message": message}}
+    if detail:
+        out["error"]["detail"] = detail
+    return out
+
 
 def _snapshot(root: Path) -> dict[str, Any]:
     findings = scan_repo(root)
@@ -20,7 +37,8 @@ def _snapshot(root: Path) -> dict[str, Any]:
     audit = run_repo_audit(root)
     non_ascii, _ = _scan_non_ascii(root)
     return {
-        "version": 1,
+        "schema_version": SCHEMA_VERSION,
+        "version": 2,
         "security": {"rule_counts": dict(sorted(sec_counts.items()))},
         "repo": {"summary": audit.get("summary", {})},
         "hygiene": {
@@ -28,6 +46,68 @@ def _snapshot(root: Path) -> dict[str, Any]:
             "stdlib_shadowing": find_stdlib_shadowing(root),
         },
     }
+
+
+def _load_waivers(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if not path.is_file():
+        return [], [{"code": "waiver_file_missing", "message": f"waiver file not found: {path}"}]
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [], [{"code": "waiver_parse_error", "message": str(exc)}]
+    waivers = payload.get("waivers") if isinstance(payload, dict) else None
+    if not isinstance(waivers, list):
+        return [], [{"code": "waiver_shape_invalid", "message": "waivers must be a list"}]
+
+    errs: list[dict[str, Any]] = []
+    out: list[dict[str, Any]] = []
+    for i, item in enumerate(waivers):
+        if not isinstance(item, dict):
+            errs.append({"code": "waiver_item_invalid", "message": f"waivers[{i}] must be an object"})
+            continue
+        required = ("type", "owner", "justification", "expires_on")
+        missing = [k for k in required if not isinstance(item.get(k), str) or not str(item.get(k)).strip()]
+        if missing:
+            errs.append({"code": "waiver_missing_required", "message": f"waivers[{i}] missing fields: {', '.join(missing)}"})
+            continue
+        try:
+            expiry = dt.date.fromisoformat(str(item["expires_on"]))
+        except ValueError:
+            errs.append({"code": "waiver_expiry_invalid", "message": f"waivers[{i}] has invalid expires_on"})
+            continue
+        if expiry < dt.date.today():
+            errs.append({"code": "waiver_expired", "message": f"waivers[{i}] is expired"})
+            continue
+        if item.get("type") not in {"security_rule_increase", "new_non_ascii", "new_stdlib_shadowing"}:
+            errs.append({"code": "waiver_type_unknown", "message": f"waivers[{i}] has unsupported type"})
+            continue
+        out.append(item)
+    return out, errs
+
+
+def _apply_waivers(
+    regressions: list[dict[str, Any]], waivers: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    remaining = [dict(item) for item in regressions]
+    used: list[dict[str, Any]] = []
+    for reg in remaining:
+        for w in waivers:
+            if w["type"] != reg.get("type"):
+                continue
+            if w["type"] == "security_rule_increase" and w.get("rule_id") != reg.get("rule_id"):
+                continue
+            if w["type"] in {"new_non_ascii", "new_stdlib_shadowing"} and w.get("path") and w.get("path") != reg.get("path"):
+                continue
+            reg["waived"] = True
+            reg["waiver"] = {
+                "owner": w["owner"],
+                "justification": w["justification"],
+                "expires_on": w["expires_on"],
+            }
+            used.append(w)
+            break
+    active = [r for r in remaining if not r.get("waived")]
+    return remaining, active
 
 
 def _regressions(base: dict[str, Any], cur: dict[str, Any]) -> list[dict[str, Any]]:
@@ -73,10 +153,13 @@ def main(argv: list[str] | None = None) -> int:
     cp = sub.add_parser("check")
     cp.add_argument("--baseline", default=".sdetkit/policies/baseline.json")
     cp.add_argument("--fail-on", choices=["any", "security"], default="any")
+    cp.add_argument("--waivers", default=None, help="JSON waiver file with owner/justification/expiry.")
+    cp.add_argument("--format", choices=["text", "json"], default="text")
 
     dp = sub.add_parser("diff")
     dp.add_argument("--baseline", required=True)
     dp.add_argument("--format", choices=["text", "json", "sarif"], default="text")
+    dp.add_argument("--waivers", default=None, help="JSON waiver file with owner/justification/expiry.")
 
     ns = p.parse_args(argv)
     root = Path.cwd()
@@ -85,34 +168,71 @@ def main(argv: list[str] | None = None) -> int:
         payload = _snapshot(root)
         out = Path(ns.output)
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        out.write_text(_stable_json(payload), encoding="utf-8")
         sys.stdout.write(out.as_posix() + "\n")
-        return 0
+        return EXIT_OK
 
     baseline = Path(ns.baseline)
     if not baseline.is_file():
-        sys.stdout.write(f"baseline not found: {baseline}\n")
-        return 2
+        msg = f"baseline not found: {baseline}"
+        if getattr(ns, "format", "text") == "json":
+            sys.stdout.write(_stable_json(_error("baseline_missing", msg)))
+        else:
+            sys.stdout.write(msg + "\n")
+        return EXIT_USAGE
     base = json.loads(baseline.read_text(encoding="utf-8"))
     cur = _snapshot(root)
     regressions = _regressions(base, cur)
+    waiver_errors: list[dict[str, Any]] = []
+    waivers: list[dict[str, Any]] = []
+    if isinstance(getattr(ns, "waivers", None), str) and ns.waivers:
+        waivers, waiver_errors = _load_waivers(Path(ns.waivers))
+    if waiver_errors:
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "ok": False,
+            "error": {"code": "waiver_validation_failed", "detail": waiver_errors},
+        }
+        sys.stdout.write(_stable_json(payload) if getattr(ns, "format", "text") == "json" else "waiver validation failed\n")
+        return EXIT_USAGE
+
+    regressions_all, regressions_active = _apply_waivers(regressions, waivers)
 
     if ns.cmd == "check":
-        for item in regressions:
-            sys.stdout.write(json.dumps(item, sort_keys=True) + "\n")
+        relevant = (
+            [item for item in regressions_active if item.get("type") == "security_rule_increase"]
+            if ns.fail_on == "security"
+            else regressions_active
+        )
+        failed = bool(relevant)
+        if ns.format == "json":
+            payload = {
+                "schema_version": SCHEMA_VERSION,
+                "ok": not failed,
+                "fail_on": ns.fail_on,
+                "baseline": baseline.as_posix(),
+                "regressions": regressions_all,
+                "active_regressions": regressions_active,
+            }
+            sys.stdout.write(_stable_json(payload))
+        else:
+            for item in regressions_all:
+                sys.stdout.write(json.dumps(item, sort_keys=True) + "\n")
         if ns.fail_on == "security":
-            security_only = [
-                item for item in regressions if item.get("type") == "security_rule_increase"
-            ]
-            return 1 if security_only else 0
-        return 1 if regressions else 0
+            return EXIT_REGRESSION if any(item.get("type") == "security_rule_increase" for item in regressions_active) else EXIT_OK
+        return EXIT_REGRESSION if regressions_active else EXIT_OK
 
-    payload = {"baseline": baseline.as_posix(), "regressions": regressions}
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "baseline": baseline.as_posix(),
+        "regressions": regressions_all,
+        "active_regressions": regressions_active,
+    }
     if ns.format == "json":
-        sys.stdout.write(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+        sys.stdout.write(_stable_json(payload))
     elif ns.format == "sarif":
-        sys.stdout.write(json.dumps(_as_sarif(regressions), sort_keys=True, indent=2) + "\n")
+        sys.stdout.write(json.dumps(_as_sarif(regressions_active), sort_keys=True, indent=2) + "\n")
     else:
-        for item in regressions:
+        for item in regressions_all:
             sys.stdout.write(f"RED-FLAG {item['type']}: {json.dumps(item, sort_keys=True)}\n")
-    return 0
+    return EXIT_OK

--- a/tests/test_doctor_contract_upgrade.py
+++ b/tests/test_doctor_contract_upgrade.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import doctor
+
+
+def test_doctor_json_schema_version_and_plan_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    assert doctor.main(["--format", "json", "--only", "pyproject"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "sdetkit.doctor.v2"
+
+    assert doctor.main(["--apply-plan", "bad", "--format", "json"]) == 2
+    bad = json.loads(capsys.readouterr().out)
+    assert bad["error"]["code"] == "plan_id_mismatch"

--- a/tests/test_evidence_pack.py
+++ b/tests/test_evidence_pack.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 
 from sdetkit import evidence
@@ -18,6 +19,30 @@ def test_evidence_pack_stable_manifest(tmp_path: Path, monkeypatch) -> None:
     assert evidence.main(["pack", "--output", str(out)]) == 0
     manifest = tmp_path / ".sdetkit" / "out" / "manifest.json"
     first = _sha(manifest)
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.evidence.v2"
     assert evidence.main(["pack", "--output", str(out)]) == 0
     second = _sha(manifest)
     assert first == second
+
+
+def test_evidence_validate_and_compare(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+
+    left = tmp_path / "left.zip"
+    right = tmp_path / "right.zip"
+    assert evidence.main(["pack", "--output", str(left)]) == 0
+    _ = capsys.readouterr()
+    assert evidence.main(["pack", "--output", str(right), "--redacted"]) == 0
+    _ = capsys.readouterr()
+
+    assert evidence.main(["validate", str(left), "--format", "json"]) == 0
+    validate_payload = json.loads(capsys.readouterr().out)
+    assert validate_payload["ok"] is True
+
+    assert evidence.main(["compare", str(left), str(right), "--format", "json"]) == 0
+    compare_payload = json.loads(capsys.readouterr().out)
+    assert compare_payload["schema_version"] == "sdetkit.evidence.v2"
+    assert set(compare_payload) >= {"added", "removed", "changed", "ok"}

--- a/tests/test_policy_control_plane.py
+++ b/tests/test_policy_control_plane.py
@@ -41,3 +41,42 @@ def test_policy_diff_stable_json(tmp_path: Path, monkeypatch, capsys) -> None:
     assert policy.main(["diff", "--baseline", str(base), "--format", "json"]) == 0
     second = capsys.readouterr().out
     assert json.loads(first) == json.loads(second)
+
+
+def test_policy_check_json_with_waiver(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    base = tmp_path / "baseline.json"
+    assert policy.main(["snapshot", "--output", str(base)]) == 0
+    _ = capsys.readouterr()
+    (tmp_path / "src" / "json.py").write_text("x=1\n", encoding="utf-8")
+    waivers = tmp_path / "waivers.json"
+    waivers.write_text(
+        json.dumps(
+            {
+                "waivers": [
+                    {
+                        "type": "new_stdlib_shadowing",
+                        "path": "src/json.py",
+                        "owner": "release-engineering",
+                        "justification": "temporary shim",
+                        "expires_on": "2099-01-01",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert policy.main([
+        "check",
+        "--baseline",
+        str(base),
+        "--waivers",
+        str(waivers),
+        "--format",
+        "json",
+    ]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "sdetkit.policy.v2"
+    assert payload["ok"] is True

--- a/tests/test_policy_fail_on.py
+++ b/tests/test_policy_fail_on.py
@@ -28,7 +28,8 @@ def test_policy_check_fail_on_security_fails_on_security_regression(
     monkeypatch.chdir(tmp_path)
 
     base_payload = {
-        "version": 1,
+        "schema_version": "sdetkit.policy.v2",
+        "version": 2,
         "security": {"rule_counts": {}},
         "repo": {"summary": {}},
         "hygiene": {"non_ascii_files": [], "stdlib_shadowing": []},
@@ -40,7 +41,8 @@ def test_policy_check_fail_on_security_fails_on_security_regression(
         policy,
         "_snapshot",
         lambda _root: {
-            "version": 1,
+            "schema_version": "sdetkit.policy.v2",
+        "version": 2,
             "security": {"rule_counts": {"SECRET_GENERIC": 1}},
             "repo": {"summary": {}},
             "hygiene": {"non_ascii_files": [], "stdlib_shadowing": []},
@@ -65,7 +67,8 @@ def test_policy_diff_text_and_missing_baseline(tmp_path: Path, monkeypatch, caps
         policy,
         "_snapshot",
         lambda _root: {
-            "version": 1,
+            "schema_version": "sdetkit.policy.v2",
+        "version": 2,
             "security": {"rule_counts": {"SECRET_GENERIC": 2}},
             "repo": {"summary": {}},
             "hygiene": {"non_ascii_files": [], "stdlib_shadowing": []},


### PR DESCRIPTION
### Motivation
- Upgrade the shallow `doctor`, `evidence`, and `policy` command surfaces into narrow, deterministic, operator-grade contracts suitable for CI/governance automation.
- Provide machine-readable outputs, explicit exit behavior, deterministic artifacts, and actionable remediation so automation and security/governance workflows can rely on stable contracts.

### Description
- Add schema/version and explicit exit codes to `doctor` by emitting `schema_version: sdetkit.doctor.v2`, returning deterministic JSON, and providing structured error payloads for plan mismatch (`plan_id_mismatch`).
- Promote `evidence` to an audit surface by introducing `schema_version: sdetkit.evidence.v2`, a deterministic `manifest.json`, and new subcommands `validate` (checksum/manifest verification) and `compare` (machine-readable diff of packs), plus a `--redacted` marker in manifest.
- Harden `policy` outputs with `schema_version: sdetkit.policy.v2`, deterministic snapshot output, and a waiver model (`--waivers`) that enforces `owner`, `justification`, and `expires_on` with validation and explicit errors; outputs now separate `regressions` vs `active_regressions` and follow stable exit codes.
- Add stable JSON helpers and deterministic serialization (`_stable_json`) across upgraded surfaces, plus targeted tests and updated docs pages (`docs/doctor.md`, `docs/evidence.md`, `docs/policy.md`) documenting contracts, exit codes, and sample artifacts.

### Testing
- Compiled updated modules with `python -m py_compile src/sdetkit/doctor.py src/sdetkit/evidence.py src/sdetkit/policy.py` and the compilation succeeded.
- Ran targeted test suite with `pytest -q tests/test_doctor_contract_upgrade.py tests/test_evidence_pack.py tests/test_policy_control_plane.py tests/test_policy_fail_on.py` and all targeted tests passed (`10 passed`).
- Added/updated unit tests asserting schema versions, deterministic evidence manifests, `validate`/`compare` contracts, and policy waiver behavior, and they executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b306671ce08327805c0ea1b7cdde93)