### PR TITLE
Reposition SDETKit as release-confidence + test-intelligence platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,45 @@
 # DevS69 SDETKit
 
-SDETKit is an umbrella **SDET / QA / release confidence platform** with deterministic CLI workflows and machine-readable artifacts.
+DevS69 SDETKit is an operator-grade **release confidence + test intelligence platform**.
+It turns go/no-go decisions into deterministic, machine-readable contracts with actionable next steps.
 
-## Umbrella kits
+## Flagship kits
 
-- **Release Confidence Kit** (`sdetkit release ...`): gate, doctor, security, repo audit, and evidence lanes.
-- **Test Intelligence Kit** (`sdetkit intelligence ...`): flake classification, deterministic env capture, changed-scope impact summary, and mutation governance.
-- **Integration Assurance Kit** (`sdetkit integration ...`): profile-driven environment/service readiness contracts.
-- **Failure Forensics Kit** (`sdetkit forensics ...`, experimental): run compare and deterministic repro bundle generation.
-
-List kits:
+- **Release Decision Kit** (`sdetkit release ...`)
+  - Gate, doctor, security, evidence, and repo governance for release decisions.
+- **Test Intelligence Kit** (`sdetkit intelligence ...`)
+  - Flake classification, impacted-tests mapping, deterministic env capture, failure fingerprinting, and mutation governance.
+- **Integration Assurance Kit** (`sdetkit integration ...`)
+  - Environment readiness profiles, integration matrix outputs, and cassette contract validation for replay safety.
+- **Failure Forensics Kit** (`sdetkit forensics ...`)
+  - Run-to-run regression analysis, stable fingerprints, deterministic repro bundles, and evidence-pack diffs.
 
 ```bash
 python -m sdetkit kits list --format json
 ```
 
-## Hero journeys (start here)
+## Hero journeys
 
 ```bash
-python -m sdetkit release gate fast
 python -m sdetkit release gate release
 python -m sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json
+python -m sdetkit intelligence failure-fingerprint --failures examples/kits/intelligence/failures.json
 python -m sdetkit integration check --profile examples/kits/integration/profile.json
-python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json
+python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json --fail-on error
 ```
+
+## Product boundary
+
+Utilities remain for compatibility (`kv`, `apiget`, `cassette-get`, docs helpers), but they are **supporting surfaces** and no longer define the primary product path.
 
 ## Backward compatibility
 
-Existing stable commands remain supported (`gate`, `doctor`, `security`, `repo`, `evidence`, `report`, etc.). Kit commands are additive product grouping aliases.
+Existing commands and aliases remain supported (`gate`, `doctor`, `security`, `repo`, `evidence`, `report`, etc.).
+Kit commands are additive product grouping aliases.
 
-## Docs
+## Kit docs
 
-- Architecture note: `docs/architecture/umbrella-kits.md`
-- Kit pages:
-  - `docs/kits/release-confidence.md`
-  - `docs/kits/test-intelligence.md`
-  - `docs/kits/integration-assurance.md`
-  - `docs/kits/failure-forensics.md`
+- `docs/kits/release-confidence.md`
+- `docs/kits/test-intelligence.md`
+- `docs/kits/integration-assurance.md`
+- `docs/kits/failure-forensics.md`

--- a/ci.sh
+++ b/ci.sh
@@ -80,6 +80,14 @@ run_gate_fast() {
   return "$rc"
 }
 
+
+run_flagship_contracts() {
+  python3 -m sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json >/dev/null
+  python3 -m sdetkit intelligence failure-fingerprint --failures examples/kits/intelligence/failures.json >/dev/null
+  python3 -m sdetkit integration check --profile examples/kits/integration/profile.json >/dev/null || true
+  python3 -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json >/dev/null
+}
+
 run_docs() {
   if [[ "$skip_docs" -eq 1 ]]; then
     return 0
@@ -94,9 +102,11 @@ run_docs() {
 case "$mode" in
   quick)
     run_gate_fast
+    run_flagship_contracts
     ;;
   all)
     run_gate_fast
+    run_flagship_contracts
     run_docs
     ;;
   *)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,97 +1,30 @@
-<div class="hero-panel" markdown>
-
-<div class="hero-badges" markdown>
-
-<span class="pill">Deterministic release-confidence checks</span>
-<span class="pill">Evidence-backed shipping decisions</span>
-<span class="pill">Curated rollout lanes</span>
-
-</div>
-
 # DevS69 SDETKit
 
-SDETKit gives engineering teams **deterministic release-confidence checks and evidence** so release decisions are consistent, auditable, and fast.
+DevS69 SDETKit is a platform for:
 
-<div class="hero-actions" markdown>
+1. **release decision-making**
+2. **deterministic evidence**
+3. **test intelligence**
+4. **integration assurance**
+5. **failure forensics**
 
-[Install](install.md){ .md-button .md-button--primary }
-[First run](ready-to-use.md){ .md-button }
-[Adopt as a team](adoption.md){ .md-button }
-[CI lane](recommended-ci-flow.md){ .md-button }
+The first 30-second path is the flagship kit surface, not generic utilities.
 
-</div>
+## Start with flagship kits
 
-</div>
+- [Release Decision Kit](kits/release-confidence.md)
+- [Test Intelligence Kit](kits/test-intelligence.md)
+- [Integration Assurance Kit](kits/integration-assurance.md)
+- [Failure Forensics Kit](kits/failure-forensics.md)
 
-## Fast start
+## Primary operator flow
 
-If you are new to SDETKit, start with [Install](install.md), then run [First run](ready-to-use.md).
+1. `sdetkit release gate release`
+2. `sdetkit release doctor`
+3. `sdetkit release security scan`
+4. `sdetkit release evidence pack`
+5. `sdetkit forensics compare --from <prev> --to <current>`
 
-## Choose one lane
+## Supporting surfaces (demoted)
 
-### 1) Beginner / first-run lane
-
-Use this if you are evaluating SDETKit or running it for the first time.
-
-1. [Choose your path](choose-your-path.md)
-2. [Install (canonical)](install.md)
-3. [First run quickstart (canonical)](ready-to-use.md)
-4. [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
-
-### 2) Team adoption lane
-
-Use this when you are rolling SDETKit into a real team workflow and repository standards.
-
-1. [Adopt in your repository (canonical)](adoption.md)
-2. [Team rollout scenario](team-rollout-scenario.md)
-3. [Adoption examples](adoption-examples.md)
-4. [Adoption troubleshooting](adoption-troubleshooting.md)
-
-### 3) CI / automation lane
-
-Use this when you need production CI behavior, artifact handling, and policy rollouts.
-
-1. [Recommended CI flow (canonical)](recommended-ci-flow.md)
-2. [CI artifact walkthrough (canonical evidence decode)](ci-artifact-walkthrough.md)
-3. [CI contract (reference)](ci-contract.md)
-4. [Reporting and trends](reporting-and-trends.md)
-
-### 4) Advanced / extensions / reference lane
-
-Use this for command surface depth, extension boundaries, and integration architecture.
-
-- [CLI reference](cli.md)
-- [API](api.md)
-- [Plugins](plugins.md)
-- [Tool server](tool-server.md)
-- [Integrations and extension boundary](integrations-and-extension-boundary.md)
-
-### 5) Archive / history lane
-
-Use this only for historical transition context.
-
-- [Archive overview](archive/index.md)
-- [Transition-era material map](archive/transition-era-material.md)
-
-## Proof and comparison pages
-
-For product-value framing and artifact-oriented examples:
-
-- [SDETKit vs ad hoc scripts and separate tools](sdetkit-vs-ad-hoc.md)
-- [Before/after evidence example](before-after-evidence-example.md)
-- [Evidence showcase](evidence-showcase.md)
-- [Decision guide](decision-guide.md)
-
-<div class="quick-jump" markdown>
-
-[⚡ Fast start](#fast-start) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-reports)
-
-</div>
-
-## Legacy reports
-
-### Top journeys
-
-- Run first command in under 60 seconds
-- Validate docs links and anchors before publishing
-- Ship a first contribution with deterministic quality gates
+Utility commands such as `kv`, `apiget`, and `cassette-get` remain available for compatibility and composition, but are intentionally secondary in product positioning.

--- a/docs/kits/failure-forensics.md
+++ b/docs/kits/failure-forensics.md
@@ -1,20 +1,27 @@
 # Failure Forensics Kit
 
 ## Purpose
-Provide deterministic run comparison and minimal repro bundle packaging.
+Explain what changed between runs and preserve reproducible failure evidence.
 
 ## Inputs
-Two run JSON files (`report` schema) and optional extra evidence files.
+- Two run records (`sdetkit.audit.run.v1`)
+- Optional evidence files for deterministic bundle generation
+- Two bundles for evidence-pack diff
 
-## Outputs/artifacts
+## Outputs / artifacts
 - `sdetkit.forensics.compare.v1`
 - `sdetkit.forensics.bundle.v1`
+- `sdetkit.forensics.bundle-diff.v1`
+
+## Exit-code contract
+- `compare`: `1` when `--fail-on` threshold is breached
+- `bundle-diff`: `1` when added/removed/changed artifacts are detected
+- `2`: invalid input
 
 ## CI role
-Summarize regressions/resolutions and preserve reproducible failure bundles.
+Detect regressions/new failures/resolved failures and preserve minimal repro metadata bundles.
 
-## Example commands
+## Example
 ```bash
-sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json
-sdetkit forensics bundle --run examples/kits/forensics/run-b.json --output build/repro.zip
+sdetkit forensics bundle-diff --from-bundle artifacts/prev.zip --to-bundle artifacts/new.zip
 ```

--- a/docs/kits/integration-assurance.md
+++ b/docs/kits/integration-assurance.md
@@ -1,20 +1,26 @@
 # Integration Assurance Kit
 
 ## Purpose
-Validate environment and service readiness contracts with offline-first deterministic checks.
+Provide offline-first confidence that runtime dependencies are actually ready.
 
 ## Inputs
-Integration profile JSON (`required_env`, `required_files`, `services`).
+- Readiness profile JSON (`required_env`, `required_files`, `services`)
+- Cassette JSON for replay contract validation
 
-## Outputs/artifacts
+## Outputs / artifacts
 - `sdetkit.integration.profile-check.v1`
 - `sdetkit.integration.matrix.v1`
+- `sdetkit.integration.cassette-validate.v1`
+
+## Exit-code contract
+- `0`: all checks passed / compatible
+- `1`: readiness or cassette contract failure
+- `2`: invalid profile/cassette input
 
 ## CI role
-Catch environment drift before integration test execution.
+Fail fast before expensive integration runs, and verify replay cassettes are valid and deterministic.
 
-## Example commands
+## Example
 ```bash
-sdetkit integration check --profile examples/kits/integration/profile.json
-sdetkit integration matrix --profile examples/kits/integration/profile.json
+sdetkit integration cassette-validate --cassette .sdetkit/cassettes/sample.json
 ```

--- a/docs/kits/release-confidence.md
+++ b/docs/kits/release-confidence.md
@@ -1,21 +1,25 @@
-# Release Confidence Kit
+# Release Decision Kit
 
 ## Purpose
-Provide deterministic release gating, diagnostics, and evidence outputs for release owners.
+Provide an opinionated go/no-go decision lane backed by deterministic evidence.
 
 ## Inputs
-Repository source tree, policy/config files, and optional CI metadata.
+Repository state, policy/config baselines, and CI metadata.
 
-## Outputs
-Gate/doctor/security/evidence JSON/SARIF/manifests from existing stable commands.
+## Outputs / artifacts
+Existing core release contracts from `gate`, `doctor`, `security`, and `evidence` including JSON/SARIF/evidence manifests.
+
+## Exit-code contract
+- `0`: pass/no blocking release conditions
+- `1`: gate/security policy violations where applicable
+- `2`: invalid input or execution contract failures
 
 ## CI role
-Primary merge and release confidence decision lane.
+Primary release controller for merge and publish decisions.
 
-## Hero commands
+## Example
 ```bash
-sdetkit release gate fast
 sdetkit release gate release
-sdetkit release doctor
-sdetkit release evidence --help
+sdetkit release doctor --format json
+sdetkit release evidence pack --output .sdetkit/out/evidence.zip
 ```

--- a/docs/kits/test-intelligence.md
+++ b/docs/kits/test-intelligence.md
@@ -1,25 +1,34 @@
 # Test Intelligence Kit
 
 ## Purpose
-Provide deterministic test-quality intelligence beyond simple lint/test wrappers.
+Turn test execution noise into deterministic release intelligence.
 
 ## Inputs
-- flake history JSON (`tests[].id`, `tests[].outcomes`)
-- changed file list + test map JSON
-- mutation governance policy JSON
+- Flake history JSON
+- Changed files list + test map
+- Mutation policy JSON
+- Failure event list for fingerprinting
 
-## Outputs/artifacts
+## Outputs / artifacts
 - `sdetkit.intelligence.flake.v1`
 - `sdetkit.intelligence.impact.v1`
 - `sdetkit.intelligence.env-capture.v1`
 - `sdetkit.intelligence.mutation-policy.v1`
+- `sdetkit.intelligence.failure-fingerprint.v1`
+
+## Exit-code contract
+- `0`: successful command and pass state (if applicable)
+- `1`: policy-style failure (`passed=false`)
+- `2`: invalid input/contract error
 
 ## CI role
-Flag flaky tests, scope impact-driven runs, and enforce mutation governance policy.
+Classify flakiness, scope impacted tests, enforce mutation governance, and capture deterministic failure fingerprints.
 
-## Example commands
+## Example
 ```bash
-sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json
-sdetkit intelligence impact summarize --changed examples/kits/intelligence/changed-files.txt --map examples/kits/intelligence/test-map.json
-sdetkit intelligence mutation-policy --policy examples/kits/intelligence/mutation-policy.json
+sdetkit intelligence failure-fingerprint --failures examples/kits/intelligence/failures.json
+```
+
+```json
+{"schema_version":"sdetkit.intelligence.failure-fingerprint.v1","summary":{"total":2,"with_nondeterminism_hints":2}}
 ```

--- a/examples/kits/intelligence/failures.json
+++ b/examples/kits/intelligence/failures.json
@@ -1,0 +1,14 @@
+{
+  "failures": [
+    {
+      "test_id": "tests/api/test_orders.py::test_retry_on_timeout",
+      "message": "request timed out after 2.0s while waiting for upstream",
+      "fixture_scope": "session"
+    },
+    {
+      "test_id": "tests/integration/test_checkout.py::test_payment_capture",
+      "message": "connection reset by peer during network call",
+      "fixture_scope": "module"
+    }
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: DevS69 SDETKit
-site_description: Release-confidence toolkit with deterministic checks and audit-friendly evidence.
+site_description: Operator-grade release confidence and test intelligence platform with deterministic evidence, integration assurance, and failure forensics.
 site_url: https://sherif69-sa.github.io/DevS69-sdetkit/
 repo_name: sherif69-sa/DevS69-sdetkit
 repo_url: https://github.com/sherif69-sa/DevS69-sdetkit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sdetkit"
 version = "1.0.2"
 requires-python = ">=3.11"
 readme = "README.md"
-description = "Developer productivity and QA automation toolkit: CLI utilities, quality gates, and testable modules."
+description = "Operator-grade release confidence and test intelligence platform: deterministic gates, evidence, integration assurance, and failure forensics."
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 keywords = ["sdet", "testing", "qa", "automation", "cli", "devtools", "quality-gates"]

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -215,8 +215,8 @@ def _add_passthrough_subcommand(
 
 def _build_root_parser() -> tuple[argparse.ArgumentParser, object]:
     help_description = """\
-SDETKit helps teams prove release confidence / shipping readiness with
-deterministic checks and audit-friendly evidence.
+DevS69 SDETKit is an operator-grade platform for release decisions,
+deterministic evidence, test intelligence, integration assurance, and failure forensics.
 
 Stability levels: Stable/Core, Integrations, Playbooks, Experimental.
 
@@ -256,7 +256,7 @@ Start here:
     _add_passthrough_subcommand(sub, "intelligence", help_text="Test Intelligence Kit")
     _add_passthrough_subcommand(sub, "integration", help_text="Integration Assurance Kit")
     _add_passthrough_subcommand(sub, "forensics", help_text="Failure Forensics Kit")
-    _add_passthrough_subcommand(sub, "kv", help_text="Parse key=value input into JSON")
+    _add_passthrough_subcommand(sub, "kv", help_text="Utility: parse key=value input into JSON (supporting surface)")
 
     ag = sub.add_parser("apiget", help="Deterministic HTTP JSON fetch and replay helper")
     _add_apiget_args(ag)
@@ -274,7 +274,7 @@ Start here:
     _add_passthrough_subcommand(sub, "patch", help_text="Apply controlled file/text patches")
 
     _add_passthrough_subcommand(
-        sub, "cassette-get", help_text="Record/replay HTTP captures for deterministic checks"
+        sub, "cassette-get", help_text="Utility: record/replay HTTP captures for deterministic checks"
     )
 
     _add_passthrough_subcommand(sub, "repo", help_text="Repository automation tasks")

--- a/src/sdetkit/forensics.py
+++ b/src/sdetkit/forensics.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import io
 import json
 import sys
 import zipfile
@@ -18,7 +17,19 @@ def _compare(from_path: Path, to_path: Path) -> dict[str, Any]:
     from_run = load_run_record(from_path)
     to_run = load_run_record(to_path)
     payload = diff_runs(from_run, to_run)
+    new_error = [x for x in payload.get("new", []) if x.get("severity") == "error"]
     payload["schema_version"] = "sdetkit.forensics.compare.v1"
+    payload["regression_summary"] = {
+        "new_failures": payload.get("counts", {}).get("new", 0),
+        "resolved_failures": payload.get("counts", {}).get("resolved", 0),
+        "changed_failures": payload.get("counts", {}).get("changed", 0),
+        "regression": bool(new_error),
+    }
+    payload["next_step"] = (
+        "Block release and open failure-forensics triage lane."
+        if new_error
+        else "No new error regressions detected."
+    )
     return payload
 
 
@@ -58,6 +69,36 @@ def _bundle(run_path: Path, output_path: Path, include: list[str]) -> dict[str, 
     }
 
 
+def _bundle_diff(from_bundle: Path, to_bundle: Path) -> dict[str, Any]:
+    with zipfile.ZipFile(from_bundle, "r") as left_zip, zipfile.ZipFile(to_bundle, "r") as right_zip:
+        left_names = set(left_zip.namelist())
+        right_names = set(right_zip.namelist())
+        added = sorted(right_names - left_names)
+        removed = sorted(left_names - right_names)
+        shared = sorted(left_names & right_names)
+        changed = sorted(
+            name
+            for name in shared
+            if hashlib.sha256(left_zip.read(name)).hexdigest()
+            != hashlib.sha256(right_zip.read(name)).hexdigest()
+        )
+
+    return {
+        "schema_version": "sdetkit.forensics.bundle-diff.v1",
+        "from_bundle": str(from_bundle),
+        "to_bundle": str(to_bundle),
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+        "summary": {
+            "added": len(added),
+            "removed": len(removed),
+            "changed": len(changed),
+            "passed": not (added or removed or changed),
+        },
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="sdetkit forensics", description="Failure Forensics Kit")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -71,6 +112,10 @@ def main(argv: list[str] | None = None) -> int:
     bundle.add_argument("--run", required=True)
     bundle.add_argument("--output", required=True)
     bundle.add_argument("--include", nargs="*", default=[])
+
+    bundle_diff = sub.add_parser("bundle-diff", help="Diff two forensics bundles")
+    bundle_diff.add_argument("--from-bundle", required=True)
+    bundle_diff.add_argument("--to-bundle", required=True)
 
     ns = parser.parse_args(argv)
     try:
@@ -87,6 +132,14 @@ def main(argv: list[str] | None = None) -> int:
             if ns.fail_on == "warn" and new_warn:
                 return 1
             return 0
+
+        if ns.cmd == "bundle-diff":
+            payload = _bundle_diff(
+                safe_path(Path.cwd(), ns.from_bundle, allow_absolute=True),
+                safe_path(Path.cwd(), ns.to_bundle, allow_absolute=True),
+            )
+            sys.stdout.write(canonical_json_dumps(payload))
+            return 0 if payload["summary"]["passed"] else 1
 
         payload = _bundle(
             safe_path(Path.cwd(), ns.run, allow_absolute=True),

--- a/src/sdetkit/integration.py
+++ b/src/sdetkit/integration.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from .atomicio import canonical_json_dumps
+from .cassette import Cassette
 from .security import SecurityError, safe_path
 
 
@@ -59,15 +60,67 @@ def _evaluate(profile: dict[str, Any]) -> dict[str, Any]:
             )
 
     checks.sort(key=lambda x: (str(x.get("kind", "")), str(x.get("name", ""))))
+    failed = [item for item in checks if not bool(item.get("passed"))]
     return {
         "schema_version": "sdetkit.integration.profile-check.v1",
         "profile_name": str(profile.get("name", "default")),
         "checks": checks,
         "summary": {
             "total": len(checks),
-            "failed": sum(1 for x in checks if not bool(x.get("passed"))),
-            "passed": all(bool(x.get("passed")) for x in checks) if checks else True,
+            "failed": len(failed),
+            "passed": not failed if checks else True,
+            "next_step": (
+                "Ready for integration lanes."
+                if not failed
+                else "Fix failed readiness checks before running integration suites."
+            ),
         },
+    }
+
+
+def _validate_cassette(cassette_path: Path) -> dict[str, Any]:
+    cassette = Cassette.load(cassette_path, allow_absolute=True)
+    interactions = cassette.interactions
+    invalid: list[dict[str, Any]] = []
+    methods: dict[str, int] = {}
+    hosts: set[str] = set()
+
+    for idx, item in enumerate(interactions):
+        req = item.get("request") if isinstance(item, dict) else None
+        resp = item.get("response") if isinstance(item, dict) else None
+        if not isinstance(req, dict) or not isinstance(resp, dict):
+            invalid.append({"index": idx, "reason": "invalid-shape"})
+            continue
+
+        method = str(req.get("method", "")).upper()
+        url = str(req.get("url", ""))
+        if not method or not url:
+            invalid.append({"index": idx, "reason": "missing-method-or-url"})
+            continue
+        methods[method] = methods.get(method, 0) + 1
+
+        try:
+            host = url.split("//", 1)[1].split("/", 1)[0]
+        except Exception:
+            host = ""
+        if host:
+            hosts.add(host)
+
+        status_code = resp.get("status_code")
+        if not isinstance(status_code, int) or status_code < 100 or status_code > 599:
+            invalid.append({"index": idx, "reason": "invalid-status-code"})
+
+    return {
+        "schema_version": "sdetkit.integration.cassette-validate.v1",
+        "cassette": str(cassette_path),
+        "summary": {
+            "interactions": len(interactions),
+            "invalid": len(invalid),
+            "hosts": sorted(hosts),
+            "methods": {k: methods[k] for k in sorted(methods)},
+            "passed": len(invalid) == 0,
+        },
+        "invalid": invalid,
     }
 
 
@@ -80,17 +133,24 @@ def main(argv: list[str] | None = None) -> int:
     check.add_argument("--profile", required=True)
     matrix = sub.add_parser("matrix", help="Print compatibility summary in JSON")
     matrix.add_argument("--profile", required=True)
+    cassette_validate = sub.add_parser(
+        "cassette-validate", help="Validate deterministic cassette contract for integration replay"
+    )
+    cassette_validate.add_argument("--cassette", required=True)
     ns = parser.parse_args(argv)
 
     try:
-        profile = _load_profile(safe_path(Path.cwd(), ns.profile, allow_absolute=True))
-        payload = _evaluate(profile)
-        if ns.cmd == "matrix":
-            payload["schema_version"] = "sdetkit.integration.matrix.v1"
-            payload["compatibility"] = {
-                "profile": payload["profile_name"],
-                "status": "compatible" if payload["summary"]["passed"] else "incompatible",
-            }
+        if ns.cmd in {"check", "matrix"}:
+            profile = _load_profile(safe_path(Path.cwd(), ns.profile, allow_absolute=True))
+            payload = _evaluate(profile)
+            if ns.cmd == "matrix":
+                payload["schema_version"] = "sdetkit.integration.matrix.v1"
+                payload["compatibility"] = {
+                    "profile": payload["profile_name"],
+                    "status": "compatible" if payload["summary"]["passed"] else "incompatible",
+                }
+        else:
+            payload = _validate_cassette(safe_path(Path.cwd(), ns.cassette, allow_absolute=True))
     except (ValueError, OSError, SecurityError) as exc:
         sys.stderr.write(f"integration error: {exc}\n")
         return 2

--- a/src/sdetkit/intelligence.py
+++ b/src/sdetkit/intelligence.py
@@ -38,10 +38,22 @@ def _cmd_flake_classify(history_path: Path, rerun_threshold: int) -> dict[str, A
         flaky = failures > 0 and passes > 0 and len(outcomes) >= rerun_threshold
         classification = "flaky" if flaky else ("stable-failing" if failures else "stable-passing")
         message = f"{classification}:{','.join(outcomes)}"
+        if classification == "flaky":
+            signal = "nondeterministic-rerun"
+            next_step = "Quarantine test and capture deterministic seed/fixture isolation evidence."
+        elif classification == "stable-failing":
+            signal = "consistent-regression"
+            next_step = "Treat as product regression and escalate to release decision gate."
+        else:
+            signal = "stable"
+            next_step = "Keep in baseline suite."
+
         out.append(
             {
                 "test_id": test_id,
                 "classification": classification,
+                "signal": signal,
+                "next_step": next_step,
                 "runs": len(outcomes),
                 "failures": failures,
                 "passes": passes,
@@ -121,6 +133,52 @@ def _cmd_mutation_policy(policy_path: Path) -> dict[str, Any]:
     }
 
 
+def _cmd_failure_fingerprint(failures_path: Path) -> dict[str, Any]:
+    doc = _load_json(failures_path)
+    if not isinstance(doc, dict) or not isinstance(doc.get("failures"), list):
+        raise ValueError("failures file must contain a failures array")
+
+    fingerprints: list[dict[str, Any]] = []
+    for item in doc["failures"]:
+        if not isinstance(item, dict):
+            continue
+        test_id = str(item.get("test_id", "")).strip()
+        message = str(item.get("message", "")).strip()
+        fixture_scope = str(item.get("fixture_scope", "unknown")).strip() or "unknown"
+        if not test_id or not message:
+            continue
+
+        msg_lower = message.lower()
+        nondeterminism_hints: list[str] = []
+        if any(token in msg_lower for token in ["timeout", "timed out", "deadline exceeded"]):
+            nondeterminism_hints.append("timing-sensitive")
+        if any(token in msg_lower for token in ["connection reset", "econnreset", "network"]):
+            nondeterminism_hints.append("network-sensitive")
+        if any(token in msg_lower for token in ["random", "seed", "nondetermin"]):
+            nondeterminism_hints.append("seed-sensitive")
+        if fixture_scope in {"session", "module"}:
+            nondeterminism_hints.append("shared-fixture-scope")
+
+        fingerprints.append(
+            {
+                "test_id": test_id,
+                "fixture_scope": fixture_scope,
+                "fingerprint": _fingerprint(test_id, message),
+                "nondeterminism_hints": sorted(set(nondeterminism_hints)),
+            }
+        )
+
+    fingerprints.sort(key=lambda item: (item["test_id"], item["fingerprint"]))
+    return {
+        "schema_version": "sdetkit.intelligence.failure-fingerprint.v1",
+        "failures": fingerprints,
+        "summary": {
+            "total": len(fingerprints),
+            "with_nondeterminism_hints": sum(1 for item in fingerprints if item["nondeterminism_hints"]),
+        },
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="sdetkit intelligence", description="Test Intelligence Kit")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -143,6 +201,12 @@ def main(argv: list[str] | None = None) -> int:
     mut = sub.add_parser("mutation-policy", help="Mutation governance evaluation")
     mut.add_argument("--policy", required=True)
 
+    fp = sub.add_parser(
+        "failure-fingerprint",
+        help="Stable failure fingerprinting with nondeterminism heuristics",
+    )
+    fp.add_argument("--failures", required=True)
+
     ns = parser.parse_args(argv)
     try:
         if ns.cmd == "flake" and ns.subcmd == "classify":
@@ -155,6 +219,10 @@ def main(argv: list[str] | None = None) -> int:
             payload = _cmd_impact(
                 safe_path(Path.cwd(), ns.changed, allow_absolute=True),
                 safe_path(Path.cwd(), ns.test_map, allow_absolute=True),
+            )
+        elif ns.cmd == "failure-fingerprint":
+            payload = _cmd_failure_fingerprint(
+                safe_path(Path.cwd(), ns.failures, allow_absolute=True)
             )
         else:
             payload = _cmd_mutation_policy(safe_path(Path.cwd(), ns.policy, allow_absolute=True))

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -42,11 +42,12 @@ _KITS: Final[list[dict[str, object]]] = [
     },
     {
         "id": "failure-forensics",
-        "stability": "experimental",
-        "summary": "Run comparison and deterministic repro bundle generation.",
+        "stability": "stable",
+        "summary": "Run-to-run regression intelligence, evidence diffing, and deterministic repro bundle generation.",
         "hero_commands": [
             "sdetkit forensics compare --from old.json --to new.json",
             "sdetkit forensics bundle --run run.json --output bundle.zip",
+            "sdetkit forensics bundle-diff --from-bundle old.zip --to-bundle new.zip",
         ],
     },
 ]

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -29,10 +29,10 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
         top_level_commands=("gate", "doctor", "security", "evidence", "playbooks"),
     ),
     CommandFamilyContract(
-        name="stable-core-engineering-workflows",
-        role="Stable day-to-day engineering and repository utility workflows.",
-        stability_tier="Stable/Core",
-        first_time_recommended=True,
+        name="supporting-utilities-and-automation",
+        role="Supporting utilities and automation lanes; useful but intentionally secondary to flagship kits.",
+        stability_tier="Stable/Supporting",
+        first_time_recommended=False,
         transition_legacy_oriented=False,
         top_level_commands=(
             "repo",

--- a/tests/test_kits_intelligence_integration_forensics.py
+++ b/tests/test_kits_intelligence_integration_forensics.py
@@ -13,7 +13,7 @@ def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str
     )
 
 
-def test_intelligence_flake_impact_and_mutation_policy_contracts() -> None:
+def test_intelligence_contracts_and_failure_fingerprinting() -> None:
     flake = _run(
         "intelligence",
         "flake",
@@ -25,6 +25,7 @@ def test_intelligence_flake_impact_and_mutation_policy_contracts() -> None:
     flake_json = json.loads(flake.stdout)
     assert flake_json["schema_version"] == "sdetkit.intelligence.flake.v1"
     assert flake_json["tests"][0]["fingerprint"]
+    assert flake_json["tests"][0]["next_step"]
 
     impact = _run(
         "intelligence",
@@ -51,12 +52,52 @@ def test_intelligence_flake_impact_and_mutation_policy_contracts() -> None:
     assert policy_json["schema_version"] == "sdetkit.intelligence.mutation-policy.v1"
     assert policy_json["passed"] is True
 
+    fingerprint = _run(
+        "intelligence",
+        "failure-fingerprint",
+        "--failures",
+        "examples/kits/intelligence/failures.json",
+    )
+    assert fingerprint.returncode == 0
+    fingerprint_json = json.loads(fingerprint.stdout)
+    assert fingerprint_json["schema_version"] == "sdetkit.intelligence.failure-fingerprint.v1"
+    assert fingerprint_json["summary"]["with_nondeterminism_hints"] >= 1
+
+
+def test_intelligence_failure_mode_invalid_failures_file(tmp_path: Path) -> None:
+    bad = tmp_path / "bad-failures.json"
+    bad.write_text('{"oops": []}', encoding="utf-8")
+    proc = _run("intelligence", "failure-fingerprint", "--failures", str(bad))
+    assert proc.returncode == 2
+    assert "intelligence error" in proc.stderr
+
 
 def test_integration_and_forensics_contracts_and_bundle_determinism(tmp_path: Path) -> None:
     integration = _run("integration", "check", "--profile", "examples/kits/integration/profile.json")
     assert integration.returncode in {0, 1}
     integration_json = json.loads(integration.stdout)
     assert integration_json["schema_version"] == "sdetkit.integration.profile-check.v1"
+    assert integration_json["summary"]["next_step"]
+
+    cassette = tmp_path / "cassette.json"
+    cassette.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "interactions": [
+                    {
+                        "request": {"method": "GET", "url": "https://example.com/ping", "body_b64": "", "headers": []},
+                        "response": {"status_code": 200, "headers": [], "body_b64": ""},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    cval = _run("integration", "cassette-validate", "--cassette", str(cassette))
+    assert cval.returncode == 0
+    cval_json = json.loads(cval.stdout)
+    assert cval_json["schema_version"] == "sdetkit.integration.cassette-validate.v1"
 
     compare = _run(
         "forensics",
@@ -69,6 +110,7 @@ def test_integration_and_forensics_contracts_and_bundle_determinism(tmp_path: Pa
     assert compare.returncode == 0
     cmp_json = json.loads(compare.stdout)
     assert cmp_json["schema_version"] == "sdetkit.forensics.compare.v1"
+    assert "regression_summary" in cmp_json
 
     out1 = tmp_path / "bundle1.zip"
     out2 = tmp_path / "bundle2.zip"
@@ -87,3 +129,29 @@ def test_integration_and_forensics_contracts_and_bundle_determinism(tmp_path: Pa
     with zipfile.ZipFile(out1) as zf:
         names = sorted(zf.namelist())
     assert names == ["manifest.json", "run.json"]
+
+    diff_same = _run("forensics", "bundle-diff", "--from-bundle", str(out1), "--to-bundle", str(out2))
+    assert diff_same.returncode == 0
+    diff_same_json = json.loads(diff_same.stdout)
+    assert diff_same_json["schema_version"] == "sdetkit.forensics.bundle-diff.v1"
+    assert diff_same_json["summary"]["passed"] is True
+
+
+def test_forensics_compare_fail_on_warn_exit_code() -> None:
+    proc = _run(
+        "forensics",
+        "compare",
+        "--from",
+        "examples/kits/forensics/run-a.json",
+        "--to",
+        "examples/kits/forensics/run-b.json",
+        "--fail-on",
+        "warn",
+    )
+    assert proc.returncode == 1
+
+
+def test_release_alias_backward_compatibility() -> None:
+    direct = _run("gate", "fast")
+    via_release = _run("release", "gate", "fast")
+    assert direct.returncode == via_release.returncode


### PR DESCRIPTION
### Motivation
- Reframe the project from a generic CLI toolkit to an opinionated operator-grade platform centered on release decisions, deterministic evidence, test intelligence, integration assurance, and failure forensics.
- Ensure flagship capabilities provide deeper, machine-readable contracts and actionable next-step guidance rather than shallow utility wrappers.
- Preserve backward compatibility for existing commands while demoting generic utilities to supporting surfaces.

### Description
- Repositioning and docs: updated package metadata, README hero, `mkdocs.yml`, and `docs/index.md` to emphasize four flagship kits: Release Decision, Test Intelligence, Integration Assurance, and Failure Forensics.
- CLI / public surface: updated root help text and `public_surface_contract` to mark utility commands as supporting surfaces and surface the new kit-first entrypoints in `cli.py` and `kits.py`.
- Test Intelligence: enriched `intelligence.flake` output with `signal` and `next_step` guidance and added `intelligence failure-fingerprint` which emits stable fingerprints and nondeterminism heuristics (timing/network/seed/shared-fixture hints) in a deterministic schema (`sdetkit.intelligence.failure-fingerprint.v1`).
- Integration Assurance: added `integration cassette-validate` to validate deterministic cassette/replay contracts and added `next_step` guidance to profile checks with stable JSON schema outputs (`sdetkit.integration.cassette-validate.v1`).
- Failure Forensics: enhanced `forensics compare` with a `regression_summary` and `next_step` guidance and added `forensics bundle-diff` to diff evidence bundles and return non-zero on drift (`sdetkit.forensics.bundle-diff.v1`).
- Kits/catalog and stability: promoted failure-forensics from experimental to stable and added kit hero commands reflecting the new capabilities.
- Tests and examples: added deterministic fixture `examples/kits/intelligence/failures.json`, updated/added contract tests in `tests/test_kits_intelligence_integration_forensics.py` covering schemas, exit codes, idempotence (bundle determinism), cassette validation, and backward-compat aliases.
- CI: added flagship kit smoke checks to the `ci.sh` quick/all flows so core contract surfaces run as part of lightweight CI validation.

### Testing
- Ran unit/CLI contract tests: `pytest -q tests/test_kits_intelligence_integration_forensics.py tests/test_kits_umbrella_cli.py` — all tests passed (`8 passed`).
- Verified kit discovery: `python -m sdetkit kits list --format json` produced updated kit catalog and hero commands as expected.
- Executed representative CLI smoke checks (flake classify, failure-fingerprint, integration cassette-validate, forensics compare) as part of CI smoke additions and confirmed deterministic JSON outputs and exit-code behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b30b2047f4832780afd81a4645608f)