### PR TITLE
Update day22 trust pack scoring artifacts

### DIFF
--- a/docs/artifacts/day22-trust-pack/day22-trust-action-plan.md
+++ b/docs/artifacts/day22-trust-pack/day22-trust-action-plan.md
@@ -2,3 +2,4 @@
 
 - Restore missing trust badges in README so reliability status is visible at a glance.
 - Ensure policy documents exist and are linked from README governance references.
+- Keep CI/security/pages workflows and docs index trust references present for reviewers.

--- a/docs/artifacts/day22-trust-pack/day22-trust-scorecard.md
+++ b/docs/artifacts/day22-trust-pack/day22-trust-scorecard.md
@@ -2,10 +2,10 @@
 
 ## Trust posture
 
-- Trust score: **20.0**
+- Trust score: **18.0**
 - Trust label: **review**
-- Weighted points: **20/100**
-- Failed checks: **8**
+- Weighted points: **18/100**
+- Failed checks: **9**
 - Critical failures: **security_doc_exists**
 
 ## Check matrix
@@ -21,9 +21,10 @@
 - **governance::ci_workflow** (6 pts): pass
 - **governance::security_workflow** (8 pts): pass
 - **governance::pages_workflow** (4 pts): pass
-- **governance::docs_index_day22** (2 pts): pass
+- **governance::docs_index_day22** (2 pts): missing
 
 ## Recommendations
 
 - Restore missing trust badges in README so reliability status is visible at a glance.
 - Ensure policy documents exist and are linked from README governance references.
+- Keep CI/security/pages workflows and docs index trust references present for reviewers.

--- a/docs/artifacts/day22-trust-pack/day22-trust-summary.json
+++ b/docs/artifacts/day22-trust-pack/day22-trust-summary.json
@@ -100,13 +100,13 @@
       "category": "governance",
       "evidence": "day-22-ultra-upgrade-report.md",
       "key": "docs_index_day22",
-      "passed": true,
+      "passed": false,
       "weight": 2
     }
   ],
   "governance_checks": {
     "ci_workflow": true,
-    "docs_index_day22": true,
+    "docs_index_day22": false,
     "pages_workflow": true,
     "security_workflow": true
   },
@@ -122,7 +122,8 @@
   },
   "recommendations": [
     "Restore missing trust badges in README so reliability status is visible at a glance.",
-    "Ensure policy documents exist and are linked from README governance references."
+    "Ensure policy documents exist and are linked from README governance references.",
+    "Keep CI/security/pages workflows and docs index trust references present for reviewers."
   ],
   "score": 100.0,
   "strict_failures": [],
@@ -133,7 +134,7 @@
         "total": 5
       },
       "governance": {
-        "passed": 4,
+        "passed": 3,
         "total": 4
       },
       "policy": {
@@ -144,11 +145,11 @@
     "critical_failures": [
       "security_doc_exists"
     ],
-    "failed_checks": 8,
+    "failed_checks": 9,
     "trust_label": "review",
-    "trust_score": 20.0,
+    "trust_score": 18.0,
     "weighted_points": {
-      "earned": 20,
+      "earned": 18,
       "total": 100
     }
   }


### PR DESCRIPTION
### Motivation
- Bring Day 22 trust reporting artifacts in line with the latest governance evaluation by marking the docs index as missing and adjusting the derived score and recommendations.

### Description
- Updated `docs/artifacts/day22-trust-pack/day22-trust-action-plan.md`, `docs/artifacts/day22-trust-pack/day22-trust-scorecard.md`, and `docs/artifacts/day22-trust-pack/day22-trust-summary.json` to mark `governance::docs_index_day22` as missing, lower the trust score from `20.0` to `18.0`, update weighted points/failed checks/governance passed counts, and add a follow-up recommendation about keeping CI/security/pages workflows and docs index trust references present.

### Testing
- Ran `ruff format --check` for the previously failing files, validated `docs/artifacts/day22-trust-pack/day22-trust-summary.json` with `python -m json.tool`, and executed the project quality pipeline via `./quality.sh` (pytest), which completed successfully with all checks passing and `1394 passed, 3 deselected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b35c1804c08320bbd944fd482acc89)