### PR TITLE
Add duplicate-key handling policies to kv parser and kvcli

### DIFF
--- a/src/sdetkit/kvcli.py
+++ b/src/sdetkit/kvcli.py
@@ -25,9 +25,29 @@ def _supports_allow_comments(parser: Callable[..., dict[str, str]]) -> bool:
     return False
 
 
+def _supports_duplicate_policy(parser: Callable[..., dict[str, str]]) -> bool:
+    try:
+        sig = inspect.signature(parser)
+    except (TypeError, ValueError):
+        return False
+
+    for param in sig.parameters.values():
+        if param.name == "duplicate_policy":
+            return True
+    return False
+
+
 def _build_comment_aware_parser(
     parser: Callable[..., dict[str, str]],
+    *,
+    duplicate_policy: str = "last",
 ) -> Callable[[str], dict[str, str]]:
+    if _supports_allow_comments(parser) and _supports_duplicate_policy(parser):
+        return lambda line: parser(
+            line,
+            allow_comments=True,
+            duplicate_policy=duplicate_policy,
+        )
     if _supports_allow_comments(parser):
         return lambda line: parser(line, allow_comments=True)
     return parser
@@ -38,6 +58,12 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--text", default=None)
     p.add_argument("--path", default=None)
     p.add_argument("--strict", action="store_true")
+    p.add_argument(
+        "--duplicates",
+        choices=("last", "first", "error"),
+        default="last",
+        help="duplicate key behavior: last wins, first wins, or error",
+    )
 
     ns = p.parse_args(argv)
 
@@ -54,7 +80,10 @@ def main(argv: list[str] | None = None) -> int:
     else:
         raw = sys.stdin.read()
 
-    parse_line = _build_comment_aware_parser(parse_kv_line)
+    parse_line = _build_comment_aware_parser(
+        parse_kv_line,
+        duplicate_policy=ns.duplicates,
+    )
 
     data: dict[str, str] = {}
     invalid_lines = 0

--- a/src/sdetkit/textutil.py
+++ b/src/sdetkit/textutil.py
@@ -1,11 +1,22 @@
 import shlex
 
 
+_DUPLICATE_POLICIES = {"last", "first", "error"}
+
+
 def normalize_line(line: str) -> str:
     return line.strip()
 
 
-def parse_kv_line(line: str, *, allow_comments: bool = False) -> dict[str, str]:
+def parse_kv_line(
+    line: str,
+    *,
+    allow_comments: bool = False,
+    duplicate_policy: str = "last",
+) -> dict[str, str]:
+    if duplicate_policy not in _DUPLICATE_POLICIES:
+        raise ValueError("bad duplicate policy")
+
     s = normalize_line(line)
     if s == "":
         return {}
@@ -26,6 +37,11 @@ def parse_kv_line(line: str, *, allow_comments: bool = False) -> dict[str, str]:
         k, v = part.split("=", 1)
         if k == "" or v == "":
             raise ValueError("bad kv")
+
+        if duplicate_policy == "error" and k in out:
+            raise ValueError(f"duplicate key: {k}")
+        if duplicate_policy == "first" and k in out:
+            continue
 
         out[k] = v
 

--- a/tests/test_kvcli.py
+++ b/tests/test_kvcli.py
@@ -178,9 +178,33 @@ def test_build_comment_aware_parser_enables_comments_for_modern_parser():
     assert parser("a=1 # trailing") == {"a": "1"}
 
 
+def test_build_comment_aware_parser_passes_duplicate_policy_for_modern_parser():
+    import sdetkit.kvcli as kvcli
+
+    parser = kvcli._build_comment_aware_parser(
+        kvcli.parse_kv_line,
+        duplicate_policy="first",
+    )
+    assert parser("a=1 a=2") == {"a": "1"}
+
+
 def test_kvcli_runner_supports_timeout(tmp_path):
     p = run_kvcli("--text", "a=1", timeout=0.2)
     assert p.returncode == 0
+
+
+def test_kvcli_duplicates_first_keeps_first_value():
+    p = run_kvcli("--duplicates", "first", "--text", "a=1 a=2")
+    assert p.returncode == 0
+    assert p.stderr == ""
+    assert json.loads(p.stdout) == {"a": "1"}
+
+
+def test_kvcli_duplicates_error_fails_on_duplicate_key():
+    p = run_kvcli("--duplicates", "error", "--text", "a=1 a=2")
+    assert p.returncode == 2
+    assert p.stdout == ""
+    assert "invalid input" in p.stderr.lower()
 
 
 def test_kvcli_main_text_ok(capsys):

--- a/tests/test_textutil.py
+++ b/tests/test_textutil.py
@@ -70,6 +70,21 @@ def test_parse_kv_line_default_keeps_comment_tokens_and_fails():
         parse_kv_line("a=1 # trailing")
 
 
+def test_parse_kv_line_duplicate_policy_first_keeps_first_value():
+    out = parse_kv_line("a=1 a=2 b=3", duplicate_policy="first")
+    assert out == {"a": "1", "b": "3"}
+
+
+def test_parse_kv_line_duplicate_policy_error_raises():
+    with pytest.raises(ValueError, match="duplicate key: a"):
+        parse_kv_line("a=1 a=2", duplicate_policy="error")
+
+
+def test_parse_kv_line_duplicate_policy_bad_value_raises():
+    with pytest.raises(ValueError, match="bad duplicate policy"):
+        parse_kv_line("a=1", duplicate_policy="unknown")
+
+
 _key = st.text(
     alphabet=st.sampled_from(list(string.ascii_letters + string.digits + "_-")),
     min_size=1,


### PR DESCRIPTION
### Motivation
- Provide configurable behavior for duplicate keys when parsing key-value lines so callers can choose `last`, `first`, or fail-fast `error` semantics. 
- Expose duplicate-key policy to the command-line tool so scripts can control merge semantics consistently.

### Description
- Add a `duplicate_policy` parameter to `parse_kv_line` with supported values `"last"`, `"first"`, and `"error"`, and validate values early with a `ValueError` in `src/sdetkit/textutil.py`.
- Implement duplicate-key handling: `last` (default) overwrites, `first` keeps the first occurrence, and `error` raises `ValueError` on duplicates in `parse_kv_line`.
- Extend `kvcli` to accept `--duplicates` with choices `last|first|error`, forward the policy into parsing, and make `_build_comment_aware_parser` detect and pass `duplicate_policy` when the parser supports it in `src/sdetkit/kvcli.py`.
- Add focused tests for parser behavior and CLI behavior in `tests/test_textutil.py` and `tests/test_kvcli.py` to cover `first`, `error`, and invalid policy cases.

### Testing
- Ran `pytest -q tests/test_textutil.py tests/test_kvcli.py` and all tests passed: `55 passed`.
- New and modified unit tests exercise the parsing modes and CLI flag and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b36c8591b48320bed1eccf99fd6b36)