### PR TITLE
Enhance forensics bundle manifest and extra-file handling

### DIFF
--- a/src/sdetkit/forensics.py
+++ b/src/sdetkit/forensics.py
@@ -35,10 +35,12 @@ def _compare(from_path: Path, to_path: Path) -> dict[str, Any]:
 
 def _bundle(run_path: Path, output_path: Path, include: list[str]) -> dict[str, Any]:
     run = load_run_record(run_path)
+    extras: list[dict[str, Any]] = []
     manifest = {
         "schema_version": "sdetkit.forensics.bundle-manifest.v1",
         "run_sha256": hashlib.sha256(canonical_json_bytes(run)).hexdigest(),
         "included_files": sorted(include),
+        "extras": extras,
     }
 
     with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
@@ -53,14 +55,35 @@ def _bundle(run_path: Path, output_path: Path, include: list[str]) -> dict[str, 
         zf.writestr(run_info, canonical_json_dumps(run))
 
         for file_name in sorted(include):
-            path = Path(file_name)
+            path = safe_path(Path.cwd(), file_name, allow_absolute=True)
             if not path.exists() or not path.is_file():
+                extras.append(
+                    {
+                        "requested": file_name,
+                        "stored": None,
+                        "status": "missing",
+                    }
+                )
                 continue
             data = path.read_bytes()
-            extra = zipfile.ZipInfo(f"extras/{path.name}")
+            if path.is_absolute():
+                sanitized = "_".join(path.parts[1:])
+            else:
+                sanitized = "_".join(path.parts)
+            archive_name = f"extras/{sanitized}"
+            extra = zipfile.ZipInfo(archive_name)
             extra.date_time = (1980, 1, 1, 0, 0, 0)
             extra.compress_type = zipfile.ZIP_DEFLATED
             zf.writestr(extra, data)
+            extras.append(
+                {
+                    "requested": file_name,
+                    "stored": archive_name,
+                    "status": "included",
+                    "sha256": hashlib.sha256(data).hexdigest(),
+                    "size_bytes": len(data),
+                }
+            )
 
     return {
         "schema_version": "sdetkit.forensics.bundle.v1",

--- a/tests/test_kits_intelligence_integration_forensics.py
+++ b/tests/test_kits_intelligence_integration_forensics.py
@@ -160,6 +160,39 @@ def test_forensics_compare_fail_on_warn_exit_code() -> None:
     assert proc.returncode == 1
 
 
+def test_forensics_bundle_include_tracks_manifest_and_sanitizes_names(tmp_path: Path) -> None:
+    nested = tmp_path / "logs" / "session.txt"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("failure details", encoding="utf-8")
+
+    output = tmp_path / "bundle.zip"
+    proc = _run(
+        "forensics",
+        "bundle",
+        "--run",
+        "examples/kits/forensics/run-b.json",
+        "--output",
+        str(output),
+        "--include",
+        str(nested),
+        str(tmp_path / "missing.log"),
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    extras = payload["manifest"]["extras"]
+    assert len(extras) == 2
+    included = [entry for entry in extras if entry["status"] == "included"]
+    missing = [entry for entry in extras if entry["status"] == "missing"]
+    assert len(included) == 1
+    assert len(missing) == 1
+    assert included[0]["stored"].startswith("extras/")
+    assert "/" not in included[0]["stored"].removeprefix("extras/")
+    assert missing[0]["stored"] is None
+
+    with zipfile.ZipFile(output) as zf:
+        assert included[0]["stored"] in zf.namelist()
+
+
 def test_release_alias_backward_compatibility() -> None:
     direct = _run("gate", "fast")
     via_release = _run("release", "gate", "fast")


### PR DESCRIPTION
### Motivation
- Improve auditability and determinism of `forensics bundle` artifacts by recording which extra files were requested, whether they were included, and their content metadata.
- Avoid name collisions and environment-dependent archive names by sanitizing and deterministically deriving stored names from full path parts.

### Description
- Extend the bundle manifest with an `extras` list that records per-requested-file entries including `requested`, `stored`, `status`, `sha256`, and `size_bytes` as applicable.
- Validate include paths using `safe_path(...)` and produce deterministic archive entries by joining sanitized `Path.parts` with underscores under the `extras/` prefix instead of using bare basenames.
- Record missing files in the manifest with `stored: None` and `status: "missing"` so bundles reflect requested-but-unavailable artifacts.
- Add a test `test_forensics_bundle_include_tracks_manifest_and_sanitizes_names` that validates manifest tracking for included and missing files and asserts that sanitized stored names appear in the zip.

### Testing
- Ran `pytest -q tests/test_kits_intelligence_integration_forensics.py`, which completed successfully with `6 passed` (test suite run time ~51s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b370450f908320afc60c39af054994)