### PR TITLE
docs(world-class): add KPI dashboard baseline and release ownership map

### DIFF
--- a/docs/artifacts/world-class-kpi-dashboard-baseline.md
+++ b/docs/artifacts/world-class-kpi-dashboard-baseline.md
@@ -1,0 +1,41 @@
+# World-Class KPI Dashboard Baseline
+
+This baseline is the first implementation pass for the "Stand up a KPI dashboard" item in the World-Class Quality Program.
+
+## Ownership
+
+| KPI lane | Primary owner | Backup owner | Review cadence |
+| --- | --- | --- | --- |
+| Reliability | QA Platform Lead | Release Manager | Weekly quality review |
+| Velocity | Dev Experience Lead | Engineering Manager | Weekly quality review |
+| Trust/Security | Security Champion | QA Platform Lead | Monthly trust review |
+| Release readiness | Release Manager | QA Platform Lead | Per release candidate |
+
+## KPI definitions
+
+| KPI | Definition | Target | Source command / artifact |
+| --- | --- | --- | --- |
+| Mainline unit+integration pass rate | Passed test jobs / total test jobs on default branch over rolling 30 days | `>= 99%` | CI run history and test summaries |
+| Change failure rate | Releases requiring rollback or hotfix / total releases in rolling 30 days | `< 5%` | Release board + changelog incidents |
+| MTTR for release regression | Time from regression detection to verified recovery | `< 60 minutes` | Incident timeline artifacts |
+| First successful local run | Time from clone to first successful `make test` for new contributor cohort | `< 30 minutes` | Onboarding diary samples |
+| PR cycle time | Median time from PR open to merge | `< 24 hours` | SCM analytics export |
+| Doc freshness SLA | Critical docs updated within 48h of behavior changes | `100%` compliance | Docs PR labels + merged timestamps |
+| Critical vulns on default branch | Open critical vulnerabilities affecting supported branch | `0` | Security scan reports |
+| Security drift remediation | Time from baseline drift detection to fix merge | `< 72 hours` | Security baseline incidents |
+| Release evidence pack coverage | Releases that include evidence pack artifacts | `100%` | Release candidate artifact inventory |
+| Rollback rate | Rolled back releases / total releases | `< 2%` | Release notes + incident logs |
+| Merge-ready to release tag | Time from release-ready approval to tag creation | `< 2 hours` | Release timeline |
+
+## Data collection contract (v0)
+
+1. Collect weekly snapshots every Monday before quality review.
+2. Publish a markdown summary in `docs/artifacts/` for auditability.
+3. Keep raw exports (JSON/CSV) attached to CI artifacts for 90 days.
+4. Escalate any KPI that breaches target for 2 consecutive snapshots.
+
+## Immediate next actions
+
+- Automate extraction for CI pass rate and PR cycle time.
+- Add an evidence-pack coverage check to the release workflow.
+- Backfill last 4 weeks of KPI values to establish trend lines.

--- a/docs/artifacts/world-class-release-ownership-map.md
+++ b/docs/artifacts/world-class-release-ownership-map.md
@@ -1,0 +1,33 @@
+# World-Class Release-Critical Ownership Map
+
+This document starts implementation of the "Assign owners for every release-critical workflow" checklist item in the World-Class Quality Program.
+
+## Ownership map
+
+| Workflow | Primary owner | Backup owner | Trigger | Evidence output |
+| --- | --- | --- | --- | --- |
+| CI quality gate health | QA Platform Lead | Dev Experience Lead | Every PR + mainline commit | Gate status summary |
+| Security baseline and vuln checks | Security Champion | QA Platform Lead | Daily + release candidate | Security scan bundle |
+| Release readiness board | Release Manager | Product Engineering Lead | At release candidate cut | Readiness board snapshot |
+| Changelog + narrative quality | Product Engineering Lead | Release Manager | Pre-tag | Changelog and release narrative |
+| Evidence pack generation | QA Platform Lead | Release Manager | Pre-tag | Evidence pack artifact |
+| Rollback/runbook verification | SRE/Operations Owner | Release Manager | Pre-tag and post-release window | Runbook verification log |
+
+## Escalation policy
+
+- Any red gate on a release candidate is escalated immediately in the release channel.
+- If primary owner is unavailable for more than 4 business hours during release day, backup owner assumes authority.
+- Tagging is blocked until all workflows have either a green status or an explicit, documented exception approved by two owners.
+
+## RACI shorthand
+
+- **R** (Responsible): primary owner in table.
+- **A** (Accountable): Release Manager for final ship/no-ship decision.
+- **C** (Consulted): Product Engineering Lead and Security Champion.
+- **I** (Informed): broader maintainer group.
+
+## Next iteration
+
+- Replace role-based owner labels with named maintainers.
+- Link each workflow to an executable CI job and runbook path.
+- Publish a monthly "ownership drift" check in trust review.

--- a/docs/world-class-quality-program.md
+++ b/docs/world-class-quality-program.md
@@ -61,6 +61,12 @@ Build and operate SDETKit as a globally trusted quality platform by combining:
 - Post-release rollback rate: `< 2%`.
 - Time from merge-ready to tagged release: `< 2 hours` for routine releases.
 
+## Kickoff progress (initial pass)
+
+- KPI dashboard baseline published: `docs/artifacts/world-class-kpi-dashboard-baseline.md`.
+- Release-critical ownership map published: `docs/artifacts/world-class-release-ownership-map.md`.
+- Next focus: quality-gate audit and flakiness hotspot burn-down.
+
 ## Operating cadence
 
 - **Weekly quality review**: inspect failures, flakiness, and lead-time trends.


### PR DESCRIPTION
### Motivation

- Kick off the World-Class Quality Program by creating concrete, audit-ready artifacts to make KPI targets and release ownership explicit. 
- Provide a minimal, executable baseline so next steps (automation, CI checks, and backfill) can be implemented quickly.

### Description

- Add `docs/artifacts/world-class-kpi-dashboard-baseline.md` containing KPI lanes, definitions, targets, data collection contract, and immediate next actions. 
- Add `docs/artifacts/world-class-release-ownership-map.md` with release-critical workflow owners, escalation policy, and RACI shorthand. 
- Update `docs/world-class-quality-program.md` to include a `Kickoff progress (initial pass)` section that links the new artifacts and calls out the next focus (quality-gate audit and flakiness burn-down).

### Testing

- Ran `mkdocs build -q` and the site build completed successfully (non-blocking theme warning printed), indicating the new markdown files render without build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3761643588320b896850f473c7ff4)