### PR TITLE
Introduce world-class KPI dashboard baseline, snapshot generator, and tests

### DIFF
--- a/docs/artifacts/world-class-kpi-dashboard-baseline.json
+++ b/docs/artifacts/world-class-kpi-dashboard-baseline.json
@@ -1,0 +1,120 @@
+{
+  "program": "world-class-quality",
+  "dashboard": "world-class-kpi",
+  "version": "v1",
+  "snapshot_window": "rolling-30-day",
+  "review_cadence": "weekly",
+  "owners": {
+    "reliability": {
+      "primary": "QA Platform Lead",
+      "backup": "Release Manager"
+    },
+    "velocity": {
+      "primary": "Dev Experience Lead",
+      "backup": "Engineering Manager"
+    },
+    "trust_security": {
+      "primary": "Security Champion",
+      "backup": "QA Platform Lead"
+    },
+    "release_readiness": {
+      "primary": "Release Manager",
+      "backup": "QA Platform Lead"
+    }
+  },
+  "kpis": [
+    {
+      "id": "mainline_pass_rate",
+      "lane": "reliability",
+      "metric": "Mainline unit+integration pass rate",
+      "target": ">=99%",
+      "status": "baseline-defined",
+      "source": "CI run history and test summaries"
+    },
+    {
+      "id": "change_failure_rate",
+      "lane": "reliability",
+      "metric": "Change failure rate",
+      "target": "<5%",
+      "status": "baseline-defined",
+      "source": "Release board + changelog incidents"
+    },
+    {
+      "id": "release_regression_mttr",
+      "lane": "reliability",
+      "metric": "MTTR for release regression",
+      "target": "<60m",
+      "status": "baseline-defined",
+      "source": "Incident timeline artifacts"
+    },
+    {
+      "id": "first_successful_local_run",
+      "lane": "velocity",
+      "metric": "First successful local run",
+      "target": "<30m",
+      "status": "baseline-defined",
+      "source": "Onboarding diary samples"
+    },
+    {
+      "id": "pr_cycle_time",
+      "lane": "velocity",
+      "metric": "PR cycle time median",
+      "target": "<24h",
+      "status": "baseline-defined",
+      "source": "SCM analytics export"
+    },
+    {
+      "id": "doc_freshness_sla",
+      "lane": "velocity",
+      "metric": "Doc freshness SLA",
+      "target": "100%",
+      "status": "baseline-defined",
+      "source": "Docs PR labels + merged timestamps"
+    },
+    {
+      "id": "critical_vulns",
+      "lane": "trust_security",
+      "metric": "Critical vulns on default branch",
+      "target": "0",
+      "status": "baseline-defined",
+      "source": "Security scan reports"
+    },
+    {
+      "id": "security_drift_remediation",
+      "lane": "trust_security",
+      "metric": "Security drift remediation",
+      "target": "<72h",
+      "status": "baseline-defined",
+      "source": "Security baseline incidents"
+    },
+    {
+      "id": "evidence_pack_coverage",
+      "lane": "release_readiness",
+      "metric": "Release evidence pack coverage",
+      "target": "100%",
+      "status": "baseline-defined",
+      "source": "Release candidate artifact inventory"
+    },
+    {
+      "id": "rollback_rate",
+      "lane": "release_readiness",
+      "metric": "Rollback rate",
+      "target": "<2%",
+      "status": "baseline-defined",
+      "source": "Release notes + incident logs"
+    },
+    {
+      "id": "merge_ready_to_tag",
+      "lane": "release_readiness",
+      "metric": "Merge-ready to release tag",
+      "target": "<2h",
+      "status": "baseline-defined",
+      "source": "Release timeline"
+    }
+  ],
+  "next_actions": [
+    "Automate extraction for CI pass rate and PR cycle time.",
+    "Add an evidence-pack coverage check to the release workflow.",
+    "Backfill last 4 weeks of KPI values to establish trend lines."
+  ]
+}

--- a/docs/artifacts/world-class-kpi-dashboard-baseline.md
+++ b/docs/artifacts/world-class-kpi-dashboard-baseline.md
@@ -2,6 +2,8 @@
 
 This baseline is the first implementation pass for the "Stand up a KPI dashboard" item in the World-Class Quality Program.
 
+Machine-readable baseline: `docs/artifacts/world-class-kpi-dashboard-baseline.json`.
+
 ## Ownership
 
 | KPI lane | Primary owner | Backup owner | Review cadence |
@@ -27,12 +29,41 @@ This baseline is the first implementation pass for the "Stand up a KPI dashboard
 | Rollback rate | Rolled back releases / total releases | `< 2%` | Release notes + incident logs |
 | Merge-ready to release tag | Time from release-ready approval to tag creation | `< 2 hours` | Release timeline |
 
-## Data collection contract (v0)
+## Data collection contract (v1)
 
 1. Collect weekly snapshots every Monday before quality review.
 2. Publish a markdown summary in `docs/artifacts/` for auditability.
-3. Keep raw exports (JSON/CSV) attached to CI artifacts for 90 days.
-4. Escalate any KPI that breaches target for 2 consecutive snapshots.
+3. Store and update baseline metadata in `docs/artifacts/world-class-kpi-dashboard-baseline.json`.
+4. Keep raw exports (JSON/CSV) attached to CI artifacts for 90 days.
+5. Escalate any KPI that breaches target for 2 consecutive snapshots.
+
+## Dashboard rollout checklist
+
+- [x] Add first weekly snapshot artifact (`docs/artifacts/world-class-kpi-dashboard-weekly-2026-03-13.md`).
+- [ ] Automate CI pass-rate extraction from workflow history.
+- [ ] Automate PR cycle time extraction from SCM analytics export.
+- [ ] Wire release evidence-pack coverage into release preflight checks.
+- [ ] Backfill last 4 weeks of KPI values.
+
+## Snapshot generation command
+
+Generate the next weekly template from the machine-readable baseline:
+
+```bash
+python scripts/generate_world_class_kpi_snapshot.py --snapshot-date YYYY-MM-DD
+```
+
+To pre-fill KPI values and auto-calculate trend deltas from current + previous exported data:
+
+```bash
+python scripts/generate_world_class_kpi_snapshot.py \
+  --snapshot-date YYYY-MM-DD \
+  --metrics-json docs/artifacts/world-class-kpi-dashboard-metrics-sample.json \
+  --previous-metrics-json docs/artifacts/world-class-kpi-dashboard-previous-metrics-sample.json \
+  --strict-metrics \
+  --summary-json docs/artifacts/world-class-kpi-dashboard-weekly-YYYY-MM-DD-summary.json  # includes target_eval + target_eval_counts + breach_kpi_ids \
+  --fail-on-target-breach
+```
 
 ## Immediate next actions
 

--- a/docs/artifacts/world-class-kpi-dashboard-metrics-sample.json
+++ b/docs/artifacts/world-class-kpi-dashboard-metrics-sample.json
@@ -1,0 +1,17 @@
+{
+  "mainline_pass_rate": {
+    "current_value": "99.4%",
+    "status": "on_track",
+    "evidence_link": "ci://runs/mainline-pass-rate"
+  },
+  "pr_cycle_time": {
+    "current_value": "21h",
+    "status": "watch",
+    "evidence_link": "scm://analytics/pr-cycle-time"
+  },
+  "critical_vulns": {
+    "current_value": "0",
+    "status": "on_track",
+    "evidence_link": "security://scan/default-branch"
+  }
+}

--- a/docs/artifacts/world-class-kpi-dashboard-previous-metrics-sample.json
+++ b/docs/artifacts/world-class-kpi-dashboard-previous-metrics-sample.json
@@ -1,0 +1,17 @@
+{
+  "mainline_pass_rate": {
+    "current_value": "99.1%",
+    "status": "on_track",
+    "evidence_link": "ci://runs/mainline-pass-rate-prev"
+  },
+  "pr_cycle_time": {
+    "current_value": "23h",
+    "status": "watch",
+    "evidence_link": "scm://analytics/pr-cycle-time-prev"
+  },
+  "critical_vulns": {
+    "current_value": "0",
+    "status": "on_track",
+    "evidence_link": "security://scan/default-branch-prev"
+  }
+}

--- a/docs/artifacts/world-class-kpi-dashboard-weekly-2026-03-13-summary.json
+++ b/docs/artifacts/world-class-kpi-dashboard-weekly-2026-03-13-summary.json
@@ -1,0 +1,152 @@
+{
+  "program": "world-class-quality",
+  "dashboard": "world-class-kpi",
+  "snapshot_date": "2026-03-13",
+  "baseline_kpi_count": 11,
+  "provided_kpi_count": 0,
+  "coverage_ratio": 0.0,
+  "missing_kpi_ids": [
+    "mainline_pass_rate",
+    "change_failure_rate",
+    "release_regression_mttr",
+    "first_successful_local_run",
+    "pr_cycle_time",
+    "doc_freshness_sla",
+    "critical_vulns",
+    "security_drift_remediation",
+    "evidence_pack_coverage",
+    "rollback_rate",
+    "merge_ready_to_tag"
+  ],
+  "target_eval_counts": {
+    "meets_target": 0,
+    "below_target": 0,
+    "above_target": 0,
+    "unknown": 11
+  },
+  "output_markdown": "docs/artifacts/world-class-kpi-dashboard-weekly-2026-03-13.md",
+  "kpis": [
+    {
+      "id": "mainline_pass_rate",
+      "lane": "reliability",
+      "target": ">=99%",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "change_failure_rate",
+      "lane": "reliability",
+      "target": "<5%",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "release_regression_mttr",
+      "lane": "reliability",
+      "target": "<60m",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "first_successful_local_run",
+      "lane": "velocity",
+      "target": "<30m",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "pr_cycle_time",
+      "lane": "velocity",
+      "target": "<24h",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "doc_freshness_sla",
+      "lane": "velocity",
+      "target": "100%",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "critical_vulns",
+      "lane": "trust_security",
+      "target": "0",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "security_drift_remediation",
+      "lane": "trust_security",
+      "target": "<72h",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "evidence_pack_coverage",
+      "lane": "release_readiness",
+      "target": "100%",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "rollback_rate",
+      "lane": "release_readiness",
+      "target": "<2%",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    },
+    {
+      "id": "merge_ready_to_tag",
+      "lane": "release_readiness",
+      "target": "<2h",
+      "current_value": "TODO",
+      "delta": "TODO",
+      "status": "TODO",
+      "evidence_link": "TODO",
+      "covered": false,
+      "target_eval": "unknown"
+    }
+  ],
+  "breach_kpi_ids": []
+}

--- a/docs/artifacts/world-class-kpi-dashboard-weekly-2026-03-13.md
+++ b/docs/artifacts/world-class-kpi-dashboard-weekly-2026-03-13.md
@@ -1,0 +1,50 @@
+# World-Class KPI Dashboard Weekly Snapshot — 2026-03-13
+
+Generated from `docs/artifacts/world-class-kpi-dashboard-baseline.json`.
+
+## Snapshot metadata
+
+- Program: `world-class-quality`
+- Dashboard: `world-class-kpi`
+- Baseline version: `v1`
+- Snapshot window: `rolling-30-day`
+- Review cadence: `weekly`
+- KPI coverage: `0/11` with provided metric values
+
+## KPI scorecard
+
+| KPI ID | Lane | KPI | Target | Current value | Delta vs previous | Status | Evidence link |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| mainline_pass_rate | reliability | Mainline unit+integration pass rate | `>=99%` | TODO | TODO | TODO | TODO |
+| change_failure_rate | reliability | Change failure rate | `<5%` | TODO | TODO | TODO | TODO |
+| release_regression_mttr | reliability | MTTR for release regression | `<60m` | TODO | TODO | TODO | TODO |
+| first_successful_local_run | velocity | First successful local run | `<30m` | TODO | TODO | TODO | TODO |
+| pr_cycle_time | velocity | PR cycle time median | `<24h` | TODO | TODO | TODO | TODO |
+| doc_freshness_sla | velocity | Doc freshness SLA | `100%` | TODO | TODO | TODO | TODO |
+| critical_vulns | trust_security | Critical vulns on default branch | `0` | TODO | TODO | TODO | TODO |
+| security_drift_remediation | trust_security | Security drift remediation | `<72h` | TODO | TODO | TODO | TODO |
+| evidence_pack_coverage | release_readiness | Release evidence pack coverage | `100%` | TODO | TODO | TODO | TODO |
+| rollback_rate | release_readiness | Rollback rate | `<2%` | TODO | TODO | TODO | TODO |
+| merge_ready_to_tag | release_readiness | Merge-ready to release tag | `<2h` | TODO | TODO | TODO | TODO |
+
+## Owners on duty
+
+| Lane | Primary owner | Backup owner |
+| --- | --- | --- |
+| Reliability | QA Platform Lead | Release Manager |
+| Velocity | Dev Experience Lead | Engineering Manager |
+| Trust Security | Security Champion | QA Platform Lead |
+| Release Readiness | Release Manager | QA Platform Lead |
+
+## Breach escalation
+
+- [ ] No KPI breached target for 2 consecutive snapshots.
+- [ ] If breached, incident owner and ETA are recorded.
+
+## Notes
+
+- Trend deltas are auto-calculated from `--previous-metrics-json` when provided.
+- Inline `previous_value` in `--metrics-json` is also supported as a fallback.
+- Use `--strict-metrics` to fail generation when any baseline KPI is missing.
+- Use `--summary-json` to emit a machine-readable snapshot rollup with target evaluation and breach IDs.
+- TODO: Attach raw export links for CI/SCM/security data.

--- a/scripts/generate_world_class_kpi_snapshot.py
+++ b/scripts/generate_world_class_kpi_snapshot.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+def _default_snapshot_date() -> str:
+    return date.today().isoformat()
+
+
+def _validate_snapshot_date(value: str) -> str:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise SystemExit(f"invalid --snapshot-date {value!r}; expected YYYY-MM-DD") from exc
+    return parsed.isoformat()
+
+
+def _normalize_metric_value(value: str) -> tuple[float, str] | None:
+    raw = value.strip().lower()
+    if raw.endswith("%"):
+        number = raw.removesuffix("%").strip()
+        try:
+            return float(number), "%"
+        except ValueError:
+            return None
+    if raw.endswith("h"):
+        number = raw.removesuffix("h").strip()
+        try:
+            return float(number), "h"
+        except ValueError:
+            return None
+    if raw.endswith("m"):
+        number = raw.removesuffix("m").strip()
+        try:
+            return float(number), "m"
+        except ValueError:
+            return None
+    try:
+        return float(raw), ""
+    except ValueError:
+        return None
+
+
+def _format_delta(current_value: str, previous_value: str) -> str:
+    current = _normalize_metric_value(current_value)
+    previous = _normalize_metric_value(previous_value)
+    if current is None or previous is None:
+        return "n/a"
+    current_num, current_unit = current
+    previous_num, previous_unit = previous
+    if current_unit != previous_unit:
+        return "n/a"
+    delta = current_num - previous_num
+    sign = "+" if delta > 0 else ""
+    if current_unit:
+        return f"{sign}{delta:.2f}{current_unit}"
+    return f"{sign}{delta:.2f}"
+
+
+def _parse_target_expression(target: str) -> tuple[str, float, str] | None:
+    normalized = target.replace(" ", "")
+    for op in (">=", "<=", ">", "<"):
+        if normalized.startswith(op):
+            parsed = _normalize_metric_value(normalized[len(op) :])
+            if parsed is None:
+                return None
+            value, unit = parsed
+            return op, value, unit
+    return None
+
+
+def _evaluate_target_status(current_value: str, target: str) -> str:
+    current = _normalize_metric_value(current_value)
+    target_expr = _parse_target_expression(target)
+    if current is None or target_expr is None:
+        return "unknown"
+
+    current_num, current_unit = current
+    op, target_num, target_unit = target_expr
+    if current_unit != target_unit:
+        return "unknown"
+
+    if op == ">=" and current_num >= target_num:
+        return "meets_target"
+    if op == ">" and current_num > target_num:
+        return "meets_target"
+    if op == "<=" and current_num <= target_num:
+        return "meets_target"
+    if op == "<" and current_num < target_num:
+        return "meets_target"
+
+    if op in {">=", ">"}:
+        return "below_target"
+    return "above_target"
+
+
+def _load_metrics_payload(path_value: str, flag_name: str) -> dict[str, dict[str, str]]:
+    payload_path = Path(path_value)
+    if not payload_path.exists():
+        raise SystemExit(f"missing {flag_name} file: {payload_path}")
+    data = json.loads(payload_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"invalid {flag_name}: top-level value must be an object")
+
+    parsed: dict[str, dict[str, str]] = {}
+    for kpi_id, payload in data.items():
+        if not isinstance(payload, dict):
+            raise SystemExit(f"invalid {flag_name}: KPI '{kpi_id}' must map to an object")
+        parsed[kpi_id] = {
+            "current_value": str(payload.get("current_value", "TODO")),
+            "status": str(payload.get("status", "TODO")),
+            "evidence_link": str(payload.get("evidence_link", "TODO")),
+            "previous_value": str(payload.get("previous_value", "")),
+        }
+    return parsed
+
+
+def _load_metrics(
+    metrics_json: str | None, previous_metrics_json: str | None
+) -> dict[str, dict[str, str]]:
+    if metrics_json is None:
+        return {}
+
+    current = _load_metrics_payload(metrics_json, "--metrics-json")
+    previous = (
+        _load_metrics_payload(previous_metrics_json, "--previous-metrics-json")
+        if previous_metrics_json
+        else {}
+    )
+
+    merged: dict[str, dict[str, str]] = {}
+    for kpi_id, payload in current.items():
+        previous_value = payload["previous_value"]
+        if not previous_value and kpi_id in previous:
+            previous_value = previous[kpi_id].get("current_value", "")
+        merged[kpi_id] = {
+            "current_value": payload["current_value"],
+            "delta": _format_delta(payload["current_value"], previous_value) if previous_value else "TODO",
+            "status": payload["status"],
+            "evidence_link": payload["evidence_link"],
+        }
+    return merged
+
+
+def _baseline_kpi_ids(baseline: dict[str, Any]) -> list[str]:
+    return [str(item.get("id", "unknown")) for item in baseline.get("kpis", [])]
+
+
+def _missing_kpi_ids(baseline: dict[str, Any], metrics: dict[str, dict[str, str]]) -> list[str]:
+    return [kpi_id for kpi_id in _baseline_kpi_ids(baseline) if kpi_id not in metrics]
+
+
+def _validate_metrics_completeness(baseline: dict[str, Any], metrics: dict[str, dict[str, str]]) -> None:
+    missing = _missing_kpi_ids(baseline, metrics)
+    if missing:
+        raise SystemExit(f"strict metrics check failed: missing KPI values for {missing}")
+
+
+def _build_summary_payload(
+    baseline: dict[str, Any], snapshot_date: str, metrics: dict[str, dict[str, str]], output_path: Path
+) -> dict[str, Any]:
+    baseline_ids = _baseline_kpi_ids(baseline)
+    missing = _missing_kpi_ids(baseline, metrics)
+    metric_entries = []
+    target_eval_counts = {"meets_target": 0, "below_target": 0, "above_target": 0, "unknown": 0}
+
+    for kpi in baseline.get("kpis", []):
+        kpi_id = str(kpi.get("id", "unknown"))
+        target = str(kpi.get("target", "unknown"))
+        metric_data = metrics.get(kpi_id)
+        current_value = metric_data["current_value"] if metric_data else "TODO"
+        target_eval = _evaluate_target_status(current_value, target)
+        target_eval_counts[target_eval] += 1
+        metric_entries.append(
+            {
+                "id": kpi_id,
+                "lane": str(kpi.get("lane", "unknown")),
+                "target": target,
+                "current_value": current_value,
+                "delta": metric_data["delta"] if metric_data else "TODO",
+                "status": metric_data["status"] if metric_data else "TODO",
+                "evidence_link": metric_data["evidence_link"] if metric_data else "TODO",
+                "covered": metric_data is not None,
+                "target_eval": target_eval,
+            }
+        )
+    return {
+        "program": baseline.get("program", "unknown"),
+        "dashboard": baseline.get("dashboard", "unknown"),
+        "snapshot_date": snapshot_date,
+        "baseline_kpi_count": len(baseline_ids),
+        "provided_kpi_count": len(metrics),
+        "coverage_ratio": len(metrics) / len(baseline_ids) if baseline_ids else 0.0,
+        "missing_kpi_ids": missing,
+        "target_eval_counts": target_eval_counts,
+        "output_markdown": str(output_path),
+        "kpis": metric_entries,
+    }
+
+
+
+
+def _breach_kpi_ids(summary: dict[str, Any]) -> list[str]:
+    ids: list[str] = []
+    for item in summary.get("kpis", []):
+        if item.get("covered") and item.get("target_eval") in {"below_target", "above_target"}:
+            ids.append(str(item.get("id", "unknown")))
+    return ids
+
+def _render_snapshot(
+    baseline: dict[str, Any], snapshot_date: str, metrics: dict[str, dict[str, str]]
+) -> str:
+    lines: list[str] = []
+    lines.append(f"# World-Class KPI Dashboard Weekly Snapshot — {snapshot_date}")
+    lines.append("")
+    lines.append("Generated from `docs/artifacts/world-class-kpi-dashboard-baseline.json`.")
+    lines.append("")
+    lines.append("## Snapshot metadata")
+    lines.append("")
+    lines.append(f"- Program: `{baseline.get('program', 'unknown')}`")
+    lines.append(f"- Dashboard: `{baseline.get('dashboard', 'unknown')}`")
+    lines.append(f"- Baseline version: `{baseline.get('version', 'unknown')}`")
+    lines.append(f"- Snapshot window: `{baseline.get('snapshot_window', 'unknown')}`")
+    lines.append(f"- Review cadence: `{baseline.get('review_cadence', 'unknown')}`")
+    lines.append(f"- KPI coverage: `{len(metrics)}/{len(baseline.get('kpis', []))}` with provided metric values")
+    lines.append("")
+    lines.append("## KPI scorecard")
+    lines.append("")
+    lines.append("| KPI ID | Lane | KPI | Target | Current value | Delta vs previous | Status | Evidence link |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
+    for kpi in baseline.get("kpis", []):
+        kpi_id = str(kpi.get("id", "unknown"))
+        metric_data = metrics.get(
+            kpi_id,
+            {
+                "current_value": "TODO",
+                "delta": "TODO",
+                "status": "TODO",
+                "evidence_link": "TODO",
+            },
+        )
+        lines.append(
+            "| {id} | {lane} | {metric} | `{target}` | {current_value} | {delta} | {status} | {evidence_link} |".format(
+                id=kpi_id,
+                lane=kpi.get("lane", "unknown"),
+                metric=kpi.get("metric", "unknown"),
+                target=kpi.get("target", "unknown"),
+                current_value=metric_data["current_value"],
+                delta=metric_data["delta"],
+                status=metric_data["status"],
+                evidence_link=metric_data["evidence_link"],
+            )
+        )
+    lines.append("")
+    lines.append("## Owners on duty")
+    lines.append("")
+    lines.append("| Lane | Primary owner | Backup owner |")
+    lines.append("| --- | --- | --- |")
+    for lane, owner_data in baseline.get("owners", {}).items():
+        lane_label = lane.replace("_", " ").title()
+        lines.append(
+            f"| {lane_label} | {owner_data.get('primary', 'unknown')} | {owner_data.get('backup', 'unknown')} |"
+        )
+    lines.append("")
+    lines.append("## Breach escalation")
+    lines.append("")
+    lines.append("- [ ] No KPI breached target for 2 consecutive snapshots.")
+    lines.append("- [ ] If breached, incident owner and ETA are recorded.")
+    lines.append("")
+    lines.append("## Notes")
+    lines.append("")
+    lines.append("- Trend deltas are auto-calculated from `--previous-metrics-json` when provided.")
+    lines.append("- Inline `previous_value` in `--metrics-json` is also supported as a fallback.")
+    lines.append("- Use `--strict-metrics` to fail generation when any baseline KPI is missing.")
+    lines.append("- Use `--summary-json` to emit a machine-readable snapshot rollup with target evaluation and breach IDs.")
+    lines.append("- TODO: Attach raw export links for CI/SCM/security data.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a weekly world-class KPI dashboard snapshot markdown from baseline JSON."
+    )
+    parser.add_argument(
+        "--baseline-json",
+        default="docs/artifacts/world-class-kpi-dashboard-baseline.json",
+        help="Path to the machine-readable baseline JSON.",
+    )
+    parser.add_argument(
+        "--metrics-json",
+        default=None,
+        help="Optional path to current KPI metric values keyed by KPI id.",
+    )
+    parser.add_argument(
+        "--previous-metrics-json",
+        default=None,
+        help="Optional path to previous snapshot KPI values keyed by KPI id.",
+    )
+    parser.add_argument(
+        "--strict-metrics",
+        action="store_true",
+        help="Fail if any KPI listed in baseline is missing from provided metrics.",
+    )
+    parser.add_argument(
+        "--summary-json",
+        default=None,
+        help="Optional path to write machine-readable snapshot summary JSON.",
+    )
+    parser.add_argument(
+        "--fail-on-target-breach",
+        action="store_true",
+        help="Fail if any covered KPI evaluates as below_target or above_target.",
+    )
+    parser.add_argument(
+        "--snapshot-date",
+        default=_default_snapshot_date(),
+        help="Snapshot date in YYYY-MM-DD format.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output markdown file path. Defaults to docs/artifacts/world-class-kpi-dashboard-weekly-<date>.md",
+    )
+    ns = parser.parse_args()
+
+    snapshot_date = _validate_snapshot_date(ns.snapshot_date)
+    baseline_path = Path(ns.baseline_json)
+    if not baseline_path.exists():
+        raise SystemExit(f"missing baseline json: {baseline_path}")
+
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    if not isinstance(baseline.get("kpis", []), list):
+        raise SystemExit("invalid baseline json: 'kpis' must be a list")
+    if not isinstance(baseline.get("owners", {}), dict):
+        raise SystemExit("invalid baseline json: 'owners' must be an object")
+
+    metrics = _load_metrics(ns.metrics_json, ns.previous_metrics_json)
+    if ns.strict_metrics:
+        _validate_metrics_completeness(baseline, metrics)
+
+    output_path = Path(ns.output or f"docs/artifacts/world-class-kpi-dashboard-weekly-{snapshot_date}.md")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(_render_snapshot(baseline, snapshot_date, metrics), encoding="utf-8")
+
+    summary = _build_summary_payload(baseline, snapshot_date, metrics, output_path)
+    breach_ids = _breach_kpi_ids(summary)
+    summary["breach_kpi_ids"] = breach_ids
+
+    if ns.summary_json:
+        summary_path = Path(ns.summary_json)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    if ns.fail_on_target_breach and breach_ids:
+        raise SystemExit(f"target breach check failed: {breach_ids}")
+
+    print(str(output_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_world_class_kpi_snapshot_generator.py
+++ b/tests/test_world_class_kpi_snapshot_generator.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/generate_world_class_kpi_snapshot.py")
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), *args], text=True, capture_output=True)
+
+
+def test_generator_writes_snapshot_from_baseline(tmp_path: Path) -> None:
+    baseline = {
+        "program": "world-class-quality",
+        "dashboard": "world-class-kpi",
+        "version": "v1",
+        "snapshot_window": "rolling-30-day",
+        "review_cadence": "weekly",
+        "owners": {"reliability": {"primary": "A", "backup": "B"}},
+        "kpis": [
+            {
+                "id": "mainline_pass_rate",
+                "lane": "reliability",
+                "metric": "Mainline unit+integration pass rate",
+                "target": ">=99%",
+            }
+        ],
+    }
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+    output_path = tmp_path / "snapshot.md"
+
+    proc = _run(
+        "--baseline-json",
+        str(baseline_path),
+        "--snapshot-date",
+        "2026-03-20",
+        "--output",
+        str(output_path),
+    )
+
+    assert proc.returncode == 0
+    assert output_path.exists()
+    text = output_path.read_text(encoding="utf-8")
+    assert "World-Class KPI Dashboard Weekly Snapshot — 2026-03-20" in text
+    assert "| mainline_pass_rate | reliability |" in text
+    assert "| Reliability | A | B |" in text
+    assert "KPI coverage: `0/1`" in text
+
+
+def test_generator_applies_metrics_json_values_and_delta(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "owners": {"reliability": {"primary": "A", "backup": "B"}},
+                "kpis": [
+                    {
+                        "id": "mainline_pass_rate",
+                        "lane": "reliability",
+                        "metric": "Mainline unit+integration pass rate",
+                        "target": ">=99%",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(
+        json.dumps(
+            {
+                "mainline_pass_rate": {
+                    "current_value": "99.4%",
+                    "previous_value": "98.9%",
+                    "status": "on_track",
+                    "evidence_link": "ci://runs/mainline-pass-rate",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "snapshot.md"
+
+    proc = _run(
+        "--baseline-json",
+        str(baseline_path),
+        "--metrics-json",
+        str(metrics_path),
+        "--snapshot-date",
+        "2026-03-20",
+        "--output",
+        str(output_path),
+    )
+
+    assert proc.returncode == 0
+    text = output_path.read_text(encoding="utf-8")
+    assert "| KPI ID | Lane | KPI | Target | Current value | Delta vs previous | Status | Evidence link |" in text
+    assert "| mainline_pass_rate | reliability | Mainline unit+integration pass rate | `>=99%` | 99.4% | +0.50% | on_track | ci://runs/mainline-pass-rate |" in text
+
+
+def test_generator_uses_previous_metrics_file_for_delta(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "owners": {},
+                "kpis": [
+                    {
+                        "id": "pr_cycle_time",
+                        "lane": "velocity",
+                        "metric": "PR cycle time",
+                        "target": "<24h",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    current_metrics_path = tmp_path / "current.json"
+    current_metrics_path.write_text(
+        json.dumps(
+            {
+                "pr_cycle_time": {
+                    "current_value": "21h",
+                    "status": "watch",
+                    "evidence_link": "scm://analytics/pr-cycle-time",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    previous_metrics_path = tmp_path / "previous.json"
+    previous_metrics_path.write_text(
+        json.dumps(
+            {
+                "pr_cycle_time": {
+                    "current_value": "23h",
+                    "status": "watch",
+                    "evidence_link": "scm://analytics/pr-cycle-time-prev",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "snapshot.md"
+
+    proc = _run(
+        "--baseline-json",
+        str(baseline_path),
+        "--metrics-json",
+        str(current_metrics_path),
+        "--previous-metrics-json",
+        str(previous_metrics_path),
+        "--output",
+        str(output_path),
+    )
+
+    assert proc.returncode == 0
+    text = output_path.read_text(encoding="utf-8")
+    assert "| pr_cycle_time | velocity | PR cycle time | `<24h` | 21h | -2.00h | watch | scm://analytics/pr-cycle-time |" in text
+
+
+def test_generator_rejects_invalid_snapshot_date(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps({"owners": {}, "kpis": []}), encoding="utf-8")
+
+    proc = _run("--baseline-json", str(baseline_path), "--snapshot-date", "2026/03/20")
+
+    assert proc.returncode != 0
+    assert "invalid --snapshot-date" in proc.stderr
+
+
+def test_generator_rejects_non_object_metrics_payload(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps({"owners": {}, "kpis": []}), encoding="utf-8")
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(json.dumps(["not-an-object"]), encoding="utf-8")
+
+    proc = _run("--baseline-json", str(baseline_path), "--metrics-json", str(metrics_path))
+
+    assert proc.returncode != 0
+    assert "top-level value must be an object" in proc.stderr
+
+
+def test_generator_uses_na_delta_when_units_do_not_match(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "owners": {},
+                "kpis": [
+                    {
+                        "id": "pr_cycle_time",
+                        "lane": "velocity",
+                        "metric": "PR cycle time",
+                        "target": "<24h",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(
+        json.dumps(
+            {
+                "pr_cycle_time": {
+                    "current_value": "21h",
+                    "previous_value": "88%",
+                    "status": "watch",
+                    "evidence_link": "scm://analytics/pr-cycle-time",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "snapshot.md"
+
+    proc = _run(
+        "--baseline-json",
+        str(baseline_path),
+        "--metrics-json",
+        str(metrics_path),
+        "--output",
+        str(output_path),
+    )
+
+    assert proc.returncode == 0
+    text = output_path.read_text(encoding="utf-8")
+    assert "| pr_cycle_time | velocity | PR cycle time | `<24h` | 21h | n/a | watch | scm://analytics/pr-cycle-time |" in text
+
+
+def test_generator_strict_metrics_fails_when_kpis_missing(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "owners": {},
+                "kpis": [
+                    {"id": "kpi_a", "lane": "reliability", "metric": "A", "target": ">=1"},
+                    {"id": "kpi_b", "lane": "reliability", "metric": "B", "target": ">=1"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(
+        json.dumps({"kpi_a": {"current_value": "1", "status": "ok", "evidence_link": "x"}}),
+        encoding="utf-8",
+    )
+
+    proc = _run(
+        "--baseline-json",
+        str(baseline_path),
+        "--metrics-json",
+        str(metrics_path),
+        "--strict-metrics",
+    )
+
+    assert proc.returncode != 0
+    assert "strict metrics check failed" in proc.stderr
+
+
+def test_generator_strict_metrics_passes_with_full_coverage(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "owners": {},
+                "kpis": [
+                    {"id": "kpi_a", "lane": "reliability", "metric": "A", "target": ">=1"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(
+        json.dumps({"kpi_a": {"current_value": "1", "status": "ok", "evidence_link": "x"}}),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "snapshot.md"
+
+    proc = _run(
+        "--baseline-json",
+        str(baseline_path),
+        "--metrics-json",
+        str(metrics_path),
+        "--strict-metrics",
+        "--output",
+        str(output_path),
+    )
+
+    assert proc.returncode == 0
+    text = output_path.read_text(encoding="utf-8")
+    assert "KPI coverage: `1/1`" in text
+
+
+def test_generator_writes_machine_readable_summary_json(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "program": "world-class-quality",
+                "dashboard": "world-class-kpi",
+                "owners": {},
+                "kpis": [
+                    {"id": "kpi_a", "lane": "reliability", "metric": "A", "target": ">=1"},
+                    {"id": "kpi_b", "lane": "velocity", "metric": "B", "target": "<2"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(
+        json.dumps({"kpi_a": {"current_value": "1", "status": "ok", "evidence_link": "x"}}),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "snapshot.md"
+    summary_path = tmp_path / "summary.json"
+
+    proc = _run(
+        "--baseline-json",
+        str(baseline_path),
+        "--metrics-json",
+        str(metrics_path),
+        "--output",
+        str(output_path),
+        "--summary-json",
+        str(summary_path),
+        "--snapshot-date",
+        "2026-03-21",
+    )
+
+    assert proc.returncode == 0
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert payload["program"] == "world-class-quality"
+    assert payload["snapshot_date"] == "2026-03-21"
+    assert payload["baseline_kpi_count"] == 2
+    assert payload["provided_kpi_count"] == 1
+    assert payload["missing_kpi_ids"] == ["kpi_b"]
+    assert payload["kpis"][0]["covered"] is True
+    assert payload["kpis"][1]["covered"] is False
+    assert payload["kpis"][0]["target_eval"] == "meets_target"
+    assert payload["kpis"][1]["target_eval"] == "unknown"
+    assert payload["target_eval_counts"] == {"meets_target": 1, "below_target": 0, "above_target": 0, "unknown": 1}
+
+
+def test_summary_target_eval_flags_below_and_above_target(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "owners": {},
+                "kpis": [
+                    {"id": "pass_rate", "lane": "reliability", "metric": "Pass", "target": ">=99%"},
+                    {"id": "cycle_time", "lane": "velocity", "metric": "Cycle", "target": "<24h"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(
+        json.dumps(
+            {
+                "pass_rate": {"current_value": "98.1%", "status": "watch", "evidence_link": "ci://x"},
+                "cycle_time": {"current_value": "30h", "status": "risk", "evidence_link": "scm://y"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "snapshot.md"
+    summary_path = tmp_path / "summary.json"
+
+    proc = _run(
+        "--baseline-json",
+        str(baseline_path),
+        "--metrics-json",
+        str(metrics_path),
+        "--output",
+        str(output_path),
+        "--summary-json",
+        str(summary_path),
+    )
+
+    assert proc.returncode == 0
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert payload["kpis"][0]["target_eval"] == "below_target"
+    assert payload["kpis"][1]["target_eval"] == "above_target"
+    assert payload["target_eval_counts"] == {"meets_target": 0, "below_target": 1, "above_target": 1, "unknown": 0}
+    assert payload["breach_kpi_ids"] == ["pass_rate", "cycle_time"]
+
+
+def test_fail_on_target_breach_returns_non_zero(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "owners": {},
+                "kpis": [
+                    {"id": "pass_rate", "lane": "reliability", "metric": "Pass", "target": ">=99%"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(
+        json.dumps({"pass_rate": {"current_value": "95%", "status": "risk", "evidence_link": "ci://x"}}),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "snapshot.md"
+
+    proc = _run(
+        "--baseline-json",
+        str(baseline_path),
+        "--metrics-json",
+        str(metrics_path),
+        "--output",
+        str(output_path),
+        "--fail-on-target-breach",
+    )
+
+    assert proc.returncode != 0
+    assert "target breach check failed" in proc.stderr


### PR DESCRIPTION
### Motivation

- Establish a machine-readable baseline for the World-Class KPI dashboard to standardize KPI definitions, owners, targets, and next actions. 
- Provide a repeatable way to generate weekly snapshot markdown and machine-readable summaries from current and previous metric exports. 
- Enable automated evaluation of target compliance and basic breach gating to drive CI/operational checks.

### Description

- Add a machine-readable baseline `docs/artifacts/world-class-kpi-dashboard-baseline.json` and update the human-readable baseline `docs/artifacts/world-class-kpi-dashboard-baseline.md` with rollout checklist and generation instructions. 
- Add sample metric payloads `world-class-kpi-dashboard-metrics-sample.json` and `world-class-kpi-dashboard-previous-metrics-sample.json` and add an initial weekly snapshot output pair `world-class-kpi-dashboard-weekly-2026-03-13.md` and `.json`. 
- Implement the snapshot generator `scripts/generate_world_class_kpi_snapshot.py` which loads baseline and metrics, normalizes values, computes deltas, evaluates target expressions, renders markdown snapshots, and can emit a machine-readable summary and fail on breaches. 
- Add comprehensive unit tests in `tests/test_world_class_kpi_snapshot_generator.py` covering snapshot generation, delta calculation, unit mismatch handling, strict coverage checks, summary output, and the `--fail-on-target-breach` behavior.

### Testing

- Ran the new unit test suite `tests/test_world_class_kpi_snapshot_generator.py` with `pytest` which executes 11 tests validating generation, parsing, evaluation, and error cases, and all tests passed. 
- Exercised the generator manually via the provided invocation pattern `python scripts/generate_world_class_kpi_snapshot.py --snapshot-date YYYY-MM-DD --metrics-json <file> --previous-metrics-json <file> --summary-json <file>` during development and verified expected outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b37c7d4ee08320bd5dae0cd2919210)