### PR TITLE
Add continuous-upgrade-cycle8-closeout command, docs, plan, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ python -m sdetkit intelligence failure-fingerprint --failures examples/kits/inte
 python -m sdetkit integration check --profile examples/kits/integration/profile.json
 python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json --fail-on error
 python -m sdetkit forensics bundle --run examples/kits/forensics/run-b.json --output build/repro.zip
+python -m sdetkit continuous-upgrade-cycle8-closeout --format json --strict
 ```
 
 ## Sample artifacts

--- a/docs/continuous-upgrade-cycle8-big-upgrade-report.md
+++ b/docs/continuous-upgrade-cycle8-big-upgrade-report.md
@@ -1,0 +1,16 @@
+# Cycle 8 big upgrade report
+
+## What shipped
+
+- Added `continuous-upgrade-cycle8-closeout` command to score Cycle 8 readiness from Cycle 7 continuous-upgrade artifacts.
+- Added deterministic pack emission and execution evidence generation for cycle-8 continuous-upgrade proof.
+- Added strict contract validation script and tests that enforce Cycle 8 closeout quality gates.
+
+## Command lane
+
+```bash
+python -m sdetkit continuous-upgrade-cycle8-closeout --format json --strict
+python -m sdetkit continuous-upgrade-cycle8-closeout --emit-pack-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack --format json --strict
+python -m sdetkit continuous-upgrade-cycle8-closeout --execute --evidence-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack/evidence --format json --strict
+python scripts/check_continuous_upgrade_cycle8_closeout_contract.py
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,3 +44,8 @@ Utility commands such as `kv`, `apiget`, and `cassette-get` remain available for
 - Run first command in under 60 seconds
 - Validate docs links and anchors before publishing
 - Ship a first contribution with deterministic quality gates
+
+### Latest continuous-upgrade lane
+
+- [Cycle 8 big upgrade report](continuous-upgrade-cycle8-big-upgrade-report.md)
+- [Continuous upgrade cycle #8 closeout](integrations-continuous-upgrade-cycle8-closeout.md)

--- a/docs/integrations-continuous-upgrade-cycle8-closeout.md
+++ b/docs/integrations-continuous-upgrade-cycle8-closeout.md
@@ -1,0 +1,51 @@
+# Cycle 8 — Continuous upgrade closeout lane
+
+Cycle 8 closes with a major upgrade that converts Cycle 7 continuous-upgrade outcomes into a deterministic next-cycle execution lane.
+
+## Why Cycle 8 matters
+
+- Converts Cycle 7 outcomes into reusable publication decisions across release recap, roadmap governance, and maintainer escalation paths.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Cycle 8 closeout into the continuous-upgrade backlog.
+
+## Required inputs (Cycle 7)
+
+- `docs/artifacts/continuous-upgrade-cycle7-closeout-pack/cycle7-continuous-upgrade-cycle7-closeout-summary.json`
+- `docs/artifacts/continuous-upgrade-cycle7-closeout-pack/cycle7-delivery-board.md`
+- `docs/roadmap/plans/continuous-upgrade-cycle8-plan.json`
+
+## Cycle 8 command lane
+
+```bash
+python -m sdetkit continuous-upgrade-cycle8-closeout --format json --strict
+python -m sdetkit continuous-upgrade-cycle8-closeout --emit-pack-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack --format json --strict
+python -m sdetkit continuous-upgrade-cycle8-closeout --execute --evidence-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack/evidence --format json --strict
+python scripts/check_continuous_upgrade_cycle8_closeout_contract.py
+```
+
+## Continuous upgrade contract
+
+- Single owner + backup reviewer are assigned for Cycle 8 continuous upgrade execution and signoff.
+- The Cycle 8 lane references Cycle 7 outcomes, controls, and trust continuity signals.
+- Every Cycle 8 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Cycle 8 closeout records continuous upgrade outputs, report publication status, and backlog inputs.
+
+## Continuous upgrade quality checklist
+
+- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to upgrade docs/templates + runnable command evidence
+- [ ] Scorecard captures continuous upgrade adoption delta, confidence, and rollback owner
+- [ ] Artifact pack includes upgrade brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log
+
+## Cycle 8 delivery board
+
+- [ ] Cycle 8 evidence brief committed
+- [ ] Cycle 8 continuous upgrade plan committed
+- [ ] Cycle 8 upgrade template upgrade ledger exported
+- [ ] Cycle 8 storyline outcomes ledger exported
+- [ ] Next-cycle roadmap draft captured from Cycle 8 outcomes
+
+## Scoring model
+
+Cycle 8 weights continuity + execution contract + governance artifact readiness for a 100-point activation score.

--- a/docs/roadmap/reports/continuous-upgrade-cycle8-big-upgrade-report.md
+++ b/docs/roadmap/reports/continuous-upgrade-cycle8-big-upgrade-report.md
@@ -1,0 +1,16 @@
+# Cycle 8 big upgrade report
+
+## What shipped
+
+- Added `continuous-upgrade-cycle8-closeout` command to score Cycle 8 readiness from Cycle 7 continuous-upgrade artifacts.
+- Added deterministic pack emission and execution evidence generation for cycle-8 continuous-upgrade proof.
+- Added strict contract validation script and tests that enforce Cycle 8 closeout quality gates.
+
+## Command lane
+
+```bash
+python -m sdetkit continuous-upgrade-cycle8-closeout --format json --strict
+python -m sdetkit continuous-upgrade-cycle8-closeout --emit-pack-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack --format json --strict
+python -m sdetkit continuous-upgrade-cycle8-closeout --execute --evidence-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack/evidence --format json --strict
+python scripts/check_continuous_upgrade_cycle8_closeout_contract.py
+```

--- a/docs/top-10-github-strategy.md
+++ b/docs/top-10-github-strategy.md
@@ -345,3 +345,5 @@ A score of **28+/35 for 3 consecutive months** indicates strong category leaders
 - **Day 94 — Continuous upgrade cycle #4 closeout lane:** continue continuous-upgrade execution with Day 93 evidence and cycle-4 handoff controls.
 - **Day 95 — Continuous upgrade cycle #5 closeout lane:** continue continuous-upgrade execution with Day 94 evidence and cycle-5 handoff controls.
 - **Day 97 — Continuous upgrade cycle #7 closeout lane:** continue continuous-upgrade execution with Day 95 evidence and cycle-7 handoff controls.
+- **Cycle 8 — Continuous upgrade closeout lane:** continue continuous-upgrade execution with cycle-7 evidence and cycle-8 handoff controls.
+

--- a/plans/continuous-upgrade-cycle8-plan.json
+++ b/plans/continuous-upgrade-cycle8-plan.json
@@ -1,0 +1,25 @@
+{
+  "plan_id": "continuous-upgrade-cycle8-001",
+  "contributors": [
+    "maintainers",
+    "release-ops",
+    "docs-ops"
+  ],
+  "upgrade_channels": [
+    "readme",
+    "docs-index",
+    "cli-lanes"
+  ],
+  "baseline": {
+    "strict_pass_rate": 0.9,
+    "doc_link_coverage": 0.88
+  },
+  "target": {
+    "strict_pass_rate": 1.0,
+    "doc_link_coverage": 0.97
+  },
+  "owner": "release-ops",
+  "rollback_owner": "incident-ops",
+  "confidence_floor": 0.9,
+  "cadence_days": 7
+}

--- a/scripts/check_continuous_upgrade_cycle8_closeout_contract.py
+++ b/scripts/check_continuous_upgrade_cycle8_closeout_contract.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import continuous_upgrade_cycle8_closeout as d98
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Cycle 8 continuous upgrade closeout contract"
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--skip-evidence", action="store_true")
+    ns = parser.parse_args()
+
+    root = Path(ns.root).resolve()
+    payload = d98.build_continuous_upgrade_cycle8_closeout_summary(root)
+    errors: list[str] = []
+
+    if not payload.get("summary", {}).get("strict_pass", False):
+        errors.append("summary.strict_pass is false")
+
+    if payload.get("summary", {}).get("activation_score", 0) < 95:
+        errors.append("activation_score below 95")
+
+    if payload.get("summary", {}).get("critical_failures"):
+        errors.append("critical_failures is not empty")
+
+    if not ns.skip_evidence:
+        evidence = (
+            root
+            / "docs/artifacts/continuous-upgrade-cycle8-closeout-pack/evidence/cycle8-execution-summary.json"
+        )
+        if not evidence.exists():
+            errors.append(f"missing evidence summary: {evidence}")
+        else:
+            data = json.loads(evidence.read_text(encoding="utf-8"))
+            if int(data.get("total_commands", 0)) < 3:
+                errors.append("evidence total_commands below 3")
+
+    if errors:
+        print("continuous-upgrade-cycle8-closeout contract check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("continuous-upgrade-cycle8-closeout contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -79,6 +79,7 @@ from . import (
     day95_continuous_upgrade_cycle5_closeout,
     day96_continuous_upgrade_cycle6_closeout,
     day97_continuous_upgrade_cycle7_closeout,
+    continuous_upgrade_cycle8_closeout,
     demo,
     docs_navigation,
     docs_qa,
@@ -655,6 +656,11 @@ Start here:
     )
     d97.set_defaults(cmd="continuous-upgrade-cycle7-closeout")
     d97.add_argument("args", nargs=argparse.REMAINDER)
+    d98 = sub.add_parser(
+        "continuous-upgrade-cycle8-closeout"
+    )
+    d98.set_defaults(cmd="continuous-upgrade-cycle8-closeout")
+    d98.add_argument("args", nargs=argparse.REMAINDER)
 
     fqo = sub.add_parser("faq-objections", help="FAQ objections playbook")
     fqo.add_argument("args", nargs=argparse.REMAINDER)
@@ -1072,6 +1078,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         "day97-continuous-upgrade-cycle7-closeout",
     }:
         return day97_continuous_upgrade_cycle7_closeout.main(list(argv[1:]))
+    if argv and argv[0] == "continuous-upgrade-cycle8-closeout":
+        return continuous_upgrade_cycle8_closeout.main(list(argv[1:]))
 
     if argv and argv[0] == "faq-objections":
         return faq_objections.main(list(argv[1:]))
@@ -1454,6 +1462,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         return day96_continuous_upgrade_cycle6_closeout.main(ns.args)
     if ns.cmd in {"continuous-upgrade-cycle7-closeout", "day97-continuous-upgrade-cycle7-closeout"}:
         return day97_continuous_upgrade_cycle7_closeout.main(ns.args)
+
+    if ns.cmd == "continuous-upgrade-cycle8-closeout":
+        return continuous_upgrade_cycle8_closeout.main(ns.args)
 
     if ns.cmd == "faq-objections":
         return faq_objections.main(ns.args)

--- a/src/sdetkit/continuous_upgrade_cycle8_closeout.py
+++ b/src/sdetkit/continuous_upgrade_cycle8_closeout.py
@@ -1,0 +1,563 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_PAGE_PATH = "docs/integrations-continuous-upgrade-cycle8-closeout.md"
+_TOP10_PATH = "docs/top-10-github-strategy.md"
+_PREV_CYCLE_SUMMARY_PATH = "docs/artifacts/continuous-upgrade-cycle7-closeout-pack/cycle7-continuous-upgrade-cycle7-closeout-summary.json"
+_PREV_CYCLE_BOARD_PATH = (
+    "docs/artifacts/continuous-upgrade-cycle7-closeout-pack/cycle7-delivery-board.md"
+)
+_PLAN_PATH = "docs/roadmap/plans/continuous-upgrade-cycle8-plan.json"
+_SECTION_HEADER = "# Cycle 8 \u2014 Continuous upgrade closeout lane"
+_REQUIRED_SECTIONS = [
+    "## Why Cycle 8 matters",
+    "## Required inputs (Cycle 7)",
+    "## Cycle 8 command lane",
+    "## Continuous upgrade contract",
+    "## Continuous upgrade quality checklist",
+    "## Cycle 8 delivery board",
+    "## Scoring model",
+]
+_REQUIRED_COMMANDS = [
+    "python -m sdetkit continuous-upgrade-cycle8-closeout --format json --strict",
+    "python -m sdetkit continuous-upgrade-cycle8-closeout --emit-pack-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack --format json --strict",
+    "python -m sdetkit continuous-upgrade-cycle8-closeout --execute --evidence-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack/evidence --format json --strict",
+    "python scripts/check_continuous_upgrade_cycle8_closeout_contract.py",
+]
+_EXECUTION_COMMANDS = [
+    "python -m sdetkit continuous-upgrade-cycle8-closeout --format json --strict",
+    "python -m sdetkit continuous-upgrade-cycle8-closeout --emit-pack-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack --format json --strict",
+    "python scripts/check_continuous_upgrade_cycle8_closeout_contract.py --skip-evidence",
+]
+_REQUIRED_CONTRACT_LINES = [
+    "Single owner + backup reviewer are assigned for Cycle 8 continuous upgrade execution and signoff.",
+    "The Cycle 8 lane references Cycle 7 outcomes, controls, and trust continuity signals.",
+    "Every Cycle 8 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "Cycle 8 closeout records continuous upgrade outputs, report publication status, and backlog inputs.",
+]
+_REQUIRED_QUALITY_LINES = [
+    "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
+    "- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag",
+    "- [ ] CTA links point to upgrade docs/templates + runnable command evidence",
+    "- [ ] Scorecard captures continuous upgrade adoption delta, confidence, and rollback owner",
+    "- [ ] Artifact pack includes upgrade brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
+]
+_REQUIRED_DELIVERY_BOARD_LINES = [
+    "- [ ] Cycle 8 evidence brief committed",
+    "- [ ] Cycle 8 continuous upgrade plan committed",
+    "- [ ] Cycle 8 upgrade template upgrade ledger exported",
+    "- [ ] Cycle 8 storyline outcomes ledger exported",
+    "- [ ] Next-cycle roadmap draft captured from Cycle 8 outcomes",
+]
+_REQUIRED_DATA_KEYS = [
+    "plan_id",
+    "contributors",
+    "upgrade_channels",
+    "baseline",
+    "target",
+    "owner",
+    "rollback_owner",
+    "confidence_floor",
+    "cadence_days",
+]
+
+_CYCLE8_DEFAULT_PAGE = """# Cycle 8 \u2014 Continuous upgrade closeout lane
+
+Cycle 8 closes with a major upgrade that converts Cycle 7 governance scale outcomes into a deterministic phase-3 wrap and publication operating lane.
+
+## Why Cycle 8 matters
+
+- Converts Cycle 7 governance scale outcomes into reusable publication decisions across release recap, roadmap governance, and maintainer escalation paths.
+- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
+- Creates a deterministic handoff from Cycle 8 closeout into the continuous-upgrade backlog.
+
+## Required inputs (Cycle 7)
+
+- `docs/artifacts/continuous-upgrade-cycle7-closeout-pack/cycle7-continuous-upgrade-cycle7-closeout-summary.json`
+- `docs/artifacts/continuous-upgrade-cycle7-closeout-pack/cycle7-delivery-board.md`
+- `docs/roadmap/plans/continuous-upgrade-cycle8-plan.json`
+
+## Cycle 8 command lane
+
+```bash
+python -m sdetkit continuous-upgrade-cycle8-closeout --format json --strict
+python -m sdetkit continuous-upgrade-cycle8-closeout --emit-pack-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack --format json --strict
+python -m sdetkit continuous-upgrade-cycle8-closeout --execute --evidence-dir docs/artifacts/continuous-upgrade-cycle8-closeout-pack/evidence --format json --strict
+python scripts/check_continuous_upgrade_cycle8_closeout_contract.py
+```
+
+## Continuous upgrade contract
+
+- Single owner + backup reviewer are assigned for Cycle 8 continuous upgrade execution and signoff.
+- The Cycle 8 lane references Cycle 7 outcomes, controls, and trust continuity signals.
+- Every Cycle 8 section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- Cycle 8 closeout records continuous upgrade outputs, report publication status, and backlog inputs.
+
+## Continuous upgrade quality checklist
+
+- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets
+- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag
+- [ ] CTA links point to upgrade docs/templates + runnable command evidence
+- [ ] Scorecard captures continuous upgrade adoption delta, confidence, and rollback owner
+- [ ] Artifact pack includes upgrade brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log
+
+## Cycle 8 delivery board
+
+- [ ] Cycle 8 evidence brief committed
+- [ ] Cycle 8 continuous upgrade plan committed
+- [ ] Cycle 8 upgrade template upgrade ledger exported
+- [ ] Cycle 8 storyline outcomes ledger exported
+- [ ] Next-cycle roadmap draft captured from Cycle 8 outcomes
+
+## Scoring model
+
+Cycle 8 weights continuity + execution contract + governance artifact readiness for a 100-point activation score.
+"""
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _checklist_count(markdown: str) -> int:
+    return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
+
+
+def _validate_plan_contract(
+    plan_data: dict[str, Any],
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    missing_keys = [key for key in _REQUIRED_DATA_KEYS if key not in plan_data]
+
+    trajectory_issues: list[str] = []
+    baseline_raw = plan_data.get("baseline")
+    baseline = baseline_raw if isinstance(baseline_raw, dict) else {}
+    target_raw = plan_data.get("target")
+    target = target_raw if isinstance(target_raw, dict) else {}
+
+    if not baseline:
+        trajectory_issues.append("baseline: missing or not an object")
+    if not target:
+        trajectory_issues.append("target: missing or not an object")
+
+    for metric, baseline_value in baseline.items():
+        target_value = target.get(metric)
+        if isinstance(baseline_value, (int, float)):
+            if not isinstance(target_value, (int, float)):
+                trajectory_issues.append(f"{metric}: missing numeric target")
+            elif target_value < baseline_value:
+                trajectory_issues.append(
+                    f"{metric}: target {target_value} below baseline {baseline_value}"
+                )
+
+    owner_issues: list[str] = []
+    for owner_field in ("owner", "rollback_owner"):
+        value = plan_data.get(owner_field)
+        if not isinstance(value, str) or not value.strip():
+            owner_issues.append(f"{owner_field}: missing owner assignment")
+
+    hygiene_issues: list[str] = []
+    contributors = plan_data.get("contributors")
+    if not isinstance(contributors, list) or not contributors:
+        hygiene_issues.append("contributors: must contain at least one contributor")
+    elif not all(isinstance(item, str) and item.strip() for item in contributors):
+        hygiene_issues.append("contributors: every contributor must be a non-empty string")
+
+    channels = plan_data.get("upgrade_channels")
+    if not isinstance(channels, list) or not channels:
+        hygiene_issues.append("upgrade_channels: must contain at least one lane")
+    elif not all(isinstance(item, str) and item.strip() for item in channels):
+        hygiene_issues.append("upgrade_channels: every channel must be a non-empty string")
+
+    confidence_floor = plan_data.get("confidence_floor")
+    if not isinstance(confidence_floor, (int, float)) or not (0 <= confidence_floor <= 1):
+        hygiene_issues.append("confidence_floor: must be a number between 0 and 1")
+
+    cadence_days = plan_data.get("cadence_days")
+    if not isinstance(cadence_days, int) or cadence_days <= 0:
+        hygiene_issues.append("cadence_days: must be a positive integer")
+
+    return missing_keys, trajectory_issues, owner_issues, hygiene_issues
+
+
+def build_continuous_upgrade_cycle8_closeout_summary(root: Path) -> dict[str, Any]:
+    readme_text = _read_text(root / "README.md")
+    docs_index_text = _read_text(root / "docs/index.md")
+    page_text = _read_text(root / _PAGE_PATH)
+    top10_text = _read_text(root / _TOP10_PATH)
+    cycle7_summary = root / _PREV_CYCLE_SUMMARY_PATH
+    cycle7_board = root / _PREV_CYCLE_BOARD_PATH
+
+    cycle7_data = _load_json(cycle7_summary)
+    cycle7_summary_data = (
+        cycle7_data.get("summary", {}) if isinstance(cycle7_data.get("summary"), dict) else {}
+    )
+    cycle7_score = int(cycle7_summary_data.get("activation_score", 0) or 0)
+    cycle7_strict = bool(cycle7_summary_data.get("strict_pass", False))
+    cycle7_check_count = (
+        len(cycle7_data.get("checks", [])) if isinstance(cycle7_data.get("checks"), list) else 0
+    )
+
+    board_text = _read_text(cycle7_board)
+    board_count = _checklist_count(board_text)
+    board_has_cycle7 = "Cycle 7" in board_text
+
+    missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
+    missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
+    missing_contract_lines = [line for line in _REQUIRED_CONTRACT_LINES if line not in page_text]
+    missing_quality_lines = [line for line in _REQUIRED_QUALITY_LINES if line not in page_text]
+    missing_board_items = [item for item in _REQUIRED_DELIVERY_BOARD_LINES if item not in page_text]
+
+    plan_data = _load_json(root / _PLAN_PATH)
+    missing_plan_keys, plan_trajectory_issues, plan_owner_issues, plan_hygiene_issues = (
+        _validate_plan_contract(plan_data)
+    )
+
+    checks: list[dict[str, Any]] = [
+        {
+            "check_id": "readme_cycle8_command",
+            "weight": 5,
+            "passed": ("continuous-upgrade-cycle8-closeout" in readme_text),
+            "evidence": "README cycle8 command lane",
+        },
+        {
+            "check_id": "docs_index_cycle8_links",
+            "weight": 8,
+            "passed": (
+                "continuous-upgrade-cycle8-big-upgrade-report.md" in docs_index_text
+                and "integrations-continuous-upgrade-cycle8-closeout.md" in docs_index_text
+            ),
+            "evidence": "continuous-upgrade-cycle8-big-upgrade-report.md + integrations-continuous-upgrade-cycle8-closeout.md",
+        },
+        {
+            "check_id": "top10_cycle8_align",
+            "weight": 5,
+            "passed": (("Cycle 7" in top10_text or "Day 97" in top10_text) and "Cycle 8" in top10_text),
+            "evidence": "Cycle 7/Day 97 + Cycle 8 strategy chain",
+        },
+        {
+            "check_id": "cycle7_summary_present",
+            "weight": 10,
+            "passed": cycle7_summary.exists(),
+            "evidence": str(cycle7_summary),
+        },
+        {
+            "check_id": "cycle7_delivery_board_present",
+            "weight": 7,
+            "passed": cycle7_board.exists(),
+            "evidence": str(cycle7_board),
+        },
+        {
+            "check_id": "cycle7_quality_floor",
+            "weight": 13,
+            "passed": cycle7_score >= 85 and cycle7_strict,
+            "evidence": {
+                "cycle7_score": cycle7_score,
+                "strict_pass": cycle7_strict,
+                "cycle7_checks": cycle7_check_count,
+            },
+        },
+        {
+            "check_id": "cycle7_board_integrity",
+            "weight": 5,
+            "passed": board_count >= 5 and board_has_cycle7,
+            "evidence": {"board_items": board_count, "contains_cycle7": board_has_cycle7},
+        },
+        {
+            "check_id": "page_header",
+            "weight": 7,
+            "passed": _SECTION_HEADER in page_text,
+            "evidence": _SECTION_HEADER,
+        },
+        {
+            "check_id": "required_sections",
+            "weight": 8,
+            "passed": not missing_sections,
+            "evidence": missing_sections or "all sections present",
+        },
+        {
+            "check_id": "required_commands",
+            "weight": 5,
+            "passed": not missing_commands,
+            "evidence": missing_commands or "all commands present",
+        },
+        {
+            "check_id": "contract_lock",
+            "weight": 5,
+            "passed": not missing_contract_lines,
+            "evidence": missing_contract_lines or "contract locked",
+        },
+        {
+            "check_id": "quality_checklist_lock",
+            "weight": 5,
+            "passed": not missing_quality_lines,
+            "evidence": missing_quality_lines or "quality checklist locked",
+        },
+        {
+            "check_id": "delivery_board_lock",
+            "weight": 5,
+            "passed": not missing_board_items,
+            "evidence": missing_board_items or "delivery board locked",
+        },
+        {
+            "check_id": "evidence_plan_data_present",
+            "weight": 4,
+            "passed": not missing_plan_keys,
+            "evidence": missing_plan_keys or _PLAN_PATH,
+        },
+        {
+            "check_id": "evidence_plan_targets_non_regressive",
+            "weight": 4,
+            "passed": not plan_trajectory_issues,
+            "evidence": plan_trajectory_issues or "target metrics are non-regressive",
+        },
+        {
+            "check_id": "evidence_plan_owner_coverage",
+            "weight": 2,
+            "passed": not plan_owner_issues,
+            "evidence": plan_owner_issues or "owner + rollback owner assigned",
+        },
+        {
+            "check_id": "evidence_plan_hygiene",
+            "weight": 2,
+            "passed": not plan_hygiene_issues,
+            "evidence": plan_hygiene_issues or "contributors/channels/confidence/cadence validated",
+        },
+    ]
+
+    failed = [c for c in checks if not c["passed"]]
+    critical_failures: list[str] = []
+    if not cycle7_summary.exists() or not cycle7_board.exists():
+        critical_failures.append("cycle7_handoff_inputs")
+
+    wins: list[str] = []
+    misses: list[str] = []
+    handoff_actions: list[str] = []
+
+    if cycle7_score >= 85 and cycle7_strict:
+        wins.append(f"Cycle 8 continuity baseline is stable with activation score={cycle7_score}.")
+    else:
+        misses.append("Cycle 8 continuity baseline is below the floor (<85) or not strict-pass.")
+        handoff_actions.append(
+            "Re-run Cycle 7 closeout command and raise baseline quality above 85 with strict pass before Cycle 8 lock."
+        )
+
+    if board_count >= 5 and board_has_cycle7:
+        wins.append(
+            f"Cycle 8 predecessor delivery board integrity validated with {board_count} checklist items."
+        )
+    else:
+        misses.append(
+            "Cycle 8 predecessor delivery board integrity is incomplete (needs >=5 items and Cycle 7 anchors)."
+        )
+        handoff_actions.append("Repair predecessor delivery board entries to include Cycle 7 anchors.")
+
+    if not missing_plan_keys:
+        wins.append("Cycle 8 continuous upgrade dataset is available for governance execution.")
+    else:
+        misses.append("Cycle 8 continuous upgrade dataset is missing required keys.")
+        handoff_actions.append(
+            "Update docs/roadmap/plans/continuous-upgrade-cycle8-plan.json to restore required keys."
+        )
+
+    if not plan_trajectory_issues:
+        wins.append("Cycle 8 target metrics are non-regressive against baseline metrics.")
+    else:
+        misses.append("Cycle 8 target metrics regress against baseline metrics.")
+        handoff_actions.append(
+            "Adjust docs/roadmap/plans/continuous-upgrade-cycle8-plan.json target metrics so each numeric target is >= baseline."
+        )
+
+    if not plan_owner_issues:
+        wins.append("Cycle 8 owner coverage includes both execution and rollback ownership.")
+    else:
+        misses.append("Cycle 8 owner coverage is missing execution and/or rollback ownership.")
+        handoff_actions.append(
+            "Assign both owner and rollback_owner in docs/roadmap/plans/continuous-upgrade-cycle8-plan.json."
+        )
+
+    if not plan_hygiene_issues:
+        wins.append(
+            "Cycle 8 plan hygiene checks passed for contributors/channels/confidence/cadence."
+        )
+    else:
+        misses.append(
+            "Cycle 8 plan hygiene checks failed for contributors/channels/confidence/cadence."
+        )
+        handoff_actions.append(
+            "Fix contributors/upgrade_channels list shapes and confidence_floor/cadence_days bounds in docs/roadmap/plans/continuous-upgrade-cycle8-plan.json."
+        )
+
+    if not failed and not critical_failures:
+        wins.append(
+            "Cycle 8 continuous upgrade closeout lane is fully complete and ready for continuous-upgrade backlog execution."
+        )
+
+    score = int(round(sum(c["weight"] for c in checks if c["passed"])))
+    return {
+        "name": "continuous-upgrade-cycle8-closeout",
+        "inputs": {
+            "readme": "README.md",
+            "docs_index": "docs/index.md",
+            "docs_page": _PAGE_PATH,
+            "top10": _TOP10_PATH,
+            "cycle7_summary": str(cycle7_summary.relative_to(root))
+            if cycle7_summary.exists()
+            else str(cycle7_summary),
+            "cycle7_delivery_board": str(cycle7_board.relative_to(root))
+            if cycle7_board.exists()
+            else str(cycle7_board),
+            "continuous_upgrade_plan": _PLAN_PATH,
+        },
+        "checks": checks,
+        "rollup": {
+            "cycle7_activation_score": cycle7_score,
+            "cycle7_checks": cycle7_check_count,
+            "cycle7_delivery_board_items": board_count,
+        },
+        "summary": {
+            "activation_score": score,
+            "passed_checks": len(checks) - len(failed),
+            "failed_checks": len(failed),
+            "critical_failures": critical_failures,
+            "strict_pass": not failed and not critical_failures,
+        },
+        "wins": wins,
+        "misses": misses,
+        "handoff_actions": handoff_actions,
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Cycle 8 continuous upgrade closeout summary",
+        f"- Activation score: {payload['summary']['activation_score']}",
+        f"- Passed checks: {payload['summary']['passed_checks']}",
+        f"- Failed checks: {payload['summary']['failed_checks']}",
+        f"- Critical failures: {payload['summary']['critical_failures']}",
+    ]
+    return "\n".join(lines)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
+    target = pack_dir if pack_dir.is_absolute() else root / pack_dir
+    _write(
+        target / "continuous-upgrade-cycle8-closeout-summary.json",
+        json.dumps(payload, indent=2) + "\n",
+    )
+    _write(
+        target / "continuous-upgrade-cycle8-closeout-summary.md", _render_text(payload) + "\n"
+    )
+    _write(target / "cycle8-evidence-brief.md", "# Cycle 8 continuous upgrade brief\n")
+    _write(target / "cycle8-continuous-upgrade-plan.md", "# Cycle 8 continuous upgrade plan\n")
+    _write(
+        target / "cycle8-upgrade-template-upgrade-ledger.json",
+        json.dumps({"upgrades": []}, indent=2) + "\n",
+    )
+    _write(
+        target / "cycle8-storyline-outcomes-ledger.json",
+        json.dumps({"outcomes": []}, indent=2) + "\n",
+    )
+    _write(target / "cycle8-upgrade-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "cycle8-execution-log.md", "# Cycle 8 execution log\n")
+    _write(
+        target / "cycle8-delivery-board.md",
+        "\n".join(["# Cycle 8 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+    )
+    _write(
+        target / "cycle8-validation-commands.md",
+        "# Cycle 8 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+    )
+
+
+def _execute_commands(root: Path, evidence_dir: Path) -> dict[str, Any]:
+    events: list[dict[str, Any]] = []
+    out_dir = evidence_dir if evidence_dir.is_absolute() else root / evidence_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, command in enumerate(_EXECUTION_COMMANDS, start=1):
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable
+        result = subprocess.run(argv, cwd=root, capture_output=True, text=True)
+        event = {
+            "command": command,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+        events.append(event)
+        _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
+    failed_commands = [event for event in events if int(event["returncode"]) != 0]
+    summary = {
+        "total_commands": len(events),
+        "failed_commands": len(failed_commands),
+        "strict_pass": not failed_commands,
+        "commands": events,
+    }
+    _write(
+        out_dir / "cycle8-execution-summary.json",
+        json.dumps(summary, indent=2) + "\n",
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Cycle 8 continuous upgrade closeout checks")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--emit-pack-dir")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--evidence-dir")
+    parser.add_argument("--write-default-doc", action="store_true")
+    ns = parser.parse_args(argv)
+
+    root = Path(ns.root).resolve()
+    if ns.write_default_doc:
+        _write(root / _PAGE_PATH, _CYCLE8_DEFAULT_PAGE)
+
+    payload = build_continuous_upgrade_cycle8_closeout_summary(root)
+
+    if ns.emit_pack_dir:
+        _emit_pack(root, Path(ns.emit_pack_dir), payload)
+    if ns.execute:
+        evidence_dir = (
+            Path(ns.evidence_dir)
+            if ns.evidence_dir
+            else Path("docs/artifacts/continuous-upgrade-cycle8-closeout-pack/evidence")
+        )
+        execution_summary = _execute_commands(root, evidence_dir)
+        payload["execution"] = execution_summary
+
+    print(json.dumps(payload, indent=2) if ns.format == "json" else _render_text(payload))
+    strict_failed = not payload["summary"]["strict_pass"]
+    if ns.execute:
+        strict_failed = strict_failed or not bool(
+            payload.get("execution", {}).get("strict_pass", True)
+        )
+    return 1 if ns.strict and strict_failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_continuous_upgrade_cycle8_closeout.py
+++ b/tests/test_continuous_upgrade_cycle8_closeout.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit import continuous_upgrade_cycle8_closeout as d98
+
+
+def _seed_repo(root: Path) -> None:
+    (root / "templates/ci/gitlab").mkdir(parents=True, exist_ok=True)
+    (root / "templates/ci/jenkins").mkdir(parents=True, exist_ok=True)
+    (root / "templates/ci/tekton").mkdir(parents=True, exist_ok=True)
+    (root / "docs/roadmap/plans").mkdir(parents=True, exist_ok=True)
+    (root / "docs/roadmap/reports").mkdir(parents=True, exist_ok=True)
+    (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_text(
+        "docs/integrations-continuous-upgrade-cycle8-closeout.md\ncontinuous-upgrade-cycle8-closeout\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "continuous-upgrade-cycle8-big-upgrade-report.md\nintegrations-continuous-upgrade-cycle8-closeout.md\n",
+        encoding="utf-8",
+    )
+    (root / "docs/top-10-github-strategy.md").write_text(
+        "- **Cycle 7 — Continuous upgrade closeout lane:** close Cycle 7 continuous-upgrade quality loop.\n"
+        "- **Cycle 8 — Continuous upgrade closeout lane:** start next-cycle continuous upgrade execution.\n",
+        encoding="utf-8",
+    )
+    (root / "docs/integrations-continuous-upgrade-cycle8-closeout.md").write_text(
+        d98._CYCLE8_DEFAULT_PAGE, encoding="utf-8"
+    )
+    (root / "docs/continuous-upgrade-cycle8-big-upgrade-report.md").write_text("# Cycle 8 report\n", encoding="utf-8")
+    (root / "scripts").mkdir(parents=True, exist_ok=True)
+    (root / "scripts/check_continuous_upgrade_cycle8_closeout_contract.py").write_text(
+        "from __future__ import annotations\n"
+        "\n"
+        "if __name__ == '__main__':\n"
+        "    raise SystemExit(0)\n",
+        encoding="utf-8",
+    )
+
+    summary = (
+        root
+        / "docs/artifacts/continuous-upgrade-cycle7-closeout-pack/cycle7-continuous-upgrade-cycle7-closeout-summary.json"
+    )
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(
+        json.dumps(
+            {
+                "summary": {"activation_score": 100, "strict_pass": True},
+                "checks": [{"passed": True}],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    board = (
+        root
+        / "docs/artifacts/continuous-upgrade-cycle7-closeout-pack/cycle7-delivery-board.md"
+    )
+    board.write_text(
+        "\n".join(
+            [
+                "# Cycle 7 delivery board",
+                "- [ ] Cycle 7 evidence brief committed",
+                "- [ ] Cycle 7 continuous upgrade plan committed",
+                "- [ ] Cycle 7 upgrade template upgrade ledger exported",
+                "- [ ] Cycle 7 storyline outcomes ledger exported",
+                "- [ ] Next-cycle roadmap draft captured from Cycle 7 outcomes",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    plan = root / "docs/roadmap/plans/continuous-upgrade-cycle8-plan.json"
+    plan.write_text(
+        json.dumps(
+            {
+                "plan_id": "cycle8-continuous-upgrade-001",
+                "contributors": ["maintainers", "release-ops"],
+                "upgrade_channels": ["readme", "docs-index", "cli-lanes"],
+                "baseline": {"strict_pass_rate": 0.9, "doc_link_coverage": 0.88},
+                "target": {"strict_pass_rate": 1.0, "doc_link_coverage": 0.97},
+                "owner": "release-ops",
+                "rollback_owner": "incident-ops",
+                "confidence_floor": 0.9,
+                "cadence_days": 7,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_cycle8_json(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = d98.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "continuous-upgrade-cycle8-closeout"
+    assert out["summary"]["activation_score"] >= 95
+
+
+def test_cycle8_emit_pack_and_execute(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    rc = d98.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--emit-pack-dir",
+            "artifacts/cycle8-pack",
+            "--execute",
+            "--evidence-dir",
+            "artifacts/cycle8-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    assert (
+        tmp_path / "artifacts/cycle8-pack/continuous-upgrade-cycle8-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/cycle8-pack/continuous-upgrade-cycle8-closeout-summary.md"
+    ).exists()
+    assert (tmp_path / "artifacts/cycle8-pack/cycle8-evidence-brief.md").exists()
+    assert (tmp_path / "artifacts/cycle8-pack/cycle8-continuous-upgrade-plan.md").exists()
+    assert (tmp_path / "artifacts/cycle8-pack/cycle8-upgrade-template-upgrade-ledger.json").exists()
+    assert (tmp_path / "artifacts/cycle8-pack/cycle8-storyline-outcomes-ledger.json").exists()
+    assert (tmp_path / "artifacts/cycle8-pack/cycle8-upgrade-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/cycle8-pack/cycle8-execution-log.md").exists()
+    assert (tmp_path / "artifacts/cycle8-pack/cycle8-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/cycle8-pack/cycle8-validation-commands.md").exists()
+    execution_summary = tmp_path / "artifacts/cycle8-pack/evidence/cycle8-execution-summary.json"
+    assert execution_summary.exists()
+    execution_data = json.loads(execution_summary.read_text(encoding="utf-8"))
+    assert execution_data["failed_commands"] == 0
+    assert execution_data["strict_pass"] is True
+
+
+def test_cycle8_execute_strict_fails_on_command_error(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.setattr(d98, "_EXECUTION_COMMANDS", ['python -c "import sys; sys.exit(3)"'])
+    rc = d98.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--execute",
+            "--evidence-dir",
+            "artifacts/cycle8-pack/evidence",
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 1
+    execution_summary = tmp_path / "artifacts/cycle8-pack/evidence/cycle8-execution-summary.json"
+    execution_data = json.loads(execution_summary.read_text(encoding="utf-8"))
+    assert execution_data["failed_commands"] == 1
+    assert execution_data["strict_pass"] is False
+
+
+def test_cycle8_strict_fails_without_cycle7(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (
+        tmp_path
+        / "docs/artifacts/continuous-upgrade-cycle7-closeout-pack/cycle7-continuous-upgrade-cycle7-closeout-summary.json"
+    ).unlink()
+    assert d98.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
+
+
+def test_cycle8_cli_dispatch(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    rc = cli.main(
+        ["continuous-upgrade-cycle8-closeout", "--root", str(tmp_path), "--format", "text"]
+    )
+    assert rc == 0
+    assert "Cycle 8 continuous upgrade closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation

- Introduce a Cycle 8 continuous-upgrade closeout lane to convert Cycle 7 outcomes into a deterministic next-cycle execution and governance handoff.  
- Provide automated checks, deterministic pack emission, and execution evidence to gate Cycle 8 readiness with strict contract validation.

### Description

- Added a new CLI entry `continuous-upgrade-cycle8-closeout` and wired it into `src/sdetkit/cli.py` to dispatch the new lane.  
- Implemented the closeout logic in `src/sdetkit/continuous_upgrade_cycle8_closeout.py`, including summary building (`build_continuous_upgrade_cycle8_closeout_summary`), pack emission (`_emit_pack`), execution (`_execute_commands`), and strict pass semantics.  
- Added documentation and artifacts: updated `README.md` hero commands, added `docs/integrations-continuous-upgrade-cycle8-closeout.md`, `docs/continuous-upgrade-cycle8-big-upgrade-report.md`, and `docs/roadmap/reports/continuous-upgrade-cycle8-big-upgrade-report.md`, and updated `docs/index.md` and `docs/top-10-github-strategy.md`.  
- Added plan data `plans/continuous-upgrade-cycle8-plan.json`, a contract-check script `scripts/check_continuous_upgrade_cycle8_closeout_contract.py`, and comprehensive tests `tests/test_continuous_upgrade_cycle8_closeout.py` that seed a repo, validate JSON/text output, emit packs, run execution, and exercise CLI dispatch.

### Testing

- Ran the new unit test module with `pytest tests/test_continuous_upgrade_cycle8_closeout.py`, which executed pack emission, execution paths, strict-fail scenarios, and CLI dispatch, and all tests passed.  
- The contract-check script is exercised by the tests via the seeded `scripts/check_continuous_upgrade_cycle8_closeout_contract.py` shim and returned expected results during execution.  
- Verified `python -m sdetkit continuous-upgrade-cycle8-closeout` dispatch via the CLI unit test which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b4723acd0c83208b64cd629b553362)