### PR TITLE
Add upgrade-audit script and Makefile target to report latest PyPI versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # --- dev targets (bootstrap) ---
 
-.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan
+.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit
 
 venv:
 	@test -x .venv/bin/python || python3 -m venv .venv
@@ -40,3 +40,7 @@ release-preflight: venv
 
 release-verify-plan: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python scripts/release_verify_post_publish.py --plan'
+
+
+upgrade-audit: venv
+	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python scripts/upgrade_audit.py'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ python -m sdetkit forensics bundle --run examples/kits/forensics/run-b.json --ou
 python -m sdetkit continuous-upgrade-name8-closeout --format json --strict
 ```
 
+## Upgrade planning (first step)
+
+Run a direct dependency audit against PyPI to identify candidate upgrades:
+
+```bash
+make upgrade-audit
+```
+
 ## Sample artifacts
 
 - `examples/kits/intelligence/*`

--- a/scripts/upgrade_audit.py
+++ b/scripts/upgrade_audit.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Audit direct dependencies and report latest PyPI versions.
+
+This script is intended as a first step for planning repository upgrades.
+It reads direct dependencies from pyproject.toml and fetches each package's
+latest release metadata from PyPI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REQ_NAME_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)")
+
+
+@dataclass(frozen=True)
+class Dependency:
+    group: str
+    raw: str
+    name: str
+
+
+def _parse_dep_name(raw_requirement: str) -> str:
+    match = REQ_NAME_RE.match(raw_requirement)
+    if not match:
+        return raw_requirement.strip()
+    return match.group(1).lower().replace("_", "-")
+
+
+def _load_dependencies(pyproject_path: Path) -> list[Dependency]:
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    project = data.get("project", {})
+    deps: list[Dependency] = []
+
+    for dep in project.get("dependencies", []):
+        deps.append(Dependency(group="default", raw=dep, name=_parse_dep_name(dep)))
+
+    for group, group_deps in project.get("optional-dependencies", {}).items():
+        for dep in group_deps:
+            deps.append(Dependency(group=group, raw=dep, name=_parse_dep_name(dep)))
+
+    return deps
+
+
+def _latest_pypi_version(package: str, timeout_s: float) -> str:
+    url = f"https://pypi.org/pypi/{package}/json"
+    request = urllib.request.Request(url, headers={"User-Agent": "sdetkit-upgrade-audit/1.0"})
+    with urllib.request.urlopen(request, timeout=timeout_s) as response:  # noqa: S310
+        payload = json.loads(response.read().decode("utf-8"))
+    version = payload.get("info", {}).get("version")
+    if not version:
+        return "unknown"
+    return str(version)
+
+
+def run(pyproject_path: Path, timeout_s: float) -> int:
+    dependencies = _load_dependencies(pyproject_path)
+
+    if not dependencies:
+        print("No dependencies found in pyproject.toml.")
+        return 0
+
+    print("# Upgrade audit (direct dependencies)")
+    print()
+    print(f"Source: `{pyproject_path}`")
+    print()
+    print("| Group | Requirement | Latest PyPI |")
+    print("|---|---|---|")
+
+    for dep in dependencies:
+        try:
+            latest = _latest_pypi_version(dep.name, timeout_s=timeout_s)
+        except urllib.error.HTTPError as exc:
+            latest = f"http-{exc.code}"
+        except urllib.error.URLError:
+            latest = "network-error"
+
+        print(f"| `{dep.group}` | `{dep.raw}` | `{latest}` |")
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Report the latest PyPI versions for direct dependencies in pyproject.toml."
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="Path to pyproject.toml (default: ./pyproject.toml)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds for each PyPI request (default: 10)",
+    )
+    args = parser.parse_args()
+
+    if not args.pyproject.exists():
+        print(f"error: file not found: {args.pyproject}", file=sys.stderr)
+        return 2
+
+    return run(args.pyproject, timeout_s=args.timeout)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a low-risk, repeatable first step for repository upgrades by inventorying direct dependencies and their latest PyPI releases.  
- Give maintainers quick visibility into candidate upgrades across normal and optional dependency groups.  

### Description

- Add `scripts/upgrade_audit.py` which parses `pyproject.toml` for `dependencies` and `optional-dependencies`, queries the PyPI JSON API for each package, and prints a Markdown table of `Group`, `Requirement`, and `Latest PyPI` version.  
- Add a `make upgrade-audit` target to the `Makefile` to run the audit inside the project virtualenv.  
- Document the new workflow by adding an "Upgrade planning (first step)" section to `README.md` that points to `make upgrade-audit`.  
- The script handles `HTTPError` and `URLError` and prints fallback tokens like `http-<code>` and `network-error` when appropriate.  

### Testing

- Ran `python scripts/upgrade_audit.py --timeout 5` and observed a Markdown table of dependencies and latest versions, which succeeded.  
- Ran `make upgrade-audit` to exercise the Makefile target in the project `venv` workflow, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b552d1bdc88320977ca6a765ca3bc9)