### PR TITLE
Default phase-boost `--start-date` to today (ISO)

### DIFF
--- a/src/sdetkit/phase_boost.py
+++ b/src/sdetkit/phase_boost.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -127,7 +128,11 @@ def _parser() -> argparse.ArgumentParser:
         description="Generate a production-ready 90-impact, 3-phase boost plan.",
     )
     parser.add_argument("--repo-name", default="DevS69-sdetkit", help="Repository name in output.")
-    parser.add_argument("--start-date", default="TBD", help="Program start date label.")
+    parser.add_argument(
+        "--start-date",
+        default=date.today().isoformat(),
+        help="Program start date label (defaults to today in ISO format).",
+    )
     parser.add_argument(
         "--output",
         type=Path,

--- a/tests/test_phase_boost.py
+++ b/tests/test_phase_boost.py
@@ -40,3 +40,9 @@ def test_phase_boost_cli_writes_markdown_and_json(tmp_path: Path):
 
     assert "S-class production readiness" in md_text
     assert payload["repository"] == "repo-prod"
+
+
+def test_phase_boost_parser_defaults_start_date_to_today_iso():
+    args = phase_boost._parser().parse_args([])
+
+    assert args.start_date == phase_boost.date.today().isoformat()


### PR DESCRIPTION
### Motivation
- Make the `phase-boost` CLI produce a sensible default start date by using today in ISO format instead of the static `"TBD"` label so generated artifacts include a meaningful timestamp.

### Description
- Change the `--start-date` default in `src/sdetkit/phase_boost.py` to `date.today().isoformat()`, add `from datetime import date`, update the argument help text, and add the regression test `test_phase_boost_parser_defaults_start_date_to_today_iso` in `tests/test_phase_boost.py`.

### Testing
- Ran `pytest -q tests/test_phase_boost.py` and it passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b5860c6aa88320830a381fa0ee1a4d)