### PR TITLE
refactor(playbooks): filter day-token names from search results

### DIFF
--- a/src/sdetkit/playbooks_cli.py
+++ b/src/sdetkit/playbooks_cli.py
@@ -90,6 +90,10 @@ _DISABLED_SERIES_GENERIC_ALIAS_MODULES: set[str] = {
 }
 
 
+def _contains_day_token(name: str) -> bool:
+    return "day" in re.split(r"[^a-z0-9]+", name.lower())
+
+
 def _cmd_to_mod(cmd: str) -> str:
     return cmd.replace("-", "_")
 
@@ -173,16 +177,28 @@ def _build_registry(pkg_dir: Path) -> tuple[dict[str, str], dict[str, str]]:
 
 
 def _apply_search_list(xs: list[str], search: str | None) -> list[str]:
+    xs = [x for x in xs if not _contains_day_token(x)]
     if not search:
         return xs
     s = search.lower()
+    if _contains_day_token(s):
+        s = " ".join(tok for tok in re.split(r"[^a-z0-9]+", s) if tok != "day")
+        s = s.strip()
+        if not s:
+            return xs
     return [x for x in xs if s in x.lower()]
 
 
 def _apply_search_aliases(d: dict[str, str], search: str | None) -> dict[str, str]:
+    d = {k: v for k, v in d.items() if not _contains_day_token(k) and not _contains_day_token(v)}
     if not search:
         return d
     s = search.lower()
+    if _contains_day_token(s):
+        s = " ".join(tok for tok in re.split(r"[^a-z0-9]+", s) if tok != "day")
+        s = s.strip()
+        if not s:
+            return d
     return {k: v for k, v in d.items() if (s in k.lower()) or (s in v.lower())}
 
 

--- a/tests/test_playbooks_cli_extra.py
+++ b/tests/test_playbooks_cli_extra.py
@@ -15,10 +15,18 @@ def test_alias_helpers_and_discovery(tmp_path: Path) -> None:
     mods = pc._discover_legacy_modules(tmp_path)
     assert "day77_community_touchpoint_closeout" in mods
     assert (
-        pc._alias_for_day_closeout("day77_community_touchpoint_closeout")
+        pc._alias_for_series_closeout("day77_community_touchpoint_closeout")
         == "community-touchpoint-closeout"
     )
-    assert pc._alias_for_day_module("day99_custom") == "custom"
+    assert pc._alias_for_series_module("day99_custom") == "custom"
+
+
+def test_search_filters_day_tokens() -> None:
+    assert pc._apply_search_list(["day-review", "weekly-review"], None) == ["weekly-review"]
+    assert pc._apply_search_list(["weekly-review", "release"], "day weekly") == ["weekly-review"]
+    assert pc._apply_search_aliases({"day-alias": "weekly-review", "stable": "release"}, None) == {
+        "stable": "release"
+    }
 
 
 def test_cmd_run_unknown_and_validate_unknown(monkeypatch, capsys) -> None:


### PR DESCRIPTION
### Motivation
- Legacy numeric-series playbook names containing the token `day` should be hidden from most discovery/search UX so users see productized names by default.
- Searches that include the word `day` should still be useful by matching the remaining meaningful terms rather than returning only `day`-prefixed names.

### Description
- Added helper `
_contains_day_token(name: str) -> bool` to detect standalone `day` tokens in names or search input.
- Updated `
_apply_search_list` to exclude playbook names containing `day` tokens and to strip `day` from search queries before matching.
- Updated `
_apply_search_aliases` to filter out alias entries that contain `day` tokens and to normalize search terms by removing `day` before matching.
- Adjusted tests in `tests/test_playbooks_cli_extra.py` to use the existing series helpers (`_alias_for_series_closeout` / `_alias_for_series_module`) and added `test_search_filters_day_tokens` to cover the new filtering behavior.
- Files changed: `src/sdetkit/playbooks_cli.py` and `tests/test_playbooks_cli_extra.py`.

### Testing
- Ran `pytest -q tests/test_playbooks_cli_extra.py tests/test_coverage_boost_targets.py` and all tests passed (`15 passed`).
- New unit test `test_search_filters_day_tokens` verifies that `day`-prefixed names are filtered and that search terms containing `day` still match remaining tokens.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b5ca9cd580832093c13945b9808e1c)