### PR TITLE
Fix editable Dagster install paths in Dockerfile.problem

### DIFF
--- a/Dockerfile.problem
+++ b/Dockerfile.problem
@@ -1,0 +1,22 @@
+FROM public.ecr.aws/x8v8d7g8/mars-base:latest
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /app
+
+# Use explicit relative paths for editable installs; pip can reject ambiguous paths.
+RUN test -d ./python_modules/dagster-pipes \
+ && test -d ./python_modules/dagster \
+ && python -m pip install --upgrade pip setuptools wheel \
+ && python -m pip install -e ./python_modules/dagster-pipes \
+ && python -m pip install -e "./python_modules/dagster[test]" \
+ && python - <<'PY'
+import dagster
+import dagster_shared
+print("docker dagster env ok")
+PY


### PR DESCRIPTION
### Motivation
- Reproduce and fix a Docker build failure where pip reports `python_modules/dagster-pipes is not a valid editable requirement` during image build. 
- Ensure editable installs use unambiguous local paths so pip accepts them in non-standard build contexts. 
- Provide clearer early failure signals when the expected local module directories are missing.

### Description
- Add `Dockerfile.problem` that mirrors the failing Dagster build flow and includes a final smoke test importing `dagster` and `dagster_shared`.
- Change editable installs to explicit relative paths by using `./python_modules/dagster-pipes` and `./python_modules/dagster[test]` to avoid pip rejecting ambiguous local requirements.
- Add preflight `test -d ./python_modules/dagster-pipes` and `test -d ./python_modules/dagster` checks so missing directories fail fast with a clear message.

### Testing
- Ran `git status --short` and `nl -ba Dockerfile.problem` to verify the file was added and contents look correct, and both succeeded. 
- Attempted `docker build -f Dockerfile.problem .` to validate the image build, but it failed in this environment with `bash: command not found: docker` so the build could not be executed here. 
- Reviewed the Dockerfile command ordering and shell syntax for correctness, and no syntax errors were detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b5f9960a2c83209d36292f30eb949c)