### PR TITLE
Fix triage tee output when target directory does not exist

### DIFF
--- a/tools/triage.py
+++ b/tools/triage.py
@@ -344,6 +344,7 @@ def _run_security_check(args: argparse.Namespace, root: Path) -> tuple[int, str]
     if args.tee:
         try:
             tee_path = _safe_user_path(root, str(args.tee))
+            tee_path.parent.mkdir(parents=True, exist_ok=True)
             tee_path.write_text(out, encoding="utf-8")
         except (OSError, ValueError) as exc:
             print(f"triage: failed to write tee output to {args.tee!r}: {exc}", file=sys.stderr)
@@ -365,6 +366,7 @@ def _run_pytest(args: argparse.Namespace, root: Path) -> tuple[int, str]:
     if args.tee:
         try:
             tee_path = _safe_user_path(root, str(args.tee))
+            tee_path.parent.mkdir(parents=True, exist_ok=True)
             tee_path.write_text(out, encoding="utf-8")
         except (OSError, ValueError) as exc:
             # Best-effort: failing to tee output should not be fatal, but log for visibility.


### PR DESCRIPTION
### Motivation
- Prevent failures when writing `--tee` output to nested paths (for example `.sdetkit/out/...`) if the parent directory does not exist, which produced noisy write errors in automated gate runs.

### Description
- Create parent directories before writing tee output by calling `tee_path.parent.mkdir(parents=True, exist_ok=True)` in both `_run_security_check` and `_run_pytest` inside `tools/triage.py`.

### Testing
- Ran `python3 tools/triage.py --mode security --run-security --security-baseline tools/security.baseline.json --max-items 20 --tee '.sdetkit/out/security-check.json'`, which completed and produced tee output successfully.
- Verified `python3 -m py_compile tools/triage.py` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b621d564908320a43aecaf037bf233)