### PR TITLE
Fix ruff F401: remove unused `doctor` import

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -86,7 +86,6 @@ from . import (
     demo,
     docs_navigation,
     docs_qa,
-    doctor,
     enterprise_use_case,
     evidence,
     external_contribution_push,


### PR DESCRIPTION
### Motivation
- Resolve a CI `ruff` failure (`F401 .doctor imported but unused`) caused by an unused `doctor` symbol in the top-level imports of `src/sdetkit/cli.py`.

### Description
- Remove the unused `doctor` import from the import list in `src/sdetkit/cli.py` to eliminate the lint error.

### Testing
- Ran `ruff check src/sdetkit/cli.py` and `python -m sdetkit release gate fast --format json`, and both completed successfully with no `ruff` errors and the release gate reporting OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6293373c88320b205138bef3a169a)