### PR TITLE
Add enterprise integration topology validation (integration topology-check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ python -m sdetkit kits list
 python -m sdetkit release gate release
 python -m sdetkit intelligence failure-fingerprint --failures examples/kits/intelligence/failures.json
 python -m sdetkit integration check --profile examples/kits/integration/profile.json
+python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json
 python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json --fail-on error
 python -m sdetkit forensics bundle --run examples/kits/forensics/run-b.json --output build/repro.zip
 python -m sdetkit continuous-upgrade-cycle9-closeout --format json --strict

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,7 @@ DevS69 SDETKit is organized around four umbrella kits. Use these first.
 - `sdetkit release gate release`
 - `sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json`
 - `sdetkit integration check --profile examples/kits/integration/profile.json`
+- `sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json`
 - `sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json`
 
 ## Compatibility and supporting surfaces

--- a/docs/kits/integration-assurance.md
+++ b/docs/kits/integration-assurance.md
@@ -5,11 +5,13 @@ Provide offline-first confidence that runtime dependencies are actually ready.
 
 ## Inputs
 - Readiness profile JSON (`required_env`, `required_files`, `services`)
+- Topology profile JSON (`topology.application_services`, `topology.data_services`, `topology.mocked_platforms`)
 - Cassette JSON for replay contract validation
 
 ## Outputs / artifacts
 - `sdetkit.integration.profile-check.v1`
 - `sdetkit.integration.matrix.v1`
+- `sdetkit.integration.topology-check.v1`
 - `sdetkit.integration.cassette-validate.v1`
 
 ## Exit-code contract
@@ -18,9 +20,10 @@ Provide offline-first confidence that runtime dependencies are actually ready.
 - `2`: invalid profile/cassette input
 
 ## CI role
-Fail fast before expensive integration runs, and verify replay cassettes are valid and deterministic.
+Fail fast before expensive integration runs, validate heterogeneous enterprise topologies, and verify replay cassettes are valid and deterministic.
 
 ## Example
 ```bash
+sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json
 sdetkit integration cassette-validate --cassette .sdetkit/cassettes/sample.json
 ```

--- a/examples/kits/integration/heterogeneous-topology.json
+++ b/examples/kits/integration/heterogeneous-topology.json
@@ -1,0 +1,60 @@
+{
+  "name": "enterprise-heterogeneous-stack",
+  "topology": {
+    "application_services": [
+      {
+        "name": "edge-gateway",
+        "role": "api-gateway",
+        "language": "go",
+        "error_handling": "typed sentinel + wrapped errors",
+        "logging_format": "zap json",
+        "interfaces": [
+          {"protocol": "rest", "audience": "external"},
+          {"protocol": "graphql", "audience": "dashboard"},
+          {"protocol": "grpc", "audience": "internal"}
+        ]
+      },
+      {
+        "name": "relevance-ml",
+        "role": "ml-serving",
+        "language": "python",
+        "error_handling": "domain exceptions + model fallback",
+        "logging_format": "structlog json",
+        "interfaces": [
+          {"protocol": "grpc", "audience": "internal"}
+        ]
+      },
+      {
+        "name": "search-indexer",
+        "role": "data-pipeline",
+        "language": "rust",
+        "error_handling": "Result<T, E> with anyhow context",
+        "logging_format": "tracing json",
+        "interfaces": [
+          {"protocol": "grpc", "audience": "internal"}
+        ]
+      }
+    ],
+    "data_services": [
+      {"name": "orders-db", "role": "transactional", "technology": "postgresql"},
+      {"name": "session-cache", "role": "cache", "technology": "redis"},
+      {"name": "export-blob", "role": "blob", "technology": "s3-compatible"}
+    ],
+    "mocked_platforms": [
+      {
+        "name": "stripe-like-payments",
+        "api_style": "resource-oriented",
+        "protocol": "rest",
+        "fidelity": ["idempotency", "pagination", "rate-limits"],
+        "operations": ["create-payment-intent", "capture-payment", "refund-payment"]
+      },
+      {
+        "name": "segment-like-events",
+        "api_style": "event-ingest",
+        "protocol": "http",
+        "fidelity": ["batching", "retry-after", "schema-validation"],
+        "operations": ["track", "identify"]
+      }
+    ]
+  }
+}

--- a/src/sdetkit/integration.py
+++ b/src/sdetkit/integration.py
@@ -13,6 +13,18 @@ from .cassette import Cassette
 from .security import SecurityError, safe_path
 
 
+REQUIRED_APP_SERVICE_RULES = (
+    ("api-gateway", "go"),
+    ("ml-serving", "python"),
+    ("data-pipeline", "rust"),
+)
+REQUIRED_DATA_SERVICE_TECH = {
+    "transactional": "postgresql",
+    "cache": "redis",
+    "blob": "s3",
+}
+
+
 def _load_profile(path: Path) -> dict[str, Any]:
     obj = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(obj, dict):
@@ -24,6 +36,27 @@ def _probe_tcp_localhost(port: int, timeout_s: float = 0.2) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(timeout_s)
         return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _normalize(value: Any) -> str:
+    return str(value).strip().lower()
+
+
+def _service_exposes_protocol(service: dict[str, Any], *, protocol: str, audience: str | None = None) -> bool:
+    interfaces = service.get("interfaces", [])
+    if not isinstance(interfaces, list):
+        return False
+    want_protocol = _normalize(protocol)
+    want_audience = _normalize(audience) if audience is not None else None
+    for interface in interfaces:
+        if not isinstance(interface, dict):
+            continue
+        if _normalize(interface.get("protocol")) != want_protocol:
+            continue
+        if want_audience is not None and _normalize(interface.get("audience")) != want_audience:
+            continue
+        return True
+    return False
 
 
 def _evaluate(profile: dict[str, Any]) -> dict[str, Any]:
@@ -78,6 +111,154 @@ def _evaluate(profile: dict[str, Any]) -> dict[str, Any]:
                 if not failed
                 else "Fix failed readiness checks before running integration suites."
             ),
+        },
+    }
+
+
+def _evaluate_topology(profile: dict[str, Any]) -> dict[str, Any]:
+    topology = profile.get("topology")
+    if not isinstance(topology, dict):
+        raise ValueError("profile.topology must be a JSON object")
+
+    app_services = [
+        item for item in topology.get("application_services", []) if isinstance(item, dict)
+    ]
+    data_services = [item for item in topology.get("data_services", []) if isinstance(item, dict)]
+    mocked_platforms = [
+        item for item in topology.get("mocked_platforms", []) if isinstance(item, dict)
+    ]
+
+    checks: list[dict[str, Any]] = []
+
+    language_map = {str(svc.get("name", "service")): _normalize(svc.get("language")) for svc in app_services}
+    role_map = {str(svc.get("role", "")): svc for svc in app_services}
+    distinct_languages = sorted({lang for lang in language_map.values() if lang})
+    checks.append(
+        {
+            "kind": "architecture",
+            "name": "heterogeneous-stack",
+            "passed": len(distinct_languages) >= 3,
+            "evidence": {"languages": distinct_languages, "service_count": len(app_services)},
+            "reason": "Need at least three distinct implementation languages across application services.",
+        }
+    )
+
+    for role, language in REQUIRED_APP_SERVICE_RULES:
+        svc = role_map.get(role)
+        actual_language = _normalize(svc.get("language")) if isinstance(svc, dict) else ""
+        checks.append(
+            {
+                "kind": "application-service",
+                "name": role,
+                "passed": actual_language == language,
+                "expected_language": language,
+                "observed_language": actual_language or None,
+            }
+        )
+
+    for svc in sorted(app_services, key=lambda item: str(item.get("name", ""))):
+        name = str(svc.get("name", "service"))
+        logging_format = _normalize(svc.get("logging_format"))
+        error_style = _normalize(svc.get("error_handling"))
+        checks.append(
+            {
+                "kind": "service-contract",
+                "name": f"{name}:logging-format",
+                "passed": bool(logging_format),
+                "observed": logging_format or None,
+            }
+        )
+        checks.append(
+            {
+                "kind": "service-contract",
+                "name": f"{name}:error-handling",
+                "passed": bool(error_style),
+                "observed": error_style or None,
+            }
+        )
+
+    checks.append(
+        {
+            "kind": "interface",
+            "name": "public-rest",
+            "passed": any(
+                _service_exposes_protocol(svc, protocol="rest", audience="external") for svc in app_services
+            ),
+        }
+    )
+    checks.append(
+        {
+            "kind": "interface",
+            "name": "internal-grpc",
+            "passed": any(
+                _service_exposes_protocol(svc, protocol="grpc", audience="internal") for svc in app_services
+            ),
+        }
+    )
+    checks.append(
+        {
+            "kind": "interface",
+            "name": "dashboard-graphql",
+            "passed": any(
+                _service_exposes_protocol(svc, protocol="graphql", audience="dashboard")
+                for svc in app_services
+            ),
+        }
+    )
+
+    data_by_role = {_normalize(svc.get("role")): _normalize(svc.get("technology")) for svc in data_services}
+    for role, technology in REQUIRED_DATA_SERVICE_TECH.items():
+        observed = data_by_role.get(role, "")
+        matches = observed == technology or (role == "blob" and observed in {"s3", "s3-compatible", "s3-like"})
+        checks.append(
+            {
+                "kind": "data-service",
+                "name": role,
+                "passed": matches,
+                "expected_technology": technology,
+                "observed_technology": observed or None,
+            }
+        )
+
+    for platform in sorted(mocked_platforms, key=lambda item: str(item.get("name", ""))):
+        name = str(platform.get("name", "mocked-platform"))
+        api_style = _normalize(platform.get("api_style"))
+        protocol = _normalize(platform.get("protocol"))
+        fidelity = sorted({_normalize(item) for item in platform.get("fidelity", []) if _normalize(item)})
+        operations = [op for op in platform.get("operations", []) if isinstance(op, str) and op.strip()]
+        checks.append(
+            {
+                "kind": "mock-platform",
+                "name": name,
+                "passed": bool(api_style and protocol and len(operations) >= 2 and fidelity),
+                "api_style": api_style or None,
+                "protocol": protocol or None,
+                "operation_count": len(operations),
+                "fidelity": fidelity,
+            }
+        )
+
+    checks.sort(key=lambda item: (str(item.get("kind", "")), str(item.get("name", ""))))
+    failed = [item for item in checks if not bool(item.get("passed"))]
+    return {
+        "schema_version": "sdetkit.integration.topology-check.v1",
+        "profile_name": str(profile.get("name", "default")),
+        "checks": checks,
+        "summary": {
+            "total": len(checks),
+            "failed": len(failed),
+            "passed": not failed if checks else True,
+            "next_step": (
+                "Topology contract is ready for enterprise integration scenarios."
+                if not failed
+                else "Fill the missing topology contracts before claiming production-grade multi-service readiness."
+            ),
+        },
+        "inventory": {
+            "application_services": sorted(language_map),
+            "languages": distinct_languages,
+            "data_services": sorted(str(item.get("name", item.get("role", "data-service"))) for item in data_services),
+            "mocked_platforms": sorted(str(item.get("name", "mocked-platform")) for item in mocked_platforms),
         },
     }
 
@@ -137,6 +318,11 @@ def main(argv: list[str] | None = None) -> int:
     check.add_argument("--profile", required=True)
     matrix = sub.add_parser("matrix", help="Print compatibility summary in JSON")
     matrix.add_argument("--profile", required=True)
+    topology = sub.add_parser(
+        "topology-check",
+        help="Validate a heterogeneous service topology contract for enterprise integration readiness",
+    )
+    topology.add_argument("--profile", required=True)
     cassette_validate = sub.add_parser(
         "cassette-validate", help="Validate deterministic cassette contract for integration replay"
     )
@@ -144,15 +330,18 @@ def main(argv: list[str] | None = None) -> int:
     ns = parser.parse_args(argv)
 
     try:
-        if ns.cmd in {"check", "matrix"}:
+        if ns.cmd in {"check", "matrix", "topology-check"}:
             profile = _load_profile(safe_path(Path.cwd(), ns.profile, allow_absolute=True))
-            payload = _evaluate(profile)
-            if ns.cmd == "matrix":
-                payload["schema_version"] = "sdetkit.integration.matrix.v1"
-                payload["compatibility"] = {
-                    "profile": payload["profile_name"],
-                    "status": "compatible" if payload["summary"]["passed"] else "incompatible",
-                }
+            if ns.cmd == "topology-check":
+                payload = _evaluate_topology(profile)
+            else:
+                payload = _evaluate(profile)
+                if ns.cmd == "matrix":
+                    payload["schema_version"] = "sdetkit.integration.matrix.v1"
+                    payload["compatibility"] = {
+                        "profile": payload["profile_name"],
+                        "status": "compatible" if payload["summary"]["passed"] else "incompatible",
+                    }
         else:
             payload = _validate_cassette(safe_path(Path.cwd(), ns.cassette, allow_absolute=True))
     except (ValueError, OSError, SecurityError) as exc:

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -49,6 +49,7 @@ _KITS: Final[list[Kit]] = [
         "hero_commands": [
             "sdetkit integration check --profile integration-profile.json",
             "sdetkit integration matrix --profile integration-profile.json",
+            "sdetkit integration topology-check --profile heterogeneous-topology.json",
         ],
     },
     {

--- a/tests/test_integration_topology_check.py
+++ b/tests/test_integration_topology_check.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "sdetkit", *args], text=True, capture_output=True, cwd=cwd
+    )
+
+
+def test_topology_check_accepts_heterogeneous_enterprise_profile() -> None:
+    proc = _run(
+        "integration",
+        "topology-check",
+        "--profile",
+        "examples/kits/integration/heterogeneous-topology.json",
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "sdetkit.integration.topology-check.v1"
+    assert payload["summary"]["passed"] is True
+    assert payload["inventory"]["languages"] == ["go", "python", "rust"]
+    assert payload["inventory"]["mocked_platforms"] == [
+        "segment-like-events",
+        "stripe-like-payments",
+    ]
+
+
+def test_topology_check_flags_missing_heterogeneous_contracts(tmp_path: Path) -> None:
+    profile = tmp_path / "bad-topology.json"
+    profile.write_text(
+        json.dumps(
+            {
+                "name": "bad-topology",
+                "topology": {
+                    "application_services": [
+                        {
+                            "name": "gateway",
+                            "role": "api-gateway",
+                            "language": "python",
+                            "logging_format": "json",
+                            "interfaces": [{"protocol": "rest", "audience": "external"}],
+                        },
+                        {
+                            "name": "worker",
+                            "role": "ml-serving",
+                            "language": "python",
+                            "error_handling": "exceptions",
+                            "interfaces": [{"protocol": "http", "audience": "internal"}],
+                        },
+                    ],
+                    "data_services": [
+                        {"name": "orders", "role": "transactional", "technology": "mysql"}
+                    ],
+                    "mocked_platforms": [
+                        {"name": "crm", "protocol": "rest", "operations": ["sync"]}
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run("integration", "topology-check", "--profile", str(profile))
+    assert proc.returncode == 1
+    payload = json.loads(proc.stdout)
+    assert payload["summary"]["passed"] is False
+    failed = {(item["kind"], item["name"]) for item in payload["checks"] if not item["passed"]}
+    assert ("application-service", "api-gateway") in failed
+    assert ("application-service", "data-pipeline") in failed
+    assert ("interface", "internal-grpc") in failed
+    assert ("data-service", "transactional") in failed
+    assert ("mock-platform", "crm") in failed
+
+
+def test_topology_check_requires_topology_object(tmp_path: Path) -> None:
+    profile = tmp_path / "missing-topology.json"
+    profile.write_text('{"name": "oops"}', encoding="utf-8")
+    proc = _run("integration", "topology-check", "--profile", str(profile))
+    assert proc.returncode == 2
+    assert "integration error" in proc.stderr


### PR DESCRIPTION
### Motivation
- Provide a deterministic, CI-friendly validation for heterogeneous multi-service architectures so integration readiness can be asserted before expensive integration runs. 
- Capture real-world expectations (Go API gateway, Python ML serving, Rust pipeline; PostgreSQL/Redis/S3-like data services; REST/gRPC/GraphQL interfaces; high-fidelity mocked external platforms). 

### Description
- Add `sdetkit integration topology-check` and implement `_evaluate_topology` in `src/sdetkit/integration.py` with rules for application-service roles, language expectations, interface coverage, data-service technology checks, and mocked-platform fidelity. 
- Introduce constants `REQUIRED_APP_SERVICE_RULES` and `REQUIRED_DATA_SERVICE_TECH` and helper utilities `_normalize` and `_service_exposes_protocol` to support topology validation. 
- Add a realistic example profile at `examples/kits/integration/heterogeneous-topology.json` and wire the new command into the integration kit CLI handling and `kits` hero commands. 
- Update user-facing docs (`README.md`, `docs/cli.md`, `docs/kits/integration-assurance.md`) and add focused tests in `tests/test_integration_topology_check.py` to cover passing, failing, and invalid profiles. 

### Testing
- `python -m pytest -q tests/test_integration_topology_check.py` — passed (all tests green). 
- `python -m pytest -q tests/test_cli_umbrella_surface.py` — passed (all tests green). 
- `python -m pytest -q tests/test_kits_intelligence_integration_forensics.py -k integration_and_forensics_contracts_and_bundle_determinism` — passed (selected test passed; others deselected). 
- `python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json` — succeeded and produced `sdetkit.integration.topology-check.v1` JSON with a passing summary.

------