### PR TITLE
Align integration topology-check with premium gate and engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ python -m sdetkit intelligence failure-fingerprint --failures examples/kits/inte
 python -m sdetkit integration check --profile examples/kits/integration/profile.json
 python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json
 # validates service owners, dependency edges, mocked platform coverage, deployments, telemetry, and data resilience
+bash premium-gate.sh --mode full
+# premium gate now emits .sdetkit/out/integration-topology.json as a first-class operational artifact
 python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json --fail-on error
 python -m sdetkit forensics bundle --run examples/kits/forensics/run-b.json --output build/repro.zip
 python -m sdetkit continuous-upgrade-cycle9-closeout --format json --strict

--- a/ci.sh
+++ b/ci.sh
@@ -85,6 +85,7 @@ run_flagship_contracts() {
   python3 -m sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json >/dev/null
   python3 -m sdetkit intelligence failure-fingerprint --failures examples/kits/intelligence/failures.json >/dev/null
   python3 -m sdetkit integration check --profile examples/kits/integration/profile.json >/dev/null || true
+  python3 -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json >/dev/null
   python3 -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json >/dev/null
 }
 

--- a/docs/premium-quality-gate.md
+++ b/docs/premium-quality-gate.md
@@ -56,7 +56,7 @@ Use `bash premium-gate.sh` locally and in CI. The gate is now a self-contained *
 
 1. **Head-1 Foundation & Quality** (`bash quality.sh`)
 2. **Head-2 Source Truth & Style** (ruff format/lint)
-3. **Head-3 Operational Confidence** (CI + doctor + maintenance + ops profile)
+3. **Head-3 Operational Confidence** (CI + doctor + maintenance + integration topology contract + ops profile)
 4. **Head-4 Security & Compliance** (SARIF scan + baseline-aware triage + evidence pack)
 5. **Head-5 Intelligence Brain** (`python3 -m sdetkit.premium_gate_engine`)
 
@@ -65,6 +65,7 @@ The script emits:
 - per-step logs under `.sdetkit/out/premium-gate.*.log`
 - a machine ledger: `.sdetkit/out/premium-step-results.ndjson`
 - a structured five-head index: `.sdetkit/out/premium-step-index.json`
+- integration topology artifact: `.sdetkit/out/integration-topology.json`
 - premium engine summary: `.sdetkit/out/premium-summary.json`
 
 Useful flags:
@@ -74,6 +75,7 @@ Useful flags:
 - `--engine-min-score <int>`
 - `--out-dir <path>`
 - `--ops-jobs <int>`
+- `SDETKIT_PREMIUM_TOPOLOGY_PROFILE=<path>` to override the topology profile used by the Head-3 topology contract step
 
 Examples:
 

--- a/premium-gate.sh
+++ b/premium-gate.sh
@@ -9,6 +9,7 @@ MODE="${SDETKIT_PREMIUM_MODE:-full}"
 CONTINUE_ON_ERROR=0
 ENGINE_MIN_SCORE="${SDETKIT_PREMIUM_MIN_SCORE:-70}"
 OPS_JOBS="${SDETKIT_PREMIUM_OPS_JOBS:-2}"
+TOPOLOGY_PROFILE="${SDETKIT_PREMIUM_TOPOLOGY_PROFILE:-examples/kits/integration/heterogeneous-topology.json}"
 
 usage() {
   cat <<'USAGE'
@@ -213,12 +214,14 @@ run_plan() {
     run_step "doctor_ascii" "Head-3 Operational Confidence" "Doctor ASCII" "python3 -m sdetkit doctor --ascii"
     run_step "doctor_json" "Head-3 Operational Confidence" "Doctor JSON" "python3 -m sdetkit doctor --json --out '$OUT_DIR/doctor.json'"
     run_step "maintenance_full" "Head-3 Operational Confidence" "Maintenance Full" "python3 -m sdetkit maintenance --mode full --format json --out '$OUT_DIR/maintenance.json'"
+    run_step "integration_topology" "Head-3 Operational Confidence" "Integration Topology Contract" "python3 -m sdetkit integration topology-check --profile '$TOPOLOGY_PROFILE' > '$OUT_DIR/integration-topology.json'"
     run_step "security_scan" "Head-4 Security & Compliance" "Security Scan (offline SARIF)" "python3 -m sdetkit security scan --fail-on none --format sarif --output '$OUT_DIR/security.sarif'"
     run_step "security_triage" "Head-4 Security & Compliance" "Security Triage (baseline-aware)" "python3 tools/triage.py --mode security --run-security --security-baseline tools/security.baseline.json --max-items 20 --tee '$OUT_DIR/security-check.json'"
     run_step "ops_ci" "Head-3 Operational Confidence" "Control Plane Ops (CI profile)" "python3 -m sdetkit ops run --profile ci --jobs '$OPS_JOBS'"
     run_step "evidence" "Head-4 Security & Compliance" "Evidence Pack" "python3 -m sdetkit evidence pack --output '$OUT_DIR/evidence.zip'"
   else
     run_step "doctor_json" "Head-3 Operational Confidence" "Doctor JSON" "python3 -m sdetkit doctor --json --out '$OUT_DIR/doctor.json'"
+    run_step "integration_topology" "Head-3 Operational Confidence" "Integration Topology Contract" "python3 -m sdetkit integration topology-check --profile '$TOPOLOGY_PROFILE' > '$OUT_DIR/integration-topology.json'"
     run_step "security_scan" "Head-4 Security & Compliance" "Security Scan (offline SARIF)" "python3 -m sdetkit security scan --fail-on none --format sarif --output '$OUT_DIR/security.sarif'"
   fi
 }
@@ -259,11 +262,11 @@ PY
   info "Step run ledger: $STEP_RESULTS_NDJSON"
 }
 
-export MODE OUT_DIR STEP_RESULTS_NDJSON
+export MODE OUT_DIR STEP_RESULTS_NDJSON TOPOLOGY_PROFILE
 
 preflight
 run_plan
 run_engine
 final_report
 
-echo "Premium gate passed. Artifacts: $OUT_DIR/doctor.json, $OUT_DIR/maintenance.json, $OUT_DIR/security.sarif, $OUT_DIR/security-check.json, $OUT_DIR/premium-summary.json, $OUT_DIR/evidence.zip"
+echo "Premium gate passed. Artifacts: $OUT_DIR/doctor.json, $OUT_DIR/maintenance.json, $OUT_DIR/integration-topology.json, $OUT_DIR/security.sarif, $OUT_DIR/security-check.json, $OUT_DIR/premium-summary.json, $OUT_DIR/evidence.zip"

--- a/src/sdetkit/premium_gate_engine.py
+++ b/src/sdetkit/premium_gate_engine.py
@@ -37,6 +37,7 @@ SEVERITY_RANK = {
 REQUIRED_ARTIFACTS = (
     "doctor.json",
     "maintenance.json",
+    "integration-topology.json",
     "security-check.json",
 )
 
@@ -52,6 +53,10 @@ RECOMMENDATION_CATALOG: dict[str, tuple[str, str]] = {
     "security": (
         "Security findings are present in control-plane inputs.",
         "Address high/critical vulnerabilities before enabling broad rollout.",
+    ),
+    "integration": (
+        "Integration topology contract drift is present in premium gate inputs.",
+        "Repair the service, dependency, and deployment contracts before promoting the topology as production-ready.",
     ),
     "engine:artifact-integrity": (
         "Gate artifacts are incomplete or unreadable.",
@@ -258,6 +263,48 @@ def _parse_security(payload: dict[str, Any]) -> SourceResult:
             )
 
     return SourceResult("security", warnings, [], checks)
+
+
+def _parse_integration_topology(payload: dict[str, Any]) -> SourceResult:
+    warnings: list[Signal] = []
+    recommendations: list[Signal] = []
+    checks: list[Signal] = []
+
+    for item in payload.get("checks", []):
+        if not isinstance(item, dict) or item.get("passed", False):
+            continue
+        kind = _safe_text(item.get("kind") or "contract")
+        name = _safe_text(item.get("name") or "unknown")
+        message = _safe_text(item.get("reason")) or f"{kind} failed: {name}"
+        warnings.append(_make_signal("integration", f"{kind}:{name}", "high", message))
+
+    summary = payload.get("summary")
+    if isinstance(summary, dict):
+        pass_rate = summary.get("pass_rate")
+        if isinstance(pass_rate, (int, float)) and float(pass_rate) < 100.0:
+            checks.append(
+                _make_signal(
+                    "integration",
+                    "pass-rate",
+                    "warn",
+                    f"integration topology pass rate below premium bar: {pass_rate}%",
+                )
+            )
+
+    inventory = payload.get("inventory")
+    if isinstance(inventory, dict):
+        counts = inventory.get("counts")
+        if isinstance(counts, dict) and int(counts.get("application_services", 0)) < 3:
+            checks.append(
+                _make_signal(
+                    "integration",
+                    "service-count",
+                    "warn",
+                    "integration topology includes fewer than three application services",
+                )
+            )
+
+    return SourceResult("integration", warnings, recommendations, checks)
 
 
 def _scan_step_logs(out_dir: Path) -> list[StepStatus]:
@@ -795,6 +842,7 @@ def collect_signals(out_dir: Path) -> dict[str, Any]:
     sources = {
         "doctor": (out_dir / "doctor.json", _parse_doctor),
         "maintenance": (out_dir / "maintenance.json", _parse_maintenance),
+        "integration": (out_dir / "integration-topology.json", _parse_integration_topology),
         "security": (out_dir / "security-check.json", _parse_security),
     }
 

--- a/tests/test_kits_intelligence_integration_forensics.py
+++ b/tests/test_kits_intelligence_integration_forensics.py
@@ -81,6 +81,17 @@ def test_integration_and_forensics_contracts_and_bundle_determinism(tmp_path: Pa
     assert integration_json["schema_version"] == "sdetkit.integration.profile-check.v1"
     assert integration_json["summary"]["next_step"]
 
+    topology = _run(
+        "integration",
+        "topology-check",
+        "--profile",
+        "examples/kits/integration/heterogeneous-topology.json",
+    )
+    assert topology.returncode == 0
+    topology_json = json.loads(topology.stdout)
+    assert topology_json["schema_version"] == "sdetkit.integration.topology-check.v1"
+    assert topology_json["summary"]["passed"] is True
+
     cassette = tmp_path / "cassette.json"
     cassette.write_text(
         json.dumps(

--- a/tests/test_premium_gate_engine.py
+++ b/tests/test_premium_gate_engine.py
@@ -9,6 +9,21 @@ import pytest
 from sdetkit import premium_gate_engine as eng
 
 
+def _write_topology_artifact(
+    path: Path, *, pass_rate: float = 100.0, app_services: int = 3, checks: list[dict[str, object]] | None = None
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "checks": checks or [],
+                "summary": {"pass_rate": pass_rate, "passed": pass_rate == 100.0},
+                "inventory": {"counts": {"application_services": app_services}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_collect_signals_reads_artifacts_and_extracts_warnings_and_recommendations(
     tmp_path: Path,
 ) -> None:
@@ -35,6 +50,7 @@ def test_collect_signals_reads_artifacts_and_extracts_warnings_and_recommendatio
         ),
         encoding="utf-8",
     )
+    _write_topology_artifact(out / "integration-topology.json")
     (out / "security-check.json").write_text(
         json.dumps({"findings": [{"rule_id": "SEC_X", "severity": "high", "path": "src/app.py"}]}),
         encoding="utf-8",
@@ -48,6 +64,7 @@ def test_collect_signals_reads_artifacts_and_extracts_warnings_and_recommendatio
     assert payload["required_artifacts"] == {
         "doctor.json": True,
         "maintenance.json": True,
+        "integration-topology.json": True,
         "security-check.json": True,
     }
     assert payload["hotspots"] == {"doctor": 1, "maintenance": 1, "security": 1}
@@ -56,7 +73,7 @@ def test_collect_signals_reads_artifacts_and_extracts_warnings_and_recommendatio
 
 def test_collect_signals_missing_artifacts_adds_engine_checks(tmp_path: Path) -> None:
     payload = eng.collect_signals(tmp_path)
-    assert payload["counts"]["engine_checks"] == 7
+    assert payload["counts"]["engine_checks"] == 9
     assert payload["counts"]["steps"] == 0
     assert payload["ok"] is False
 
@@ -76,6 +93,7 @@ def test_main_writes_json_output_and_double_check(tmp_path: Path, capsys) -> Non
     (out / "maintenance.json").write_text(
         json.dumps({"checks": [], "recommendations": ["all good"]}), encoding="utf-8"
     )
+    _write_topology_artifact(out / "integration-topology.json")
     (out / "security-check.json").write_text(json.dumps({"findings": []}), encoding="utf-8")
     (out / "premium-gate.Quality.log").write_text("all clear\n", encoding="utf-8")
 
@@ -105,6 +123,7 @@ def test_main_min_score_gate_can_fail(tmp_path: Path) -> None:
     (tmp_path / "maintenance.json").write_text(
         json.dumps({"checks": [], "recommendations": []}), encoding="utf-8"
     )
+    _write_topology_artifact(tmp_path / "integration-topology.json")
     (tmp_path / "security-check.json").write_text(json.dumps({"findings": []}), encoding="utf-8")
     (tmp_path / "premium-gate.Quality.log").write_text("ok\n", encoding="utf-8")
     rc = eng.main(["--out-dir", str(tmp_path), "--min-score", "95", "--format", "json"])
@@ -164,6 +183,7 @@ def test_main_auto_fix_adds_manual_followup_recommendation(tmp_path: Path, capsy
     (tmp_path / "maintenance.json").write_text(
         json.dumps({"checks": [], "recommendations": []}), encoding="utf-8"
     )
+    _write_topology_artifact(tmp_path / "integration-topology.json")
     (tmp_path / "security-check.json").write_text(
         json.dumps({"findings": [{"rule_id": "SEC_UNKNOWN", "path": "src/missing.py"}]}),
         encoding="utf-8",
@@ -188,6 +208,7 @@ def test_collect_signals_ignores_info_security_findings(tmp_path: Path) -> None:
     (tmp_path / "maintenance.json").write_text(
         json.dumps({"checks": [], "recommendations": []}), encoding="utf-8"
     )
+    _write_topology_artifact(tmp_path / "integration-topology.json")
     (tmp_path / "security-check.json").write_text(
         json.dumps(
             {
@@ -227,6 +248,7 @@ def test_main_markdown_format_includes_five_heads_and_plan(tmp_path: Path, capsy
     (tmp_path / "maintenance.json").write_text(
         json.dumps({"checks": [], "recommendations": []}), encoding="utf-8"
     )
+    _write_topology_artifact(tmp_path / "integration-topology.json")
     (tmp_path / "security-check.json").write_text(
         json.dumps({"findings": [{"rule_id": "SEC_UNKNOWN", "path": "src/missing.py"}]}),
         encoding="utf-8",
@@ -274,6 +296,7 @@ def test_main_learn_db_and_commit_persists_records(tmp_path: Path) -> None:
     (tmp_path / "maintenance.json").write_text(
         json.dumps({"checks": [], "recommendations": []}), encoding="utf-8"
     )
+    _write_topology_artifact(tmp_path / "integration-topology.json")
     (tmp_path / "security-check.json").write_text(json.dumps({"findings": []}), encoding="utf-8")
     (tmp_path / "premium-gate.Quality.log").write_text("ok\n", encoding="utf-8")
     db = tmp_path / "premium-insights.db"
@@ -314,6 +337,7 @@ def test_main_applies_learned_guidelines_to_recommendations(tmp_path: Path, caps
     (tmp_path / "maintenance.json").write_text(
         json.dumps({"checks": [], "recommendations": []}), encoding="utf-8"
     )
+    _write_topology_artifact(tmp_path / "integration-topology.json")
     (tmp_path / "security-check.json").write_text(json.dumps({"findings": []}), encoding="utf-8")
     (tmp_path / "premium-gate.Quality.log").write_text("ok\n", encoding="utf-8")
     db = tmp_path / "premium-insights.db"
@@ -340,3 +364,33 @@ def test_main_applies_learned_guidelines_to_recommendations(tmp_path: Path, caps
     payload = json.loads(capsys.readouterr().out)
     assert any(item["category"] == "learned-guideline" for item in payload["recommendations"])
     assert payload.get("manual_fix_plan")
+
+
+def test_collect_signals_reads_integration_topology_contract(tmp_path: Path) -> None:
+    (tmp_path / "doctor.json").write_text(
+        json.dumps({"checks": {}, "recommendations": []}), encoding="utf-8"
+    )
+    (tmp_path / "maintenance.json").write_text(
+        json.dumps({"checks": [], "recommendations": []}), encoding="utf-8"
+    )
+    _write_topology_artifact(
+        tmp_path / "integration-topology.json",
+        pass_rate=92.5,
+        app_services=2,
+        checks=[
+            {
+                "kind": "dependency-contract",
+                "name": "ml-serving",
+                "passed": False,
+                "reason": "missing dependency",
+            }
+        ],
+    )
+    (tmp_path / "security-check.json").write_text(json.dumps({"findings": []}), encoding="utf-8")
+
+    payload = eng.collect_signals(tmp_path)
+    assert payload["required_artifacts"]["integration-topology.json"] is True
+    assert payload["hotspots"]["integration"] == 1
+    categories = {item["category"] for item in payload["engine_checks"]}
+    assert "pass-rate" in categories
+    assert "service-count" in categories


### PR DESCRIPTION
### Motivation
- Ensure the `integration topology-check` is a first-class artifact for the premium gate so topology contract drift is detected and surfaced in premium recommendations.
- Make the premium gate workflow and flagship CI coverage consistent with the CLI `integration topology-check` command and the rest of the SDETKit premium workflow.

### Description
- Add a Head-3 premium gate step that runs `sdetkit integration topology-check` and writes `.sdetkit/out/integration-topology.json`, and make the profile path overridable via `SDETKIT_PREMIUM_TOPOLOGY_PROFILE` in `premium-gate.sh`.
- Teach the premium engine to treat `integration-topology.json` as a required artifact by adding it to `REQUIRED_ARTIFACTS` and implementing `_parse_integration_topology` which converts failing topology checks into warnings/checks and knowledge recommendations in `src/sdetkit/premium_gate_engine.py`.
- Include `integration topology-check` in the flagship CI coverage (`ci.sh`) and update README and `docs/premium-quality-gate.md` to document the new artifact and environment override.
- Extend tests to cover the new artifact and parsing logic by updating `tests/test_premium_gate_engine.py` and `tests/test_kits_intelligence_integration_forensics.py` to validate topology-check outputs and engine ingestion.

### Testing
- Ran targeted unit tests: `python -m pytest -q tests/test_integration_topology_check.py tests/test_kits_intelligence_integration_forensics.py tests/test_premium_gate_engine.py`, which completed successfully (`24 passed`).
- Ran static checks: `python -m ruff check src/sdetkit/premium_gate_engine.py tests/test_premium_gate_engine.py tests/test_kits_intelligence_integration_forensics.py`, which passed.
- Exercised the CLI topology check: `python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json`, which produced a passing topology payload and expected `summary` values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb1c8d25e483209691c112920c5bae)