### PR TITLE
Expand umbrella kit capability catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ It turns CI and test signals into deterministic contracts, machine-readable arti
 - **Failure Forensics Kit** — `sdetkit forensics ...`
 - **Catalog** — `sdetkit kits list` / `sdetkit kits describe <kit>`
 
+## Choose your SDET lane fast
+
+- **Release confidence**: use when you need go/no-go readiness, repo health signals, and approval evidence.
+- **Test intelligence**: use when you need smarter triage for flakes, failure clustering, impact analysis, or reproducible env capture.
+- **Integration assurance**: use when you need stronger service-profile checks, environment readiness validation, and topology-aware contracts.
+- **Failure forensics**: use when you need run-to-run diffs, repro bundles, and escalation-ready evidence packs.
+
+For a fuller capability map, run:
+
+```bash
+python -m sdetkit kits list
+python -m sdetkit kits describe release
+python -m sdetkit kits describe intelligence
+python -m sdetkit kits describe integration
+python -m sdetkit kits describe forensics
+```
+
 ## Hero commands
 
 ```bash

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -15,6 +15,10 @@ class Kit(TypedDict):
     stability: str
     summary: str
     hero_commands: list[str]
+    capabilities: list[str]
+    typical_inputs: list[str]
+    key_artifacts: list[str]
+    learning_path: list[str]
 
 
 _KITS: Final[list[Kit]] = [
@@ -29,6 +33,27 @@ _KITS: Final[list[Kit]] = [
             "sdetkit release doctor",
             "sdetkit release evidence",
         ],
+        "capabilities": [
+            "Pre-merge quality gates",
+            "Release preflight diagnostics",
+            "Policy and security enforcement",
+            "Evidence packaging for approvals",
+        ],
+        "typical_inputs": [
+            "Repository working tree",
+            "CI configuration",
+            "Quality and policy baselines",
+        ],
+        "key_artifacts": [
+            "Gate JSON summaries",
+            "Doctor readiness reports",
+            "Release evidence bundles",
+        ],
+        "learning_path": [
+            "sdetkit release gate fast",
+            "sdetkit release doctor",
+            "sdetkit release gate release",
+        ],
     },
     {
         "id": "test-intelligence",
@@ -39,6 +64,27 @@ _KITS: Final[list[Kit]] = [
             "sdetkit intelligence flake classify --history history.json",
             "sdetkit intelligence impact summarize --changed changed.txt --map testmap.json",
             "sdetkit intelligence capture-env",
+        ],
+        "capabilities": [
+            "Flake and failure classification",
+            "Change impact summaries",
+            "Environment capture for reproducibility",
+            "Signal shaping for quality governance",
+        ],
+        "typical_inputs": [
+            "Failure history JSON",
+            "Changed file lists",
+            "Test ownership or mapping data",
+        ],
+        "key_artifacts": [
+            "Flake classification reports",
+            "Impact summaries",
+            "Captured environment snapshots",
+        ],
+        "learning_path": [
+            "sdetkit intelligence capture-env",
+            "sdetkit intelligence flake classify --history history.json",
+            "sdetkit intelligence impact summarize --changed changed.txt --map testmap.json",
         ],
     },
     {
@@ -51,6 +97,27 @@ _KITS: Final[list[Kit]] = [
             "sdetkit integration matrix --profile integration-profile.json",
             "sdetkit integration topology-check --profile heterogeneous-topology.json",
         ],
+        "capabilities": [
+            "Service profile validation",
+            "Environment readiness checks",
+            "Dependency topology validation",
+            "Cross-system contract coverage",
+        ],
+        "typical_inputs": [
+            "Integration profile JSON",
+            "Topology maps",
+            "Environment dependency metadata",
+        ],
+        "key_artifacts": [
+            "Integration readiness reports",
+            "Matrix coverage outputs",
+            "Topology contract artifacts",
+        ],
+        "learning_path": [
+            "sdetkit integration check --profile integration-profile.json",
+            "sdetkit integration matrix --profile integration-profile.json",
+            "sdetkit integration topology-check --profile heterogeneous-topology.json",
+        ],
     },
     {
         "id": "failure-forensics",
@@ -58,6 +125,27 @@ _KITS: Final[list[Kit]] = [
         "stability": "stable",
         "summary": "Run-to-run regression intelligence, evidence diffing, and deterministic repro bundle generation.",
         "hero_commands": [
+            "sdetkit forensics compare --from old.json --to new.json",
+            "sdetkit forensics bundle --run run.json --output bundle.zip",
+            "sdetkit forensics bundle-diff --from-bundle old.zip --to-bundle new.zip",
+        ],
+        "capabilities": [
+            "Run-to-run diff analysis",
+            "Deterministic repro bundle generation",
+            "Evidence comparisons across failures",
+            "Escalation-ready debugging packs",
+        ],
+        "typical_inputs": [
+            "Structured run result JSON",
+            "Historical evidence bundles",
+            "Build or test failure metadata",
+        ],
+        "key_artifacts": [
+            "Forensics diff summaries",
+            "Repro ZIP bundles",
+            "Bundle-to-bundle comparison outputs",
+        ],
+        "learning_path": [
             "sdetkit forensics compare --from old.json --to new.json",
             "sdetkit forensics bundle --run run.json --output bundle.zip",
             "sdetkit forensics bundle-diff --from-bundle old.zip --to-bundle new.zip",
@@ -108,8 +196,20 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{kit['id']} [{kit['stability']}]")
         print(f"route: sdetkit {kit['slug']} ...")
         print(f"summary: {kit['summary']}")
+        print("capabilities:")
+        for item in kit["capabilities"]:
+            print(f"  - {item}")
+        print("typical inputs:")
+        for item in kit["typical_inputs"]:
+            print(f"  - {item}")
+        print("key artifacts:")
+        for item in kit["key_artifacts"]:
+            print(f"  - {item}")
         print("hero commands:")
         for cmd in kit["hero_commands"]:
+            print(f"  - {cmd}")
+        print("learning path:")
+        for cmd in kit["learning_path"]:
             print(f"  - {cmd}")
         return 0
 
@@ -130,6 +230,8 @@ def main(argv: list[str] | None = None) -> int:
     for kit in kits_sorted:
         print(f"- {kit['id']} [{kit['stability']}]")
         print(f"  {kit['summary']}")
+        print(f"  capabilities: {', '.join(kit['capabilities'])}")
+        print(f"  start with: {kit['learning_path'][0]}")
     return 0
 
 

--- a/tests/test_cli_umbrella_surface.py
+++ b/tests/test_cli_umbrella_surface.py
@@ -29,6 +29,12 @@ def test_kits_list_and_describe_contract() -> None:
         "release",
         "intelligence",
     ]
+    release_kit = next(item for item in payload["kits"] if item["slug"] == "release")
+    assert "capabilities" in release_kit
+    assert "typical_inputs" in release_kit
+    assert "key_artifacts" in release_kit
+    assert "learning_path" in release_kit
+    assert release_kit["learning_path"][0] == "sdetkit release gate fast"
 
     describe_proc = _run("kits", "describe", "release", "--format", "json")
     assert describe_proc.returncode == 0
@@ -36,9 +42,19 @@ def test_kits_list_and_describe_contract() -> None:
     assert describe_payload["schema_version"] == "sdetkit.kits.catalog.v1"
     assert describe_payload["kit"]["id"] == "release-confidence"
     assert describe_payload["kit"]["slug"] == "release"
+    assert "Pre-merge quality gates" in describe_payload["kit"]["capabilities"]
 
 
 def test_kits_describe_unknown_is_usage_error() -> None:
     proc = _run("kits", "describe", "unknown-kit")
     assert proc.returncode == 2
     assert "kits error" in proc.stderr
+
+
+def test_kits_describe_text_includes_capability_map() -> None:
+    proc = _run("kits", "describe", "integration")
+    assert proc.returncode == 0
+    assert "capabilities:" in proc.stdout
+    assert "typical inputs:" in proc.stdout
+    assert "key artifacts:" in proc.stdout
+    assert "learning path:" in proc.stdout

--- a/tests/test_kits_umbrella_cli.py
+++ b/tests/test_kits_umbrella_cli.py
@@ -27,6 +27,11 @@ def test_kits_list_json_schema_and_order() -> None:
     ids = [x["id"] for x in payload["kits"]]
     assert ids == sorted(ids)
     assert "release-confidence" in ids
+    release = next(x for x in payload["kits"] if x["id"] == "release-confidence")
+    assert release["capabilities"]
+    assert release["typical_inputs"]
+    assert release["key_artifacts"]
+    assert release["learning_path"]
 
 
 def test_release_alias_routes_to_gate_and_backcompat_gate_still_works() -> None:


### PR DESCRIPTION
### Motivation
- Broaden the SDET surface and improve discoverability by exposing richer, actionable metadata for each umbrella kit so teams can pick the right lane faster.
- Surface onboarding guidance and artifacts alongside hero commands to reduce friction when adopting `sdetkit` workflows.

### Description
- Add new kit metadata fields to the catalog (`capabilities`, `typical_inputs`, `key_artifacts`, `learning_path`) and update the `Kit` TypedDict accordingly in `src/sdetkit/kits.py`.
- Populate the new metadata for each primary kit (`release-confidence`, `test-intelligence`, `integration-assurance`, `failure-forensics`) in `_KITS` and include the fields in the JSON payload returned by `sdetkit kits`.
- Extend the text output for `sdetkit kits describe <kit>` and `sdetkit kits list` to print capabilities, typical inputs, key artifacts, and a recommended learning path.
- Add a short discovery/help section to `README.md` explaining the SDET lanes and sample `sdetkit kits` commands.
- Add/adjust tests (`tests/test_cli_umbrella_surface.py`, `tests/test_kits_umbrella_cli.py`) to assert the new catalog fields and the enriched text output.

### Testing
- Ran `pytest -q tests/test_cli_umbrella_surface.py tests/test_kits_umbrella_cli.py` and the suite passed (`7 passed` in the test run environment).
- Ran `python -m sdetkit kits describe integration` to validate the enriched `describe` text output and it printed the new capability map successfully.
- Ran `python -m sdetkit kits list` to validate the enriched list text output and it printed capabilities and a start command.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb1f61d5208320ae81aed5b4f32e50)