### PR TITLE
feat: strengthen upgrade audit planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ python -m sdetkit continuous-upgrade-cycle11-closeout --format json --strict
 
 ## Upgrade planning (first step)
 
-Run a direct dependency audit against PyPI to identify candidate upgrades:
+Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps:
 
 ```bash
 make upgrade-audit
+python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
 ```
 
 ## Sample artifacts

--- a/scripts/upgrade_audit.py
+++ b/scripts/upgrade_audit.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Audit direct dependencies and report latest PyPI versions.
+"""Audit dependency manifests and report upgrade planning signals.
 
 This script is intended as a first step for planning repository upgrades.
-It reads direct dependencies from pyproject.toml and fetches each package's
-latest release metadata from PyPI.
+It reads dependency declarations from ``pyproject.toml`` and one or more
+requirements files, highlights cross-manifest drift, and fetches the latest
+PyPI release metadata for each package.
 """
 
 from __future__ import annotations
@@ -15,17 +16,33 @@ import sys
 import tomllib
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 REQ_NAME_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)")
+PINNED_VERSION_RE = re.compile(r"==\s*([A-Za-z0-9_.!+-]+)")
 
 
 @dataclass(frozen=True)
 class Dependency:
+    source: str
     group: str
     raw: str
     name: str
+    pinned_version: str | None
+
+
+@dataclass(frozen=True)
+class PackageReport:
+    name: str
+    sources: list[str]
+    groups: list[str]
+    requirements: list[str]
+    pinned_versions: list[str]
+    alignment: str
+    latest_version: str
+    latest_release_date: str | None
+    upgrade_signal: str
 
 
 def _parse_dep_name(raw_requirement: str) -> str:
@@ -35,63 +52,250 @@ def _parse_dep_name(raw_requirement: str) -> str:
     return match.group(1).lower().replace("_", "-")
 
 
-def _load_dependencies(pyproject_path: Path) -> list[Dependency]:
-    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+def _extract_pinned_version(raw_requirement: str) -> str | None:
+    match = PINNED_VERSION_RE.search(raw_requirement)
+    if match:
+        return match.group(1)
+    return None
 
+
+def _normalize_requirement_line(line: str) -> str | None:
+    candidate = line.split("#", 1)[0].strip()
+    if not candidate:
+        return None
+    if candidate.startswith(("-e", "--editable", "-r", "--requirement", "-c", "--constraint")):
+        return None
+    if candidate.startswith(("http://", "https://", "git+", ".", "/")):
+        return None
+    return candidate
+
+
+def _load_pyproject_dependencies(pyproject_path: Path) -> list[Dependency]:
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
     project = data.get("project", {})
     deps: list[Dependency] = []
 
     for dep in project.get("dependencies", []):
-        deps.append(Dependency(group="default", raw=dep, name=_parse_dep_name(dep)))
+        deps.append(
+            Dependency(
+                source=pyproject_path.name,
+                group="default",
+                raw=dep,
+                name=_parse_dep_name(dep),
+                pinned_version=_extract_pinned_version(dep),
+            )
+        )
 
     for group, group_deps in project.get("optional-dependencies", {}).items():
         for dep in group_deps:
-            deps.append(Dependency(group=group, raw=dep, name=_parse_dep_name(dep)))
+            deps.append(
+                Dependency(
+                    source=pyproject_path.name,
+                    group=str(group),
+                    raw=dep,
+                    name=_parse_dep_name(dep),
+                    pinned_version=_extract_pinned_version(dep),
+                )
+            )
 
     return deps
 
 
-def _latest_pypi_version(package: str, timeout_s: float) -> str:
+def _load_requirements_dependencies(requirements_path: Path) -> list[Dependency]:
+    deps: list[Dependency] = []
+    for raw_line in requirements_path.read_text(encoding="utf-8").splitlines():
+        candidate = _normalize_requirement_line(raw_line)
+        if candidate is None:
+            continue
+        deps.append(
+            Dependency(
+                source=requirements_path.name,
+                group="requirements",
+                raw=candidate,
+                name=_parse_dep_name(candidate),
+                pinned_version=_extract_pinned_version(candidate),
+            )
+        )
+    return deps
+
+
+def _discover_requirement_files(root: Path, include_lockfiles: bool) -> list[Path]:
+    files = sorted(root.glob("requirements*.txt"))
+    if not include_lockfiles:
+        files = [path for path in files if not path.name.endswith(".lock")]
+    return files
+
+
+def _load_dependencies(
+    pyproject_path: Path,
+    requirement_paths: list[Path],
+) -> list[Dependency]:
+    deps = _load_pyproject_dependencies(pyproject_path)
+    for path in requirement_paths:
+        deps.extend(_load_requirements_dependencies(path))
+    return deps
+
+
+def _latest_pypi_metadata(package: str, timeout_s: float) -> tuple[str, str | None]:
     url = f"https://pypi.org/pypi/{package}/json"
-    request = urllib.request.Request(url, headers={"User-Agent": "sdetkit-upgrade-audit/1.0"})
+    request = urllib.request.Request(url, headers={"User-Agent": "sdetkit-upgrade-audit/2.0"})
     with urllib.request.urlopen(request, timeout=timeout_s) as response:  # noqa: S310
         payload = json.loads(response.read().decode("utf-8"))
-    version = payload.get("info", {}).get("version")
-    if not version:
-        return "unknown"
-    return str(version)
+
+    info = payload.get("info", {})
+    version = str(info.get("version") or "unknown")
+    release_date: str | None = None
+    releases = payload.get("releases", {})
+    if isinstance(releases, dict):
+        release_files = releases.get(version) or []
+        if isinstance(release_files, list):
+            for item in release_files:
+                if isinstance(item, dict) and item.get("upload_time_iso_8601"):
+                    release_date = str(item["upload_time_iso_8601"])
+                    break
+    return version, release_date
 
 
-def run(pyproject_path: Path, timeout_s: float) -> int:
-    dependencies = _load_dependencies(pyproject_path)
+def _build_package_report(
+    name: str, deps: list[Dependency], latest_version: str, release_date: str | None
+) -> PackageReport:
+    sources = sorted({dep.source for dep in deps})
+    groups = sorted({dep.group for dep in deps})
+    requirements = sorted({dep.raw for dep in deps})
+    pinned_versions = sorted({dep.pinned_version for dep in deps if dep.pinned_version})
+
+    alignment = "aligned"
+    if len(requirements) > 1:
+        alignment = "drift"
+    elif not pinned_versions:
+        alignment = "range-or-unpinned"
+
+    upgrade_signal = "watch"
+    if alignment == "drift":
+        upgrade_signal = "high"
+    elif len(pinned_versions) == 1 and latest_version not in {"unknown", pinned_versions[0]}:
+        upgrade_signal = "high" if "default" in groups else "medium"
+    elif latest_version == "unknown":
+        upgrade_signal = "unknown"
+
+    return PackageReport(
+        name=name,
+        sources=sources,
+        groups=groups,
+        requirements=requirements,
+        pinned_versions=pinned_versions,
+        alignment=alignment,
+        latest_version=latest_version,
+        latest_release_date=release_date,
+        upgrade_signal=upgrade_signal,
+    )
+
+
+def _render_markdown(
+    reports: list[PackageReport],
+    *,
+    pyproject_path: Path,
+    requirement_paths: list[Path],
+) -> str:
+    drift_count = sum(1 for report in reports if report.alignment == "drift")
+    high_priority = sum(1 for report in reports if report.upgrade_signal == "high")
+    lines = [
+        "# Upgrade audit",
+        "",
+        f"Source pyproject: `{pyproject_path}`",
+        f"Requirement manifests: {', '.join(f'`{path}`' for path in requirement_paths) if requirement_paths else '`none`'}",
+        "",
+        f"- packages audited: {len(reports)}",
+        f"- manifest drift packages: {drift_count}",
+        f"- high-priority upgrade signals: {high_priority}",
+        "",
+        "| Package | Alignment | Upgrade signal | Latest PyPI | Release date | Requirements |",
+        "|---|---|---|---|---|---|",
+    ]
+    for report in reports:
+        release_date = report.latest_release_date or "-"
+        requirements = " <br> ".join(f"`{item}`" for item in report.requirements)
+        lines.append(
+            "| "
+            f"`{report.name}` | {report.alignment} | {report.upgrade_signal} | `{report.latest_version}` | {release_date} | {requirements} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _render_json(
+    reports: list[PackageReport],
+    *,
+    pyproject_path: Path,
+    requirement_paths: list[Path],
+) -> str:
+    payload = {
+        "pyproject": str(pyproject_path),
+        "requirements": [str(path) for path in requirement_paths],
+        "summary": {
+            "packages_audited": len(reports),
+            "manifest_drift_packages": sum(1 for report in reports if report.alignment == "drift"),
+            "high_priority_upgrade_signals": sum(
+                1 for report in reports if report.upgrade_signal == "high"
+            ),
+        },
+        "packages": [asdict(report) for report in reports],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def run(
+    pyproject_path: Path,
+    timeout_s: float,
+    *,
+    requirement_paths: list[Path],
+    output_format: str,
+) -> int:
+    dependencies = _load_dependencies(pyproject_path, requirement_paths)
 
     if not dependencies:
-        print("No dependencies found in pyproject.toml.")
+        print("No dependencies found in the configured manifests.")
         return 0
 
-    print("# Upgrade audit (direct dependencies)")
-    print()
-    print(f"Source: `{pyproject_path}`")
-    print()
-    print("| Group | Requirement | Latest PyPI |")
-    print("|---|---|---|")
-
+    by_package: dict[str, list[Dependency]] = {}
     for dep in dependencies:
+        by_package.setdefault(dep.name, []).append(dep)
+
+    reports: list[PackageReport] = []
+    for package in sorted(by_package):
         try:
-            latest = _latest_pypi_version(dep.name, timeout_s=timeout_s)
+            latest_version, release_date = _latest_pypi_metadata(package, timeout_s=timeout_s)
         except urllib.error.HTTPError as exc:
-            latest = f"http-{exc.code}"
+            latest_version, release_date = f"http-{exc.code}", None
         except urllib.error.URLError:
-            latest = "network-error"
+            latest_version, release_date = "network-error", None
 
-        print(f"| `{dep.group}` | `{dep.raw}` | `{latest}` |")
+        reports.append(
+            _build_package_report(
+                package,
+                by_package[package],
+                latest_version=latest_version,
+                release_date=release_date,
+            )
+        )
 
+    rendered = {
+        "json": _render_json(
+            reports, pyproject_path=pyproject_path, requirement_paths=requirement_paths
+        ),
+        "md": _render_markdown(
+            reports, pyproject_path=pyproject_path, requirement_paths=requirement_paths
+        ),
+    }[output_format]
+    sys.stdout.write(rendered)
     return 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Report the latest PyPI versions for direct dependencies in pyproject.toml."
+        description=(
+            "Audit dependency manifests, highlight drift, and report the latest PyPI versions "
+            "for each declared package."
+        )
     )
     parser.add_argument(
         "--pyproject",
@@ -105,13 +309,49 @@ def main() -> int:
         default=10.0,
         help="HTTP timeout in seconds for each PyPI request (default: 10)",
     )
+    parser.add_argument(
+        "--format",
+        choices=["md", "json"],
+        default="md",
+        help="Output format (default: md)",
+    )
+    parser.add_argument(
+        "--requirements",
+        type=Path,
+        action="append",
+        default=None,
+        help="Additional requirements file to scan. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--include-lockfiles",
+        action="store_true",
+        help="Include requirements*.txt.lock files discovered in the repo root.",
+    )
     args = parser.parse_args()
 
     if not args.pyproject.exists():
         print(f"error: file not found: {args.pyproject}", file=sys.stderr)
         return 2
 
-    return run(args.pyproject, timeout_s=args.timeout)
+    requirement_paths = args.requirements
+    if requirement_paths is None:
+        requirement_paths = _discover_requirement_files(
+            args.pyproject.parent,
+            include_lockfiles=bool(args.include_lockfiles),
+        )
+
+    missing = [path for path in requirement_paths if not path.exists()]
+    if missing:
+        for path in missing:
+            print(f"error: requirements file not found: {path}", file=sys.stderr)
+        return 2
+
+    return run(
+        args.pyproject,
+        timeout_s=args.timeout,
+        requirement_paths=requirement_paths,
+        output_format=args.format,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "upgrade_audit.py"
+SPEC = importlib.util.spec_from_file_location("upgrade_audit", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+upgrade_audit = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = upgrade_audit
+SPEC.loader.exec_module(upgrade_audit)
+
+
+def test_load_dependencies_collects_pyproject_and_requirements(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = ["httpx>=0.27,<1"]
+
+[project.optional-dependencies]
+dev = ["ruff==0.15.6"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        """
+# comment
+-e .
+httpx==0.28.1
+ruff==0.15.6
+-r nested.txt
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    deps = upgrade_audit._load_dependencies(pyproject, [requirements])
+
+    assert [dep.name for dep in deps] == ["httpx", "ruff", "httpx", "ruff"]
+    assert [dep.source for dep in deps] == [
+        "pyproject.toml",
+        "pyproject.toml",
+        "requirements.txt",
+        "requirements.txt",
+    ]
+    assert deps[0].pinned_version is None
+    assert deps[1].pinned_version == "0.15.6"
+    assert deps[2].pinned_version == "0.28.1"
+
+
+def test_build_package_report_flags_drift_and_priority() -> None:
+    deps = [
+        upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="default",
+            raw="httpx>=0.27,<1",
+            name="httpx",
+            pinned_version=None,
+        ),
+        upgrade_audit.Dependency(
+            source="requirements.txt",
+            group="requirements",
+            raw="httpx==0.28.1",
+            name="httpx",
+            pinned_version="0.28.1",
+        ),
+    ]
+
+    report = upgrade_audit._build_package_report(
+        "httpx",
+        deps,
+        latest_version="0.29.0",
+        release_date="2026-01-01T00:00:00Z",
+    )
+
+    assert report.alignment == "drift"
+    assert report.upgrade_signal == "high"
+    assert report.latest_version == "0.29.0"
+    assert report.latest_release_date == "2026-01-01T00:00:00Z"
+
+
+def test_render_json_summary_counts() -> None:
+    reports = [
+        upgrade_audit.PackageReport(
+            name="httpx",
+            sources=["pyproject.toml", "requirements.txt"],
+            groups=["default", "requirements"],
+            requirements=["httpx>=0.27,<1", "httpx==0.28.1"],
+            pinned_versions=["0.28.1"],
+            alignment="drift",
+            latest_version="0.29.0",
+            latest_release_date="2026-01-01T00:00:00Z",
+            upgrade_signal="high",
+        ),
+        upgrade_audit.PackageReport(
+            name="ruff",
+            sources=["pyproject.toml", "requirements.txt"],
+            groups=["dev", "requirements"],
+            requirements=["ruff==0.15.6"],
+            pinned_versions=["0.15.6"],
+            alignment="aligned",
+            latest_version="0.15.6",
+            latest_release_date=None,
+            upgrade_signal="watch",
+        ),
+    ]
+
+    payload = json.loads(
+        upgrade_audit._render_json(
+            reports,
+            pyproject_path=Path("pyproject.toml"),
+            requirement_paths=[Path("requirements.txt")],
+        )
+    )
+
+    assert payload["summary"] == {
+        "packages_audited": 2,
+        "manifest_drift_packages": 1,
+        "high_priority_upgrade_signals": 1,
+    }
+    assert payload["packages"][0]["name"] == "httpx"
+
+
+def test_run_renders_markdown_without_network(monkeypatch, capsys, tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = ["httpx>=0.27,<1"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("httpx==0.28.1\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        upgrade_audit,
+        "_latest_pypi_metadata",
+        lambda package, timeout_s: ("0.29.0", "2026-01-01T00:00:00Z"),
+    )
+
+    rc = upgrade_audit.run(
+        pyproject,
+        timeout_s=0.1,
+        requirement_paths=[requirements],
+        output_format="md",
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "# Upgrade audit" in out
+    assert "manifest drift packages: 1" in out
+    assert "`httpx` | drift | high | `0.29.0`" in out


### PR DESCRIPTION
### Motivation
- Improve repository upgrade planning by auditing all dependency manifests rather than only direct pyproject dependencies. 
- Detect and surface cross-file version drift and actionable high-priority upgrade signals to make upgrade decisions deterministic and automatable.

### Description
- Expanded `scripts/upgrade_audit.py` to parse `pyproject.toml` plus `requirements*.txt`, normalize lines, and extract pinned versions using `_load_pyproject_dependencies`, `_load_requirements_dependencies`, and related helpers. 
- Added PyPI metadata retrieval with release date extraction in `_latest_pypi_metadata` and package-level summarization via `_build_package_report`. 
- Added structured output modes: Markdown and JSON renderers (`_render_markdown`, `_render_json`) and CLI flags `--format`, `--requirements`, and `--include-lockfiles` to control manifest discovery and output. 
- Documented the richer workflow in `README.md` and added focused tests in `tests/test_upgrade_audit_script.py` covering manifest parsing, drift detection, JSON summary generation, and Markdown rendering. 

### Testing
- Ran the focused unit tests with `pytest -q tests/test_upgrade_audit_script.py` which passed (`4 passed`).
- Ran a combined test run with `pytest -q tests/test_upgrade_audit_script.py tests/test_maintenance_cli.py` which succeeded, and a broader subset run that completed successfully (`26 passed`).
- Executed the script live with `python scripts/upgrade_audit.py --format json > /tmp/upgrade-audit.json` and verified output summary populated (packages audited, drift counts, high-priority signals).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb209d5ef88320b115128d0db113d1)