### PR TITLE
Enhance upgrade audit prioritization and CI gating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # --- dev targets (bootstrap) ---
 
-.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit
+.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci
 
 venv:
 	@test -x .venv/bin/python || python3 -m venv .venv
@@ -44,3 +44,7 @@ release-verify-plan: venv
 
 upgrade-audit: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python scripts/upgrade_audit.py'
+
+
+upgrade-audit-ci: venv
+	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python scripts/upgrade_audit.py --fail-on high'

--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ python -m sdetkit continuous-upgrade-cycle11-closeout --format json --strict
 
 ## Upgrade planning (first step)
 
-Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, estimated version-gap size (major/minor/patch), release recency, and focus notes for each package:
+Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, and a concrete next action for each package. You can also fail CI at a chosen signal threshold:
 
 ```bash
 make upgrade-audit
 python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
+python scripts/upgrade_audit.py --fail-on high
 ```
 
 ## Sample artifacts

--- a/scripts/upgrade_audit.py
+++ b/scripts/upgrade_audit.py
@@ -47,7 +47,19 @@ class PackageReport:
     version_gap: str
     release_age_days: int | None
     upgrade_signal: str
+    risk_score: int
+    next_action: str
     notes: list[str]
+
+
+SIGNAL_PRIORITY = {
+    "critical": 5,
+    "high": 4,
+    "medium": 3,
+    "watch": 2,
+    "investigate": 2,
+    "unknown": 1,
+}
 
 
 def _parse_dep_name(raw_requirement: str) -> str:
@@ -307,6 +319,41 @@ def _build_package_report(
     elif latest_version == "network-error" or latest_version.startswith("http-"):
         upgrade_signal = "investigate"
 
+    risk_score = 0
+    if alignment == "drift":
+        risk_score += 45
+    elif alignment == "range-or-unpinned":
+        risk_score += 15
+
+    risk_score += {
+        "major": 35,
+        "minor": 20,
+        "patch": 10,
+        "different": 15,
+        "unknown": 5,
+    }.get(version_gap, 0)
+
+    if "default" in groups:
+        risk_score += 10
+    if release_age_days is not None and release_age_days <= 30:
+        risk_score += 10
+    if upgrade_signal == "investigate":
+        risk_score += 10
+
+    next_action = "Keep under observation; no immediate action required."
+    if upgrade_signal == "critical":
+        next_action = "Resolve manifest drift first, then validate the major upgrade in a dedicated branch."
+    elif upgrade_signal == "high":
+        next_action = "Plan an upgrade spike with regression coverage before the next release cut."
+    elif upgrade_signal == "medium":
+        next_action = "Queue the upgrade for the next maintenance batch and validate targeted smoke tests."
+    elif upgrade_signal == "watch":
+        next_action = "Track the package and batch it with nearby dependency maintenance work."
+    elif upgrade_signal == "investigate":
+        next_action = "Retry metadata collection and inspect package naming or connectivity issues."
+    elif upgrade_signal == "unknown":
+        next_action = "Review the declared version range manually because the gap could not be classified."
+
     return PackageReport(
         name=name,
         sources=sources,
@@ -320,6 +367,8 @@ def _build_package_report(
         version_gap=version_gap,
         release_age_days=release_age_days,
         upgrade_signal=upgrade_signal,
+        risk_score=risk_score,
+        next_action=next_action,
         notes=notes,
     )
 
@@ -333,6 +382,8 @@ def _render_markdown(
     drift_count = sum(1 for report in reports if report.alignment == "drift")
     high_priority = sum(1 for report in reports if report.upgrade_signal == "high")
     critical_priority = sum(1 for report in reports if report.upgrade_signal == "critical")
+    medium_priority = sum(1 for report in reports if report.upgrade_signal == "medium")
+    investigate_priority = sum(1 for report in reports if report.upgrade_signal == "investigate")
     lines = [
         "# Upgrade audit",
         "",
@@ -343,9 +394,11 @@ def _render_markdown(
         f"- manifest drift packages: {drift_count}",
         f"- critical upgrade signals: {critical_priority}",
         f"- high-priority upgrade signals: {high_priority}",
+        f"- medium-priority upgrade signals: {medium_priority}",
+        f"- investigate signals: {investigate_priority}",
         "",
-        "| Package | Current | Latest PyPI | Gap | Alignment | Signal | Release age (days) | Requirements |",
-        "|---|---|---|---|---|---|---|---|",
+        "| Package | Current | Latest PyPI | Gap | Alignment | Signal | Risk | Release age (days) | Requirements |",
+        "|---|---|---|---|---|---|---|---|---|",
     ]
     for report in reports:
         release_age = "-" if report.release_age_days is None else str(report.release_age_days)
@@ -353,13 +406,12 @@ def _render_markdown(
         lines.append(
             "| "
             f"`{report.name}` | `{report.current_version}` | `{report.latest_version}` | {report.version_gap} | "
-            f"{report.alignment} | {report.upgrade_signal} | {release_age} | {requirements} |"
+            f"{report.alignment} | {report.upgrade_signal} | {report.risk_score} | {release_age} | {requirements} |"
         )
     lines.extend(["", "## Focus notes", ""])
     for report in reports:
-        if not report.notes:
-            continue
-        lines.append(f"- `{report.name}`: {' '.join(report.notes)}")
+        note_text = " ".join(report.notes) if report.notes else "No additional notes."
+        lines.append(f"- `{report.name}` ({report.next_action}) {note_text}")
     return "\n".join(lines) + "\n"
 
 
@@ -381,10 +433,31 @@ def _render_json(
             "high_priority_upgrade_signals": sum(
                 1 for report in reports if report.upgrade_signal == "high"
             ),
+            "medium_priority_upgrade_signals": sum(
+                1 for report in reports if report.upgrade_signal == "medium"
+            ),
+            "investigate_upgrade_signals": sum(
+                1 for report in reports if report.upgrade_signal == "investigate"
+            ),
+            "max_risk_score": max((report.risk_score for report in reports), default=0),
         },
         "packages": [asdict(report) for report in reports],
     }
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _sort_reports(reports: list[PackageReport]) -> list[PackageReport]:
+    return sorted(
+        reports,
+        key=lambda report: (-report.risk_score, -SIGNAL_PRIORITY.get(report.upgrade_signal, 0), report.name),
+    )
+
+
+def _should_fail(reports: list[PackageReport], fail_on: str) -> bool:
+    if fail_on == "never":
+        return False
+    threshold = SIGNAL_PRIORITY[fail_on]
+    return any(SIGNAL_PRIORITY.get(report.upgrade_signal, 0) >= threshold for report in reports)
 
 
 def run(
@@ -393,6 +466,7 @@ def run(
     *,
     requirement_paths: list[Path],
     output_format: str,
+    fail_on: str = "never",
 ) -> int:
     dependencies = _load_dependencies(pyproject_path, requirement_paths)
 
@@ -422,6 +496,8 @@ def run(
             )
         )
 
+    reports = _sort_reports(reports)
+
     rendered = {
         "json": _render_json(
             reports, pyproject_path=pyproject_path, requirement_paths=requirement_paths
@@ -431,7 +507,7 @@ def run(
         ),
     }[output_format]
     sys.stdout.write(rendered)
-    return 0
+    return 1 if _should_fail(reports, fail_on) else 0
 
 
 def main() -> int:
@@ -471,6 +547,12 @@ def main() -> int:
         action="store_true",
         help="Include requirements*.txt.lock files discovered in the repo root.",
     )
+    parser.add_argument(
+        "--fail-on",
+        choices=["critical", "high", "medium", "watch", "investigate", "unknown", "never"],
+        default="never",
+        help="Exit with code 1 when a package meets or exceeds this signal threshold.",
+    )
     args = parser.parse_args()
 
     if not args.pyproject.exists():
@@ -495,6 +577,7 @@ def main() -> int:
         timeout_s=args.timeout,
         requirement_paths=requirement_paths,
         output_format=args.format,
+        fail_on=args.fail_on,
     )
 
 

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -82,8 +82,10 @@ def test_build_package_report_flags_drift_and_priority() -> None:
     assert report.current_version == "0.28.1"
     assert report.version_gap == "minor"
     assert report.upgrade_signal == "high"
+    assert report.risk_score >= 75
     assert report.latest_version == "0.29.0"
     assert report.latest_release_date == "2026-01-01T00:00:00Z"
+    assert "Plan an upgrade spike" in report.next_action
     assert "Cross-manifest requirement drift detected." in report.notes
 
 
@@ -108,6 +110,7 @@ def test_build_package_report_flags_major_jump_as_critical() -> None:
     assert report.current_version == "0.28.1"
     assert report.version_gap == "major"
     assert report.upgrade_signal == "high"
+    assert report.risk_score >= 45
     assert any("major-version jump" in note for note in report.notes)
 
 
@@ -126,6 +129,8 @@ def test_render_json_summary_counts() -> None:
             version_gap="minor",
             release_age_days=0,
             upgrade_signal="high",
+            risk_score=85,
+            next_action="Plan an upgrade spike with regression coverage before the next release cut.",
             notes=["Cross-manifest requirement drift detected."],
         ),
         upgrade_audit.PackageReport(
@@ -141,6 +146,8 @@ def test_render_json_summary_counts() -> None:
             version_gap="up-to-date",
             release_age_days=None,
             upgrade_signal="watch",
+            risk_score=10,
+            next_action="Keep under observation; no immediate action required.",
             notes=[],
         ),
     ]
@@ -158,6 +165,9 @@ def test_render_json_summary_counts() -> None:
         "packages_audited": 2,
         "manifest_drift_packages": 1,
         "high_priority_upgrade_signals": 1,
+        "investigate_upgrade_signals": 0,
+        "max_risk_score": 85,
+        "medium_priority_upgrade_signals": 0,
     }
     assert payload["packages"][0]["name"] == "httpx"
 
@@ -192,6 +202,80 @@ dependencies = ["httpx>=0.27,<1"]
     out = capsys.readouterr().out
     assert "# Upgrade audit" in out
     assert "manifest drift packages: 1" in out
-    assert "Current | Latest PyPI | Gap | Alignment | Signal" in out
+    assert "Current | Latest PyPI | Gap | Alignment | Signal | Risk" in out
     assert "`httpx` | `0.28.1` | `0.29.0` | minor | drift | high |" in out
     assert "Focus notes" in out
+    assert "Plan an upgrade spike with regression coverage before the next release cut." in out
+
+
+def test_run_returns_failure_when_signal_threshold_is_met(monkeypatch, tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = ["httpx>=0.27,<1"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("httpx==0.28.1\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        upgrade_audit,
+        "_latest_pypi_metadata",
+        lambda package, timeout_s: ("1.0.0", "2026-01-01T00:00:00Z"),
+    )
+
+    rc = upgrade_audit.run(
+        pyproject,
+        timeout_s=0.1,
+        requirement_paths=[requirements],
+        output_format="json",
+        fail_on="high",
+    )
+
+    assert rc == 1
+
+
+def test_sort_reports_surfaces_highest_risk_first() -> None:
+    reports = [
+        upgrade_audit.PackageReport(
+            name="watch-pkg",
+            sources=["requirements.txt"],
+            groups=["requirements"],
+            requirements=["watch-pkg==1.0.0"],
+            pinned_versions=["1.0.0"],
+            current_version="1.0.0",
+            alignment="aligned",
+            latest_version="1.0.1",
+            latest_release_date=None,
+            version_gap="patch",
+            release_age_days=None,
+            upgrade_signal="watch",
+            risk_score=10,
+            next_action="Track the package and batch it with nearby dependency maintenance work.",
+            notes=[],
+        ),
+        upgrade_audit.PackageReport(
+            name="critical-pkg",
+            sources=["pyproject.toml", "requirements.txt"],
+            groups=["default", "requirements"],
+            requirements=["critical-pkg>=1,<2", "critical-pkg==1.2.3"],
+            pinned_versions=["1.2.3"],
+            current_version="1.2.3",
+            alignment="drift",
+            latest_version="2.0.0",
+            latest_release_date=None,
+            version_gap="major",
+            release_age_days=None,
+            upgrade_signal="critical",
+            risk_score=90,
+            next_action="Resolve manifest drift first, then validate the major upgrade in a dedicated branch.",
+            notes=[],
+        ),
+    ]
+
+    sorted_reports = upgrade_audit._sort_reports(reports)
+
+    assert [report.name for report in sorted_reports] == ["critical-pkg", "watch-pkg"]


### PR DESCRIPTION
### Motivation
- Make the dependency upgrade audit more actionable by surfacing an ordered risk score and concrete next steps for each package to improve triage and automation readiness.
- Allow repositories and CI to fail fast on high-risk upgrades by providing a configurable threshold so upgrade signals can gate releases.

### Description
- Add `risk_score` and `next_action` fields to `scripts/upgrade_audit.py` and compute them from alignment, version-gap, groups, and release recency, and add a `SIGNAL_PRIORITY` map for deterministic prioritization.
- Introduce `_sort_reports` to order packages by `risk_score` and signal priority, and `_should_fail` plus a `--fail-on` CLI flag to enable threshold-based CI gating (returns non-zero when threshold met).
- Extend JSON/Markdown renderers to include risk counts, `max_risk_score`, risk columns, and action-oriented focus notes, and update `README.md` to document `--fail-on` usage and add a `make upgrade-audit-ci` Makefile target.
- Expand tests in `tests/test_upgrade_audit_script.py` to validate `risk_score`, `next_action`, ordering behavior, and threshold-based failure behavior.

### Testing
- Ran `python -m pytest tests/test_upgrade_audit_script.py` which passed (`7 passed`) validating new report fields, ordering, and CI-threshold behavior. 
- Ran `ruff` checks with `python -m ruff check scripts/upgrade_audit.py tests/test_upgrade_audit_script.py` which returned no issues. 
- Executed `python scripts/upgrade_audit.py --format json --fail-on high` which produced an audit JSON and exited with code `1` as expected when high-priority signals were present, confirming the CI gating behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb290a57f88320b6899f1acee47d54)