### PR TITLE
Add selective/parallel maintenance checks and make upgrade audit constraint-aware

### DIFF
--- a/scripts/upgrade_audit.py
+++ b/scripts/upgrade_audit.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 REQ_NAME_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)")
 PINNED_VERSION_RE = re.compile(r"==\s*([A-Za-z0-9_.!+-]+)")
+CONSTRAINT_RE = re.compile(r"(==|~=|>=|<=|>|<)\s*([A-Za-z0-9_.!+-]+)")
 
 
 @dataclass(frozen=True)
@@ -43,6 +44,7 @@ class PackageReport:
     pinned_versions: list[str]
     current_version: str
     alignment: str
+    constraint_status: str
     latest_version: str
     latest_release_date: str | None
     version_gap: str
@@ -95,6 +97,15 @@ def _extract_minimum_version(raw_requirement: str) -> str | None:
                 if normalized:
                     return normalized
     return None
+
+
+def _parse_requirement_constraints(raw_requirement: str) -> list[tuple[str, str]]:
+    base = raw_requirement.split(";", 1)[0].strip()
+    if not base:
+        return []
+    start = REQ_NAME_RE.match(base)
+    spec = base[start.end() :] if start else base
+    return [(operator, version) for operator, version in CONSTRAINT_RE.findall(spec)]
 
 
 def _normalize_requirement_line(line: str) -> str | None:
@@ -259,7 +270,9 @@ def _fetch_package_metadata(
     if offline:
         if cached_entry:
             return _metadata_from_cache(cached_entry, source="cache-stale")
-        return PackageMetadata(latest_version="offline-no-cache", release_date=None, source="offline")
+        return PackageMetadata(
+            latest_version="offline-no-cache", release_date=None, source="offline"
+        )
 
     try:
         latest_version, release_date = _latest_pypi_metadata(package, timeout_s=timeout_s)
@@ -338,6 +351,55 @@ def _version_key(version: str) -> tuple[tuple[int, object], ...]:
     return tuple(parts)
 
 
+def _compare_versions(left: str, right: str) -> int:
+    left_key = _version_key(left)
+    right_key = _version_key(right)
+    if left_key < right_key:
+        return -1
+    if left_key > right_key:
+        return 1
+    return 0
+
+
+def _compatible_upper_bound(version: str) -> str | None:
+    parts = [int(part) for part in re.findall(r"\d+", version)]
+    if not parts:
+        return None
+    if len(parts) == 1:
+        return str(parts[0] + 1)
+    upper = parts[:-1]
+    upper[-1] += 1
+    return ".".join(str(part) for part in upper)
+
+
+def _constraint_allows_version(constraint: tuple[str, str], version: str) -> bool:
+    operator, required = constraint
+    cmp = _compare_versions(version, required)
+    if operator == "==":
+        return cmp == 0
+    if operator == ">=":
+        return cmp >= 0
+    if operator == "<=":
+        return cmp <= 0
+    if operator == ">":
+        return cmp > 0
+    if operator == "<":
+        return cmp < 0
+    if operator == "~=":
+        upper = _compatible_upper_bound(required)
+        if upper is None:
+            return False
+        return cmp >= 0 and _compare_versions(version, upper) < 0
+    return False
+
+
+def _requirement_allows_version(raw_requirement: str, version: str) -> bool | None:
+    constraints = _parse_requirement_constraints(raw_requirement)
+    if not constraints:
+        return None
+    return all(_constraint_allows_version(constraint, version) for constraint in constraints)
+
+
 def _pick_current_version(deps: list[Dependency]) -> str:
     pinned_versions = sorted(
         {dep.pinned_version for dep in deps if dep.pinned_version},
@@ -357,6 +419,43 @@ def _pick_current_version(deps: list[Dependency]) -> str:
     if lower_bounds:
         return lower_bounds[-1]
     return "unbounded"
+
+
+def _constraint_status(deps: list[Dependency], latest_version: str) -> str:
+    if latest_version in {
+        "unknown",
+        "network-error",
+        "offline-no-cache",
+    } or latest_version.startswith("http-"):
+        return "unknown"
+    allowed_results = [
+        result
+        for dep in deps
+        if (result := _requirement_allows_version(dep.raw, latest_version)) is not None
+    ]
+    if not allowed_results:
+        return "unbounded"
+    return "allowed" if all(allowed_results) else "blocked"
+
+
+def _infer_alignment(deps: list[Dependency], current_version: str) -> str:
+    requirements = sorted({dep.raw for dep in deps})
+    pinned_versions = sorted({dep.pinned_version for dep in deps if dep.pinned_version})
+    if len(requirements) == 1:
+        return "range-or-unpinned" if not pinned_versions else "aligned"
+
+    if len(pinned_versions) > 1:
+        return "drift"
+
+    allowed_results = [
+        result
+        for dep in deps
+        if current_version != "unbounded"
+        and (result := _requirement_allows_version(dep.raw, current_version)) is not None
+    ]
+    if allowed_results and all(allowed_results):
+        return "compatible"
+    return "drift"
 
 
 def _major_minor_patch(version: str) -> tuple[int, int, int] | None:
@@ -420,18 +519,20 @@ def _build_package_report(
     current_version = _pick_current_version(deps)
     version_gap = _classify_version_gap(current_version, latest_version)
     release_age_days = _release_age_days(release_date)
-
-    alignment = "aligned"
-    if len(requirements) > 1:
-        alignment = "drift"
-    elif not pinned_versions:
-        alignment = "range-or-unpinned"
+    alignment = _infer_alignment(deps, current_version)
+    constraint_status = _constraint_status(deps, latest_version)
 
     notes: list[str] = []
     if alignment == "drift":
         notes.append("Cross-manifest requirement drift detected.")
+    elif alignment == "compatible":
+        notes.append("Cross-manifest requirements differ but remain mutually compatible.")
     if alignment == "range-or-unpinned":
         notes.append("Package is not pinned to a single exact version.")
+    if constraint_status == "allowed":
+        notes.append("Latest PyPI release is already allowed by the declared version policy.")
+    elif constraint_status == "blocked":
+        notes.append("Latest PyPI release falls outside the currently declared version policy.")
     if version_gap == "major":
         notes.append("Latest PyPI release is a major-version jump from the repo baseline.")
     elif version_gap == "minor":
@@ -444,6 +545,8 @@ def _build_package_report(
     upgrade_signal = "watch"
     if alignment == "drift":
         upgrade_signal = "critical" if version_gap == "major" else "high"
+    elif constraint_status == "allowed":
+        upgrade_signal = "watch" if "default" not in groups else "medium"
     elif version_gap == "major":
         upgrade_signal = "high" if "default" in groups else "medium"
     elif version_gap == "minor":
@@ -460,7 +563,11 @@ def _build_package_report(
     risk_score = 0
     if alignment == "drift":
         risk_score += 45
+    elif alignment == "compatible":
+        risk_score += 10
     elif alignment == "range-or-unpinned":
+        risk_score += 15
+    if constraint_status == "blocked":
         risk_score += 15
 
     risk_score += {
@@ -480,19 +587,27 @@ def _build_package_report(
 
     next_action = "Keep under observation; no immediate action required."
     if upgrade_signal == "critical":
-        next_action = "Resolve manifest drift first, then validate the major upgrade in a dedicated branch."
+        next_action = (
+            "Resolve manifest drift first, then validate the major upgrade in a dedicated branch."
+        )
     elif upgrade_signal == "high":
         next_action = "Plan an upgrade spike with regression coverage before the next release cut."
     elif upgrade_signal == "medium":
-        next_action = "Queue the upgrade for the next maintenance batch and validate targeted smoke tests."
-    elif upgrade_signal == "watch":
-        next_action = "Track the package and batch it with nearby dependency maintenance work."
-    elif upgrade_signal == "investigate":
         next_action = (
-            "Retry metadata collection and inspect package naming, cache freshness, or connectivity issues."
+            "Queue the upgrade for the next maintenance batch and validate targeted smoke tests."
         )
+    elif upgrade_signal == "watch":
+        next_action = (
+            "Keep the package on watch; the declared version policy already covers the latest release."
+            if constraint_status == "allowed"
+            else "Track the package and batch it with nearby dependency maintenance work."
+        )
+    elif upgrade_signal == "investigate":
+        next_action = "Retry metadata collection and inspect package naming, cache freshness, or connectivity issues."
     elif upgrade_signal == "unknown":
-        next_action = "Review the declared version range manually because the gap could not be classified."
+        next_action = (
+            "Review the declared version range manually because the gap could not be classified."
+        )
 
     return PackageReport(
         name=name,
@@ -502,6 +617,7 @@ def _build_package_report(
         pinned_versions=pinned_versions,
         current_version=current_version,
         alignment=alignment,
+        constraint_status=constraint_status,
         latest_version=latest_version,
         latest_release_date=release_date,
         version_gap=version_gap,
@@ -520,11 +636,16 @@ def _render_markdown(
     requirement_paths: list[Path],
 ) -> str:
     drift_count = sum(1 for report in reports if report.alignment == "drift")
+    compatible_count = sum(1 for report in reports if report.alignment == "compatible")
     high_priority = sum(1 for report in reports if report.upgrade_signal == "high")
     critical_priority = sum(1 for report in reports if report.upgrade_signal == "critical")
     medium_priority = sum(1 for report in reports if report.upgrade_signal == "medium")
     investigate_priority = sum(1 for report in reports if report.upgrade_signal == "investigate")
-    cached_results = sum(1 for report in reports if any("cache" in note.lower() for note in report.notes))
+    policy_covered = sum(1 for report in reports if report.constraint_status == "allowed")
+    policy_blocked = sum(1 for report in reports if report.constraint_status == "blocked")
+    cached_results = sum(
+        1 for report in reports if any("cache" in note.lower() for note in report.notes)
+    )
     lines = [
         "# Upgrade audit",
         "",
@@ -533,14 +654,17 @@ def _render_markdown(
         "",
         f"- packages audited: {len(reports)}",
         f"- manifest drift packages: {drift_count}",
+        f"- compatible multi-manifest packages: {compatible_count}",
+        f"- policy-covered latest releases: {policy_covered}",
+        f"- policy-blocked latest releases: {policy_blocked}",
         f"- critical upgrade signals: {critical_priority}",
         f"- high-priority upgrade signals: {high_priority}",
         f"- medium-priority upgrade signals: {medium_priority}",
         f"- investigate signals: {investigate_priority}",
         f"- packages using cached metadata: {cached_results}",
         "",
-        "| Package | Current | Latest PyPI | Gap | Alignment | Signal | Risk | Release age (days) | Requirements |",
-        "|---|---|---|---|---|---|---|---|---|",
+        "| Package | Current | Latest PyPI | Gap | Alignment | Policy | Signal | Risk | Release age (days) | Requirements |",
+        "|---|---|---|---|---|---|---|---|---|---|",
     ]
     for report in reports:
         release_age = "-" if report.release_age_days is None else str(report.release_age_days)
@@ -548,7 +672,7 @@ def _render_markdown(
         lines.append(
             "| "
             f"`{report.name}` | `{report.current_version}` | `{report.latest_version}` | {report.version_gap} | "
-            f"{report.alignment} | {report.upgrade_signal} | {report.risk_score} | {release_age} | {requirements} |"
+            f"{report.alignment} | {report.constraint_status} | {report.upgrade_signal} | {report.risk_score} | {release_age} | {requirements} |"
         )
     lines.extend(["", "## Focus notes", ""])
     for report in reports:
@@ -569,6 +693,15 @@ def _render_json(
         "summary": {
             "packages_audited": len(reports),
             "manifest_drift_packages": sum(1 for report in reports if report.alignment == "drift"),
+            "compatible_constraint_packages": sum(
+                1 for report in reports if report.alignment == "compatible"
+            ),
+            "policy_covered_packages": sum(
+                1 for report in reports if report.constraint_status == "allowed"
+            ),
+            "policy_blocked_packages": sum(
+                1 for report in reports if report.constraint_status == "blocked"
+            ),
             "critical_upgrade_signals": sum(
                 1 for report in reports if report.upgrade_signal == "critical"
             ),
@@ -594,7 +727,11 @@ def _render_json(
 def _sort_reports(reports: list[PackageReport]) -> list[PackageReport]:
     return sorted(
         reports,
-        key=lambda report: (-report.risk_score, -SIGNAL_PRIORITY.get(report.upgrade_signal, 0), report.name),
+        key=lambda report: (
+            -report.risk_score,
+            -SIGNAL_PRIORITY.get(report.upgrade_signal, 0),
+            report.name,
+        ),
     )
 
 

--- a/src/sdetkit/maintenance/cli.py
+++ b/src/sdetkit/maintenance/cli.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +33,24 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--fix", action="store_true")
     parser.add_argument("--deterministic", action="store_true")
     parser.add_argument("--quiet", action="store_true")
+    parser.add_argument(
+        "--include-check",
+        action="append",
+        default=None,
+        help="Run only the named check(s). Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--exclude-check",
+        action="append",
+        default=None,
+        help="Skip the named check(s). Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=1,
+        help="Maximum number of checks to run in parallel (default: 1).",
+    )
     return parser
 
 
@@ -101,30 +120,107 @@ def _deterministic_generated_at(env: dict[str, str]) -> str:
         return DETERMINISTIC_GENERATED_AT
 
 
-def _build_report(ctx: MaintenanceContext, *, deterministic: bool = False) -> dict[str, Any]:
-    started = time.monotonic()
-    checks: dict[str, dict[str, Any]] = {}
-    crashes = False
-    for name, runner in checks_for_mode(ctx.mode):
-        try:
-            result: CheckResult = runner(ctx)
-        except Exception as exc:
-            crashes = True
-            result = CheckResult(
+def _normalize_names(values: list[str] | None) -> list[str]:
+    return sorted({value.strip() for value in values or [] if value.strip()})
+
+
+def _select_checks(
+    available_checks: list[tuple[str, Any]],
+    *,
+    include_checks: list[str] | None = None,
+    exclude_checks: list[str] | None = None,
+) -> list[tuple[str, Any]]:
+    include = set(_normalize_names(include_checks))
+    exclude = set(_normalize_names(exclude_checks))
+    selected: list[tuple[str, Any]] = []
+    for name, runner in available_checks:
+        if include and name not in include:
+            continue
+        if name in exclude:
+            continue
+        selected.append((name, runner))
+    return selected
+
+
+def _run_check(name: str, runner: Any, ctx: MaintenanceContext) -> tuple[str, CheckResult, bool]:
+    try:
+        return name, runner(ctx), False
+    except Exception as exc:
+        return (
+            name,
+            CheckResult(
                 ok=False,
                 summary=f"check crashed: {exc}",
                 details={"error": repr(exc)},
                 actions=[],
-            )
-        checks[name] = result.as_dict()
+            ),
+            True,
+        )
+
+
+def _build_recommendations(checks: dict[str, dict[str, Any]]) -> list[str]:
+    failing = sorted(name for name, item in checks.items() if not item["ok"])
+    if not failing:
+        return ["All maintenance checks passed."]
+
+    recommendations = [f"Review failing checks: {', '.join(failing)}."]
+    suggested_actions: list[str] = []
+    for name in failing:
+        actions = checks[name].get("actions", [])
+        if not isinstance(actions, list):
+            continue
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            title = str(action.get("title", "")).strip()
+            applied = bool(action.get("applied", False))
+            if title and not applied:
+                suggested_actions.append(title)
+    if suggested_actions:
+        unique_actions = sorted(dict.fromkeys(suggested_actions))
+        recommendations.append(f"Suggested next actions: {', '.join(unique_actions[:5])}.")
+    return recommendations
+
+
+def _build_report(
+    ctx: MaintenanceContext,
+    *,
+    deterministic: bool = False,
+    include_checks: list[str] | None = None,
+    exclude_checks: list[str] | None = None,
+    jobs: int = 1,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    checks: dict[str, dict[str, Any]] = {}
+    crashes = False
+    available_checks = checks_for_mode(ctx.mode)
+    selected_checks = _select_checks(
+        available_checks,
+        include_checks=include_checks,
+        exclude_checks=exclude_checks,
+    )
+    worker_count = max(1, jobs)
+
+    if worker_count == 1 or len(selected_checks) <= 1:
+        for name, runner in selected_checks:
+            _, result, crashed = _run_check(name, runner, ctx)
+            crashes = crashes or crashed
+            checks[name] = result.as_dict()
+    else:
+        with ThreadPoolExecutor(max_workers=worker_count) as pool:
+            futures = {
+                pool.submit(_run_check, name, runner, ctx): name for name, runner in selected_checks
+            }
+            for future in as_completed(futures):
+                name, result, crashed = future.result()
+                crashes = crashes or crashed
+                checks[name] = result.as_dict()
+
+    checks = dict(sorted(checks.items()))
     passed = sum(1 for item in checks.values() if item["ok"])
     total = len(checks)
     score = 100 if total == 0 else round((passed / total) * 100)
-    recommendations = [
-        f"Review failing checks: {', '.join(sorted(name for name, item in checks.items() if not item['ok']))}."
-    ]
-    if all(item["ok"] for item in checks.values()):
-        recommendations = ["All maintenance checks passed."]
+    recommendations = _build_recommendations(checks)
     report = {
         "ok": all(item["ok"] for item in checks.values()),
         "score": score,
@@ -140,6 +236,11 @@ def _build_report(ctx: MaintenanceContext, *, deterministic: bool = False) -> di
             "python": ctx.python_exe,
             "duration_seconds": 0.0 if deterministic else round(time.monotonic() - started, 3),
             "had_crash": crashes,
+            "jobs": worker_count,
+            "available_checks": [name for name, _runner in available_checks],
+            "selected_checks": [name for name, _runner in selected_checks],
+            "excluded_checks": _normalize_names(exclude_checks),
+            "include_checks": _normalize_names(include_checks),
         },
     }
     return report
@@ -179,7 +280,13 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     try:
-        report = _build_report(ctx, deterministic=bool(ns.deterministic))
+        report = _build_report(
+            ctx,
+            deterministic=bool(ns.deterministic),
+            include_checks=ns.include_check,
+            exclude_checks=ns.exclude_check,
+            jobs=max(int(ns.jobs), 1),
+        )
         rendered = {
             "json": json.dumps(report, sort_keys=True),
             "text": _render_text(report),

--- a/tests/test_maintenance_cli.py
+++ b/tests/test_maintenance_cli.py
@@ -110,6 +110,30 @@ def test_fix_mode_records_actions() -> None:
     assert lint_actions
 
 
+def test_cli_supports_include_exclude_and_jobs(monkeypatch, capsys) -> None:
+    def _ok(_ctx: MaintenanceContext):
+        return cli.CheckResult(ok=True, summary="ok", details={}, actions=[])
+
+    monkeypatch.setattr(cli, "checks_for_mode", lambda _mode: [("a", _ok), ("b", _ok)])
+    rc = cli.main(
+        [
+            "--format",
+            "json",
+            "--include-check",
+            "a",
+            "--exclude-check",
+            "b",
+            "--jobs",
+            "3",
+            "--deterministic",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out.splitlines()[0])
+    assert payload["meta"]["jobs"] == 3
+    assert payload["meta"]["selected_checks"] == ["a"]
+
+
 def test_doctor_check_handles_empty_output(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(doctor_check.doctor, "main", lambda _args: 2)
     ctx = MaintenanceContext(

--- a/tests/test_maintenance_cli_extra.py
+++ b/tests/test_maintenance_cli_extra.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from sdetkit.maintenance import cli as mcli
-from sdetkit.maintenance.types import CheckResult, MaintenanceContext
+from sdetkit.maintenance.types import CheckAction, CheckResult, MaintenanceContext
 
 
 def test_build_report_handles_runner_crash(monkeypatch, tmp_path: Path) -> None:
@@ -28,6 +28,47 @@ def test_build_report_handles_runner_crash(monkeypatch, tmp_path: Path) -> None:
     assert report["ok"] is False
     assert report["meta"]["had_crash"] is True
     assert "check crashed" in report["checks"]["b"]["summary"]
+
+
+def test_build_report_filters_checks_and_aggregates_actions(monkeypatch, tmp_path: Path) -> None:
+    def _fail(_ctx: MaintenanceContext) -> CheckResult:
+        return CheckResult(
+            ok=False,
+            summary="needs work",
+            details={},
+            actions=[CheckAction(id="lint", title="Run lint", applied=False)],
+        )
+
+    def _ok(_ctx: MaintenanceContext) -> CheckResult:
+        return CheckResult(ok=True, summary="ok", details={}, actions=[])
+
+    monkeypatch.setattr(
+        mcli,
+        "checks_for_mode",
+        lambda mode: [("lint_check", _fail), ("tests_check", _ok), ("doctor_check", _ok)],
+    )
+
+    ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe="python",
+        mode="quick",
+        fix=False,
+        env={},
+        logger=mcli.StderrLogger(),
+    )
+    report = mcli._build_report(
+        ctx,
+        deterministic=True,
+        include_checks=["lint_check", "tests_check"],
+        exclude_checks=["tests_check"],
+        jobs=4,
+    )
+
+    assert set(report["checks"]) == {"lint_check"}
+    assert report["meta"]["selected_checks"] == ["lint_check"]
+    assert report["meta"]["excluded_checks"] == ["tests_check"]
+    assert report["meta"]["jobs"] == 4
+    assert "Suggested next actions: Run lint." in report["recommendations"]
 
 
 def test_main_json_output_and_write_file(monkeypatch, tmp_path: Path, capsys) -> None:

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -78,15 +78,48 @@ def test_build_package_report_flags_drift_and_priority() -> None:
         release_date="2026-01-01T00:00:00Z",
     )
 
-    assert report.alignment == "drift"
+    assert report.alignment == "compatible"
+    assert report.constraint_status == "blocked"
     assert report.current_version == "0.28.1"
     assert report.version_gap == "minor"
-    assert report.upgrade_signal == "high"
-    assert report.risk_score >= 75
+    assert report.upgrade_signal == "medium"
+    assert report.risk_score >= 45
     assert report.latest_version == "0.29.0"
     assert report.latest_release_date == "2026-01-01T00:00:00Z"
-    assert "Plan an upgrade spike" in report.next_action
-    assert "Cross-manifest requirement drift detected." in report.notes
+    assert "Queue the upgrade" in report.next_action
+    assert "mutually compatible" in " ".join(report.notes)
+
+
+def test_build_package_report_marks_compatible_policy_covered_manifests() -> None:
+    deps = [
+        upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="default",
+            raw="httpx>=0.27,<1",
+            name="httpx",
+            pinned_version=None,
+        ),
+        upgrade_audit.Dependency(
+            source="requirements.txt",
+            group="requirements",
+            raw="httpx==0.28.1",
+            name="httpx",
+            pinned_version="0.28.1",
+        ),
+    ]
+
+    report = upgrade_audit._build_package_report(
+        "httpx",
+        deps,
+        latest_version="0.28.1",
+        release_date="2026-01-01T00:00:00Z",
+    )
+
+    assert report.alignment == "compatible"
+    assert report.constraint_status == "allowed"
+    assert report.upgrade_signal == "medium"
+    assert "mutually compatible" in " ".join(report.notes)
+    assert "already allowed by the declared version policy" in " ".join(report.notes)
 
 
 def test_build_package_report_flags_major_jump_as_critical() -> None:
@@ -124,6 +157,7 @@ def test_render_json_summary_counts() -> None:
             pinned_versions=["0.28.1"],
             current_version="0.28.1",
             alignment="drift",
+            constraint_status="blocked",
             latest_version="0.29.0",
             latest_release_date="2026-01-01T00:00:00Z",
             version_gap="minor",
@@ -141,6 +175,7 @@ def test_render_json_summary_counts() -> None:
             pinned_versions=["0.15.6"],
             current_version="0.15.6",
             alignment="aligned",
+            constraint_status="allowed",
             latest_version="0.15.6",
             latest_release_date=None,
             version_gap="up-to-date",
@@ -161,6 +196,7 @@ def test_render_json_summary_counts() -> None:
     )
 
     assert payload["summary"] == {
+        "compatible_constraint_packages": 0,
         "cached_metadata_packages": 0,
         "critical_upgrade_signals": 0,
         "packages_audited": 2,
@@ -169,6 +205,8 @@ def test_render_json_summary_counts() -> None:
         "investigate_upgrade_signals": 0,
         "max_risk_score": 85,
         "medium_priority_upgrade_signals": 0,
+        "policy_blocked_packages": 1,
+        "policy_covered_packages": 1,
     }
     assert payload["packages"][0]["name"] == "httpx"
 
@@ -203,12 +241,15 @@ dependencies = ["httpx>=0.27,<1"]
     assert rc == 0
     out = capsys.readouterr().out
     assert "# Upgrade audit" in out
-    assert "manifest drift packages: 1" in out
+    assert "manifest drift packages: 0" in out
+    assert "compatible multi-manifest packages: 1" in out
     assert "packages using cached metadata: 0" in out
-    assert "Current | Latest PyPI | Gap | Alignment | Signal | Risk" in out
-    assert "`httpx` | `0.28.1` | `0.29.0` | minor | drift | high |" in out
+    assert "Current | Latest PyPI | Gap | Alignment | Policy | Signal | Risk" in out
+    assert "`httpx` | `0.28.1` | `0.29.0` | minor | compatible | blocked | medium |" in out
     assert "Focus notes" in out
-    assert "Plan an upgrade spike with regression coverage before the next release cut." in out
+    assert (
+        "Queue the upgrade for the next maintenance batch and validate targeted smoke tests." in out
+    )
 
 
 def test_run_returns_failure_when_signal_threshold_is_met(monkeypatch, tmp_path: Path) -> None:
@@ -252,6 +293,7 @@ def test_sort_reports_surfaces_highest_risk_first() -> None:
             pinned_versions=["1.0.0"],
             current_version="1.0.0",
             alignment="aligned",
+            constraint_status="blocked",
             latest_version="1.0.1",
             latest_release_date=None,
             version_gap="patch",
@@ -269,6 +311,7 @@ def test_sort_reports_surfaces_highest_risk_first() -> None:
             pinned_versions=["1.2.3"],
             current_version="1.2.3",
             alignment="drift",
+            constraint_status="blocked",
             latest_version="2.0.0",
             latest_release_date=None,
             version_gap="major",


### PR DESCRIPTION
### Motivation
- Allow maintenance runs to be targeted and scaled (select specific checks, skip others, run in parallel) for faster, more actionable repo maintenance.
- Improve the upgrade-audit signal quality by making it constraint-aware so compatible multi-manifest version ranges are not treated as hard drift.

### Description
- Maintenance CLI: added `--include-check`, `--exclude-check`, and `--jobs` flags, implemented check selection and parallel execution using `ThreadPoolExecutor`, and added richer recommendations aggregation and extra metadata (`jobs`, `available_checks`, `selected_checks`, `excluded_checks`) in the report (`src/sdetkit/maintenance/cli.py`).
- Upgrade audit: added constraint parsing and evaluation (`CONSTRAINT_RE`, `_parse_requirement_constraints`, `_requirement_allows_version`), introduced `constraint_status` and `compatible` alignment, adjusted `upgrade_signal`/`risk_score`/`next_action`, and surfaced policy coverage in both markdown and JSON summaries (`scripts/upgrade_audit.py`).
- Tests: expanded and updated unit tests to cover include/exclude/jobs behavior and the new audit classifications (`tests/test_maintenance_cli.py`, `tests/test_maintenance_cli_extra.py`, `tests/test_upgrade_audit_script.py`).

### Testing
- Ran targeted pytest and full test suite: `python -m pytest -q tests/test_maintenance_cli.py tests/test_maintenance_cli_extra.py tests/test_upgrade_audit_script.py` and final run results: `36 passed` (tests passed after fixes).
- Lint/type checks: `python -m ruff check src/sdetkit/maintenance/cli.py scripts/upgrade_audit.py tests/...` returned `All checks passed!`.
- Exercised runtime scenarios: `python scripts/upgrade_audit.py --format json > /tmp/upgrade-audit.json` and `python -m sdetkit.maintenance --format json --mode quick --include-check lint_check --jobs 2 --deterministic > /tmp/maintenance.json`, both returned expected JSON output and summary metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb2f45565c832098b11d03c661d007)