### PR TITLE
Enhance upgrade audit prioritization filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
 python scripts/upgrade_audit.py --fail-on high
 python scripts/upgrade_audit.py --cache-ttl-hours 6 --max-workers 12
 python scripts/upgrade_audit.py --offline --format md
+python scripts/upgrade_audit.py --signal high --policy blocked --top 5
 ```
 
 ## Sample artifacts

--- a/scripts/upgrade_audit.py
+++ b/scripts/upgrade_audit.py
@@ -47,6 +47,7 @@ class PackageReport:
     constraint_status: str
     latest_version: str
     latest_release_date: str | None
+    metadata_source: str
     version_gap: str
     release_age_days: int | None
     upgrade_signal: str
@@ -510,7 +511,12 @@ def _release_age_days(release_date: str | None) -> int | None:
 
 
 def _build_package_report(
-    name: str, deps: list[Dependency], latest_version: str, release_date: str | None
+    name: str,
+    deps: list[Dependency],
+    latest_version: str,
+    release_date: str | None,
+    *,
+    metadata_source: str = "pypi",
 ) -> PackageReport:
     sources = sorted({dep.source for dep in deps})
     groups = sorted({dep.group for dep in deps})
@@ -620,6 +626,7 @@ def _build_package_report(
         constraint_status=constraint_status,
         latest_version=latest_version,
         latest_release_date=release_date,
+        metadata_source=metadata_source,
         version_gap=version_gap,
         release_age_days=release_age_days,
         upgrade_signal=upgrade_signal,
@@ -627,6 +634,43 @@ def _build_package_report(
         next_action=next_action,
         notes=notes,
     )
+
+
+def _priority_queue(reports: list[PackageReport], *, limit: int = 5) -> list[dict[str, object]]:
+    queue: list[dict[str, object]] = []
+    for report in reports[: max(limit, 0)]:
+        queue.append(
+            {
+                "name": report.name,
+                "signal": report.upgrade_signal,
+                "risk_score": report.risk_score,
+                "alignment": report.alignment,
+                "policy": report.constraint_status,
+                "current_version": report.current_version,
+                "latest_version": report.latest_version,
+                "next_action": report.next_action,
+            }
+        )
+    return queue
+
+
+def _filter_reports(
+    reports: list[PackageReport],
+    *,
+    signals: list[str] | None = None,
+    policies: list[str] | None = None,
+    top: int | None = None,
+) -> list[PackageReport]:
+    filtered = reports
+    if signals:
+        allowed_signals = {item.strip() for item in signals if item.strip()}
+        filtered = [report for report in filtered if report.upgrade_signal in allowed_signals]
+    if policies:
+        allowed_policies = {item.strip() for item in policies if item.strip()}
+        filtered = [report for report in filtered if report.constraint_status in allowed_policies]
+    if top is not None:
+        filtered = filtered[: max(top, 0)]
+    return filtered
 
 
 def _render_markdown(
@@ -663,16 +707,21 @@ def _render_markdown(
         f"- investigate signals: {investigate_priority}",
         f"- packages using cached metadata: {cached_results}",
         "",
-        "| Package | Current | Latest PyPI | Gap | Alignment | Policy | Signal | Risk | Release age (days) | Requirements |",
-        "|---|---|---|---|---|---|---|---|---|---|",
+        "| Package | Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk | Release age (days) | Requirements |",
+        "|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for report in reports:
         release_age = "-" if report.release_age_days is None else str(report.release_age_days)
         requirements = " <br> ".join(f"`{item}`" for item in report.requirements)
         lines.append(
             "| "
-            f"`{report.name}` | `{report.current_version}` | `{report.latest_version}` | {report.version_gap} | "
+            f"`{report.name}` | `{report.current_version}` | `{report.latest_version}` | {report.metadata_source} | {report.version_gap} | "
             f"{report.alignment} | {report.constraint_status} | {report.upgrade_signal} | {report.risk_score} | {release_age} | {requirements} |"
+        )
+    lines.extend(["", "## Priority queue", ""])
+    for item in _priority_queue(reports):
+        lines.append(
+            f"- `{item['name']}` [{item['signal']}, risk {item['risk_score']}] → {item['next_action']}"
         )
     lines.extend(["", "## Focus notes", ""])
     for report in reports:
@@ -719,6 +768,7 @@ def _render_json(
             ),
             "max_risk_score": max((report.risk_score for report in reports), default=0),
         },
+        "priority_queue": _priority_queue(reports),
         "packages": [asdict(report) for report in reports],
     }
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
@@ -753,6 +803,9 @@ def run(
     cache_ttl_hours: float = 24.0,
     offline: bool = False,
     max_workers: int = 8,
+    signals: list[str] | None = None,
+    policies: list[str] | None = None,
+    top: int | None = None,
 ) -> int:
     dependencies = _load_dependencies(pyproject_path, requirement_paths)
 
@@ -782,6 +835,7 @@ def run(
                 by_package[package],
                 latest_version=metadata.latest_version,
                 release_date=metadata.release_date,
+                metadata_source=metadata.source,
             )
         )
         report = reports[-1]
@@ -789,6 +843,7 @@ def run(
             report.notes.append(f"Latest metadata source: {metadata.source}.")
 
     reports = _sort_reports(reports)
+    reports = _filter_reports(reports, signals=signals, policies=policies, top=top)
 
     rendered = {
         "json": _render_json(
@@ -868,6 +923,26 @@ def main() -> int:
         default=8,
         help="Maximum number of parallel PyPI metadata requests (default: 8).",
     )
+    parser.add_argument(
+        "--signal",
+        action="append",
+        choices=["critical", "high", "medium", "watch", "investigate", "unknown"],
+        default=None,
+        help="Show only packages with the selected upgrade signal(s). Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--policy",
+        action="append",
+        choices=["allowed", "blocked", "unknown", "unbounded"],
+        default=None,
+        help="Show only packages with the selected policy status(es). Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=None,
+        help="Limit output to the highest-risk N packages after filtering.",
+    )
     args = parser.parse_args()
 
     if not args.pyproject.exists():
@@ -897,6 +972,9 @@ def main() -> int:
         cache_ttl_hours=args.cache_ttl_hours,
         offline=bool(args.offline),
         max_workers=max(args.max_workers, 1),
+        signals=args.signal,
+        policies=args.policy,
+        top=args.top,
     )
 
 

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -86,6 +86,7 @@ def test_build_package_report_flags_drift_and_priority() -> None:
     assert report.risk_score >= 45
     assert report.latest_version == "0.29.0"
     assert report.latest_release_date == "2026-01-01T00:00:00Z"
+    assert report.metadata_source == "pypi"
     assert "Queue the upgrade" in report.next_action
     assert "mutually compatible" in " ".join(report.notes)
 
@@ -160,6 +161,7 @@ def test_render_json_summary_counts() -> None:
             constraint_status="blocked",
             latest_version="0.29.0",
             latest_release_date="2026-01-01T00:00:00Z",
+            metadata_source="pypi",
             version_gap="minor",
             release_age_days=0,
             upgrade_signal="high",
@@ -178,6 +180,7 @@ def test_render_json_summary_counts() -> None:
             constraint_status="allowed",
             latest_version="0.15.6",
             latest_release_date=None,
+            metadata_source="cache",
             version_gap="up-to-date",
             release_age_days=None,
             upgrade_signal="watch",
@@ -244,8 +247,9 @@ dependencies = ["httpx>=0.27,<1"]
     assert "manifest drift packages: 0" in out
     assert "compatible multi-manifest packages: 1" in out
     assert "packages using cached metadata: 0" in out
-    assert "Current | Latest PyPI | Gap | Alignment | Policy | Signal | Risk" in out
-    assert "`httpx` | `0.28.1` | `0.29.0` | minor | compatible | blocked | medium |" in out
+    assert "Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk" in out
+    assert "`httpx` | `0.28.1` | `0.29.0` | pypi | minor | compatible | blocked | medium |" in out
+    assert "Priority queue" in out
     assert "Focus notes" in out
     assert (
         "Queue the upgrade for the next maintenance batch and validate targeted smoke tests." in out
@@ -296,6 +300,7 @@ def test_sort_reports_surfaces_highest_risk_first() -> None:
             constraint_status="blocked",
             latest_version="1.0.1",
             latest_release_date=None,
+            metadata_source="pypi",
             version_gap="patch",
             release_age_days=None,
             upgrade_signal="watch",
@@ -314,6 +319,7 @@ def test_sort_reports_surfaces_highest_risk_first() -> None:
             constraint_status="blocked",
             latest_version="2.0.0",
             latest_release_date=None,
+            metadata_source="pypi",
             version_gap="major",
             release_age_days=None,
             upgrade_signal="critical",
@@ -369,4 +375,95 @@ dependencies = ["httpx==0.28.1"]
     payload = json.loads(capsys.readouterr().out)
     assert payload["summary"]["cached_metadata_packages"] == 1
     assert payload["packages"][0]["latest_version"] == "0.28.1"
+    assert payload["packages"][0]["metadata_source"] == "cache"
     assert "Latest metadata source: cache." in payload["packages"][0]["notes"]
+
+
+def test_filter_reports_supports_signal_policy_and_top() -> None:
+    reports = [
+        upgrade_audit.PackageReport(
+            name="critical-pkg",
+            sources=["pyproject.toml"],
+            groups=["default"],
+            requirements=["critical-pkg==1.0.0"],
+            pinned_versions=["1.0.0"],
+            current_version="1.0.0",
+            alignment="aligned",
+            constraint_status="blocked",
+            latest_version="2.0.0",
+            latest_release_date="2026-01-01T00:00:00Z",
+            metadata_source="pypi",
+            version_gap="major",
+            release_age_days=0,
+            upgrade_signal="high",
+            risk_score=80,
+            next_action="Plan an upgrade spike with regression coverage before the next release cut.",
+            notes=[],
+        ),
+        upgrade_audit.PackageReport(
+            name="watch-pkg",
+            sources=["requirements.txt"],
+            groups=["requirements"],
+            requirements=["watch-pkg==1.0.0"],
+            pinned_versions=["1.0.0"],
+            current_version="1.0.0",
+            alignment="aligned",
+            constraint_status="allowed",
+            latest_version="1.0.1",
+            latest_release_date=None,
+            metadata_source="cache",
+            version_gap="patch",
+            release_age_days=None,
+            upgrade_signal="watch",
+            risk_score=10,
+            next_action="Keep under observation; no immediate action required.",
+            notes=[],
+        ),
+    ]
+
+    filtered = upgrade_audit._filter_reports(
+        reports,
+        signals=["high", "critical"],
+        policies=["blocked"],
+        top=1,
+    )
+
+    assert [report.name for report in filtered] == ["critical-pkg"]
+
+
+def test_run_applies_signal_policy_and_top_filters(monkeypatch, capsys, tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = ["httpx>=0.27,<1", "ruff==0.15.6"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("httpx==0.28.1\nruff==0.15.6\n", encoding="utf-8")
+
+    def _fake_metadata(package: str, timeout_s: float) -> tuple[str, str | None]:
+        if package == "httpx":
+            return "0.29.0", "2026-01-01T00:00:00Z"
+        return "0.15.6", "2026-01-01T00:00:00Z"
+
+    monkeypatch.setattr(upgrade_audit, "_latest_pypi_metadata", _fake_metadata)
+
+    rc = upgrade_audit.run(
+        pyproject,
+        timeout_s=0.1,
+        requirement_paths=[requirements],
+        output_format="json",
+        cache_path=tmp_path / "audit-cache.json",
+        signals=["medium"],
+        policies=["blocked"],
+        top=1,
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["packages_audited"] == 1
+    assert payload["priority_queue"][0]["name"] == "httpx"
+    assert [item["name"] for item in payload["packages"]] == ["httpx"]


### PR DESCRIPTION
### Motivation
- Improve the repository upgrade-audit to make upgrade planning actionable by surfacing metadata provenance and focusing maintainers on the highest-risk upgrade candidates. 
- Provide CLI filtering and output primitives so teams can query and export a concise prioritized set of packages for triage and CI gating. 

### Description
- Track metadata provenance per package by adding `metadata_source` to `PackageReport` and include the source in both JSON and Markdown outputs. 
- Add a generated priority queue and a `_priority_queue` helper so reports expose a compact, ordered list of top upgrade candidates. 
- Introduce filtering controls (`--signal`, `--policy`, `--top`) and `_filter_reports` to limit results by upgrade signal, policy status, and top-N highest-risk packages. 
- Wire the new flags through `run()` and `main()`, update rendered tables to show `Source`, and document the focused audit usage in `README.md`. 
- Expand `tests/test_upgrade_audit_script.py` to validate metadata-source reporting, priority-queue generation, filtering behavior, and JSON/Markdown output. 

### Testing
- Ran `python -m pytest -q tests/test_upgrade_audit_script.py` and the suite passed (11 passed). 
- Ran `python -m pytest -q tests/test_upgrade_audit_script.py tests/test_maintenance_cli.py -q` and the targeted tests passed. 
- Executed `python scripts/upgrade_audit.py --offline --format json --signal medium --policy blocked --top 5` to validate end-to-end offline/filtered output and it completed successfully producing JSON output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb3353f5988320ad434d3da5d746d0)