### PR TITLE
Fix Ruff formatting regressions

### DIFF
--- a/src/sdetkit/integration.py
+++ b/src/sdetkit/integration.py
@@ -12,7 +12,6 @@ from .atomicio import canonical_json_dumps
 from .cassette import Cassette
 from .security import SecurityError, safe_path
 
-
 REQUIRED_APP_SERVICE_RULES = (
     ("api-gateway", "go"),
     ("ml-serving", "python"),
@@ -219,7 +218,9 @@ def _evaluate_topology(profile: dict[str, Any]) -> dict[str, Any]:
     data_role_aliases = {
         _normalize(svc.get("name")): _normalize(svc.get("role")) for svc in data_services
     }
-    mock_name_aliases = {_normalize(svc.get("name")): _normalize(svc.get("name")) for svc in mocked_platforms}
+    mock_name_aliases = {
+        _normalize(svc.get("name")): _normalize(svc.get("name")) for svc in mocked_platforms
+    }
     distinct_languages = sorted({lang for lang in language_map.values() if lang})
     checks.append(
         {
@@ -331,7 +332,8 @@ def _evaluate_topology(profile: dict[str, Any]) -> dict[str, Any]:
             {
                 "kind": "deployment",
                 "name": f"{name}:production-scale",
-                "passed": len(production_regions) >= 1 and any(replicas >= 2 for replicas in production_replicas),
+                "passed": len(production_regions) >= 1
+                and any(replicas >= 2 for replicas in production_replicas),
                 "production_regions": sorted(production_regions),
                 "production_replicas": production_replicas,
             }
@@ -487,7 +489,9 @@ def _evaluate_topology(profile: dict[str, Any]) -> dict[str, Any]:
         fidelity = sorted(
             {_normalize(item) for item in platform.get("fidelity", []) if _normalize(item)}
         )
-        operations = [op for op in platform.get("operations", []) if isinstance(op, str) and op.strip()]
+        operations = [
+            op for op in platform.get("operations", []) if isinstance(op, str) and op.strip()
+        ]
         checks.append(
             {
                 "kind": "mock-platform",

--- a/tests/test_integration_topology_check.py
+++ b/tests/test_integration_topology_check.py
@@ -71,11 +71,7 @@ def test_topology_check_flags_missing_heterogeneous_contracts(tmp_path: Path) ->
                         },
                     ],
                     "data_services": [
-                        {
-                            "name": "orders",
-                            "role": "transactional",
-                            "technology": "mysql"
-                        }
+                        {"name": "orders", "role": "transactional", "technology": "mysql"}
                     ],
                     "mocked_platforms": [
                         {"name": "crm", "protocol": "rest", "operations": ["sync"]}

--- a/tests/test_premium_gate_engine.py
+++ b/tests/test_premium_gate_engine.py
@@ -10,7 +10,11 @@ from sdetkit import premium_gate_engine as eng
 
 
 def _write_topology_artifact(
-    path: Path, *, pass_rate: float = 100.0, app_services: int = 3, checks: list[dict[str, object]] | None = None
+    path: Path,
+    *,
+    pass_rate: float = 100.0,
+    app_services: int = 3,
+    checks: list[dict[str, object]] | None = None,
 ) -> None:
     path.write_text(
         json.dumps(


### PR DESCRIPTION
### Motivation
- Address failures from the quality gate caused by Ruff import-sorting/formatting regressions that made CI/`release gate fast` and `ci.sh quick` fail. 

### Description
- Normalize the import/blank-line block and adjust long comprehensions/boolean expressions in `src/sdetkit/integration.py` so the file conforms to Ruff formatting rules. 
- Reformat the inline JSON fixture in `tests/test_integration_topology_check.py` to satisfy Ruff's style without changing test behavior. 
- Reflow the helper function signature in `tests/test_premium_gate_engine.py` to the multi-line style required by the formatter. 
- Resulting files touched: `src/sdetkit/integration.py`, `tests/test_integration_topology_check.py`, and `tests/test_premium_gate_engine.py`.

### Testing
- Ran `python -m ruff check .` and `python -m ruff format --check .`, which both reported success after the fixes. (Ruff: OK; Ruff format: OK.)
- Executed `python -m sdetkit release gate fast --format json`, which completed successfully and reported the gate steps as OK. 
- Ran the CI quick script `bash ci.sh quick --skip-docs --artifact-dir build`, which completed and showed `ruff`, `mypy`, and `pytest` steps passed; `pytest` ran 19 tests and all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb39bd7de883208ee8c8decee73a11)