### PR TITLE
Enhance upgrade-audit: floor-and-lock detection, manifest actions, and bump dependency floors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python -m sdetkit continuous-upgrade-cycle11-closeout --format json --strict
 
 ## Upgrade planning (first step)
 
-Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, and a concrete next action for each package. You can invoke it from either the standalone script or the primary Intelligence kit surface, and you can fail CI at a chosen signal threshold:
+Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, manifest actions, suggested target versions, and floor-and-lock baseline detection for repos that intentionally mix flexible ranges with tested pins. You can invoke it from either the standalone script or the primary Intelligence kit surface, and you can fail CI at a chosen signal threshold:
 
 ```bash
 make upgrade-audit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Topic :: Utilities",
 ]
 dependencies = [
-  "httpx>=0.27,<1"
+  "httpx>=0.28.1,<1"
 ]
 [project.urls]
 Homepage = "https://github.com/sherif69-sa/DevS69-sdetkit"
@@ -63,10 +63,10 @@ packaging = [
   "twine==6.2.0"
 ]
 telegram = [
-  "python-telegram-bot>=21,<23"
+  "python-telegram-bot>=22.7,<23"
 ]
 whatsapp = [
-  "twilio>=9,<10"
+  "twilio>=9.10.3,<10"
 ]
 
 [tool.setuptools]

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -43,6 +43,8 @@ class PackageReport:
     release_age_days: int | None
     upgrade_signal: str
     risk_score: int
+    manifest_action: str
+    suggested_version: str | None
     next_action: str
     notes: list[str]
 
@@ -446,8 +448,36 @@ def _infer_alignment(deps: list[Dependency], current_version: str) -> str:
         and (result := _requirement_allows_version(dep.raw, current_version)) is not None
     ]
     if allowed_results and all(allowed_results):
+        has_pin = any(dep.pinned_version for dep in deps)
+        has_range = any(dep.pinned_version is None for dep in deps)
+        if has_pin and has_range:
+            return "floor-lock"
         return "compatible"
     return "drift"
+
+
+def _manifest_action(
+    *,
+    current_version: str,
+    latest_version: str,
+    alignment: str,
+    constraint_status: str,
+    version_gap: str,
+) -> tuple[str, str | None]:
+    unavailable_versions = {"unknown", "network-error", "offline-no-cache"}
+    if latest_version in unavailable_versions or latest_version.startswith("http-"):
+        return "investigate-metadata", None
+    if current_version in {"unbounded", "unknown"}:
+        return "establish-baseline", latest_version if latest_version != current_version else None
+    if current_version == latest_version:
+        return "none", None
+    if constraint_status == "allowed":
+        if alignment in {"floor-lock", "range-or-unpinned"}:
+            return "raise-floor", latest_version
+        return "refresh-pin", latest_version
+    if version_gap == "major":
+        return "plan-major-upgrade", latest_version
+    return "stage-upgrade", latest_version
 
 
 def _major_minor_patch(version: str) -> tuple[int, int, int] | None:
@@ -524,6 +554,10 @@ def _build_package_report(
         notes.append("Cross-manifest requirement drift detected.")
     elif alignment == "compatible":
         notes.append("Cross-manifest requirements differ but remain mutually compatible.")
+    elif alignment == "floor-lock":
+        notes.append(
+            "Cross-manifest requirements follow a floor-and-lock pattern with a tested pinned baseline."
+        )
     if alignment == "range-or-unpinned":
         notes.append("Package is not pinned to a single exact version.")
     if constraint_status == "allowed":
@@ -542,6 +576,8 @@ def _build_package_report(
     upgrade_signal = "watch"
     if alignment == "drift":
         upgrade_signal = "critical" if version_gap == "major" else "high"
+    elif alignment == "floor-lock" and constraint_status == "allowed":
+        upgrade_signal = "watch"
     elif constraint_status == "allowed":
         upgrade_signal = "watch" if "default" not in groups else "medium"
     elif version_gap == "major":
@@ -562,6 +598,8 @@ def _build_package_report(
         risk_score += 45
     elif alignment == "compatible":
         risk_score += 10
+    elif alignment == "floor-lock":
+        risk_score += 5
     elif alignment == "range-or-unpinned":
         risk_score += 15
     if constraint_status == "blocked":
@@ -582,14 +620,28 @@ def _build_package_report(
     if upgrade_signal == "investigate":
         risk_score += 10
 
+    manifest_action, suggested_version = _manifest_action(
+        current_version=current_version,
+        latest_version=latest_version,
+        alignment=alignment,
+        constraint_status=constraint_status,
+        version_gap=version_gap,
+    )
+
     next_action = "Keep under observation; no immediate action required."
-    if upgrade_signal == "critical":
+    if manifest_action == "raise-floor":
+        next_action = (
+            "Raise the tested floor in flexible manifests, refresh pins, and validate the package in the next maintenance window."
+        )
+    elif manifest_action == "refresh-pin":
+        next_action = "Refresh pinned manifests to the newer tested version and rerun targeted validation."
+    elif upgrade_signal == "critical":
         next_action = (
             "Resolve manifest drift first, then validate the major upgrade in a dedicated branch."
         )
-    elif upgrade_signal == "high":
+    elif manifest_action == "plan-major-upgrade":
         next_action = "Plan an upgrade spike with regression coverage before the next release cut."
-    elif upgrade_signal == "medium":
+    elif manifest_action == "stage-upgrade":
         next_action = (
             "Queue the upgrade for the next maintenance batch and validate targeted smoke tests."
         )
@@ -599,12 +651,19 @@ def _build_package_report(
             if constraint_status == "allowed"
             else "Track the package and batch it with nearby dependency maintenance work."
         )
-    elif upgrade_signal == "investigate":
+    elif manifest_action == "investigate-metadata":
         next_action = "Retry metadata collection and inspect package naming, cache freshness, or connectivity issues."
     elif upgrade_signal == "unknown":
         next_action = (
             "Review the declared version range manually because the gap could not be classified."
         )
+    elif manifest_action == "establish-baseline":
+        next_action = "Pin or bound the package explicitly before attempting future upgrade automation."
+
+    if manifest_action != "none":
+        notes.append(f"Recommended manifest action: {manifest_action}.")
+    if suggested_version is not None:
+        notes.append(f"Suggested target version: {suggested_version}.")
 
     return PackageReport(
         name=name,
@@ -622,6 +681,8 @@ def _build_package_report(
         release_age_days=release_age_days,
         upgrade_signal=upgrade_signal,
         risk_score=risk_score,
+        manifest_action=manifest_action,
+        suggested_version=suggested_version,
         next_action=next_action,
         notes=notes,
     )
@@ -639,6 +700,8 @@ def _priority_queue(reports: list[PackageReport], *, limit: int = 5) -> list[dic
                 "policy": report.constraint_status,
                 "current_version": report.current_version,
                 "latest_version": report.latest_version,
+                "manifest_action": report.manifest_action,
+                "suggested_version": report.suggested_version,
                 "next_action": report.next_action,
                 "lane": _recommended_lane(report),
             }
@@ -649,6 +712,8 @@ def _priority_queue(reports: list[PackageReport], *, limit: int = 5) -> list[dic
 def _recommended_lane(report: PackageReport) -> str:
     if report.alignment == "drift":
         return "stabilize-manifests"
+    if report.manifest_action in {"raise-floor", "refresh-pin"}:
+        return "refresh-baselines"
     if report.upgrade_signal in {"critical", "high"}:
         return "upgrade-now"
     if report.upgrade_signal == "medium":
@@ -706,6 +771,7 @@ def _render_markdown(
 ) -> str:
     drift_count = sum(1 for report in reports if report.alignment == "drift")
     compatible_count = sum(1 for report in reports if report.alignment == "compatible")
+    floor_lock_count = sum(1 for report in reports if report.alignment == "floor-lock")
     high_priority = sum(1 for report in reports if report.upgrade_signal == "high")
     critical_priority = sum(1 for report in reports if report.upgrade_signal == "critical")
     medium_priority = sum(1 for report in reports if report.upgrade_signal == "medium")
@@ -724,6 +790,7 @@ def _render_markdown(
         f"- packages audited: {len(reports)}",
         f"- manifest drift packages: {drift_count}",
         f"- compatible multi-manifest packages: {compatible_count}",
+        f"- floor-and-lock baseline packages: {floor_lock_count}",
         f"- policy-covered latest releases: {policy_covered}",
         f"- policy-blocked latest releases: {policy_blocked}",
         f"- critical upgrade signals: {critical_priority}",
@@ -732,8 +799,8 @@ def _render_markdown(
         f"- investigate signals: {investigate_priority}",
         f"- packages using cached metadata: {cached_results}",
         "",
-        "| Package | Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk | Release age (days) | Requirements |",
-        "|---|---|---|---|---|---|---|---|---|---|---|",
+        "| Package | Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested | Release age (days) | Requirements |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for report in reports:
         release_age = "-" if report.release_age_days is None else str(report.release_age_days)
@@ -741,12 +808,14 @@ def _render_markdown(
         lines.append(
             "| "
             f"`{report.name}` | `{report.current_version}` | `{report.latest_version}` | {report.metadata_source} | {report.version_gap} | "
-            f"{report.alignment} | {report.constraint_status} | {report.upgrade_signal} | {report.risk_score} | {release_age} | {requirements} |"
+            f"{report.alignment} | {report.constraint_status} | {report.upgrade_signal} | {report.risk_score} | {report.manifest_action} | {report.suggested_version or '-'} | {release_age} | {requirements} |"
         )
     lines.extend(["", "## Priority queue", ""])
     for item in _priority_queue(reports):
         lines.append(
-            f"- `{item['name']}` [{item['signal']}, risk {item['risk_score']}, lane {item['lane']}] → {item['next_action']}"
+            f"- `{item['name']}` [{item['signal']}, risk {item['risk_score']}, lane {item['lane']}, action {item['manifest_action']}]"
+            + (f" target `{item['suggested_version']}`" if item['suggested_version'] else "")
+            + f" → {item['next_action']}"
         )
     lines.extend(["", "## Recommended upgrade lanes", ""])
     for item in _lane_summary(reports):
@@ -777,6 +846,7 @@ def _render_json(
             "compatible_constraint_packages": sum(
                 1 for report in reports if report.alignment == "compatible"
             ),
+            "floor_lock_packages": sum(1 for report in reports if report.alignment == "floor-lock"),
             "policy_covered_packages": sum(
                 1 for report in reports if report.constraint_status == "allowed"
             ),

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -71,17 +71,17 @@ def test_build_package_report_flags_drift_and_priority() -> None:
         release_date="2026-01-01T00:00:00Z",
     )
 
-    assert report.alignment == "compatible"
+    assert report.alignment == "floor-lock"
     assert report.constraint_status == "blocked"
     assert report.current_version == "0.28.1"
     assert report.version_gap == "minor"
     assert report.upgrade_signal == "medium"
-    assert report.risk_score >= 45
+    assert report.risk_score >= 40
     assert report.latest_version == "0.29.0"
     assert report.latest_release_date == "2026-01-01T00:00:00Z"
     assert report.metadata_source == "pypi"
     assert "Queue the upgrade" in report.next_action
-    assert "mutually compatible" in " ".join(report.notes)
+    assert "floor-and-lock pattern" in " ".join(report.notes)
 
 
 def test_build_package_report_marks_compatible_policy_covered_manifests() -> None:
@@ -109,10 +109,11 @@ def test_build_package_report_marks_compatible_policy_covered_manifests() -> Non
         release_date="2026-01-01T00:00:00Z",
     )
 
-    assert report.alignment == "compatible"
+    assert report.alignment == "floor-lock"
     assert report.constraint_status == "allowed"
-    assert report.upgrade_signal == "medium"
-    assert "mutually compatible" in " ".join(report.notes)
+    assert report.upgrade_signal == "watch"
+    assert report.manifest_action == "none"
+    assert "floor-and-lock pattern" in " ".join(report.notes)
     assert "already allowed by the declared version policy" in " ".join(report.notes)
 
 
@@ -159,6 +160,8 @@ def test_render_json_summary_counts() -> None:
             release_age_days=0,
             upgrade_signal="high",
             risk_score=85,
+            manifest_action="stage-upgrade",
+            suggested_version="0.29.0",
             next_action="Plan an upgrade spike with regression coverage before the next release cut.",
             notes=["Cross-manifest requirement drift detected."],
         ),
@@ -178,6 +181,8 @@ def test_render_json_summary_counts() -> None:
             release_age_days=None,
             upgrade_signal="watch",
             risk_score=10,
+            manifest_action="none",
+            suggested_version=None,
             next_action="Keep under observation; no immediate action required.",
             notes=[],
         ),
@@ -193,6 +198,7 @@ def test_render_json_summary_counts() -> None:
 
     assert payload["summary"] == {
         "compatible_constraint_packages": 0,
+        "floor_lock_packages": 0,
         "cached_metadata_packages": 0,
         "critical_upgrade_signals": 0,
         "packages_audited": 2,
@@ -238,10 +244,11 @@ dependencies = ["httpx>=0.27,<1"]
     out = capsys.readouterr().out
     assert "# Upgrade audit" in out
     assert "manifest drift packages: 0" in out
-    assert "compatible multi-manifest packages: 1" in out
+    assert "compatible multi-manifest packages: 0" in out
+    assert "floor-and-lock baseline packages: 1" in out
     assert "packages using cached metadata: 0" in out
-    assert "Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk" in out
-    assert "`httpx` | `0.28.1` | `0.29.0` | pypi | minor | compatible | blocked | medium |" in out
+    assert "Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested" in out
+    assert "`httpx` | `0.28.1` | `0.29.0` | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |" in out
     assert "Priority queue" in out
     assert "Focus notes" in out
     assert (
@@ -298,6 +305,8 @@ def test_sort_reports_surfaces_highest_risk_first() -> None:
             release_age_days=None,
             upgrade_signal="watch",
             risk_score=10,
+            manifest_action="stage-upgrade",
+            suggested_version="1.0.1",
             next_action="Track the package and batch it with nearby dependency maintenance work.",
             notes=[],
         ),
@@ -317,6 +326,8 @@ def test_sort_reports_surfaces_highest_risk_first() -> None:
             release_age_days=None,
             upgrade_signal="critical",
             risk_score=90,
+            manifest_action="plan-major-upgrade",
+            suggested_version="2.0.0",
             next_action="Resolve manifest drift first, then validate the major upgrade in a dedicated branch.",
             notes=[],
         ),
@@ -390,6 +401,8 @@ def test_filter_reports_supports_signal_policy_and_top() -> None:
             release_age_days=0,
             upgrade_signal="high",
             risk_score=80,
+            manifest_action="plan-major-upgrade",
+            suggested_version="2.0.0",
             next_action="Plan an upgrade spike with regression coverage before the next release cut.",
             notes=[],
         ),
@@ -409,6 +422,8 @@ def test_filter_reports_supports_signal_policy_and_top() -> None:
             release_age_days=None,
             upgrade_signal="watch",
             risk_score=10,
+            manifest_action="none",
+            suggested_version=None,
             next_action="Keep under observation; no immediate action required.",
             notes=[],
         ),
@@ -480,6 +495,8 @@ def test_render_json_includes_lane_summary_and_priority_lane() -> None:
             release_age_days=0,
             upgrade_signal="critical",
             risk_score=90,
+            manifest_action="plan-major-upgrade",
+            suggested_version="2.0.0",
             next_action="Resolve manifest drift first, then validate the major upgrade in a dedicated branch.",
             notes=["Cross-manifest requirement drift detected."],
         ),
@@ -499,6 +516,8 @@ def test_render_json_includes_lane_summary_and_priority_lane() -> None:
             release_age_days=None,
             upgrade_signal="watch",
             risk_score=10,
+            manifest_action="none",
+            suggested_version=None,
             next_action="Keep under observation; no immediate action required.",
             notes=["Latest metadata source: cache."],
         ),
@@ -535,6 +554,8 @@ def test_render_markdown_includes_recommended_upgrade_lanes() -> None:
             release_age_days=0,
             upgrade_signal="medium",
             risk_score=55,
+            manifest_action="stage-upgrade",
+            suggested_version="0.29.0",
             next_action="Queue the upgrade for the next maintenance batch and validate targeted smoke tests.",
             notes=["Cross-manifest requirements differ but remain mutually compatible."],
         )


### PR DESCRIPTION
### Motivation
- Improve upgrade planning signals by detecting common "floor-and-lock" manifest patterns where projects mix flexible ranges with a tested pinned baseline. 
- Surface actionable guidance (manifest actions and suggested target versions) so maintainers can convert audit signals into concrete next steps. 
- Refresh a few runtime/integration dependency floors to validated baselines to reduce noise and align the repo with audited pins. 

### Description
- Add floor-and-lock alignment detection to `upgrade_audit` and classify cross-manifest patterns as `floor-lock` when a pinned baseline coexists with flexible ranges. 
- Introduce `_manifest_action` logic that returns a `manifest_action` plus `suggested_version` and propagate those fields through the `PackageReport` and JSON/markdown outputs. 
- Adjust risk scoring and next-action generation to account for floor-lock patterns and recommended manifest actions (e.g., `raise-floor`, `refresh-pin`, `stage-upgrade`, `plan-major-upgrade`, `establish-baseline`). 
- Extend markdown tables and JSON payloads to include `Action` and `Suggested` columns/fields and add summary counts for `floor_lock_packages` and related lanes, plus add a new `refresh-baselines` lane where applicable. 
- Bump declared dependency floors in `pyproject.toml` for `httpx` (to `>=0.28.1,<1`), `python-telegram-bot` (to `>=22.7,<23`), and `twilio` (to `>=9.10.3,<10`) to match validated baselines. 
- Update and expand `tests/test_upgrade_audit_script.py` to assert the new alignment, `manifest_action`, `suggested_version`, and enriched rendering behavior, and update an integration test expectation in `tests/test_kits_intelligence_integration_forensics.py`. 

### Testing
- Ran targeted unit tests with `pytest -q tests/test_upgrade_audit_script.py` and `pytest -q tests/test_kits_intelligence_integration_forensics.py`, and the updated suites passed. 
- Exercised the CLI surface with `python -m sdetkit intelligence upgrade-audit --format json --top 10` to validate offline/cache behavior and JSON output shape, which produced the richer payload and lanes as expected. 
- Byte-compile smoke check with `python -m compileall src/sdetkit/upgrade_audit.py src/sdetkit/intelligence.py` completed without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb4b3e79d88320bfc0d62b50b9c718)