### PR TITLE
Enhance upgrade-audit filtering and summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ Run a dependency-manifest audit against PyPI to identify candidate upgrades, det
 make upgrade-audit
 python -m sdetkit intelligence upgrade-audit --format json --top 5
 python -m sdetkit intelligence upgrade-audit --format md --offline
+python -m sdetkit intelligence upgrade-audit --outdated-only --package "http*"
 python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
 python scripts/upgrade_audit.py --fail-on high
 python scripts/upgrade_audit.py --cache-ttl-hours 6 --max-workers 12
 python scripts/upgrade_audit.py --offline --format md
 python scripts/upgrade_audit.py --signal high --policy blocked --top 5
+python scripts/upgrade_audit.py --metadata-source cache-stale --outdated-only
 ```
 
 ## Sample artifacts

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ mkdocs-material==9.7.5
 
 # Backport for environments below Python 3.11
 # (kept for compatibility in ad-hoc environments)
-tomli; python_version < "3.11"
+tomli==2.4.0; python_version < "3.11"

--- a/src/sdetkit/intelligence.py
+++ b/src/sdetkit/intelligence.py
@@ -242,6 +242,14 @@ def main(argv: list[str] | None = None) -> int:
         choices=["allowed", "blocked", "unknown", "unbounded"],
         default=None,
     )
+    ua.add_argument("--package", action="append", default=None)
+    ua.add_argument(
+        "--metadata-source",
+        action="append",
+        choices=["pypi", "cache", "cache-stale", "offline"],
+        default=None,
+    )
+    ua.add_argument("--outdated-only", action="store_true")
     ua.add_argument("--top", type=int, default=None)
 
     ns = parser.parse_args(argv)
@@ -284,6 +292,9 @@ def main(argv: list[str] | None = None) -> int:
                 max_workers=max(ns.max_workers, 1),
                 signals=ns.signal,
                 policies=ns.policy,
+                packages=ns.package,
+                metadata_sources=ns.metadata_source,
+                outdated_only=bool(ns.outdated_only),
                 top=ns.top,
             )
         else:

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import fnmatch
 import json
 import re
 import sys
@@ -744,11 +745,62 @@ def _lane_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
     ]
 
 
+def _is_actionable_upgrade(report: PackageReport) -> bool:
+    return report.manifest_action != "none"
+
+
+def _report_summary(reports: list[PackageReport]) -> dict[str, int]:
+    return {
+        "packages_audited": len(reports),
+        "manifest_drift_packages": sum(1 for report in reports if report.alignment == "drift"),
+        "compatible_constraint_packages": sum(
+            1 for report in reports if report.alignment == "compatible"
+        ),
+        "floor_lock_packages": sum(1 for report in reports if report.alignment == "floor-lock"),
+        "policy_covered_packages": sum(
+            1 for report in reports if report.constraint_status == "allowed"
+        ),
+        "policy_blocked_packages": sum(
+            1 for report in reports if report.constraint_status == "blocked"
+        ),
+        "critical_upgrade_signals": sum(
+            1 for report in reports if report.upgrade_signal == "critical"
+        ),
+        "high_priority_upgrade_signals": sum(
+            1 for report in reports if report.upgrade_signal == "high"
+        ),
+        "medium_priority_upgrade_signals": sum(
+            1 for report in reports if report.upgrade_signal == "medium"
+        ),
+        "investigate_upgrade_signals": sum(
+            1 for report in reports if report.upgrade_signal == "investigate"
+        ),
+        "cached_metadata_packages": sum(
+            1 for report in reports if report.metadata_source.startswith("cache")
+        ),
+        "stale_metadata_packages": sum(
+            1 for report in reports if report.metadata_source == "cache-stale"
+        ),
+        "actionable_packages": sum(1 for report in reports if _is_actionable_upgrade(report)),
+        "max_risk_score": max((report.risk_score for report in reports), default=0),
+    }
+
+
+def _matches_package_filters(report: PackageReport, package_filters: list[str] | None) -> bool:
+    if not package_filters:
+        return True
+    normalized = report.name.lower()
+    return any(fnmatch.fnmatch(normalized, pattern) for pattern in package_filters)
+
+
 def _filter_reports(
     reports: list[PackageReport],
     *,
     signals: list[str] | None = None,
     policies: list[str] | None = None,
+    packages: list[str] | None = None,
+    metadata_sources: list[str] | None = None,
+    outdated_only: bool = False,
     top: int | None = None,
 ) -> list[PackageReport]:
     filtered = reports
@@ -758,6 +810,16 @@ def _filter_reports(
     if policies:
         allowed_policies = {item.strip() for item in policies if item.strip()}
         filtered = [report for report in filtered if report.constraint_status in allowed_policies]
+    if packages:
+        package_filters = [item.strip().lower() for item in packages if item.strip()]
+        filtered = [
+            report for report in filtered if _matches_package_filters(report, package_filters)
+        ]
+    if metadata_sources:
+        allowed_sources = {item.strip() for item in metadata_sources if item.strip()}
+        filtered = [report for report in filtered if report.metadata_source in allowed_sources]
+    if outdated_only:
+        filtered = [report for report in filtered if _is_actionable_upgrade(report)]
     if top is not None:
         filtered = filtered[: max(top, 0)]
     return filtered
@@ -769,35 +831,26 @@ def _render_markdown(
     pyproject_path: Path,
     requirement_paths: list[Path],
 ) -> str:
-    drift_count = sum(1 for report in reports if report.alignment == "drift")
-    compatible_count = sum(1 for report in reports if report.alignment == "compatible")
-    floor_lock_count = sum(1 for report in reports if report.alignment == "floor-lock")
-    high_priority = sum(1 for report in reports if report.upgrade_signal == "high")
-    critical_priority = sum(1 for report in reports if report.upgrade_signal == "critical")
-    medium_priority = sum(1 for report in reports if report.upgrade_signal == "medium")
-    investigate_priority = sum(1 for report in reports if report.upgrade_signal == "investigate")
-    policy_covered = sum(1 for report in reports if report.constraint_status == "allowed")
-    policy_blocked = sum(1 for report in reports if report.constraint_status == "blocked")
-    cached_results = sum(
-        1 for report in reports if any("cache" in note.lower() for note in report.notes)
-    )
+    summary = _report_summary(reports)
     lines = [
         "# Upgrade audit",
         "",
         f"Source pyproject: `{pyproject_path}`",
         f"Requirement manifests: {', '.join(f'`{path}`' for path in requirement_paths) if requirement_paths else '`none`'}",
         "",
-        f"- packages audited: {len(reports)}",
-        f"- manifest drift packages: {drift_count}",
-        f"- compatible multi-manifest packages: {compatible_count}",
-        f"- floor-and-lock baseline packages: {floor_lock_count}",
-        f"- policy-covered latest releases: {policy_covered}",
-        f"- policy-blocked latest releases: {policy_blocked}",
-        f"- critical upgrade signals: {critical_priority}",
-        f"- high-priority upgrade signals: {high_priority}",
-        f"- medium-priority upgrade signals: {medium_priority}",
-        f"- investigate signals: {investigate_priority}",
-        f"- packages using cached metadata: {cached_results}",
+        f"- packages audited: {summary['packages_audited']}",
+        f"- manifest drift packages: {summary['manifest_drift_packages']}",
+        f"- compatible multi-manifest packages: {summary['compatible_constraint_packages']}",
+        f"- floor-and-lock baseline packages: {summary['floor_lock_packages']}",
+        f"- policy-covered latest releases: {summary['policy_covered_packages']}",
+        f"- policy-blocked latest releases: {summary['policy_blocked_packages']}",
+        f"- critical upgrade signals: {summary['critical_upgrade_signals']}",
+        f"- high-priority upgrade signals: {summary['high_priority_upgrade_signals']}",
+        f"- medium-priority upgrade signals: {summary['medium_priority_upgrade_signals']}",
+        f"- investigate signals: {summary['investigate_upgrade_signals']}",
+        f"- packages using cached metadata: {summary['cached_metadata_packages']}",
+        f"- stale cached metadata packages: {summary['stale_metadata_packages']}",
+        f"- actionable upgrade candidates: {summary['actionable_packages']}",
         "",
         "| Package | Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested | Release age (days) | Requirements |",
         "|---|---|---|---|---|---|---|---|---|---|---|---|---|",
@@ -840,36 +893,7 @@ def _render_json(
     payload = {
         "pyproject": str(pyproject_path),
         "requirements": [str(path) for path in requirement_paths],
-        "summary": {
-            "packages_audited": len(reports),
-            "manifest_drift_packages": sum(1 for report in reports if report.alignment == "drift"),
-            "compatible_constraint_packages": sum(
-                1 for report in reports if report.alignment == "compatible"
-            ),
-            "floor_lock_packages": sum(1 for report in reports if report.alignment == "floor-lock"),
-            "policy_covered_packages": sum(
-                1 for report in reports if report.constraint_status == "allowed"
-            ),
-            "policy_blocked_packages": sum(
-                1 for report in reports if report.constraint_status == "blocked"
-            ),
-            "critical_upgrade_signals": sum(
-                1 for report in reports if report.upgrade_signal == "critical"
-            ),
-            "high_priority_upgrade_signals": sum(
-                1 for report in reports if report.upgrade_signal == "high"
-            ),
-            "medium_priority_upgrade_signals": sum(
-                1 for report in reports if report.upgrade_signal == "medium"
-            ),
-            "investigate_upgrade_signals": sum(
-                1 for report in reports if report.upgrade_signal == "investigate"
-            ),
-            "cached_metadata_packages": sum(
-                1 for report in reports if any("cache" in note.lower() for note in report.notes)
-            ),
-            "max_risk_score": max((report.risk_score for report in reports), default=0),
-        },
+        "summary": _report_summary(reports),
         "priority_queue": _priority_queue(reports),
         "lanes": _lane_summary(reports),
         "packages": [asdict(report) for report in reports],
@@ -908,6 +932,9 @@ def run(
     max_workers: int = 8,
     signals: list[str] | None = None,
     policies: list[str] | None = None,
+    packages: list[str] | None = None,
+    metadata_sources: list[str] | None = None,
+    outdated_only: bool = False,
     top: int | None = None,
 ) -> int:
     dependencies = _load_dependencies(pyproject_path, requirement_paths)
@@ -946,7 +973,15 @@ def run(
             report.notes.append(f"Latest metadata source: {metadata.source}.")
 
     reports = _sort_reports(reports)
-    reports = _filter_reports(reports, signals=signals, policies=policies, top=top)
+    reports = _filter_reports(
+        reports,
+        signals=signals,
+        policies=policies,
+        packages=packages,
+        metadata_sources=metadata_sources,
+        outdated_only=outdated_only,
+        top=top,
+    )
 
     rendered = {
         "json": _render_json(
@@ -1042,6 +1077,24 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         help="Show only packages with the selected policy status(es). Can be passed multiple times.",
     )
     parser.add_argument(
+        "--package",
+        action="append",
+        default=None,
+        help="Show only packages matching the provided name or glob pattern. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--metadata-source",
+        action="append",
+        choices=["pypi", "cache", "cache-stale", "offline"],
+        default=None,
+        help="Show only packages resolved from the selected metadata source(s).",
+    )
+    parser.add_argument(
+        "--outdated-only",
+        action="store_true",
+        help="Show only actionable upgrade candidates and baseline-establishment work.",
+    )
+    parser.add_argument(
         "--top",
         type=int,
         default=None,
@@ -1089,6 +1142,9 @@ def main(argv: list[str] | None = None) -> int:
         max_workers=max(args.max_workers, 1),
         signals=args.signal,
         policies=args.policy,
+        packages=args.package,
+        metadata_sources=args.metadata_source,
+        outdated_only=bool(args.outdated_only),
         top=args.top,
     )
 

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -197,18 +197,20 @@ def test_render_json_summary_counts() -> None:
     )
 
     assert payload["summary"] == {
+        "actionable_packages": 1,
+        "cached_metadata_packages": 1,
         "compatible_constraint_packages": 0,
-        "floor_lock_packages": 0,
-        "cached_metadata_packages": 0,
         "critical_upgrade_signals": 0,
-        "packages_audited": 2,
-        "manifest_drift_packages": 1,
+        "floor_lock_packages": 0,
         "high_priority_upgrade_signals": 1,
         "investigate_upgrade_signals": 0,
+        "manifest_drift_packages": 1,
         "max_risk_score": 85,
         "medium_priority_upgrade_signals": 0,
+        "packages_audited": 2,
         "policy_blocked_packages": 1,
         "policy_covered_packages": 1,
+        "stale_metadata_packages": 0,
     }
     assert payload["packages"][0]["name"] == "httpx"
 
@@ -247,6 +249,8 @@ dependencies = ["httpx>=0.27,<1"]
     assert "compatible multi-manifest packages: 0" in out
     assert "floor-and-lock baseline packages: 1" in out
     assert "packages using cached metadata: 0" in out
+    assert "stale cached metadata packages: 0" in out
+    assert "actionable upgrade candidates: 1" in out
     assert "Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested" in out
     assert "`httpx` | `0.28.1` | `0.29.0` | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |" in out
     assert "Priority queue" in out
@@ -378,9 +382,66 @@ dependencies = ["httpx==0.28.1"]
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["summary"]["cached_metadata_packages"] == 1
+    assert payload["summary"]["stale_metadata_packages"] == 0
     assert payload["packages"][0]["latest_version"] == "0.28.1"
     assert payload["packages"][0]["metadata_source"] == "cache"
     assert "Latest metadata source: cache." in payload["packages"][0]["notes"]
+
+
+def test_filter_reports_supports_package_metadata_source_and_outdated_only() -> None:
+    reports = [
+        upgrade_audit.PackageReport(
+            name="httpx",
+            sources=["pyproject.toml"],
+            groups=["default"],
+            requirements=["httpx==0.28.1"],
+            pinned_versions=["0.28.1"],
+            current_version="0.28.1",
+            alignment="aligned",
+            constraint_status="blocked",
+            latest_version="0.29.0",
+            latest_release_date="2026-01-01T00:00:00Z",
+            metadata_source="cache-stale",
+            version_gap="minor",
+            release_age_days=0,
+            upgrade_signal="medium",
+            risk_score=55,
+            manifest_action="stage-upgrade",
+            suggested_version="0.29.0",
+            next_action="Queue the upgrade for the next maintenance batch and validate targeted smoke tests.",
+            notes=[],
+        ),
+        upgrade_audit.PackageReport(
+            name="ruff",
+            sources=["requirements.txt"],
+            groups=["requirements"],
+            requirements=["ruff==0.15.6"],
+            pinned_versions=["0.15.6"],
+            current_version="0.15.6",
+            alignment="aligned",
+            constraint_status="allowed",
+            latest_version="0.15.6",
+            latest_release_date=None,
+            metadata_source="pypi",
+            version_gap="up-to-date",
+            release_age_days=None,
+            upgrade_signal="watch",
+            risk_score=10,
+            manifest_action="none",
+            suggested_version=None,
+            next_action="Keep under observation; no immediate action required.",
+            notes=[],
+        ),
+    ]
+
+    filtered = upgrade_audit._filter_reports(
+        reports,
+        packages=["http*"],
+        metadata_sources=["cache-stale"],
+        outdated_only=True,
+    )
+
+    assert [report.name for report in filtered] == ["httpx"]
 
 
 def test_filter_reports_supports_signal_policy_and_top() -> None:
@@ -569,3 +630,72 @@ def test_render_markdown_includes_recommended_upgrade_lanes() -> None:
 
     assert "## Recommended upgrade lanes" in rendered
     assert "**next-maintenance-batch**" in rendered
+
+
+def test_run_applies_package_metadata_source_and_outdated_filters(
+    monkeypatch, capsys, tmp_path: Path
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = ["httpx==0.28.1", "ruff==0.15.6"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    cache_path = tmp_path / "cache.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-01-02T00:00:00+00:00",
+                "packages": {
+                    "httpx": {
+                        "fetched_at": 1.0,
+                        "latest_version": "0.29.0",
+                        "release_date": "2026-01-01T00:00:00Z",
+                    },
+                    "ruff": {
+                        "fetched_at": 1.0,
+                        "latest_version": "0.15.6",
+                        "release_date": "2026-01-01T00:00:00Z",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = upgrade_audit.run(
+        pyproject,
+        timeout_s=0.1,
+        requirement_paths=[],
+        output_format="json",
+        offline=True,
+        cache_path=cache_path,
+        cache_ttl_hours=0,
+        packages=["http*"],
+        metadata_sources=["cache-stale"],
+        outdated_only=True,
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["packages_audited"] == 1
+    assert payload["summary"]["stale_metadata_packages"] == 1
+    assert payload["summary"]["actionable_packages"] == 1
+    assert [item["name"] for item in payload["packages"]] == ["httpx"]
+
+
+def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\ndependencies=[]\n", encoding="utf-8")
+
+    parser = upgrade_audit.build_parser()
+    args = parser.parse_args(["--pyproject", str(pyproject), "--outdated-only", "--package", "http*"])
+
+    requirement_paths = upgrade_audit._resolve_requirement_paths(args)
+
+    assert args.outdated_only is True
+    assert args.package == ["http*"]
+    assert requirement_paths == []


### PR DESCRIPTION
### Motivation
- Improve the upgrade-audit UX by enabling focused queries (package globs, metadata source, actionable-only) and surface more consistent, machine-friendly summary metrics across JSON and Markdown outputs.
- Make it easier to script and automate targeted maintenance runs from both the standalone `upgrade-audit` script and the Intelligence CLI surface.

### Description
- Add package glob filtering, metadata-source filtering, and an `--outdated-only` flag to `upgrade_audit.run` and the `upgrade-audit` CLI, and wire the same options through `sdetkit intelligence upgrade-audit` via `src/sdetkit/intelligence.py` (new CLI args: `--package`, `--metadata-source`, `--outdated-only`).
- Factor summary generation into a shared helper `_report_summary` and add actionable/cached/stale metrics (`actionable_packages`, `cached_metadata_packages`, `stale_metadata_packages`) used by both `_render_json` and `_render_markdown` in `src/sdetkit/upgrade_audit.py`.
- Add helper functions `_is_actionable_upgrade`, `_matches_package_filters`, extend `_filter_reports` to support the new filters, and adjust sorting/filtering flow in `run` accordingly.
- Document the new workflows in `README.md`, pin the `tomli` backport to `tomli==2.4.0` in `requirements.txt`, and extend tests in `tests/test_upgrade_audit_script.py` to cover the new filters and summary fields.

### Testing
- Ran the upgraded unit test suite for the audit script with `PYTHONPATH=src pytest -q tests/test_upgrade_audit_script.py`, and all tests passed (`16 passed`).
- Ran static checks with `python -m ruff check src/sdetkit/upgrade_audit.py src/sdetkit/intelligence.py tests/test_upgrade_audit_script.py`, which completed with no issues.
- Exercised the CLI end-to-end with `PYTHONPATH=src python -m sdetkit intelligence upgrade-audit --offline --outdated-only --package 'tomli' --format json` and validated expected JSON output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb507224788320bddaa7116bd7734c)