### PR TITLE
Improve contributor onboarding journeys and add starter contribution profiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,12 @@ If you are unsure where to start, run:
 python -m sdetkit first-contribution --format text --strict
 ```
 
+Then pick a guided journey:
+
+```bash
+python -m sdetkit onboarding --journey first-pr --role sdet --format markdown
+```
+
 ## Where to find starter work
 
 - Look for open issues labelled **`good first issue`**, **`help wanted`**, **`documentation`**, **`tests`**, or **`needs-triage`**.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ python -m sdetkit kits describe forensics
 python -m sdetkit intelligence upgrade-audit --format json --top 5
 ```
 
+## Contributor quickstart (90 seconds)
+
+If you want the fastest path from curiosity to contribution, run this trio:
+
+```bash
+python -m sdetkit onboarding --journey fast-start --format markdown
+python -m sdetkit first-contribution --format markdown --strict
+python -m sdetkit onboarding --journey first-pr --role sdet --format markdown
+```
+
+These commands give a new contributor three things immediately:
+
+- a role-aware entrypoint instead of a generic wall of commands,
+- a first-PR checklist that can be validated locally,
+- and a curated command journey that turns the repo into an obvious place to start.
+
 ## Hero commands
 
 ```bash

--- a/src/sdetkit/first_contribution.py
+++ b/src/sdetkit/first_contribution.py
@@ -6,6 +6,27 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+_STARTER_PROFILES = {
+    "docs-polish": {
+        "label": "Docs polish",
+        "impact": "Clarify commands, fix internal links, and improve first-run confidence.",
+        "starter_files": ["README.md", "docs/choose-your-path.md", "CONTRIBUTING.md"],
+        "validation": ["python -m pre_commit run -a", "mkdocs build"],
+    },
+    "test-hardening": {
+        "label": "Test hardening",
+        "impact": "Add focused regression coverage without changing the public surface area.",
+        "starter_files": ["tests/", "src/sdetkit/"],
+        "validation": ["python -m pytest -q", "bash quality.sh cov"],
+    },
+    "automation-upgrade": {
+        "label": "Automation upgrade",
+        "impact": "Improve CI repeatability, artifact quality, or release safety checks.",
+        "starter_files": ["scripts/", "templates/automations/", ".github/"],
+        "validation": ["python -m pre_commit run -a", "bash quality.sh cov", "python -m build"],
+    },
+}
+
 _CHECKLIST_SECTION_HEADER = "## 0) Day 10 first-contribution checklist"
 
 _CHECKLIST_ITEMS = [
@@ -128,6 +149,7 @@ def build_first_contribution_status(root: str = ".") -> dict[str, Any]:
         "required_commands": list(_COMMAND_BLOCKS),
         "guide": str(guide),
         "missing": missing,
+        "starter_profiles": _STARTER_PROFILES,
         "actions": {
             "open_guide": "docs/contributing.md",
             "validate": "sdetkit first-contribution --format json --strict",
@@ -156,6 +178,11 @@ def _render_text(payload: dict[str, Any]) -> str:
             lines.append(f"- {item}")
     else:
         lines.append("Guide coverage gaps: none")
+    lines.extend(["", "Starter profiles:"])
+    for key, details in payload["starter_profiles"].items():
+        lines.append(f"- {details['label']} ({key}): {details['impact']}")
+        lines.append(f"  files     : {', '.join(details['starter_files'])}")
+        lines.append(f"  validate  : {'; '.join(details['validation'])}")
     lines.extend(["", "Actions:"])
     lines.append(f"- Open guide: {payload['actions']['open_guide']}")
     lines.append(f"- Validate: {payload['actions']['validate']}")
@@ -178,7 +205,15 @@ def _render_markdown(payload: dict[str, Any]) -> str:
         lines.append(f"- [ ] {item}")
     lines.extend(["", "## Required command sequence", "", "```bash"])
     lines.extend(payload["required_commands"])
-    lines.extend(["```", "", "## Guide coverage gaps", ""])
+    lines.extend(["```", "", "## Starter profiles", ""])
+    for key, details in payload["starter_profiles"].items():
+        lines.append(f"### {details['label']} (`{key}`)")
+        lines.append("")
+        lines.append(f"- Impact: {details['impact']}")
+        lines.append(f"- Good starter files: `{'`, `'.join(details['starter_files'])}`")
+        lines.append(f"- Validate with: `{'`, `'.join(details['validation'])}`")
+        lines.append("")
+    lines.extend(["## Guide coverage gaps", ""])
     if payload["missing"]:
         for item in payload["missing"]:
             lines.append(f"- `{item}`")

--- a/src/sdetkit/onboarding.py
+++ b/src/sdetkit/onboarding.py
@@ -63,17 +63,66 @@ _PLATFORM_SETUP = {
     },
 }
 
+_JOURNEY_PLAYBOOK = {
+    "fast-start": {
+        "label": "Fast start / first 15 minutes",
+        "goal": "Get one trustworthy signal from the repo and understand which kit to explore next.",
+        "steps": [
+            "python -m sdetkit kits list",
+            "python -m sdetkit doctor --format markdown",
+            "python -m sdetkit onboarding --role sdet --platform linux --format markdown",
+        ],
+        "outcome": "You leave with a visible quality snapshot and a role-specific next move.",
+    },
+    "first-pr": {
+        "label": "First PR / contributor runway",
+        "goal": "Move from clone to a reviewable first contribution with minimal repo spelunking.",
+        "steps": [
+            "python -m sdetkit first-contribution --format markdown --strict",
+            "python -m sdetkit onboarding --journey first-pr --format markdown",
+            "python -m pytest tests/test_onboarding_cli.py tests/test_first_contribution_extra.py -q",
+        ],
+        "outcome": "You have an explicit checklist, a scoped starter path, and a focused validation loop.",
+    },
+    "ci-rollout": {
+        "label": "CI rollout / team standardization",
+        "goal": "Adopt deterministic gates in automation without guessing command order.",
+        "steps": [
+            "python -m sdetkit release gate fast --format json --stable-json --out build/gate-fast.json",
+            "python -m sdetkit repo audit --format markdown",
+            "python -m sdetkit onboarding --role platform --journey ci-rollout --format markdown",
+        ],
+        "outcome": "You get a reusable baseline artifact and a crisp path to CI integration.",
+    },
+    "artifact-review": {
+        "label": "Artifact review / stakeholder proof",
+        "goal": "Create evidence that is easy to hand to leads, reviewers, and release owners.",
+        "steps": [
+            "python -m sdetkit evidence pack --output build/evidence.zip",
+            "python -m sdetkit forensics bundle --run examples/kits/forensics/run-b.json --output build/repro.zip",
+            "python -m sdetkit onboarding --role manager --journey artifact-review --format markdown",
+        ],
+        "outcome": "You produce artifacts that make the repo feel operational, not just aspirational.",
+    },
+}
+
 
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="sdetkit onboarding",
-        description="Render role-based onboarding guidance and cross-platform setup snippets.",
+        description="Render role-based onboarding guidance, cross-platform setup snippets, and contributor journeys.",
     )
     p.add_argument(
         "--role",
         choices=["all", *_ROLE_PLAYBOOK.keys()],
         default="all",
         help="Role-specific onboarding path to print.",
+    )
+    p.add_argument(
+        "--journey",
+        choices=["all", *_JOURNEY_PLAYBOOK.keys()],
+        default="all",
+        help="Curated command journey to print alongside role guidance.",
     )
     p.add_argument(
         "--format",
@@ -101,19 +150,59 @@ def _platform_payload(platform: str) -> dict[str, dict[str, Any]]:
     return {platform: _PLATFORM_SETUP[platform]}
 
 
-def _as_json(role: str, platform: str) -> str:
-    payload: dict[str, Any]
+def _journey_payload(journey: str) -> dict[str, dict[str, Any]]:
+    if journey == "all":
+        return {name: details for name, details in _JOURNEY_PLAYBOOK.items()}
+    return {journey: _JOURNEY_PLAYBOOK[journey]}
+
+
+def _role_payload(role: str) -> dict[str, dict[str, Any]]:
     if role == "all":
-        payload = {name: details for name, details in _ROLE_PLAYBOOK.items()}
-    else:
-        payload = {role: _ROLE_PLAYBOOK[role]}
+        return {name: details for name, details in _ROLE_PLAYBOOK.items()}
+    return {role: _ROLE_PLAYBOOK[role]}
+
+
+def _build_payload(role: str, platform: str, journey: str) -> dict[str, Any]:
     setup = _platform_payload(platform)
-    payload["platform_setup"] = setup
-    payload["day5_platform_setup"] = setup
-    return json.dumps(payload, indent=2, sort_keys=True)
+    journeys = _journey_payload(journey)
+    payload: dict[str, Any] = {
+        "roles": _role_payload(role),
+        "journeys": journeys,
+        "platform_setup": setup,
+        "day5_platform_setup": setup,
+        "recommended_sequence": [
+            "sdetkit kits list",
+            "sdetkit onboarding --journey fast-start --format markdown",
+            "sdetkit first-contribution --format markdown --strict",
+        ],
+    }
+    if role != "all":
+        payload[role] = _ROLE_PLAYBOOK[role]
+    return payload
 
 
-def _as_markdown(role: str, platform: str) -> str:
+def _as_json(role: str, platform: str, journey: str) -> str:
+    return json.dumps(_build_payload(role, platform, journey), indent=2, sort_keys=True)
+
+
+def _render_journeys_markdown(journey: str) -> list[str]:
+    lines = ["", "## Contributor journeys", ""]
+    for key, details in _JOURNEY_PLAYBOOK.items():
+        if journey != "all" and journey != key:
+            continue
+        lines.append(f"### {details['label']}")
+        lines.append("")
+        lines.append(f"- Goal: {details['goal']}")
+        lines.append(f"- Outcome: {details['outcome']}")
+        lines.append("")
+        lines.append("```bash")
+        lines.extend(details["steps"])
+        lines.append("```")
+        lines.append("")
+    return lines
+
+
+def _as_markdown(role: str, platform: str, journey: str) -> str:
     rows: list[str] = ["| Role | First command | Next action |", "|---|---|---|"]
     for key, details in _ROLE_PLAYBOOK.items():
         if role != "all" and role != key:
@@ -121,7 +210,7 @@ def _as_markdown(role: str, platform: str) -> str:
         rows.append(
             f"| {details['label']} | `{details['first_command']}` | {details['next_action']} |"
         )
-    rows.append("")
+    rows.extend(_render_journeys_markdown(journey))
     rows.append("## Platform setup snippets")
     rows.append("")
     for key, details in _PLATFORM_SETUP.items():
@@ -133,11 +222,19 @@ def _as_markdown(role: str, platform: str) -> str:
         rows.extend(details["commands"])
         rows.append("```")
         rows.append("")
+    rows.append("Recommended sequence:")
+    rows.append("")
+    rows.append("```bash")
+    rows.append("python -m sdetkit kits list")
+    rows.append("python -m sdetkit onboarding --journey fast-start --format markdown")
+    rows.append("python -m sdetkit first-contribution --format markdown --strict")
+    rows.append("```")
+    rows.append("")
     rows.append("Quick start: [Docs fast start](../index.md#fast-start)")
     return "\n".join(rows)
 
 
-def _as_text(role: str, platform: str) -> str:
+def _as_text(role: str, platform: str, journey: str) -> str:
     lines = ["Onboarding paths", ""]
     for key, details in _ROLE_PLAYBOOK.items():
         if role != "all" and role != key:
@@ -147,6 +244,17 @@ def _as_text(role: str, platform: str) -> str:
         lines.append(f"  next : {details['next_action']}")
         lines.append(f"  docs : {', '.join(details['docs'])}")
         lines.append("")
+    lines.extend(["Contributor journeys", ""])
+    for key, details in _JOURNEY_PLAYBOOK.items():
+        if journey != "all" and journey != key:
+            continue
+        lines.append(f"[{details['label']}]")
+        lines.append(f"  goal   : {details['goal']}")
+        lines.append(f"  outcome: {details['outcome']}")
+        lines.append("  steps  :")
+        for step in details["steps"]:
+            lines.append(f"    - {step}")
+        lines.append("")
     lines.extend(["Platform setup snippets", ""])
     for key, details in _PLATFORM_SETUP.items():
         if platform != "all" and platform != key:
@@ -155,22 +263,27 @@ def _as_text(role: str, platform: str) -> str:
         for cmd in details["commands"]:
             lines.append(f"  {cmd}")
         lines.append("")
+    lines.append("Recommended sequence:")
+    lines.append("  1. sdetkit kits list")
+    lines.append("  2. sdetkit onboarding --journey fast-start --format markdown")
+    lines.append("  3. sdetkit first-contribution --format markdown --strict")
+    lines.append("")
     lines.append("Start here: docs/index.md -> Fast start")
     return "\n".join(lines)
 
 
-def _render(role: str, platform: str, fmt: str) -> str:
+def _render(role: str, platform: str, journey: str, fmt: str) -> str:
     if fmt == "json":
-        return _as_json(role, platform)
+        return _as_json(role, platform, journey)
     if fmt == "markdown":
-        return _as_markdown(role, platform)
-    return _as_text(role, platform)
+        return _as_markdown(role, platform, journey)
+    return _as_text(role, platform, journey)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     ns = _build_parser().parse_args(argv)
 
-    rendered = _render(ns.role, ns.platform, ns.format)
+    rendered = _render(ns.role, ns.platform, ns.journey, ns.format)
     print(rendered)
 
     if ns.output:

--- a/tests/test_first_contribution_extra.py
+++ b/tests/test_first_contribution_extra.py
@@ -37,3 +37,19 @@ def test_main_json_strict_fail(tmp_path: Path, capsys) -> None:
     assert rc == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["missing"]
+
+
+def test_build_status_exposes_starter_profiles(tmp_path: Path) -> None:
+    (tmp_path / "CONTRIBUTING.md").write_text(fc._DAY10_DEFAULT_BLOCK, encoding="utf-8")
+    payload = fc.build_first_contribution_status(str(tmp_path))
+    assert payload["starter_profiles"]["docs-polish"]["label"] == "Docs polish"
+    assert "mkdocs build" in payload["starter_profiles"]["docs-polish"]["validation"]
+
+
+def test_markdown_render_lists_starter_profiles(tmp_path: Path, capsys) -> None:
+    (tmp_path / "CONTRIBUTING.md").write_text(fc._DAY10_DEFAULT_BLOCK, encoding="utf-8")
+    rc = fc.main(["--root", str(tmp_path), "--format", "markdown"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "## Starter profiles" in out
+    assert "Automation upgrade" in out

--- a/tests/test_onboarding_cli.py
+++ b/tests/test_onboarding_cli.py
@@ -69,6 +69,27 @@ def test_onboarding_help_describes_product_surface(capsys):
         onboarding.main(["--help"])
     assert excinfo.value.code == 0
     out = capsys.readouterr().out
-    assert "Render role-based onboarding guidance and cross-platform setup snippets." in out
+    assert "Render role-based onboarding guidance, cross-platform setup snippets, and" in out
+    assert "contributor journeys." in out
+    assert "--journey {all,fast-start,first-pr,ci-rollout,artifact-review}" in out
     assert "--platform {all,linux,macos,windows}" in out
     assert "Cross-platform setup snippets to print." in out
+
+
+def test_onboarding_journey_markdown_highlights_first_pr_runway(capsys):
+    rc = onboarding.main(["--journey", "first-pr", "--format", "markdown"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Contributor journeys" in out
+    assert "First PR / contributor runway" in out
+    assert "python -m sdetkit first-contribution --format markdown --strict" in out
+    assert "Fast start / first 15 minutes" not in out
+
+
+def test_onboarding_json_includes_journey_and_sequence(capsys):
+    rc = onboarding.main(["--role", "security", "--journey", "artifact-review", "--format", "json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert "journeys" in data
+    assert "artifact-review" in data["journeys"]
+    assert data["recommended_sequence"][0] == "sdetkit kits list"


### PR DESCRIPTION
### Motivation
- Make the repository easier to enter for new contributors by providing curated, role-aware onboarding flows and a short contributor quickstart.
- Surface explicit, high-value starter work so new contributors can pick a small, validated path and get immediate feedback.
- Reduce friction from discovery-to-PR by encoding recommended command sequences and validation steps directly in the CLI and docs.

### Description
- Add curated journey playbook support to the onboarding surface (`src/sdetkit/onboarding.py`) with `--journey` and journeys: `fast-start`, `first-pr`, `ci-rollout`, and `artifact-review`, and include a structured JSON payload and recommended sequence.
- Extend the first-contribution surface (`src/sdetkit/first_contribution.py`) with `_STARTER_PROFILES` (profiles: `docs-polish`, `test-hardening`, `automation-upgrade`) and surface them in text/markdown/JSON outputs and status payloads.
- Update top-level onboarding UX by adding a short contributor quickstart snippet to `README.md` and linking the guided journey from `CONTRIBUTING.md`.
- Extend and adjust tests to cover the new journey/help/JSON behavior and starter-profile rendering (`tests/test_onboarding_cli.py`, `tests/test_first_contribution_extra.py`).

### Testing
- Ran the focused unit tests: `python -m pytest -q tests/test_onboarding_cli.py tests/test_first_contribution_extra.py` which passed (`14 passed`).
- Ran lint/format checks: `python -m ruff check src/sdetkit/onboarding.py src/sdetkit/first_contribution.py tests/test_onboarding_cli.py tests/test_first_contribution_extra.py` which succeeded.
- Exercised the new CLI flows manually: `python -m sdetkit onboarding --journey first-pr --role sdet --format markdown` and `python -m sdetkit first-contribution --format markdown --strict`, both of which produced the expected output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb53d2f7288320abf71fbba9e5fc58)