### PR TITLE
Add ecosystem kind metadata to monorepo project discovery

### DIFF
--- a/docs/monorepo-projects.md
+++ b/docs/monorepo-projects.md
@@ -46,6 +46,8 @@ packs = "core,security"
 - List discovered projects:
   - `sdetkit repo projects list .`
   - `sdetkit repo projects list . --json`
+  - `sdetkit repo projects list . --kind python`
+  - `sdetkit repo projects list . --kind node --json`
 - Aggregate audit:
   - `sdetkit repo audit . --all-projects`
   - `sdetkit repo audit . --all-projects --format json`
@@ -58,6 +60,10 @@ packs = "core,security"
 
 - Project discovery is deterministic (manifest order).
 - `--sort` switches to alphabetical project ordering.
+- Project listings now include an inferred `kind` (`python`, `node`, `rust`, `go`,
+  `maven`, `gradle`, `dotnet`, or `unknown`) and a summary count by kind.
+- `repo projects list --kind ...` lets you filter large monorepos down to only the
+  ecosystems you want to audit or inspect first.
 - JSON aggregate schema: `sdetkit.audit.aggregate.v1`.
 - SARIF output emits one SARIF file with separate `runs` per project.
 - Baseline default per project root is `.sdetkit/audit-baseline.json`.

--- a/src/sdetkit/projects.py
+++ b/src/sdetkit/projects.py
@@ -30,6 +30,7 @@ class ProjectsConfigError(ValueError):
 class RepoProject:
     name: str
     root: str
+    kind: str | None
     config_path: str | None
     profile: str | None
     packs: tuple[str, ...]
@@ -42,6 +43,7 @@ class ResolvedRepoProject:
     name: str
     root: Path
     root_rel: str
+    kind: str | None
     config_path: Path | None
     config_rel: str | None
     profile: str | None
@@ -310,6 +312,48 @@ def _csproj_project_name(csproj: Path) -> str | None:
     return csproj.stem or None
 
 
+def _detect_project_identity(project_dir: Path, filenames: set[str]) -> tuple[str | None, str | None]:
+    if "pyproject.toml" in filenames:
+        if name := _pyproject_project_name(project_dir / "pyproject.toml"):
+            return name, "python"
+    if "Cargo.toml" in filenames:
+        if name := _cargo_project_name(project_dir / "Cargo.toml"):
+            return name, "rust"
+    if "go.mod" in filenames:
+        if name := _go_module_name(project_dir / "go.mod"):
+            return name, "go"
+    if "package.json" in filenames:
+        if name := _package_json_project_name(project_dir / "package.json"):
+            return name, "node"
+    if "pom.xml" in filenames:
+        if name := _maven_project_name(project_dir / "pom.xml"):
+            return name, "maven"
+    if "settings.gradle" in filenames or "settings.gradle.kts" in filenames:
+        settings_name = "settings.gradle" if "settings.gradle" in filenames else "settings.gradle.kts"
+        if name := _gradle_project_name(project_dir / settings_name):
+            return name, "gradle"
+    csproj_files = sorted(name for name in filenames if name.endswith(".csproj"))
+    if csproj_files:
+        if name := _csproj_project_name(project_dir / csproj_files[0]):
+            return name, "dotnet"
+    return None, None
+
+
+def _infer_project_kind(repo_root: Path, root_rel: str, config_rel: str | None) -> str | None:
+    candidate_dir = repo_root / root_rel
+    filenames: set[str] = set()
+    try:
+        if candidate_dir.is_dir():
+            filenames.update(path.name for path in candidate_dir.iterdir() if path.is_file())
+    except OSError:
+        pass
+    if config_rel:
+        config_name = Path(config_rel).name
+        filenames.add(config_name)
+    _, kind = _detect_project_identity(candidate_dir, filenames)
+    return kind
+
+
 def _autodiscover_roots(*, data: dict[str, Any] | None, field_prefix: str) -> tuple[str, ...]:
     if data is None:
         return _AUTODISCOVER_BASES
@@ -358,46 +402,22 @@ def _autodiscover_projects(
             dirnames[:] = sorted(
                 d for d in dirnames if d not in _SKIP_DIRS and not d.startswith(".")
             )
-            has_pyproject = "pyproject.toml" in filenames
-            has_cargo_toml = "Cargo.toml" in filenames
-            has_go_mod = "go.mod" in filenames
-            has_package_json = "package.json" in filenames
-            has_pom_xml = "pom.xml" in filenames
-            has_gradle_settings = (
-                "settings.gradle" in filenames or "settings.gradle.kts" in filenames
-            )
-            csproj_files = sorted(name for name in filenames if name.endswith(".csproj"))
+            filename_set = set(filenames)
             if not any(
                 (
-                    has_pyproject,
-                    has_cargo_toml,
-                    has_go_mod,
-                    has_package_json,
-                    has_pom_xml,
-                    has_gradle_settings,
-                    csproj_files,
+                    "pyproject.toml" in filename_set,
+                    "Cargo.toml" in filename_set,
+                    "go.mod" in filename_set,
+                    "package.json" in filename_set,
+                    "pom.xml" in filename_set,
+                    "settings.gradle" in filename_set,
+                    "settings.gradle.kts" in filename_set,
+                    any(name.endswith(".csproj") for name in filename_set),
                 )
             ):
                 continue
             project_dir = Path(dirpath)
-            name: str | None = None
-            if has_pyproject:
-                name = _pyproject_project_name(project_dir / "pyproject.toml")
-            if not name and has_cargo_toml:
-                name = _cargo_project_name(project_dir / "Cargo.toml")
-            if not name and has_go_mod:
-                name = _go_module_name(project_dir / "go.mod")
-            if not name and has_package_json:
-                name = _package_json_project_name(project_dir / "package.json")
-            if not name and has_pom_xml:
-                name = _maven_project_name(project_dir / "pom.xml")
-            if not name and has_gradle_settings:
-                settings_name = (
-                    "settings.gradle" if "settings.gradle" in filenames else "settings.gradle.kts"
-                )
-                name = _gradle_project_name(project_dir / settings_name)
-            if not name and csproj_files:
-                name = _csproj_project_name(project_dir / csproj_files[0])
+            name, kind = _detect_project_identity(project_dir, filename_set)
             if not name:
                 continue
             root_rel = project_dir.relative_to(repo_root).as_posix()
@@ -411,6 +431,7 @@ def _autodiscover_projects(
                 RepoProject(
                     name=name,
                     root=_normalize_rel(root_rel, field="root"),
+                    kind=kind,
                     config_path=None,
                     profile=None,
                     packs=(),
@@ -475,22 +496,17 @@ def discover_projects(
             raise ProjectsConfigError(f"duplicate project root: {normalized_root}")
         seen_names.add(name)
         seen_roots.add(normalized_root)
+        cfg = _as_str(entry.get("config"), field="config")
+        baseline = _as_str(entry.get("baseline"), field="baseline")
         projects.append(
             RepoProject(
                 name=name,
                 root=normalized_root,
-                config_path=(
-                    _normalize_rel(cfg, field="config")
-                    if (cfg := _as_str(entry.get("config"), field="config"))
-                    else None
-                ),
+                kind=_infer_project_kind(repo_root, normalized_root, cfg),
+                config_path=_normalize_rel(cfg, field="config") if cfg else None,
                 profile=_as_str(entry.get("profile"), field="profile"),
                 packs=_as_str_list_or_csv(entry.get("packs"), field="packs"),
-                baseline_path=(
-                    _normalize_rel(base, field="baseline")
-                    if (base := _as_str(entry.get("baseline"), field="baseline"))
-                    else None
-                ),
+                baseline_path=_normalize_rel(baseline, field="baseline") if baseline else None,
                 exclude_paths=_as_str_list_or_csv(entry.get("exclude"), field="exclude"),
             )
         )
@@ -516,6 +532,7 @@ def resolve_project(repo_root: Path, project: RepoProject) -> ResolvedRepoProjec
         name=project.name,
         root=root,
         root_rel=root_rel,
+        kind=project.kind,
         config_path=(repo_root / project.config_path).resolve(strict=False)
         if project.config_path
         else None,

--- a/src/sdetkit/repo.py
+++ b/src/sdetkit/repo.py
@@ -3460,6 +3460,12 @@ def main(argv: list[str] | None = None) -> int:
     projlist.add_argument("path", nargs="?", default=".")
     projlist.add_argument("--json", action="store_true")
     projlist.add_argument("--sort", action="store_true")
+    projlist.add_argument(
+        "--kind",
+        action="append",
+        choices=["python", "rust", "go", "node", "maven", "gradle", "dotnet", "unknown"],
+        default=[],
+    )
     projlist.add_argument("--allow-absolute-path", action="store_true")
 
     rules_parser = sub.add_parser("rules")
@@ -3600,11 +3606,16 @@ def main(argv: list[str] | None = None) -> int:
             print(str(exc), file=sys.stderr)
             return 2
         records = []
+        selected_kinds = set(ns.kind)
         for project in projects:
             resolved = resolve_project(projects_root, project)
+            project_kind = getattr(resolved, "kind", None) or "unknown"
+            if selected_kinds and project_kind not in selected_kinds:
+                continue
             records.append(
                 {
                     "name": resolved.name,
+                    "kind": project_kind,
                     "root": resolved.root_rel,
                     "root_resolved": str(resolved.root),
                     "config": resolved.config_rel,
@@ -3615,7 +3626,15 @@ def main(argv: list[str] | None = None) -> int:
                     "exclude": list(resolved.exclude_paths),
                 }
             )
-        projects_payload = {"manifest": source, "projects": records}
+        kind_counts: dict[str, int] = {}
+        for rec in records:
+            kind = str(rec["kind"])
+            kind_counts[kind] = kind_counts.get(kind, 0) + 1
+        projects_payload = {
+            "manifest": source,
+            "projects": records,
+            "summary": {"count": len(records), "kinds": kind_counts},
+        }
         if ns.json:
             sys.stdout.write(
                 json.dumps(projects_payload, ensure_ascii=True, sort_keys=True, indent=2) + "\n"
@@ -3624,7 +3643,14 @@ def main(argv: list[str] | None = None) -> int:
         if source:
             print(f"Manifest: {source}")
         for rec in records:
-            print(f"- {rec['name']}: root={rec['root']} baseline={rec['baseline']}")
+            print(
+                f"- {rec['name']} [{rec['kind']}]: root={rec['root']} baseline={rec['baseline']}"
+            )
+        if records:
+            kind_summary = ", ".join(
+                f"{kind}={count}" for kind, count in sorted(kind_counts.items(), key=lambda item: item[0])
+            )
+            print(f"Summary: count={len(records)} kinds={kind_summary}")
         return 0
 
     target_path = getattr(ns, "path", getattr(ns, "root", "."))

--- a/tests/test_projects_autodiscover.py
+++ b/tests/test_projects_autodiscover.py
@@ -25,14 +25,15 @@ def test_autodiscover_packages_ignores_node_modules(tmp_path: Path) -> None:
 
     source, projects = discover_projects(repo, sort=True)
     assert source == "autodiscover"
-    assert [(p.name, p.root) for p in projects] == [
-        ("pkg-a", "packages/a"),
-        ("pkg-b", "packages/b"),
+    assert [(p.name, p.root, p.kind) for p in projects] == [
+        ("pkg-a", "packages/a", "python"),
+        ("pkg-b", "packages/b", "python"),
     ]
 
     resolved = [resolve_project(repo, p) for p in projects]
     assert [r.root_rel for r in resolved] == ["packages/a", "packages/b"]
     assert resolved[0].baseline_rel == "packages/a/.sdetkit/audit-baseline.json"
+    assert [r.kind for r in resolved] == ["python", "python"]
 
 
 def test_autodiscover_detects_common_monorepo_roots_by_default(tmp_path: Path) -> None:
@@ -45,10 +46,10 @@ def test_autodiscover_detects_common_monorepo_roots_by_default(tmp_path: Path) -
 
     source, projects = discover_projects(repo, sort=True)
     assert source == "autodiscover"
-    assert [(p.name, p.root) for p in projects] == [
-        ("crate-engine", "crates/engine"),
-        ("lib-core", "libs/core"),
-        ("svc-api", "services/api"),
+    assert [(p.name, p.root, p.kind) for p in projects] == [
+        ("crate-engine", "crates/engine", "python"),
+        ("lib-core", "libs/core", "python"),
+        ("svc-api", "services/api", "python"),
     ]
 
 
@@ -260,9 +261,9 @@ def test_autodiscover_detects_node_package_json_projects(tmp_path: Path) -> None
     )
 
     _, projects = discover_projects(repo, sort=True)
-    assert [(p.name, p.root) for p in projects] == [
-        ("@acme/web", "apps/web"),
-        ("acme-api", "packages/api"),
+    assert [(p.name, p.root, p.kind) for p in projects] == [
+        ("@acme/web", "apps/web", "node"),
+        ("acme-api", "packages/api", "node"),
     ]
 
 
@@ -312,9 +313,9 @@ version = "0.1.0"
 
     source, projects = discover_projects(repo, sort=True)
     assert source == "autodiscover"
-    assert [(p.name, p.root) for p in projects] == [
-        ("acme-worker", "packages/worker"),
-        ("github.com/acme/gateway", "apps/gateway"),
+    assert [(p.name, p.root, p.kind) for p in projects] == [
+        ("acme-worker", "packages/worker", "rust"),
+        ("github.com/acme/gateway", "apps/gateway", "go"),
     ]
 
 
@@ -411,10 +412,10 @@ def test_autodiscover_detects_maven_gradle_and_dotnet_projects(tmp_path: Path) -
 
     source, projects = discover_projects(repo, sort=True)
     assert source == "autodiscover"
-    assert [(p.name, p.root) for p in projects] == [
-        ("Acme.Payments", "libs/payments"),
-        ("billing-service", "services/billing"),
-        ("checkout-app", "apps/checkout"),
+    assert [(p.name, p.root, p.kind) for p in projects] == [
+        ("Acme.Payments", "libs/payments", "dotnet"),
+        ("billing-service", "services/billing", "maven"),
+        ("checkout-app", "apps/checkout", "gradle"),
     ]
 
 

--- a/tests/test_repo_monorepo_projects.py
+++ b/tests/test_repo_monorepo_projects.py
@@ -79,6 +79,72 @@ def test_projects_list_json_is_deterministic(tmp_path: Path) -> None:
     assert first.stdout == second.stdout
     payload = json.loads(first.stdout)
     assert [item["name"] for item in payload["projects"]] == ["api", "core"]
+    assert [item["kind"] for item in payload["projects"]] == ["python", "python"]
+    assert payload["summary"] == {"count": 2, "kinds": {"python": 2}}
+
+
+def test_projects_list_kind_filter_and_text_summary(tmp_path: Path) -> None:
+    _seed_monorepo(tmp_path)
+    (tmp_path / "services" / "api" / "pyproject.toml").write_text(
+        "[project]\nname='api'\n", encoding="utf-8"
+    )
+    (tmp_path / "libs" / "core" / "pyproject.toml").write_text(
+        "[project]\nname='core'\n", encoding="utf-8"
+    )
+    (tmp_path / ".sdetkit" / "projects.toml").write_text(
+        """
+autodiscover = true
+autodiscover_roots = ["services", "libs", "apps"]
+
+[[project]]
+name = "api"
+root = "services/api"
+exclude = ["docs/*"]
+
+[[project]]
+name = "core"
+root = "libs/core"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    web = tmp_path / "apps" / "web"
+    web.mkdir(parents=True)
+    (web / "package.json").write_text('{"name": "@acme/web"}\n', encoding="utf-8")
+
+    runner = CliRunner()
+    out_json = runner.invoke(
+        [
+            "repo",
+            "projects",
+            "list",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--json",
+            "--kind",
+            "node",
+        ]
+    )
+    assert out_json.exit_code == 0
+    payload = json.loads(out_json.stdout)
+    assert payload["summary"] == {"count": 1, "kinds": {"node": 1}}
+    assert [(item["name"], item["kind"]) for item in payload["projects"]] == [("@acme/web", "node")]
+
+    out_text = runner.invoke(
+        [
+            "repo",
+            "projects",
+            "list",
+            str(tmp_path),
+            "--allow-absolute-path",
+            "--kind",
+            "python",
+        ]
+    )
+    assert out_text.exit_code == 0
+    assert "- api [python]:" in out_text.stdout
+    assert "- core [python]:" in out_text.stdout
+    assert "Summary: count=2 kinds=python=2" in out_text.stdout
 
 
 def test_audit_all_projects_json_and_sarif_runs(tmp_path: Path) -> None:

--- a/tests/test_repo_pr_fix.py
+++ b/tests/test_repo_pr_fix.py
@@ -315,4 +315,5 @@ def test_repo_rules_and_projects_text_modes(tmp_path: Path, monkeypatch) -> None
     projects = runner.invoke(["repo", "projects", "list", str(tmp_path), "--allow-absolute-path"])
     assert projects.exit_code == 0
     assert "Manifest: manifest.yml" in projects.stdout
-    assert "- app:" in projects.stdout
+    assert "- app [unknown]:" in projects.stdout
+    assert "Summary: count=1 kinds=unknown=1" in projects.stdout


### PR DESCRIPTION
### Motivation
- Make monorepo project discovery more informative by inferring the ecosystem for each discovered project so large multi-language repos are easier to filter and prioritize.
- Provide a lightweight, extensible detector path so new project-types can be added without duplicating autodiscovery logic.

### Description
- Add a `kind: str | None` field to `RepoProject` and `ResolvedRepoProject` and populate it from a shared detector function `_detect_project_identity` that recognizes `pyproject.toml`, `package.json`, `Cargo.toml`, `go.mod`, `pom.xml`, Gradle settings, and `.csproj` files.
- Add `_infer_project_kind` to infer a project's kind when manifest entries exist and wire the kind into `discover_projects` and `resolve_project` results.
- Extend `sdetkit repo projects list` with a `--kind` filter, include per-project `kind` in JSON output and add a `summary` block with `count` and `kinds` counts, and print `kind` and a short kinds summary in text mode.
- Update docs (`docs/monorepo-projects.md`) and tests to cover inferred kinds, filtering, JSON summaries, and text-mode compatibility; refactor tests where needed to remain compatible with the new output.

### Testing
- Ran the monorepo and CLI test slice: `pytest -q tests/test_projects_autodiscover.py tests/test_repo_monorepo_projects.py tests/test_projects_manifest_edges_wave5.py tests/test_repo_audit.py tests/test_repo_plugins_fix_audit.py tests/test_repo_pr_fix.py` and all affected tests passed (66 passed).
- Verified module compilation with `python -m compileall src/sdetkit/projects.py src/sdetkit/repo.py` and lint checks with `python -m ruff check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb5c0e2040832088aea977b23cefa2)