### PR TITLE
Add dependency group/source rollups and filters to upgrade-audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,19 +86,21 @@ python -m sdetkit continuous-upgrade-cycle11-closeout --format json --strict
 
 ## Upgrade planning (first step)
 
-Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, manifest actions, suggested target versions, and floor-and-lock baseline detection for repos that intentionally mix flexible ranges with tested pins. You can invoke it from either the standalone script or the primary Intelligence kit surface, and you can fail CI at a chosen signal threshold:
+Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, group/source rollups, manifest actions, suggested target versions, and floor-and-lock baseline detection for repos that intentionally mix flexible ranges with tested pins. You can invoke it from either the standalone script or the primary Intelligence kit surface, filter the results down to the hottest dependency groups or manifest sources, and fail CI at a chosen signal threshold:
 
 ```bash
 make upgrade-audit
 python -m sdetkit intelligence upgrade-audit --format json --top 5
 python -m sdetkit intelligence upgrade-audit --format md --offline
 python -m sdetkit intelligence upgrade-audit --outdated-only --package "http*"
+python -m sdetkit intelligence upgrade-audit --group default --source pyproject.toml --format md
 python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
 python scripts/upgrade_audit.py --fail-on high
 python scripts/upgrade_audit.py --cache-ttl-hours 6 --max-workers 12
 python scripts/upgrade_audit.py --offline --format md
 python scripts/upgrade_audit.py --signal high --policy blocked --top 5
 python scripts/upgrade_audit.py --metadata-source cache-stale --outdated-only
+python scripts/upgrade_audit.py --group requirements --source requirements.txt --top 10
 ```
 
 ## Sample artifacts

--- a/src/sdetkit/intelligence.py
+++ b/src/sdetkit/intelligence.py
@@ -243,6 +243,8 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
     )
     ua.add_argument("--package", action="append", default=None)
+    ua.add_argument("--group", action="append", default=None)
+    ua.add_argument("--source", action="append", default=None)
     ua.add_argument(
         "--metadata-source",
         action="append",
@@ -293,6 +295,8 @@ def main(argv: list[str] | None = None) -> int:
                 signals=ns.signal,
                 policies=ns.policy,
                 packages=ns.package,
+                groups=ns.group,
+                sources=ns.source,
                 metadata_sources=ns.metadata_source,
                 outdated_only=bool(ns.outdated_only),
                 top=ns.top,

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -786,11 +786,68 @@ def _report_summary(reports: list[PackageReport]) -> dict[str, int]:
     }
 
 
+def _group_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
+    buckets: dict[str, list[PackageReport]] = {}
+    for report in reports:
+        for group in report.groups:
+            buckets.setdefault(group, []).append(report)
+    ordered = sorted(
+        buckets.items(),
+        key=lambda item: (
+            -max((report.risk_score for report in item[1]), default=0),
+            -len(item[1]),
+            item[0],
+        ),
+    )
+    return [
+        {
+            "group": group,
+            "count": len(items),
+            "max_risk_score": max((report.risk_score for report in items), default=0),
+            "actionable_packages": sum(1 for report in items if _is_actionable_upgrade(report)),
+            "packages": [report.name for report in items[:5]],
+        }
+        for group, items in ordered
+    ]
+
+
+def _source_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
+    buckets: dict[str, list[PackageReport]] = {}
+    for report in reports:
+        for source in report.sources:
+            buckets.setdefault(source, []).append(report)
+    ordered = sorted(
+        buckets.items(),
+        key=lambda item: (
+            -max((report.risk_score for report in item[1]), default=0),
+            -len(item[1]),
+            item[0],
+        ),
+    )
+    return [
+        {
+            "source": source,
+            "count": len(items),
+            "max_risk_score": max((report.risk_score for report in items), default=0),
+            "actionable_packages": sum(1 for report in items if _is_actionable_upgrade(report)),
+            "packages": [report.name for report in items[:5]],
+        }
+        for source, items in ordered
+    ]
+
+
 def _matches_package_filters(report: PackageReport, package_filters: list[str] | None) -> bool:
     if not package_filters:
         return True
     normalized = report.name.lower()
     return any(fnmatch.fnmatch(normalized, pattern) for pattern in package_filters)
+
+
+def _matches_any_filter(values: list[str], allowed_filters: list[str] | None) -> bool:
+    if not allowed_filters:
+        return True
+    normalized_values = {value.lower() for value in values}
+    return any(filter_value in normalized_values for filter_value in allowed_filters)
 
 
 def _filter_reports(
@@ -799,6 +856,8 @@ def _filter_reports(
     signals: list[str] | None = None,
     policies: list[str] | None = None,
     packages: list[str] | None = None,
+    groups: list[str] | None = None,
+    sources: list[str] | None = None,
     metadata_sources: list[str] | None = None,
     outdated_only: bool = False,
     top: int | None = None,
@@ -814,6 +873,14 @@ def _filter_reports(
         package_filters = [item.strip().lower() for item in packages if item.strip()]
         filtered = [
             report for report in filtered if _matches_package_filters(report, package_filters)
+        ]
+    if groups:
+        group_filters = [item.strip().lower() for item in groups if item.strip()]
+        filtered = [report for report in filtered if _matches_any_filter(report.groups, group_filters)]
+    if sources:
+        source_filters = [item.strip().lower() for item in sources if item.strip()]
+        filtered = [
+            report for report in filtered if _matches_any_filter(report.sources, source_filters)
         ]
     if metadata_sources:
         allowed_sources = {item.strip() for item in metadata_sources if item.strip()}
@@ -877,6 +944,20 @@ def _render_markdown(
             f"- **{item['lane']}**: {item['count']} package(s), max risk {item['max_risk_score']}"
             + (f" — {pkg_list}" if pkg_list else "")
         )
+    lines.extend(["", "## Dependency groups", ""])
+    for item in _group_summary(reports):
+        pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
+        lines.append(
+            f"- **{item['group']}**: {item['count']} package(s), actionable {item['actionable_packages']}, max risk {item['max_risk_score']}"
+            + (f" — {pkg_list}" if pkg_list else "")
+        )
+    lines.extend(["", "## Manifest sources", ""])
+    for item in _source_summary(reports):
+        pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
+        lines.append(
+            f"- **{item['source']}**: {item['count']} package(s), actionable {item['actionable_packages']}, max risk {item['max_risk_score']}"
+            + (f" — {pkg_list}" if pkg_list else "")
+        )
     lines.extend(["", "## Focus notes", ""])
     for report in reports:
         note_text = " ".join(report.notes) if report.notes else "No additional notes."
@@ -896,6 +977,8 @@ def _render_json(
         "summary": _report_summary(reports),
         "priority_queue": _priority_queue(reports),
         "lanes": _lane_summary(reports),
+        "groups": _group_summary(reports),
+        "sources": _source_summary(reports),
         "packages": [asdict(report) for report in reports],
     }
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
@@ -933,6 +1016,8 @@ def run(
     signals: list[str] | None = None,
     policies: list[str] | None = None,
     packages: list[str] | None = None,
+    groups: list[str] | None = None,
+    sources: list[str] | None = None,
     metadata_sources: list[str] | None = None,
     outdated_only: bool = False,
     top: int | None = None,
@@ -978,6 +1063,8 @@ def run(
         signals=signals,
         policies=policies,
         packages=packages,
+        groups=groups,
+        sources=sources,
         metadata_sources=metadata_sources,
         outdated_only=outdated_only,
         top=top,
@@ -1083,6 +1170,18 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         help="Show only packages matching the provided name or glob pattern. Can be passed multiple times.",
     )
     parser.add_argument(
+        "--group",
+        action="append",
+        default=None,
+        help="Show only packages declared in the selected dependency group(s). Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=None,
+        help="Show only packages declared in the selected manifest source file(s). Can be passed multiple times.",
+    )
+    parser.add_argument(
         "--metadata-source",
         action="append",
         choices=["pypi", "cache", "cache-stale", "offline"],
@@ -1143,6 +1242,8 @@ def main(argv: list[str] | None = None) -> int:
         signals=args.signal,
         policies=args.policy,
         packages=args.package,
+        groups=args.group,
+        sources=args.source,
         metadata_sources=args.metadata_source,
         outdated_only=bool(args.outdated_only),
         top=args.top,

--- a/tests/test_kits_intelligence_integration_forensics.py
+++ b/tests/test_kits_intelligence_integration_forensics.py
@@ -101,6 +101,10 @@ dependencies = ["httpx==0.28.1"]
         str(cache_path),
         "--format",
         "json",
+        "--group",
+        "default",
+        "--source",
+        "pyproject.toml",
     )
 
     assert proc.returncode == 0
@@ -108,6 +112,8 @@ dependencies = ["httpx==0.28.1"]
     assert payload["packages"][0]["name"] == "httpx"
     assert payload["priority_queue"][0]["lane"] == "next-maintenance-batch"
     assert payload["lanes"][0]["lane"] == "next-maintenance-batch"
+    assert payload["groups"][0]["group"] == "default"
+    assert payload["sources"][0]["source"] == "pyproject.toml"
 
 
 def test_intelligence_failure_mode_invalid_failures_file(tmp_path: Path) -> None:

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -595,6 +595,10 @@ def test_render_json_includes_lane_summary_and_priority_lane() -> None:
     assert payload["priority_queue"][0]["lane"] == "stabilize-manifests"
     assert payload["lanes"][0]["lane"] == "stabilize-manifests"
     assert payload["lanes"][0]["packages"] == ["critical-pkg"]
+    assert payload["groups"][0]["group"] == "requirements"
+    assert payload["groups"][0]["actionable_packages"] == 1
+    assert payload["sources"][0]["source"] == "requirements.txt"
+    assert payload["sources"][0]["count"] == 2
 
 
 def test_render_markdown_includes_recommended_upgrade_lanes() -> None:
@@ -629,6 +633,8 @@ def test_render_markdown_includes_recommended_upgrade_lanes() -> None:
     )
 
     assert "## Recommended upgrade lanes" in rendered
+    assert "## Dependency groups" in rendered
+    assert "## Manifest sources" in rendered
     assert "**next-maintenance-batch**" in rendered
 
 
@@ -687,15 +693,84 @@ dependencies = ["httpx==0.28.1", "ruff==0.15.6"]
     assert [item["name"] for item in payload["packages"]] == ["httpx"]
 
 
+def test_filter_reports_supports_group_and_source_filters() -> None:
+    reports = [
+        upgrade_audit.PackageReport(
+            name="httpx",
+            sources=["pyproject.toml", "requirements.txt"],
+            groups=["default", "requirements"],
+            requirements=["httpx==0.28.1"],
+            pinned_versions=["0.28.1"],
+            current_version="0.28.1",
+            alignment="aligned",
+            constraint_status="blocked",
+            latest_version="0.29.0",
+            latest_release_date="2026-01-01T00:00:00Z",
+            metadata_source="pypi",
+            version_gap="minor",
+            release_age_days=0,
+            upgrade_signal="medium",
+            risk_score=55,
+            manifest_action="stage-upgrade",
+            suggested_version="0.29.0",
+            next_action="Queue the upgrade for the next maintenance batch and validate targeted smoke tests.",
+            notes=[],
+        ),
+        upgrade_audit.PackageReport(
+            name="mkdocs",
+            sources=["requirements-docs.txt"],
+            groups=["docs"],
+            requirements=["mkdocs==1.6.1"],
+            pinned_versions=["1.6.1"],
+            current_version="1.6.1",
+            alignment="aligned",
+            constraint_status="allowed",
+            latest_version="1.6.1",
+            latest_release_date=None,
+            metadata_source="cache",
+            version_gap="up-to-date",
+            release_age_days=None,
+            upgrade_signal="watch",
+            risk_score=10,
+            manifest_action="none",
+            suggested_version=None,
+            next_action="Keep under observation; no immediate action required.",
+            notes=[],
+        ),
+    ]
+
+    filtered = upgrade_audit._filter_reports(
+        reports,
+        groups=["default"],
+        sources=["requirements.txt"],
+    )
+
+    assert [report.name for report in filtered] == ["httpx"]
+
+
 def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[project]\ndependencies=[]\n", encoding="utf-8")
 
     parser = upgrade_audit.build_parser()
-    args = parser.parse_args(["--pyproject", str(pyproject), "--outdated-only", "--package", "http*"])
+    args = parser.parse_args(
+        [
+            "--pyproject",
+            str(pyproject),
+            "--outdated-only",
+            "--package",
+            "http*",
+            "--group",
+            "default",
+            "--source",
+            "pyproject.toml",
+        ]
+    )
 
     requirement_paths = upgrade_audit._resolve_requirement_paths(args)
 
     assert args.outdated_only is True
     assert args.package == ["http*"]
+    assert args.group == ["default"]
+    assert args.source == ["pyproject.toml"]
     assert requirement_paths == []


### PR DESCRIPTION
### Motivation

- Improve upgrade-planning ergonomics by allowing audits to be prioritized by dependency groups and manifest sources instead of only by package lists.
- Surface group- and source-level rollups so teams can focus maintenance on ownership boundaries and manifest files.

### Description

- Added group and source rollup summaries via new functions ` _group_summary` and `_source_summary` and included them in JSON and Markdown outputs from `_render_json` and `_render_markdown`.
- Added filtering by dependency group and manifest source to `_filter_reports` with a helper `_matches_any_filter`, and threaded `groups`/`sources` through `run` and `build_parser` as new CLI flags `--group` and `--source`.
- Exposed the same `--group` / `--source` selectors on the umbrella kit surface by passing them through `sdetkit intelligence upgrade-audit` in `src/sdetkit/intelligence.py`.
- Updated docs (`README.md`) with examples for group/source-focused audit commands and added/adjusted tests to cover rollups, filters, CLI defaults, and the intelligence primary surface (`tests/test_upgrade_audit_script.py` and `tests/test_kits_intelligence_integration_forensics.py`).

### Testing

- Ran the focused test matrix: `PYTHONPATH=src pytest -q tests/test_upgrade_audit_script.py::test_render_json_includes_lane_summary_and_priority_lane tests/test_upgrade_audit_script.py::test_render_markdown_includes_recommended_upgrade_lanes tests/test_upgrade_audit_script.py::test_filter_reports_supports_group_and_source_filters tests/test_upgrade_audit_script.py::test_resolve_requirement_paths_supports_outdated_only_cli_defaults tests/test_kits_intelligence_integration_forensics.py::test_intelligence_upgrade_audit_primary_surface`, and all passed.
- Verified runtime output with `PYTHONPATH=src python -m sdetkit intelligence upgrade-audit --offline --format json --group default --source pyproject.toml --top 3` which produced the expected `groups` and `sources` rollups.
- Performed a static compile check with `python -m compileall src/sdetkit` and ran `git diff --check`; both reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb602897c48320b3906690be7be33f)