### PR TITLE
Upgrade audit: Python-compat-aware targeting and recursive requirements support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ python -m sdetkit continuous-upgrade-cycle11-closeout --format json --strict
 
 ## Upgrade planning (first step)
 
-Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, group/source rollups, manifest actions, suggested target versions, and floor-and-lock baseline detection for repos that intentionally mix flexible ranges with tested pins. You can invoke it from either the standalone script or the primary Intelligence kit surface, filter the results down to the hottest dependency groups or manifest sources, and fail CI at a chosen signal threshold:
+Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, Python-policy-aware compatible targets, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, group/source rollups, manifest actions, suggested target versions, and floor-and-lock baseline detection for repos that intentionally mix flexible ranges with tested pins. It also follows nested `-r` / `--requirement` includes so split requirement stacks are audited as a single upgrade surface. You can invoke it from either the standalone script or the primary Intelligence kit surface, filter the results down to the hottest dependency groups or manifest sources, and fail CI at a chosen signal threshold:
 
 ```bash
 make upgrade-audit

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -34,7 +34,13 @@ class PackageReport:
     groups: list[str]
     requirements: list[str]
     pinned_versions: list[str]
+    project_python_requires: str | None
     current_version: str
+    target_version: str
+    target_release_date: str | None
+    latest_compatible_version: str | None
+    latest_compatible_release_date: str | None
+    compatibility_status: str
     alignment: str
     constraint_status: str
     latest_version: str
@@ -54,6 +60,9 @@ class PackageReport:
 class PackageMetadata:
     latest_version: str
     release_date: str | None
+    compatible_version: str | None
+    compatible_release_date: str | None
+    compatibility_status: str
     source: str
 
 
@@ -107,7 +116,7 @@ def _normalize_requirement_line(line: str) -> str | None:
     candidate = line.split("#", 1)[0].strip()
     if not candidate:
         return None
-    if candidate.startswith(("-e", "--editable", "-r", "--requirement", "-c", "--constraint")):
+    if candidate.startswith(("-e", "--editable")):
         return None
     if candidate.startswith(("http://", "https://", "git+", ".", "/")):
         return None
@@ -146,9 +155,32 @@ def _load_pyproject_dependencies(pyproject_path: Path) -> list[Dependency]:
 
 
 def _load_requirements_dependencies(requirements_path: Path) -> list[Dependency]:
+    return _load_requirements_dependencies_recursive(requirements_path, seen=set())
+
+
+def _load_requirements_dependencies_recursive(
+    requirements_path: Path,
+    *,
+    seen: set[Path],
+) -> list[Dependency]:
+    resolved_path = requirements_path.resolve()
+    if resolved_path in seen:
+        return []
+    seen.add(resolved_path)
     deps: list[Dependency] = []
     for raw_line in requirements_path.read_text(encoding="utf-8").splitlines():
-        candidate = _normalize_requirement_line(raw_line)
+        stripped = raw_line.split("#", 1)[0].strip()
+        if not stripped:
+            continue
+        include_target = _parse_requirements_include(stripped)
+        if include_target is not None:
+            include_path = (requirements_path.parent / include_target).resolve()
+            if include_path.exists():
+                deps.extend(
+                    _load_requirements_dependencies_recursive(include_path, seen=seen)
+                )
+            continue
+        candidate = _normalize_requirement_line(stripped)
         if candidate is None:
             continue
         deps.append(
@@ -161,6 +193,14 @@ def _load_requirements_dependencies(requirements_path: Path) -> list[Dependency]
             )
         )
     return deps
+
+
+def _parse_requirements_include(line: str) -> str | None:
+    for prefix in ("-r ", "--requirement ", "-c ", "--constraint "):
+        if line.startswith(prefix):
+            include_target = line[len(prefix) :].strip()
+            return include_target or None
+    return None
 
 
 def _discover_requirement_files(root: Path, include_lockfiles: bool) -> list[Path]:
@@ -180,7 +220,12 @@ def _load_dependencies(
     return deps
 
 
-def _latest_pypi_metadata(package: str, timeout_s: float) -> tuple[str, str | None]:
+def _latest_pypi_metadata(
+    package: str,
+    timeout_s: float,
+    *,
+    project_python_requires: str | None,
+) -> tuple[str, str | None, str | None, str | None, str]:
     url = f"https://pypi.org/pypi/{package}/json"
     request = urllib.request.Request(url, headers={"User-Agent": "sdetkit-upgrade-audit/2.1"})
     with urllib.request.urlopen(request, timeout=timeout_s) as response:  # noqa: S310
@@ -197,7 +242,11 @@ def _latest_pypi_metadata(package: str, timeout_s: float) -> tuple[str, str | No
                 if isinstance(item, dict) and item.get("upload_time_iso_8601"):
                     release_date = str(item["upload_time_iso_8601"])
                     break
-    return version, release_date
+    compatible_version, compatible_release_date, compatibility_status = _latest_compatible_release(
+        payload,
+        project_python_requires=project_python_requires,
+    )
+    return version, release_date, compatible_version, compatible_release_date, compatibility_status
 
 
 def _load_cache(cache_path: Path) -> dict[str, dict[str, str | float | None]]:
@@ -239,13 +288,25 @@ def _cache_entry_fresh(entry: dict[str, str | float | None], ttl_hours: float) -
 def _metadata_from_cache(entry: dict[str, str | float | None], *, source: str) -> PackageMetadata:
     latest_version = entry.get("latest_version")
     release_date = entry.get("release_date")
+    compatible_version = entry.get("compatible_version")
+    compatible_release_date = entry.get("compatible_release_date")
+    compatibility_status = entry.get("compatibility_status")
     if not isinstance(latest_version, str):
         latest_version = "unknown"
     if release_date is not None and not isinstance(release_date, str):
         release_date = None
+    if compatible_version is not None and not isinstance(compatible_version, str):
+        compatible_version = None
+    if compatible_release_date is not None and not isinstance(compatible_release_date, str):
+        compatible_release_date = None
+    if not isinstance(compatibility_status, str):
+        compatibility_status = "unknown"
     return PackageMetadata(
         latest_version=latest_version,
         release_date=release_date,
+        compatible_version=compatible_version,
+        compatible_release_date=compatible_release_date,
+        compatibility_status=compatibility_status,
         source=source,
     )
 
@@ -257,6 +318,7 @@ def _fetch_package_metadata(
     cache: dict[str, dict[str, str | float | None]],
     cache_ttl_hours: float,
     offline: bool,
+    project_python_requires: str | None,
 ) -> PackageMetadata:
     cached_entry = cache.get(package)
     if cached_entry and _cache_entry_fresh(cached_entry, cache_ttl_hours):
@@ -266,24 +328,51 @@ def _fetch_package_metadata(
         if cached_entry:
             return _metadata_from_cache(cached_entry, source="cache-stale")
         return PackageMetadata(
-            latest_version="offline-no-cache", release_date=None, source="offline"
+            latest_version="offline-no-cache",
+            release_date=None,
+            compatible_version=None,
+            compatible_release_date=None,
+            compatibility_status="unknown",
+            source="offline",
         )
 
     try:
-        latest_version, release_date = _latest_pypi_metadata(package, timeout_s=timeout_s)
+        (
+            latest_version,
+            release_date,
+            compatible_version,
+            compatible_release_date,
+            compatibility_status,
+        ) = _latest_pypi_metadata(
+            package,
+            timeout_s=timeout_s,
+            project_python_requires=project_python_requires,
+        )
     except urllib.error.HTTPError as exc:
         latest_version, release_date = f"http-{exc.code}", None
+        compatible_version, compatible_release_date, compatibility_status = None, None, "unknown"
     except urllib.error.URLError:
         if cached_entry:
             return _metadata_from_cache(cached_entry, source="cache-stale")
         latest_version, release_date = "network-error", None
+        compatible_version, compatible_release_date, compatibility_status = None, None, "unknown"
 
     cache[package] = {
         "fetched_at": dt.datetime.now(dt.UTC).timestamp(),
         "latest_version": latest_version,
         "release_date": release_date,
+        "compatible_version": compatible_version,
+        "compatible_release_date": compatible_release_date,
+        "compatibility_status": compatibility_status,
     }
-    return PackageMetadata(latest_version=latest_version, release_date=release_date, source="pypi")
+    return PackageMetadata(
+        latest_version=latest_version,
+        release_date=release_date,
+        compatible_version=compatible_version,
+        compatible_release_date=compatible_release_date,
+        compatibility_status=compatibility_status,
+        source="pypi",
+    )
 
 
 def _collect_package_metadata(
@@ -294,6 +383,7 @@ def _collect_package_metadata(
     cache_ttl_hours: float,
     offline: bool,
     max_workers: int,
+    project_python_requires: str | None,
 ) -> dict[str, PackageMetadata]:
     cache = _load_cache(cache_path)
     metadata: dict[str, PackageMetadata] = {}
@@ -306,6 +396,7 @@ def _collect_package_metadata(
                 cache=cache,
                 cache_ttl_hours=cache_ttl_hours,
                 offline=offline,
+                project_python_requires=project_python_requires,
             )
     else:
         with ThreadPoolExecutor(max_workers=worker_count) as executor:
@@ -317,6 +408,7 @@ def _collect_package_metadata(
                     cache=cache,
                     cache_ttl_hours=cache_ttl_hours,
                     offline=offline,
+                    project_python_requires=project_python_requires,
                 ): package
                 for package in packages
             }
@@ -326,6 +418,13 @@ def _collect_package_metadata(
     if not offline:
         _persist_cache(cache_path, cache)
     return metadata
+
+
+def _load_project_python_requires(pyproject_path: Path) -> str | None:
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    value = project.get("requires-python")
+    return str(value).strip() if isinstance(value, str) and value.strip() else None
 
 
 def _version_key(version: str) -> tuple[tuple[int, object], ...]:
@@ -354,6 +453,36 @@ def _compare_versions(left: str, right: str) -> int:
     if left_key > right_key:
         return 1
     return 0
+
+
+def _parse_python_constraints(specifier: str | None) -> list[tuple[str, str]]:
+    if not specifier:
+        return []
+    return [(operator, version) for operator, version in CONSTRAINT_RE.findall(specifier)]
+
+
+def _candidate_repo_python_versions(project_python_requires: str | None) -> list[str]:
+    constraints = _parse_python_constraints(project_python_requires)
+    if not constraints:
+        return []
+    minimums = [
+        version
+        for operator, version in constraints
+        if operator in {">=", ">", "~=", "=="}
+    ]
+    if minimums:
+        return [sorted(minimums, key=_version_key)[-1]]
+    upper_bounds = [version for operator, version in constraints if operator in {"<", "<="}]
+    if upper_bounds:
+        upper = sorted(upper_bounds, key=_version_key)[0]
+        parts = _major_minor_patch(upper)
+        if parts is not None:
+            major, minor, _patch = parts
+            if minor > 0:
+                return [f"{major}.{minor - 1}"]
+            if major > 0:
+                return [f"{major - 1}.9"]
+    return []
 
 
 def _compatible_upper_bound(version: str) -> str | None:
@@ -386,6 +515,81 @@ def _constraint_allows_version(constraint: tuple[str, str], version: str) -> boo
             return False
         return cmp >= 0 and _compare_versions(version, upper) < 0
     return False
+
+
+def _specifier_allows_version(specifier: str | None, version: str) -> bool | None:
+    constraints = _parse_python_constraints(specifier)
+    if not constraints:
+        return None
+    return all(_constraint_allows_version(constraint, version) for constraint in constraints)
+
+
+def _release_is_python_compatible(
+    release_files: list[dict[str, object]],
+    *,
+    project_python_requires: str | None,
+) -> tuple[bool | None, str]:
+    repo_versions = _candidate_repo_python_versions(project_python_requires)
+    if not repo_versions:
+        return None, "unknown"
+    if not release_files:
+        return None, "unknown"
+
+    compatibility_observed = False
+    for release_file in release_files:
+        if not isinstance(release_file, dict) or bool(release_file.get("yanked")):
+            continue
+        requires_python = release_file.get("requires_python")
+        if requires_python is not None and not isinstance(requires_python, str):
+            continue
+        compatibility_observed = True
+        if all(_specifier_allows_version(requires_python, version) is not False for version in repo_versions):
+            return True, "compatible"
+    if compatibility_observed:
+        return False, "requires-newer-python"
+    return None, "unknown"
+
+
+def _release_date_from_files(release_files: list[dict[str, object]]) -> str | None:
+    dates = [
+        str(item["upload_time_iso_8601"])
+        for item in release_files
+        if isinstance(item, dict) and item.get("upload_time_iso_8601")
+    ]
+    return sorted(dates)[0] if dates else None
+
+
+def _latest_compatible_release(
+    payload: dict[str, object],
+    *,
+    project_python_requires: str | None,
+) -> tuple[str | None, str | None, str]:
+    releases = payload.get("releases", {})
+    if not isinstance(releases, dict):
+        return None, None, "unknown"
+
+    latest_compatible_version: str | None = None
+    latest_compatible_release_date: str | None = None
+    latest_status = "unknown"
+    for version, release_files in sorted(releases.items(), key=lambda item: _version_key(str(item[0])), reverse=True):
+        if not isinstance(version, str) or not isinstance(release_files, list):
+            continue
+        compatible, status = _release_is_python_compatible(
+            release_files,
+            project_python_requires=project_python_requires,
+        )
+        if compatible is True:
+            latest_compatible_version = version
+            latest_compatible_release_date = _release_date_from_files(release_files)
+            latest_status = (
+                "compatible-latest"
+                if version == str(payload.get("info", {}).get("version") or "")
+                else "compatible-available"
+            )
+            break
+        if status == "requires-newer-python" and latest_status == "unknown":
+            latest_status = status
+    return latest_compatible_version, latest_compatible_release_date, latest_status
 
 
 def _requirement_allows_version(raw_requirement: str, version: str) -> bool | None:
@@ -538,6 +742,10 @@ def _build_package_report(
     latest_version: str,
     release_date: str | None,
     *,
+    project_python_requires: str | None = None,
+    compatible_version: str | None = None,
+    compatible_release_date: str | None = None,
+    compatibility_status: str = "unknown",
     metadata_source: str = "pypi",
 ) -> PackageReport:
     sources = sorted({dep.source for dep in deps})
@@ -545,10 +753,12 @@ def _build_package_report(
     requirements = sorted({dep.raw for dep in deps})
     pinned_versions = sorted({dep.pinned_version for dep in deps if dep.pinned_version})
     current_version = _pick_current_version(deps)
-    version_gap = _classify_version_gap(current_version, latest_version)
-    release_age_days = _release_age_days(release_date)
+    target_version = compatible_version or latest_version
+    target_release_date = compatible_release_date if compatible_version else release_date
+    version_gap = _classify_version_gap(current_version, target_version)
+    release_age_days = _release_age_days(target_release_date)
     alignment = _infer_alignment(deps, current_version)
-    constraint_status = _constraint_status(deps, latest_version)
+    constraint_status = _constraint_status(deps, target_version)
 
     notes: list[str] = []
     if alignment == "drift":
@@ -573,6 +783,17 @@ def _build_package_report(
         notes.append("Latest PyPI release is a patch-level bump from the repo baseline.")
     if release_age_days is not None and release_age_days <= 30:
         notes.append("Latest PyPI release is recent enough to merit fast follow-up validation.")
+    if project_python_requires:
+        notes.append(f"Repo Python support policy: {project_python_requires}.")
+    if compatibility_status == "compatible-available" and compatible_version and compatible_version != latest_version:
+        notes.append(
+            "Newest PyPI release requires a newer Python baseline than this repo; "
+            f"using compatible target {compatible_version} for action planning."
+        )
+    elif compatibility_status == "requires-newer-python":
+        notes.append(
+            "Available PyPI releases appear to require a newer Python baseline than this repo currently declares."
+        )
 
     upgrade_signal = "watch"
     if alignment == "drift":
@@ -623,7 +844,7 @@ def _build_package_report(
 
     manifest_action, suggested_version = _manifest_action(
         current_version=current_version,
-        latest_version=latest_version,
+        latest_version=target_version,
         alignment=alignment,
         constraint_status=constraint_status,
         version_gap=version_gap,
@@ -672,7 +893,13 @@ def _build_package_report(
         groups=groups,
         requirements=requirements,
         pinned_versions=pinned_versions,
+        project_python_requires=project_python_requires,
         current_version=current_version,
+        target_version=target_version,
+        target_release_date=target_release_date,
+        latest_compatible_version=compatible_version,
+        latest_compatible_release_date=compatible_release_date,
+        compatibility_status=compatibility_status,
         alignment=alignment,
         constraint_status=constraint_status,
         latest_version=latest_version,
@@ -780,6 +1007,15 @@ def _report_summary(reports: list[PackageReport]) -> dict[str, int]:
         ),
         "stale_metadata_packages": sum(
             1 for report in reports if report.metadata_source == "cache-stale"
+        ),
+        "python_compatible_latest_packages": sum(
+            1 for report in reports if report.compatibility_status == "compatible-latest"
+        ),
+        "python_compatible_fallback_packages": sum(
+            1 for report in reports if report.compatibility_status == "compatible-available"
+        ),
+        "python_incompatible_latest_packages": sum(
+            1 for report in reports if report.compatibility_status == "requires-newer-python"
         ),
         "actionable_packages": sum(1 for report in reports if _is_actionable_upgrade(report)),
         "max_risk_score": max((report.risk_score for report in reports), default=0),
@@ -917,17 +1153,20 @@ def _render_markdown(
         f"- investigate signals: {summary['investigate_upgrade_signals']}",
         f"- packages using cached metadata: {summary['cached_metadata_packages']}",
         f"- stale cached metadata packages: {summary['stale_metadata_packages']}",
+        f"- latest releases compatible with repo Python policy: {summary['python_compatible_latest_packages']}",
+        f"- fallback compatible targets below latest: {summary['python_compatible_fallback_packages']}",
+        f"- latest releases requiring newer Python: {summary['python_incompatible_latest_packages']}",
         f"- actionable upgrade candidates: {summary['actionable_packages']}",
         "",
-        "| Package | Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested | Release age (days) | Requirements |",
-        "|---|---|---|---|---|---|---|---|---|---|---|---|---|",
+        "| Package | Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested | Release age (days) | Requirements |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for report in reports:
         release_age = "-" if report.release_age_days is None else str(report.release_age_days)
         requirements = " <br> ".join(f"`{item}`" for item in report.requirements)
         lines.append(
             "| "
-            f"`{report.name}` | `{report.current_version}` | `{report.latest_version}` | {report.metadata_source} | {report.version_gap} | "
+            f"`{report.name}` | `{report.current_version}` | `{report.target_version}` | `{report.latest_version}` | {report.compatibility_status} | {report.metadata_source} | {report.version_gap} | "
             f"{report.alignment} | {report.constraint_status} | {report.upgrade_signal} | {report.risk_score} | {report.manifest_action} | {report.suggested_version or '-'} | {release_age} | {requirements} |"
         )
     lines.extend(["", "## Priority queue", ""])
@@ -1023,6 +1262,7 @@ def run(
     top: int | None = None,
 ) -> int:
     dependencies = _load_dependencies(pyproject_path, requirement_paths)
+    project_python_requires = _load_project_python_requires(pyproject_path)
 
     if not dependencies:
         print("No dependencies found in the configured manifests.")
@@ -1040,6 +1280,7 @@ def run(
         cache_ttl_hours=cache_ttl_hours,
         offline=offline,
         max_workers=max_workers,
+        project_python_requires=project_python_requires,
     )
     reports: list[PackageReport] = []
     for package in packages:
@@ -1050,6 +1291,10 @@ def run(
                 by_package[package],
                 latest_version=metadata.latest_version,
                 release_date=metadata.release_date,
+                project_python_requires=project_python_requires,
+                compatible_version=metadata.compatible_version,
+                compatible_release_date=metadata.compatible_release_date,
+                compatibility_status=metadata.compatibility_status,
                 metadata_source=metadata.source,
             )
         )

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -6,6 +6,38 @@ from pathlib import Path
 from sdetkit import upgrade_audit
 
 
+def _report(**overrides: object) -> upgrade_audit.PackageReport:
+    payload: dict[str, object] = {
+        "name": "pkg",
+        "sources": ["pyproject.toml"],
+        "groups": ["default"],
+        "requirements": ["pkg==1.0.0"],
+        "pinned_versions": ["1.0.0"],
+        "project_python_requires": ">=3.11",
+        "current_version": "1.0.0",
+        "target_version": "1.0.0",
+        "target_release_date": None,
+        "latest_compatible_version": "1.0.0",
+        "latest_compatible_release_date": None,
+        "compatibility_status": "compatible-latest",
+        "alignment": "aligned",
+        "constraint_status": "allowed",
+        "latest_version": "1.0.0",
+        "latest_release_date": None,
+        "metadata_source": "pypi",
+        "version_gap": "up-to-date",
+        "release_age_days": None,
+        "upgrade_signal": "watch",
+        "risk_score": 10,
+        "manifest_action": "none",
+        "suggested_version": None,
+        "next_action": "Keep under observation; no immediate action required.",
+        "notes": [],
+    }
+    payload.update(overrides)
+    return upgrade_audit.PackageReport(**payload)
+
+
 def test_load_dependencies_collects_pyproject_and_requirements(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
@@ -46,6 +78,20 @@ ruff==0.15.6
     assert deps[2].pinned_version == "0.28.1"
 
 
+def test_load_dependencies_follows_nested_requirement_files(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\ndependencies=[]\n", encoding="utf-8")
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("-r nested.txt\nhttpx==0.28.1\n", encoding="utf-8")
+    nested = tmp_path / "nested.txt"
+    nested.write_text("ruff==0.15.6\n", encoding="utf-8")
+
+    deps = upgrade_audit._load_dependencies(pyproject, [requirements])
+
+    assert [dep.name for dep in deps] == ["ruff", "httpx"]
+    assert [dep.source for dep in deps] == ["nested.txt", "requirements.txt"]
+
+
 def test_build_package_report_flags_drift_and_priority() -> None:
     deps = [
         upgrade_audit.Dependency(
@@ -82,6 +128,35 @@ def test_build_package_report_flags_drift_and_priority() -> None:
     assert report.metadata_source == "pypi"
     assert "Queue the upgrade" in report.next_action
     assert "floor-and-lock pattern" in " ".join(report.notes)
+
+
+def test_build_package_report_uses_compatible_target_when_latest_needs_newer_python() -> None:
+    deps = [
+        upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="default",
+            raw="httpx==0.28.1",
+            name="httpx",
+            pinned_version="0.28.1",
+        )
+    ]
+
+    report = upgrade_audit._build_package_report(
+        "httpx",
+        deps,
+        latest_version="0.30.0",
+        release_date="2026-03-01T00:00:00Z",
+        project_python_requires=">=3.11",
+        compatible_version="0.29.0",
+        compatible_release_date="2026-02-01T00:00:00Z",
+        compatibility_status="compatible-available",
+    )
+
+    assert report.target_version == "0.29.0"
+    assert report.version_gap == "minor"
+    assert report.suggested_version == "0.29.0"
+    assert report.compatibility_status == "compatible-available"
+    assert "using compatible target 0.29.0" in " ".join(report.notes)
 
 
 def test_build_package_report_marks_compatible_policy_covered_manifests() -> None:
@@ -144,13 +219,18 @@ def test_build_package_report_flags_major_jump_as_critical() -> None:
 
 def test_render_json_summary_counts() -> None:
     reports = [
-        upgrade_audit.PackageReport(
+        _report(
             name="httpx",
             sources=["pyproject.toml", "requirements.txt"],
             groups=["default", "requirements"],
             requirements=["httpx>=0.27,<1", "httpx==0.28.1"],
             pinned_versions=["0.28.1"],
             current_version="0.28.1",
+            target_version="0.29.0",
+            target_release_date="2026-01-01T00:00:00Z",
+            latest_compatible_version="0.29.0",
+            latest_compatible_release_date="2026-01-01T00:00:00Z",
+            compatibility_status="compatible-latest",
             alignment="drift",
             constraint_status="blocked",
             latest_version="0.29.0",
@@ -165,7 +245,7 @@ def test_render_json_summary_counts() -> None:
             next_action="Plan an upgrade spike with regression coverage before the next release cut.",
             notes=["Cross-manifest requirement drift detected."],
         ),
-        upgrade_audit.PackageReport(
+        _report(
             name="ruff",
             sources=["pyproject.toml", "requirements.txt"],
             groups=["dev", "requirements"],
@@ -210,6 +290,9 @@ def test_render_json_summary_counts() -> None:
         "packages_audited": 2,
         "policy_blocked_packages": 1,
         "policy_covered_packages": 1,
+        "python_compatible_fallback_packages": 0,
+        "python_compatible_latest_packages": 2,
+        "python_incompatible_latest_packages": 0,
         "stale_metadata_packages": 0,
     }
     assert payload["packages"][0]["name"] == "httpx"
@@ -231,7 +314,13 @@ dependencies = ["httpx>=0.27,<1"]
     monkeypatch.setattr(
         upgrade_audit,
         "_latest_pypi_metadata",
-        lambda package, timeout_s: ("0.29.0", "2026-01-01T00:00:00Z"),
+        lambda package, timeout_s, project_python_requires=None: (
+            "0.29.0",
+            "2026-01-01T00:00:00Z",
+            "0.29.0",
+            "2026-01-01T00:00:00Z",
+            "compatible-latest",
+        ),
     )
 
     rc = upgrade_audit.run(
@@ -250,9 +339,10 @@ dependencies = ["httpx>=0.27,<1"]
     assert "floor-and-lock baseline packages: 1" in out
     assert "packages using cached metadata: 0" in out
     assert "stale cached metadata packages: 0" in out
+    assert "latest releases compatible with repo Python policy: 1" in out
     assert "actionable upgrade candidates: 1" in out
-    assert "Current | Latest PyPI | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested" in out
-    assert "`httpx` | `0.28.1` | `0.29.0` | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |" in out
+    assert "Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested" in out
+    assert "`httpx` | `0.28.1` | `0.29.0` | `0.29.0` | compatible-latest | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |" in out
     assert "Priority queue" in out
     assert "Focus notes" in out
     assert (
@@ -276,7 +366,13 @@ dependencies = ["httpx>=0.27,<1"]
     monkeypatch.setattr(
         upgrade_audit,
         "_latest_pypi_metadata",
-        lambda package, timeout_s: ("1.0.0", "2026-01-01T00:00:00Z"),
+        lambda package, timeout_s, project_python_requires=None: (
+            "1.0.0",
+            "2026-01-01T00:00:00Z",
+            "1.0.0",
+            "2026-01-01T00:00:00Z",
+            "compatible-latest",
+        ),
     )
 
     rc = upgrade_audit.run(
@@ -293,7 +389,7 @@ dependencies = ["httpx>=0.27,<1"]
 
 def test_sort_reports_surfaces_highest_risk_first() -> None:
     reports = [
-        upgrade_audit.PackageReport(
+        _report(
             name="watch-pkg",
             sources=["requirements.txt"],
             groups=["requirements"],
@@ -314,7 +410,7 @@ def test_sort_reports_surfaces_highest_risk_first() -> None:
             next_action="Track the package and batch it with nearby dependency maintenance work.",
             notes=[],
         ),
-        upgrade_audit.PackageReport(
+        _report(
             name="critical-pkg",
             sources=["pyproject.toml", "requirements.txt"],
             groups=["default", "requirements"],
@@ -362,6 +458,9 @@ dependencies = ["httpx==0.28.1"]
                         "fetched_at": 1_767_000_000.0,
                         "latest_version": "0.28.1",
                         "release_date": "2026-01-01T00:00:00Z",
+                        "compatible_version": "0.28.1",
+                        "compatible_release_date": "2026-01-01T00:00:00Z",
+                        "compatibility_status": "compatible-latest",
                     }
                 },
             }
@@ -390,13 +489,18 @@ dependencies = ["httpx==0.28.1"]
 
 def test_filter_reports_supports_package_metadata_source_and_outdated_only() -> None:
     reports = [
-        upgrade_audit.PackageReport(
+        _report(
             name="httpx",
             sources=["pyproject.toml"],
             groups=["default"],
             requirements=["httpx==0.28.1"],
             pinned_versions=["0.28.1"],
             current_version="0.28.1",
+            target_version="0.29.0",
+            target_release_date="2026-01-01T00:00:00Z",
+            latest_compatible_version="0.29.0",
+            latest_compatible_release_date="2026-01-01T00:00:00Z",
+            compatibility_status="compatible-latest",
             alignment="aligned",
             constraint_status="blocked",
             latest_version="0.29.0",
@@ -411,7 +515,7 @@ def test_filter_reports_supports_package_metadata_source_and_outdated_only() -> 
             next_action="Queue the upgrade for the next maintenance batch and validate targeted smoke tests.",
             notes=[],
         ),
-        upgrade_audit.PackageReport(
+        _report(
             name="ruff",
             sources=["requirements.txt"],
             groups=["requirements"],
@@ -446,13 +550,18 @@ def test_filter_reports_supports_package_metadata_source_and_outdated_only() -> 
 
 def test_filter_reports_supports_signal_policy_and_top() -> None:
     reports = [
-        upgrade_audit.PackageReport(
+        _report(
             name="critical-pkg",
             sources=["pyproject.toml"],
             groups=["default"],
             requirements=["critical-pkg==1.0.0"],
             pinned_versions=["1.0.0"],
             current_version="1.0.0",
+            target_version="2.0.0",
+            target_release_date="2026-01-01T00:00:00Z",
+            latest_compatible_version="2.0.0",
+            latest_compatible_release_date="2026-01-01T00:00:00Z",
+            compatibility_status="compatible-latest",
             alignment="aligned",
             constraint_status="blocked",
             latest_version="2.0.0",
@@ -467,7 +576,7 @@ def test_filter_reports_supports_signal_policy_and_top() -> None:
             next_action="Plan an upgrade spike with regression coverage before the next release cut.",
             notes=[],
         ),
-        upgrade_audit.PackageReport(
+        _report(
             name="watch-pkg",
             sources=["requirements.txt"],
             groups=["requirements"],
@@ -513,10 +622,26 @@ dependencies = ["httpx>=0.27,<1", "ruff==0.15.6"]
     requirements = tmp_path / "requirements.txt"
     requirements.write_text("httpx==0.28.1\nruff==0.15.6\n", encoding="utf-8")
 
-    def _fake_metadata(package: str, timeout_s: float) -> tuple[str, str | None]:
+    def _fake_metadata(
+        package: str,
+        timeout_s: float,
+        project_python_requires: str | None = None,
+    ) -> tuple[str, str | None, str | None, str | None, str]:
         if package == "httpx":
-            return "0.29.0", "2026-01-01T00:00:00Z"
-        return "0.15.6", "2026-01-01T00:00:00Z"
+            return (
+                "0.29.0",
+                "2026-01-01T00:00:00Z",
+                "0.29.0",
+                "2026-01-01T00:00:00Z",
+                "compatible-latest",
+            )
+        return (
+            "0.15.6",
+            "2026-01-01T00:00:00Z",
+            "0.15.6",
+            "2026-01-01T00:00:00Z",
+            "compatible-latest",
+        )
 
     monkeypatch.setattr(upgrade_audit, "_latest_pypi_metadata", _fake_metadata)
 
@@ -540,13 +665,18 @@ dependencies = ["httpx>=0.27,<1", "ruff==0.15.6"]
 
 def test_render_json_includes_lane_summary_and_priority_lane() -> None:
     reports = [
-        upgrade_audit.PackageReport(
+        _report(
             name="critical-pkg",
             sources=["pyproject.toml", "requirements.txt"],
             groups=["default", "requirements"],
             requirements=["critical-pkg>=1,<2", "critical-pkg==1.2.3"],
             pinned_versions=["1.2.3"],
             current_version="1.2.3",
+            target_version="2.0.0",
+            target_release_date="2026-01-01T00:00:00Z",
+            latest_compatible_version="2.0.0",
+            latest_compatible_release_date="2026-01-01T00:00:00Z",
+            compatibility_status="compatible-latest",
             alignment="drift",
             constraint_status="blocked",
             latest_version="2.0.0",
@@ -561,7 +691,7 @@ def test_render_json_includes_lane_summary_and_priority_lane() -> None:
             next_action="Resolve manifest drift first, then validate the major upgrade in a dedicated branch.",
             notes=["Cross-manifest requirement drift detected."],
         ),
-        upgrade_audit.PackageReport(
+        _report(
             name="watch-pkg",
             sources=["requirements.txt"],
             groups=["requirements"],
@@ -603,13 +733,18 @@ def test_render_json_includes_lane_summary_and_priority_lane() -> None:
 
 def test_render_markdown_includes_recommended_upgrade_lanes() -> None:
     reports = [
-        upgrade_audit.PackageReport(
+        _report(
             name="httpx",
             sources=["pyproject.toml", "requirements.txt"],
             groups=["default", "requirements"],
             requirements=["httpx>=0.27,<1", "httpx==0.28.1"],
             pinned_versions=["0.28.1"],
             current_version="0.28.1",
+            target_version="0.29.0",
+            target_release_date="2026-01-01T00:00:00Z",
+            latest_compatible_version="0.29.0",
+            latest_compatible_release_date="2026-01-01T00:00:00Z",
+            compatibility_status="compatible-latest",
             alignment="compatible",
             constraint_status="blocked",
             latest_version="0.29.0",
@@ -660,11 +795,17 @@ dependencies = ["httpx==0.28.1", "ruff==0.15.6"]
                         "fetched_at": 1.0,
                         "latest_version": "0.29.0",
                         "release_date": "2026-01-01T00:00:00Z",
+                        "compatible_version": "0.29.0",
+                        "compatible_release_date": "2026-01-01T00:00:00Z",
+                        "compatibility_status": "compatible-latest",
                     },
                     "ruff": {
                         "fetched_at": 1.0,
                         "latest_version": "0.15.6",
                         "release_date": "2026-01-01T00:00:00Z",
+                        "compatible_version": "0.15.6",
+                        "compatible_release_date": "2026-01-01T00:00:00Z",
+                        "compatibility_status": "compatible-latest",
                     },
                 },
             }
@@ -695,13 +836,18 @@ dependencies = ["httpx==0.28.1", "ruff==0.15.6"]
 
 def test_filter_reports_supports_group_and_source_filters() -> None:
     reports = [
-        upgrade_audit.PackageReport(
+        _report(
             name="httpx",
             sources=["pyproject.toml", "requirements.txt"],
             groups=["default", "requirements"],
             requirements=["httpx==0.28.1"],
             pinned_versions=["0.28.1"],
             current_version="0.28.1",
+            target_version="0.29.0",
+            target_release_date="2026-01-01T00:00:00Z",
+            latest_compatible_version="0.29.0",
+            latest_compatible_release_date="2026-01-01T00:00:00Z",
+            compatibility_status="compatible-latest",
             alignment="aligned",
             constraint_status="blocked",
             latest_version="0.29.0",
@@ -716,7 +862,7 @@ def test_filter_reports_supports_group_and_source_filters() -> None:
             next_action="Queue the upgrade for the next maintenance batch and validate targeted smoke tests.",
             notes=[],
         ),
-        upgrade_audit.PackageReport(
+        _report(
             name="mkdocs",
             sources=["requirements-docs.txt"],
             groups=["docs"],


### PR DESCRIPTION
### Motivation
- Improve upgrade planning accuracy by distinguishing the absolute latest PyPI release from the newest release that is actually compatible with the repo's declared `requires-python` window.
- Ensure audits include split requirement stacks by following nested `-r`/`--requirement` includes so the manifest surface is complete and actionable.

### Description
- Add Python-policy-aware metadata collection and targeting by returning both the latest PyPI release and the latest compatible release from `_latest_pypi_metadata` and `_latest_compatible_release`, and propagate those into `PackageMetadata` and `PackageReport`.
- Use the compatible target (when available) as the actionable `target_version` for gap classification, constraint checks, manifest actions, suggested versions and risk scoring in `_build_package_report`.
- Follow nested requirement includes during requirements parsing by implementing `_load_requirements_dependencies_recursive` and `_parse_requirements_include`, and include compatible fields in the persisted cache payload.
- Expand markdown/json output and summary to show the actionable `Target`, PyPI `Latest`, Python compatibility status, and new summary counts; update README and CLI integration to document the features.

### Testing
- Ran `pytest -q tests/test_upgrade_audit_script.py` and all tests passed (`19 passed`).
- Ran `pytest -q tests/test_kits_intelligence_integration_forensics.py` and all tests passed (`7 passed`).
- Performed a CLI smoke run `PYTHONPATH=src python -m sdetkit intelligence upgrade-audit --offline --format json --top 3` and validated output (packages audited and top package name printed) and the generated JSON schema fields.
- Verified module compilation with `python -m py_compile src/sdetkit/upgrade_audit.py tests/test_upgrade_audit_script.py` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb631c04a883209e593ee6bad5373f)