### PR TITLE
Make upgrade-audit stable-first; add `--include-prereleases`, fix package filter and cache semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Run a dependency-manifest audit against PyPI to identify candidate upgrades, det
 ```bash
 make upgrade-audit
 python -m sdetkit intelligence upgrade-audit --format json --top 5
+python -m sdetkit intelligence upgrade-audit --include-prereleases --package httpx
 python -m sdetkit intelligence upgrade-audit --format md --offline
 python -m sdetkit intelligence upgrade-audit --outdated-only --package "http*"
 python -m sdetkit intelligence upgrade-audit --group default --source pyproject.toml --format md
@@ -98,10 +99,13 @@ python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
 python scripts/upgrade_audit.py --fail-on high
 python scripts/upgrade_audit.py --cache-ttl-hours 6 --max-workers 12
 python scripts/upgrade_audit.py --offline --format md
+python scripts/upgrade_audit.py --include-prereleases --signal high
 python scripts/upgrade_audit.py --signal high --policy blocked --top 5
 python scripts/upgrade_audit.py --metadata-source cache-stale --outdated-only
 python scripts/upgrade_audit.py --group requirements --source requirements.txt --top 10
 ```
+
+By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue.
 
 ## Sample artifacts
 

--- a/docs/upgrade-implementation-research.md
+++ b/docs/upgrade-implementation-research.md
@@ -8,6 +8,8 @@ This document summarizes practical upgrade methods for SDETKit with a focus on:
 
 The baseline inventory came from the repository's direct dependency audit command (`make upgrade-audit`).
 
+> Note: the upgrade audit now defaults to stable-release planning. Prerelease/dev tags are only pulled into the suggested target lane when `--include-prereleases` is passed explicitly.
+
 ## 1) Current baseline and where risk concentrates
 
 ### Runtime and tooling baseline

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -225,6 +225,7 @@ def _latest_pypi_metadata(
     timeout_s: float,
     *,
     project_python_requires: str | None,
+    include_prereleases: bool,
 ) -> tuple[str, str | None, str | None, str | None, str]:
     url = f"https://pypi.org/pypi/{package}/json"
     request = urllib.request.Request(url, headers={"User-Agent": "sdetkit-upgrade-audit/2.1"})
@@ -245,6 +246,7 @@ def _latest_pypi_metadata(
     compatible_version, compatible_release_date, compatibility_status = _latest_compatible_release(
         payload,
         project_python_requires=project_python_requires,
+        include_prereleases=include_prereleases,
     )
     return version, release_date, compatible_version, compatible_release_date, compatibility_status
 
@@ -277,9 +279,16 @@ def _persist_cache(cache_path: Path, cache: dict[str, dict[str, str | float | No
     cache_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def _cache_entry_fresh(entry: dict[str, str | float | None], ttl_hours: float) -> bool:
+def _cache_entry_fresh(
+    entry: dict[str, str | float | None],
+    ttl_hours: float,
+    *,
+    include_prereleases: bool,
+) -> bool:
     fetched_at = entry.get("fetched_at")
     if not isinstance(fetched_at, (int, float)):
+        return False
+    if entry.get("include_prereleases") is not include_prereleases:
         return False
     age_s = dt.datetime.now(dt.UTC).timestamp() - float(fetched_at)
     return age_s <= max(ttl_hours, 0) * 3600
@@ -319,14 +328,28 @@ def _fetch_package_metadata(
     cache_ttl_hours: float,
     offline: bool,
     project_python_requires: str | None,
+    include_prereleases: bool,
 ) -> PackageMetadata:
     cached_entry = cache.get(package)
-    if cached_entry and _cache_entry_fresh(cached_entry, cache_ttl_hours):
+    if cached_entry and _cache_entry_fresh(
+        cached_entry,
+        cache_ttl_hours,
+        include_prereleases=include_prereleases,
+    ):
         return _metadata_from_cache(cached_entry, source="cache")
 
     if offline:
         if cached_entry:
-            return _metadata_from_cache(cached_entry, source="cache-stale")
+            source = (
+                "cache"
+                if _cache_entry_fresh(
+                    cached_entry,
+                    cache_ttl_hours,
+                    include_prereleases=include_prereleases,
+                )
+                else "cache-stale"
+            )
+            return _metadata_from_cache(cached_entry, source=source)
         return PackageMetadata(
             latest_version="offline-no-cache",
             release_date=None,
@@ -347,6 +370,7 @@ def _fetch_package_metadata(
             package,
             timeout_s=timeout_s,
             project_python_requires=project_python_requires,
+            include_prereleases=include_prereleases,
         )
     except urllib.error.HTTPError as exc:
         latest_version, release_date = f"http-{exc.code}", None
@@ -359,6 +383,7 @@ def _fetch_package_metadata(
 
     cache[package] = {
         "fetched_at": dt.datetime.now(dt.UTC).timestamp(),
+        "include_prereleases": include_prereleases,
         "latest_version": latest_version,
         "release_date": release_date,
         "compatible_version": compatible_version,
@@ -384,6 +409,7 @@ def _collect_package_metadata(
     offline: bool,
     max_workers: int,
     project_python_requires: str | None,
+    include_prereleases: bool,
 ) -> dict[str, PackageMetadata]:
     cache = _load_cache(cache_path)
     metadata: dict[str, PackageMetadata] = {}
@@ -397,6 +423,7 @@ def _collect_package_metadata(
                 cache_ttl_hours=cache_ttl_hours,
                 offline=offline,
                 project_python_requires=project_python_requires,
+                include_prereleases=include_prereleases,
             )
     else:
         with ThreadPoolExecutor(max_workers=worker_count) as executor:
@@ -409,6 +436,7 @@ def _collect_package_metadata(
                     cache_ttl_hours=cache_ttl_hours,
                     offline=offline,
                     project_python_requires=project_python_requires,
+                    include_prereleases=include_prereleases,
                 ): package
                 for package in packages
             }
@@ -559,10 +587,16 @@ def _release_date_from_files(release_files: list[dict[str, object]]) -> str | No
     return sorted(dates)[0] if dates else None
 
 
+def _is_prerelease_version(version: str) -> bool:
+    normalized = version.strip().lower()
+    return bool(re.search(r"(?<![a-z])(a|alpha|b|beta|rc|c|pre|preview|dev)\d*", normalized))
+
+
 def _latest_compatible_release(
     payload: dict[str, object],
     *,
     project_python_requires: str | None,
+    include_prereleases: bool,
 ) -> tuple[str | None, str | None, str]:
     releases = payload.get("releases", {})
     if not isinstance(releases, dict):
@@ -573,6 +607,8 @@ def _latest_compatible_release(
     latest_status = "unknown"
     for version, release_files in sorted(releases.items(), key=lambda item: _version_key(str(item[0])), reverse=True):
         if not isinstance(version, str) or not isinstance(release_files, list):
+            continue
+        if not include_prereleases and _is_prerelease_version(version):
             continue
         compatible, status = _release_is_python_compatible(
             release_files,
@@ -1260,6 +1296,7 @@ def run(
     metadata_sources: list[str] | None = None,
     outdated_only: bool = False,
     top: int | None = None,
+    include_prereleases: bool = False,
 ) -> int:
     dependencies = _load_dependencies(pyproject_path, requirement_paths)
     project_python_requires = _load_project_python_requires(pyproject_path)
@@ -1272,18 +1309,20 @@ def run(
     for dep in dependencies:
         by_package.setdefault(dep.name, []).append(dep)
 
-    packages = sorted(by_package)
+    package_filters = packages
+    package_names = sorted(by_package)
     metadata_by_package = _collect_package_metadata(
-        packages,
+        package_names,
         timeout_s=timeout_s,
         cache_path=cache_path,
         cache_ttl_hours=cache_ttl_hours,
         offline=offline,
         max_workers=max_workers,
         project_python_requires=project_python_requires,
+        include_prereleases=include_prereleases,
     )
     reports: list[PackageReport] = []
-    for package in packages:
+    for package in package_names:
         metadata = metadata_by_package[package]
         reports.append(
             _build_package_report(
@@ -1307,7 +1346,7 @@ def run(
         reports,
         signals=signals,
         policies=policies,
-        packages=packages,
+        packages=package_filters,
         groups=groups,
         sources=sources,
         metadata_sources=metadata_sources,
@@ -1387,6 +1426,11 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         "--offline",
         action="store_true",
         help="Skip PyPI calls and use cached metadata when available.",
+    )
+    parser.add_argument(
+        "--include-prereleases",
+        action="store_true",
+        help="Include prerelease/dev versions when choosing compatible upgrade targets.",
     )
     parser.add_argument(
         "--max-workers",
@@ -1492,6 +1536,7 @@ def main(argv: list[str] | None = None) -> int:
         metadata_sources=args.metadata_source,
         outdated_only=bool(args.outdated_only),
         top=args.top,
+        include_prereleases=bool(args.include_prereleases),
     )
 
 

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -314,7 +314,7 @@ dependencies = ["httpx>=0.27,<1"]
     monkeypatch.setattr(
         upgrade_audit,
         "_latest_pypi_metadata",
-        lambda package, timeout_s, project_python_requires=None: (
+        lambda package, timeout_s, project_python_requires=None, include_prereleases=False: (
             "0.29.0",
             "2026-01-01T00:00:00Z",
             "0.29.0",
@@ -366,7 +366,7 @@ dependencies = ["httpx>=0.27,<1"]
     monkeypatch.setattr(
         upgrade_audit,
         "_latest_pypi_metadata",
-        lambda package, timeout_s, project_python_requires=None: (
+        lambda package, timeout_s, project_python_requires=None, include_prereleases=False: (
             "1.0.0",
             "2026-01-01T00:00:00Z",
             "1.0.0",
@@ -456,6 +456,7 @@ dependencies = ["httpx==0.28.1"]
                 "packages": {
                     "httpx": {
                         "fetched_at": 1_767_000_000.0,
+                        "include_prereleases": False,
                         "latest_version": "0.28.1",
                         "release_date": "2026-01-01T00:00:00Z",
                         "compatible_version": "0.28.1",
@@ -626,6 +627,7 @@ dependencies = ["httpx>=0.27,<1", "ruff==0.15.6"]
         package: str,
         timeout_s: float,
         project_python_requires: str | None = None,
+        include_prereleases: bool = False,
     ) -> tuple[str, str | None, str | None, str | None, str]:
         if package == "httpx":
             return (
@@ -834,6 +836,116 @@ dependencies = ["httpx==0.28.1", "ruff==0.15.6"]
     assert [item["name"] for item in payload["packages"]] == ["httpx"]
 
 
+def test_latest_compatible_release_skips_prereleases_by_default() -> None:
+    payload = {
+        "info": {"version": "0.28.1"},
+        "releases": {
+            "0.28.1": [
+                {
+                    "upload_time_iso_8601": "2024-12-06T15:37:21.509172Z",
+                    "requires_python": ">=3.8",
+                }
+            ],
+            "1.0.dev3": [
+                {
+                    "upload_time_iso_8601": "2025-09-15T16:15:10.458000Z",
+                    "requires_python": ">=3.11",
+                }
+            ],
+        },
+    }
+
+    compatible_version, release_date, status = upgrade_audit._latest_compatible_release(
+        payload,
+        project_python_requires=">=3.11",
+        include_prereleases=False,
+    )
+
+    assert compatible_version == "0.28.1"
+    assert release_date == "2024-12-06T15:37:21.509172Z"
+    assert status == "compatible-latest"
+
+
+def test_latest_compatible_release_can_include_prereleases() -> None:
+    payload = {
+        "info": {"version": "0.28.1"},
+        "releases": {
+            "0.28.1": [
+                {
+                    "upload_time_iso_8601": "2024-12-06T15:37:21.509172Z",
+                    "requires_python": ">=3.8",
+                }
+            ],
+            "1.0.dev3": [
+                {
+                    "upload_time_iso_8601": "2025-09-15T16:15:10.458000Z",
+                    "requires_python": ">=3.11",
+                }
+            ],
+        },
+    }
+
+    compatible_version, release_date, status = upgrade_audit._latest_compatible_release(
+        payload,
+        project_python_requires=">=3.11",
+        include_prereleases=True,
+    )
+
+    assert compatible_version == "1.0.dev3"
+    assert release_date == "2025-09-15T16:15:10.458000Z"
+    assert status == "compatible-available"
+
+
+def test_run_respects_package_filter_without_shadowing(monkeypatch, capsys, tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = ["httpx==0.28.1", "ruff==0.15.6"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def _fake_metadata(
+        package: str,
+        timeout_s: float,
+        project_python_requires: str | None = None,
+        include_prereleases: bool = False,
+    ) -> tuple[str, str | None, str | None, str | None, str]:
+        if package == "httpx":
+            return (
+                "0.29.0",
+                "2026-01-01T00:00:00Z",
+                "0.29.0",
+                "2026-01-01T00:00:00Z",
+                "compatible-latest",
+            )
+        return (
+            "0.15.6",
+            "2026-01-01T00:00:00Z",
+            "0.15.6",
+            "2026-01-01T00:00:00Z",
+            "compatible-latest",
+        )
+
+    monkeypatch.setattr(upgrade_audit, "_latest_pypi_metadata", _fake_metadata)
+
+    rc = upgrade_audit.run(
+        pyproject,
+        timeout_s=0.1,
+        requirement_paths=[],
+        output_format="json",
+        cache_path=tmp_path / "audit-cache.json",
+        packages=["ruff"],
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["packages_audited"] == 1
+    assert [item["name"] for item in payload["packages"]] == ["ruff"]
+
+
 def test_filter_reports_supports_group_and_source_filters() -> None:
     reports = [
         _report(
@@ -919,4 +1031,5 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
     assert args.package == ["http*"]
     assert args.group == ["default"]
     assert args.source == ["pyproject.toml"]
+    assert args.include_prereleases is False
     assert requirement_paths == []


### PR DESCRIPTION
### Motivation
- The upgrade audit was promoting prerelease/dev releases as normal upgrade targets and could surface noisy/actionable upgrades incorrectly. 
- The CLI `--package` filter was being shadowed by the discovered package list, preventing explicit package filtering. 
- Cached metadata did not track prerelease-mode semantics, causing stale/incorrect reuse in offline runs.

### Description
- Add an explicit `--include-prereleases` CLI flag and thread `include_prereleases` through `run()`, `_collect_package_metadata()`, and `_fetch_package_metadata()` in `src/sdetkit/upgrade_audit.py` to support opt-in prerelease planning. 
- Default behavior now prefers stable releases: `_latest_compatible_release()` skips prerelease/dev versions unless `include_prereleases=True`. 
- Make cache entries prerelease-aware by recording `include_prereleases` and using it in `_cache_entry_fresh()` so cache freshness honours the prerelease planning mode. 
- Fix package filtering shadowing by preserving the original `packages` filter and using the discovered package list for metadata collection, then applying filters during `_filter_reports()`. 
- Add a `_is_prerelease_version()` helper and targeted unit tests in `tests/test_upgrade_audit_script.py`, and update documentation examples in `README.md` and `docs/upgrade-implementation-research.md` to document the new flag and default stable-first behavior.

### Testing
- Ran `pytest` for the audit surface: `python -m pytest -q tests/test_upgrade_audit_script.py` (all tests passed). 
- Exercised the intelligence CLI path test: `python -m pytest -q tests/test_kits_intelligence_integration_forensics.py -k upgrade_audit_primary_surface` (passed). 
- Ran linting with `ruff` on modified files (`src/sdetkit/upgrade_audit.py`, tests and docs) and it passed. 
- Performed a live sanity check exercising `upgrade_audit.run()` with and without `include_prereleases` to confirm default stable-first behavior and explicit prerelease opt-in.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb65eedfc083208fcce5b8acb17089)