### PR TITLE
feat: add CI constraints and repo-impact-aware upgrade-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install project + dev/test extras
-        run: python -m pip install -e .[dev,test]
+        run: python -m pip install -c constraints-ci.txt -e .[dev,test]
 
       - name: Canonical fast gate (offline default)
         if: ${{ github.event.inputs.run_network_tests != 'true' }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Install packaging tooling
         run: |
-          python -m pip install -e .[dev,packaging]
+          python -m pip install -c constraints-ci.txt -e .[dev,packaging]
 
       - name: Build distributions
         run: python -m build
@@ -213,7 +213,7 @@ jobs:
 
       - name: Install project + all extras
         run: |
-          python -m pip install -e .[dev,test,docs]
+          python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
 
       - name: Pre-commit
         run: python -m pre_commit run -a

--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install project + dev/test extras
         run: |
-          python -m pip install -e .[dev,test]
+          python -m pip install -c constraints-ci.txt -e .[dev,test]
 
       - name: Run maintenance
         run: bash scripts/maintenance_ci.sh "${{ inputs.mode }}" "${{ inputs.fix && 'true' || 'false' }}" artifacts/maintenance

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install project + quality tooling
         run: |
-          python -m pip install -e .[dev,test,docs]
+          python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
       - name: Doctor (ASCII)
         run: |
           python -m sdetkit.doctor --ascii

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install project + dev/test extras
         run: |
-          python -m pip install -e .[dev,test]
+          python -m pip install -c constraints-ci.txt -e .[dev,test]
 
       - name: Run maintenance baseline
         run: bash scripts/maintenance_ci.sh full false artifacts/maintenance

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ venv:
 	@test -x .venv/bin/python || python3 -m venv .venv
 
 install: venv
-	@bash -lc '. .venv/bin/activate && python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .'
+	@bash -lc '. .venv/bin/activate && python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .'
 
 test: install
 	@bash -lc '. .venv/bin/activate && bash quality.sh test'
@@ -31,11 +31,11 @@ docs-build: install
 
 
 package-validate: venv
-	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python -m pip install -e .[packaging] && rm -rf dist build && python -m build && python -m twine check dist/* && python -m check_wheel_contents --ignore W009 dist/*.whl && python -m venv .venv-smoke && . .venv-smoke/bin/activate && python -m pip install --force-reinstall dist/*.whl && sdetkit --help'
+	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python -m pip install -c constraints-ci.txt -e .[packaging] && rm -rf dist build && python -m build && python -m twine check dist/* && python -m check_wheel_contents --ignore W009 dist/*.whl && python -m venv .venv-smoke && . .venv-smoke/bin/activate && python -m pip install --force-reinstall dist/*.whl && sdetkit --help'
 
 
 release-preflight: venv
-	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .[packaging] && python scripts/release_preflight.py && python -m sdetkit doctor --release --skip clean_tree --format md && $(MAKE) package-validate'
+	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .[packaging] && python scripts/release_preflight.py && python -m sdetkit doctor --release --skip clean_tree --format md && $(MAKE) package-validate'
 
 
 release-verify-plan: venv

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ python -m sdetkit continuous-upgrade-cycle11-closeout --format json --strict
 
 ## Upgrade planning (first step)
 
-Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, Python-policy-aware compatible targets, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, group/source rollups, manifest actions, suggested target versions, and floor-and-lock baseline detection for repos that intentionally mix flexible ranges with tested pins. It also follows nested `-r` / `--requirement` includes so split requirement stacks are audited as a single upgrade surface. You can invoke it from either the standalone script or the primary Intelligence kit surface, filter the results down to the hottest dependency groups or manifest sources, and fail CI at a chosen signal threshold:
+Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, Python-policy-aware compatible targets, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, repo impact areas, validation command suggestions, group/source rollups, manifest actions, suggested target versions, and floor-and-lock baseline detection for repos that intentionally mix flexible ranges with tested pins. It also follows nested `-r` / `--requirement` includes so split requirement stacks are audited as a single upgrade surface. You can invoke it from either the standalone script or the primary Intelligence kit surface, filter the results down to the hottest dependency groups, manifest sources, or repo impact areas, and fail CI at a chosen signal threshold:
 
 ```bash
 make upgrade-audit
@@ -101,11 +101,14 @@ python scripts/upgrade_audit.py --cache-ttl-hours 6 --max-workers 12
 python scripts/upgrade_audit.py --offline --format md
 python scripts/upgrade_audit.py --include-prereleases --signal high
 python scripts/upgrade_audit.py --signal high --policy blocked --top 5
+python scripts/upgrade_audit.py --impact-area runtime-core --format md
 python scripts/upgrade_audit.py --metadata-source cache-stale --outdated-only
 python scripts/upgrade_audit.py --group requirements --source requirements.txt --top 10
 ```
 
 By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue.
+
+To make those upgrade lanes reproducible in CI, the repo now pins the validated toolchain in `constraints-ci.txt` while leaving `pyproject.toml` flexible enough for package consumers.
 
 ## Sample artifacts
 

--- a/constraints-ci.txt
+++ b/constraints-ci.txt
@@ -1,0 +1,15 @@
+# Frozen CI/tested dependency baseline used to keep `pip install -e .[...]`
+# reproducible across workflows while preserving flexible ranges in pyproject.toml.
+httpx==0.28.1
+build==1.4.0
+check-wheel-contents==0.6.3
+hypothesis==6.151.9
+mkdocs==1.6.1
+mkdocs-material==9.7.5
+mypy==1.19.1
+pre-commit==4.5.1
+pytest==9.0.2
+pytest-asyncio==1.3.0
+pytest-cov==7.0.0
+ruff==0.15.6
+twine==6.2.0

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -9,4 +9,4 @@ fi
 
 . .venv/bin/activate
 
-python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .
+python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .

--- a/src/sdetkit/intelligence.py
+++ b/src/sdetkit/intelligence.py
@@ -251,6 +251,20 @@ def main(argv: list[str] | None = None) -> int:
         choices=["pypi", "cache", "cache-stale", "offline"],
         default=None,
     )
+    ua.add_argument(
+        "--impact-area",
+        action="append",
+        choices=[
+            "runtime-core",
+            "quality-tooling",
+            "integration-adapters",
+            "docs-tooling",
+            "packaging-release",
+            "security-compliance",
+            "repo-tooling",
+        ],
+        default=None,
+    )
     ua.add_argument("--outdated-only", action="store_true")
     ua.add_argument("--top", type=int, default=None)
 
@@ -298,6 +312,7 @@ def main(argv: list[str] | None = None) -> int:
                 groups=ns.group,
                 sources=ns.source,
                 metadata_sources=ns.metadata_source,
+                impact_areas=ns.impact_area,
                 outdated_only=bool(ns.outdated_only),
                 top=ns.top,
             )

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -52,6 +52,8 @@ class PackageReport:
     risk_score: int
     manifest_action: str
     suggested_version: str | None
+    impact_area: str
+    validation_commands: list[str]
     next_action: str
     notes: list[str]
 
@@ -885,6 +887,38 @@ def _build_package_report(
         constraint_status=constraint_status,
         version_gap=version_gap,
     )
+    impact_area = _impact_area(
+        PackageReport(
+            name=name,
+            sources=sources,
+            groups=groups,
+            requirements=requirements,
+            pinned_versions=pinned_versions,
+            project_python_requires=project_python_requires,
+            current_version=current_version,
+            target_version=target_version,
+            target_release_date=target_release_date,
+            latest_compatible_version=compatible_version,
+            latest_compatible_release_date=compatible_release_date,
+            compatibility_status=compatibility_status,
+            alignment=alignment,
+            constraint_status=constraint_status,
+            latest_version=latest_version,
+            latest_release_date=release_date,
+            metadata_source=metadata_source,
+            version_gap=version_gap,
+            release_age_days=release_age_days,
+            upgrade_signal=upgrade_signal,
+            risk_score=risk_score,
+            manifest_action=manifest_action,
+            suggested_version=suggested_version,
+            impact_area="repo-tooling",
+            validation_commands=[],
+            next_action="",
+            notes=[],
+        )
+    )
+    validation_commands = _validation_commands_for_impact(impact_area)
 
     next_action = "Keep under observation; no immediate action required."
     if manifest_action == "raise-floor":
@@ -922,6 +956,7 @@ def _build_package_report(
         notes.append(f"Recommended manifest action: {manifest_action}.")
     if suggested_version is not None:
         notes.append(f"Suggested target version: {suggested_version}.")
+    notes.append(f"Repo impact area: {impact_area}.")
 
     return PackageReport(
         name=name,
@@ -947,6 +982,8 @@ def _build_package_report(
         risk_score=risk_score,
         manifest_action=manifest_action,
         suggested_version=suggested_version,
+        impact_area=impact_area,
+        validation_commands=validation_commands,
         next_action=next_action,
         notes=notes,
     )
@@ -966,6 +1003,8 @@ def _priority_queue(reports: list[PackageReport], *, limit: int = 5) -> list[dic
                 "latest_version": report.latest_version,
                 "manifest_action": report.manifest_action,
                 "suggested_version": report.suggested_version,
+                "impact_area": report.impact_area,
+                "validation_commands": report.validation_commands,
                 "next_action": report.next_action,
                 "lane": _recommended_lane(report),
             }
@@ -989,6 +1028,71 @@ def _recommended_lane(report: PackageReport) -> str:
     return "backlog-watchlist"
 
 
+def _impact_area(report: PackageReport) -> str:
+    groups = set(report.groups)
+    package = report.name
+
+    if "default" in groups:
+        return "runtime-core"
+    if groups & {"telegram", "whatsapp"} or package in {"python-telegram-bot", "twilio"}:
+        return "integration-adapters"
+    if "docs" in groups or package.startswith("mkdocs"):
+        return "docs-tooling"
+    if "packaging" in groups or package in {"build", "twine", "check-wheel-contents"}:
+        return "packaging-release"
+    if package in {"pip-audit", "cyclonedx-bom"}:
+        return "security-compliance"
+    if package in {
+        "pytest",
+        "pytest-asyncio",
+        "pytest-cov",
+        "hypothesis",
+        "mutmut",
+        "ruff",
+        "mypy",
+        "pre-commit",
+    }:
+        return "quality-tooling"
+    return "repo-tooling"
+
+
+def _validation_commands_for_impact(impact_area: str) -> list[str]:
+    if impact_area == "runtime-core":
+        return [
+            "bash ci.sh quick --skip-docs --artifact-dir build",
+            "bash quality.sh cov",
+        ]
+    if impact_area == "integration-adapters":
+        return [
+            "bash ci.sh quick --skip-docs --artifact-dir build",
+            "python -m pytest -q tests/test_notify_plugins.py tests/test_notify_plugins_extra.py",
+        ]
+    if impact_area == "docs-tooling":
+        return [
+            "bash ci.sh all --artifact-dir build",
+            "make docs-build",
+        ]
+    if impact_area == "packaging-release":
+        return [
+            "make package-validate",
+            "make release-preflight",
+        ]
+    if impact_area == "security-compliance":
+        return [
+            "bash security.sh",
+            "python -m sdetkit security enforce --format json",
+        ]
+    if impact_area == "quality-tooling":
+        return [
+            "bash quality.sh ci",
+            "bash quality.sh cov",
+        ]
+    return [
+        "bash ci.sh quick --skip-docs --artifact-dir build",
+        "bash quality.sh ci",
+    ]
+
+
 def _lane_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
     buckets: dict[str, list[PackageReport]] = {}
     for report in reports:
@@ -1005,6 +1109,31 @@ def _lane_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
             "packages": [r.name for r in items[:5]],
         }
         for lane, items in ordered
+    ]
+
+
+def _impact_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
+    buckets: dict[str, list[PackageReport]] = {}
+    for report in reports:
+        buckets.setdefault(report.impact_area, []).append(report)
+    ordered = sorted(
+        buckets.items(),
+        key=lambda item: (
+            -max((report.risk_score for report in item[1]), default=0),
+            -sum(1 for report in item[1] if _is_actionable_upgrade(report)),
+            item[0],
+        ),
+    )
+    return [
+        {
+            "impact_area": impact_area,
+            "count": len(items),
+            "actionable_packages": sum(1 for report in items if _is_actionable_upgrade(report)),
+            "max_risk_score": max((report.risk_score for report in items), default=0),
+            "packages": [report.name for report in items[:5]],
+            "validation_commands": items[0].validation_commands if items else [],
+        }
+        for impact_area, items in ordered
     ]
 
 
@@ -1054,6 +1183,13 @@ def _report_summary(reports: list[PackageReport]) -> dict[str, int]:
             1 for report in reports if report.compatibility_status == "requires-newer-python"
         ),
         "actionable_packages": sum(1 for report in reports if _is_actionable_upgrade(report)),
+        "runtime_core_packages": sum(1 for report in reports if report.impact_area == "runtime-core"),
+        "quality_tooling_packages": sum(
+            1 for report in reports if report.impact_area == "quality-tooling"
+        ),
+        "integration_adapter_packages": sum(
+            1 for report in reports if report.impact_area == "integration-adapters"
+        ),
         "max_risk_score": max((report.risk_score for report in reports), default=0),
     }
 
@@ -1131,6 +1267,7 @@ def _filter_reports(
     groups: list[str] | None = None,
     sources: list[str] | None = None,
     metadata_sources: list[str] | None = None,
+    impact_areas: list[str] | None = None,
     outdated_only: bool = False,
     top: int | None = None,
 ) -> list[PackageReport]:
@@ -1157,6 +1294,9 @@ def _filter_reports(
     if metadata_sources:
         allowed_sources = {item.strip() for item in metadata_sources if item.strip()}
         filtered = [report for report in filtered if report.metadata_source in allowed_sources]
+    if impact_areas:
+        allowed_impact_areas = {item.strip() for item in impact_areas if item.strip()}
+        filtered = [report for report in filtered if report.impact_area in allowed_impact_areas]
     if outdated_only:
         filtered = [report for report in filtered if _is_actionable_upgrade(report)]
     if top is not None:
@@ -1193,16 +1333,19 @@ def _render_markdown(
         f"- fallback compatible targets below latest: {summary['python_compatible_fallback_packages']}",
         f"- latest releases requiring newer Python: {summary['python_incompatible_latest_packages']}",
         f"- actionable upgrade candidates: {summary['actionable_packages']}",
+        f"- runtime core packages: {summary['runtime_core_packages']}",
+        f"- quality tooling packages: {summary['quality_tooling_packages']}",
+        f"- integration adapter packages: {summary['integration_adapter_packages']}",
         "",
-        "| Package | Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested | Release age (days) | Requirements |",
-        "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|",
+        "| Package | Impact | Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested | Release age (days) | Requirements |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for report in reports:
         release_age = "-" if report.release_age_days is None else str(report.release_age_days)
         requirements = " <br> ".join(f"`{item}`" for item in report.requirements)
         lines.append(
             "| "
-            f"`{report.name}` | `{report.current_version}` | `{report.target_version}` | `{report.latest_version}` | {report.compatibility_status} | {report.metadata_source} | {report.version_gap} | "
+            f"`{report.name}` | {report.impact_area} | `{report.current_version}` | `{report.target_version}` | `{report.latest_version}` | {report.compatibility_status} | {report.metadata_source} | {report.version_gap} | "
             f"{report.alignment} | {report.constraint_status} | {report.upgrade_signal} | {report.risk_score} | {report.manifest_action} | {report.suggested_version or '-'} | {release_age} | {requirements} |"
         )
     lines.extend(["", "## Priority queue", ""])
@@ -1218,6 +1361,15 @@ def _render_markdown(
         lines.append(
             f"- **{item['lane']}**: {item['count']} package(s), max risk {item['max_risk_score']}"
             + (f" — {pkg_list}" if pkg_list else "")
+        )
+    lines.extend(["", "## Repo impact map", ""])
+    for item in _impact_summary(reports):
+        pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
+        validations = ", ".join(f"`{command}`" for command in item["validation_commands"])
+        lines.append(
+            f"- **{item['impact_area']}**: {item['count']} package(s), actionable {item['actionable_packages']}, max risk {item['max_risk_score']}"
+            + (f" — {pkg_list}" if pkg_list else "")
+            + (f" — validate with {validations}" if validations else "")
         )
     lines.extend(["", "## Dependency groups", ""])
     for item in _group_summary(reports):
@@ -1236,7 +1388,11 @@ def _render_markdown(
     lines.extend(["", "## Focus notes", ""])
     for report in reports:
         note_text = " ".join(report.notes) if report.notes else "No additional notes."
-        lines.append(f"- `{report.name}` ({report.next_action}) {note_text}")
+        validations = ", ".join(f"`{command}`" for command in report.validation_commands)
+        lines.append(
+            f"- `{report.name}` [{report.impact_area}] ({report.next_action}) {note_text}"
+            + (f" Validate with {validations}." if validations else "")
+        )
     return "\n".join(lines) + "\n"
 
 
@@ -1252,6 +1408,7 @@ def _render_json(
         "summary": _report_summary(reports),
         "priority_queue": _priority_queue(reports),
         "lanes": _lane_summary(reports),
+        "impact": _impact_summary(reports),
         "groups": _group_summary(reports),
         "sources": _source_summary(reports),
         "packages": [asdict(report) for report in reports],
@@ -1294,6 +1451,7 @@ def run(
     groups: list[str] | None = None,
     sources: list[str] | None = None,
     metadata_sources: list[str] | None = None,
+    impact_areas: list[str] | None = None,
     outdated_only: bool = False,
     top: int | None = None,
     include_prereleases: bool = False,
@@ -1350,6 +1508,7 @@ def run(
         groups=groups,
         sources=sources,
         metadata_sources=metadata_sources,
+        impact_areas=impact_areas,
         outdated_only=outdated_only,
         top=top,
     )
@@ -1478,6 +1637,21 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         help="Show only packages resolved from the selected metadata source(s).",
     )
     parser.add_argument(
+        "--impact-area",
+        action="append",
+        choices=[
+            "runtime-core",
+            "quality-tooling",
+            "integration-adapters",
+            "docs-tooling",
+            "packaging-release",
+            "security-compliance",
+            "repo-tooling",
+        ],
+        default=None,
+        help="Show only packages in the selected repo impact area(s).",
+    )
+    parser.add_argument(
         "--outdated-only",
         action="store_true",
         help="Show only actionable upgrade candidates and baseline-establishment work.",
@@ -1534,6 +1708,7 @@ def main(argv: list[str] | None = None) -> int:
         groups=args.group,
         sources=args.source,
         metadata_sources=args.metadata_source,
+        impact_areas=args.impact_area,
         outdated_only=bool(args.outdated_only),
         top=args.top,
         include_prereleases=bool(args.include_prereleases),

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -31,6 +31,8 @@ def _report(**overrides: object) -> upgrade_audit.PackageReport:
         "risk_score": 10,
         "manifest_action": "none",
         "suggested_version": None,
+        "impact_area": "repo-tooling",
+        "validation_commands": ["bash ci.sh quick --skip-docs --artifact-dir build"],
         "next_action": "Keep under observation; no immediate action required.",
         "notes": [],
     }
@@ -123,6 +125,11 @@ def test_build_package_report_flags_drift_and_priority() -> None:
     assert report.version_gap == "minor"
     assert report.upgrade_signal == "medium"
     assert report.risk_score >= 40
+    assert report.impact_area == "runtime-core"
+    assert report.validation_commands == [
+        "bash ci.sh quick --skip-docs --artifact-dir build",
+        "bash quality.sh cov",
+    ]
     assert report.latest_version == "0.29.0"
     assert report.latest_release_date == "2026-01-01T00:00:00Z"
     assert report.metadata_source == "pypi"
@@ -242,6 +249,11 @@ def test_render_json_summary_counts() -> None:
             risk_score=85,
             manifest_action="stage-upgrade",
             suggested_version="0.29.0",
+            impact_area="runtime-core",
+            validation_commands=[
+                "bash ci.sh quick --skip-docs --artifact-dir build",
+                "bash quality.sh cov",
+            ],
             next_action="Plan an upgrade spike with regression coverage before the next release cut.",
             notes=["Cross-manifest requirement drift detected."],
         ),
@@ -263,6 +275,8 @@ def test_render_json_summary_counts() -> None:
             risk_score=10,
             manifest_action="none",
             suggested_version=None,
+            impact_area="quality-tooling",
+            validation_commands=["bash quality.sh ci", "bash quality.sh cov"],
             next_action="Keep under observation; no immediate action required.",
             notes=[],
         ),
@@ -283,6 +297,7 @@ def test_render_json_summary_counts() -> None:
         "critical_upgrade_signals": 0,
         "floor_lock_packages": 0,
         "high_priority_upgrade_signals": 1,
+        "integration_adapter_packages": 0,
         "investigate_upgrade_signals": 0,
         "manifest_drift_packages": 1,
         "max_risk_score": 85,
@@ -293,6 +308,8 @@ def test_render_json_summary_counts() -> None:
         "python_compatible_fallback_packages": 0,
         "python_compatible_latest_packages": 2,
         "python_incompatible_latest_packages": 0,
+        "quality_tooling_packages": 1,
+        "runtime_core_packages": 1,
         "stale_metadata_packages": 0,
     }
     assert payload["packages"][0]["name"] == "httpx"
@@ -341,9 +358,11 @@ dependencies = ["httpx>=0.27,<1"]
     assert "stale cached metadata packages: 0" in out
     assert "latest releases compatible with repo Python policy: 1" in out
     assert "actionable upgrade candidates: 1" in out
+    assert "runtime core packages: 1" in out
     assert "Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested" in out
-    assert "`httpx` | `0.28.1` | `0.29.0` | `0.29.0` | compatible-latest | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |" in out
+    assert "`httpx` | runtime-core | `0.28.1` | `0.29.0` | `0.29.0` | compatible-latest | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |" in out
     assert "Priority queue" in out
+    assert "Repo impact map" in out
     assert "Focus notes" in out
     assert (
         "Queue the upgrade for the next maintenance batch and validate targeted smoke tests." in out
@@ -690,6 +709,11 @@ def test_render_json_includes_lane_summary_and_priority_lane() -> None:
             risk_score=90,
             manifest_action="plan-major-upgrade",
             suggested_version="2.0.0",
+            impact_area="runtime-core",
+            validation_commands=[
+                "bash ci.sh quick --skip-docs --artifact-dir build",
+                "bash quality.sh cov",
+            ],
             next_action="Resolve manifest drift first, then validate the major upgrade in a dedicated branch.",
             notes=["Cross-manifest requirement drift detected."],
         ),
@@ -711,6 +735,8 @@ def test_render_json_includes_lane_summary_and_priority_lane() -> None:
             risk_score=10,
             manifest_action="none",
             suggested_version=None,
+            impact_area="repo-tooling",
+            validation_commands=["bash ci.sh quick --skip-docs --artifact-dir build"],
             next_action="Keep under observation; no immediate action required.",
             notes=["Latest metadata source: cache."],
         ),
@@ -727,6 +753,11 @@ def test_render_json_includes_lane_summary_and_priority_lane() -> None:
     assert payload["priority_queue"][0]["lane"] == "stabilize-manifests"
     assert payload["lanes"][0]["lane"] == "stabilize-manifests"
     assert payload["lanes"][0]["packages"] == ["critical-pkg"]
+    assert payload["impact"][0]["impact_area"] == "runtime-core"
+    assert payload["impact"][0]["validation_commands"] == [
+        "bash ci.sh quick --skip-docs --artifact-dir build",
+        "bash quality.sh cov",
+    ]
     assert payload["groups"][0]["group"] == "requirements"
     assert payload["groups"][0]["actionable_packages"] == 1
     assert payload["sources"][0]["source"] == "requirements.txt"
@@ -758,6 +789,11 @@ def test_render_markdown_includes_recommended_upgrade_lanes() -> None:
             risk_score=55,
             manifest_action="stage-upgrade",
             suggested_version="0.29.0",
+            impact_area="runtime-core",
+            validation_commands=[
+                "bash ci.sh quick --skip-docs --artifact-dir build",
+                "bash quality.sh cov",
+            ],
             next_action="Queue the upgrade for the next maintenance batch and validate targeted smoke tests.",
             notes=["Cross-manifest requirements differ but remain mutually compatible."],
         )
@@ -770,6 +806,7 @@ def test_render_markdown_includes_recommended_upgrade_lanes() -> None:
     )
 
     assert "## Recommended upgrade lanes" in rendered
+    assert "## Repo impact map" in rendered
     assert "## Dependency groups" in rendered
     assert "## Manifest sources" in rendered
     assert "**next-maintenance-batch**" in rendered
@@ -1006,6 +1043,28 @@ def test_filter_reports_supports_group_and_source_filters() -> None:
     assert [report.name for report in filtered] == ["httpx"]
 
 
+def test_filter_reports_supports_impact_area_filters() -> None:
+    reports = [
+        _report(
+            name="httpx",
+            impact_area="runtime-core",
+            validation_commands=[
+                "bash ci.sh quick --skip-docs --artifact-dir build",
+                "bash quality.sh cov",
+            ],
+        ),
+        _report(
+            name="ruff",
+            impact_area="quality-tooling",
+            validation_commands=["bash quality.sh ci", "bash quality.sh cov"],
+        ),
+    ]
+
+    filtered = upgrade_audit._filter_reports(reports, impact_areas=["quality-tooling"])
+
+    assert [report.name for report in filtered] == ["ruff"]
+
+
 def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[project]\ndependencies=[]\n", encoding="utf-8")
@@ -1031,5 +1090,6 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
     assert args.package == ["http*"]
     assert args.group == ["default"]
     assert args.source == ["pyproject.toml"]
+    assert args.impact_area is None
     assert args.include_prereleases is False
     assert requirement_paths == []


### PR DESCRIPTION
### Motivation
- Make CI and maintenance runs reproducible by pinning the validated toolchain for installs so upgrade/validation lanes do not drift with flexible extras. 
- Surface actionable, repo-specific guidance from the upgrade audit so maintainers know which validation lane to run (runtime, docs, packaging, quality, security, integration) after an upgrade candidate is found.

### Description
- Add a frozen CI baseline file `constraints-ci.txt` and wire it into the bootstrap, Make targets, and GitHub Actions installs to ensure consistent installs across local and CI runs (`scripts/bootstrap.sh`, `Makefile`, workflows under `.github/workflows/`).
- Extend the upgrade-audit implementation to classify packages into `impact_area` (e.g. `runtime-core`, `quality-tooling`, `integration-adapters`, `docs-tooling`, `packaging-release`, `security-compliance`, `repo-tooling`) and attach `validation_commands` for recommended validation lanes, and expose an `_impact_summary` in JSON/Markdown output (`src/sdetkit/upgrade_audit.py`).
- Add an `--impact-area` filter and propagate it through the intelligence umbrella CLI so the audit can be run scoped to impact areas (`src/sdetkit/intelligence.py`).
- Update README to document the new impact-aware audit workflow and add tests exercising impact metadata, rendering, and filtering (`tests/test_upgrade_audit_script.py`).

### Testing
- Ran unit/regression tests for the audit surface: `PYTHONPATH=src pytest -q tests/test_upgrade_audit_script.py` (23 passed). 
- Validated intelligence surface behavior: `PYTHONPATH=src pytest -q tests/test_kits_intelligence_integration_forensics.py -k upgrade_audit_primary_surface` (1 passed, 6 deselected).
- Performed style and static checks: `python -m ruff check src/sdetkit/upgrade_audit.py src/sdetkit/intelligence.py tests/test_upgrade_audit_script.py` (passed).
- Byte-compiled modules to check syntax: `python -m compileall src/sdetkit/upgrade_audit.py src/sdetkit/intelligence.py` (passed).
- Spot-checked runtime CLI: `PYTHONPATH=src python -m sdetkit intelligence upgrade-audit --format json --top 5 --impact-area runtime-core` (produced expected impact summary output).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb689dd7fc8320b2a7942b1d919fcd)