### PR TITLE
Enhance upgrade-audit: manifest-action filtering, prefiltering, and action summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ python -m sdetkit intelligence upgrade-audit --format json --top 5
 python -m sdetkit intelligence upgrade-audit --include-prereleases --package httpx
 python -m sdetkit intelligence upgrade-audit --format md --offline
 python -m sdetkit intelligence upgrade-audit --outdated-only --package "http*"
+python -m sdetkit intelligence upgrade-audit --manifest-action stage-upgrade --top 10
 python -m sdetkit intelligence upgrade-audit --group default --source pyproject.toml --format md
 python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
 python scripts/upgrade_audit.py --fail-on high
@@ -106,7 +107,7 @@ python scripts/upgrade_audit.py --metadata-source cache-stale --outdated-only
 python scripts/upgrade_audit.py --group requirements --source requirements.txt --top 10
 ```
 
-By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue.
+By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue. When you already know the maintenance lane you want, filter directly by `--manifest-action` to isolate packages that need a pin refresh, floor raise, staged upgrade, or dedicated major-upgrade branch.
 
 To make those upgrade lanes reproducible in CI, the repo now pins the validated toolchain in `constraints-ci.txt` while leaving `pyproject.toml` flexible enough for package consumers.
 

--- a/src/sdetkit/intelligence.py
+++ b/src/sdetkit/intelligence.py
@@ -265,8 +265,23 @@ def main(argv: list[str] | None = None) -> int:
         ],
         default=None,
     )
+    ua.add_argument(
+        "--manifest-action",
+        action="append",
+        choices=[
+            "none",
+            "refresh-pin",
+            "raise-floor",
+            "stage-upgrade",
+            "plan-major-upgrade",
+            "establish-baseline",
+            "investigate-metadata",
+        ],
+        default=None,
+    )
     ua.add_argument("--outdated-only", action="store_true")
     ua.add_argument("--top", type=int, default=None)
+    ua.add_argument("--include-prereleases", action="store_true")
 
     ns = parser.parse_args(argv)
     try:
@@ -313,8 +328,10 @@ def main(argv: list[str] | None = None) -> int:
                 sources=ns.source,
                 metadata_sources=ns.metadata_source,
                 impact_areas=ns.impact_area,
+                manifest_actions=ns.manifest_action,
                 outdated_only=bool(ns.outdated_only),
                 top=ns.top,
+                include_prereleases=bool(ns.include_prereleases),
             )
         else:
             payload = _cmd_mutation_policy(safe_path(Path.cwd(), ns.policy, allow_absolute=True))

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -1258,6 +1258,54 @@ def _matches_any_filter(values: list[str], allowed_filters: list[str] | None) ->
     return any(filter_value in normalized_values for filter_value in allowed_filters)
 
 
+def _matches_dependency_filters(
+    deps: list[Dependency],
+    *,
+    packages: list[str] | None = None,
+    groups: list[str] | None = None,
+    sources: list[str] | None = None,
+) -> bool:
+    if packages:
+        package_filters = [item.strip().lower() for item in packages if item.strip()]
+        if package_filters and not any(
+            fnmatch.fnmatch(dep.name.lower(), pattern) for pattern in package_filters for dep in deps
+        ):
+            return False
+    if groups:
+        group_filters = {item.strip().lower() for item in groups if item.strip()}
+        if group_filters and not any(dep.group.lower() in group_filters for dep in deps):
+            return False
+    if sources:
+        source_filters = {item.strip().lower() for item in sources if item.strip()}
+        if source_filters and not any(dep.source.lower() in source_filters for dep in deps):
+            return False
+    return True
+
+
+def _action_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
+    buckets: dict[str, list[PackageReport]] = {}
+    for report in reports:
+        buckets.setdefault(report.manifest_action, []).append(report)
+    ordered = sorted(
+        buckets.items(),
+        key=lambda item: (
+            -sum(1 for report in item[1] if _is_actionable_upgrade(report)),
+            -max((report.risk_score for report in item[1]), default=0),
+            item[0],
+        ),
+    )
+    return [
+        {
+            "manifest_action": action,
+            "count": len(items),
+            "actionable_packages": sum(1 for report in items if _is_actionable_upgrade(report)),
+            "max_risk_score": max((report.risk_score for report in items), default=0),
+            "packages": [report.name for report in items[:5]],
+        }
+        for action, items in ordered
+    ]
+
+
 def _filter_reports(
     reports: list[PackageReport],
     *,
@@ -1268,6 +1316,7 @@ def _filter_reports(
     sources: list[str] | None = None,
     metadata_sources: list[str] | None = None,
     impact_areas: list[str] | None = None,
+    manifest_actions: list[str] | None = None,
     outdated_only: bool = False,
     top: int | None = None,
 ) -> list[PackageReport]:
@@ -1297,6 +1346,9 @@ def _filter_reports(
     if impact_areas:
         allowed_impact_areas = {item.strip() for item in impact_areas if item.strip()}
         filtered = [report for report in filtered if report.impact_area in allowed_impact_areas]
+    if manifest_actions:
+        allowed_actions = {item.strip() for item in manifest_actions if item.strip()}
+        filtered = [report for report in filtered if report.manifest_action in allowed_actions]
     if outdated_only:
         filtered = [report for report in filtered if _is_actionable_upgrade(report)]
     if top is not None:
@@ -1371,6 +1423,13 @@ def _render_markdown(
             + (f" — {pkg_list}" if pkg_list else "")
             + (f" — validate with {validations}" if validations else "")
         )
+    lines.extend(["", "## Manifest actions", ""])
+    for item in _action_summary(reports):
+        pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
+        lines.append(
+            f"- **{item['manifest_action']}**: {item['count']} package(s), actionable {item['actionable_packages']}, max risk {item['max_risk_score']}"
+            + (f" — {pkg_list}" if pkg_list else "")
+        )
     lines.extend(["", "## Dependency groups", ""])
     for item in _group_summary(reports):
         pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
@@ -1409,6 +1468,7 @@ def _render_json(
         "priority_queue": _priority_queue(reports),
         "lanes": _lane_summary(reports),
         "impact": _impact_summary(reports),
+        "actions": _action_summary(reports),
         "groups": _group_summary(reports),
         "sources": _source_summary(reports),
         "packages": [asdict(report) for report in reports],
@@ -1452,6 +1512,7 @@ def run(
     sources: list[str] | None = None,
     metadata_sources: list[str] | None = None,
     impact_areas: list[str] | None = None,
+    manifest_actions: list[str] | None = None,
     outdated_only: bool = False,
     top: int | None = None,
     include_prereleases: bool = False,
@@ -1468,7 +1529,30 @@ def run(
         by_package.setdefault(dep.name, []).append(dep)
 
     package_filters = packages
+    if packages or groups or sources:
+        by_package = {
+            name: deps
+            for name, deps in by_package.items()
+            if _matches_dependency_filters(
+                deps,
+                packages=packages,
+                groups=groups,
+                sources=sources,
+            )
+        }
     package_names = sorted(by_package)
+    if not package_names:
+        rendered = {
+            "json": _render_json(
+                [], pyproject_path=pyproject_path, requirement_paths=requirement_paths
+            ),
+            "md": _render_markdown(
+                [], pyproject_path=pyproject_path, requirement_paths=requirement_paths
+            ),
+        }[output_format]
+        sys.stdout.write(rendered)
+        return 0
+
     metadata_by_package = _collect_package_metadata(
         package_names,
         timeout_s=timeout_s,
@@ -1509,6 +1593,7 @@ def run(
         sources=sources,
         metadata_sources=metadata_sources,
         impact_areas=impact_areas,
+        manifest_actions=manifest_actions,
         outdated_only=outdated_only,
         top=top,
     )
@@ -1650,6 +1735,21 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         ],
         default=None,
         help="Show only packages in the selected repo impact area(s).",
+    )
+    parser.add_argument(
+        "--manifest-action",
+        action="append",
+        choices=[
+            "none",
+            "refresh-pin",
+            "raise-floor",
+            "stage-upgrade",
+            "plan-major-upgrade",
+            "establish-baseline",
+            "investigate-metadata",
+        ],
+        default=None,
+        help="Show only packages with the selected manifest action(s).",
     )
     parser.add_argument(
         "--outdated-only",

--- a/tests/test_kits_intelligence_integration_forensics.py
+++ b/tests/test_kits_intelligence_integration_forensics.py
@@ -105,6 +105,9 @@ dependencies = ["httpx==0.28.1"]
         "default",
         "--source",
         "pyproject.toml",
+        "--manifest-action",
+        "none",
+        "--include-prereleases",
     )
 
     assert proc.returncode == 0
@@ -114,6 +117,7 @@ dependencies = ["httpx==0.28.1"]
     assert payload["lanes"][0]["lane"] == "next-maintenance-batch"
     assert payload["groups"][0]["group"] == "default"
     assert payload["sources"][0]["source"] == "pyproject.toml"
+    assert payload["actions"][0]["manifest_action"] == "none"
 
 
 def test_intelligence_failure_mode_invalid_failures_file(tmp_path: Path) -> None:

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -1043,6 +1043,82 @@ def test_filter_reports_supports_group_and_source_filters() -> None:
     assert [report.name for report in filtered] == ["httpx"]
 
 
+def test_filter_reports_supports_manifest_action_filters() -> None:
+    reports = [
+        _report(name="httpx", manifest_action="stage-upgrade"),
+        _report(name="ruff", manifest_action="none"),
+    ]
+
+    filtered = upgrade_audit._filter_reports(reports, manifest_actions=["stage-upgrade"])
+
+    assert [report.name for report in filtered] == ["httpx"]
+
+
+def test_run_prefilters_dependency_metadata_collection(monkeypatch, tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = ["httpx==0.28.1", "filelock==3.25.2"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    requested_packages: list[str] = []
+
+    def _fake_collect(
+        packages: list[str],
+        *,
+        timeout_s: float,
+        cache_path: Path,
+        cache_ttl_hours: float,
+        offline: bool,
+        max_workers: int,
+        project_python_requires: str | None,
+        include_prereleases: bool,
+    ) -> dict[str, upgrade_audit.PackageMetadata]:
+        requested_packages.extend(packages)
+        return {
+            package: upgrade_audit.PackageMetadata(
+                latest_version="0.28.1" if package == "httpx" else "3.25.2",
+                release_date="2026-01-01T00:00:00Z",
+                compatible_version="0.28.1" if package == "httpx" else "3.25.2",
+                compatible_release_date="2026-01-01T00:00:00Z",
+                compatibility_status="compatible-latest",
+                source="pypi",
+            )
+            for package in packages
+        }
+
+    monkeypatch.setattr(upgrade_audit, "_collect_package_metadata", _fake_collect)
+
+    rc = upgrade_audit.run(
+        pyproject,
+        timeout_s=0.1,
+        requirement_paths=[],
+        output_format="json",
+        packages=["http*"],
+    )
+
+    assert rc == 0
+    assert requested_packages == ["httpx"]
+
+
+def test_action_summary_groups_packages_by_manifest_action() -> None:
+    reports = [
+        _report(name="httpx", manifest_action="stage-upgrade", risk_score=50),
+        _report(name="ruff", manifest_action="none", risk_score=10),
+        _report(name="pytest", manifest_action="stage-upgrade", risk_score=40),
+    ]
+
+    summary = upgrade_audit._action_summary(reports)
+
+    assert summary[0]["manifest_action"] == "stage-upgrade"
+    assert summary[0]["count"] == 2
+    assert summary[0]["packages"] == ["httpx", "pytest"]
+
+
 def test_filter_reports_supports_impact_area_filters() -> None:
     reports = [
         _report(
@@ -1091,5 +1167,6 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
     assert args.group == ["default"]
     assert args.source == ["pyproject.toml"]
     assert args.impact_area is None
+    assert args.manifest_action is None
     assert args.include_prereleases is False
     assert requirement_paths == []


### PR DESCRIPTION
### Motivation
- Make the upgrade-audit surface more actionable by exposing a manifest-level "action" dimension so operators can target specific maintenance lanes (pin refresh, staged upgrade, major upgrade, etc.).
- Reduce unnecessary PyPI/cache work for targeted audits by prefiltering dependencies when users supply `--package`, `--group`, or `--source` selectors.
- Improve observability of recommended work by surfacing grouped manifest-action summaries in both JSON and Markdown outputs.

### Description
- Add `_matches_dependency_filters` and `_action_summary` helpers and wire a `manifest_action` dimension into the audit pipeline in `src/sdetkit/upgrade_audit.py` so reports include an `actions` rollup and Markdown `## Manifest actions` section.
- Add `--manifest-action` and `--include-prereleases` CLI options to the intelligence umbrella surface and to the audit parser (wiring through `src/sdetkit/intelligence.py` and the audit `build_parser`).
- Prefilter `by_package` before calling `_collect_package_metadata` when `--package`, `--group`, or `--source` are provided to avoid fetching metadata for non-matching packages and return an empty rendered report when nothing matches.
- Extend JSON and Markdown renderers to include `actions` and manifest-action summaries; update `README.md` examples and guidance to show `--manifest-action` usage.
- Add regression tests and test updates in `tests/test_upgrade_audit_script.py` and `tests/test_kits_intelligence_integration_forensics.py` to cover manifest-action filtering, action summaries, prefiltering behavior, and umbrella CLI surface parity.

### Testing
- Ran static checks with `python -m ruff check src/sdetkit/upgrade_audit.py src/sdetkit/intelligence.py tests/test_upgrade_audit_script.py tests/test_kits_intelligence_integration_forensics.py README.md` and all checks passed.
- Executed targeted pytest runs for the new/updated coverage: `PYTHONPATH=src pytest -q` for selected upgrade-audit and kit tests, and the focused suite passed (examples: `test_filter_reports_supports_manifest_action_filters`, `test_run_prefilters_dependency_metadata_collection`, `test_action_summary_groups_packages_by_manifest_action`, `test_filter_reports_supports_impact_area_filters`, `test_resolve_requirement_paths_supports_outdated_only_cli_defaults`, and `test_intelligence_upgrade_audit_primary_surface` all passed).
- Verified runtime behavior with a smoke invocation `PYTHONPATH=src python -m sdetkit intelligence upgrade-audit --format json --manifest-action none --package httpx --offline --cache-path .sdetkit/cache/upgrade-audit-cache.json`, which produced the expected package/action output and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb6c0ba8e4832088ec456770f60c7c)