### PR TITLE
Add repo-aware usage tiers to upgrade-audit and wire through intelligence CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ python -m sdetkit continuous-upgrade-cycle11-closeout --format json --strict
 
 ## Upgrade planning (first step)
 
-Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, Python-policy-aware compatible targets, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, repo impact areas, validation command suggestions, group/source rollups, manifest actions, suggested target versions, and floor-and-lock baseline detection for repos that intentionally mix flexible ranges with tested pins. It also follows nested `-r` / `--requirement` includes so split requirement stacks are audited as a single upgrade surface. You can invoke it from either the standalone script or the primary Intelligence kit surface, filter the results down to the hottest dependency groups, manifest sources, or repo impact areas, and fail CI at a chosen signal threshold:
+Run a dependency-manifest audit against PyPI to identify candidate upgrades, detect cross-file version drift, and prioritize the highest-signal upgrade gaps. The audit now surfaces the repo baseline version, Python-policy-aware compatible targets, estimated version-gap size (major/minor/patch), release recency, an ordered risk score, recommended maintenance lanes, repo impact areas, observed repo-usage tiers derived from imports across `src/` and `tests/`, validation command suggestions, group/source rollups, manifest actions, suggested target versions, and floor-and-lock baseline detection for repos that intentionally mix flexible ranges with tested pins. It also follows nested `-r` / `--requirement` includes so split requirement stacks are audited as a single upgrade surface. You can invoke it from either the standalone script or the primary Intelligence kit surface, filter the results down to the hottest dependency groups, manifest sources, repo-usage tiers, or repo impact areas, and fail CI at a chosen signal threshold:
 
 ```bash
 make upgrade-audit
@@ -94,6 +94,7 @@ python -m sdetkit intelligence upgrade-audit --format json --top 5
 python -m sdetkit intelligence upgrade-audit --include-prereleases --package httpx
 python -m sdetkit intelligence upgrade-audit --format md --offline
 python -m sdetkit intelligence upgrade-audit --outdated-only --package "http*"
+python -m sdetkit intelligence upgrade-audit --used-in-repo-only --repo-usage-tier hot-path --format md
 python -m sdetkit intelligence upgrade-audit --manifest-action stage-upgrade --top 10
 python -m sdetkit intelligence upgrade-audit --group default --source pyproject.toml --format md
 python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
@@ -103,6 +104,7 @@ python scripts/upgrade_audit.py --offline --format md
 python scripts/upgrade_audit.py --include-prereleases --signal high
 python scripts/upgrade_audit.py --signal high --policy blocked --top 5
 python scripts/upgrade_audit.py --impact-area runtime-core --format md
+python scripts/upgrade_audit.py --repo-usage-tier active --used-in-repo-only --top 10
 python scripts/upgrade_audit.py --metadata-source cache-stale --outdated-only
 python scripts/upgrade_audit.py --group requirements --source requirements.txt --top 10
 ```

--- a/src/sdetkit/intelligence.py
+++ b/src/sdetkit/intelligence.py
@@ -279,6 +279,13 @@ def main(argv: list[str] | None = None) -> int:
         ],
         default=None,
     )
+    ua.add_argument(
+        "--repo-usage-tier",
+        action="append",
+        choices=["hot-path", "active", "edge", "declared-only"],
+        default=None,
+    )
+    ua.add_argument("--used-in-repo-only", action="store_true")
     ua.add_argument("--outdated-only", action="store_true")
     ua.add_argument("--top", type=int, default=None)
     ua.add_argument("--include-prereleases", action="store_true")
@@ -329,6 +336,8 @@ def main(argv: list[str] | None = None) -> int:
                 metadata_sources=ns.metadata_source,
                 impact_areas=ns.impact_area,
                 manifest_actions=ns.manifest_action,
+                repo_usage_tiers=ns.repo_usage_tier,
+                used_in_repo_only=bool(ns.used_in_repo_only),
                 outdated_only=bool(ns.outdated_only),
                 top=ns.top,
                 include_prereleases=bool(ns.include_prereleases),

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import datetime as dt
 import fnmatch
 import json
@@ -53,6 +54,9 @@ class PackageReport:
     manifest_action: str
     suggested_version: str | None
     impact_area: str
+    repo_usage_count: int
+    repo_usage_tier: str
+    repo_usage_files: list[str]
     validation_commands: list[str]
     next_action: str
     notes: list[str]
@@ -77,6 +81,16 @@ SIGNAL_PRIORITY = {
     "unknown": 1,
 }
 DEFAULT_CACHE_PATH = Path(".sdetkit/cache/upgrade-audit-cache.json")
+COMMON_IMPORT_ALIASES = {
+    "python-telegram-bot": {"telegram"},
+    "twilio": {"twilio"},
+    "mkdocs-material": {"material"},
+    "pytest-asyncio": {"pytest_asyncio"},
+    "pytest-cov": {"pytest_cov"},
+    "check-wheel-contents": {"check_wheel_contents"},
+    "cyclonedx-bom": {"cyclonedx_py"},
+    "pre-commit": {"pre_commit"},
+}
 
 
 def _parse_dep_name(raw_requirement: str) -> str:
@@ -637,6 +651,73 @@ def _requirement_allows_version(raw_requirement: str, version: str) -> bool | No
     return all(_constraint_allows_version(constraint, version) for constraint in constraints)
 
 
+def _candidate_import_roots(package: str) -> set[str]:
+    normalized = package.lower().replace("-", "_").replace(".", "_")
+    candidates = {normalized}
+    candidates.update(COMMON_IMPORT_ALIASES.get(package, set()))
+    return {candidate for candidate in candidates if candidate}
+
+
+def _iter_repo_python_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for folder in (root / "src", root / "tests"):
+        if not folder.exists():
+            continue
+        for path in sorted(folder.rglob("*.py")):
+            if ".egg-info" in path.parts:
+                continue
+            files.append(path)
+    return files
+
+
+def _extract_import_roots(path: Path) -> set[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return set()
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0].strip().lower()
+                if root:
+                    roots.add(root)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            root = node.module.split(".", 1)[0].strip().lower()
+            if root:
+                roots.add(root)
+    return roots
+
+
+def _collect_repo_usage(root: Path, package_names: list[str]) -> dict[str, list[str]]:
+    packages_by_root: dict[str, set[str]] = {}
+    for package in package_names:
+        for root_name in _candidate_import_roots(package):
+            packages_by_root.setdefault(root_name, set()).add(package)
+
+    usage: dict[str, set[str]] = {package: set() for package in package_names}
+    for path in _iter_repo_python_files(root):
+        rel_path = path.relative_to(root).as_posix()
+        matched_packages = {
+            package
+            for root_name in _extract_import_roots(path)
+            for package in packages_by_root.get(root_name, set())
+        }
+        for package in matched_packages:
+            usage[package].add(rel_path)
+    return {package: sorted(paths) for package, paths in usage.items()}
+
+
+def _repo_usage_tier(repo_usage_count: int) -> str:
+    if repo_usage_count >= 5:
+        return "hot-path"
+    if repo_usage_count >= 2:
+        return "active"
+    if repo_usage_count == 1:
+        return "edge"
+    return "declared-only"
+
+
 def _pick_current_version(deps: list[Dependency]) -> str:
     pinned_versions = sorted(
         {dep.pinned_version for dep in deps if dep.pinned_version},
@@ -785,6 +866,7 @@ def _build_package_report(
     compatible_release_date: str | None = None,
     compatibility_status: str = "unknown",
     metadata_source: str = "pypi",
+    repo_usage_files: list[str] | None = None,
 ) -> PackageReport:
     sources = sorted({dep.source for dep in deps})
     groups = sorted({dep.group for dep in deps})
@@ -797,6 +879,9 @@ def _build_package_report(
     release_age_days = _release_age_days(target_release_date)
     alignment = _infer_alignment(deps, current_version)
     constraint_status = _constraint_status(deps, target_version)
+    repo_usage_files = sorted(repo_usage_files or [])
+    repo_usage_count = len(repo_usage_files)
+    repo_usage_tier = _repo_usage_tier(repo_usage_count)
 
     notes: list[str] = []
     if alignment == "drift":
@@ -879,6 +964,12 @@ def _build_package_report(
         risk_score += 10
     if upgrade_signal == "investigate":
         risk_score += 10
+    risk_score += {
+        "hot-path": 15,
+        "active": 8,
+        "edge": 3,
+        "declared-only": 0,
+    }[repo_usage_tier]
 
     manifest_action, suggested_version = _manifest_action(
         current_version=current_version,
@@ -913,6 +1004,9 @@ def _build_package_report(
             manifest_action=manifest_action,
             suggested_version=suggested_version,
             impact_area="repo-tooling",
+            repo_usage_count=repo_usage_count,
+            repo_usage_tier=repo_usage_tier,
+            repo_usage_files=repo_usage_files,
             validation_commands=[],
             next_action="",
             notes=[],
@@ -957,6 +1051,16 @@ def _build_package_report(
     if suggested_version is not None:
         notes.append(f"Suggested target version: {suggested_version}.")
     notes.append(f"Repo impact area: {impact_area}.")
+    if repo_usage_files:
+        sample_files = ", ".join(repo_usage_files[:3])
+        extra = "" if len(repo_usage_files) <= 3 else f" (+{len(repo_usage_files) - 3} more)"
+        notes.append(
+            f"Repo usage: {repo_usage_count} file(s), tier {repo_usage_tier}; observed in {sample_files}{extra}."
+        )
+    else:
+        notes.append(
+            "Repo usage: declared in manifests but not imported from tracked src/tests Python files."
+        )
 
     return PackageReport(
         name=name,
@@ -983,6 +1087,9 @@ def _build_package_report(
         manifest_action=manifest_action,
         suggested_version=suggested_version,
         impact_area=impact_area,
+        repo_usage_count=repo_usage_count,
+        repo_usage_tier=repo_usage_tier,
+        repo_usage_files=repo_usage_files,
         validation_commands=validation_commands,
         next_action=next_action,
         notes=notes,
@@ -1004,6 +1111,9 @@ def _priority_queue(reports: list[PackageReport], *, limit: int = 5) -> list[dic
                 "manifest_action": report.manifest_action,
                 "suggested_version": report.suggested_version,
                 "impact_area": report.impact_area,
+                "repo_usage_count": report.repo_usage_count,
+                "repo_usage_tier": report.repo_usage_tier,
+                "repo_usage_files": report.repo_usage_files,
                 "validation_commands": report.validation_commands,
                 "next_action": report.next_action,
                 "lane": _recommended_lane(report),
@@ -1141,6 +1251,31 @@ def _is_actionable_upgrade(report: PackageReport) -> bool:
     return report.manifest_action != "none"
 
 
+def _repo_usage_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
+    buckets: dict[str, list[PackageReport]] = {}
+    for report in reports:
+        buckets.setdefault(report.repo_usage_tier, []).append(report)
+    order = {"hot-path": 0, "active": 1, "edge": 2, "declared-only": 3}
+    ordered = sorted(
+        buckets.items(),
+        key=lambda item: (
+            order.get(item[0], 99),
+            -max((report.repo_usage_count for report in item[1]), default=0),
+            item[0],
+        ),
+    )
+    return [
+        {
+            "repo_usage_tier": tier,
+            "count": len(items),
+            "max_repo_usage_count": max((report.repo_usage_count for report in items), default=0),
+            "actionable_packages": sum(1 for report in items if _is_actionable_upgrade(report)),
+            "packages": [report.name for report in items[:5]],
+        }
+        for tier, items in ordered
+    ]
+
+
 def _report_summary(reports: list[PackageReport]) -> dict[str, int]:
     return {
         "packages_audited": len(reports),
@@ -1183,6 +1318,12 @@ def _report_summary(reports: list[PackageReport]) -> dict[str, int]:
             1 for report in reports if report.compatibility_status == "requires-newer-python"
         ),
         "actionable_packages": sum(1 for report in reports if _is_actionable_upgrade(report)),
+        "hot_path_packages": sum(1 for report in reports if report.repo_usage_tier == "hot-path"),
+        "active_usage_packages": sum(1 for report in reports if report.repo_usage_tier == "active"),
+        "edge_usage_packages": sum(1 for report in reports if report.repo_usage_tier == "edge"),
+        "declared_only_packages": sum(
+            1 for report in reports if report.repo_usage_tier == "declared-only"
+        ),
         "runtime_core_packages": sum(1 for report in reports if report.impact_area == "runtime-core"),
         "quality_tooling_packages": sum(
             1 for report in reports if report.impact_area == "quality-tooling"
@@ -1317,6 +1458,8 @@ def _filter_reports(
     metadata_sources: list[str] | None = None,
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
+    repo_usage_tiers: list[str] | None = None,
+    used_in_repo_only: bool = False,
     outdated_only: bool = False,
     top: int | None = None,
 ) -> list[PackageReport]:
@@ -1349,6 +1492,11 @@ def _filter_reports(
     if manifest_actions:
         allowed_actions = {item.strip() for item in manifest_actions if item.strip()}
         filtered = [report for report in filtered if report.manifest_action in allowed_actions]
+    if repo_usage_tiers:
+        allowed_tiers = {item.strip() for item in repo_usage_tiers if item.strip()}
+        filtered = [report for report in filtered if report.repo_usage_tier in allowed_tiers]
+    if used_in_repo_only:
+        filtered = [report for report in filtered if report.repo_usage_count > 0]
     if outdated_only:
         filtered = [report for report in filtered if _is_actionable_upgrade(report)]
     if top is not None:
@@ -1385,19 +1533,24 @@ def _render_markdown(
         f"- fallback compatible targets below latest: {summary['python_compatible_fallback_packages']}",
         f"- latest releases requiring newer Python: {summary['python_incompatible_latest_packages']}",
         f"- actionable upgrade candidates: {summary['actionable_packages']}",
+        f"- hot-path repo-used packages: {summary['hot_path_packages']}",
+        f"- active repo-used packages: {summary['active_usage_packages']}",
+        f"- edge repo-used packages: {summary['edge_usage_packages']}",
+        f"- declared-only packages: {summary['declared_only_packages']}",
         f"- runtime core packages: {summary['runtime_core_packages']}",
         f"- quality tooling packages: {summary['quality_tooling_packages']}",
         f"- integration adapter packages: {summary['integration_adapter_packages']}",
         "",
-        "| Package | Impact | Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested | Release age (days) | Requirements |",
-        "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|",
+        "| Package | Impact | Repo usage | Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested | Release age (days) | Requirements |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for report in reports:
         release_age = "-" if report.release_age_days is None else str(report.release_age_days)
         requirements = " <br> ".join(f"`{item}`" for item in report.requirements)
+        repo_usage = f"{report.repo_usage_tier} ({report.repo_usage_count})"
         lines.append(
             "| "
-            f"`{report.name}` | {report.impact_area} | `{report.current_version}` | `{report.target_version}` | `{report.latest_version}` | {report.compatibility_status} | {report.metadata_source} | {report.version_gap} | "
+            f"`{report.name}` | {report.impact_area} | {repo_usage} | `{report.current_version}` | `{report.target_version}` | `{report.latest_version}` | {report.compatibility_status} | {report.metadata_source} | {report.version_gap} | "
             f"{report.alignment} | {report.constraint_status} | {report.upgrade_signal} | {report.risk_score} | {report.manifest_action} | {report.suggested_version or '-'} | {release_age} | {requirements} |"
         )
     lines.extend(["", "## Priority queue", ""])
@@ -1412,6 +1565,13 @@ def _render_markdown(
         pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
         lines.append(
             f"- **{item['lane']}**: {item['count']} package(s), max risk {item['max_risk_score']}"
+            + (f" — {pkg_list}" if pkg_list else "")
+        )
+    lines.extend(["", "## Repo usage tiers", ""])
+    for item in _repo_usage_summary(reports):
+        pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
+        lines.append(
+            f"- **{item['repo_usage_tier']}**: {item['count']} package(s), actionable {item['actionable_packages']}, max repo usage {item['max_repo_usage_count']}"
             + (f" — {pkg_list}" if pkg_list else "")
         )
     lines.extend(["", "## Repo impact map", ""])
@@ -1467,6 +1627,7 @@ def _render_json(
         "summary": _report_summary(reports),
         "priority_queue": _priority_queue(reports),
         "lanes": _lane_summary(reports),
+        "repo_usage": _repo_usage_summary(reports),
         "impact": _impact_summary(reports),
         "actions": _action_summary(reports),
         "groups": _group_summary(reports),
@@ -1513,6 +1674,8 @@ def run(
     metadata_sources: list[str] | None = None,
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
+    repo_usage_tiers: list[str] | None = None,
+    used_in_repo_only: bool = False,
     outdated_only: bool = False,
     top: int | None = None,
     include_prereleases: bool = False,
@@ -1553,6 +1716,7 @@ def run(
         sys.stdout.write(rendered)
         return 0
 
+    repo_usage = _collect_repo_usage(pyproject_path.parent, package_names)
     metadata_by_package = _collect_package_metadata(
         package_names,
         timeout_s=timeout_s,
@@ -1577,6 +1741,7 @@ def run(
                 compatible_release_date=metadata.compatible_release_date,
                 compatibility_status=metadata.compatibility_status,
                 metadata_source=metadata.source,
+                repo_usage_files=repo_usage.get(package, []),
             )
         )
         report = reports[-1]
@@ -1594,6 +1759,8 @@ def run(
         metadata_sources=metadata_sources,
         impact_areas=impact_areas,
         manifest_actions=manifest_actions,
+        repo_usage_tiers=repo_usage_tiers,
+        used_in_repo_only=used_in_repo_only,
         outdated_only=outdated_only,
         top=top,
     )
@@ -1752,6 +1919,18 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         help="Show only packages with the selected manifest action(s).",
     )
     parser.add_argument(
+        "--repo-usage-tier",
+        action="append",
+        choices=["hot-path", "active", "edge", "declared-only"],
+        default=None,
+        help="Show only packages matching the selected observed repo-usage tier(s).",
+    )
+    parser.add_argument(
+        "--used-in-repo-only",
+        action="store_true",
+        help="Show only packages imported from tracked src/tests Python files.",
+    )
+    parser.add_argument(
         "--outdated-only",
         action="store_true",
         help="Show only actionable upgrade candidates and baseline-establishment work.",
@@ -1809,6 +1988,9 @@ def main(argv: list[str] | None = None) -> int:
         sources=args.source,
         metadata_sources=args.metadata_source,
         impact_areas=args.impact_area,
+        manifest_actions=args.manifest_action,
+        repo_usage_tiers=args.repo_usage_tier,
+        used_in_repo_only=bool(args.used_in_repo_only),
         outdated_only=bool(args.outdated_only),
         top=args.top,
         include_prereleases=bool(args.include_prereleases),

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -32,6 +32,9 @@ def _report(**overrides: object) -> upgrade_audit.PackageReport:
         "manifest_action": "none",
         "suggested_version": None,
         "impact_area": "repo-tooling",
+        "repo_usage_count": 0,
+        "repo_usage_tier": "declared-only",
+        "repo_usage_files": [],
         "validation_commands": ["bash ci.sh quick --skip-docs --artifact-dir build"],
         "next_action": "Keep under observation; no immediate action required.",
         "notes": [],
@@ -92,6 +95,26 @@ def test_load_dependencies_follows_nested_requirement_files(tmp_path: Path) -> N
 
     assert [dep.name for dep in deps] == ["ruff", "httpx"]
     assert [dep.source for dep in deps] == ["nested.txt", "requirements.txt"]
+
+
+def test_collect_repo_usage_tracks_imported_packages(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src" / "demo"
+    src_dir.mkdir(parents=True)
+    (src_dir / "__init__.py").write_text("import httpx\n", encoding="utf-8")
+    (src_dir / "client.py").write_text("from telegram import Bot\n", encoding="utf-8")
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_client.py").write_text("import pytest_asyncio\n", encoding="utf-8")
+
+    usage = upgrade_audit._collect_repo_usage(
+        tmp_path,
+        ["httpx", "python-telegram-bot", "pytest-asyncio", "twilio"],
+    )
+
+    assert usage["httpx"] == ["src/demo/__init__.py"]
+    assert usage["python-telegram-bot"] == ["src/demo/client.py"]
+    assert usage["pytest-asyncio"] == ["tests/test_client.py"]
+    assert usage["twilio"] == []
 
 
 def test_build_package_report_flags_drift_and_priority() -> None:
@@ -164,6 +187,38 @@ def test_build_package_report_uses_compatible_target_when_latest_needs_newer_pyt
     assert report.suggested_version == "0.29.0"
     assert report.compatibility_status == "compatible-available"
     assert "using compatible target 0.29.0" in " ".join(report.notes)
+
+
+def test_build_package_report_includes_repo_usage_and_risk_boost() -> None:
+    deps = [
+        upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="default",
+            raw="httpx==0.28.1",
+            name="httpx",
+            pinned_version="0.28.1",
+        )
+    ]
+
+    report = upgrade_audit._build_package_report(
+        "httpx",
+        deps,
+        latest_version="0.29.0",
+        release_date="2026-03-01T00:00:00Z",
+        repo_usage_files=[
+            "src/sdetkit/apiclient.py",
+            "src/sdetkit/netclient.py",
+            "tests/test_apiclient.py",
+            "tests/test_netclient_extra.py",
+            "tests/test_apiget_request_builder.py",
+        ],
+    )
+
+    assert report.repo_usage_count == 5
+    assert report.repo_usage_tier == "hot-path"
+    assert report.repo_usage_files[0] == "src/sdetkit/apiclient.py"
+    assert report.risk_score >= 60
+    assert "tier hot-path" in " ".join(report.notes)
 
 
 def test_build_package_report_marks_compatible_policy_covered_manifests() -> None:
@@ -292,11 +347,15 @@ def test_render_json_summary_counts() -> None:
 
     assert payload["summary"] == {
         "actionable_packages": 1,
+        "active_usage_packages": 0,
         "cached_metadata_packages": 1,
         "compatible_constraint_packages": 0,
         "critical_upgrade_signals": 0,
+        "declared_only_packages": 2,
+        "edge_usage_packages": 0,
         "floor_lock_packages": 0,
         "high_priority_upgrade_signals": 1,
+        "hot_path_packages": 0,
         "integration_adapter_packages": 0,
         "investigate_upgrade_signals": 0,
         "manifest_drift_packages": 1,
@@ -312,6 +371,7 @@ def test_render_json_summary_counts() -> None:
         "runtime_core_packages": 1,
         "stale_metadata_packages": 0,
     }
+    assert payload["repo_usage"][0]["repo_usage_tier"] == "declared-only"
     assert payload["packages"][0]["name"] == "httpx"
 
 
@@ -358,10 +418,12 @@ dependencies = ["httpx>=0.27,<1"]
     assert "stale cached metadata packages: 0" in out
     assert "latest releases compatible with repo Python policy: 1" in out
     assert "actionable upgrade candidates: 1" in out
+    assert "declared-only packages: 1" in out
     assert "runtime core packages: 1" in out
-    assert "Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested" in out
-    assert "`httpx` | runtime-core | `0.28.1` | `0.29.0` | `0.29.0` | compatible-latest | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |" in out
+    assert "Impact | Repo usage | Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested" in out
+    assert "`httpx` | runtime-core | declared-only (0) | `0.28.1` | `0.29.0` | `0.29.0` | compatible-latest | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |" in out
     assert "Priority queue" in out
+    assert "Repo usage tiers" in out
     assert "Repo impact map" in out
     assert "Focus notes" in out
     assert (
@@ -1141,6 +1203,22 @@ def test_filter_reports_supports_impact_area_filters() -> None:
     assert [report.name for report in filtered] == ["ruff"]
 
 
+def test_filter_reports_supports_repo_usage_filters() -> None:
+    reports = [
+        _report(name="httpx", repo_usage_count=7, repo_usage_tier="hot-path"),
+        _report(name="ruff", repo_usage_count=2, repo_usage_tier="active"),
+        _report(name="twilio", repo_usage_count=0, repo_usage_tier="declared-only"),
+    ]
+
+    filtered = upgrade_audit._filter_reports(
+        reports,
+        repo_usage_tiers=["active", "hot-path"],
+        used_in_repo_only=True,
+    )
+
+    assert [report.name for report in filtered] == ["httpx", "ruff"]
+
+
 def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[project]\ndependencies=[]\n", encoding="utf-8")
@@ -1157,6 +1235,9 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
             "default",
             "--source",
             "pyproject.toml",
+            "--repo-usage-tier",
+            "hot-path",
+            "--used-in-repo-only",
         ]
     )
 
@@ -1168,5 +1249,7 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
     assert args.source == ["pyproject.toml"]
     assert args.impact_area is None
     assert args.manifest_action is None
+    assert args.repo_usage_tier == ["hot-path"]
+    assert args.used_in_repo_only is True
     assert args.include_prereleases is False
     assert requirement_paths == []


### PR DESCRIPTION
### Motivation
- Make dependency upgrade prioritization reflect real repository blast radius by observing which packages are actually imported from `src/` and `tests/` so high-usage packages get higher upgrade priority. 
- Provide operators with filtering and reporting surfaces to focus maintenance on packages that matter to runtime paths (hot/active/edge) rather than only manifest declarations.

### Description
- Add import-based repo-usage collection: new helpers `_candidate_import_roots`, `_iter_repo_python_files`, `_extract_import_roots`, and `_collect_repo_usage` scan tracked `src/` and `tests/` files and map packages to `repo_usage_files` (in `src/sdetkit/upgrade_audit.py`).
- Surface usage metadata in reports: attach `repo_usage_count`, `repo_usage_tier`, and `repo_usage_files` to `PackageReport`, include `repo_usage` summary in JSON output, and show usage tier/count in Markdown tables and notes. 
- Fold usage into prioritization: `_repo_usage_tier` computes tiers (`hot-path`, `active`, `edge`, `declared-only`) and the `risk_score` is boosted by tier so frequently used packages rank higher. 
- Add CLI filtering and options: new parser flags `--repo-usage-tier` and `--used-in-repo-only` added to the standalone `upgrade-audit` (`build_parser`) and to the `sdetkit intelligence upgrade-audit` surface (`src/sdetkit/intelligence.py`) so users can target repo-used packages from CLI. 
- Misc: update `README.md` to document the repo-usage flows and add focused tests in `tests/test_upgrade_audit_script.py` to cover import-detection, tiering, JSON/Markdown rendering, and CLI parsing; also add small `COMMON_IMPORT_ALIASES` to improve common name matching. 

### Testing
- Ran unit tests for the audit surface with `env PYTHONPATH=src pytest -q tests/test_upgrade_audit_script.py` and they passed (`29 passed`).
- Exercised the intelligence primary surface with relevant tests `env PYTHONPATH=src pytest -q tests/test_kits_intelligence_integration_forensics.py -k "intelligence_upgrade_audit_primary_surface or intelligence_contracts_and_failure_fingerprinting or intelligence_failure_mode_invalid_failures_file"` and they passed (`3 passed, 4 deselected`).
- Verified CLI behavior and output by running `python -m sdetkit intelligence upgrade-audit --offline --format json --used-in-repo-only --repo-usage-tier hot-path --top 3` and asserting the produced JSON contains `repo_usage` tiers and expected `packages_audited`, which succeeded.
- Compiled the modified modules with `python -m compileall src/sdetkit/upgrade_audit.py src/sdetkit/intelligence.py` to ensure syntax correctness and confirmed no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb70985fb08320816671ecf4ab9432)