### PR TITLE
Add upgrade-audit support & compact hints to `doctor`; add `quality.sh doctor` lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ python scripts/upgrade_audit.py --impact-area runtime-core --format md
 python scripts/upgrade_audit.py --repo-usage-tier active --used-in-repo-only --top 10
 python scripts/upgrade_audit.py --metadata-source cache-stale --outdated-only
 python scripts/upgrade_audit.py --group requirements --source requirements.txt --top 10
+python -m sdetkit doctor --upgrade-audit --upgrade-audit-offline --format json
+bash quality.sh doctor
 ```
 
 By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue. When you already know the maintenance lane you want, filter directly by `--manifest-action` to isolate packages that need a pin refresh, floor raise, staged upgrade, or dedicated major-upgrade branch.

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -6,7 +6,9 @@
 
 - `sdetkit doctor --all --format json`
 - `sdetkit doctor --dev --ci --deps --clean-tree --repo --format md`
+- `sdetkit doctor --upgrade-audit --upgrade-audit-offline --format json`
 - `sdetkit doctor --only pyproject --format json`
+- `bash quality.sh doctor`
 
 ## Contract
 
@@ -28,6 +30,10 @@
 - stdlib-shadowing and non-ASCII hygiene
 
 Each failing check includes actionable remediation (`fix`) and supporting evidence.
+
+When `--upgrade-audit` is enabled, `doctor` also emits ranked dependency-maintenance hints with
+repo impact areas, recommended lanes, and validation commands so dependency planning becomes part
+of the same readiness report.
 
 ## Determinism
 

--- a/quality.sh
+++ b/quality.sh
@@ -34,6 +34,7 @@ run_fmt()     { need_cmd ruff; python -m ruff format .; }
 run_fmt_check() { need_cmd ruff; python -m ruff format --check .; }
 run_lint()    { need_cmd ruff; python -m ruff check .; }
 run_type()    { need_cmd mypy; python -m mypy --config-file pyproject.toml src; }
+run_doctor()  { python -m sdetkit doctor --dev --ci --deps --repo --upgrade-audit --format md; }
 run_gate_fast() { python -m sdetkit gate fast; }
 run_full_test() { need_cmd pytest; python -m pytest -q -o addopts=; }
 run_test()    { need_cmd pytest; python -m pytest; }
@@ -69,6 +70,7 @@ case "$mode" in
   fmt) run_fmt ;;
   lint) run_lint ;;
   type) run_type ;;
+  doctor) run_doctor ;;
   test) run_gate_fast ;;
   cov) run_cov ;;
   full-test) run_full_test ;;
@@ -88,7 +90,7 @@ case "$mode" in
     run_cov
     ;;
   *)
-    echo "Usage: bash quality.sh {all|ci|fmt|lint|type|test|full-test|cov|mut|muthtml}" >&2
+    echo "Usage: bash quality.sh {all|ci|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml}" >&2
     exit 2
     ;;
 esac

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -14,7 +14,7 @@ from importlib import metadata
 from pathlib import Path
 from typing import Any
 
-from . import _toml
+from . import _toml, upgrade_audit
 from .import_hazards import find_stdlib_shadowing
 from .security import SecurityError, safe_path
 
@@ -32,6 +32,7 @@ CHECK_ORDER = [
     "security_files",
     "repo_readiness",
     "release_meta",
+    "upgrade_audit",
     "ascii",
 ]
 
@@ -49,6 +50,7 @@ SUPPORTED_POLICY_CHECKS = {
     "pre_commit",
     "repo_readiness",
     "release_meta",
+    "upgrade_audit",
 }
 
 
@@ -134,6 +136,15 @@ def _baseline_checks() -> dict[str, dict[str, Any]]:
             skipped=True,
             fix=[
                 "Run doctor with --release to validate version, changelog, and release workflow wiring."
+            ],
+        ),
+        "upgrade_audit": _make_check(
+            ok=True,
+            severity="medium",
+            summary="upgrade audit check not requested",
+            skipped=True,
+            fix=[
+                "Run doctor with --upgrade-audit to surface dependency upgrade hints and impact areas."
             ],
         ),
     }
@@ -644,11 +655,202 @@ def _recommendations(data: dict[str, Any]) -> list[str]:
         recs.append("Run dependency updates and resolve `pip check` conflicts.")
     if data.get("clean_tree_ok") is False:
         recs.append("Commit or stash pending changes before release/CI validation.")
+    upgrade_meta = data.get("checks", {}).get("upgrade_audit", {}).get("meta", {})
+    priority_queue = upgrade_meta.get("priority_queue", [])
+    if isinstance(priority_queue, list):
+        for item in priority_queue[:2]:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name", "")).strip()
+            action = str(item.get("manifest_action", "")).strip()
+            suggested = item.get("suggested_version")
+            next_action = str(item.get("next_action", "")).strip()
+            if name and action and action != "none":
+                version_text = f" to {suggested}" if isinstance(suggested, str) and suggested else ""
+                recs.append(f"Upgrade-audit priority: {name} via {action}{version_text}. {next_action}")
     if not recs:
         recs.append(
             "No immediate blockers detected. Keep CI, docs, and tests green for premium delivery quality."
         )
     return recs
+
+
+def _build_hints(data: dict[str, Any]) -> list[str]:
+    hints: list[str] = []
+
+    next_actions = data.get("next_actions", [])
+    if isinstance(next_actions, list):
+        for item in next_actions[:3]:
+            if not isinstance(item, dict):
+                continue
+            check_id = str(item.get("id", "")).strip()
+            summary = str(item.get("summary", "")).strip()
+            fix_list = item.get("fix", [])
+            first_fix = ""
+            if isinstance(fix_list, list) and fix_list:
+                first_fix = str(fix_list[0]).strip()
+            parts = [part for part in [f"{check_id}: {summary}" if check_id and summary else "", first_fix] if part]
+            if parts:
+                hints.append(" — ".join(parts))
+
+    upgrade_meta = data.get("checks", {}).get("upgrade_audit", {}).get("meta", {})
+    priority_queue = upgrade_meta.get("priority_queue", [])
+    if isinstance(priority_queue, list):
+        for item in priority_queue[:3]:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name", "")).strip()
+            if not name:
+                continue
+            action = str(item.get("manifest_action", "")).strip()
+            target = str(item.get("suggested_version", "")).strip()
+            validations = item.get("validation_commands", [])
+            validation = ""
+            if isinstance(validations, list) and validations:
+                validation = str(validations[0]).strip()
+            lane = str(item.get("lane", "")).strip()
+            detail = f"{name}: {action or 'review'}"
+            if target:
+                detail += f" -> {target}"
+            if lane:
+                detail += f" [{lane}]"
+            if validation:
+                detail += f" — validate with {validation}"
+            hints.append(detail)
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for hint in hints:
+        normalized = hint.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return deduped[:5]
+
+
+def _check_upgrade_audit(
+    root: Path,
+    *,
+    offline: bool,
+) -> tuple[bool, str, list[dict[str, Any]], list[str], dict[str, Any]]:
+    pyproject_path = root / "pyproject.toml"
+    if not pyproject_path.exists():
+        return (
+            False,
+            "pyproject.toml is missing for upgrade audit",
+            [{"type": "missing_file", "message": "pyproject.toml is missing", "path": "pyproject.toml"}],
+            ["Add pyproject.toml before running upgrade audit checks."],
+            {},
+        )
+
+    requirement_paths = upgrade_audit._discover_requirement_files(root, include_lockfiles=False)
+    dependencies = upgrade_audit._load_dependencies(pyproject_path, requirement_paths)
+    if not dependencies:
+        return (
+            True,
+            "no dependencies declared for upgrade audit",
+            [],
+            ["Add dependency manifests when you are ready to track package upgrades."],
+            {
+                "packages_audited": 0,
+                "actionable_packages": 0,
+                "priority_queue": [],
+                "offline": offline,
+            },
+        )
+
+    by_package: dict[str, list[upgrade_audit.Dependency]] = {}
+    for dep in dependencies:
+        by_package.setdefault(dep.name, []).append(dep)
+
+    package_names = sorted(by_package)
+    project_python_requires = upgrade_audit._load_project_python_requires(pyproject_path)
+    repo_usage = upgrade_audit._collect_repo_usage(root, package_names)
+    metadata_by_package = upgrade_audit._collect_package_metadata(
+        package_names,
+        timeout_s=5.0,
+        cache_path=upgrade_audit.DEFAULT_CACHE_PATH,
+        cache_ttl_hours=24.0,
+        offline=offline,
+        max_workers=4,
+        project_python_requires=project_python_requires,
+        include_prereleases=False,
+    )
+
+    reports: list[upgrade_audit.PackageReport] = []
+    for package in package_names:
+        metadata = metadata_by_package[package]
+        reports.append(
+            upgrade_audit._build_package_report(
+                package,
+                by_package[package],
+                latest_version=metadata.latest_version,
+                release_date=metadata.release_date,
+                project_python_requires=project_python_requires,
+                compatible_version=metadata.compatible_version,
+                compatible_release_date=metadata.compatible_release_date,
+                compatibility_status=metadata.compatibility_status,
+                metadata_source=metadata.source,
+                repo_usage_files=repo_usage.get(package, []),
+            )
+        )
+    reports = upgrade_audit._sort_reports(reports)
+    actionable = [report for report in reports if upgrade_audit._is_actionable_upgrade(report)]
+    priority_source = actionable if actionable else reports
+    priority_queue = upgrade_audit._priority_queue(priority_source, limit=3)
+
+    has_high_risk = any(report.upgrade_signal in {"critical", "high"} for report in actionable)
+    has_drift = any(report.alignment == "drift" for report in reports)
+    ok = not has_high_risk and not has_drift
+
+    summary_bits = [f"{len(actionable)} actionable package(s)"]
+    if priority_queue:
+        top = priority_queue[0]
+        top_name = str(top.get("name", "")).strip()
+        top_signal = str(top.get("signal", "")).strip()
+        top_action = str(top.get("manifest_action", "")).strip()
+        if top_name:
+            summary_bits.append(f"top priority {top_name} [{top_signal or 'watch'} / {top_action or 'review'}]")
+    summary = "upgrade audit found " + "; ".join(summary_bits)
+
+    evidence: list[dict[str, Any]] = []
+    for item in priority_queue:
+        name = str(item.get("name", "")).strip()
+        signal = str(item.get("signal", "")).strip()
+        action = str(item.get("manifest_action", "")).strip()
+        impact_area = str(item.get("impact_area", "")).strip()
+        next_action = str(item.get("next_action", "")).strip()
+        version = str(item.get("suggested_version", "")).strip()
+        message = f"{name}: {signal or 'watch'} / {action or 'review'}"
+        if version:
+            message += f" -> {version}"
+        if impact_area:
+            message += f" [{impact_area}]"
+        if next_action:
+            message += f" — {next_action}"
+        evidence.append({"type": "upgrade_priority", "message": message, "path": "pyproject.toml"})
+
+    fix = ["Run `python -m sdetkit intelligence upgrade-audit --format md --top 5` for the full ranked report."]
+    fix.extend(
+        str(command)
+        for item in priority_queue
+        for command in item.get("validation_commands", [])
+        if isinstance(command, str)
+    )
+    deduped_fix: list[str] = []
+    for item in fix:
+        if item not in deduped_fix:
+            deduped_fix.append(item)
+
+    meta = {
+        "packages_audited": len(reports),
+        "actionable_packages": len(actionable),
+        "priority_queue": priority_queue,
+        "offline": offline,
+        "requirements": [path.name for path in requirement_paths],
+    }
+    return ok, summary, evidence, deduped_fix[:5], meta
 
 
 def _print_human_report(data: dict[str, Any]) -> None:
@@ -661,6 +863,11 @@ def _print_human_report(data: dict[str, Any]) -> None:
     lines.append("recommendations:")
     for rec in data.get("recommendations", []):
         lines.append(f"- {rec}")
+    hints = data.get("hints", [])
+    if hints:
+        lines.append("hints:")
+        for hint in hints:
+            lines.append(f"- {hint}")
     sys.stdout.write("\n".join(lines) + "\n")
 
 
@@ -679,6 +886,11 @@ def _print_pr_report(data: dict[str, Any]) -> None:
     lines.append("- next steps:")
     for rec in data.get("recommendations", []):
         lines.append(f"  - {rec}")
+    hints = data.get("hints", [])
+    if hints:
+        lines.append("- hints:")
+        for hint in hints:
+            lines.append(f"  - {hint}")
     sys.stdout.write("\n".join(lines) + "\n")
 
 
@@ -739,6 +951,14 @@ def _format_doctor_markdown(data: dict[str, Any]) -> str:
             else:
                 lines.append(f"  - {message}")
     if not has_evidence:
+        lines.append("- None")
+    lines.append("")
+    lines.append("#### Hints")
+    hints = data.get("hints", [])
+    if hints:
+        for hint in hints:
+            lines.append(f"- {hint}")
+    else:
         lines.append("- None")
     return "\n".join(lines) + "\n"
 
@@ -865,6 +1085,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--deps", action="store_true")
     parser.add_argument("--clean-tree", dest="clean_tree", action="store_true")
     parser.add_argument("--repo", "--repo-readiness", dest="repo_readiness", action="store_true")
+    parser.add_argument(
+        "--upgrade-audit",
+        dest="upgrade_audit",
+        action="store_true",
+        help="Run dependency upgrade audit hints and impact analysis.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-offline",
+        dest="upgrade_audit_offline",
+        action="store_true",
+        help="Use cached metadata only for upgrade-audit hints.",
+    )
     parser.add_argument("--dev", action="store_true")
     parser.add_argument("--pyproject", action="store_true")
     parser.add_argument("--pr", action="store_true", help="print a PR-ready markdown summary")
@@ -914,6 +1146,7 @@ def main(argv: list[str] | None = None) -> int:
         ns.deps = False
         ns.clean_tree = False
         ns.repo_readiness = False
+        ns.upgrade_audit = False
         ns.dev = False
         ns.pyproject = False
         ns.all = False
@@ -938,6 +1171,8 @@ def main(argv: list[str] | None = None) -> int:
             ns.dev = True
         if "release_meta" in only_set:
             ns.release = True
+        if "upgrade_audit" in only_set:
+            ns.upgrade_audit = True
 
     def _is_selected(check_id: str) -> bool:
         if only_set:
@@ -987,6 +1222,7 @@ def main(argv: list[str] | None = None) -> int:
         ns.ci = True
         ns.deps = True
         ns.clean_tree = True
+        ns.upgrade_audit = True
 
     if release_any and _is_selected("release_meta"):
         ns.pyproject = True
@@ -999,6 +1235,7 @@ def main(argv: list[str] | None = None) -> int:
         ns.deps = True
         ns.dev = True
         ns.repo_readiness = True
+        ns.upgrade_audit = True
 
     if ns.dev and (ns.ci or ns.deps or ns.clean_tree):
         ns.pyproject = True
@@ -1279,6 +1516,23 @@ def main(argv: list[str] | None = None) -> int:
         )
         score_items.append(rr_ok)
 
+    if ns.upgrade_audit and _is_selected("upgrade_audit"):
+        ua_ok, ua_summary, ua_evidence, ua_fix, ua_meta = _check_upgrade_audit(
+            root,
+            offline=bool(ns.upgrade_audit_offline),
+        )
+        data["upgrade_audit_ok"] = ua_ok
+        data["checks"]["upgrade_audit"] = _make_check(
+            ok=ua_ok,
+            severity="medium" if ua_ok else "high",
+            summary=ua_summary,
+            evidence=ua_evidence,
+            fix=ua_fix,
+            skipped=False,
+            meta=ua_meta,
+        )
+        score_items.append(ua_ok)
+
     policy = _load_policy(root, ns.policy)
     if policy.get("_error"):
         sys.stderr.write(str(policy["_error"]) + "\n")
@@ -1333,6 +1587,7 @@ def main(argv: list[str] | None = None) -> int:
     }
     data["score"] = _calculate_score(score_items)
     data["recommendations"] = _recommendations(data)
+    data["hints"] = _build_hints(data)
     data["ok"] = bool(gate_ok)
     if failed_checks:
         data["failed_checks"] = failed_checks
@@ -1355,6 +1610,11 @@ def main(argv: list[str] | None = None) -> int:
         lines.append("recommendations:")
         for rec in data.get("recommendations", []):
             lines.append(f"- {rec}")
+        hints = data.get("hints", [])
+        if hints:
+            lines.append("hints:")
+            for hint in hints:
+                lines.append(f"- {hint}")
         output = "\n".join(lines) + "\n"
         is_json = False
 

--- a/tests/test_doctor_upgrade_audit.py
+++ b/tests/test_doctor_upgrade_audit.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import doctor
+
+
+def _write_minimal_pyproject(root: Path) -> None:
+    (root / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='1.0.0'\ndependencies=['httpx>=0.28.1,<1']\n",
+        encoding="utf-8",
+    )
+
+
+def test_doctor_upgrade_audit_emits_priority_hints(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_minimal_pyproject(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    dep = doctor.upgrade_audit.Dependency(
+        source="pyproject.toml",
+        group="default",
+        raw="httpx>=0.28.1,<1",
+        name="httpx",
+        pinned_version=None,
+    )
+
+    monkeypatch.setattr(doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(doctor.upgrade_audit, "_load_dependencies", lambda *_args, **_kwargs: [dep])
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_load_project_python_requires",
+        lambda *_args, **_kwargs: ">=3.11",
+    )
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_repo_usage",
+        lambda *_args, **_kwargs: {"httpx": ["src/sdetkit/netclient.py"]},
+    )
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_package_metadata",
+        lambda *_args, **_kwargs: {
+            "httpx": doctor.upgrade_audit.PackageMetadata(
+                latest_version="0.29.0",
+                release_date="2026-03-01T00:00:00+00:00",
+                compatible_version="0.29.0",
+                compatible_release_date="2026-03-01T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="cache",
+            )
+        },
+    )
+
+    rc = doctor.main(["--upgrade-audit", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checks"]["upgrade_audit"]["ok"] is True
+    assert payload["checks"]["upgrade_audit"]["meta"]["priority_queue"][0]["name"] == "httpx"
+    assert any("httpx" in hint for hint in payload["hints"])
+
+
+def test_doctor_only_upgrade_audit_reports_drift_failure(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_minimal_pyproject(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    deps = [
+        doctor.upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="default",
+            raw="httpx==0.28.1",
+            name="httpx",
+            pinned_version="0.28.1",
+        ),
+        doctor.upgrade_audit.Dependency(
+            source="requirements.txt",
+            group="requirements",
+            raw="httpx==1.0.0",
+            name="httpx",
+            pinned_version="1.0.0",
+        ),
+    ]
+
+    monkeypatch.setattr(doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(doctor.upgrade_audit, "_load_dependencies", lambda *_args, **_kwargs: deps)
+    monkeypatch.setattr(doctor.upgrade_audit, "_load_project_python_requires", lambda *_args, **_kwargs: ">=3.11")
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_repo_usage",
+        lambda *_args, **_kwargs: {"httpx": ["src/sdetkit/netclient.py", "tests/test_netclient_extra.py"]},
+    )
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_package_metadata",
+        lambda *_args, **_kwargs: {
+            "httpx": doctor.upgrade_audit.PackageMetadata(
+                latest_version="2.0.0",
+                release_date="2026-03-01T00:00:00+00:00",
+                compatible_version="2.0.0",
+                compatible_release_date="2026-03-01T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="cache",
+            )
+        },
+    )
+
+    rc = doctor.main(["--only", "upgrade_audit", "--format", "json"])
+
+    assert rc == doctor.EXIT_FAILED
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checks"]["upgrade_audit"]["ok"] is False
+    assert payload["failed_checks"] == ["upgrade_audit"]
+    assert payload["selected_checks"] == ["upgrade_audit"]


### PR DESCRIPTION
### Motivation
- Make dependency upgrade planning a first-class part of the readiness `doctor` workflow so upgrade signals and next actions are visible alongside existing checks.
- Surface compact, actionable hints from both failing checks and the upgrade-audit priority queue to reduce time-to-action for maintainers.
- Provide a simple local quality lane to run the expanded doctor flow (`quality.sh doctor`) and document the usage in README/docs.

### Description
- Integrated the existing `upgrade_audit` module into `doctor` and added a new check id `upgrade_audit` with policy support and a stable check entry in `CHECK_ORDER` (files: `src/sdetkit/doctor.py`).
- Implemented `_check_upgrade_audit` to run a short, bounded audit (cached/online options) and return prioritized evidence, `meta.priority_queue`, suggested validation commands, and recommended next actions (file: `src/sdetkit/doctor.py`).
- Added `_build_hints` and `hints` output to include short, de-duplicated actionable strings in human, PR/markdown and JSON report forms (`doctor` now injects `hints` into its payload and outputs) (file: `src/sdetkit/doctor.py`).
- Added CLI flags `--upgrade-audit` and `--upgrade-audit-offline` to `doctor` and wired the check into selection/--only behavior so it can fail the gate when policy thresholds are met (file: `src/sdetkit/doctor.py`).
- Added a `doctor` mode to `quality.sh` to run the expanded doctor lane (file: `quality.sh`).
- Documented the new options and example invocation in `README.md` and `docs/doctor.md`.
- Added focused tests that mock `upgrade_audit` metadata to validate both healthy and failing upgrade-audit flows (new file: `tests/test_doctor_upgrade_audit.py`).

### Testing
- Ran the focused pytest set: `tests/test_doctor_upgrade_audit.py`, `tests/test_doctor_md_and_out.py`, `tests/test_doctor_repo_readiness.py`, and `tests/test_cli_doctor.py`, and all tests passed (successful `pytest` run).
- Ran static checks with `ruff` against the modified files and the checks passed.
- The new tests validate both a successful upgrade-audit hint path and a failing drift scenario when `doctor` is restricted to the `upgrade_audit` check (asserting expected exit code and JSON fields).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb74acacdc8320bfe29d9395f2e45f)