### PR TITLE
Add free-text `--query` to upgrade-audit and enrich doctor upgrade-audit summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ python -m sdetkit intelligence upgrade-audit --include-prereleases --package htt
 python -m sdetkit intelligence upgrade-audit --format md --offline
 python -m sdetkit intelligence upgrade-audit --outdated-only --package "http*"
 python -m sdetkit intelligence upgrade-audit --used-in-repo-only --repo-usage-tier hot-path --format md
+python -m sdetkit intelligence upgrade-audit --query runtime-core --query "next maintenance"
 python -m sdetkit intelligence upgrade-audit --manifest-action stage-upgrade --top 10
 python -m sdetkit intelligence upgrade-audit --group default --source pyproject.toml --format md
 python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
@@ -111,7 +112,7 @@ python -m sdetkit doctor --upgrade-audit --upgrade-audit-offline --format json
 bash quality.sh doctor
 ```
 
-By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue. When you already know the maintenance lane you want, filter directly by `--manifest-action` to isolate packages that need a pin refresh, floor raise, staged upgrade, or dedicated major-upgrade branch.
+By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue. When you already know the maintenance lane you want, filter directly by `--manifest-action` to isolate packages that need a pin refresh, floor raise, staged upgrade, or dedicated major-upgrade branch. Use `--query` when you want text search across package names, notes, repo-usage files, recommended lanes, and validation commands without pre-classifying the package first.
 
 To make those upgrade lanes reproducible in CI, the repo now pins the validated toolchain in `constraints-ci.txt` while leaving `pyproject.toml` flexible enough for package consumers.
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -33,7 +33,9 @@ Each failing check includes actionable remediation (`fix`) and supporting eviden
 
 When `--upgrade-audit` is enabled, `doctor` also emits ranked dependency-maintenance hints with
 repo impact areas, recommended lanes, and validation commands so dependency planning becomes part
-of the same readiness report.
+of the same readiness report. The upgrade-audit metadata now also carries lane and impact summaries,
+so doctor recommendations can call out quality-tooling, runtime-core, and integration-adapter work
+with concrete follow-up commands instead of only listing raw packages.
 
 ## Determinism
 

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -666,8 +666,39 @@ def _recommendations(data: dict[str, Any]) -> list[str]:
             suggested = item.get("suggested_version")
             next_action = str(item.get("next_action", "")).strip()
             if name and action and action != "none":
-                version_text = f" to {suggested}" if isinstance(suggested, str) and suggested else ""
-                recs.append(f"Upgrade-audit priority: {name} via {action}{version_text}. {next_action}")
+                version_text = (
+                    f" to {suggested}" if isinstance(suggested, str) and suggested else ""
+                )
+                recs.append(
+                    f"Upgrade-audit priority: {name} via {action}{version_text}. {next_action}"
+                )
+    impact_summary = upgrade_meta.get("impact_summary", [])
+    if isinstance(impact_summary, list):
+        for item in impact_summary:
+            if not isinstance(item, dict) or int(item.get("actionable_packages", 0)) <= 0:
+                continue
+            impact_area = str(item.get("impact_area", "")).strip()
+            commands = item.get("validation_commands", [])
+            command_text = ""
+            if isinstance(commands, list) and commands:
+                command_text = str(commands[0]).strip()
+            if impact_area == "quality-tooling":
+                rec = "Quality lane follow-up: batch actionable quality-tooling upgrades with full gate reruns."
+                if command_text:
+                    rec += f" Start with {command_text}."
+                recs.append(rec)
+            elif impact_area == "runtime-core":
+                rec = "Runtime lane follow-up: validate runtime-core dependency upgrades against the fast gate first."
+                if command_text:
+                    rec += f" Start with {command_text}."
+                recs.append(rec)
+            elif impact_area == "integration-adapters":
+                rec = "Integration lane follow-up: keep adapter upgrades isolated and verify notification/integration tests."
+                if command_text:
+                    rec += f" Start with {command_text}."
+                recs.append(rec)
+            if len(recs) >= 6:
+                break
     if not recs:
         recs.append(
             "No immediate blockers detected. Keep CI, docs, and tests green for premium delivery quality."
@@ -689,7 +720,11 @@ def _build_hints(data: dict[str, Any]) -> list[str]:
             first_fix = ""
             if isinstance(fix_list, list) and fix_list:
                 first_fix = str(fix_list[0]).strip()
-            parts = [part for part in [f"{check_id}: {summary}" if check_id and summary else "", first_fix] if part]
+            parts = [
+                part
+                for part in [f"{check_id}: {summary}" if check_id and summary else "", first_fix]
+                if part
+            ]
             if parts:
                 hints.append(" — ".join(parts))
 
@@ -718,6 +753,42 @@ def _build_hints(data: dict[str, Any]) -> list[str]:
                 detail += f" — validate with {validation}"
             hints.append(detail)
 
+    lane_summary = upgrade_meta.get("lane_summary", [])
+    if isinstance(lane_summary, list):
+        for item in lane_summary[:2]:
+            if not isinstance(item, dict):
+                continue
+            lane = str(item.get("lane", "")).strip()
+            count = int(item.get("count", 0))
+            packages = item.get("packages", [])
+            package_text = ""
+            if isinstance(packages, list) and packages:
+                package_text = ", ".join(
+                    str(name).strip() for name in packages[:3] if str(name).strip()
+                )
+            if lane and count > 0:
+                detail = f"lane {lane}: {count} package(s)"
+                if package_text:
+                    detail += f" — focus on {package_text}"
+                hints.append(detail)
+
+    impact_summary = upgrade_meta.get("impact_summary", [])
+    if isinstance(impact_summary, list):
+        for item in impact_summary[:2]:
+            if not isinstance(item, dict):
+                continue
+            impact_area = str(item.get("impact_area", "")).strip()
+            actionable = int(item.get("actionable_packages", 0))
+            commands = item.get("validation_commands", [])
+            command_text = ""
+            if isinstance(commands, list) and commands:
+                command_text = str(commands[0]).strip()
+            if impact_area and actionable > 0:
+                detail = f"impact {impact_area}: {actionable} actionable package(s)"
+                if command_text:
+                    detail += f" — validate with {command_text}"
+                hints.append(detail)
+
     deduped: list[str] = []
     seen: set[str] = set()
     for hint in hints:
@@ -739,7 +810,13 @@ def _check_upgrade_audit(
         return (
             False,
             "pyproject.toml is missing for upgrade audit",
-            [{"type": "missing_file", "message": "pyproject.toml is missing", "path": "pyproject.toml"}],
+            [
+                {
+                    "type": "missing_file",
+                    "message": "pyproject.toml is missing",
+                    "path": "pyproject.toml",
+                }
+            ],
             ["Add pyproject.toml before running upgrade audit checks."],
             {},
         )
@@ -811,7 +888,9 @@ def _check_upgrade_audit(
         top_signal = str(top.get("signal", "")).strip()
         top_action = str(top.get("manifest_action", "")).strip()
         if top_name:
-            summary_bits.append(f"top priority {top_name} [{top_signal or 'watch'} / {top_action or 'review'}]")
+            summary_bits.append(
+                f"top priority {top_name} [{top_signal or 'watch'} / {top_action or 'review'}]"
+            )
     summary = "upgrade audit found " + "; ".join(summary_bits)
 
     evidence: list[dict[str, Any]] = []
@@ -831,7 +910,9 @@ def _check_upgrade_audit(
             message += f" — {next_action}"
         evidence.append({"type": "upgrade_priority", "message": message, "path": "pyproject.toml"})
 
-    fix = ["Run `python -m sdetkit intelligence upgrade-audit --format md --top 5` for the full ranked report."]
+    fix = [
+        "Run `python -m sdetkit intelligence upgrade-audit --format md --top 5` for the full ranked report."
+    ]
     fix.extend(
         str(command)
         for item in priority_queue
@@ -847,6 +928,9 @@ def _check_upgrade_audit(
         "packages_audited": len(reports),
         "actionable_packages": len(actionable),
         "priority_queue": priority_queue,
+        "lane_summary": upgrade_audit._lane_summary(reports),
+        "impact_summary": upgrade_audit._impact_summary(reports),
+        "repo_usage_summary": upgrade_audit._repo_usage_summary(reports),
         "offline": offline,
         "requirements": [path.name for path in requirement_paths],
     }

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -192,9 +192,7 @@ def _load_requirements_dependencies_recursive(
         if include_target is not None:
             include_path = (requirements_path.parent / include_target).resolve()
             if include_path.exists():
-                deps.extend(
-                    _load_requirements_dependencies_recursive(include_path, seen=seen)
-                )
+                deps.extend(_load_requirements_dependencies_recursive(include_path, seen=seen))
             continue
         candidate = _normalize_requirement_line(stripped)
         if candidate is None:
@@ -509,11 +507,7 @@ def _candidate_repo_python_versions(project_python_requires: str | None) -> list
     constraints = _parse_python_constraints(project_python_requires)
     if not constraints:
         return []
-    minimums = [
-        version
-        for operator, version in constraints
-        if operator in {">=", ">", "~=", "=="}
-    ]
+    minimums = [version for operator, version in constraints if operator in {">=", ">", "~=", "=="}]
     if minimums:
         return [sorted(minimums, key=_version_key)[-1]]
     upper_bounds = [version for operator, version in constraints if operator in {"<", "<="}]
@@ -587,7 +581,10 @@ def _release_is_python_compatible(
         if requires_python is not None and not isinstance(requires_python, str):
             continue
         compatibility_observed = True
-        if all(_specifier_allows_version(requires_python, version) is not False for version in repo_versions):
+        if all(
+            _specifier_allows_version(requires_python, version) is not False
+            for version in repo_versions
+        ):
             return True, "compatible"
     if compatibility_observed:
         return False, "requires-newer-python"
@@ -621,7 +618,9 @@ def _latest_compatible_release(
     latest_compatible_version: str | None = None
     latest_compatible_release_date: str | None = None
     latest_status = "unknown"
-    for version, release_files in sorted(releases.items(), key=lambda item: _version_key(str(item[0])), reverse=True):
+    for version, release_files in sorted(
+        releases.items(), key=lambda item: _version_key(str(item[0])), reverse=True
+    ):
         if not isinstance(version, str) or not isinstance(release_files, list):
             continue
         if not include_prereleases and _is_prerelease_version(version):
@@ -908,7 +907,11 @@ def _build_package_report(
         notes.append("Latest PyPI release is recent enough to merit fast follow-up validation.")
     if project_python_requires:
         notes.append(f"Repo Python support policy: {project_python_requires}.")
-    if compatibility_status == "compatible-available" and compatible_version and compatible_version != latest_version:
+    if (
+        compatibility_status == "compatible-available"
+        and compatible_version
+        and compatible_version != latest_version
+    ):
         notes.append(
             "Newest PyPI release requires a newer Python baseline than this repo; "
             f"using compatible target {compatible_version} for action planning."
@@ -1016,11 +1019,11 @@ def _build_package_report(
 
     next_action = "Keep under observation; no immediate action required."
     if manifest_action == "raise-floor":
-        next_action = (
-            "Raise the tested floor in flexible manifests, refresh pins, and validate the package in the next maintenance window."
-        )
+        next_action = "Raise the tested floor in flexible manifests, refresh pins, and validate the package in the next maintenance window."
     elif manifest_action == "refresh-pin":
-        next_action = "Refresh pinned manifests to the newer tested version and rerun targeted validation."
+        next_action = (
+            "Refresh pinned manifests to the newer tested version and rerun targeted validation."
+        )
     elif upgrade_signal == "critical":
         next_action = (
             "Resolve manifest drift first, then validate the major upgrade in a dedicated branch."
@@ -1044,7 +1047,9 @@ def _build_package_report(
             "Review the declared version range manually because the gap could not be classified."
         )
     elif manifest_action == "establish-baseline":
-        next_action = "Pin or bound the package explicitly before attempting future upgrade automation."
+        next_action = (
+            "Pin or bound the package explicitly before attempting future upgrade automation."
+        )
 
     if manifest_action != "none":
         notes.append(f"Recommended manifest action: {manifest_action}.")
@@ -1324,7 +1329,9 @@ def _report_summary(reports: list[PackageReport]) -> dict[str, int]:
         "declared_only_packages": sum(
             1 for report in reports if report.repo_usage_tier == "declared-only"
         ),
-        "runtime_core_packages": sum(1 for report in reports if report.impact_area == "runtime-core"),
+        "runtime_core_packages": sum(
+            1 for report in reports if report.impact_area == "runtime-core"
+        ),
         "quality_tooling_packages": sum(
             1 for report in reports if report.impact_area == "quality-tooling"
         ),
@@ -1399,6 +1406,31 @@ def _matches_any_filter(values: list[str], allowed_filters: list[str] | None) ->
     return any(filter_value in normalized_values for filter_value in allowed_filters)
 
 
+def _matches_text_query(report: PackageReport, query_terms: list[str] | None) -> bool:
+    if not query_terms:
+        return True
+
+    haystacks = [
+        report.name,
+        report.impact_area,
+        report.manifest_action,
+        report.next_action,
+        report.upgrade_signal,
+        report.alignment,
+        report.constraint_status,
+        report.repo_usage_tier,
+        _recommended_lane(report),
+    ]
+    haystacks.extend(report.groups)
+    haystacks.extend(report.sources)
+    haystacks.extend(report.requirements)
+    haystacks.extend(report.notes)
+    haystacks.extend(report.repo_usage_files)
+    haystacks.extend(report.validation_commands)
+    searchable_text = "\n".join(item for item in haystacks if item).lower()
+    return all(term in searchable_text for term in query_terms)
+
+
 def _matches_dependency_filters(
     deps: list[Dependency],
     *,
@@ -1409,7 +1441,9 @@ def _matches_dependency_filters(
     if packages:
         package_filters = [item.strip().lower() for item in packages if item.strip()]
         if package_filters and not any(
-            fnmatch.fnmatch(dep.name.lower(), pattern) for pattern in package_filters for dep in deps
+            fnmatch.fnmatch(dep.name.lower(), pattern)
+            for pattern in package_filters
+            for dep in deps
         ):
             return False
     if groups:
@@ -1459,6 +1493,7 @@ def _filter_reports(
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
     repo_usage_tiers: list[str] | None = None,
+    queries: list[str] | None = None,
     used_in_repo_only: bool = False,
     outdated_only: bool = False,
     top: int | None = None,
@@ -1477,7 +1512,9 @@ def _filter_reports(
         ]
     if groups:
         group_filters = [item.strip().lower() for item in groups if item.strip()]
-        filtered = [report for report in filtered if _matches_any_filter(report.groups, group_filters)]
+        filtered = [
+            report for report in filtered if _matches_any_filter(report.groups, group_filters)
+        ]
     if sources:
         source_filters = [item.strip().lower() for item in sources if item.strip()]
         filtered = [
@@ -1495,6 +1532,9 @@ def _filter_reports(
     if repo_usage_tiers:
         allowed_tiers = {item.strip() for item in repo_usage_tiers if item.strip()}
         filtered = [report for report in filtered if report.repo_usage_tier in allowed_tiers]
+    if queries:
+        query_terms = [item.strip().lower() for item in queries if item.strip()]
+        filtered = [report for report in filtered if _matches_text_query(report, query_terms)]
     if used_in_repo_only:
         filtered = [report for report in filtered if report.repo_usage_count > 0]
     if outdated_only:
@@ -1557,7 +1597,7 @@ def _render_markdown(
     for item in _priority_queue(reports):
         lines.append(
             f"- `{item['name']}` [{item['signal']}, risk {item['risk_score']}, lane {item['lane']}, action {item['manifest_action']}]"
-            + (f" target `{item['suggested_version']}`" if item['suggested_version'] else "")
+            + (f" target `{item['suggested_version']}`" if item["suggested_version"] else "")
             + f" → {item['next_action']}"
         )
     lines.extend(["", "## Recommended upgrade lanes", ""])
@@ -1675,6 +1715,7 @@ def run(
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
     repo_usage_tiers: list[str] | None = None,
+    queries: list[str] | None = None,
     used_in_repo_only: bool = False,
     outdated_only: bool = False,
     top: int | None = None,
@@ -1760,6 +1801,7 @@ def run(
         impact_areas=impact_areas,
         manifest_actions=manifest_actions,
         repo_usage_tiers=repo_usage_tiers,
+        queries=queries,
         used_in_repo_only=used_in_repo_only,
         outdated_only=outdated_only,
         top=top,
@@ -1926,6 +1968,15 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         help="Show only packages matching the selected observed repo-usage tier(s).",
     )
     parser.add_argument(
+        "--query",
+        action="append",
+        default=None,
+        help=(
+            "Free-text search across package names, lanes, notes, usage files, commands, and "
+            "actions. Can be passed multiple times."
+        ),
+    )
+    parser.add_argument(
         "--used-in-repo-only",
         action="store_true",
         help="Show only packages imported from tracked src/tests Python files.",
@@ -1990,6 +2041,7 @@ def main(argv: list[str] | None = None) -> int:
         impact_areas=args.impact_area,
         manifest_actions=args.manifest_action,
         repo_usage_tiers=args.repo_usage_tier,
+        queries=args.query,
         used_in_repo_only=bool(args.used_in_repo_only),
         outdated_only=bool(args.outdated_only),
         top=args.top,

--- a/tests/test_doctor_upgrade_audit.py
+++ b/tests/test_doctor_upgrade_audit.py
@@ -13,9 +13,7 @@ def _write_minimal_pyproject(root: Path) -> None:
     )
 
 
-def test_doctor_upgrade_audit_emits_priority_hints(
-    tmp_path: Path, monkeypatch, capsys
-) -> None:
+def test_doctor_upgrade_audit_emits_priority_hints(tmp_path: Path, monkeypatch, capsys) -> None:
     _write_minimal_pyproject(tmp_path)
     monkeypatch.chdir(tmp_path)
 
@@ -27,7 +25,9 @@ def test_doctor_upgrade_audit_emits_priority_hints(
         pinned_version=None,
     )
 
-    monkeypatch.setattr(doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: []
+    )
     monkeypatch.setattr(doctor.upgrade_audit, "_load_dependencies", lambda *_args, **_kwargs: [dep])
     monkeypatch.setattr(
         doctor.upgrade_audit,
@@ -60,7 +60,16 @@ def test_doctor_upgrade_audit_emits_priority_hints(
     payload = json.loads(capsys.readouterr().out)
     assert payload["checks"]["upgrade_audit"]["ok"] is True
     assert payload["checks"]["upgrade_audit"]["meta"]["priority_queue"][0]["name"] == "httpx"
+    assert (
+        payload["checks"]["upgrade_audit"]["meta"]["lane_summary"][0]["lane"] == "refresh-baselines"
+    )
+    assert (
+        payload["checks"]["upgrade_audit"]["meta"]["impact_summary"][0]["impact_area"]
+        == "runtime-core"
+    )
     assert any("httpx" in hint for hint in payload["hints"])
+    assert any("impact runtime-core" in hint for hint in payload["hints"])
+    assert any("Runtime lane follow-up" in item for item in payload["recommendations"])
 
 
 def test_doctor_only_upgrade_audit_reports_drift_failure(
@@ -86,13 +95,19 @@ def test_doctor_only_upgrade_audit_reports_drift_failure(
         ),
     ]
 
-    monkeypatch.setattr(doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: []
+    )
     monkeypatch.setattr(doctor.upgrade_audit, "_load_dependencies", lambda *_args, **_kwargs: deps)
-    monkeypatch.setattr(doctor.upgrade_audit, "_load_project_python_requires", lambda *_args, **_kwargs: ">=3.11")
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_load_project_python_requires", lambda *_args, **_kwargs: ">=3.11"
+    )
     monkeypatch.setattr(
         doctor.upgrade_audit,
         "_collect_repo_usage",
-        lambda *_args, **_kwargs: {"httpx": ["src/sdetkit/netclient.py", "tests/test_netclient_extra.py"]},
+        lambda *_args, **_kwargs: {
+            "httpx": ["src/sdetkit/netclient.py", "tests/test_netclient_extra.py"]
+        },
     )
     monkeypatch.setattr(
         doctor.upgrade_audit,

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -420,8 +420,14 @@ dependencies = ["httpx>=0.27,<1"]
     assert "actionable upgrade candidates: 1" in out
     assert "declared-only packages: 1" in out
     assert "runtime core packages: 1" in out
-    assert "Impact | Repo usage | Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested" in out
-    assert "`httpx` | runtime-core | declared-only (0) | `0.28.1` | `0.29.0` | `0.29.0` | compatible-latest | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |" in out
+    assert (
+        "Impact | Repo usage | Current | Target | Latest PyPI | Py policy | Source | Gap | Alignment | Policy | Signal | Risk | Action | Suggested"
+        in out
+    )
+    assert (
+        "`httpx` | runtime-core | declared-only (0) | `0.28.1` | `0.29.0` | `0.29.0` | compatible-latest | pypi | minor | floor-lock | blocked | medium | 50 | stage-upgrade | 0.29.0 |"
+        in out
+    )
     assert "Priority queue" in out
     assert "Repo usage tiers" in out
     assert "Repo impact map" in out
@@ -1219,6 +1225,35 @@ def test_filter_reports_supports_repo_usage_filters() -> None:
     assert [report.name for report in filtered] == ["httpx", "ruff"]
 
 
+def test_filter_reports_supports_text_query_across_actions_and_notes() -> None:
+    reports = [
+        _report(
+            name="httpx",
+            manifest_action="stage-upgrade",
+            impact_area="runtime-core",
+            next_action="Queue the upgrade for the next maintenance batch.",
+            notes=["Observed in src/sdetkit/netclient.py."],
+            repo_usage_files=["src/sdetkit/netclient.py"],
+            validation_commands=["bash ci.sh quick --skip-docs --artifact-dir build"],
+        ),
+        _report(
+            name="ruff",
+            manifest_action="none",
+            impact_area="quality-tooling",
+            next_action="Keep under observation; no immediate action required.",
+            notes=["Latest metadata source: cache."],
+            validation_commands=["bash quality.sh ci"],
+        ),
+    ]
+
+    filtered = upgrade_audit._filter_reports(
+        reports,
+        queries=["runtime-core", "netclient.py", "stage-upgrade"],
+    )
+
+    assert [report.name for report in filtered] == ["httpx"]
+
+
 def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[project]\ndependencies=[]\n", encoding="utf-8")
@@ -1237,6 +1272,8 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
             "pyproject.toml",
             "--repo-usage-tier",
             "hot-path",
+            "--query",
+            "runtime-core",
             "--used-in-repo-only",
         ]
     )
@@ -1250,6 +1287,7 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
     assert args.impact_area is None
     assert args.manifest_action is None
     assert args.repo_usage_tier == ["hot-path"]
+    assert args.query == ["runtime-core"]
     assert args.used_in_repo_only is True
     assert args.include_prereleases is False
     assert requirement_paths == []


### PR DESCRIPTION
### Motivation
- Make the upgrade-audit output more searchable so maintainers can find packages by name, lane, notes, usage files, validation commands, or actions. 
- Surface lane/impact/repo-usage summaries from the audit so `doctor --upgrade-audit` can give higher-value, lane-aware recommendations instead of only listing raw package bullets. 
- Improve actionable guidance for quality, runtime, and integration work to speed triage and maintenance planning.

### Description
- Added a free-text search helper `_matches_text_query` and a `--query`/`--query ...` CLI flag to `upgrade-audit` that searches names, lanes, notes, repo-usage files, validation commands, and other package report fields and threads that filter through `_filter_reports` into `run`.
- Emitted lane, impact, and repo-usage summaries from `upgrade_audit` into the doctor check meta (`lane_summary`, `impact_summary`, `repo_usage_summary`) and threaded those summaries into `doctor` metadata.
- Enhanced `doctor` to convert lane/impact summaries into clearer `hints` and `recommendations` (runtime-core, quality-tooling, integration-adapters follow-ups) with suggested validation commands.
- Updated tests to cover text-query filtering and the richer doctor upgrade-audit metadata and behavior, and updated docs/README to document `--query` and the new summary-driven guidance.

### Testing
- Ran targeted unit tests: `python -m pytest -q tests/test_doctor_upgrade_audit.py tests/test_upgrade_audit_script.py` and the suite passed (32 passed across the targeted tests).
- Ran style and formatting checks: `python -m ruff check ...` and `python -m ruff format --check ...` (no lint failures; files reformatted where necessary during the change cycle).
- Executed runtime smoke: `python -m sdetkit.doctor --upgrade-audit --upgrade-audit-offline --format json` to exercise the integrated output and confirm hints/recommendations appear as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb76d7456883208ffbcdae605d129f)