### PR TITLE
Boost doctor upgrade-audit focus and quality summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,14 @@ python scripts/upgrade_audit.py --repo-usage-tier active --used-in-repo-only --t
 python scripts/upgrade_audit.py --metadata-source cache-stale --outdated-only
 python scripts/upgrade_audit.py --group requirements --source requirements.txt --top 10
 python -m sdetkit doctor --upgrade-audit --upgrade-audit-offline --format json
+python -m sdetkit doctor --upgrade-audit --upgrade-audit-query quality --upgrade-audit-impact-area quality-tooling --upgrade-audit-top 5 --format md
+python -m sdetkit doctor --upgrade-audit --upgrade-audit-manifest-action refresh-pin --upgrade-audit-top 3 --format json
 bash quality.sh doctor
 ```
 
 By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue. When you already know the maintenance lane you want, filter directly by `--manifest-action` to isolate packages that need a pin refresh, floor raise, staged upgrade, or dedicated major-upgrade branch. Use `--query` when you want text search across package names, notes, repo-usage files, recommended lanes, and validation commands without pre-classifying the package first.
+
+The doctor surface now carries those same upgrade-audit focus controls, so you can search and narrow dependency work without leaving the readiness report. It also emits a quality summary block with pass/fail/skipped counts, pass rate, failing check IDs, and hint coverage so the readiness signal is easier to scan in CI, markdown, and JSON outputs.
 
 To make those upgrade lanes reproducible in CI, the repo now pins the validated toolchain in `constraints-ci.txt` while leaving `pyproject.toml` flexible enough for package consumers.
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -7,6 +7,8 @@
 - `sdetkit doctor --all --format json`
 - `sdetkit doctor --dev --ci --deps --clean-tree --repo --format md`
 - `sdetkit doctor --upgrade-audit --upgrade-audit-offline --format json`
+- `sdetkit doctor --upgrade-audit --upgrade-audit-query quality --upgrade-audit-impact-area quality-tooling --upgrade-audit-top 5 --format md`
+- `sdetkit doctor --upgrade-audit --upgrade-audit-manifest-action refresh-pin --upgrade-audit-top 3 --format json`
 - `sdetkit doctor --only pyproject --format json`
 - `bash quality.sh doctor`
 
@@ -36,6 +38,16 @@ repo impact areas, recommended lanes, and validation commands so dependency plan
 of the same readiness report. The upgrade-audit metadata now also carries lane and impact summaries,
 so doctor recommendations can call out quality-tooling, runtime-core, and integration-adapter work
 with concrete follow-up commands instead of only listing raw packages.
+
+Doctor also exposes focused upgrade-audit controls directly from the readiness surface:
+
+- `--upgrade-audit-query` to search across package names, lanes, notes, usage files, and commands.
+- `--upgrade-audit-impact-area` to zoom into runtime-core, quality-tooling, integration-adapters, and other repo impact maps.
+- `--upgrade-audit-manifest-action` to isolate pin refresh, floor raise, staged upgrade, and major-planning work.
+- `--upgrade-audit-top` to trim the result set to the highest-risk matching packages.
+
+All output formats now include a quality summary that reports pass/fail/skipped check counts,
+pass rate, highest failure severity, failing check IDs, and hint/fix/evidence coverage.
 
 ## Determinism
 

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -706,7 +706,60 @@ def _recommendations(data: dict[str, Any]) -> list[str]:
     return recs
 
 
-def _build_hints(data: dict[str, Any]) -> list[str]:
+def _build_quality_summary(
+    checks: dict[str, dict[str, Any]],
+    *,
+    selected_checks: list[str],
+    hints: list[str] | None = None,
+) -> dict[str, Any]:
+    ordered_selected = [check_id for check_id in CHECK_ORDER if check_id in selected_checks]
+    passed = 0
+    failed = 0
+    skipped = 0
+    highest_failure_severity = "none"
+    highest_failure_rank = 0
+    failed_check_ids: list[str] = []
+    fix_count = 0
+    evidence_count = 0
+
+    for check_id in ordered_selected:
+        item = checks.get(check_id, {})
+        if item.get("skipped"):
+            skipped += 1
+            continue
+        if item.get("ok"):
+            passed += 1
+            continue
+        failed += 1
+        failed_check_ids.append(check_id)
+        severity = str(item.get("severity", "medium"))
+        severity_rank = SEVERITY_ORDER.get(severity, 0)
+        if severity_rank > highest_failure_rank:
+            highest_failure_rank = severity_rank
+            highest_failure_severity = severity
+        fix_count += len(item.get("fix", []))
+        evidence_count += len(item.get("evidence", []))
+
+    total = len(ordered_selected)
+    actionable = passed + failed
+    pass_rate = 100 if actionable == 0 else round((passed / actionable) * 100)
+
+    return {
+        "selected_checks": total,
+        "actionable_checks": actionable,
+        "passed_checks": passed,
+        "failed_checks": failed,
+        "skipped_checks": skipped,
+        "pass_rate": pass_rate,
+        "highest_failure_severity": highest_failure_severity,
+        "failed_check_ids": failed_check_ids,
+        "fix_count": fix_count,
+        "evidence_count": evidence_count,
+        "hint_count": len(hints or []),
+    }
+
+
+def _build_hints(data: dict[str, Any], *, limit: int = 5) -> list[str]:
     hints: list[str] = []
 
     next_actions = data.get("next_actions", [])
@@ -744,13 +797,22 @@ def _build_hints(data: dict[str, Any]) -> list[str]:
             if isinstance(validations, list) and validations:
                 validation = str(validations[0]).strip()
             lane = str(item.get("lane", "")).strip()
-            detail = f"{name}: {action or 'review'}"
-            if target:
-                detail += f" -> {target}"
+            actionable = action and action != "none"
+            if actionable:
+                detail = f"{name}: {action}"
+                if target:
+                    detail += f" -> {target}"
+                if lane:
+                    detail += f" [{lane}]"
+                if validation:
+                    detail += f" — validate with {validation}"
+                hints.append(detail)
+                continue
+            detail = f"watchlist {name}"
             if lane:
                 detail += f" [{lane}]"
             if validation:
-                detail += f" — validate with {validation}"
+                detail += f" — keep validating with {validation}"
             hints.append(detail)
 
     lane_summary = upgrade_meta.get("lane_summary", [])
@@ -760,6 +822,7 @@ def _build_hints(data: dict[str, Any]) -> list[str]:
                 continue
             lane = str(item.get("lane", "")).strip()
             count = int(item.get("count", 0))
+            actionable = int(item.get("actionable_packages", 0))
             packages = item.get("packages", [])
             package_text = ""
             if isinstance(packages, list) and packages:
@@ -768,6 +831,8 @@ def _build_hints(data: dict[str, Any]) -> list[str]:
                 )
             if lane and count > 0:
                 detail = f"lane {lane}: {count} package(s)"
+                if actionable > 0:
+                    detail += f", actionable {actionable}"
                 if package_text:
                     detail += f" — focus on {package_text}"
                 hints.append(detail)
@@ -797,13 +862,17 @@ def _build_hints(data: dict[str, Any]) -> list[str]:
             continue
         seen.add(normalized)
         deduped.append(normalized)
-    return deduped[:5]
+    return deduped[: max(limit, 0)]
 
 
 def _check_upgrade_audit(
     root: Path,
     *,
     offline: bool,
+    queries: list[str] | None = None,
+    impact_areas: list[str] | None = None,
+    manifest_actions: list[str] | None = None,
+    top: int | None = None,
 ) -> tuple[bool, str, list[dict[str, Any]], list[str], dict[str, Any]]:
     pyproject_path = root / "pyproject.toml"
     if not pyproject_path.exists():
@@ -873,23 +942,35 @@ def _check_upgrade_audit(
             )
         )
     reports = upgrade_audit._sort_reports(reports)
-    actionable = [report for report in reports if upgrade_audit._is_actionable_upgrade(report)]
-    priority_source = actionable if actionable else reports
+    filtered_reports = upgrade_audit._filter_reports(
+        reports,
+        impact_areas=impact_areas,
+        manifest_actions=manifest_actions,
+        queries=queries,
+        top=top,
+    )
+    actionable = [
+        report for report in filtered_reports if upgrade_audit._is_actionable_upgrade(report)
+    ]
+    priority_source = actionable if actionable else filtered_reports
     priority_queue = upgrade_audit._priority_queue(priority_source, limit=3)
 
     has_high_risk = any(report.upgrade_signal in {"critical", "high"} for report in actionable)
-    has_drift = any(report.alignment == "drift" for report in reports)
+    has_drift = any(report.alignment == "drift" for report in filtered_reports)
     ok = not has_high_risk and not has_drift
 
     summary_bits = [f"{len(actionable)} actionable package(s)"]
+    if len(filtered_reports) != len(reports):
+        summary_bits.append(f"focused view {len(filtered_reports)}/{len(reports)} package(s)")
     if priority_queue:
-        top = priority_queue[0]
-        top_name = str(top.get("name", "")).strip()
-        top_signal = str(top.get("signal", "")).strip()
-        top_action = str(top.get("manifest_action", "")).strip()
+        top_item = priority_queue[0]
+        top_name = str(top_item.get("name", "")).strip()
+        top_signal = str(top_item.get("signal", "")).strip()
+        top_action = str(top_item.get("manifest_action", "")).strip()
         if top_name:
+            summary_label = "watchlist led by" if top_action == "none" else "top priority"
             summary_bits.append(
-                f"top priority {top_name} [{top_signal or 'watch'} / {top_action or 'review'}]"
+                f"{summary_label} {top_name} [{top_signal or 'watch'} / {top_action or 'review'}]"
             )
     summary = "upgrade audit found " + "; ".join(summary_bits)
 
@@ -901,6 +982,7 @@ def _check_upgrade_audit(
         impact_area = str(item.get("impact_area", "")).strip()
         next_action = str(item.get("next_action", "")).strip()
         version = str(item.get("suggested_version", "")).strip()
+        actionable_item = bool(action and action != "none")
         message = f"{name}: {signal or 'watch'} / {action or 'review'}"
         if version:
             message += f" -> {version}"
@@ -908,6 +990,8 @@ def _check_upgrade_audit(
             message += f" [{impact_area}]"
         if next_action:
             message += f" — {next_action}"
+        elif not actionable_item:
+            message += " — no immediate manifest change required"
         evidence.append({"type": "upgrade_priority", "message": message, "path": "pyproject.toml"})
 
     fix = [
@@ -926,19 +1010,34 @@ def _check_upgrade_audit(
 
     meta = {
         "packages_audited": len(reports),
+        "packages_in_scope": len(filtered_reports),
         "actionable_packages": len(actionable),
         "priority_queue": priority_queue,
-        "lane_summary": upgrade_audit._lane_summary(reports),
-        "impact_summary": upgrade_audit._impact_summary(reports),
-        "repo_usage_summary": upgrade_audit._repo_usage_summary(reports),
+        "lane_summary": upgrade_audit._lane_summary(filtered_reports),
+        "impact_summary": upgrade_audit._impact_summary(filtered_reports),
+        "repo_usage_summary": upgrade_audit._repo_usage_summary(filtered_reports),
         "offline": offline,
         "requirements": [path.name for path in requirement_paths],
+        "filters": {
+            "queries": queries or [],
+            "impact_areas": impact_areas or [],
+            "manifest_actions": manifest_actions or [],
+            "top": top,
+        },
     }
     return ok, summary, evidence, deduped_fix[:5], meta
 
 
 def _print_human_report(data: dict[str, Any]) -> None:
     lines = [f"doctor score: {data['score']}%"]
+    quality = data.get("quality", {})
+    if isinstance(quality, dict) and quality:
+        lines.append(
+            "quality: "
+            f"{quality.get('passed_checks', 0)} passed / "
+            f"{quality.get('failed_checks', 0)} failed / "
+            f"{quality.get('skipped_checks', 0)} skipped"
+        )
     checks = data.get("checks", {})
     for key in sorted(checks):
         item = checks[key]
@@ -957,10 +1056,17 @@ def _print_human_report(data: dict[str, Any]) -> None:
 
 def _print_pr_report(data: dict[str, Any]) -> None:
     checks = data.get("checks", {})
+    quality = data.get("quality", {})
     lines = [
         "### SDET Doctor Report",
         f"- overall: {'PASS' if data.get('ok') else 'FAIL'}",
         f"- score: {data.get('score')}%",
+        (
+            "- quality: "
+            f"{quality.get('passed_checks', 0)} passed / "
+            f"{quality.get('failed_checks', 0)} failed / "
+            f"{quality.get('skipped_checks', 0)} skipped"
+        ),
         "- checks:",
     ]
     for key in sorted(checks):
@@ -981,10 +1087,17 @@ def _print_pr_report(data: dict[str, Any]) -> None:
 def _format_doctor_markdown(data: dict[str, Any]) -> str:
     checks = data.get("checks", {})
     ordered_ids = sorted(checks)
+    quality = data.get("quality", {})
     lines = [
         "### SDET Doctor Report",
         f"- overall: {'PASS' if data.get('ok') else 'FAIL'}",
         f"- score: {data.get('score')}%",
+        (
+            "- quality: "
+            f"{quality.get('passed_checks', 0)} passed / "
+            f"{quality.get('failed_checks', 0)} failed / "
+            f"{quality.get('skipped_checks', 0)} skipped"
+        ),
         "",
         "| Check | Severity | Status | Summary |",
         "| --- | --- | --- | --- |",
@@ -1005,6 +1118,27 @@ def _format_doctor_markdown(data: dict[str, Any]) -> str:
         for fix in item.get("fix", []):
             action_rows.append((rank, check_id, str(fix)))
 
+    lines.append("")
+    lines.append("#### Quality summary")
+    if isinstance(quality, dict) and quality:
+        lines.append(
+            f"- pass rate: {quality.get('pass_rate', 0)}% across {quality.get('actionable_checks', 0)} actionable check(s)"
+        )
+        lines.append(
+            f"- highest failure severity: {quality.get('highest_failure_severity', 'none')}"
+        )
+        failed_check_ids = quality.get("failed_check_ids", [])
+        if isinstance(failed_check_ids, list) and failed_check_ids:
+            lines.append(
+                "- failing checks: " + ", ".join(f"`{check_id}`" for check_id in failed_check_ids)
+            )
+        else:
+            lines.append("- failing checks: none")
+        lines.append(
+            f"- hint coverage: {quality.get('hint_count', 0)} hint(s), {quality.get('fix_count', 0)} fix item(s), {quality.get('evidence_count', 0)} evidence item(s)"
+        )
+    else:
+        lines.append("- None")
     lines.append("")
     lines.append("#### Action items")
     if action_rows:
@@ -1180,6 +1314,52 @@ def main(argv: list[str] | None = None) -> int:
         dest="upgrade_audit_offline",
         action="store_true",
         help="Use cached metadata only for upgrade-audit hints.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-query",
+        dest="upgrade_audit_queries",
+        action="append",
+        default=None,
+        help="Focus doctor upgrade-audit hints using free-text search across packages, lanes, notes, and commands.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-impact-area",
+        dest="upgrade_audit_impact_areas",
+        action="append",
+        choices=[
+            "runtime-core",
+            "quality-tooling",
+            "integration-adapters",
+            "docs-tooling",
+            "packaging-release",
+            "security-compliance",
+            "repo-tooling",
+        ],
+        default=None,
+        help="Focus doctor upgrade-audit hints on specific repo impact areas.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-manifest-action",
+        dest="upgrade_audit_manifest_actions",
+        action="append",
+        choices=[
+            "none",
+            "refresh-pin",
+            "raise-floor",
+            "stage-upgrade",
+            "plan-major-upgrade",
+            "establish-baseline",
+            "investigate-metadata",
+        ],
+        default=None,
+        help="Focus doctor upgrade-audit hints on specific manifest actions.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-top",
+        dest="upgrade_audit_top",
+        type=int,
+        default=None,
+        help="Limit doctor upgrade-audit hint generation to the highest-risk N matching packages.",
     )
     parser.add_argument("--dev", action="store_true")
     parser.add_argument("--pyproject", action="store_true")
@@ -1604,6 +1784,10 @@ def main(argv: list[str] | None = None) -> int:
         ua_ok, ua_summary, ua_evidence, ua_fix, ua_meta = _check_upgrade_audit(
             root,
             offline=bool(ns.upgrade_audit_offline),
+            queries=ns.upgrade_audit_queries,
+            impact_areas=ns.upgrade_audit_impact_areas,
+            manifest_actions=ns.upgrade_audit_manifest_actions,
+            top=ns.upgrade_audit_top,
         )
         data["upgrade_audit_ok"] = ua_ok
         data["checks"]["upgrade_audit"] = _make_check(
@@ -1672,6 +1856,11 @@ def main(argv: list[str] | None = None) -> int:
     data["score"] = _calculate_score(score_items)
     data["recommendations"] = _recommendations(data)
     data["hints"] = _build_hints(data)
+    data["quality"] = _build_quality_summary(
+        data["checks"],
+        selected_checks=data["selected_checks"],
+        hints=data["hints"],
+    )
     data["ok"] = bool(gate_ok)
     if failed_checks:
         data["failed_checks"] = failed_checks

--- a/tests/test_doctor_md_and_out.py
+++ b/tests/test_doctor_md_and_out.py
@@ -27,6 +27,7 @@ def test_doctor_markdown_contains_table_actions_and_stable_order(tmp_path: Path)
     assert proc.returncode == 2
     assert "### SDET Doctor Report" in proc.stdout
     assert "| Check | Severity | Status | Summary |" in proc.stdout
+    assert "#### Quality summary" in proc.stdout
     assert "#### Action items" in proc.stdout
     assert "#### Evidence" in proc.stdout
 

--- a/tests/test_doctor_upgrade_audit.py
+++ b/tests/test_doctor_upgrade_audit.py
@@ -67,9 +67,11 @@ def test_doctor_upgrade_audit_emits_priority_hints(tmp_path: Path, monkeypatch, 
         payload["checks"]["upgrade_audit"]["meta"]["impact_summary"][0]["impact_area"]
         == "runtime-core"
     )
-    assert any("httpx" in hint for hint in payload["hints"])
+    assert any("httpx: raise-floor" in hint for hint in payload["hints"])
     assert any("impact runtime-core" in hint for hint in payload["hints"])
     assert any("Runtime lane follow-up" in item for item in payload["recommendations"])
+    assert payload["quality"]["passed_checks"] >= 1
+    assert payload["quality"]["hint_count"] == len(payload["hints"])
 
 
 def test_doctor_only_upgrade_audit_reports_drift_failure(
@@ -131,3 +133,94 @@ def test_doctor_only_upgrade_audit_reports_drift_failure(
     assert payload["checks"]["upgrade_audit"]["ok"] is False
     assert payload["failed_checks"] == ["upgrade_audit"]
     assert payload["selected_checks"] == ["upgrade_audit"]
+    assert payload["quality"]["failed_checks"] == 1
+
+
+def test_doctor_upgrade_audit_supports_query_and_action_filters(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_minimal_pyproject(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    deps = [
+        doctor.upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="default",
+            raw="httpx>=0.28.1,<1",
+            name="httpx",
+            pinned_version=None,
+        ),
+        doctor.upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="dev",
+            raw="mypy==1.19.1",
+            name="mypy",
+            pinned_version="1.19.1",
+        ),
+    ]
+
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(doctor.upgrade_audit, "_load_dependencies", lambda *_args, **_kwargs: deps)
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_load_project_python_requires", lambda *_args, **_kwargs: ">=3.11"
+    )
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_repo_usage",
+        lambda *_args, **_kwargs: {
+            "httpx": ["src/sdetkit/netclient.py"],
+            "mypy": ["src/sdetkit/doctor.py"],
+        },
+    )
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_package_metadata",
+        lambda *_args, **_kwargs: {
+            "httpx": doctor.upgrade_audit.PackageMetadata(
+                latest_version="0.29.0",
+                release_date="2026-03-01T00:00:00+00:00",
+                compatible_version="0.29.0",
+                compatible_release_date="2026-03-01T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="cache",
+            ),
+            "mypy": doctor.upgrade_audit.PackageMetadata(
+                latest_version="9.0.0",
+                release_date="2026-03-01T00:00:00+00:00",
+                compatible_version="9.0.0",
+                compatible_release_date="2026-03-01T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="cache",
+            ),
+        },
+    )
+
+    rc = doctor.main(
+        [
+            "--upgrade-audit",
+            "--upgrade-audit-query",
+            "quality",
+            "--upgrade-audit-impact-area",
+            "quality-tooling",
+            "--upgrade-audit-manifest-action",
+            "plan-major-upgrade",
+            "--upgrade-audit-top",
+            "1",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    meta = payload["checks"]["upgrade_audit"]["meta"]
+    assert meta["packages_audited"] == 2
+    assert meta["packages_in_scope"] == 1
+    assert meta["filters"]["queries"] == ["quality"]
+    assert meta["filters"]["impact_areas"] == ["quality-tooling"]
+    assert meta["filters"]["manifest_actions"] == ["plan-major-upgrade"]
+    assert meta["filters"]["top"] == 1
+    assert meta["priority_queue"][0]["name"] == "mypy"
+    assert any("mypy" in hint for hint in payload["hints"])


### PR DESCRIPTION
### Motivation

- Improve the usefulness of the `doctor` readiness surface for dependency maintenance by enabling focused, queryable upgrade-audit views. 
- Make readiness signals easier to scan in CI and PRs by surfacing a compact machine-readable quality summary (pass/fail/skipped, pass rate, failing check IDs, hint/fix/evidence counts). 
- Clarify upgrade hints so watchlist items and actionable items read cleanly and recommend concrete validation commands when available.

### Description

- Add focused upgrade-audit CLI filters to `doctor`: `--upgrade-audit-query`, `--upgrade-audit-impact-area`, `--upgrade-audit-manifest-action`, and `--upgrade-audit-top`, and thread them into `_check_upgrade_audit` to scope reports via `upgrade_audit._filter_reports`.
- Add `_build_quality_summary` to compute `selected_checks`, `actionable_checks`, `passed_checks`, `failed_checks`, `skipped_checks`, `pass_rate`, `highest_failure_severity`, `failed_check_ids`, `fix_count`, `evidence_count`, and `hint_count`, and attach it to `data["quality"]` for JSON/MD/text outputs.
- Improve hint generation in `_build_hints` to: format actionable items (`<name>: <action> -> <target> [lane] — validate with <cmd>`), present non-actionable items as `watchlist <name> [...] — keep validating with <cmd>`, and include actionable counts in lane/impact lines.
- Surface the quality summary in human, PR, and Markdown renderers (`_print_human_report`, `_print_pr_report`, `_format_doctor_markdown`) and add filter metadata (`meta["filters"]`, `packages_in_scope`) into upgrade-audit meta.
- Update tests and docs: modify and extend `tests/test_doctor_upgrade_audit.py` and `tests/test_doctor_md_and_out.py`, update `README.md` and `docs/doctor.md` with usage examples and notes.

### Testing

- Ran the targeted unit tests: `python -m pytest -q tests/test_doctor_upgrade_audit.py tests/test_doctor_md_and_out.py tests/test_cli_doctor.py`, and additional doctor suites `python -m pytest -q tests/test_doctor_plan.py tests/test_doctor_devx.py tests/test_doctor_diagnostics.py`, all of which passed.
- Linted the changed modules with `ruff` (`python -m ruff check src/sdetkit/doctor.py tests/test_doctor_upgrade_audit.py tests/test_doctor_md_and_out.py`) and it succeeded.
- Exercised the new CLI flows manually: `python -m sdetkit.doctor --upgrade-audit --upgrade-audit-query quality --upgrade-audit-impact-area quality-tooling --upgrade-audit-top 5 --format md` and verified focused output and quality summary rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb78aa495c832085e584210d89cf19)