### PR TITLE
Boost doctor upgrade-audit focus controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ python scripts/upgrade_audit.py --group requirements --source requirements.txt -
 python -m sdetkit doctor --upgrade-audit --upgrade-audit-offline --format json
 python -m sdetkit doctor --upgrade-audit --upgrade-audit-query quality --upgrade-audit-impact-area quality-tooling --upgrade-audit-top 5 --format md
 python -m sdetkit doctor --upgrade-audit --upgrade-audit-manifest-action refresh-pin --upgrade-audit-top 3 --format json
+python -m sdetkit doctor --upgrade-audit --upgrade-audit-package "http*" --upgrade-audit-source pyproject.toml --upgrade-audit-metadata-source cache-stale --format json
+python -m sdetkit doctor --upgrade-audit --upgrade-audit-policy blocked --upgrade-audit-repo-usage-tier hot-path --upgrade-audit-used-in-repo-only --format md
 bash quality.sh doctor
 ```
 
 By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue. When you already know the maintenance lane you want, filter directly by `--manifest-action` to isolate packages that need a pin refresh, floor raise, staged upgrade, or dedicated major-upgrade branch. Use `--query` when you want text search across package names, notes, repo-usage files, recommended lanes, and validation commands without pre-classifying the package first.
 
-The doctor surface now carries those same upgrade-audit focus controls, so you can search and narrow dependency work without leaving the readiness report. It also emits a quality summary block with pass/fail/skipped counts, pass rate, failing check IDs, and hint coverage so the readiness signal is easier to scan in CI, markdown, and JSON outputs.
+The doctor surface now carries those same upgrade-audit focus controls, so you can search and narrow dependency work without leaving the readiness report. In addition to query, impact-area, and manifest-action targeting, doctor now supports package, manifest source, metadata source, signal, policy, and repo-usage-tier filters plus `--upgrade-audit-used-in-repo-only` / `--upgrade-audit-outdated-only` for tighter maintenance slices. The readiness payload also exposes grouped action, dependency-group, and manifest-source summaries so CI and PR checks can explain which upgrade lane is hottest without re-running the full audit. It also emits a quality summary block with pass/fail/skipped counts, pass rate, failing check IDs, and hint coverage so the readiness signal is easier to scan in CI, markdown, and JSON outputs.
 
 To make those upgrade lanes reproducible in CI, the repo now pins the validated toolchain in `constraints-ci.txt` while leaving `pyproject.toml` flexible enough for package consumers.
 

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -854,6 +854,38 @@ def _build_hints(data: dict[str, Any], *, limit: int = 5) -> list[str]:
                     detail += f" — validate with {command_text}"
                 hints.append(detail)
 
+    action_summary = upgrade_meta.get("action_summary", [])
+    if isinstance(action_summary, list):
+        for item in action_summary[:2]:
+            if not isinstance(item, dict):
+                continue
+            action = str(item.get("manifest_action", "")).strip()
+            count = int(item.get("count", 0))
+            packages = item.get("packages", [])
+            package_text = ""
+            if isinstance(packages, list) and packages:
+                package_text = ", ".join(
+                    str(name).strip() for name in packages[:3] if str(name).strip()
+                )
+            if action and count > 0:
+                detail = f"action {action}: {count} package(s)"
+                if package_text:
+                    detail += f" — includes {package_text}"
+                hints.append(detail)
+
+    for key, label in (("group_summary", "group"), ("source_summary", "source")):
+        summary_rows = upgrade_meta.get(key, [])
+        if not isinstance(summary_rows, list):
+            continue
+        for item in summary_rows[:2]:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get(label, "")).strip()
+            count = int(item.get("count", 0))
+            actionable = int(item.get("actionable_packages", 0))
+            if name and count > 0 and actionable > 0:
+                hints.append(f"{label} {name}: {count} package(s), actionable {actionable}")
+
     deduped: list[str] = []
     seen: set[str] = set()
     for hint in hints:
@@ -869,9 +901,18 @@ def _check_upgrade_audit(
     root: Path,
     *,
     offline: bool,
+    signals: list[str] | None = None,
+    policies: list[str] | None = None,
+    packages: list[str] | None = None,
+    groups: list[str] | None = None,
+    sources: list[str] | None = None,
+    metadata_sources: list[str] | None = None,
     queries: list[str] | None = None,
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
+    repo_usage_tiers: list[str] | None = None,
+    used_in_repo_only: bool = False,
+    outdated_only: bool = False,
     top: int | None = None,
 ) -> tuple[bool, str, list[dict[str, Any]], list[str], dict[str, Any]]:
     pyproject_path = root / "pyproject.toml"
@@ -944,9 +985,18 @@ def _check_upgrade_audit(
     reports = upgrade_audit._sort_reports(reports)
     filtered_reports = upgrade_audit._filter_reports(
         reports,
+        signals=signals,
+        policies=policies,
+        packages=packages,
+        groups=groups,
+        sources=sources,
+        metadata_sources=metadata_sources,
         impact_areas=impact_areas,
         manifest_actions=manifest_actions,
+        repo_usage_tiers=repo_usage_tiers,
         queries=queries,
+        used_in_repo_only=used_in_repo_only,
+        outdated_only=outdated_only,
         top=top,
     )
     actionable = [
@@ -1016,12 +1066,24 @@ def _check_upgrade_audit(
         "lane_summary": upgrade_audit._lane_summary(filtered_reports),
         "impact_summary": upgrade_audit._impact_summary(filtered_reports),
         "repo_usage_summary": upgrade_audit._repo_usage_summary(filtered_reports),
+        "action_summary": upgrade_audit._action_summary(filtered_reports),
+        "group_summary": upgrade_audit._group_summary(filtered_reports),
+        "source_summary": upgrade_audit._source_summary(filtered_reports),
         "offline": offline,
         "requirements": [path.name for path in requirement_paths],
         "filters": {
+            "signals": signals or [],
+            "policies": policies or [],
+            "packages": packages or [],
+            "groups": groups or [],
+            "sources": sources or [],
+            "metadata_sources": metadata_sources or [],
             "queries": queries or [],
             "impact_areas": impact_areas or [],
             "manifest_actions": manifest_actions or [],
+            "repo_usage_tiers": repo_usage_tiers or [],
+            "used_in_repo_only": used_in_repo_only,
+            "outdated_only": outdated_only,
             "top": top,
         },
     }
@@ -1282,6 +1344,17 @@ def main(argv: list[str] | None = None) -> int:
         "--apply-plan",
         "--snapshot",
         "--diff-snapshot",
+        "--upgrade-audit-signal",
+        "--upgrade-audit-policy",
+        "--upgrade-audit-package",
+        "--upgrade-audit-group",
+        "--upgrade-audit-source",
+        "--upgrade-audit-metadata-source",
+        "--upgrade-audit-query",
+        "--upgrade-audit-impact-area",
+        "--upgrade-audit-manifest-action",
+        "--upgrade-audit-repo-usage-tier",
+        "--upgrade-audit-top",
     }
     i = 0
     while i < len(args0):
@@ -1314,6 +1387,51 @@ def main(argv: list[str] | None = None) -> int:
         dest="upgrade_audit_offline",
         action="store_true",
         help="Use cached metadata only for upgrade-audit hints.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-signal",
+        dest="upgrade_audit_signals",
+        action="append",
+        choices=["critical", "high", "medium", "watch", "investigate", "unknown"],
+        default=None,
+        help="Focus doctor upgrade-audit hints on specific upgrade signal severities.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-policy",
+        dest="upgrade_audit_policies",
+        action="append",
+        choices=["allowed", "blocked", "no-spec"],
+        default=None,
+        help="Focus doctor upgrade-audit hints on version-policy status.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-package",
+        dest="upgrade_audit_packages",
+        action="append",
+        default=None,
+        help="Focus doctor upgrade-audit hints on one or more package names or glob patterns.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-group",
+        dest="upgrade_audit_groups",
+        action="append",
+        default=None,
+        help="Focus doctor upgrade-audit hints on dependency groups such as default, dev, test, or docs.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-source",
+        dest="upgrade_audit_sources",
+        action="append",
+        default=None,
+        help="Focus doctor upgrade-audit hints on manifest sources such as pyproject.toml or requirements.txt.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-metadata-source",
+        dest="upgrade_audit_metadata_sources",
+        action="append",
+        choices=["pypi", "cache", "cache-stale", "offline-no-cache", "error"],
+        default=None,
+        help="Focus doctor upgrade-audit hints on where package metadata came from.",
     )
     parser.add_argument(
         "--upgrade-audit-query",
@@ -1360,6 +1478,26 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         default=None,
         help="Limit doctor upgrade-audit hint generation to the highest-risk N matching packages.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-repo-usage-tier",
+        dest="upgrade_audit_repo_usage_tiers",
+        action="append",
+        choices=["hot-path", "active", "edge", "declared-only"],
+        default=None,
+        help="Focus doctor upgrade-audit hints on packages by repo-usage tier.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-used-in-repo-only",
+        dest="upgrade_audit_used_in_repo_only",
+        action="store_true",
+        help="Limit doctor upgrade-audit hints to dependencies that appear in repo code or tests.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-outdated-only",
+        dest="upgrade_audit_outdated_only",
+        action="store_true",
+        help="Limit doctor upgrade-audit hints to actionable upgrades only.",
     )
     parser.add_argument("--dev", action="store_true")
     parser.add_argument("--pyproject", action="store_true")
@@ -1784,9 +1922,18 @@ def main(argv: list[str] | None = None) -> int:
         ua_ok, ua_summary, ua_evidence, ua_fix, ua_meta = _check_upgrade_audit(
             root,
             offline=bool(ns.upgrade_audit_offline),
+            signals=ns.upgrade_audit_signals,
+            policies=ns.upgrade_audit_policies,
+            packages=ns.upgrade_audit_packages,
+            groups=ns.upgrade_audit_groups,
+            sources=ns.upgrade_audit_sources,
+            metadata_sources=ns.upgrade_audit_metadata_sources,
             queries=ns.upgrade_audit_queries,
             impact_areas=ns.upgrade_audit_impact_areas,
             manifest_actions=ns.upgrade_audit_manifest_actions,
+            repo_usage_tiers=ns.upgrade_audit_repo_usage_tiers,
+            used_in_repo_only=bool(ns.upgrade_audit_used_in_repo_only),
+            outdated_only=bool(ns.upgrade_audit_outdated_only),
             top=ns.upgrade_audit_top,
         )
         data["upgrade_audit_ok"] = ua_ok

--- a/tests/test_doctor_upgrade_audit.py
+++ b/tests/test_doctor_upgrade_audit.py
@@ -223,4 +223,99 @@ def test_doctor_upgrade_audit_supports_query_and_action_filters(
     assert meta["filters"]["manifest_actions"] == ["plan-major-upgrade"]
     assert meta["filters"]["top"] == 1
     assert meta["priority_queue"][0]["name"] == "mypy"
+    assert meta["action_summary"][0]["manifest_action"] == "plan-major-upgrade"
+    assert meta["group_summary"][0]["group"] == "dev"
+    assert meta["source_summary"][0]["source"] == "pyproject.toml"
     assert any("mypy" in hint for hint in payload["hints"])
+
+
+def test_doctor_upgrade_audit_supports_package_source_and_usage_filters(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_minimal_pyproject(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    deps = [
+        doctor.upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="default",
+            raw="httpx>=0.28.1,<1",
+            name="httpx",
+            pinned_version=None,
+        ),
+        doctor.upgrade_audit.Dependency(
+            source="requirements-docs.txt",
+            group="docs",
+            raw="mkdocs-material==9.7.5",
+            name="mkdocs-material",
+            pinned_version="9.7.5",
+        ),
+    ]
+
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(doctor.upgrade_audit, "_load_dependencies", lambda *_args, **_kwargs: deps)
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_load_project_python_requires", lambda *_args, **_kwargs: ">=3.11"
+    )
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_repo_usage",
+        lambda *_args, **_kwargs: {
+            "httpx": ["src/sdetkit/netclient.py", "tests/test_netclient_extra.py"],
+            "mkdocs-material": [],
+        },
+    )
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_package_metadata",
+        lambda *_args, **_kwargs: {
+            "httpx": doctor.upgrade_audit.PackageMetadata(
+                latest_version="0.29.0",
+                release_date="2026-03-01T00:00:00+00:00",
+                compatible_version="0.29.0",
+                compatible_release_date="2026-03-01T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="cache-stale",
+            ),
+            "mkdocs-material": doctor.upgrade_audit.PackageMetadata(
+                latest_version="9.7.6",
+                release_date="2026-03-01T00:00:00+00:00",
+                compatible_version="9.7.6",
+                compatible_release_date="2026-03-01T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="pypi",
+            ),
+        },
+    )
+
+    rc = doctor.main(
+        [
+            "--upgrade-audit",
+            "--upgrade-audit-package",
+            "httpx",
+            "--upgrade-audit-source",
+            "pyproject.toml",
+            "--upgrade-audit-metadata-source",
+            "cache-stale",
+            "--upgrade-audit-repo-usage-tier",
+            "active",
+            "--upgrade-audit-used-in-repo-only",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    meta = payload["checks"]["upgrade_audit"]["meta"]
+    assert meta["packages_audited"] == 2
+    assert meta["packages_in_scope"] == 1
+    assert meta["filters"]["packages"] == ["httpx"]
+    assert meta["filters"]["sources"] == ["pyproject.toml"]
+    assert meta["filters"]["metadata_sources"] == ["cache-stale"]
+    assert meta["filters"]["repo_usage_tiers"] == ["active"]
+    assert meta["filters"]["used_in_repo_only"] is True
+    assert meta["priority_queue"][0]["name"] == "httpx"
+    assert meta["source_summary"][0]["source"] == "pyproject.toml"


### PR DESCRIPTION
### Motivation

- Make the doctor readiness surface able to run tightly scoped dependency audits without leaving `doctor` by passing more of the upgrade-audit filtering surface through to the audit engine.
- Surface higher-level grouped summaries and hints (action, dependency-group, and manifest-source) so CI/PR checks can explain which upgrade lanes are hottest and where to validate first.

### Description

- Wire a broader set of upgrade-audit filters into `sdetkit doctor` including `--upgrade-audit-signal`, `--upgrade-audit-policy`, `--upgrade-audit-package`, `--upgrade-audit-group`, `--upgrade-audit-source`, `--upgrade-audit-metadata-source`, `--upgrade-audit-repo-usage-tier`, `--upgrade-audit-used-in-repo-only`, and `--upgrade-audit-outdated-only`, and propagate them into `_check_upgrade_audit` and the underlying audit filters. (src/sdetkit/doctor.py)
- Add grouped summaries to the doctor upgrade-audit metadata: `action_summary`, `group_summary`, and `source_summary`, and include those summaries in the `meta` payload returned by the check. (src/sdetkit/doctor.py)
- Extend `_build_hints` so doctor emits concise hints derived from the new summaries and action buckets when actionable items exist. (src/sdetkit/doctor.py)
- Add regression tests that assert the new filter passthrough and grouped summaries, and update README examples to document the new doctor upgrade-audit flags and usage. (tests/test_doctor_upgrade_audit.py, README.md)

### Testing

- Ran targeted pytest subset: `python -m pytest -q tests/test_doctor_upgrade_audit.py tests/test_doctor_md_and_out.py tests/test_doctor_score_and_recommendations.py tests/test_doctor_diagnostics.py tests/test_cli_doctor.py` and all tests passed (`16 passed`).
- Linted/checked formatting with `ruff check src/sdetkit/doctor.py tests/test_doctor_upgrade_audit.py README.md` and it reported no issues.
- Exercised the doctor upgrade-audit end-to-end: `PYTHONPATH=src python -m sdetkit.doctor --upgrade-audit --upgrade-audit-package 'http*' --upgrade-audit-source pyproject.toml --upgrade-audit-top 1 --format json` and verified the `meta` payload includes the new filters and summaries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb7aa41b0c8320b759714f9762b0ed)