### PR TITLE
Boost doctor & upgrade-audit insights: repo hotspots, richer quality telemetry, and maintenance reporting

### DIFF
--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -721,6 +721,9 @@ def _build_quality_summary(
     failed_check_ids: list[str] = []
     fix_count = 0
     evidence_count = 0
+    severity_breakdown = {"low": 0, "medium": 0, "high": 0}
+    checks_with_fix = 0
+    checks_with_evidence = 0
 
     for check_id in ordered_selected:
         item = checks.get(check_id, {})
@@ -737,8 +740,16 @@ def _build_quality_summary(
         if severity_rank > highest_failure_rank:
             highest_failure_rank = severity_rank
             highest_failure_severity = severity
-        fix_count += len(item.get("fix", []))
-        evidence_count += len(item.get("evidence", []))
+        if severity in severity_breakdown:
+            severity_breakdown[severity] += 1
+        item_fix_count = len(item.get("fix", []))
+        item_evidence_count = len(item.get("evidence", []))
+        fix_count += item_fix_count
+        evidence_count += item_evidence_count
+        if item_fix_count:
+            checks_with_fix += 1
+        if item_evidence_count:
+            checks_with_evidence += 1
 
     total = len(ordered_selected)
     actionable = passed + failed
@@ -755,6 +766,9 @@ def _build_quality_summary(
         "failed_check_ids": failed_check_ids,
         "fix_count": fix_count,
         "evidence_count": evidence_count,
+        "failed_severity_breakdown": severity_breakdown,
+        "checks_with_fix": checks_with_fix,
+        "checks_with_evidence": checks_with_evidence,
         "hint_count": len(hints or []),
     }
 
@@ -871,6 +885,31 @@ def _build_hints(data: dict[str, Any], *, limit: int = 5) -> list[str]:
                 detail = f"action {action}: {count} package(s)"
                 if package_text:
                     detail += f" — includes {package_text}"
+                hints.append(detail)
+
+    hotspots = upgrade_meta.get("hotspots", [])
+    if isinstance(hotspots, list):
+        for item in hotspots[:2]:
+            if not isinstance(item, dict):
+                continue
+            path = str(item.get("path", "")).strip()
+            actionable = int(item.get("actionable_packages", 0))
+            packages = item.get("packages", [])
+            package_text = ""
+            if isinstance(packages, list) and packages:
+                package_text = ", ".join(
+                    str(name).strip() for name in packages[:3] if str(name).strip()
+                )
+            commands = item.get("validation_commands", [])
+            command_text = ""
+            if isinstance(commands, list) and commands:
+                command_text = str(commands[0]).strip()
+            if path:
+                detail = f"hotspot {path}: {actionable} actionable package(s)"
+                if package_text:
+                    detail += f" — packages {package_text}"
+                if command_text:
+                    detail += f" — validate with {command_text}"
                 hints.append(detail)
 
     for key, label in (("group_summary", "group"), ("source_summary", "source")):
@@ -1066,6 +1105,7 @@ def _check_upgrade_audit(
         "lane_summary": upgrade_audit._lane_summary(filtered_reports),
         "impact_summary": upgrade_audit._impact_summary(filtered_reports),
         "repo_usage_summary": upgrade_audit._repo_usage_summary(filtered_reports),
+        "hotspots": upgrade_audit._repo_hotspots(filtered_reports),
         "action_summary": upgrade_audit._action_summary(filtered_reports),
         "group_summary": upgrade_audit._group_summary(filtered_reports),
         "source_summary": upgrade_audit._source_summary(filtered_reports),
@@ -1198,6 +1238,17 @@ def _format_doctor_markdown(data: dict[str, Any]) -> str:
             lines.append("- failing checks: none")
         lines.append(
             f"- hint coverage: {quality.get('hint_count', 0)} hint(s), {quality.get('fix_count', 0)} fix item(s), {quality.get('evidence_count', 0)} evidence item(s)"
+        )
+        severity_breakdown = quality.get("failed_severity_breakdown", {})
+        if isinstance(severity_breakdown, dict):
+            lines.append(
+                "- failure mix: "
+                f"high {severity_breakdown.get('high', 0)}, "
+                f"medium {severity_breakdown.get('medium', 0)}, "
+                f"low {severity_breakdown.get('low', 0)}"
+            )
+        lines.append(
+            f"- fix-ready checks: {quality.get('checks_with_fix', 0)}, evidence-rich checks: {quality.get('checks_with_evidence', 0)}"
         )
     else:
         lines.append("- None")

--- a/src/sdetkit/maintenance/checks/doctor_check.py
+++ b/src/sdetkit/maintenance/checks/doctor_check.py
@@ -45,18 +45,61 @@ def run(ctx: MaintenanceContext) -> CheckResult:
                 )
             ],
         )
+    quality = parsed.get("quality", {}) if isinstance(parsed, dict) else {}
+    hints = parsed.get("hints", []) if isinstance(parsed, dict) else []
+    quality_failed = int(quality.get("failed_checks", 0)) if isinstance(quality, dict) else 0
+    hint_count = len(hints) if isinstance(hints, list) else 0
+    summary = f"doctor score {parsed.get('score', 0)}%"
+    if quality_failed or hint_count:
+        summary += f" ({quality_failed} failed, {hint_count} hint(s))"
+
+    actions = [
+        CheckAction(
+            id="doctor-run",
+            title="Run doctor checks",
+            applied=False,
+            notes="Use `sdetkit doctor --all` for detailed review",
+        )
+    ]
+    next_actions = parsed.get("next_actions", []) if isinstance(parsed, dict) else []
+    if isinstance(next_actions, list):
+        for item in next_actions[:3]:
+            if not isinstance(item, dict):
+                continue
+            check_id = str(item.get("id", "")).strip() or "doctor-follow-up"
+            fixes = item.get("fix", [])
+            first_fix = ""
+            if isinstance(fixes, list) and fixes:
+                first_fix = str(fixes[0]).strip()
+            title = first_fix or str(item.get("summary", "")).strip() or "Inspect doctor finding"
+            if title:
+                actions.append(
+                    CheckAction(
+                        id=f"doctor-{check_id}",
+                        title=title,
+                        applied=False,
+                        notes=str(item.get("severity", "medium")),
+                    )
+                )
+
     return CheckResult(
         ok=bool(parsed.get("ok", False)),
-        summary=f"doctor score {parsed.get('score', 0)}%",
-        details={"doctor": parsed, "exit_code": code},
-        actions=[
-            CheckAction(
-                id="doctor-run",
-                title="Run doctor checks",
-                applied=False,
-                notes="Use `sdetkit doctor --all` for detailed review",
-            )
-        ],
+        summary=summary,
+        details={
+            "doctor": parsed,
+            "exit_code": code,
+            "quality": quality if isinstance(quality, dict) else {},
+            "hint_samples": hints[:5] if isinstance(hints, list) else [],
+            "priority_queue": parsed.get("checks", {})
+            .get("upgrade_audit", {})
+            .get("meta", {})
+            .get("priority_queue", []),
+            "hotspots": parsed.get("checks", {})
+            .get("upgrade_audit", {})
+            .get("meta", {})
+            .get("hotspots", []),
+        },
+        actions=actions,
     )
 
 

--- a/src/sdetkit/maintenance/cli.py
+++ b/src/sdetkit/maintenance/cli.py
@@ -64,6 +64,19 @@ def _render_text(report: dict[str, Any]) -> str:
     for name in sorted(report["checks"]):
         check = report["checks"][name]
         lines.append(f"- {'OK' if check['ok'] else 'FAIL'} {name}: {check['summary']}")
+        details = check.get("details", {})
+        quality = details.get("quality", {}) if isinstance(details, dict) else {}
+        if isinstance(quality, dict) and quality:
+            lines.append(
+                "    quality: "
+                f"{quality.get('passed_checks', 0)} passed / "
+                f"{quality.get('failed_checks', 0)} failed / "
+                f"{quality.get('skipped_checks', 0)} skipped"
+            )
+        hint_samples = details.get("hint_samples", []) if isinstance(details, dict) else []
+        if isinstance(hint_samples, list):
+            for hint in hint_samples[:2]:
+                lines.append(f"    hint: {hint}")
     if failing:
         lines.append("failing checks: " + ", ".join(sorted(failing)))
     return "\n".join(lines) + "\n"
@@ -99,6 +112,42 @@ def _render_markdown(report: dict[str, Any]) -> str:
     lines.append("### Recommendations")
     for rec in report["recommendations"]:
         lines.append(f"- {_md_escape_cell(rec)}")
+    lines.append("")
+    lines.append("### Quality signals")
+    has_quality = False
+    for name in sorted(report["checks"]):
+        check = report["checks"][name]
+        details = check.get("details", {})
+        if not isinstance(details, dict):
+            continue
+        quality = details.get("quality", {})
+        if not isinstance(quality, dict) or not quality:
+            continue
+        has_quality = True
+        lines.append(
+            f"- `{_md_escape_cell(name)}`: {_md_escape_cell(quality.get('passed_checks', 0))} passed / "
+            f"{_md_escape_cell(quality.get('failed_checks', 0))} failed / "
+            f"{_md_escape_cell(quality.get('skipped_checks', 0))} skipped; pass rate {_md_escape_cell(str(quality.get('pass_rate', 0)))}%"
+        )
+    if not has_quality:
+        lines.append("- No embedded quality summaries were reported.")
+    lines.append("")
+    lines.append("### Hint samples")
+    has_hints = False
+    for name in sorted(report["checks"]):
+        check = report["checks"][name]
+        details = check.get("details", {})
+        if not isinstance(details, dict):
+            continue
+        hint_samples = details.get("hint_samples", [])
+        if not isinstance(hint_samples, list) or not hint_samples:
+            continue
+        has_hints = True
+        lines.append(f"- `{_md_escape_cell(name)}`")
+        for hint in hint_samples[:3]:
+            lines.append(f"  - {_md_escape_cell(hint)}")
+    if not has_hints:
+        lines.append("- No hint samples were reported.")
     return "\n".join(lines) + "\n"
 
 
@@ -179,6 +228,9 @@ def _build_recommendations(checks: dict[str, dict[str, Any]]) -> list[str]:
     if suggested_actions:
         unique_actions = sorted(dict.fromkeys(suggested_actions))
         recommendations.append(f"Suggested next actions: {', '.join(unique_actions[:5])}.")
+    doctor_hints = checks.get("doctor_check", {}).get("details", {}).get("hint_samples", [])
+    if isinstance(doctor_hints, list) and doctor_hints:
+        recommendations.append(f"Doctor hint spotlight: {doctor_hints[0]}")
     return recommendations
 
 

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -1281,6 +1281,54 @@ def _repo_usage_summary(reports: list[PackageReport]) -> list[dict[str, object]]
     ]
 
 
+def _repo_hotspots(reports: list[PackageReport], *, limit: int = 5) -> list[dict[str, object]]:
+    buckets: dict[str, list[PackageReport]] = {}
+    for report in reports:
+        for path in report.repo_usage_files:
+            normalized = str(path).strip()
+            if normalized:
+                buckets.setdefault(normalized, []).append(report)
+
+    ordered = sorted(
+        buckets.items(),
+        key=lambda item: (
+            -sum(1 for report in item[1] if _is_actionable_upgrade(report)),
+            -max((report.risk_score for report in item[1]), default=0),
+            -len(item[1]),
+            item[0],
+        ),
+    )
+
+    hotspots: list[dict[str, object]] = []
+    for path, items in ordered[: max(limit, 0)]:
+        packages = [report.name for report in items[:5]]
+        validation_commands: list[str] = []
+        seen_commands: set[str] = set()
+        for report in items:
+            for command in report.validation_commands:
+                normalized = str(command).strip()
+                if normalized and normalized not in seen_commands:
+                    seen_commands.add(normalized)
+                    validation_commands.append(normalized)
+                if len(validation_commands) >= 3:
+                    break
+            if len(validation_commands) >= 3:
+                break
+
+        hotspots.append(
+            {
+                "path": path,
+                "count": len(items),
+                "actionable_packages": sum(1 for report in items if _is_actionable_upgrade(report)),
+                "max_risk_score": max((report.risk_score for report in items), default=0),
+                "lanes": sorted({_recommended_lane(report) for report in items})[:3],
+                "packages": packages,
+                "validation_commands": validation_commands,
+            }
+        )
+    return hotspots
+
+
 def _report_summary(reports: list[PackageReport]) -> dict[str, int]:
     return {
         "packages_audited": len(reports),
@@ -1614,6 +1662,17 @@ def _render_markdown(
             f"- **{item['repo_usage_tier']}**: {item['count']} package(s), actionable {item['actionable_packages']}, max repo usage {item['max_repo_usage_count']}"
             + (f" — {pkg_list}" if pkg_list else "")
         )
+    lines.extend(["", "## Repo hotspots", ""])
+    for item in _repo_hotspots(reports):
+        pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
+        lane_list = ", ".join(f"`{lane}`" for lane in item["lanes"])
+        validations = ", ".join(f"`{command}`" for command in item["validation_commands"])
+        lines.append(
+            f"- **{item['path']}**: {item['count']} package(s), actionable {item['actionable_packages']}, max risk {item['max_risk_score']}"
+            + (f" — {pkg_list}" if pkg_list else "")
+            + (f" — lanes {lane_list}" if lane_list else "")
+            + (f" — validate with {validations}" if validations else "")
+        )
     lines.extend(["", "## Repo impact map", ""])
     for item in _impact_summary(reports):
         pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
@@ -1668,6 +1727,7 @@ def _render_json(
         "priority_queue": _priority_queue(reports),
         "lanes": _lane_summary(reports),
         "repo_usage": _repo_usage_summary(reports),
+        "hotspots": _repo_hotspots(reports),
         "impact": _impact_summary(reports),
         "actions": _action_summary(reports),
         "groups": _group_summary(reports),

--- a/tests/test_doctor_md_and_out.py
+++ b/tests/test_doctor_md_and_out.py
@@ -30,6 +30,8 @@ def test_doctor_markdown_contains_table_actions_and_stable_order(tmp_path: Path)
     assert "#### Quality summary" in proc.stdout
     assert "#### Action items" in proc.stdout
     assert "#### Evidence" in proc.stdout
+    assert "- failure mix:" in proc.stdout
+    assert "- fix-ready checks:" in proc.stdout
 
     ci_idx = proc.stdout.index("| `ci_workflows` | high | FAIL |")
     sec_idx = proc.stdout.index("| `security_files` | medium | FAIL |")

--- a/tests/test_doctor_upgrade_audit.py
+++ b/tests/test_doctor_upgrade_audit.py
@@ -67,8 +67,13 @@ def test_doctor_upgrade_audit_emits_priority_hints(tmp_path: Path, monkeypatch, 
         payload["checks"]["upgrade_audit"]["meta"]["impact_summary"][0]["impact_area"]
         == "runtime-core"
     )
+    assert (
+        payload["checks"]["upgrade_audit"]["meta"]["hotspots"][0]["path"]
+        == "src/sdetkit/netclient.py"
+    )
     assert any("httpx: raise-floor" in hint for hint in payload["hints"])
     assert any("impact runtime-core" in hint for hint in payload["hints"])
+    assert any("hotspot src/sdetkit/netclient.py" in hint for hint in payload["hints"])
     assert any("Runtime lane follow-up" in item for item in payload["recommendations"])
     assert payload["quality"]["passed_checks"] >= 1
     assert payload["quality"]["hint_count"] == len(payload["hints"])

--- a/tests/test_maintenance_cli.py
+++ b/tests/test_maintenance_cli.py
@@ -172,6 +172,64 @@ def test_doctor_check_full_mode_and_bad_json(monkeypatch, tmp_path: Path, capsys
     capsys.readouterr()
 
 
+def test_doctor_check_captures_quality_hints_and_hotspots(monkeypatch, tmp_path: Path) -> None:
+    def _fake_main(args: list[str]) -> int:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "score": 82,
+                    "quality": {
+                        "passed_checks": 2,
+                        "failed_checks": 1,
+                        "skipped_checks": 0,
+                        "pass_rate": 67,
+                    },
+                    "hints": ["impact quality-tooling: 1 actionable package(s)"],
+                    "next_actions": [
+                        {
+                            "id": "upgrade_audit",
+                            "summary": "upgrade audit needs follow-up",
+                            "severity": "medium",
+                            "fix": [
+                                "Run `python -m sdetkit intelligence upgrade-audit --format md --top 5`"
+                            ],
+                        }
+                    ],
+                    "checks": {
+                        "upgrade_audit": {
+                            "meta": {
+                                "priority_queue": [{"name": "ruff"}],
+                                "hotspots": [{"path": "src/sdetkit/doctor.py"}],
+                            }
+                        }
+                    },
+                }
+            )
+        )
+        assert args == ["--format", "json", "--pyproject", "--dev"]
+        return 2
+
+    monkeypatch.setattr(doctor_check.doctor, "main", _fake_main)
+    ctx = MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe=sys.executable,
+        mode="quick",
+        fix=False,
+        env={},
+        logger=object(),
+    )
+
+    result = doctor_check.run(ctx)
+
+    assert result.ok is False
+    assert result.summary == "doctor score 82% (1 failed, 1 hint(s))"
+    assert result.details["quality"]["failed_checks"] == 1
+    assert result.details["hint_samples"] == ["impact quality-tooling: 1 actionable package(s)"]
+    assert result.details["hotspots"][0]["path"] == "src/sdetkit/doctor.py"
+    assert result.actions[1].title.startswith("Run `python -m sdetkit intelligence upgrade-audit")
+
+
 def test_deps_check_deterministic_and_conflict_paths(monkeypatch, tmp_path: Path) -> None:
     pip_conflict = SimpleNamespace(returncode=1, stdout="", stderr="broken")
     monkeypatch.setattr(deps_check, "run_cmd", lambda _cmd, cwd: pip_conflict)

--- a/tests/test_maintenance_cli_extra.py
+++ b/tests/test_maintenance_cli_extra.py
@@ -86,6 +86,41 @@ def test_main_json_output_and_write_file(monkeypatch, tmp_path: Path, capsys) ->
     assert (tmp_path / "reports/m.json").exists()
 
 
+def test_renderers_include_quality_signals_and_hints(tmp_path: Path) -> None:
+    report = {
+        "ok": False,
+        "score": 50,
+        "checks": {
+            "doctor_check": {
+                "ok": False,
+                "summary": "doctor score 82% (1 failed, 1 hint(s))",
+                "details": {
+                    "quality": {
+                        "passed_checks": 2,
+                        "failed_checks": 1,
+                        "skipped_checks": 0,
+                        "pass_rate": 67,
+                    },
+                    "hint_samples": ["impact quality-tooling: 1 actionable package(s)"],
+                },
+                "actions": [],
+            }
+        },
+        "recommendations": [
+            "Doctor hint spotlight: impact quality-tooling: 1 actionable package(s)"
+        ],
+        "meta": {"mode": "quick"},
+    }
+
+    text = mcli._render_text(report)
+    md = mcli._render_markdown(report)
+
+    assert "quality: 2 passed / 1 failed / 0 skipped" in text
+    assert "hint: impact quality-tooling: 1 actionable package(s)" in text
+    assert "### Quality signals" in md
+    assert "### Hint samples" in md
+
+
 def test_main_handles_unknown_format_keyerror(monkeypatch) -> None:
     class _NS:
         format = "broken"

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -372,6 +372,7 @@ def test_render_json_summary_counts() -> None:
         "stale_metadata_packages": 0,
     }
     assert payload["repo_usage"][0]["repo_usage_tier"] == "declared-only"
+    assert payload["hotspots"] == []
     assert payload["packages"][0]["name"] == "httpx"
 
 
@@ -874,6 +875,7 @@ def test_render_markdown_includes_recommended_upgrade_lanes() -> None:
     )
 
     assert "## Recommended upgrade lanes" in rendered
+    assert "## Repo hotspots" in rendered
     assert "## Repo impact map" in rendered
     assert "## Dependency groups" in rendered
     assert "## Manifest sources" in rendered
@@ -1185,6 +1187,43 @@ def test_action_summary_groups_packages_by_manifest_action() -> None:
     assert summary[0]["manifest_action"] == "stage-upgrade"
     assert summary[0]["count"] == 2
     assert summary[0]["packages"] == ["httpx", "pytest"]
+
+
+def test_repo_hotspots_prioritize_actionable_shared_paths() -> None:
+    reports = [
+        _report(
+            name="httpx",
+            manifest_action="stage-upgrade",
+            risk_score=60,
+            repo_usage_files=["src/sdetkit/netclient.py", "src/sdetkit/doctor.py"],
+            validation_commands=["bash ci.sh quick --skip-docs --artifact-dir build"],
+        ),
+        _report(
+            name="pytest",
+            manifest_action="refresh-pin",
+            risk_score=50,
+            repo_usage_files=["src/sdetkit/doctor.py"],
+            validation_commands=["bash quality.sh ci"],
+        ),
+        _report(
+            name="ruff",
+            manifest_action="none",
+            risk_score=10,
+            repo_usage_files=["src/sdetkit/doctor.py"],
+            validation_commands=["bash quality.sh cov"],
+        ),
+    ]
+
+    hotspots = upgrade_audit._repo_hotspots(reports)
+
+    assert hotspots[0]["path"] == "src/sdetkit/doctor.py"
+    assert hotspots[0]["actionable_packages"] == 2
+    assert hotspots[0]["packages"] == ["httpx", "pytest", "ruff"]
+    assert hotspots[0]["validation_commands"] == [
+        "bash ci.sh quick --skip-docs --artifact-dir build",
+        "bash quality.sh ci",
+        "bash quality.sh cov",
+    ]
 
 
 def test_filter_reports_supports_impact_area_filters() -> None:


### PR DESCRIPTION
### Motivation
- Make dependency-upgrade work more actionable by mapping upgrade recommendations back to the repo paths they impact. 
- Improve the doctor quality surface so maintenance runs expose failure mix, fix/evidence coverage, and higher-signal hints for faster triage. 
- Surface doctor quality/hint data in maintenance runs so quick checks and CI can act on high-leverage next steps without re-running full audits.

### Description
- Add `_repo_hotspots` to `src/sdetkit/upgrade_audit.py` and include `hotspots` in both JSON (`_render_json`) and Markdown (`_render_markdown`) outputs to show top repo paths, associated packages, lanes, and validation commands. 
- Enrich doctor quality summaries in `src/sdetkit/doctor.py` with `failed_severity_breakdown`, `checks_with_fix`, and `checks_with_evidence`, and emit upgrade-audit hotspot hints into the doctor `hints` stream. 
- Update the maintenance doctor check `src/sdetkit/maintenance/checks/doctor_check.py` to capture `quality`, `hint_samples`, `priority_queue`, and `hotspots` from doctor JSON output and include actionable follow-up `CheckAction` entries. 
- Enhance maintenance renderers in `src/sdetkit/maintenance/cli.py` to display embedded doctor quality signals and hint samples in both text and Markdown, and add a doctor hint spotlight to recommendations. 
- Add and update tests to cover hotspots, doctor hint output, upgraded Markdown quality sections, and maintenance rendering (`tests/test_upgrade_audit_script.py`, `tests/test_doctor_upgrade_audit.py`, `tests/test_doctor_md_and_out.py`, `tests/test_maintenance_cli.py`, `tests/test_maintenance_cli_extra.py`).

### Testing
- Ran the targeted pytest suite: `python -m pytest -q tests/test_upgrade_audit_script.py tests/test_doctor_upgrade_audit.py tests/test_doctor_md_and_out.py tests/test_maintenance_cli.py tests/test_maintenance_cli_extra.py`, all tests passed. 
- Ran linter/format checks with `ruff` on the modified modules (`src/sdetkit/upgrade_audit.py`, `src/sdetkit/doctor.py`, `src/sdetkit/maintenance/cli.py`, `src/sdetkit/maintenance/checks/doctor_check.py`), no issues. 
- Executed the doctor upgrade-audit surface manually with `python -m sdetkit doctor --upgrade-audit --upgrade-audit-top 3 --format json` and verified `hotspots`, `quality`, and `hints` fields are present. 
- Exercised maintenance quick run with doctor included using `python -m sdetkit maintenance --format md --mode quick --include-check doctor_check --deterministic` and confirmed embedded doctor quality/hint summaries appear in the maintenance report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb7cf631108320ad86a1d6a3aec936)