### PR TITLE
Boost upgrade audit planning insights

### DIFF
--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -699,6 +699,23 @@ def _recommendations(data: dict[str, Any]) -> list[str]:
                 recs.append(rec)
             if len(recs) >= 6:
                 break
+    risk_summary = upgrade_meta.get("risk_summary", [])
+    if isinstance(risk_summary, list):
+        for item in risk_summary:
+            if not isinstance(item, dict):
+                continue
+            band = str(item.get("risk_band", "")).strip()
+            actionable = int(item.get("actionable_packages", 0))
+            packages = item.get("packages", [])
+            package_text = ", ".join(
+                str(name).strip() for name in packages[:3] if str(name).strip()
+            )
+            if band in {"critical", "high"} and actionable > 0:
+                rec = f"Risk compression: clear the {band}-band upgrade queue before broad repo churn."
+                if package_text:
+                    rec += f" Start with {package_text}."
+                recs.append(rec)
+                break
     release_freshness_summary = upgrade_meta.get("release_freshness_summary", [])
     if isinstance(release_freshness_summary, list):
         for item in release_freshness_summary:
@@ -722,6 +739,18 @@ def _recommendations(data: dict[str, Any]) -> list[str]:
                     rec += f" Start with {package_text}."
                 recs.append(rec)
             if len(recs) >= 6:
+                break
+    validation_summary = upgrade_meta.get("validation_summary", [])
+    if isinstance(validation_summary, list):
+        for item in validation_summary:
+            if not isinstance(item, dict):
+                continue
+            command = str(item.get("command", "")).strip()
+            actionable = int(item.get("actionable_packages", 0))
+            if command and actionable > 0:
+                recs.append(
+                    f"Validation batching: use `{command}` as a shared guardrail across {actionable} actionable package(s)."
+                )
                 break
     if not recs:
         recs.append(
@@ -797,7 +826,7 @@ def _build_quality_summary(
     }
 
 
-def _build_hints(data: dict[str, Any], *, limit: int = 7) -> list[str]:
+def _build_hints(data: dict[str, Any], *, limit: int = 8) -> list[str]:
     hints: list[str] = []
 
     next_actions = data.get("next_actions", [])
@@ -958,6 +987,28 @@ def _build_hints(data: dict[str, Any], *, limit: int = 7) -> list[str]:
                     detail += f" — validate with {command_text}"
                 hints.append(detail)
 
+    risk_summary = upgrade_meta.get("risk_summary", [])
+    if isinstance(risk_summary, list):
+        for item in risk_summary[:2]:
+            if not isinstance(item, dict):
+                continue
+            band = str(item.get("risk_band", "")).strip()
+            count = int(item.get("count", 0))
+            actionable = int(item.get("actionable_packages", 0))
+            packages = item.get("packages", [])
+            package_text = ""
+            if isinstance(packages, list) and packages:
+                package_text = ", ".join(
+                    str(name).strip() for name in packages[:3] if str(name).strip()
+                )
+            if band and count > 0:
+                detail = f"risk {band}: {count} package(s)"
+                if actionable > 0:
+                    detail += f", actionable {actionable}"
+                if package_text:
+                    detail += f" — includes {package_text}"
+                hints.append(detail)
+
     for key, label in (("group_summary", "group"), ("source_summary", "source")):
         summary_rows = upgrade_meta.get(key, [])
         if not isinstance(summary_rows, list):
@@ -970,6 +1021,20 @@ def _build_hints(data: dict[str, Any], *, limit: int = 7) -> list[str]:
             actionable = int(item.get("actionable_packages", 0))
             if name and count > 0 and actionable > 0:
                 hints.append(f"{label} {name}: {count} package(s), actionable {actionable}")
+
+    validation_summary = upgrade_meta.get("validation_summary", [])
+    if isinstance(validation_summary, list):
+        for item in validation_summary[:2]:
+            if not isinstance(item, dict):
+                continue
+            command = str(item.get("command", "")).strip()
+            actionable = int(item.get("actionable_packages", 0))
+            count = int(item.get("count", 0))
+            if command and count > 0:
+                detail = f"validation {command}: {count} package(s)"
+                if actionable > 0:
+                    detail += f", actionable {actionable}"
+                hints.append(detail)
 
     deduped: list[str] = []
     seen: set[str] = set()
@@ -992,10 +1057,12 @@ def _check_upgrade_audit(
     groups: list[str] | None = None,
     sources: list[str] | None = None,
     metadata_sources: list[str] | None = None,
+    lanes: list[str] | None = None,
     queries: list[str] | None = None,
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
     repo_usage_tiers: list[str] | None = None,
+    release_freshness: list[str] | None = None,
     used_in_repo_only: bool = False,
     outdated_only: bool = False,
     min_release_age_days: int | None = None,
@@ -1078,9 +1145,11 @@ def _check_upgrade_audit(
         groups=groups,
         sources=sources,
         metadata_sources=metadata_sources,
+        lanes=lanes,
         impact_areas=impact_areas,
         manifest_actions=manifest_actions,
         repo_usage_tiers=repo_usage_tiers,
+        release_freshness=release_freshness,
         queries=queries,
         min_release_age_days=min_release_age_days,
         max_release_age_days=max_release_age_days,
@@ -1153,11 +1222,13 @@ def _check_upgrade_audit(
         "actionable_packages": len(actionable),
         "priority_queue": priority_queue,
         "lane_summary": upgrade_audit._lane_summary(filtered_reports),
+        "risk_summary": upgrade_audit._risk_summary(filtered_reports),
         "impact_summary": upgrade_audit._impact_summary(filtered_reports),
         "repo_usage_summary": upgrade_audit._repo_usage_summary(filtered_reports),
         "hotspots": upgrade_audit._repo_hotspots(filtered_reports),
         "release_freshness_summary": upgrade_audit._release_freshness_summary(filtered_reports),
         "action_summary": upgrade_audit._action_summary(filtered_reports),
+        "validation_summary": upgrade_audit._validation_summary(filtered_reports),
         "group_summary": upgrade_audit._group_summary(filtered_reports),
         "source_summary": upgrade_audit._source_summary(filtered_reports),
         "offline": offline,
@@ -1169,10 +1240,12 @@ def _check_upgrade_audit(
             "groups": groups or [],
             "sources": sources or [],
             "metadata_sources": metadata_sources or [],
+            "lanes": lanes or [],
             "queries": queries or [],
             "impact_areas": impact_areas or [],
             "manifest_actions": manifest_actions or [],
             "repo_usage_tiers": repo_usage_tiers or [],
+            "release_freshness": release_freshness or [],
             "min_release_age_days": min_release_age_days,
             "max_release_age_days": max_release_age_days,
             "used_in_repo_only": used_in_repo_only,
@@ -1454,10 +1527,12 @@ def main(argv: list[str] | None = None) -> int:
         "--upgrade-audit-group",
         "--upgrade-audit-source",
         "--upgrade-audit-metadata-source",
+        "--upgrade-audit-lane",
         "--upgrade-audit-query",
         "--upgrade-audit-impact-area",
         "--upgrade-audit-manifest-action",
         "--upgrade-audit-repo-usage-tier",
+        "--upgrade-audit-release-freshness",
         "--upgrade-audit-top",
         "--upgrade-audit-min-release-age-days",
         "--upgrade-audit-max-release-age-days",
@@ -1540,6 +1615,22 @@ def main(argv: list[str] | None = None) -> int:
         help="Focus doctor upgrade-audit hints on where package metadata came from.",
     )
     parser.add_argument(
+        "--upgrade-audit-lane",
+        dest="upgrade_audit_lanes",
+        action="append",
+        choices=[
+            "stabilize-manifests",
+            "refresh-baselines",
+            "upgrade-now",
+            "next-maintenance-batch",
+            "investigate-metadata",
+            "policy-covered-watchlist",
+            "backlog-watchlist",
+        ],
+        default=None,
+        help="Focus doctor upgrade-audit hints on specific execution lanes.",
+    )
+    parser.add_argument(
         "--upgrade-audit-query",
         dest="upgrade_audit_queries",
         action="append",
@@ -1592,6 +1683,14 @@ def main(argv: list[str] | None = None) -> int:
         choices=["hot-path", "active", "edge", "declared-only"],
         default=None,
         help="Focus doctor upgrade-audit hints on packages by repo-usage tier.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-release-freshness",
+        dest="upgrade_audit_release_freshness",
+        action="append",
+        choices=list(upgrade_audit.RELEASE_FRESHNESS_BUCKETS),
+        default=None,
+        help="Focus doctor upgrade-audit hints on selected target-release freshness buckets.",
     )
     parser.add_argument(
         "--upgrade-audit-min-release-age-days",
@@ -2048,10 +2147,12 @@ def main(argv: list[str] | None = None) -> int:
             groups=ns.upgrade_audit_groups,
             sources=ns.upgrade_audit_sources,
             metadata_sources=ns.upgrade_audit_metadata_sources,
+            lanes=ns.upgrade_audit_lanes,
             queries=ns.upgrade_audit_queries,
             impact_areas=ns.upgrade_audit_impact_areas,
             manifest_actions=ns.upgrade_audit_manifest_actions,
             repo_usage_tiers=ns.upgrade_audit_repo_usage_tiers,
+            release_freshness=ns.upgrade_audit_release_freshness,
             min_release_age_days=ns.upgrade_audit_min_release_age_days,
             max_release_age_days=ns.upgrade_audit_max_release_age_days,
             used_in_repo_only=bool(ns.upgrade_audit_used_in_repo_only),

--- a/src/sdetkit/maintenance/checks/doctor_check.py
+++ b/src/sdetkit/maintenance/checks/doctor_check.py
@@ -94,6 +94,14 @@ def run(ctx: MaintenanceContext) -> CheckResult:
             .get("upgrade_audit", {})
             .get("meta", {})
             .get("priority_queue", []),
+            "risk_summary": parsed.get("checks", {})
+            .get("upgrade_audit", {})
+            .get("meta", {})
+            .get("risk_summary", []),
+            "validation_summary": parsed.get("checks", {})
+            .get("upgrade_audit", {})
+            .get("meta", {})
+            .get("validation_summary", []),
             "hotspots": parsed.get("checks", {})
             .get("upgrade_audit", {})
             .get("meta", {})

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -1162,6 +1162,18 @@ def _recommended_lane(report: PackageReport) -> str:
     return "backlog-watchlist"
 
 
+def _risk_band(report: PackageReport) -> str:
+    if report.risk_score >= 80:
+        return "critical"
+    if report.risk_score >= 60:
+        return "high"
+    if report.risk_score >= 35:
+        return "medium"
+    if report.risk_score > 0:
+        return "low"
+    return "none"
+
+
 def _impact_area(report: PackageReport) -> str:
     groups = set(report.groups)
     package = report.name
@@ -1243,6 +1255,31 @@ def _lane_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
             "packages": [r.name for r in items[:5]],
         }
         for lane, items in ordered
+    ]
+
+
+def _risk_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
+    buckets: dict[str, list[PackageReport]] = {}
+    order = {"critical": 0, "high": 1, "medium": 2, "low": 3, "none": 4}
+    for report in reports:
+        buckets.setdefault(_risk_band(report), []).append(report)
+    ordered = sorted(
+        buckets.items(),
+        key=lambda item: (
+            order.get(item[0], 99),
+            -max((report.risk_score for report in item[1]), default=0),
+            item[0],
+        ),
+    )
+    return [
+        {
+            "risk_band": band,
+            "count": len(items),
+            "actionable_packages": sum(1 for report in items if _is_actionable_upgrade(report)),
+            "max_risk_score": max((report.risk_score for report in items), default=0),
+            "packages": [report.name for report in items[:5]],
+        }
+        for band, items in ordered
     ]
 
 
@@ -1346,6 +1383,34 @@ def _repo_hotspots(reports: list[PackageReport], *, limit: int = 5) -> list[dict
             }
         )
     return hotspots
+
+
+def _validation_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
+    buckets: dict[str, list[PackageReport]] = {}
+    for report in reports:
+        for command in report.validation_commands:
+            normalized = str(command).strip()
+            if normalized:
+                buckets.setdefault(normalized, []).append(report)
+    ordered = sorted(
+        buckets.items(),
+        key=lambda item: (
+            -sum(1 for report in item[1] if _is_actionable_upgrade(report)),
+            -max((report.risk_score for report in item[1]), default=0),
+            -len(item[1]),
+            item[0],
+        ),
+    )
+    return [
+        {
+            "command": command,
+            "count": len(items),
+            "actionable_packages": sum(1 for report in items if _is_actionable_upgrade(report)),
+            "max_risk_score": max((report.risk_score for report in items), default=0),
+            "packages": [report.name for report in items[:5]],
+        }
+        for command, items in ordered
+    ]
 
 
 def _release_freshness_summary(reports: list[PackageReport]) -> list[dict[str, object]]:
@@ -1599,9 +1664,11 @@ def _filter_reports(
     groups: list[str] | None = None,
     sources: list[str] | None = None,
     metadata_sources: list[str] | None = None,
+    lanes: list[str] | None = None,
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
     repo_usage_tiers: list[str] | None = None,
+    release_freshness: list[str] | None = None,
     queries: list[str] | None = None,
     min_release_age_days: int | None = None,
     max_release_age_days: int | None = None,
@@ -1634,6 +1701,9 @@ def _filter_reports(
     if metadata_sources:
         allowed_sources = {item.strip() for item in metadata_sources if item.strip()}
         filtered = [report for report in filtered if report.metadata_source in allowed_sources]
+    if lanes:
+        allowed_lanes = {item.strip() for item in lanes if item.strip()}
+        filtered = [report for report in filtered if _recommended_lane(report) in allowed_lanes]
     if impact_areas:
         allowed_impact_areas = {item.strip() for item in impact_areas if item.strip()}
         filtered = [report for report in filtered if report.impact_area in allowed_impact_areas]
@@ -1643,6 +1713,13 @@ def _filter_reports(
     if repo_usage_tiers:
         allowed_tiers = {item.strip() for item in repo_usage_tiers if item.strip()}
         filtered = [report for report in filtered if report.repo_usage_tier in allowed_tiers]
+    if release_freshness:
+        allowed_buckets = {item.strip() for item in release_freshness if item.strip()}
+        filtered = [
+            report
+            for report in filtered
+            if _release_freshness_bucket(report.release_age_days) in allowed_buckets
+        ]
     if queries:
         query_terms = [item.strip().lower() for item in queries if item.strip()]
         filtered = [report for report in filtered if _matches_text_query(report, query_terms)]
@@ -1737,6 +1814,13 @@ def _render_markdown(
             f"- **{item['lane']}**: {item['count']} package(s), max risk {item['max_risk_score']}"
             + (f" — {pkg_list}" if pkg_list else "")
         )
+    lines.extend(["", "## Risk bands", ""])
+    for item in _risk_summary(reports):
+        pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
+        lines.append(
+            f"- **{item['risk_band']}**: {item['count']} package(s), actionable {item['actionable_packages']}, max risk {item['max_risk_score']}"
+            + (f" — {pkg_list}" if pkg_list else "")
+        )
     lines.extend(["", "## Repo usage tiers", ""])
     for item in _repo_usage_summary(reports):
         pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
@@ -1778,6 +1862,13 @@ def _render_markdown(
             f"- **{item['manifest_action']}**: {item['count']} package(s), actionable {item['actionable_packages']}, max risk {item['max_risk_score']}"
             + (f" — {pkg_list}" if pkg_list else "")
         )
+    lines.extend(["", "## Validation commands", ""])
+    for item in _validation_summary(reports):
+        pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
+        lines.append(
+            f"- `{item['command']}`: {item['count']} package(s), actionable {item['actionable_packages']}, max risk {item['max_risk_score']}"
+            + (f" — {pkg_list}" if pkg_list else "")
+        )
     lines.extend(["", "## Dependency groups", ""])
     for item in _group_summary(reports):
         pkg_list = ", ".join(f"`{name}`" for name in item["packages"])
@@ -1815,11 +1906,13 @@ def _render_json(
         "summary": _report_summary(reports),
         "priority_queue": _priority_queue(reports),
         "lanes": _lane_summary(reports),
+        "risk": _risk_summary(reports),
         "repo_usage": _repo_usage_summary(reports),
         "hotspots": _repo_hotspots(reports),
         "impact": _impact_summary(reports),
         "release_freshness": _release_freshness_summary(reports),
         "actions": _action_summary(reports),
+        "validations": _validation_summary(reports),
         "groups": _group_summary(reports),
         "sources": _source_summary(reports),
         "packages": [asdict(report) for report in reports],
@@ -1862,9 +1955,11 @@ def run(
     groups: list[str] | None = None,
     sources: list[str] | None = None,
     metadata_sources: list[str] | None = None,
+    lanes: list[str] | None = None,
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
     repo_usage_tiers: list[str] | None = None,
+    release_freshness: list[str] | None = None,
     queries: list[str] | None = None,
     min_release_age_days: int | None = None,
     max_release_age_days: int | None = None,
@@ -1950,9 +2045,11 @@ def run(
         groups=groups,
         sources=sources,
         metadata_sources=metadata_sources,
+        lanes=lanes,
         impact_areas=impact_areas,
         manifest_actions=manifest_actions,
         repo_usage_tiers=repo_usage_tiers,
+        release_freshness=release_freshness,
         queries=queries,
         min_release_age_days=min_release_age_days,
         max_release_age_days=max_release_age_days,
@@ -2085,6 +2182,21 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         help="Show only packages resolved from the selected metadata source(s).",
     )
     parser.add_argument(
+        "--lane",
+        action="append",
+        choices=[
+            "stabilize-manifests",
+            "refresh-baselines",
+            "upgrade-now",
+            "next-maintenance-batch",
+            "investigate-metadata",
+            "policy-covered-watchlist",
+            "backlog-watchlist",
+        ],
+        default=None,
+        help="Show only packages in the selected recommended upgrade lane(s).",
+    )
+    parser.add_argument(
         "--impact-area",
         action="append",
         choices=[
@@ -2120,6 +2232,13 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         choices=["hot-path", "active", "edge", "declared-only"],
         default=None,
         help="Show only packages matching the selected observed repo-usage tier(s).",
+    )
+    parser.add_argument(
+        "--release-freshness",
+        action="append",
+        choices=list(RELEASE_FRESHNESS_BUCKETS),
+        default=None,
+        help="Show only packages in the selected target-release freshness bucket(s).",
     )
     parser.add_argument(
         "--query",
@@ -2204,9 +2323,11 @@ def main(argv: list[str] | None = None) -> int:
         groups=args.group,
         sources=args.source,
         metadata_sources=args.metadata_source,
+        lanes=args.lane,
         impact_areas=args.impact_area,
         manifest_actions=args.manifest_action,
         repo_usage_tiers=args.repo_usage_tier,
+        release_freshness=args.release_freshness,
         queries=args.query,
         min_release_age_days=args.min_release_age_days,
         max_release_age_days=args.max_release_age_days,

--- a/tests/test_doctor_upgrade_audit.py
+++ b/tests/test_doctor_upgrade_audit.py
@@ -498,3 +498,94 @@ def test_upgrade_audit_json_and_markdown_include_release_freshness_sections() ->
     assert "## Release freshness" in markdown_payload
     assert "fresh releases (<=14d)" in markdown_payload
     assert "stale releases (>365d)" in markdown_payload
+
+
+def test_doctor_upgrade_audit_supports_lane_and_release_freshness_filters(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_minimal_pyproject(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    deps = [
+        doctor.upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="default",
+            raw="httpx==0.28.1",
+            name="httpx",
+            pinned_version="0.28.1",
+        ),
+        doctor.upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="dev",
+            raw="ruff==0.15.6",
+            name="ruff",
+            pinned_version="0.15.6",
+        ),
+    ]
+
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(doctor.upgrade_audit, "_load_dependencies", lambda *_args, **_kwargs: deps)
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_load_project_python_requires", lambda *_args, **_kwargs: ">=3.11"
+    )
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_repo_usage",
+        lambda *_args, **_kwargs: {
+            "httpx": ["src/sdetkit/netclient.py"],
+            "ruff": ["pyproject.toml"],
+        },
+    )
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_package_metadata",
+        lambda *_args, **_kwargs: {
+            "httpx": doctor.upgrade_audit.PackageMetadata(
+                latest_version="1.0.0",
+                release_date="2026-03-15T00:00:00+00:00",
+                compatible_version="1.0.0",
+                compatible_release_date="2026-03-15T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="cache",
+            ),
+            "ruff": doctor.upgrade_audit.PackageMetadata(
+                latest_version="0.15.6",
+                release_date="2024-01-01T00:00:00+00:00",
+                compatible_version="0.15.6",
+                compatible_release_date="2024-01-01T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="cache",
+            ),
+        },
+    )
+
+    rc = doctor.main(
+        [
+            "--only",
+            "upgrade_audit",
+            "--upgrade-audit",
+            "--upgrade-audit-lane",
+            "upgrade-now",
+            "--upgrade-audit-release-freshness",
+            "fresh-release",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == doctor.EXIT_FAILED
+    payload = json.loads(capsys.readouterr().out)
+    meta = payload["checks"]["upgrade_audit"]["meta"]
+    assert meta["packages_audited"] == 2
+    assert meta["packages_in_scope"] == 1
+    assert meta["filters"]["lanes"] == ["upgrade-now"]
+    assert meta["filters"]["release_freshness"] == ["fresh-release"]
+    assert meta["priority_queue"][0]["name"] == "httpx"
+    assert meta["risk_summary"][0]["risk_band"] in {"critical", "high"}
+    assert (
+        meta["validation_summary"][0]["command"]
+        == "bash ci.sh quick --skip-docs --artifact-dir build"
+    )
+    assert any("risk " in hint for hint in payload["hints"])

--- a/tests/test_maintenance_cli.py
+++ b/tests/test_maintenance_cli.py
@@ -200,6 +200,10 @@ def test_doctor_check_captures_quality_hints_and_hotspots(monkeypatch, tmp_path:
                         "upgrade_audit": {
                             "meta": {
                                 "priority_queue": [{"name": "ruff"}],
+                                "risk_summary": [{"risk_band": "medium", "count": 1}],
+                                "validation_summary": [
+                                    {"command": "bash quality.sh ci", "count": 1}
+                                ],
                                 "hotspots": [{"path": "src/sdetkit/doctor.py"}],
                             }
                         }
@@ -226,6 +230,8 @@ def test_doctor_check_captures_quality_hints_and_hotspots(monkeypatch, tmp_path:
     assert result.summary == "doctor score 82% (1 failed, 1 hint(s))"
     assert result.details["quality"]["failed_checks"] == 1
     assert result.details["hint_samples"] == ["impact quality-tooling: 1 actionable package(s)"]
+    assert result.details["risk_summary"][0]["risk_band"] == "medium"
+    assert result.details["validation_summary"][0]["command"] == "bash quality.sh ci"
     assert result.details["hotspots"][0]["path"] == "src/sdetkit/doctor.py"
     assert result.actions[1].title.startswith("Run `python -m sdetkit intelligence upgrade-audit")
 

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -348,12 +348,15 @@ def test_render_json_summary_counts() -> None:
     assert payload["summary"] == {
         "actionable_packages": 1,
         "active_usage_packages": 0,
+        "aging_release_packages": 0,
         "cached_metadata_packages": 1,
         "compatible_constraint_packages": 0,
+        "current_release_packages": 0,
         "critical_upgrade_signals": 0,
         "declared_only_packages": 2,
         "edge_usage_packages": 0,
         "floor_lock_packages": 0,
+        "fresh_release_packages": 1,
         "high_priority_upgrade_signals": 1,
         "hot_path_packages": 0,
         "integration_adapter_packages": 0,
@@ -369,7 +372,9 @@ def test_render_json_summary_counts() -> None:
         "python_incompatible_latest_packages": 0,
         "quality_tooling_packages": 1,
         "runtime_core_packages": 1,
+        "stale_release_packages": 0,
         "stale_metadata_packages": 0,
+        "unknown_release_age_packages": 1,
     }
     assert payload["repo_usage"][0]["repo_usage_tier"] == "declared-only"
     assert payload["hotspots"] == []
@@ -1293,6 +1298,77 @@ def test_filter_reports_supports_text_query_across_actions_and_notes() -> None:
     assert [report.name for report in filtered] == ["httpx"]
 
 
+def test_filter_reports_supports_lane_and_release_freshness_filters() -> None:
+    reports = [
+        _report(
+            name="httpx",
+            manifest_action="stage-upgrade",
+            upgrade_signal="medium",
+            risk_score=55,
+            release_age_days=5,
+        ),
+        _report(
+            name="ruff",
+            manifest_action="raise-floor",
+            constraint_status="allowed",
+            upgrade_signal="watch",
+            risk_score=20,
+            release_age_days=420,
+        ),
+    ]
+
+    filtered = upgrade_audit._filter_reports(
+        reports,
+        lanes=["next-maintenance-batch"],
+        release_freshness=["fresh-release"],
+    )
+
+    assert [report.name for report in filtered] == ["httpx"]
+
+
+def test_render_json_and_markdown_include_risk_and_validation_summaries() -> None:
+    reports = [
+        _report(
+            name="httpx",
+            risk_score=88,
+            manifest_action="plan-major-upgrade",
+            upgrade_signal="critical",
+            validation_commands=[
+                "bash ci.sh quick --skip-docs --artifact-dir build",
+                "bash quality.sh cov",
+            ],
+        ),
+        _report(
+            name="ruff",
+            impact_area="quality-tooling",
+            risk_score=42,
+            manifest_action="stage-upgrade",
+            upgrade_signal="medium",
+            validation_commands=["bash quality.sh ci"],
+        ),
+    ]
+
+    payload = json.loads(
+        upgrade_audit._render_json(
+            reports,
+            pyproject_path=Path("pyproject.toml"),
+            requirement_paths=[Path("requirements.txt")],
+        )
+    )
+    rendered = upgrade_audit._render_markdown(
+        reports,
+        pyproject_path=Path("pyproject.toml"),
+        requirement_paths=[Path("requirements.txt")],
+    )
+
+    assert payload["risk"][0]["risk_band"] == "critical"
+    assert (
+        payload["validations"][0]["command"] == "bash ci.sh quick --skip-docs --artifact-dir build"
+    )
+    assert "## Risk bands" in rendered
+    assert "## Validation commands" in rendered
+
+
 def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[project]\ndependencies=[]\n", encoding="utf-8")
@@ -1311,6 +1387,10 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
             "pyproject.toml",
             "--repo-usage-tier",
             "hot-path",
+            "--lane",
+            "upgrade-now",
+            "--release-freshness",
+            "fresh-release",
             "--query",
             "runtime-core",
             "--used-in-repo-only",
@@ -1326,6 +1406,8 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
     assert args.impact_area is None
     assert args.manifest_action is None
     assert args.repo_usage_tier == ["hot-path"]
+    assert args.lane == ["upgrade-now"]
+    assert args.release_freshness == ["fresh-release"]
     assert args.query == ["runtime-core"]
     assert args.used_in_repo_only is True
     assert args.include_prereleases is False


### PR DESCRIPTION
### Motivation
- Make dependency upgrade audits more actionable by surfacing risk bands and shared validation commands to prioritize work and batch validations. 
- Enable focused, execution-ready filtering of upgrade candidates by recommended lane and target-release freshness. 
- Improve doctor/maintenance workflows by exposing richer upgrade-audit metadata so downstream automation and maintenance checks can recommend concrete validation steps.

### Description
- Add risk-band classification and risk summary aggregation plus a validation-command summary to `upgrade_audit` and include them in JSON/Markdown output (`_risk_band`, `_risk_summary`, `_validation_summary`, plus wiring into `_render_json` / `_render_markdown`).
- Add lane and release-freshness filters to the `upgrade-audit` CLI and wire the same options into the `doctor` CLI so hints can be focused (`--lane`, `--release-freshness` and doctor equivalents).
- Enrich `doctor` hints and recommendations to include risk-compression guidance and shared validation batching recommendations and increase hint capacity to surface the new summaries.
- Surface the new `risk_summary` and `validation_summary` in the maintenance `doctor_check` output and add/adjust tests to cover filtering, summaries, rendering, and doctor integration; minor tidy-ups in a few helper modules.

### Testing
- Ran targeted unit tests: `python -m pytest -q tests/test_upgrade_audit_script.py tests/test_doctor_upgrade_audit.py tests/test_maintenance_cli.py` and they passed.
- Performed full test/lint verification with `python -m pytest` (test suite) and `python -m ruff check` over the modified modules and the final run returned all tests passing and lint checks clean (final run: 64 passed).
- All automated checks referenced above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb832c8ee08320ac17e81c9b487909)