### PR TITLE
feat: smart remediation loop for premium gate (auto-run scripts & artifact refresh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ python -m sdetkit integration topology-check --profile examples/kits/integration
 # validates service owners, dependency edges, mocked platform coverage, deployments, telemetry, and data resilience
 bash premium-gate.sh --mode full
 # premium gate now emits .sdetkit/out/integration-topology.json as a first-class operational artifact
+# head-5 also auto-runs repo-safe remediation scripts unless you pass --no-auto-run-scripts
 python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json --fail-on error
 python -m sdetkit forensics bundle --run examples/kits/forensics/run-b.json --output build/repro.zip
 python -m sdetkit continuous-upgrade-cycle9-closeout --format json --strict

--- a/docs/premium-quality-gate.md
+++ b/docs/premium-quality-gate.md
@@ -67,6 +67,7 @@ The script emits:
 - a structured five-head index: `.sdetkit/out/premium-step-index.json`
 - integration topology artifact: `.sdetkit/out/integration-topology.json`
 - premium engine summary: `.sdetkit/out/premium-summary.json`
+- smart remediation logs when the engine auto-runs repo scripts: `.sdetkit/out/premium-autofix.*.log`
 
 Useful flags:
 
@@ -75,6 +76,7 @@ Useful flags:
 - `--engine-min-score <int>`
 - `--out-dir <path>`
 - `--ops-jobs <int>`
+- `--no-auto-run-scripts` to keep the engine in analysis-only mode
 - `SDETKIT_PREMIUM_TOPOLOGY_PROFILE=<path>` to override the topology profile used by the Head-3 topology contract step
 
 Examples:
@@ -83,8 +85,25 @@ Examples:
 bash premium-gate.sh --mode full
 bash premium-gate.sh --mode full --continue-on-error
 bash premium-gate.sh --mode fast --engine-min-score 75
+bash premium-gate.sh --mode full --no-auto-run-scripts
 bash premium-gate.sh --mode engine-only --out-dir .sdetkit/out
 ```
+
+## Smart remediation loop
+
+Head-5 now does more than report problems:
+
+- it applies the existing safe security auto-fixes,
+- it selects repo-safe remediation scripts based on the current warning mix,
+- it refreshes artifacts like `doctor.json`, `maintenance.json`, and `security-check.json`,
+- and it records a pre/post score delta in `premium-summary.json`.
+
+Today the smart script lane can automatically trigger:
+
+- `sdetkit gate fast --fix-only` when doctor/style/quality drift is detected,
+- `sdetkit doctor --json --out ...` to refresh doctor evidence after fixes,
+- `sdetkit maintenance --mode full --fix --format json --out ...` for maintenance drift,
+- and `tools/triage.py --mode security ... --tee ...` to rebuild the baseline-aware security artifact after security auto-fixes.
 
 
 ## Local insights API (editable guideline reference + commit learning)

--- a/premium-gate.sh
+++ b/premium-gate.sh
@@ -10,6 +10,7 @@ CONTINUE_ON_ERROR=0
 ENGINE_MIN_SCORE="${SDETKIT_PREMIUM_MIN_SCORE:-70}"
 OPS_JOBS="${SDETKIT_PREMIUM_OPS_JOBS:-2}"
 TOPOLOGY_PROFILE="${SDETKIT_PREMIUM_TOPOLOGY_PROFILE:-examples/kits/integration/heterogeneous-topology.json}"
+AUTO_RUN_SCRIPTS="${SDETKIT_PREMIUM_AUTO_RUN_SCRIPTS:-1}"
 
 usage() {
   cat <<'USAGE'
@@ -20,6 +21,7 @@ Options:
   --out-dir <path>                 Artifact/log directory (default: .sdetkit/out)
   --engine-min-score <int>         Minimum premium engine score (default: 70)
   --ops-jobs <int>                 Parallel jobs for ops run (default: 2)
+  --no-auto-run-scripts            Disable smart remediation script execution inside the premium engine
   --continue-on-error              Continue collecting evidence after a failing step
   -h, --help                       Show this help
 USAGE
@@ -45,6 +47,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --continue-on-error)
       CONTINUE_ON_ERROR=1
+      shift
+      ;;
+    --no-auto-run-scripts)
+      AUTO_RUN_SCRIPTS=0
       shift
       ;;
     -h|--help)
@@ -228,7 +234,12 @@ run_plan() {
 
 run_engine() {
   section "Real-time warnings and recommendations summary"
-  run_step "premium_engine" "Head-5 Intelligence Brain" "Premium Gate Engine" "python3 -m sdetkit.premium_gate_engine --out-dir '$OUT_DIR' --double-check --min-score '$ENGINE_MIN_SCORE' --auto-fix --fix-root '$ROOT_DIR' --learn-db --learn-commit --db-path '$OUT_DIR/premium-insights.db' --format markdown --json-output '$OUT_DIR/premium-summary.json'"
+  local engine_cmd
+  engine_cmd="python3 -m sdetkit.premium_gate_engine --out-dir '$OUT_DIR' --double-check --min-score '$ENGINE_MIN_SCORE' --auto-fix --fix-root '$ROOT_DIR' --learn-db --learn-commit --db-path '$OUT_DIR/premium-insights.db' --format markdown --json-output '$OUT_DIR/premium-summary.json'"
+  if [[ "$AUTO_RUN_SCRIPTS" == "1" ]]; then
+    engine_cmd+=" --auto-run-scripts"
+  fi
+  run_step "premium_engine" "Head-5 Intelligence Brain" "Premium Gate Engine" "$engine_cmd"
 }
 
 final_report() {

--- a/src/sdetkit/premium_gate_engine.py
+++ b/src/sdetkit/premium_gate_engine.py
@@ -132,6 +132,26 @@ class FixPlanItem:
     suggested_edit: str
 
 
+@dataclass(frozen=True)
+class ScriptCandidate:
+    script_id: str
+    reason: str
+    command: list[str]
+    artifact_paths: list[str]
+
+
+@dataclass(frozen=True)
+class ScriptRunResult:
+    script_id: str
+    status: str
+    rc: int
+    command: list[str]
+    reason: str
+    artifact_paths: list[str]
+    log_path: str
+    message: str
+
+
 def _safe_text(value: Any) -> str:
     return "" if value is None else str(value).strip()
 
@@ -544,6 +564,196 @@ def _build_fix_plan_item(result: AutoFixResult) -> FixPlanItem:
     return FixPlanItem(
         rule_id=rule, path=result.path, priority=priority, reason=base_reason, suggested_edit=edit
     )
+
+
+def _has_signal(payload: dict[str, Any], *, source: str) -> bool:
+    for key in ("warnings", "engine_checks", "recommendations"):
+        items = payload.get(key, [])
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if isinstance(item, dict) and _safe_text(item.get("source")) == source:
+                return True
+    return False
+
+
+def _failed_step_ids(payload: dict[str, Any]) -> set[str]:
+    steps = payload.get("step_status", [])
+    failed: set[str] = set()
+    if not isinstance(steps, list):
+        return failed
+    for item in steps:
+        if not isinstance(item, dict) or bool(item.get("ok", True)):
+            continue
+        name = _safe_text(item.get("name"))
+        if name:
+            failed.add(name)
+    return failed
+
+
+def _build_script_candidates(
+    payload: dict[str, Any],
+    *,
+    out_dir: Path,
+    fix_root: Path,
+    auto_fix_results: list[AutoFixResult] | None = None,
+) -> list[ScriptCandidate]:
+    candidates: list[ScriptCandidate] = []
+    failed_steps = _failed_step_ids(payload)
+    has_doctor_signal = _has_signal(payload, source="doctor") or "doctor_json" in failed_steps
+    has_maintenance_signal = _has_signal(payload, source="maintenance") or (
+        "maintenance_full" in failed_steps
+    )
+    has_security_signal = _has_signal(payload, source="security") or (
+        "security_triage" in failed_steps
+    )
+    has_style_or_quality_signal = bool(
+        failed_steps.intersection(
+            {"quality", "ruff_format", "ruff_lint", "ruff", "ruff_format_apply"}
+        )
+    )
+    autofix_applied = any(item.status == "fixed" for item in auto_fix_results or [])
+
+    if has_doctor_signal or has_style_or_quality_signal:
+        candidates.append(
+            ScriptCandidate(
+                script_id="gate_fast_fix_only",
+                reason="Doctor/style/quality signals detected; run the repo-safe formatter/fix lane.",
+                command=[
+                    sys.executable,
+                    "-m",
+                    "sdetkit",
+                    "gate",
+                    "fast",
+                    "--root",
+                    str(fix_root),
+                    "--fix-only",
+                    "--format",
+                    "json",
+                    "--out",
+                    str(out_dir / "gate-fast-fix.json"),
+                ],
+                artifact_paths=["gate-fast-fix.json"],
+            )
+        )
+        candidates.append(
+            ScriptCandidate(
+                script_id="doctor_refresh",
+                reason="Refresh doctor evidence after auto-remediation so premium scoring uses current artifacts.",
+                command=[
+                    sys.executable,
+                    "-m",
+                    "sdetkit",
+                    "doctor",
+                    "--json",
+                    "--out",
+                    str(out_dir / "doctor.json"),
+                ],
+                artifact_paths=["doctor.json"],
+            )
+        )
+
+    if has_maintenance_signal:
+        candidates.append(
+            ScriptCandidate(
+                script_id="maintenance_fix",
+                reason="Maintenance issues were detected; run the fix-aware maintenance lane to regenerate artifacts.",
+                command=[
+                    sys.executable,
+                    "-m",
+                    "sdetkit",
+                    "maintenance",
+                    "--mode",
+                    "full",
+                    "--fix",
+                    "--format",
+                    "json",
+                    "--out",
+                    str(out_dir / "maintenance.json"),
+                ],
+                artifact_paths=["maintenance.json"],
+            )
+        )
+
+    if has_security_signal or autofix_applied:
+        candidates.append(
+            ScriptCandidate(
+                script_id="security_triage_refresh",
+                reason="Security findings or auto-fixes changed the repo; refresh the baseline-aware security artifact.",
+                command=[
+                    sys.executable,
+                    "tools/triage.py",
+                    "--mode",
+                    "security",
+                    "--run-security",
+                    "--security-baseline",
+                    "tools/security.baseline.json",
+                    "--max-items",
+                    "20",
+                    "--tee",
+                    str(out_dir / "security-check.json"),
+                ],
+                artifact_paths=["security-check.json"],
+            )
+        )
+
+    deduped: list[ScriptCandidate] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate.script_id in seen:
+            continue
+        seen.add(candidate.script_id)
+        deduped.append(candidate)
+    return deduped
+
+
+def _run_script_candidate(
+    candidate: ScriptCandidate, *, cwd: Path, out_dir: Path
+) -> ScriptRunResult:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    log_path = out_dir / f"premium-autofix.{candidate.script_id}.log"
+    proc = subprocess.run(candidate.command, cwd=cwd, capture_output=True, text=True, check=False)
+    log_text = []
+    if proc.stdout:
+        log_text.append(proc.stdout.rstrip())
+    if proc.stderr:
+        log_text.append(proc.stderr.rstrip())
+    log_path.write_text(
+        "\n".join(part for part in log_text if part) + ("\n" if log_text else ""), encoding="utf-8"
+    )
+    status = "passed" if proc.returncode == 0 else "failed"
+    message = "script completed successfully" if proc.returncode == 0 else "script failed"
+    return ScriptRunResult(
+        script_id=candidate.script_id,
+        status=status,
+        rc=int(proc.returncode),
+        command=list(candidate.command),
+        reason=candidate.reason,
+        artifact_paths=list(candidate.artifact_paths),
+        log_path=str(log_path),
+        message=message,
+    )
+
+
+def run_smart_scripts(
+    payload: dict[str, Any],
+    *,
+    out_dir: Path,
+    fix_root: Path,
+    auto_fix_results: list[AutoFixResult] | None = None,
+    max_scripts: int = 4,
+) -> tuple[list[ScriptCandidate], list[ScriptRunResult]]:
+    candidates = _build_script_candidates(
+        payload,
+        out_dir=out_dir,
+        fix_root=fix_root,
+        auto_fix_results=auto_fix_results,
+    )
+    selected = candidates[: max(0, max_scripts)]
+    results = [
+        _run_script_candidate(candidate, cwd=fix_root, out_dir=out_dir) for candidate in selected
+    ]
+    return selected, results
 
 
 def _init_db(db_path: Path) -> None:
@@ -1088,6 +1298,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--double-check", action="store_true")
     parser.add_argument("--min-score", type=int, default=None)
     parser.add_argument("--auto-fix", action="store_true")
+    parser.add_argument("--auto-run-scripts", action="store_true")
+    parser.add_argument("--max-auto-scripts", type=int, default=4)
     parser.add_argument("--fix-root", default=".")
     parser.add_argument("--learn-db", action="store_true")
     parser.add_argument("--learn-commit", action="store_true")
@@ -1103,14 +1315,16 @@ def main(argv: list[str] | None = None) -> int:
         serve_insights_api(str(ns.host), int(ns.port), out_dir, db_path)
         return 0
 
+    fix_root = Path(ns.fix_root)
     payload = collect_signals(out_dir)
     payload = _apply_learned_guideline_actions(payload, db_path)
 
     if ns.double_check:
         payload = _apply_double_check(payload, collect_signals(out_dir))
 
+    fixes: list[AutoFixResult] = []
     if ns.auto_fix:
-        fixes = run_autofix(out_dir, Path(ns.fix_root))
+        fixes = run_autofix(out_dir, fix_root)
         payload = dict(payload)
         payload["auto_fix_results"] = [asdict(x) for x in fixes]
         manual_plan = [
@@ -1131,6 +1345,57 @@ def main(argv: list[str] | None = None) -> int:
                     )
                 )
             )
+
+    if ns.auto_run_scripts:
+        pre_script_score = int(payload.get("score", 0))
+        selected_scripts, script_results = run_smart_scripts(
+            payload,
+            out_dir=out_dir,
+            fix_root=fix_root,
+            auto_fix_results=fixes,
+            max_scripts=int(ns.max_auto_scripts),
+        )
+        refreshed = collect_signals(out_dir)
+        refreshed = _apply_learned_guideline_actions(refreshed, db_path)
+        extras = {
+            key: value
+            for key, value in payload.items()
+            if key
+            in {
+                "auto_fix_results",
+                "manual_fix_plan",
+            }
+        }
+        payload = {**refreshed, **extras}
+        payload["script_runs"] = [asdict(item) for item in script_results]
+        payload["smart_remediation"] = {
+            "selected_scripts": [item.script_id for item in selected_scripts],
+            "selected_count": len(selected_scripts),
+            "successful_scripts": sum(1 for item in script_results if item.status == "passed"),
+            "failed_scripts": sum(1 for item in script_results if item.status != "passed"),
+            "pre_script_score": pre_script_score,
+            "post_script_score": int(refreshed.get("score", 0)),
+        }
+        payload["smart_remediation"]["score_delta"] = (
+            payload["smart_remediation"]["post_script_score"]
+            - payload["smart_remediation"]["pre_script_score"]
+        )
+        if any(item.status != "passed" for item in script_results):
+            payload.setdefault("recommendations", []).append(
+                asdict(
+                    _make_signal(
+                        "engine",
+                        "script-followup",
+                        "high",
+                        "One or more smart remediation scripts failed. Inspect premium-autofix logs and rerun the premium gate after targeted fixes.",
+                    )
+                )
+            )
+        payload["counts"] = {
+            **payload.get("counts", {}),
+            "recommendations": len(payload.get("recommendations", [])),
+            "script_runs": len(script_results),
+        }
 
     if ns.json_output:
         Path(ns.json_output).write_text(

--- a/tests/test_premium_gate_engine.py
+++ b/tests/test_premium_gate_engine.py
@@ -398,3 +398,117 @@ def test_collect_signals_reads_integration_topology_contract(tmp_path: Path) -> 
     categories = {item["category"] for item in payload["engine_checks"]}
     assert "pass-rate" in categories
     assert "service-count" in categories
+
+
+def test_build_script_candidates_targets_doctor_maintenance_and_security(tmp_path: Path) -> None:
+    payload = {
+        "warnings": [
+            {"source": "doctor", "category": "policy", "severity": "high", "message": "drift"},
+            {
+                "source": "maintenance",
+                "category": "tests",
+                "severity": "medium",
+                "message": "failed",
+            },
+            {"source": "security", "category": "SEC_X", "severity": "high", "message": "finding"},
+        ],
+        "engine_checks": [],
+        "recommendations": [],
+        "step_status": [{"name": "ruff_lint", "ok": False, "details": "failed"}],
+    }
+
+    candidates = eng._build_script_candidates(
+        payload,
+        out_dir=tmp_path,
+        fix_root=tmp_path,
+        auto_fix_results=[eng.AutoFixResult("SEC_X", "src/app.py", "fixed", "patched")],
+    )
+
+    assert [item.script_id for item in candidates] == [
+        "gate_fast_fix_only",
+        "doctor_refresh",
+        "maintenance_fix",
+        "security_triage_refresh",
+    ]
+
+
+def test_main_auto_run_scripts_records_results_and_score_delta(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    (tmp_path / "doctor.json").write_text(
+        json.dumps({"checks": {}, "recommendations": []}), encoding="utf-8"
+    )
+    (tmp_path / "maintenance.json").write_text(
+        json.dumps(
+            {
+                "score": 60,
+                "checks": [
+                    {"name": "tests", "ok": False, "severity": "medium", "summary": "tests failed"}
+                ],
+                "recommendations": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_topology_artifact(tmp_path / "integration-topology.json")
+    (tmp_path / "security-check.json").write_text(
+        json.dumps({"findings": [{"rule_id": "SEC_X", "severity": "high", "path": "src/app.py"}]}),
+        encoding="utf-8",
+    )
+    (tmp_path / "premium-gate.Quality.log").write_text("warning: drift\n", encoding="utf-8")
+
+    calls: list[str] = []
+
+    def fake_run_scripts(payload, *, out_dir, fix_root, auto_fix_results=None, max_scripts=4):
+        assert out_dir == tmp_path
+        assert fix_root == tmp_path
+        calls.append("run")
+        (tmp_path / "maintenance.json").write_text(
+            json.dumps({"score": 100, "checks": [], "recommendations": []}), encoding="utf-8"
+        )
+        (tmp_path / "security-check.json").write_text(
+            json.dumps({"findings": [], "totals": {"critical": 0, "high": 0}}), encoding="utf-8"
+        )
+        return (
+            [
+                eng.ScriptCandidate(
+                    "maintenance_fix",
+                    "refresh maintenance",
+                    ["python", "-m", "sdetkit", "maintenance"],
+                    ["maintenance.json"],
+                )
+            ],
+            [
+                eng.ScriptRunResult(
+                    "maintenance_fix",
+                    "passed",
+                    0,
+                    ["python", "-m", "sdetkit", "maintenance"],
+                    "refresh maintenance",
+                    ["maintenance.json"],
+                    str(tmp_path / "premium-autofix.maintenance_fix.log"),
+                    "script completed successfully",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(eng, "run_smart_scripts", fake_run_scripts)
+
+    rc = eng.main(
+        [
+            "--out-dir",
+            str(tmp_path),
+            "--fix-root",
+            str(tmp_path),
+            "--auto-run-scripts",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert calls == ["run"]
+    assert payload["script_runs"][0]["script_id"] == "maintenance_fix"
+    assert payload["smart_remediation"]["selected_scripts"] == ["maintenance_fix"]
+    assert payload["smart_remediation"]["score_delta"] >= 0
+    assert payload["counts"]["script_runs"] == 1


### PR DESCRIPTION
### Motivation

- Raise the premium gate's automation level by letting the Head-5 engine not only report issues but also safely run repository remediation scripts and re-measure artifacts so CI can auto-heal and re-evaluate in one pass. 

### Description

- Added a smart remediation subsystem to `sdetkit.premium_gate_engine` including new dataclasses `ScriptCandidate` and `ScriptRunResult` and helpers `_build_script_candidates`, `_run_script_candidate`, and `run_smart_scripts` to select and execute repo-safe scripts based on warnings/failed steps and previous autofix results. 
- Wire the engine to optionally run the smart remediation loop with CLI flags `--auto-run-scripts` and `--max-auto-scripts` (defaults preserved), and keep `--auto-fix` unchanged for the existing security auto-fix path. 
- After scripts run the engine refreshes artifacts (e.g. `doctor.json`, `maintenance.json`, `security-check.json`), merges follow-up metadata, and records pre/post remediation scores and per-script logs in the payload under `script_runs` and `smart_remediation`. 
- Enable the behavior by default in the top-level orchestration script and add an escape hatch: `premium-gate.sh` reads `SDETKIT_PREMIUM_AUTO_RUN_SCRIPTS` (default `1`) and accepts `--no-auto-run-scripts` to disable smart remediation. 
- Documentation updates to `README.md` and `docs/premium-quality-gate.md` describing the new artifacts (`.sdetkit/out/premium-autofix.*.log`), flags, and the smart remediation loop. 
- Tests: added targeted tests in `tests/test_premium_gate_engine.py` to validate script-candidate selection and that `main()` records script runs and score delta metadata. 

### Testing

- Ran static/lint checks: `python -m ruff check src/sdetkit/premium_gate_engine.py tests/test_premium_gate_engine.py` (passed) and `python -m ruff format --check ...` (passed after formatting). 
- Unit tests executed: `python -m pytest -q tests/test_premium_gate_engine.py tests/test_gate_fast.py tests/test_doctor_plan.py` and all tests passed (`29 passed`). 
- Shell validation: `bash -n premium-gate.sh` (syntax OK). 
- The test suite and linters passed after formatting and the new tests confirm script selection, run-result recording, artifact refresh behavior, and score delta reporting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc7fa0de3c83208fbf41b89607170e)