### PR TITLE
Enhance premium gate remediation intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ python -m sdetkit integration topology-check --profile examples/kits/integration
 bash premium-gate.sh --mode full
 # premium gate now emits .sdetkit/out/integration-topology.json as a first-class operational artifact
 # head-5 also auto-runs repo-safe remediation scripts unless you pass --no-auto-run-scripts
+# and writes .sdetkit/out/premium-remediation-plan.json so PRs can review selected vs deferred fixes
+python -m sdetkit.premium_gate_engine --out-dir .sdetkit/out --search doctor --format json
+python -m sdetkit.premium_gate_engine --db-path .sdetkit/out/premium-insights.db --list-guidelines --search security
 python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json --fail-on error
 python -m sdetkit forensics bundle --run examples/kits/forensics/run-b.json --output build/repro.zip
 python -m sdetkit continuous-upgrade-cycle9-closeout --format json --strict
@@ -123,6 +126,8 @@ bash quality.sh doctor
 By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue. When you already know the maintenance lane you want, filter directly by `--manifest-action` to isolate packages that need a pin refresh, floor raise, staged upgrade, or dedicated major-upgrade branch. Use `--query` when you want text search across package names, notes, repo-usage files, recommended lanes, and validation commands without pre-classifying the package first. Use `--max-release-age-days 14` to build a fast-follow watchlist for just-landed releases, or `--min-release-age-days 365 --outdated-only` to isolate older targets that have gone stale and deserve a deliberate cleanup pass.
 
 The doctor surface now carries those same upgrade-audit focus controls, so you can search and narrow dependency work without leaving the readiness report. In addition to query, impact-area, manifest-action, and repo-usage targeting, doctor now supports release-age slicing via `--upgrade-audit-min-release-age-days` and `--upgrade-audit-max-release-age-days`, plus `--upgrade-audit-used-in-repo-only` / `--upgrade-audit-outdated-only` for tighter maintenance slices. The readiness payload also exposes grouped action, dependency-group, manifest-source, and release-freshness summaries so CI and PR checks can explain whether the repo’s hottest maintenance lane is “fresh releases to validate” or “older targets to retire” without re-running the full audit. It also emits a quality summary block with pass/fail/skipped counts, pass rate, failing check IDs, and hint coverage so the readiness signal is easier to scan in CI, markdown, and JSON outputs.
+
+The premium gate intelligence layer now goes further as well: it ranks remediation scripts by observed hotspot severity, emits a first-class `premium-remediation-plan.json` artifact, refreshes integration topology when contract drift is detected, and supports focused search across rendered findings plus learned guideline lookup from the premium insights database.
 
 To make those upgrade lanes reproducible in CI, the repo now pins the validated toolchain in `constraints-ci.txt` while leaving `pyproject.toml` flexible enough for package consumers.
 

--- a/premium-gate.sh
+++ b/premium-gate.sh
@@ -235,7 +235,7 @@ run_plan() {
 run_engine() {
   section "Real-time warnings and recommendations summary"
   local engine_cmd
-  engine_cmd="python3 -m sdetkit.premium_gate_engine --out-dir '$OUT_DIR' --double-check --min-score '$ENGINE_MIN_SCORE' --auto-fix --fix-root '$ROOT_DIR' --learn-db --learn-commit --db-path '$OUT_DIR/premium-insights.db' --format markdown --json-output '$OUT_DIR/premium-summary.json'"
+  engine_cmd="python3 -m sdetkit.premium_gate_engine --out-dir '$OUT_DIR' --double-check --min-score '$ENGINE_MIN_SCORE' --auto-fix --fix-root '$ROOT_DIR' --learn-db --learn-commit --db-path '$OUT_DIR/premium-insights.db' --format markdown --json-output '$OUT_DIR/premium-summary.json' --plan-output '$OUT_DIR/premium-remediation-plan.json'"
   if [[ "$AUTO_RUN_SCRIPTS" == "1" ]]; then
     engine_cmd+=" --auto-run-scripts"
   fi
@@ -269,6 +269,9 @@ PY
   if [[ -f "$OUT_DIR/premium-summary.json" ]]; then
     info "Engine JSON: $OUT_DIR/premium-summary.json"
   fi
+  if [[ -f "$OUT_DIR/premium-remediation-plan.json" ]]; then
+    info "Remediation plan: $OUT_DIR/premium-remediation-plan.json"
+  fi
   info "Step index: $STEP_INDEX_JSON"
   info "Step run ledger: $STEP_RESULTS_NDJSON"
 }
@@ -280,4 +283,4 @@ run_plan
 run_engine
 final_report
 
-echo "Premium gate passed. Artifacts: $OUT_DIR/doctor.json, $OUT_DIR/maintenance.json, $OUT_DIR/integration-topology.json, $OUT_DIR/security.sarif, $OUT_DIR/security-check.json, $OUT_DIR/premium-summary.json, $OUT_DIR/evidence.zip"
+echo "Premium gate passed. Artifacts: $OUT_DIR/doctor.json, $OUT_DIR/maintenance.json, $OUT_DIR/integration-topology.json, $OUT_DIR/security.sarif, $OUT_DIR/security-check.json, $OUT_DIR/premium-summary.json, $OUT_DIR/premium-remediation-plan.json, $OUT_DIR/evidence.zip"

--- a/src/sdetkit/premium_gate_engine.py
+++ b/src/sdetkit/premium_gate_engine.py
@@ -138,6 +138,9 @@ class ScriptCandidate:
     reason: str
     command: list[str]
     artifact_paths: list[str]
+    priority: str = "medium"
+    score: int = 0
+    trigger_sources: list[str] | None = None
 
 
 @dataclass(frozen=True)
@@ -150,6 +153,9 @@ class ScriptRunResult:
     artifact_paths: list[str]
     log_path: str
     message: str
+
+
+_PRIORITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1}
 
 
 def _safe_text(value: Any) -> str:
@@ -600,6 +606,8 @@ def _build_script_candidates(
 ) -> list[ScriptCandidate]:
     candidates: list[ScriptCandidate] = []
     failed_steps = _failed_step_ids(payload)
+    hotspots = payload.get("hotspots", {})
+    hotspot_counts = hotspots if isinstance(hotspots, dict) else {}
     has_doctor_signal = _has_signal(payload, source="doctor") or "doctor_json" in failed_steps
     has_maintenance_signal = _has_signal(payload, source="maintenance") or (
         "maintenance_full" in failed_steps
@@ -613,6 +621,31 @@ def _build_script_candidates(
         )
     )
     autofix_applied = any(item.status == "fixed" for item in auto_fix_results or [])
+    has_integration_signal = _has_signal(payload, source="integration") or (
+        "integration_topology" in failed_steps
+    )
+
+    def _candidate_score(*sources: str, bonus: int = 0) -> int:
+        score = bonus
+        for source in sources:
+            score += int(hotspot_counts.get(source, 0)) * 10
+        score += sum(6 for step_id in failed_steps if any(source in step_id for source in sources))
+        return score
+
+    def _priority_for(*sources: str) -> str:
+        severities = [
+            _safe_text(item.get("severity"))
+            for key in ("warnings", "engine_checks")
+            for item in payload.get(key, [])
+            if isinstance(item, dict) and _safe_text(item.get("source")) in sources
+        ]
+        if any(sev == "critical" for sev in severities):
+            return "critical"
+        if any(sev in {"high", "warn"} for sev in severities):
+            return "high"
+        if any(sev == "medium" for sev in severities):
+            return "medium"
+        return "low"
 
     if has_doctor_signal or has_style_or_quality_signal:
         candidates.append(
@@ -634,6 +667,9 @@ def _build_script_candidates(
                     str(out_dir / "gate-fast-fix.json"),
                 ],
                 artifact_paths=["gate-fast-fix.json"],
+                priority="high" if has_style_or_quality_signal else _priority_for("doctor"),
+                score=_candidate_score("doctor", bonus=18 if has_style_or_quality_signal else 8),
+                trigger_sources=["doctor", "quality", "style"],
             )
         )
         candidates.append(
@@ -650,6 +686,9 @@ def _build_script_candidates(
                     str(out_dir / "doctor.json"),
                 ],
                 artifact_paths=["doctor.json"],
+                priority=_priority_for("doctor"),
+                score=_candidate_score("doctor", bonus=6),
+                trigger_sources=["doctor"],
             )
         )
 
@@ -672,6 +711,9 @@ def _build_script_candidates(
                     str(out_dir / "maintenance.json"),
                 ],
                 artifact_paths=["maintenance.json"],
+                priority=_priority_for("maintenance"),
+                score=_candidate_score("maintenance", bonus=14),
+                trigger_sources=["maintenance"],
             )
         )
 
@@ -694,6 +736,33 @@ def _build_script_candidates(
                     str(out_dir / "security-check.json"),
                 ],
                 artifact_paths=["security-check.json"],
+                priority=_priority_for("security"),
+                score=_candidate_score("security", bonus=16 if autofix_applied else 12),
+                trigger_sources=["security"],
+            )
+        )
+
+    if has_integration_signal:
+        candidates.append(
+            ScriptCandidate(
+                script_id="integration_topology_refresh",
+                reason=(
+                    "Integration topology drift was detected; regenerate the topology contract "
+                    "artifact so premium scoring can verify the latest shape."
+                ),
+                command=[
+                    sys.executable,
+                    "-m",
+                    "sdetkit",
+                    "integration",
+                    "topology-check",
+                    "--profile",
+                    str(fix_root / "examples/kits/integration/heterogeneous-topology.json"),
+                ],
+                artifact_paths=["integration-topology.json"],
+                priority=_priority_for("integration"),
+                score=_candidate_score("integration", bonus=15),
+                trigger_sources=["integration"],
             )
         )
 
@@ -704,7 +773,56 @@ def _build_script_candidates(
             continue
         seen.add(candidate.script_id)
         deduped.append(candidate)
-    return deduped
+    return sorted(
+        deduped,
+        key=lambda item: (-item.score, -_PRIORITY_RANK.get(item.priority, 0), item.script_id),
+    )
+
+
+def _build_script_plan(
+    payload: dict[str, Any],
+    *,
+    out_dir: Path,
+    fix_root: Path,
+    auto_fix_results: list[AutoFixResult] | None = None,
+    max_scripts: int = 4,
+) -> dict[str, Any]:
+    candidates = _build_script_candidates(
+        payload,
+        out_dir=out_dir,
+        fix_root=fix_root,
+        auto_fix_results=auto_fix_results,
+    )
+    selected = candidates[: max(0, max_scripts)]
+    deferred = candidates[max(0, max_scripts) :]
+    return {
+        "selected": [
+            {
+                "script_id": item.script_id,
+                "priority": item.priority,
+                "score": item.score,
+                "reason": item.reason,
+                "trigger_sources": list(item.trigger_sources or []),
+                "artifact_paths": list(item.artifact_paths),
+                "command": list(item.command),
+            }
+            for item in selected
+        ],
+        "deferred": [
+            {
+                "script_id": item.script_id,
+                "priority": item.priority,
+                "score": item.score,
+                "reason": item.reason,
+                "trigger_sources": list(item.trigger_sources or []),
+                "artifact_paths": list(item.artifact_paths),
+                "command": list(item.command),
+            }
+            for item in deferred
+        ],
+        "max_scripts": max(0, max_scripts),
+        "candidate_count": len(candidates),
+    }
 
 
 def _run_script_candidate(
@@ -1202,6 +1320,76 @@ def _apply_double_check(payload: dict[str, Any], second: dict[str, Any]) -> dict
     return out
 
 
+def search_guidelines(
+    db_path: Path, query: str, *, active_only: bool = True, limit: int = 100
+) -> list[dict[str, Any]]:
+    needle = _safe_text(query).lower()
+    rows = list_guidelines(db_path, active_only=active_only, limit=limit)
+    if not needle:
+        return rows
+    filtered: list[dict[str, Any]] = []
+    for row in rows:
+        haystack = " ".join(
+            [
+                _safe_text(row.get("title")),
+                _safe_text(row.get("body")),
+                " ".join(row.get("tags", []) if isinstance(row.get("tags"), list) else []),
+                _safe_text(row.get("source")),
+            ]
+        ).lower()
+        if needle in haystack:
+            filtered.append(row)
+    return filtered
+
+
+def filter_payload(payload: dict[str, Any], query: str) -> dict[str, Any]:
+    needle = _safe_text(query).lower()
+    if not needle:
+        return payload
+
+    def _matches(item: Any) -> bool:
+        if isinstance(item, dict):
+            return needle in json.dumps(item, sort_keys=True).lower()
+        return needle in _safe_text(item).lower()
+
+    out = dict(payload)
+    for key in (
+        "warnings",
+        "recommendations",
+        "engine_checks",
+        "step_status",
+        "manual_fix_plan",
+        "auto_fix_results",
+        "script_runs",
+    ):
+        value = payload.get(key, [])
+        if isinstance(value, list):
+            out[key] = [item for item in value if _matches(item)]
+    smart = payload.get("smart_remediation")
+    if isinstance(smart, dict):
+        plan = smart.get("plan")
+        if isinstance(plan, dict):
+            smart = {
+                **smart,
+                "plan": {
+                    **plan,
+                    "selected": [item for item in plan.get("selected", []) if _matches(item)],
+                    "deferred": [item for item in plan.get("deferred", []) if _matches(item)],
+                },
+            }
+        out["smart_remediation"] = smart
+    out["search_query"] = needle
+    out["counts"] = {
+        **payload.get("counts", {}),
+        "warnings": len(out.get("warnings", [])),
+        "recommendations": len(out.get("recommendations", [])),
+        "engine_checks": len(out.get("engine_checks", [])),
+        "steps": len(out.get("step_status", [])),
+        "script_runs": len(out.get("script_runs", [])),
+    }
+    return out
+
+
 def render_text(payload: dict[str, Any]) -> str:
     lines = [
         f"premium gate intelligence score: {payload['score']}%",
@@ -1248,6 +1436,20 @@ def render_text(payload: dict[str, Any]) -> str:
                 f"- \U0001f527 {item['priority']} {item['rule_id']} {item['path']}: {item['suggested_edit']}"
             )
 
+    smart = payload.get("smart_remediation")
+    if isinstance(smart, dict):
+        lines.append("smart remediation:")
+        lines.append(
+            f"- selected={smart.get('selected_count', 0)} success={smart.get('successful_scripts', 0)} "
+            f"failed={smart.get('failed_scripts', 0)} score_delta={smart.get('score_delta', 0)}"
+        )
+        plan = smart.get("plan")
+        if isinstance(plan, dict):
+            for item in plan.get("selected", [])[:10]:
+                lines.append(
+                    f"- \U0001f680 {item['script_id']} [{item['priority']}] score={item['score']}: {item['reason']}"
+                )
+
     return "\n".join(lines)
 
 
@@ -1286,6 +1488,33 @@ def render_markdown(payload: dict[str, Any]) -> str:
             lines.append(
                 f"- \U0001f527 `{item['priority']}` `{item['rule_id']}` `{item['path']}` \u2014 {item['suggested_edit']}"
             )
+    smart = payload.get("smart_remediation")
+    if isinstance(smart, dict):
+        lines.append("")
+        lines.append("## smart remediation")
+        lines.append(
+            "- selected: "
+            f"**{smart.get('selected_count', 0)}**, "
+            f"successful: **{smart.get('successful_scripts', 0)}**, "
+            f"failed: **{smart.get('failed_scripts', 0)}**, "
+            f"score delta: **{smart.get('score_delta', 0)}**"
+        )
+        plan = smart.get("plan")
+        if isinstance(plan, dict):
+            if plan.get("selected"):
+                lines.append("")
+                lines.append("### selected scripts")
+                for item in plan["selected"][:10]:
+                    lines.append(
+                        f"- \U0001f680 `{item['script_id']}` ({item['priority']}, score={item['score']}): {item['reason']}"
+                    )
+            if plan.get("deferred"):
+                lines.append("")
+                lines.append("### deferred scripts")
+                for item in plan["deferred"][:10]:
+                    lines.append(
+                        f"- \u23ed️ `{item['script_id']}` ({item['priority']}, score={item['score']}): {item['reason']}"
+                    )
     return "\n".join(lines)
 
 
@@ -1300,9 +1529,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--auto-fix", action="store_true")
     parser.add_argument("--auto-run-scripts", action="store_true")
     parser.add_argument("--max-auto-scripts", type=int, default=4)
+    parser.add_argument("--plan-output", default=None)
     parser.add_argument("--fix-root", default=".")
     parser.add_argument("--learn-db", action="store_true")
     parser.add_argument("--learn-commit", action="store_true")
+    parser.add_argument("--list-guidelines", action="store_true")
+    parser.add_argument("--search", default=None)
     parser.add_argument("--serve-api", action="store_true")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8799)
@@ -1313,6 +1545,16 @@ def main(argv: list[str] | None = None) -> int:
 
     if ns.serve_api:
         serve_insights_api(str(ns.host), int(ns.port), out_dir, db_path)
+        return 0
+
+    if ns.list_guidelines:
+        guidelines = search_guidelines(db_path, _safe_text(ns.search), active_only=True, limit=500)
+        payload = {
+            "guidelines": guidelines,
+            "count": len(guidelines),
+            "search_query": ns.search or "",
+        }
+        sys.stdout.write(f"{json.dumps(payload, indent=2, sort_keys=True)}\n")
         return 0
 
     fix_root = Path(ns.fix_root)
@@ -1348,6 +1590,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if ns.auto_run_scripts:
         pre_script_score = int(payload.get("score", 0))
+        plan = _build_script_plan(
+            payload,
+            out_dir=out_dir,
+            fix_root=fix_root,
+            auto_fix_results=fixes,
+            max_scripts=int(ns.max_auto_scripts),
+        )
         selected_scripts, script_results = run_smart_scripts(
             payload,
             out_dir=out_dir,
@@ -1375,6 +1624,7 @@ def main(argv: list[str] | None = None) -> int:
             "failed_scripts": sum(1 for item in script_results if item.status != "passed"),
             "pre_script_score": pre_script_score,
             "post_script_score": int(refreshed.get("score", 0)),
+            "plan": plan,
         }
         payload["smart_remediation"]["score_delta"] = (
             payload["smart_remediation"]["post_script_score"]
@@ -1396,6 +1646,21 @@ def main(argv: list[str] | None = None) -> int:
             "recommendations": len(payload.get("recommendations", [])),
             "script_runs": len(script_results),
         }
+
+    if ns.plan_output:
+        plan_payload = _build_script_plan(
+            payload,
+            out_dir=out_dir,
+            fix_root=fix_root,
+            auto_fix_results=fixes,
+            max_scripts=int(ns.max_auto_scripts),
+        )
+        Path(ns.plan_output).write_text(
+            json.dumps(plan_payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    rendered_payload = filter_payload(payload, _safe_text(ns.search)) if ns.search else payload
 
     if ns.json_output:
         Path(ns.json_output).write_text(
@@ -1429,11 +1694,11 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     if ns.format == "json":
-        sys.stdout.write(f"{json.dumps(payload, indent=2, sort_keys=True)}\n")
+        sys.stdout.write(f"{json.dumps(rendered_payload, indent=2, sort_keys=True)}\n")
     elif ns.format == "markdown":
-        sys.stdout.write(f"{render_markdown(payload)}\n")
+        sys.stdout.write(f"{render_markdown(rendered_payload)}\n")
     else:
-        sys.stdout.write(f"{render_text(payload)}\n")
+        sys.stdout.write(f"{render_text(rendered_payload)}\n")
 
     if ns.min_score is not None and payload["score"] < ns.min_score:
         return 2

--- a/tests/test_premium_gate_engine.py
+++ b/tests/test_premium_gate_engine.py
@@ -424,12 +424,15 @@ def test_build_script_candidates_targets_doctor_maintenance_and_security(tmp_pat
         auto_fix_results=[eng.AutoFixResult("SEC_X", "src/app.py", "fixed", "patched")],
     )
 
-    assert [item.script_id for item in candidates] == [
+    ids = [item.script_id for item in candidates]
+    assert ids[:4] == [
         "gate_fast_fix_only",
-        "doctor_refresh",
-        "maintenance_fix",
         "security_triage_refresh",
+        "maintenance_fix",
+        "doctor_refresh",
     ]
+    assert candidates[0].score >= candidates[-1].score
+    assert candidates[0].priority in {"high", "critical"}
 
 
 def test_main_auto_run_scripts_records_results_and_score_delta(
@@ -476,6 +479,9 @@ def test_main_auto_run_scripts_records_results_and_score_delta(
                     "refresh maintenance",
                     ["python", "-m", "sdetkit", "maintenance"],
                     ["maintenance.json"],
+                    "high",
+                    24,
+                    ["maintenance"],
                 )
             ],
             [
@@ -512,3 +518,80 @@ def test_main_auto_run_scripts_records_results_and_score_delta(
     assert payload["smart_remediation"]["selected_scripts"] == ["maintenance_fix"]
     assert payload["smart_remediation"]["score_delta"] >= 0
     assert payload["counts"]["script_runs"] == 1
+    assert payload["smart_remediation"]["plan"]["selected"][0]["script_id"] == "maintenance_fix"
+
+
+def test_filter_payload_and_guideline_search_support_targeted_queries(tmp_path: Path) -> None:
+    db = tmp_path / "premium-insights.db"
+    eng.add_guideline(db, "doctor:policy", "enforce doctor policy", ["doctor", "policy"])
+    eng.add_guideline(db, "security:SEC_X", "rotate token", ["security", "critical"])
+
+    payload = {
+        "warnings": [
+            {
+                "source": "doctor",
+                "category": "policy",
+                "severity": "high",
+                "message": "policy drift",
+            },
+            {"source": "security", "category": "SEC_X", "severity": "critical", "message": "token"},
+        ],
+        "recommendations": [
+            {"source": "engine", "category": "playbook", "message": "rotate token"}
+        ],
+        "engine_checks": [],
+        "step_status": [{"name": "doctor_json", "ok": False, "details": "failed"}],
+        "counts": {"warnings": 2, "recommendations": 1, "engine_checks": 0, "steps": 1},
+        "smart_remediation": {
+            "plan": {"selected": [{"script_id": "doctor_refresh"}], "deferred": []}
+        },
+    }
+
+    filtered = eng.filter_payload(payload, "doctor")
+    assert len(filtered["warnings"]) == 1
+    assert filtered["warnings"][0]["source"] == "doctor"
+    assert filtered["counts"]["warnings"] == 1
+
+    guidelines = eng.search_guidelines(db, "rotate")
+    assert len(guidelines) == 1
+    assert guidelines[0]["title"] == "security:SEC_X"
+
+
+def test_main_plan_output_and_search_filter_rendered_payload(tmp_path: Path, capsys) -> None:
+    (tmp_path / "doctor.json").write_text(
+        json.dumps(
+            {
+                "checks": {"policy": {"ok": False, "severity": "high", "message": "policy drift"}},
+                "recommendations": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "maintenance.json").write_text(
+        json.dumps({"checks": [], "recommendations": []}),
+        encoding="utf-8",
+    )
+    _write_topology_artifact(tmp_path / "integration-topology.json")
+    (tmp_path / "security-check.json").write_text(json.dumps({"findings": []}), encoding="utf-8")
+    (tmp_path / "premium-gate.Quality.log").write_text("warning: drift\n", encoding="utf-8")
+    plan_path = tmp_path / "plan.json"
+
+    rc = eng.main(
+        [
+            "--out-dir",
+            str(tmp_path),
+            "--plan-output",
+            str(plan_path),
+            "--search",
+            "doctor",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["search_query"] == "doctor"
+    assert len(payload["warnings"]) == 1
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert plan["candidate_count"] >= 1
+    assert plan["selected"][0]["script_id"] == "gate_fast_fix_only"


### PR DESCRIPTION
### Motivation
- Improve the premium gate "Head-5" intelligence so automated remediation is more reviewable and selects higher-signal fixes first.
- Provide searchable guidance and plan artifacts to make auto-fix/auto-run behavior auditable in PRs and operator workflows.

### Description
- Add `priority`, `score`, and `trigger_sources` metadata to `ScriptCandidate` and compute a ranking by hotspot counts and severity in `src/sdetkit/premium_gate_engine.py` so remediation candidates are ordered by signal strength (`_PRIORITY_RANK`, `_candidate_score`, sorted output).
- Emit a structured remediation plan via a new `_build_script_plan` function and surface it on the CLI with `--plan-output`, and include the plan in `smart_remediation.plan` when `--auto-run-scripts` is used.
- Add integration-topology refresh candidate when topology drift is detected and wire candidate scoring/priority heuristics; add search/filter utilities `filter_payload` and `search_guidelines` and CLI flags `--search` and `--list-guidelines` to focus rendered findings and query learned guidelines.
- Surface remediation plan from the shell orchestration script by passing `--plan-output` in `premium-gate.sh` and documenting usage and examples in `README.md`.
- Extend tests in `tests/test_premium_gate_engine.py` to assert ranking, plan creation, search/filter behavior, and guideline lookup; minor test updates to reflect sorted ordering.

### Testing
- Ran unit tests: `python -m pytest tests/test_premium_gate_engine.py tests/test_premium_gate_engine_extra.py -q` — all tests passed (`21 passed`).
- Static checks: `python -m ruff check` and `python -m ruff format` were run on modified files and passed/auto-formatted as needed.
- Shell validation: `bash -n premium-gate.sh` returned clean syntax for the updated wrapper script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc849649b883208364ff4063c77e0d)