### PR TITLE
Add validation-command filter to upgrade-audit, expose richer audit filters in CLI/doctor, and refresh ruff/mkdocs pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ python -m sdetkit intelligence upgrade-audit --outdated-only --package "http*"
 python -m sdetkit intelligence upgrade-audit --used-in-repo-only --repo-usage-tier hot-path --format md
 python -m sdetkit intelligence upgrade-audit --query runtime-core --query "next maintenance"
 python -m sdetkit intelligence upgrade-audit --manifest-action stage-upgrade --top 10
+python -m sdetkit intelligence upgrade-audit --validation-command "make docs-build"
 python -m sdetkit intelligence upgrade-audit --group default --source pyproject.toml --format md
 python scripts/upgrade_audit.py --format json > build/upgrade-audit.json
 python scripts/upgrade_audit.py --fail-on high
@@ -124,6 +125,8 @@ bash quality.sh doctor
 ```
 
 By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue. When you already know the maintenance lane you want, filter directly by `--manifest-action` to isolate packages that need a pin refresh, floor raise, staged upgrade, or dedicated major-upgrade branch. Use `--query` when you want text search across package names, notes, repo-usage files, recommended lanes, and validation commands without pre-classifying the package first. Use `--max-release-age-days 14` to build a fast-follow watchlist for just-landed releases, or `--min-release-age-days 365 --outdated-only` to isolate older targets that have gone stale and deserve a deliberate cleanup pass.
+
+When you want a surgically targeted maintenance queue, filter by `--validation-command` as well. That lets you answer questions like “show me only upgrades that roll into `make docs-build`” or “which candidates are covered by `bash quality.sh *` smoke validation” without scanning the whole report.
 
 The doctor surface now carries those same upgrade-audit focus controls, so you can search and narrow dependency work without leaving the readiness report. In addition to query, impact-area, manifest-action, and repo-usage targeting, doctor now supports release-age slicing via `--upgrade-audit-min-release-age-days` and `--upgrade-audit-max-release-age-days`, plus `--upgrade-audit-used-in-repo-only` / `--upgrade-audit-outdated-only` for tighter maintenance slices. The readiness payload also exposes grouped action, dependency-group, manifest-source, and release-freshness summaries so CI and PR checks can explain whether the repo’s hottest maintenance lane is “fresh releases to validate” or “older targets to retire” without re-running the full audit. It also emits a quality summary block with pass/fail/skipped counts, pass rate, failing check IDs, and hint coverage so the readiness signal is easier to scan in CI, markdown, and JSON outputs.
 

--- a/constraints-ci.txt
+++ b/constraints-ci.txt
@@ -5,11 +5,11 @@ build==1.4.0
 check-wheel-contents==0.6.3
 hypothesis==6.151.9
 mkdocs==1.6.1
-mkdocs-material==9.7.5
+mkdocs-material==9.7.6
 mypy==1.19.1
 pre-commit==4.5.1
 pytest==9.0.2
 pytest-asyncio==1.3.0
 pytest-cov==7.0.0
-ruff==0.15.6
+ruff==0.15.7
 twine==6.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
   "build==1.4.0",
   "mypy==1.19.1",
   "pre-commit==4.5.1",
-  "ruff==0.15.6",
+  "ruff==0.15.7",
   "twine==6.2.0"
 ]
 test = [
@@ -55,7 +55,7 @@ test = [
 ]
 docs = [
   "mkdocs==1.6.1",
-  "mkdocs-material==9.7.5"
+  "mkdocs-material==9.7.6"
 ]
 packaging = [
   "build==1.4.0",

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,2 @@
 mkdocs==1.6.1
-mkdocs-material==9.7.5
+mkdocs-material==9.7.6

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,6 @@ pytest-cov==7.0.0
 pytest-asyncio==1.3.0
 hypothesis==6.151.9
 httpx==0.28.1
-ruff==0.15.6
+ruff==0.15.7
 mypy==1.19.1
 mutmut==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ httpx==0.28.1
 filelock==3.25.2
 
 # Dev + QA tooling
-ruff==0.15.6
+ruff==0.15.7
 mypy==1.19.1
 pre-commit==4.5.1
 pytest==9.0.2
@@ -24,7 +24,7 @@ cyclonedx-bom==7.2.2
 
 # Docs
 mkdocs==1.6.1
-mkdocs-material==9.7.5
+mkdocs-material==9.7.6
 
 # Backport for environments below Python 3.11
 # (kept for compatibility in ad-hoc environments)

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -1061,6 +1061,7 @@ def _check_upgrade_audit(
     queries: list[str] | None = None,
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
+    validation_commands: list[str] | None = None,
     repo_usage_tiers: list[str] | None = None,
     release_freshness: list[str] | None = None,
     used_in_repo_only: bool = False,
@@ -1153,6 +1154,7 @@ def _check_upgrade_audit(
         queries=queries,
         min_release_age_days=min_release_age_days,
         max_release_age_days=max_release_age_days,
+        validation_commands=validation_commands,
         used_in_repo_only=used_in_repo_only,
         outdated_only=outdated_only,
         top=top,
@@ -1244,6 +1246,7 @@ def _check_upgrade_audit(
             "queries": queries or [],
             "impact_areas": impact_areas or [],
             "manifest_actions": manifest_actions or [],
+            "validation_commands": validation_commands or [],
             "repo_usage_tiers": repo_usage_tiers or [],
             "release_freshness": release_freshness or [],
             "min_release_age_days": min_release_age_days,
@@ -1531,6 +1534,7 @@ def main(argv: list[str] | None = None) -> int:
         "--upgrade-audit-query",
         "--upgrade-audit-impact-area",
         "--upgrade-audit-manifest-action",
+        "--upgrade-audit-validation-command",
         "--upgrade-audit-repo-usage-tier",
         "--upgrade-audit-release-freshness",
         "--upgrade-audit-top",
@@ -1668,6 +1672,16 @@ def main(argv: list[str] | None = None) -> int:
         ],
         default=None,
         help="Focus doctor upgrade-audit hints on specific manifest actions.",
+    )
+    parser.add_argument(
+        "--upgrade-audit-validation-command",
+        dest="upgrade_audit_validation_commands",
+        action="append",
+        default=None,
+        help=(
+            "Focus doctor upgrade-audit hints on packages whose suggested validation commands "
+            "match a command or glob pattern."
+        ),
     )
     parser.add_argument(
         "--upgrade-audit-top",
@@ -2151,6 +2165,7 @@ def main(argv: list[str] | None = None) -> int:
             queries=ns.upgrade_audit_queries,
             impact_areas=ns.upgrade_audit_impact_areas,
             manifest_actions=ns.upgrade_audit_manifest_actions,
+            validation_commands=ns.upgrade_audit_validation_commands,
             repo_usage_tiers=ns.upgrade_audit_repo_usage_tiers,
             release_freshness=ns.upgrade_audit_release_freshness,
             min_release_age_days=ns.upgrade_audit_min_release_age_days,

--- a/src/sdetkit/intelligence.py
+++ b/src/sdetkit/intelligence.py
@@ -252,6 +252,21 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
     )
     ua.add_argument(
+        "--lane",
+        action="append",
+        choices=[
+            "stabilize-manifests",
+            "refresh-baselines",
+            "upgrade-now",
+            "next-maintenance-batch",
+            "investigate-metadata",
+            "policy-covered-watchlist",
+            "backlog-watchlist",
+        ],
+        default=None,
+    )
+    ua.add_argument("--query", action="append", default=None)
+    ua.add_argument(
         "--impact-area",
         action="append",
         choices=[
@@ -279,12 +294,21 @@ def main(argv: list[str] | None = None) -> int:
         ],
         default=None,
     )
+    ua.add_argument("--validation-command", action="append", default=None)
     ua.add_argument(
         "--repo-usage-tier",
         action="append",
         choices=["hot-path", "active", "edge", "declared-only"],
         default=None,
     )
+    ua.add_argument(
+        "--release-freshness",
+        action="append",
+        choices=list(upgrade_audit.RELEASE_FRESHNESS_BUCKETS),
+        default=None,
+    )
+    ua.add_argument("--min-release-age-days", type=int, default=None)
+    ua.add_argument("--max-release-age-days", type=int, default=None)
     ua.add_argument("--used-in-repo-only", action="store_true")
     ua.add_argument("--outdated-only", action="store_true")
     ua.add_argument("--top", type=int, default=None)
@@ -334,9 +358,15 @@ def main(argv: list[str] | None = None) -> int:
                 groups=ns.group,
                 sources=ns.source,
                 metadata_sources=ns.metadata_source,
+                lanes=ns.lane,
+                queries=ns.query,
                 impact_areas=ns.impact_area,
                 manifest_actions=ns.manifest_action,
+                validation_commands=ns.validation_command,
                 repo_usage_tiers=ns.repo_usage_tier,
+                release_freshness=ns.release_freshness,
+                min_release_age_days=ns.min_release_age_days,
+                max_release_age_days=ns.max_release_age_days,
                 used_in_repo_only=bool(ns.used_in_repo_only),
                 outdated_only=bool(ns.outdated_only),
                 top=ns.top,

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -1580,6 +1580,17 @@ def _matches_any_filter(values: list[str], allowed_filters: list[str] | None) ->
     return any(filter_value in normalized_values for filter_value in allowed_filters)
 
 
+def _matches_command_filters(commands: list[str], command_filters: list[str] | None) -> bool:
+    if not command_filters:
+        return True
+    normalized_commands = [command.lower() for command in commands if command.strip()]
+    return any(
+        fnmatch.fnmatch(command, pattern)
+        for pattern in command_filters
+        for command in normalized_commands
+    )
+
+
 def _matches_text_query(report: PackageReport, query_terms: list[str] | None) -> bool:
     if not query_terms:
         return True
@@ -1667,6 +1678,7 @@ def _filter_reports(
     lanes: list[str] | None = None,
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
+    validation_commands: list[str] | None = None,
     repo_usage_tiers: list[str] | None = None,
     release_freshness: list[str] | None = None,
     queries: list[str] | None = None,
@@ -1710,6 +1722,13 @@ def _filter_reports(
     if manifest_actions:
         allowed_actions = {item.strip() for item in manifest_actions if item.strip()}
         filtered = [report for report in filtered if report.manifest_action in allowed_actions]
+    if validation_commands:
+        command_filters = [item.strip().lower() for item in validation_commands if item.strip()]
+        filtered = [
+            report
+            for report in filtered
+            if _matches_command_filters(report.validation_commands, command_filters)
+        ]
     if repo_usage_tiers:
         allowed_tiers = {item.strip() for item in repo_usage_tiers if item.strip()}
         filtered = [report for report in filtered if report.repo_usage_tier in allowed_tiers]
@@ -1958,6 +1977,7 @@ def run(
     lanes: list[str] | None = None,
     impact_areas: list[str] | None = None,
     manifest_actions: list[str] | None = None,
+    validation_commands: list[str] | None = None,
     repo_usage_tiers: list[str] | None = None,
     release_freshness: list[str] | None = None,
     queries: list[str] | None = None,
@@ -2048,6 +2068,7 @@ def run(
         lanes=lanes,
         impact_areas=impact_areas,
         manifest_actions=manifest_actions,
+        validation_commands=validation_commands,
         repo_usage_tiers=repo_usage_tiers,
         release_freshness=release_freshness,
         queries=queries,
@@ -2227,6 +2248,15 @@ def build_parser(*, prog: str = "upgrade-audit") -> argparse.ArgumentParser:
         help="Show only packages with the selected manifest action(s).",
     )
     parser.add_argument(
+        "--validation-command",
+        action="append",
+        default=None,
+        help=(
+            "Show only packages whose suggested validation commands match the provided command "
+            "or glob pattern. Can be passed multiple times."
+        ),
+    )
+    parser.add_argument(
         "--repo-usage-tier",
         action="append",
         choices=["hot-path", "active", "edge", "declared-only"],
@@ -2326,6 +2356,7 @@ def main(argv: list[str] | None = None) -> int:
         lanes=args.lane,
         impact_areas=args.impact_area,
         manifest_actions=args.manifest_action,
+        validation_commands=args.validation_command,
         repo_usage_tiers=args.repo_usage_tier,
         release_freshness=args.release_freshness,
         queries=args.query,

--- a/tests/test_doctor_upgrade_audit.py
+++ b/tests/test_doctor_upgrade_audit.py
@@ -589,3 +589,77 @@ def test_doctor_upgrade_audit_supports_lane_and_release_freshness_filters(
         == "bash ci.sh quick --skip-docs --artifact-dir build"
     )
     assert any("risk " in hint for hint in payload["hints"])
+
+
+def test_doctor_upgrade_audit_supports_validation_command_filters(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_minimal_pyproject(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    deps = [
+        doctor.upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="docs",
+            raw="mkdocs-material==9.7.6",
+            name="mkdocs-material",
+            pinned_version="9.7.6",
+        ),
+        doctor.upgrade_audit.Dependency(
+            source="pyproject.toml",
+            group="dev",
+            raw="ruff==0.15.7",
+            name="ruff",
+            pinned_version="0.15.7",
+        ),
+    ]
+
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_discover_requirement_files", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(doctor.upgrade_audit, "_load_dependencies", lambda *_args, **_kwargs: deps)
+    monkeypatch.setattr(
+        doctor.upgrade_audit, "_load_project_python_requires", lambda *_args, **_kwargs: ">=3.11"
+    )
+    monkeypatch.setattr(doctor.upgrade_audit, "_collect_repo_usage", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        doctor.upgrade_audit,
+        "_collect_package_metadata",
+        lambda *_args, **_kwargs: {
+            "mkdocs-material": doctor.upgrade_audit.PackageMetadata(
+                latest_version="9.7.7",
+                release_date="2026-03-15T00:00:00+00:00",
+                compatible_version="9.7.7",
+                compatible_release_date="2026-03-15T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="cache",
+            ),
+            "ruff": doctor.upgrade_audit.PackageMetadata(
+                latest_version="0.15.7",
+                release_date="2026-03-15T00:00:00+00:00",
+                compatible_version="0.15.7",
+                compatible_release_date="2026-03-15T00:00:00+00:00",
+                compatibility_status="compatible-latest",
+                source="cache",
+            ),
+        },
+    )
+
+    rc = doctor.main(
+        [
+            "--only",
+            "upgrade_audit",
+            "--upgrade-audit",
+            "--upgrade-audit-validation-command",
+            "make docs-build",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc in {0, doctor.EXIT_FAILED}
+    payload = json.loads(capsys.readouterr().out)
+    meta = payload["checks"]["upgrade_audit"]["meta"]
+    assert meta["packages_in_scope"] == 1
+    assert meta["filters"]["validation_commands"] == ["make docs-build"]
+    assert meta["priority_queue"][0]["name"] == "mkdocs-material"

--- a/tests/test_kits_intelligence_integration_forensics.py
+++ b/tests/test_kits_intelligence_integration_forensics.py
@@ -83,7 +83,7 @@ dependencies = ["httpx==0.28.1"]
                     "httpx": {
                         "fetched_at": 1_767_000_000.0,
                         "latest_version": "0.28.1",
-                        "release_date": "2026-01-01T00:00:00Z",
+                        "release_date": "2026-03-18T00:00:00Z",
                     }
                 },
             }
@@ -107,6 +107,10 @@ dependencies = ["httpx==0.28.1"]
         "pyproject.toml",
         "--manifest-action",
         "none",
+        "--validation-command",
+        "bash ci.sh quick --skip-docs --artifact-dir build",
+        "--release-freshness",
+        "fresh-release",
         "--include-prereleases",
     )
 
@@ -118,6 +122,7 @@ dependencies = ["httpx==0.28.1"]
     assert payload["groups"][0]["group"] == "default"
     assert payload["sources"][0]["source"] == "pyproject.toml"
     assert payload["actions"][0]["manifest_action"] == "none"
+    assert payload["validations"][0]["command"] == "bash ci.sh quick --skip-docs --artifact-dir build"
 
 
 def test_intelligence_failure_mode_invalid_failures_file(tmp_path: Path) -> None:

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -1326,6 +1326,26 @@ def test_filter_reports_supports_lane_and_release_freshness_filters() -> None:
     assert [report.name for report in filtered] == ["httpx"]
 
 
+def test_filter_reports_supports_validation_command_filters() -> None:
+    reports = [
+        _report(
+            name="mkdocs-material",
+            validation_commands=["bash ci.sh all --artifact-dir build", "make docs-build"],
+        ),
+        _report(
+            name="ruff",
+            validation_commands=["bash quality.sh ci", "bash quality.sh cov"],
+        ),
+    ]
+
+    filtered = upgrade_audit._filter_reports(
+        reports,
+        validation_commands=["make docs-build", "bash quality.sh *"],
+    )
+
+    assert [report.name for report in filtered] == ["mkdocs-material", "ruff"]
+
+
 def test_render_json_and_markdown_include_risk_and_validation_summaries() -> None:
     reports = [
         _report(
@@ -1389,6 +1409,8 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
             "hot-path",
             "--lane",
             "upgrade-now",
+            "--validation-command",
+            "bash quality.sh *",
             "--release-freshness",
             "fresh-release",
             "--query",
@@ -1407,6 +1429,7 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
     assert args.manifest_action is None
     assert args.repo_usage_tier == ["hot-path"]
     assert args.lane == ["upgrade-now"]
+    assert args.validation_command == ["bash quality.sh *"]
     assert args.release_freshness == ["fresh-release"]
     assert args.query == ["runtime-core"]
     assert args.used_in_repo_only is True


### PR DESCRIPTION
### Motivation
- Enable surgical maintenance queues by allowing upgrade-audit consumers to filter candidates by their suggested validation workflows (e.g., target CI commands). 
- Bring parity between the standalone `upgrade-audit` script, the `sdetkit intelligence` umbrella surface, and the `doctor` readiness flow so filters are portable across surfaces. 
- Refresh a couple of repo-tooling pins discovered by the audit to keep CI/tooling up to date.

### Description
- Added a `--validation-command`/`validation_commands` filter to the upgrade-audit engine and matching `_matches_command_filters` helper to match supplied command strings or glob patterns against `PackageReport.validation_commands`.
- Wired the new filter through the CLI surfaces: the standalone `upgrade-audit` parser (`build_parser`/`main`/`run`), the `sdetkit intelligence` umbrella surface, and the `doctor` check flow and doctor CLI flags so doctor metadata preserves the filter context and includes it in `meta["filters"]`.
- Exposed additional audit controls on the intelligence surface (`--lane`, `--query`, `--release-freshness`, `--min-release-age-days`, `--max-release-age-days`) to match documented guidance and allow the same focused queries via the umbrella CLI.
- Updated README to document `--validation-command` usage and added help text for targeted maintenance queries.
- Bumped pinned tooling versions for repository/test manifests and CI constraints: `ruff` -> `0.15.7` and `mkdocs-material` -> `9.7.6` across `pyproject.toml`, `requirements*.txt`, and `constraints-ci.txt`.
- Added unit/regression tests covering validation-command filtering and the new CLI/doctor wiring.

### Testing
- Ran the focused pytest suite: `python -m pytest -q tests/test_upgrade_audit_script.py tests/test_doctor_upgrade_audit.py tests/test_kits_intelligence_integration_forensics.py -x` and all tests passed (`49 passed`).
- Exercised the umbrella CLI flow with the new filter: `python -m sdetkit intelligence upgrade-audit --format json --top 3 --validation-command 'bash quality.sh *'` which produced expected output including validation summaries.
- Ensured code compiles: `python -m compileall src/sdetkit` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc8b2f4e3483208b168e0673ba8d1e)