### PR TITLE
Upgrade AgentOS umbrella blueprinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ The doctor surface now carries those same upgrade-audit focus controls, so you c
 
 The umbrella architecture is stronger too: `sdetkit kits search <query>` now ranks the best-fit kit for a problem statement, and `sdetkit kits blueprint --goal "..."` builds a cross-kit execution plan that explicitly layers AgentOS in as the control plane for recurring automation, history capture, and dashboard exports. That makes it easier to move from discovery to an opinionated release/test/integration/forensics operating model without stitching the surfaces together by hand.
 
+The blueprint surface now goes further for umbrella-architecture upgrades: it emits explicit architecture layers, an operating model cadence, prioritized upgrade backlog items, and operating metrics so a team can move from "which kit should I start with?" to "how do I productize the whole umbrella with AgentOS on top?" without inventing its own framework first. When you want AgentOS to generate that operating plan directly, run:
+
+```bash
+python -m sdetkit kits blueprint --goal "upgrade umbrella architecture with agentos optimization"
+python -m sdetkit agent run "umbrella architecture optimization blueprint" --approve
+python -m sdetkit agent demo --scenario umbrella-upgrade-control-plane
+```
+
 The premium gate intelligence layer now goes further as well: it ranks remediation scripts by observed hotspot severity, can merge in repo-local smart fix scripts from `.sdetkit/premium-remediation-scripts.json`, emits a first-class `premium-remediation-plan.json` artifact, refreshes integration topology when contract drift is detected, and supports focused search across rendered findings plus learned guideline lookup from the premium insights database.
 
 The security auto-remediation lane is stronger too: premium gate can now prioritize a built-in `security_fix_apply` smart script before baseline-aware security re-triage, and the security fixer now safely rewrites `shell=True` to `shell=False` alongside request timeout injection and `yaml.safe_load` upgrades for deterministic repo-safe cleanup.

--- a/docs/agentos-foundation.md
+++ b/docs/agentos-foundation.md
@@ -69,8 +69,12 @@ This improves deterministic behavior and repeatability for local-provider runs.
   - Ranks the best umbrella kit for a repo problem statement such as `topology`, `release evidence`, or `upgrade risk`
 - `sdetkit kits blueprint --goal "agentized release upgrade search"`
   - Produces an umbrella architecture plan that composes kits with AgentOS as the control plane
+- `sdetkit agent run "umbrella architecture optimization blueprint" --approve`
+  - Uses AgentOS to render a deterministic umbrella blueprint artifact at `.sdetkit/agent/workdir/umbrella-blueprint.json`
 - `sdetkit agent demo --scenario repo-enterprise-audit`
   - Runs an offline deterministic end-to-end enterprise audit scenario
+- `sdetkit agent demo --scenario umbrella-upgrade-control-plane`
+  - Demonstrates AgentOS generating an umbrella-upgrade control-plane artifact plus dashboard outputs
 
 ## Config (`.sdetkit/agent/config.yaml`)
 
@@ -104,3 +108,14 @@ Provider modes:
 See `docs/enterprise-productization-blueprint.md` for deployment modes, governance controls, adoption plans, and packaging deliverables.
 
 See also: [AgentOS cookbook](agentos-cookbook.md), [Determinism contract](determinism-contract.md), and [Security model](security-model.md).
+
+## Dashboard signal upgrades
+
+The AgentOS dashboard now tracks more than total run counts. It also summarizes:
+
+- worker utilization across orchestrated actions,
+- task-family mix (template, action, audit, blueprint, other),
+- approval outcomes including denied actions and failures after approval,
+- latest status and current success streak.
+
+That makes the dashboard more useful as an operational control-plane surface rather than just a history export.

--- a/docs/architecture/umbrella-kits.md
+++ b/docs/architecture/umbrella-kits.md
@@ -17,6 +17,17 @@ SDETKit exposes one unified umbrella with four kits:
 
 Kit commands emit deterministic machine-readable outputs with explicit `schema_version`, stable ordering, and exit code contracts.
 
+## Upgrade blueprint model
+
+`sdetkit kits blueprint --goal "..."` now emits a fuller operating model for umbrella upgrades:
+
+- **architecture layers** — experience surface, AgentOS control plane, and deterministic artifact plane,
+- **operating model** — discovery, execution, and review cadences for recurring adoption,
+- **upgrade backlog** — prioritized upgrade themes such as umbrella routing, AgentOS promotion, topology assurance, and upgrade-audit integration,
+- **metrics** — high-signal operating measures such as routing accuracy, artifact coverage, and AgentOS run success rate.
+
+That turns the umbrella architecture from a static catalog into an execution-ready blueprint for teams that want to scale the repo as a product surface instead of a loose collection of commands.
+
 ## Compatibility and migration
 
 Use `docs/migration-compatibility-note.md` for migration guidance and the current experimental summary.

--- a/src/sdetkit/agent/actions.py
+++ b/src/sdetkit/agent/actions.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from sdetkit import repo
 from sdetkit.atomicio import atomic_write_text
+from sdetkit.kits import blueprint_payload
 from sdetkit.report import build_dashboard
 
 
@@ -43,6 +44,7 @@ class ActionRegistry:
             "shell.run": self._shell_run,
             "repo.audit": self._repo_audit,
             "report.build": self._report_build,
+            "kits.blueprint": self._kits_blueprint,
         }
 
     def run(self, name: str, params: dict[str, Any]) -> ActionResult:
@@ -154,6 +156,41 @@ class ActionRegistry:
         target = self._safe_rel(output)
         build_dashboard(history_dir=history_dir, output=target, fmt=fmt, since=None)
         return ActionResult("report.build", True, {"output": output, "format": fmt})
+
+    def _kits_blueprint(self, params: dict[str, Any]) -> ActionResult:
+        goal = str(params.get("goal", "")).strip() or None
+        output = str(params.get("output", ".sdetkit/agent/workdir/umbrella-blueprint.json"))
+        limit = int(params.get("limit", 3) or 3)
+        selected = params.get("kits") or []
+        selected_kits = [str(item) for item in selected] if isinstance(selected, list) else []
+        if not self._is_write_allowed(output):
+            return ActionResult(
+                "kits.blueprint",
+                False,
+                {
+                    "error": "write denied by allowlist",
+                    "path": output,
+                    "allowlist": list(self.write_allowlist),
+                },
+            )
+        try:
+            target = self._safe_rel(output)
+            payload = blueprint_payload(goal=goal, selected_kits=selected_kits, limit=limit)
+            atomic_write_text(
+                target, json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2) + "\n"
+            )
+        except (OSError, ValueError) as exc:
+            return ActionResult("kits.blueprint", False, {"error": str(exc), "path": output})
+        return ActionResult(
+            "kits.blueprint",
+            True,
+            {
+                "goal": goal,
+                "output": output,
+                "selected_kits": [kit["id"] for kit in payload["selected_kits"]],
+                "upgrade_count": len(payload.get("upgrade_backlog", [])),
+            },
+        )
 
 
 def maybe_parse_action_task(task: str) -> tuple[str, dict[str, Any]] | None:

--- a/src/sdetkit/agent/cli.py
+++ b/src/sdetkit/agent/cli.py
@@ -161,7 +161,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     demo_p.add_argument(
         "--scenario",
-        choices=["repo-enterprise-audit"],
+        choices=["repo-enterprise-audit", "umbrella-upgrade-control-plane"],
         required=True,
         help="Demo scenario identifier.",
     )

--- a/src/sdetkit/agent/core.py
+++ b/src/sdetkit/agent/core.py
@@ -260,6 +260,17 @@ def _rule_based_plan(task: str, *, max_actions: int) -> list[tuple[str, dict[str
     if parsed is not None:
         return [parsed][:max_actions]
     normalized = task.lower()
+    if any(term in normalized for term in ("umbrella", "architecture", "blueprint")):
+        return [
+            (
+                "kits.blueprint",
+                {
+                    "goal": task,
+                    "output": ".sdetkit/agent/workdir/umbrella-blueprint.json",
+                    "limit": 3,
+                },
+            )
+        ][:max_actions]
     if "audit" in normalized:
         return [("repo.audit", {"profile": "default"})][:max_actions]
     if "report" in normalized:

--- a/src/sdetkit/agent/dashboard.py
+++ b/src/sdetkit/agent/dashboard.py
@@ -59,16 +59,39 @@ def summarize_history(history_dir: Path) -> dict[str, Any]:
 
     template_counter: Counter[str] = Counter()
     action_counter: Counter[str] = Counter()
+    worker_counter: Counter[str] = Counter()
+    task_family_counter: Counter[str] = Counter()
     failure_tasks: list[dict[str, Any]] = []
+    approvals = {
+        "approved": 0,
+        "denied": 0,
+        "failed_after_approval": 0,
+    }
 
     for run in runs:
         task = str(run.get("task", ""))
         template_id = _extract_template_id(task)
         if template_id:
             template_counter[template_id] += 1
+            task_family_counter["template"] += 1
+        elif task.strip().startswith("action "):
+            task_family_counter["action"] += 1
+        elif "blueprint" in task.lower() or "umbrella" in task.lower():
+            task_family_counter["blueprint"] += 1
+        elif "audit" in task.lower():
+            task_family_counter["audit"] += 1
+        else:
+            task_family_counter["other"] += 1
         for action in run.get("actions", []):
             if isinstance(action, dict):
                 action_counter[str(action.get("action", "unknown"))] += 1
+                worker_counter[str(action.get("worker_id", "unknown"))] += 1
+                if bool(action.get("denied")):
+                    approvals["denied"] += 1
+                elif bool(action.get("approved")):
+                    approvals["approved"] += 1
+                    if not bool(action.get("ok")):
+                        approvals["failed_after_approval"] += 1
         if str(run.get("status", "")) != "ok":
             failure_tasks.append(
                 {
@@ -80,6 +103,12 @@ def summarize_history(history_dir: Path) -> dict[str, Any]:
             )
 
     failure_tasks.sort(key=lambda x: (x["captured_at"], x["hash"]))
+    latest_status = str(runs[-1].get("status", "")) if runs else "unknown"
+    success_streak = 0
+    for run in reversed(runs):
+        if str(run.get("status", "")) != "ok":
+            break
+        success_streak += 1
 
     return {
         "runs": {
@@ -87,9 +116,14 @@ def summarize_history(history_dir: Path) -> dict[str, Any]:
             "success": success,
             "failed": failed,
             "success_rate": success_rate,
+            "latest_status": latest_status,
+            "success_streak": success_streak,
         },
         "top_templates": _counter_to_rows(template_counter),
         "top_actions": _counter_to_rows(action_counter),
+        "workers": _counter_to_rows(worker_counter),
+        "task_families": _counter_to_rows(task_family_counter),
+        "approvals": approvals,
         "failures": failure_tasks,
         "records": [
             {
@@ -115,6 +149,8 @@ def render_markdown(summary: dict[str, Any]) -> str:
         f"- Successful runs: {runs['success']}",
         f"- Failed runs: {runs['failed']}",
         f"- Success rate: {runs['success_rate']:.2f}%",
+        f"- Latest status: {runs['latest_status']}",
+        f"- Success streak: {runs['success_streak']}",
         "",
         "## Top templates",
     ]
@@ -132,6 +168,33 @@ def render_markdown(summary: dict[str, Any]) -> str:
             lines.append(f"- `{item['name']}`: {item['count']}")
     else:
         lines.append("- none")
+
+    lines.extend(["", "## Worker utilization"])
+    workers = summary.get("workers", [])
+    if workers:
+        for item in workers:
+            lines.append(f"- `{item['name']}`: {item['count']}")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Task families"])
+    task_families = summary.get("task_families", [])
+    if task_families:
+        for item in task_families:
+            lines.append(f"- `{item['name']}`: {item['count']}")
+    else:
+        lines.append("- none")
+
+    approvals = summary.get("approvals", {})
+    lines.extend(
+        [
+            "",
+            "## Approvals",
+            f"- approved actions: {approvals.get('approved', 0)}",
+            f"- denied actions: {approvals.get('denied', 0)}",
+            f"- failed after approval: {approvals.get('failed_after_approval', 0)}",
+        ]
+    )
 
     lines.extend(["", "## Failed runs"])
     failures = summary.get("failures", [])
@@ -184,10 +247,24 @@ def render_html(summary: dict[str, Any]) -> str:
             f"<p>Successful runs: {runs['success']}</p>",
             f"<p>Failed runs: {runs['failed']}</p>",
             f"<p>Success rate: {runs['success_rate']:.2f}%</p>",
+            f"<p>Latest status: {html.escape(str(runs['latest_status']))}</p>",
+            f"<p>Success streak: {runs['success_streak']}</p>",
             "<h2>Top templates</h2>",
             _table(summary.get("top_templates", []), "name", "count"),
             "<h2>Top actions</h2>",
             _table(summary.get("top_actions", []), "name", "count"),
+            "<h2>Worker utilization</h2>",
+            _table(summary.get("workers", []), "name", "count"),
+            "<h2>Task families</h2>",
+            _table(summary.get("task_families", []), "name", "count"),
+            "<h2>Approvals</h2>",
+            (
+                "<table><thead><tr><th>Metric</th><th>Count</th></tr></thead><tbody>"
+                f"<tr><td>approved</td><td>{int(summary.get('approvals', {}).get('approved', 0))}</td></tr>"
+                f"<tr><td>denied</td><td>{int(summary.get('approvals', {}).get('denied', 0))}</td></tr>"
+                f"<tr><td>failed_after_approval</td><td>{int(summary.get('approvals', {}).get('failed_after_approval', 0))}</td></tr>"
+                "</tbody></table>"
+            ),
             "<h2>Failed runs</h2>",
             (
                 "<table><thead><tr><th>Captured at</th><th>Hash</th><th>Status</th><th>Task</th></tr></thead>"

--- a/src/sdetkit/agent/demo.py
+++ b/src/sdetkit/agent/demo.py
@@ -11,7 +11,11 @@ _DEMO_SCENARIOS: dict[str, tuple[str, ...]] = {
         "repo-health-audit",
         "security-governance-summary",
         "report-dashboard",
-    )
+    ),
+    "umbrella-upgrade-control-plane": (
+        "repo-health-audit",
+        "report-dashboard",
+    ),
 }
 
 
@@ -37,6 +41,14 @@ def run_demo(*, root: Path, scenario: str) -> dict[str, object]:
             root,
             config_path=root / ".sdetkit/agent/config.yaml",
             task=f"template:{template_id}",
+            auto_approve=True,
+        )
+
+    if scenario == "umbrella-upgrade-control-plane":
+        run_agent(
+            root,
+            config_path=root / ".sdetkit/agent/config.yaml",
+            task="umbrella architecture optimization blueprint",
             auto_approve=True,
         )
 

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -125,7 +125,7 @@ _KITS: Final[list[Kit]] = [
         ],
         "agent_workflows": [
             "sdetkit agent run 'template:report-dashboard' --approve",
-            "sdetkit agent run 'action repo.audit {\"profile\":\"default\"}' --approve",
+            'sdetkit agent run \'action repo.audit {"profile":"default"}\' --approve',
             "sdetkit agent dashboard build --format md",
         ],
         "composes_with": ["release-confidence", "integration-assurance"],
@@ -296,6 +296,163 @@ def _kit_overview(kit: Kit) -> dict[str, object]:
     }
 
 
+def _goal_tokens(goal: str | None) -> set[str]:
+    if goal is None:
+        return set()
+    return set(_tokenize(goal))
+
+
+def _architecture_layers(selected: list[Kit]) -> list[dict[str, object]]:
+    return [
+        {
+            "name": "experience-surface",
+            "summary": "Umbrella kits stay the product entrypoint so teams discover the right lane quickly.",
+            "components": [f"sdetkit {kit['slug']} ..." for kit in selected],
+        },
+        {
+            "name": "control-plane",
+            "summary": (
+                "AgentOS coordinates recurring runs, review loops, history capture, and artifact "
+                "exports above the kit surfaces."
+            ),
+            "components": [
+                "sdetkit agent init",
+                "sdetkit agent run '<goal>' --approve",
+                "sdetkit agent dashboard build --format html",
+            ],
+        },
+        {
+            "name": "artifact-plane",
+            "summary": "Every lane emits deterministic artifacts that can be wired into CI, reviews, and evidence packs.",
+            "components": sorted(
+                {artifact for kit in selected for artifact in kit["key_artifacts"]}
+            ),
+        },
+    ]
+
+
+def _operating_model(selected: list[Kit], goal: str | None) -> list[dict[str, object]]:
+    goal_text = goal or "umbrella upgrade"
+    return [
+        {
+            "cadence": "continuous",
+            "focus": "Discovery and routing",
+            "commands": [
+                "sdetkit kits search topology",
+                f'sdetkit kits blueprint --goal "{goal_text}"',
+            ],
+        },
+        {
+            "cadence": "per-change",
+            "focus": "Execution and deterministic artifact generation",
+            "commands": [kit["learning_path"][0] for kit in selected],
+        },
+        {
+            "cadence": "daily-or-release",
+            "focus": "AgentOS control-plane review",
+            "commands": [
+                f'sdetkit agent run "{goal_text}" --approve',
+                "sdetkit agent history list --limit 10",
+                "sdetkit agent dashboard build --format html",
+            ],
+        },
+    ]
+
+
+def _upgrade_backlog(selected: list[Kit], goal: str | None) -> list[dict[str, object]]:
+    goal_terms = _goal_tokens(goal)
+    backlog: list[dict[str, object]] = []
+
+    def add_upgrade(
+        upgrade_id: str,
+        title: str,
+        summary: str,
+        commands: list[str],
+        triggers: set[str],
+    ) -> None:
+        if triggers and goal_terms and goal_terms.isdisjoint(triggers):
+            return
+        backlog.append(
+            {
+                "id": upgrade_id,
+                "title": title,
+                "summary": summary,
+                "commands": commands,
+            }
+        )
+
+    add_upgrade(
+        "umbrella-routing",
+        "Tighten umbrella routing",
+        "Use kit search and kit composition to route incoming work to the smallest reliable lane.",
+        [
+            "sdetkit kits list",
+            "sdetkit kits search upgrade risk",
+            "sdetkit kits blueprint --goal 'umbrella routing hardening'",
+        ],
+        {"umbrella", "architecture", "search", "upgrade"},
+    )
+    add_upgrade(
+        "agent-control-plane",
+        "Promote AgentOS to the recurring control plane",
+        "Run repeatable orchestration, history export, and dashboard builds as the management layer over kits.",
+        [
+            "sdetkit agent init",
+            "sdetkit agent run 'template:repo-health-audit' --approve",
+            "sdetkit agent dashboard build --format html",
+        ],
+        {"agent", "agentos", "automation", "control", "orchestration", "upgrade"},
+    )
+    add_upgrade(
+        "integration-topology",
+        "Expand topology-aware integration assurance",
+        "Treat heterogeneous dependency maps and environment contracts as first-class release inputs.",
+        [
+            "sdetkit integration check --profile examples/kits/integration/profile.json",
+            "sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json",
+        ],
+        {"integration", "topology", "umbrella", "architecture"},
+    )
+    add_upgrade(
+        "release-upgrade-audit",
+        "Fold dependency maintenance into release readiness",
+        "Prioritize upgrade work using the intelligence lane so release decisions carry freshness and validation guidance.",
+        [
+            "sdetkit intelligence upgrade-audit --format json --top 5",
+            "sdetkit release doctor",
+        ],
+        {"upgrade", "dependency", "release", "optimization"},
+    )
+    add_upgrade(
+        "forensics-feedback-loop",
+        "Feed forensics back into the umbrella",
+        "Close the loop by comparing run deltas and using evidence bundles to improve the release and integration lanes.",
+        [
+            "sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json",
+            "sdetkit forensics bundle --run examples/kits/forensics/run-b.json --output build/repro.zip",
+        ],
+        {"forensics", "failure", "incident", "optimization"},
+    )
+
+    if not backlog:
+        for upgrade in (
+            {
+                "id": "umbrella-routing",
+                "title": "Tighten umbrella routing",
+                "summary": "Use kit search and blueprinting to keep the public surface crisp as capabilities grow.",
+                "commands": ["sdetkit kits search release evidence"],
+            },
+            {
+                "id": "agent-control-plane",
+                "title": "Promote AgentOS to the recurring control plane",
+                "summary": "Capture deterministic history and dashboards above the execution kits.",
+                "commands": ["sdetkit agent dashboard build --format html"],
+            },
+        ):
+            backlog.append(upgrade)
+    return backlog
+
+
 def list_payload() -> dict[str, object]:
     return {
         "schema_version": SCHEMA_VERSION,
@@ -398,6 +555,15 @@ def blueprint_payload(
             "sdetkit agent dashboard build --format html",
         ],
     }
+    architecture_layers = _architecture_layers(resolved[: max(limit, 1)])
+    operating_model = _operating_model(resolved[: max(limit, 1)], goal)
+    upgrade_backlog = _upgrade_backlog(resolved[: max(limit, 1)], goal)
+    metrics = [
+        "kit routing accuracy",
+        "artifact coverage per execution lane",
+        "AgentOS run success rate",
+        "time-to-evidence for release and incident review",
+    ]
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -405,6 +571,10 @@ def blueprint_payload(
         "selected_kits": [_kit_overview(kit) for kit in resolved[: max(limit, 1)]],
         "control_plane": control_plane,
         "phases": phases,
+        "architecture_layers": architecture_layers,
+        "operating_model": operating_model,
+        "upgrade_backlog": upgrade_backlog,
+        "metrics": metrics,
     }
 
 
@@ -523,6 +693,15 @@ def main(argv: list[str] | None = None) -> int:
         print("phases:")
         for phase in payload["phases"]:
             print(f"- {phase['phase']}: {phase['summary']}")
+        print("architecture layers:")
+        for layer in payload["architecture_layers"]:
+            print(f"- {layer['name']}: {layer['summary']}")
+        print("operating model:")
+        for lane in payload["operating_model"]:
+            print(f"- {lane['cadence']}: {lane['focus']}")
+        print("upgrade backlog:")
+        for item in payload["upgrade_backlog"]:
+            print(f"- {item['title']}: {item['summary']}")
         return 0
 
     if ns.target:

--- a/tests/test_agent_foundation.py
+++ b/tests/test_agent_foundation.py
@@ -56,6 +56,21 @@ def test_manager_plan_generation_is_deterministic_in_no_llm_mode(tmp_path: Path)
     assert plan1[0].worker_id == "worker-1"
 
 
+def test_manager_plan_routes_umbrella_tasks_to_blueprint_action(tmp_path: Path) -> None:
+    init_agent(tmp_path, tmp_path / ".sdetkit/agent/config.yaml")
+    cfg = load_config(tmp_path / ".sdetkit/agent/config.yaml")
+
+    _message, plan = _manager_plan(
+        task="umbrella architecture optimization blueprint",
+        config=cfg,
+        provider=CountingProvider(),
+        worker_ids=["worker-1", "worker-2"],
+    )
+
+    assert plan[0].action == "kits.blueprint"
+    assert plan[0].params["goal"] == "umbrella architecture optimization blueprint"
+
+
 def test_worker_action_execution_success(tmp_path: Path) -> None:
     registry = ActionRegistry(
         root=tmp_path,
@@ -68,6 +83,30 @@ def test_worker_action_execution_success(tmp_path: Path) -> None:
 
     assert result.ok is True
     assert (tmp_path / ".sdetkit/agent/workdir/out.txt").read_text(encoding="utf-8") == "hello"
+
+
+def test_worker_can_write_umbrella_blueprint_artifact(tmp_path: Path) -> None:
+    init_agent(tmp_path, tmp_path / ".sdetkit/agent/config.yaml")
+    registry = ActionRegistry(
+        root=tmp_path,
+        write_allowlist=(".sdetkit/agent/workdir",),
+        shell_allowlist=(),
+    )
+
+    result = registry.run(
+        "kits.blueprint",
+        {
+            "goal": "upgrade umbrella architecture with agentos",
+            "output": ".sdetkit/agent/workdir/umbrella-blueprint.json",
+            "kits": ["release", "integration"],
+        },
+    )
+
+    assert result.ok is True
+    artifact = tmp_path / ".sdetkit/agent/workdir/umbrella-blueprint.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["upgrade_backlog"]
+    assert payload["selected_kits"][0]["id"] == "release-confidence"
 
 
 def test_reviewer_rejects_failed_action(tmp_path: Path, monkeypatch) -> None:
@@ -172,3 +211,58 @@ def test_agent_run_records_are_canonical_and_stable(tmp_path: Path, monkeypatch)
     on_disk = history_file.read_text(encoding="utf-8")
     loaded = json.loads(on_disk)
     assert on_disk == canonical_json_dumps(loaded)
+
+
+def test_agent_dashboard_summary_tracks_workers_approvals_and_task_families(tmp_path: Path) -> None:
+    init_agent(tmp_path, tmp_path / ".sdetkit/agent/config.yaml")
+    history_dir = tmp_path / ".sdetkit" / "agent" / "history"
+
+    (history_dir / "a.json").write_text(
+        json.dumps(
+            {
+                "hash": "a",
+                "captured_at": "2026-03-20T00:00:00Z",
+                "status": "ok",
+                "task": "template:repo-health-audit",
+                "actions": [
+                    {
+                        "action": "repo.audit",
+                        "worker_id": "worker-1",
+                        "ok": True,
+                        "approved": True,
+                        "denied": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (history_dir / "b.json").write_text(
+        json.dumps(
+            {
+                "hash": "b",
+                "captured_at": "2026-03-20T00:01:00Z",
+                "status": "error",
+                "task": "umbrella architecture optimization blueprint",
+                "actions": [
+                    {
+                        "action": "shell.run",
+                        "worker_id": "worker-2",
+                        "ok": False,
+                        "approved": False,
+                        "denied": True,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from sdetkit.agent.dashboard import summarize_history
+
+    summary = summarize_history(history_dir)
+    assert summary["workers"][0]["name"] in {"worker-1", "worker-2"}
+    assert summary["approvals"]["approved"] == 1
+    assert summary["approvals"]["denied"] == 1
+    families = {item["name"] for item in summary["task_families"]}
+    assert {"template", "blueprint"} <= families

--- a/tests/test_agent_productization.py
+++ b/tests/test_agent_productization.py
@@ -58,6 +58,9 @@ def test_dashboard_and_history_export_formats(tmp_path: Path, monkeypatch, capsy
     assert payload["format"] == "json"
     parsed = json.loads((tmp_path / "dashboard.json").read_text(encoding="utf-8"))
     assert parsed["runs"]["total"] == 2
+    assert "latest_status" in parsed["runs"]
+    assert "workers" in parsed
+    assert "approvals" in parsed
 
     assert cli.main(["dashboard", "build", "--format", "csv", "--output", "dashboard.csv"]) == 0
     csv_lines = (tmp_path / "dashboard.csv").read_text(encoding="utf-8").splitlines()
@@ -102,3 +105,21 @@ def test_demo_repo_enterprise_audit_outputs_artifacts(tmp_path: Path, monkeypatc
     assert Path(artifacts["dashboard_html"]).exists()
     assert Path(artifacts["dashboard_md"]).exists()
     assert Path(artifacts["history_dir"]).exists()
+
+
+def test_demo_umbrella_upgrade_control_plane_outputs_blueprint(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1700000000")
+    for template_id in ["repo-health-audit", "report-dashboard"]:
+        _write_template(tmp_path, template_id)
+
+    monkeypatch.chdir(tmp_path)
+    assert cli.main(["demo", "--scenario", "umbrella-upgrade-control-plane"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["status"] == "ok"
+    blueprint = tmp_path / ".sdetkit" / "agent" / "workdir" / "umbrella-blueprint.json"
+    assert blueprint.exists()
+    blueprint_payload = json.loads(blueprint.read_text(encoding="utf-8"))
+    assert blueprint_payload["architecture_layers"][0]["name"] == "experience-surface"

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from sdetkit import kits
+
+
+def test_blueprint_payload_exposes_upgrade_layers_and_operating_model() -> None:
+    payload = kits.blueprint_payload(
+        goal="upgrade umbrella architecture with agentos optimization",
+        selected_kits=["release", "integration"],
+        limit=3,
+    )
+
+    assert payload["selected_kits"][0]["id"] == "release-confidence"
+    assert payload["architecture_layers"][0]["name"] == "experience-surface"
+    assert payload["operating_model"][0]["cadence"] == "continuous"
+    assert "AgentOS run success rate" in payload["metrics"]
+    backlog_ids = {item["id"] for item in payload["upgrade_backlog"]}
+    assert "umbrella-routing" in backlog_ids
+    assert "agent-control-plane" in backlog_ids
+    assert "integration-topology" in backlog_ids


### PR DESCRIPTION
### Motivation

- Provide a richer, execution-ready umbrella blueprint so teams can move from kit discovery to a repeatable productization plan.  
- Enable AgentOS to act as the deterministic control plane that can generate umbrella upgrade artifacts automatically.  
- Improve operational visibility from AgentOS dashboards so teams can monitor run-level signals like worker utilization and approvals.

### Description

- Extend `sdetkit.kits.blueprint_payload` to include `architecture_layers`, `operating_model`, `upgrade_backlog`, and `metrics` for umbrella-architecture planning.  
- Add an AgentOS action `kits.blueprint` (and wire it into `ActionRegistry`) so agent runs can emit deterministic blueprint artifacts to `.sdetkit/agent/workdir/umbrella-blueprint.json`.  
- Add rule-based routing in the AgentOS planner so umbrella/architecture-related tasks route to the `kits.blueprint` action and expose a demo scenario `umbrella-upgrade-control-plane` that runs the blueprint generation flow.  
- Enrich the AgentOS dashboard with worker utilization, task-family counts (template/action/audit/blueprint/other), approval outcomes, latest status, and current success streak, plus documentation and tests to cover the new surfaces.

### Testing

- Ran static checks with `ruff` against the modified sources and helper tests, and the checks completed successfully.  
- Executed unit tests with `pytest` for targeted suites using `tests/test_kits_blueprint.py`, `tests/test_agent_foundation.py`, and `tests/test_agent_productization.py`, and all tests passed (`18 passed`).  
- Validated the new blueprint command end-to-end with `python -m sdetkit kits blueprint --goal "upgrade umbrella architecture with agentos optimization" --format json` and confirmed the blueprint artifact contains the new `architecture_layers` and `upgrade_backlog` fields.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc9c098fc883209d3f8873be3af9cc)