### PR TITLE
Boost umbrella optimization alignment (kits.optimize + AgentOS integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ python -m sdetkit agent run "umbrella architecture optimization blueprint" --app
 python -m sdetkit agent demo --scenario umbrella-upgrade-control-plane
 ```
 
-The new optimize surface takes the blueprint one step further by inspecting the repo and aligning the umbrella kits with the operational lanes that actually keep the platform healthy: doctor, `quality.sh`, premium gate, integration topology, and AgentOS. That gives you a single alignment payload showing which lanes are ready, which command should lead each domain, and which performance boosters are already available in the repo.
+The new optimize surface takes the blueprint one step further by inspecting the repo and aligning the umbrella kits with the operational lanes that actually keep the platform healthy: doctor, `quality.sh`, premium gate, integration topology, and AgentOS. That gives you a single alignment payload showing which lanes are ready, which command should lead each domain, which operating sequence should be used, which search queries help continue the maintenance loop, the explicit doctor-to-quality promotion contract, any missing domains, and which performance boosters are already available in the repo.
+
+It now also emits an alignment score so the umbrella architecture has a single numeric readiness signal that can be tracked in CI, dashboards, and AgentOS history exports while the repo keeps getting upgraded.
 
 The premium gate intelligence layer now goes further as well: it ranks remediation scripts by observed hotspot severity, can merge in repo-local smart fix scripts from `.sdetkit/premium-remediation-scripts.json`, emits a first-class `premium-remediation-plan.json` artifact, refreshes integration topology when contract drift is detected, and supports focused search across rendered findings plus learned guideline lookup from the premium insights database.
 

--- a/src/sdetkit/agent/actions.py
+++ b/src/sdetkit/agent/actions.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from sdetkit import repo
 from sdetkit.atomicio import atomic_write_text
-from sdetkit.kits import blueprint_payload
+from sdetkit.kits import blueprint_payload, optimize_payload
 from sdetkit.report import build_dashboard
 
 
@@ -45,6 +45,7 @@ class ActionRegistry:
             "repo.audit": self._repo_audit,
             "report.build": self._report_build,
             "kits.blueprint": self._kits_blueprint,
+            "kits.optimize": self._kits_optimize,
         }
 
     def run(self, name: str, params: dict[str, Any]) -> ActionResult:
@@ -189,6 +190,47 @@ class ActionRegistry:
                 "output": output,
                 "selected_kits": [kit["id"] for kit in payload["selected_kits"]],
                 "upgrade_count": len(payload.get("upgrade_backlog", [])),
+            },
+        )
+
+    def _kits_optimize(self, params: dict[str, Any]) -> ActionResult:
+        goal = str(params.get("goal", "")).strip() or None
+        output = str(params.get("output", ".sdetkit/agent/workdir/umbrella-optimize.json"))
+        limit = int(params.get("limit", 3) or 3)
+        selected = params.get("kits") or []
+        selected_kits = [str(item) for item in selected] if isinstance(selected, list) else []
+        if not self._is_write_allowed(output):
+            return ActionResult(
+                "kits.optimize",
+                False,
+                {
+                    "error": "write denied by allowlist",
+                    "path": output,
+                    "allowlist": list(self.write_allowlist),
+                },
+            )
+        try:
+            target = self._safe_rel(output)
+            payload = optimize_payload(
+                root=self.root,
+                goal=goal,
+                selected_kits=selected_kits,
+                limit=limit,
+            )
+            atomic_write_text(
+                target, json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2) + "\n"
+            )
+        except (OSError, ValueError) as exc:
+            return ActionResult("kits.optimize", False, {"error": str(exc), "path": output})
+        return ActionResult(
+            "kits.optimize",
+            True,
+            {
+                "goal": goal,
+                "output": output,
+                "selected_kits": [kit["id"] for kit in payload["selected_kits"]],
+                "alignment_score": payload["alignment_score"]["score"],
+                "missing_domains": payload["missing_domains"],
             },
         )
 

--- a/src/sdetkit/agent/core.py
+++ b/src/sdetkit/agent/core.py
@@ -260,6 +260,30 @@ def _rule_based_plan(task: str, *, max_actions: int) -> list[tuple[str, dict[str
     if parsed is not None:
         return [parsed][:max_actions]
     normalized = task.lower()
+    if any(term in normalized for term in ("umbrella", "architecture", "blueprint")) and (
+        "blueprint" in normalized
+    ):
+        return [
+            (
+                "kits.blueprint",
+                {
+                    "goal": task,
+                    "output": ".sdetkit/agent/workdir/umbrella-blueprint.json",
+                    "limit": 3,
+                },
+            )
+        ][:max_actions]
+    if "optimize" in normalized or "optimization" in normalized:
+        return [
+            (
+                "kits.optimize",
+                {
+                    "goal": task,
+                    "output": ".sdetkit/agent/workdir/umbrella-optimize.json",
+                    "limit": 3,
+                },
+            )
+        ][:max_actions]
     if any(term in normalized for term in ("umbrella", "architecture", "blueprint")):
         return [
             (

--- a/src/sdetkit/agent/demo.py
+++ b/src/sdetkit/agent/demo.py
@@ -51,6 +51,12 @@ def run_demo(*, root: Path, scenario: str) -> dict[str, object]:
             task="umbrella architecture optimization blueprint",
             auto_approve=True,
         )
+        run_agent(
+            root,
+            config_path=root / ".sdetkit/agent/config.yaml",
+            task="optimize umbrella architecture and align doctor quality gate integration agentos",
+            auto_approve=True,
+        )
 
     run_agent(
         root,

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -585,6 +585,115 @@ def _performance_boosters(repo_signals: dict[str, bool]) -> list[dict[str, str]]
     return boosters
 
 
+def _alignment_status(ready: int, total: int) -> str:
+    if total <= 0:
+        return "unknown"
+    ratio = ready / total
+    if ratio >= 0.9:
+        return "maximized"
+    if ratio >= 0.7:
+        return "strong"
+    if ratio >= 0.4:
+        return "partial"
+    return "needs-work"
+
+
+def _alignment_score(repo_signals: dict[str, bool]) -> dict[str, object]:
+    weighted_signals = [
+        ("quality_script", 2),
+        ("premium_gate", 2),
+        ("ci_script", 1),
+        ("constraints", 1),
+        ("gate_snapshot", 1),
+        ("integration_profile", 1),
+        ("topology_profile", 2),
+        ("agent_templates", 2),
+        ("pyproject", 1),
+    ]
+    total = sum(weight for _signal, weight in weighted_signals)
+    earned = sum(weight for signal, weight in weighted_signals if repo_signals.get(signal))
+    score = int(round((earned / total) * 100)) if total else 0
+    ready = sum(1 for signal, _weight in weighted_signals if repo_signals.get(signal))
+    return {
+        "score": score,
+        "ready_signals": ready,
+        "total_signals": len(weighted_signals),
+        "status": _alignment_status(ready, len(weighted_signals)),
+    }
+
+
+def _search_queries(goal: str | None) -> list[dict[str, str]]:
+    goal_text = goal or "umbrella optimization"
+    return [
+        {
+            "topic": "doctor-upgrade-lane",
+            "query": f"{goal_text} doctor upgrade audit quality gate",
+        },
+        {
+            "topic": "agentos-control-plane",
+            "query": f"{goal_text} agentos control plane dashboard history",
+        },
+        {
+            "topic": "integration-topology",
+            "query": f"{goal_text} integration topology premium gate",
+        },
+    ]
+
+
+def _operating_sequence(
+    doctor_lane: dict[str, object],
+    quality_lane: dict[str, object],
+    integration_lane: dict[str, object],
+    agentos_lane: dict[str, object],
+) -> list[dict[str, object]]:
+    quality_commands = quality_lane.get("commands", [])
+    integration_commands = integration_lane.get("commands", [])
+    agent_commands = agentos_lane.get("commands", [])
+    return [
+        {
+            "stage": "doctor-first",
+            "summary": "Start with readiness, dependency drift, and repo-health diagnostics.",
+            "commands": [doctor_lane["command"]],
+        },
+        {
+            "stage": "quality-gate",
+            "summary": "Use the deterministic merge bar and premium lane as the execution guardrail.",
+            "commands": [str(item) for item in quality_commands],
+        },
+        {
+            "stage": "integration-proof",
+            "summary": "Refresh topology-aware proof so architecture changes stay contract-safe.",
+            "commands": [str(item) for item in integration_commands],
+        },
+        {
+            "stage": "agentos-governance",
+            "summary": "Capture the execution lane in AgentOS so history and dashboards stay in sync.",
+            "commands": [str(item) for item in agent_commands],
+        },
+    ]
+
+
+def _doctor_quality_contract(
+    doctor_lane: dict[str, object],
+    quality_lane: dict[str, object],
+    integration_lane: dict[str, object],
+) -> dict[str, object]:
+    quality_commands = [str(item) for item in quality_lane.get("commands", [])]
+    integration_commands = [str(item) for item in integration_lane.get("commands", [])]
+    promotion_blockers = [
+        "doctor must run before premium gate",
+        "quality gate should inherit doctor upgrade-readiness findings",
+    ]
+    if integration_commands:
+        promotion_blockers.append("topology checks must stay in the same review loop as premium gate")
+    return {
+        "entrypoint": doctor_lane["command"],
+        "promotion_commands": quality_commands,
+        "integration_commands": integration_commands,
+        "promotion_blockers": promotion_blockers,
+    }
+
+
 def optimize_payload(
     *,
     root: Path,
@@ -610,6 +719,14 @@ def optimize_payload(
     quality_lane = _quality_gate_lane(goal, repo_signals)
     integration_lane = _integration_lane(goal, repo_signals)
     agentos_lane = _agentos_lane(goal, repo_signals)
+    alignment_score = _alignment_score(repo_signals)
+    operating_sequence = _operating_sequence(
+        doctor_lane, quality_lane, integration_lane, agentos_lane
+    )
+    doctor_quality_contract = _doctor_quality_contract(
+        doctor_lane, quality_lane, integration_lane
+    )
+    search_queries = _search_queries(goal)
     next_boosts = [
         {
             "id": "doctor-quality-sync",
@@ -665,6 +782,7 @@ def optimize_payload(
             "primary_command": agentos_lane["commands"][0],
         },
     ]
+    missing_domains = [item["domain"] for item in alignment_matrix if item["status"] != "ready"]
     return {
         "schema_version": SCHEMA_VERSION,
         "goal": goal,
@@ -675,7 +793,12 @@ def optimize_payload(
         "quality_gate_lane": quality_lane,
         "integration_lane": integration_lane,
         "agentos_lane": agentos_lane,
+        "alignment_score": alignment_score,
         "alignment_matrix": alignment_matrix,
+        "doctor_quality_contract": doctor_quality_contract,
+        "operating_sequence": operating_sequence,
+        "search_queries": search_queries,
+        "missing_domains": missing_domains,
         "performance_boosters": _performance_boosters(repo_signals),
         "next_boosts": next_boosts,
     }
@@ -951,11 +1074,19 @@ def main(argv: list[str] | None = None) -> int:
         print("Umbrella optimization plan")
         if goal:
             print(f"goal: {goal}")
+        print(
+            "alignment score: "
+            f"{payload['alignment_score']['score']}% ({payload['alignment_score']['status']})"
+        )
         print("alignment matrix:")
         for item in payload["alignment_matrix"]:
             print(f"- {item['domain']}: {item['status']}")
             if item["primary_command"]:
                 print(f"  command: {item['primary_command']}")
+        print("doctor/quality contract:")
+        print(f"- entrypoint: {payload['doctor_quality_contract']['entrypoint']}")
+        for command in payload["doctor_quality_contract"]["promotion_commands"]:
+            print(f"  - promote with: {command}")
         print("doctor lane:")
         print(f"- {payload['doctor_lane']['command']}")
         print(f"  why: {payload['doctor_lane']['why']}")
@@ -968,6 +1099,12 @@ def main(argv: list[str] | None = None) -> int:
         print("agentos lane:")
         for command in payload["agentos_lane"]["commands"]:
             print(f"- {command}")
+        print("operating sequence:")
+        for item in payload["operating_sequence"]:
+            print(f"- {item['stage']}: {item['summary']}")
+        print("search queries:")
+        for item in payload["search_queries"]:
+            print(f"- {item['topic']}: {item['query']}")
         print("performance boosters:")
         for item in payload["performance_boosters"]:
             print(f"- {item['title']}: {item['detail']}")

--- a/tests/test_agent_actions_extra.py
+++ b/tests/test_agent_actions_extra.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -93,3 +94,44 @@ def test_action_registry_repo_audit_and_report_build(tmp_path: Path, monkeypatch
     assert seen["fmt"] == "html"
     assert str(seen["history_dir"]).endswith(".sdetkit/agent/history")
     assert (tmp_path / ".sdetkit" / "out.html").read_text(encoding="utf-8") == "dashboard"
+
+
+def test_action_registry_can_write_optimize_artifact(tmp_path: Path) -> None:
+    reg = ActionRegistry(root=tmp_path, write_allowlist=(".sdetkit/agent/workdir",), shell_allowlist=())
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "premium-gate.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "ci.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "constraints-ci.txt").write_text("ruff==0.15.7\n", encoding="utf-8")
+    (tmp_path / "examples" / "kits" / "integration").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "examples" / "kits" / "integration" / "profile.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "examples" / "kits" / "integration" / "heterogeneous-topology.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "templates" / "automations").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "templates" / "automations" / "repo-health-audit.yaml").write_text(
+        "metadata:\n  id: repo-health-audit\nworkflow: []\n",
+        encoding="utf-8",
+    )
+
+    result = reg.run(
+        "kits.optimize",
+        {
+            "goal": "upgrade umbrella architecture with agentos optimization",
+            "output": ".sdetkit/agent/workdir/umbrella-optimize.json",
+        },
+    )
+
+    assert result.ok is True
+    assert result.payload["alignment_score"] > 0
+    artifact = tmp_path / ".sdetkit" / "agent" / "workdir" / "umbrella-optimize.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["alignment_score"]["status"] in {"strong", "maximized"}
+    assert payload["operating_sequence"][0]["stage"] == "doctor-first"

--- a/tests/test_agent_foundation.py
+++ b/tests/test_agent_foundation.py
@@ -71,6 +71,21 @@ def test_manager_plan_routes_umbrella_tasks_to_blueprint_action(tmp_path: Path) 
     assert plan[0].params["goal"] == "umbrella architecture optimization blueprint"
 
 
+def test_manager_plan_routes_optimize_tasks_to_optimize_action(tmp_path: Path) -> None:
+    init_agent(tmp_path, tmp_path / ".sdetkit/agent/config.yaml")
+    cfg = load_config(tmp_path / ".sdetkit/agent/config.yaml")
+
+    _message, plan = _manager_plan(
+        task="optimize umbrella architecture and align doctor quality gate integration agentos",
+        config=cfg,
+        provider=CountingProvider(),
+        worker_ids=["worker-1", "worker-2"],
+    )
+
+    assert plan[0].action == "kits.optimize"
+    assert plan[0].params["goal"].startswith("optimize umbrella architecture")
+
+
 def test_worker_action_execution_success(tmp_path: Path) -> None:
     registry = ActionRegistry(
         root=tmp_path,
@@ -107,6 +122,51 @@ def test_worker_can_write_umbrella_blueprint_artifact(tmp_path: Path) -> None:
     payload = json.loads(artifact.read_text(encoding="utf-8"))
     assert payload["upgrade_backlog"]
     assert payload["selected_kits"][0]["id"] == "release-confidence"
+
+
+def test_worker_can_write_umbrella_optimize_artifact(tmp_path: Path) -> None:
+    init_agent(tmp_path, tmp_path / ".sdetkit/agent/config.yaml")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "premium-gate.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "ci.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "constraints-ci.txt").write_text("ruff==0.15.7\n", encoding="utf-8")
+    (tmp_path / "examples" / "kits" / "integration").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "examples" / "kits" / "integration" / "profile.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "examples" / "kits" / "integration" / "heterogeneous-topology.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "templates" / "automations").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "templates" / "automations" / "repo-health-audit.yaml").write_text(
+        "metadata:\n  id: repo-health-audit\nworkflow: []\n",
+        encoding="utf-8",
+    )
+    registry = ActionRegistry(
+        root=tmp_path,
+        write_allowlist=(".sdetkit/agent/workdir",),
+        shell_allowlist=(),
+    )
+
+    result = registry.run(
+        "kits.optimize",
+        {
+            "goal": "upgrade umbrella architecture with agentos optimization",
+            "output": ".sdetkit/agent/workdir/umbrella-optimize.json",
+        },
+    )
+
+    assert result.ok is True
+    artifact = tmp_path / ".sdetkit/agent/workdir/umbrella-optimize.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["alignment_score"]["score"] > 0
+    assert payload["doctor_quality_contract"]["entrypoint"].startswith("sdetkit doctor ")
 
 
 def test_reviewer_rejects_failed_action(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_agent_productization.py
+++ b/tests/test_agent_productization.py
@@ -120,6 +120,10 @@ def test_demo_umbrella_upgrade_control_plane_outputs_blueprint(
 
     assert payload["status"] == "ok"
     blueprint = tmp_path / ".sdetkit" / "agent" / "workdir" / "umbrella-blueprint.json"
+    optimize = tmp_path / ".sdetkit" / "agent" / "workdir" / "umbrella-optimize.json"
     assert blueprint.exists()
+    assert optimize.exists()
     blueprint_payload = json.loads(blueprint.read_text(encoding="utf-8"))
+    optimize_payload = json.loads(optimize.read_text(encoding="utf-8"))
     assert blueprint_payload["architecture_layers"][0]["name"] == "experience-surface"
+    assert optimize_payload["operating_sequence"][0]["stage"] == "doctor-first"

--- a/tests/test_kits_umbrella_cli.py
+++ b/tests/test_kits_umbrella_cli.py
@@ -93,5 +93,9 @@ def test_kits_optimize_emits_alignment_plan_json() -> None:
     assert payload["schema_version"] == "sdetkit.kits.catalog.v1"
     assert payload["doctor_lane"]["command"].startswith("sdetkit doctor ")
     assert payload["quality_gate_lane"]["commands"]
+    assert payload["alignment_score"]["score"] > 0
+    assert payload["doctor_quality_contract"]["entrypoint"] == payload["doctor_lane"]["command"]
+    assert payload["operating_sequence"][0]["stage"] == "doctor-first"
+    assert payload["search_queries"][0]["topic"] == "doctor-upgrade-lane"
     assert any(item["domain"] == "agentos" for item in payload["alignment_matrix"])
     assert payload["blueprint"]["control_plane"]["name"] == "agentos-control-plane"


### PR DESCRIPTION
### Motivation
- Improve the umbrella upgrade/AgentOS control-plane by providing a single alignment signal and richer coordination artifacts so doctor, quality gate, premium gate, integration topology, and AgentOS can operate as a unified upgrade loop.
- Make optimize flows actionable by AgentOS and provide deterministic artifacts that CI, dashboards, and history exports can use to track progress.

### Description
- Expanded `sdetkit kits optimize` to emit an `alignment_score`, `operating_sequence`, `doctor_quality_contract`, `search_queries`, and `missing_domains` in the optimization payload so the umbrella alignment surface carries numeric readiness, a staged operating plan, explicit promotion rules, and search hints.
- Added helper functions in `src/sdetkit/kits.py`: `_alignment_status`, `_alignment_score`, `_search_queries`, `_operating_sequence`, and `_doctor_quality_contract`, and wired them into `optimize_payload` and the CLI textual output.
- Introduced a first-class AgentOS action `kits.optimize` in `src/sdetkit/agent/actions.py` that safely writes `.sdetkit/agent/workdir/umbrella-optimize.json` and returns a compact summary payload (including `alignment_score` and `missing_domains`).
- Routed AgentOS task planning to produce optimization actions when prompts include optimization terms by updating `_rule_based_plan` in `src/sdetkit/agent/core.py` so AgentOS can run the richer optimize action while preserving existing blueprint routing.
- Updated the umbrella demo to emit both the blueprint and the optimize artifacts (in `src/sdetkit/agent/demo.py`) and documented the new optimize signals in `README.md`.
- Added and updated focused unit tests to cover the new optimize contract, AgentOS action support, task routing, demo artifact generation, and CLI output (`tests/test_kits_umbrella_cli.py`, `tests/test_agent_actions_extra.py`, `tests/test_agent_foundation.py`, `tests/test_agent_productization.py`).

### Testing
- Ran targeted pytest suite: `python -m pytest -q tests/test_kits_umbrella_cli.py tests/test_agent_actions_extra.py tests/test_agent_foundation.py tests/test_agent_productization.py` and all tests passed (`30 passed`).
- Ran linter: `python -m ruff check ...` and all checks passed.
- Exercised the new CLI and demo flows: `python -m sdetkit kits optimize "upgrade umbrella architecture with agentos optimization" --format json` (produced payload with `alignment_score` and `operating_sequence`), and `python -m sdetkit agent demo --scenario umbrella-upgrade-control-plane` (produced both blueprint and optimize artifacts); both runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bca3655f3c83208aa21abd2f597c6c)