### PR TITLE
Add umbrella quality 'boost' lane, align kits.optimize, and fix upgrade_audit script wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,14 @@ The blueprint surface now goes further for umbrella-architecture upgrades: it em
 ```bash
 python -m sdetkit kits blueprint --goal "upgrade umbrella architecture with agentos optimization"
 python -m sdetkit kits optimize --goal "upgrade umbrella architecture with agentos optimization" --format json
+bash quality.sh boost
 python -m sdetkit agent run "umbrella architecture optimization blueprint" --approve
 python -m sdetkit agent demo --scenario umbrella-upgrade-control-plane
 ```
 
 The new optimize surface takes the blueprint one step further by inspecting the repo and aligning the umbrella kits with the operational lanes that actually keep the platform healthy: doctor, `quality.sh`, premium gate, integration topology, and AgentOS. That gives you a single alignment payload showing which lanes are ready, which command should lead each domain, which operating sequence should be used, which search queries help continue the maintenance loop, the explicit doctor-to-quality promotion contract, any missing domains, and which performance boosters are already available in the repo.
+
+When you want that alignment to execute as a single repo-safe lane instead of a planning artifact, `bash quality.sh boost` now chains doctor, intelligent premium auto-fix, the fast gate, premium validation, topology proof, and an umbrella optimization summary into one command.
 
 It now also emits an alignment score so the umbrella architecture has a single numeric readiness signal that can be tracked in CI, dashboards, and AgentOS history exports while the repo keeps getting upgraded.
 

--- a/quality.sh
+++ b/quality.sh
@@ -30,12 +30,68 @@ need_cmd() {
   exit 127
 }
 
+valid_modes=(all ci fmt lint type doctor test full-test cov mut muthtml boost)
+
+mode_suggestion() {
+  python3 - "$1" "${valid_modes[@]}" <<'PY'
+import difflib
+import sys
+
+unknown = sys.argv[1]
+choices = sys.argv[2:]
+match = difflib.get_close_matches(unknown, choices, n=1)
+if match:
+    print(match[0])
+PY
+}
+
 run_fmt()     { need_cmd ruff; python -m ruff format .; }
 run_fmt_check() { need_cmd ruff; python -m ruff format --check .; }
 run_lint()    { need_cmd ruff; python -m ruff check .; }
 run_type()    { need_cmd mypy; python -m mypy --config-file pyproject.toml src; }
 run_doctor()  { python -m sdetkit doctor --dev --ci --deps --repo --upgrade-audit --format md; }
 run_gate_fast() { python -m sdetkit gate fast; }
+run_premium_autofix() {
+  if [[ -f "premium-gate.sh" ]]; then
+    python -m sdetkit.premium_gate_engine \
+      --out-dir .sdetkit/out \
+      --double-check \
+      --auto-fix \
+      --auto-run-scripts \
+      --format markdown
+  else
+    echo "skip premium auto-fix: premium-gate.sh not found"
+  fi
+}
+run_premium_fast() {
+  if [[ -f "premium-gate.sh" ]]; then
+    bash premium-gate.sh --mode "${SDETKIT_BOOST_PREMIUM_MODE:-fast}"
+  else
+    echo "skip premium gate: premium-gate.sh not found"
+  fi
+}
+run_topology_check() {
+  local profile="${SDETKIT_BOOST_TOPOLOGY_PROFILE:-examples/kits/integration/heterogeneous-topology.json}"
+  if [[ -f "$profile" ]]; then
+    python -m sdetkit integration topology-check --profile "$profile"
+  else
+    echo "skip topology check: $profile not found"
+  fi
+}
+run_optimize_summary() {
+  python -m sdetkit kits optimize \
+    --goal "${SDETKIT_BOOST_GOAL:-upgrade umbrella architecture with agentos optimization}" \
+    --format text
+}
+run_boost() {
+  run_doctor
+  run_type
+  run_premium_autofix
+  run_gate_fast
+  run_premium_fast
+  run_topology_check
+  run_optimize_summary
+}
 run_full_test() { need_cmd pytest; python -m pytest -q -o addopts=; }
 run_test()    { need_cmd pytest; python -m pytest; }
 run_cov() {
@@ -76,6 +132,7 @@ case "$mode" in
   full-test) run_full_test ;;
   mut) run_mut ;;
   muthtml) run_muthtml ;;
+  boost) run_boost ;;
   ci)
     run_fmt_check
     run_lint
@@ -90,7 +147,11 @@ case "$mode" in
     run_cov
     ;;
   *)
-    echo "Usage: bash quality.sh {all|ci|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml}" >&2
+    echo "Usage: bash quality.sh {all|ci|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost}" >&2
+    suggestion="$(mode_suggestion "$mode" || true)"
+    if [[ -n "$suggestion" ]]; then
+      echo "Did you mean: bash quality.sh $suggestion" >&2
+    fi
     exit 2
     ;;
 esac

--- a/scripts/upgrade_audit.py
+++ b/scripts/upgrade_audit.py
@@ -1,13 +1,7 @@
 #!/usr/bin/env python3
 """Audit dependency manifests and report upgrade planning signals."""
 
-from __future__ import annotations
-
-from sdetkit import upgrade_audit as _upgrade_audit
-
-globals().update(_upgrade_audit.__dict__)
-main = _upgrade_audit.main
-
+from sdetkit.upgrade_audit import main
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -692,6 +692,25 @@ def _auto_fix_lane(
     }
 
 
+def _quality_boost_lane(goal: str | None) -> Payload:
+    goal_text = goal or "umbrella optimization"
+    return {
+        "command": "bash quality.sh boost",
+        "goal": goal_text,
+        "why": (
+            "Use a single boost lane to align doctor, intelligent auto-fix, deterministic quality "
+            "checks, topology proof, and umbrella optimization output."
+        ),
+        "phases": [
+            "doctor-first",
+            "intelligent-autofix",
+            "quality-gate",
+            "integration-proof",
+            "umbrella-optimize",
+        ],
+    }
+
+
 def _operating_sequence(
     doctor_lane: Payload,
     quality_lane: Payload,
@@ -783,6 +802,7 @@ def optimize_payload(
     integration_lane = _integration_lane(goal, repo_signals)
     agentos_lane = _agentos_lane(goal, repo_signals)
     auto_fix_lane = _auto_fix_lane(repo_signals, quality_lane, goal)
+    quality_boost_lane = _quality_boost_lane(goal)
     alignment_score = _alignment_score(repo_signals)
     operating_sequence = _operating_sequence(
         doctor_lane, quality_lane, integration_lane, agentos_lane, auto_fix_lane
@@ -792,6 +812,12 @@ def optimize_payload(
     )
     search_queries = _search_queries(goal)
     next_boosts = [
+        {
+            "id": "quality-boost",
+            "title": "Collapse the umbrella flow into a single boost command",
+            "summary": "Run doctor, auto-fix, premium validation, topology proof, and optimization reporting in one lane.",
+            "commands": [str(quality_boost_lane["command"])],
+        },
         {
             "id": "doctor-quality-sync",
             "title": "Align doctor with the quality gate",
@@ -871,6 +897,7 @@ def optimize_payload(
         "integration_lane": integration_lane,
         "agentos_lane": agentos_lane,
         "auto_fix_lane": auto_fix_lane,
+        "quality_boost_lane": quality_boost_lane,
         "alignment_score": alignment_score,
         "alignment_matrix": alignment_matrix,
         "doctor_quality_contract": doctor_quality_contract,
@@ -1182,6 +1209,10 @@ def main(argv: list[str] | None = None) -> int:
         auto_fix_lane = _payload_dict(optimize_result.get("auto_fix_lane"))
         for command in _string_list(auto_fix_lane["commands"]):
             print(f"- {command}")
+        print("quality boost lane:")
+        quality_boost_lane = _payload_dict(optimize_result.get("quality_boost_lane"))
+        print(f"- {quality_boost_lane['command']}")
+        print(f"  why: {quality_boost_lane['why']}")
         print("integration lane:")
         integration_lane = _payload_dict(optimize_result.get("integration_lane"))
         for command in _string_list(integration_lane["commands"]):

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -56,6 +56,8 @@ def test_optimize_payload_aligns_doctor_quality_gate_agentos_and_topology(tmp_pa
     assert payload["quality_gate_lane"]["commands"][0] == "bash quality.sh ci"
     assert payload["quality_gate_lane"]["commands"][1] == "bash premium-gate.sh --mode full"
     assert payload["auto_fix_lane"]["commands"][0] == "bash quality.sh type"
+    assert payload["quality_boost_lane"]["command"] == "bash quality.sh boost"
+    assert payload["quality_boost_lane"]["phases"][0] == "doctor-first"
     assert payload["integration_lane"]["coverage"] == "topology-aware"
     assert (
         payload["agentos_lane"]["commands"][1]
@@ -70,3 +72,4 @@ def test_optimize_payload_aligns_doctor_quality_gate_agentos_and_topology(tmp_pa
     assert "topology-premium-loop" in booster_ids
     assert payload["doctor_quality_contract"]["auto_fix_commands"]
     assert payload["operating_sequence"][1]["stage"] == "intelligent-autofix"
+    assert payload["next_boosts"][0]["id"] == "quality-boost"

--- a/tests/test_kits_umbrella_cli.py
+++ b/tests/test_kits_umbrella_cli.py
@@ -104,6 +104,7 @@ def test_kits_optimize_emits_alignment_plan_json() -> None:
     assert payload["doctor_lane"]["command"].startswith("sdetkit doctor ")
     assert payload["quality_gate_lane"]["commands"]
     assert payload["auto_fix_lane"]["commands"]
+    assert payload["quality_boost_lane"]["command"] == "bash quality.sh boost"
     assert payload["alignment_score"]["score"] > 0
     assert payload["doctor_quality_contract"]["entrypoint"] == payload["doctor_lane"]["command"]
     assert payload["doctor_quality_contract"]["auto_fix_commands"]
@@ -111,4 +112,5 @@ def test_kits_optimize_emits_alignment_plan_json() -> None:
     assert payload["operating_sequence"][0]["stage"] == "doctor-first"
     assert payload["search_queries"][0]["topic"] == "doctor-upgrade-lane"
     assert any(item["domain"] == "agentos" for item in payload["alignment_matrix"])
+    assert payload["next_boosts"][0]["id"] == "quality-boost"
     assert payload["blueprint"]["control_plane"]["name"] == "agentos-control-plane"

--- a/tests/test_quality_script.py
+++ b/tests/test_quality_script.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def test_quality_script_unknown_mode_suggests_closest_match() -> None:
+    result = subprocess.run(
+        ["bash", "quality.sh", "cit"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "Did you mean: bash quality.sh ci" in result.stderr

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 from sdetkit import upgrade_audit
@@ -1435,3 +1437,35 @@ def test_resolve_requirement_paths_supports_outdated_only_cli_defaults(tmp_path:
     assert args.used_in_repo_only is True
     assert args.include_prereleases is False
     assert requirement_paths == []
+
+
+def test_upgrade_audit_script_wrapper_emits_json(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "demo"
+version = "0.1.0"
+dependencies = ["httpx==0.28.1"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/upgrade_audit.py",
+            "--pyproject",
+            str(pyproject),
+            "--format",
+            "json",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["pyproject"] == str(pyproject)
+    assert payload["packages"][0]["name"] == "httpx"


### PR DESCRIPTION
### Motivation

- Provide a one-command umbrella boost that chains doctor, intelligent premium auto-fix, deterministic gate, topology proof, and an optimize summary so umbrella kits, premium gate, quality script, topology checks, and AgentOS run as a coordinated flow. 
- Surface and align a first-class quality-boost lane in the `kits.optimize` payload so tooling and automation can recommend and execute the same lane.
- Fix a bug in the standalone `scripts/upgrade_audit.py` wrapper so running the script directly emits the same JSON payload as the module entrypoint.

### Description

- Added a new `boost` mode to `quality.sh` that runs doctor, typing checks, premium auto-fix, the fast gate, premium validation, topology proof, and a summary optimize report via `bash quality.sh boost` and added a fuzzy suggestion helper for mistyped modes. 
- Extended `src/sdetkit/kits.py` with a `_quality_boost_lane` and wire `quality_boost_lane` into `optimize_payload`, `next_boosts`, and the CLI text output so `kits optimize` exposes the boost lane and recommends `quality-boost`. 
- Fixed `scripts/upgrade_audit.py` by replacing the previous `globals().update(...)` wrapper with a clean import of `main` (`from sdetkit.upgrade_audit import main`) so the script path emits JSON correctly. 
- Updated documentation (`README.md`) to mention `bash quality.sh boost`. 
- Added and updated tests: `tests/test_quality_script.py` (mode suggestion), augmented `tests/test_kits_blueprint.py` and `tests/test_kits_umbrella_cli.py` to assert the new `quality_boost_lane` and `quality-boost` recommendation, and added `test_upgrade_audit_script_wrapper_emits_json` to `tests/test_upgrade_audit_script.py` to cover the wrapper fix. 

Files changed (high level): `quality.sh`, `src/sdetkit/kits.py`, `scripts/upgrade_audit.py`, `README.md`, tests under `tests/`.

### Testing

- Ran targeted pytest: `python -m pytest -q tests/test_kits_blueprint.py tests/test_kits_umbrella_cli.py tests/test_upgrade_audit_script.py tests/test_quality_script.py`, and all assertions passed (test run succeeded). 
- Exercised full CI quality lane: `bash quality.sh ci` (format check, lint, type, gate fast, pytest) and it completed with "All checks passed!". 
- Validated the upgrade-audit script direct invocation: `python scripts/upgrade_audit.py --pyproject pyproject.toml --format json --top 3` produced JSON output as expected. 
- Ran linters/formatters (`ruff` fix/check and `bash -n quality.sh`) and addressed issues; linter/format steps passed during CI validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bcaadac8848320b09fcab94839f9f3)