### PR TITLE
feat: support pyproject dependency-groups in upgrade audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - add Name 86 launch readiness closeout lane command, docs, checks, and tests (`name86-launch-readiness-closeout`).
+- upgrade audit: parse modern `pyproject.toml` `[dependency-groups]` declarations, including `{include-group = "..."}` expansions.
 
 # Changelog
 ## [1.0.2]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ python -m sdetkit doctor --upgrade-audit --upgrade-audit-max-release-age-days 14
 bash quality.sh doctor
 ```
 
+The audit also understands modern top-level `[dependency-groups]` declarations in `pyproject.toml`, including `{include-group = "..."}` expansion, so repos that have moved beyond legacy dev/test extras still get the same upgrade visibility and maintenance prioritization.
+
 By default, the audit plans against stable releases first so dev/rc tags do not get promoted as normal maintenance work; use `--include-prereleases` when you explicitly want prerelease targets in the queue. When you already know the maintenance lane you want, filter directly by `--manifest-action` to isolate packages that need a pin refresh, floor raise, staged upgrade, or dedicated major-upgrade branch. Use `--query` when you want text search across package names, notes, repo-usage files, recommended lanes, and validation commands without pre-classifying the package first. Use `--max-release-age-days 14` to build a fast-follow watchlist for just-landed releases, or `--min-release-age-days 365 --outdated-only` to isolate older targets that have gone stale and deserve a deliberate cleanup pass.
 
 When you want a surgically targeted maintenance queue, filter by `--validation-command` as well. That lets you answer questions like “show me only upgrades that roll into `make docs-build`” or “which candidates are covered by `bash quality.sh *` smoke validation” without scanning the whole report.

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -180,7 +180,58 @@ def _load_pyproject_dependencies(pyproject_path: Path) -> list[Dependency]:
                 )
             )
 
+    dependency_groups = data.get("dependency-groups", {})
+    deps.extend(_load_dependency_group_dependencies(pyproject_path, dependency_groups))
+
     return deps
+
+
+def _load_dependency_group_dependencies(
+    pyproject_path: Path,
+    dependency_groups: object,
+) -> list[Dependency]:
+    if not isinstance(dependency_groups, dict):
+        return []
+
+    resolved: list[Dependency] = []
+
+    def _resolve_group_items(group_name: str, trail: tuple[str, ...]) -> list[str]:
+        if group_name in trail:
+            return []
+
+        raw_items = dependency_groups.get(group_name)
+        if not isinstance(raw_items, list):
+            return []
+
+        items: list[str] = []
+        for entry in raw_items:
+            if isinstance(entry, str):
+                normalized = entry.strip()
+                if normalized:
+                    items.append(normalized)
+                continue
+            if isinstance(entry, dict):
+                include_group = entry.get("include-group")
+                if isinstance(include_group, str) and include_group.strip():
+                    items.extend(_resolve_group_items(include_group.strip(), (*trail, group_name)))
+        return items
+
+    for raw_group_name in dependency_groups:
+        group_name = str(raw_group_name).strip()
+        if not group_name:
+            continue
+        for dep in _resolve_group_items(group_name, ()):
+            resolved.append(
+                Dependency(
+                    source=pyproject_path.name,
+                    group=group_name,
+                    raw=dep,
+                    name=_parse_dep_name(dep),
+                    pinned_version=_extract_pinned_version(dep),
+                )
+            )
+
+    return resolved
 
 
 def _load_requirements_dependencies(requirements_path: Path) -> list[Dependency]:

--- a/tests/test_upgrade_audit_script.py
+++ b/tests/test_upgrade_audit_script.py
@@ -85,6 +85,66 @@ ruff==0.15.6
     assert deps[2].pinned_version == "0.28.1"
 
 
+def test_load_dependencies_collects_dependency_groups_and_include_group_entries(
+    tmp_path: Path,
+) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = ["httpx>=0.27,<1"]
+
+[dependency-groups]
+lint = ["ruff==0.15.7"]
+docs = ["mkdocs==1.6.1"]
+dev = [
+  {include-group = "lint"},
+  {include-group = "docs"},
+  "pytest==8.4.2",
+]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    deps = upgrade_audit._load_dependencies(pyproject, [])
+
+    assert [(dep.group, dep.name) for dep in deps] == [
+        ("default", "httpx"),
+        ("lint", "ruff"),
+        ("docs", "mkdocs"),
+        ("dev", "ruff"),
+        ("dev", "mkdocs"),
+        ("dev", "pytest"),
+    ]
+    assert [dep.pinned_version for dep in deps[1:]] == ["0.15.7", "1.6.1", "0.15.7", "1.6.1", "8.4.2"]
+
+
+def test_load_dependencies_ignores_recursive_dependency_group_includes(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = []
+
+[dependency-groups]
+lint = [{include-group = "dev"}, "ruff==0.15.7"]
+dev = [{include-group = "lint"}, "pytest==8.4.2"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    deps = upgrade_audit._load_dependencies(pyproject, [])
+
+    assert [(dep.group, dep.name) for dep in deps] == [
+        ("lint", "pytest"),
+        ("lint", "ruff"),
+        ("dev", "ruff"),
+        ("dev", "pytest"),
+    ]
+
+
 def test_load_dependencies_follows_nested_requirement_files(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[project]\ndependencies=[]\n", encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Modern Python projects increasingly use top-level `[dependency-groups]` in `pyproject.toml` (PEP 735) instead of legacy extras, so the upgrade-audit should surface those packages for maintenance planning. 
- Expandable group entries such as `{include-group = "..."}` must be resolved and guarded against recursion so audits remain accurate and safe on real-world manifests.

### Description
- Add `_load_dependency_group_dependencies` and wire it into `_load_pyproject_dependencies` to parse top-level `dependency-groups` and expand `{include-group = "..."}` entries. 
- Resolve included groups recursively with a trail to avoid infinite loops and emit `Dependency` records with correct `group`, `raw`, `name`, and `pinned_version` fields. 
- Add regression tests covering direct groups, included-group expansion, and cyclic includes in `tests/test_upgrade_audit_script.py`. 
- Update `README.md` and `CHANGELOG.md` to document the new support.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_upgrade_audit_script.py` and the targeted upgrade-audit tests passed (`37 passed`).
- Ran `PYTHONPATH=src pytest -q tests/test_doctor_upgrade_audit.py` and `PYTHONPATH=src pytest -q tests/test_kits_blueprint.py` and both suites passed (`8 passed` and `2 passed` respectively). 
- Compiled package sources with `python -m compileall src/sdetkit` with no compilation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bcb034fc748320977c787be3dbc79e)