### PR TITLE
Add kits route-map: searchable package-to-validation route map

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ python -m sdetkit kits search topology
 python -m sdetkit kits blueprint --goal "agentized release upgrade search"
 python -m sdetkit kits optimize --goal "upgrade umbrella architecture with agentos optimization"
 python -m sdetkit kits expand --goal "upgrade umbrella architecture with agentos optimization"
+python -m sdetkit kits route-map httpx --repo-usage-tier hot-path --format json
 python -m sdetkit intelligence upgrade-audit --format json --top 5
 ```
 
@@ -155,6 +156,8 @@ When you want that alignment to execute as a single repo-safe lane instead of a 
 It now also emits an alignment score so the umbrella architecture has a single numeric readiness signal that can be tracked in CI, dashboards, and AgentOS history exports while the repo keeps getting upgraded.
 
 When you want the repo to go beyond alignment planning and explicitly suggest what to add next, `sdetkit kits expand --goal "..."` turns those optimize signals into prioritized feature candidates, targeted search missions, and rollout tracks. That makes it easier to decide which new addition should land now, which should be queued next, and which search direction is most likely to unlock the next repo-wide upgrade.
+
+One of those additions is now implemented directly as `sdetkit kits route-map`, which turns the dependency inventory into a searchable package-to-validation route map. That gives refactors and upgrade work a smaller proof loop by surfacing the best-fit validation command, impact area, repo usage tier, and next action for each package instead of forcing operators to guess which broad lane to run first.
 
 The premium gate intelligence layer now goes further as well: it ranks remediation scripts by observed hotspot severity, can merge in repo-local smart fix scripts from `.sdetkit/premium-remediation-scripts.json`, emits a first-class `premium-remediation-plan.json` artifact, refreshes integration topology when contract drift is detected, and supports focused search across rendered findings plus learned guideline lookup from the premium insights database.
 

--- a/docs/kits/expansion-lab.md
+++ b/docs/kits/expansion-lab.md
@@ -31,6 +31,13 @@ Depending on the repo signals and dependency inventory, the expansion lab can su
 - a **runtime fast-follow watchlist** for hot-path dependencies,
 - or an **optimization control center** that collapses boost + AgentOS outputs into one recurring operating view.
 
+The validation route map is now available directly via `sdetkit kits route-map`, so one strong follow-up pattern is:
+
+```bash
+python -m sdetkit kits expand --goal "upgrade umbrella architecture with agentos optimization"
+python -m sdetkit kits route-map --impact-area runtime-core --limit 5
+```
+
 ## How to use it well
 
 1. Run `sdetkit kits optimize --goal "..."` first if you need the full alignment payload.

--- a/docs/kits/validation-route-map.md
+++ b/docs/kits/validation-route-map.md
@@ -1,0 +1,45 @@
+# Validation route map
+
+`sdetkit kits route-map` turns the repo's dependency and repo-usage signals into a searchable package-to-validation map.
+
+Use it when you want a tighter answer than "run the whole suite":
+
+> Which package or maintenance area changed, and what is the smallest safe command I should run next?
+
+## Why it helps
+
+The umbrella optimization and expansion surfaces already identify **validation route map** as one of the highest-leverage upgrades for the repo. This command makes that recommendation real by exposing:
+
+- the package,
+- its impact area,
+- repo-usage tier,
+- the primary validation command,
+- alternate validation commands,
+- source manifests and dependency groups,
+- and the next maintenance action.
+
+That helps with both **refactors** and **upgrade work** because the route map points you to the narrowest proof loop instead of a generic, expensive validation sweep.
+
+## Example commands
+
+```bash
+python -m sdetkit kits route-map --format json
+python -m sdetkit kits route-map httpx --repo-usage-tier hot-path --format json
+python -m sdetkit kits route-map --impact-area runtime-core --limit 5
+python -m sdetkit kits route-map topology --impact-area integration-adapters
+```
+
+## Typical workflow
+
+1. Run `python -m sdetkit kits optimize --goal "upgrade umbrella architecture with agentos optimization"` to understand the repo-wide operating posture.
+2. Run `python -m sdetkit kits route-map ...` to narrow the next validation lane for a package, impact area, or maintenance slice.
+3. Run the `primary_validation` command for the best match first.
+4. Escalate to alternate validation commands only when the smaller route shows risk.
+
+## Good queries
+
+- package names like `httpx`, `pytest`, or `mkdocs`
+- impact-oriented terms like `runtime`, `quality`, or `docs`
+- repo paths or surface words that show up in usage files
+
+This makes the route map work well as both a maintenance lookup and a targeted search surface for repo upgrades.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Test Intelligence Kit: kits/test-intelligence.md
       - Integration Assurance Kit: kits/integration-assurance.md
       - Failure Forensics Kit: kits/failure-forensics.md
+      - Validation route map: kits/validation-route-map.md
       - Expansion lab: kits/expansion-lab.md
   - Team adoption:
       - Adopt in your repository (canonical): adoption.md

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -675,6 +675,7 @@ def _upgrade_inventory(root: Path) -> Payload:
             "summary": "No pyproject.toml was found, so upgrade inventory could not be derived.",
             "packages_audited": 0,
             "priority_packages": [],
+            "route_map": [],
             "impact_summary": [],
             "validation_summary": [],
             "group_summary": [],
@@ -690,6 +691,7 @@ def _upgrade_inventory(root: Path) -> Payload:
             "summary": "No dependency manifests were discovered for upgrade inventory planning.",
             "packages_audited": 0,
             "priority_packages": [],
+            "route_map": [],
             "impact_summary": [],
             "validation_summary": [],
             "group_summary": [],
@@ -754,6 +756,25 @@ def _upgrade_inventory(root: Path) -> Payload:
             f"\"{top_validation[0]['command']}\" --format md"
         )
 
+    route_map = [
+        {
+            "package": report.name,
+            "impact_area": report.impact_area,
+            "repo_usage_tier": report.repo_usage_tier,
+            "repo_usage_count": report.repo_usage_count,
+            "groups": report.groups,
+            "sources": report.sources,
+            "validation_commands": report.validation_commands,
+            "primary_validation": report.validation_commands[0]
+            if report.validation_commands
+            else "python -m sdetkit intelligence upgrade-audit --package "
+            f"\"{report.name}\" --format md",
+            "next_action": report.next_action,
+            "repo_usage_files": report.repo_usage_files[:5],
+        }
+        for report in reports
+    ]
+
     return {
         "status": "ready",
         "summary": (
@@ -772,12 +793,75 @@ def _upgrade_inventory(root: Path) -> Payload:
             }
             for report in priority_packages
         ],
+        "route_map": route_map,
         "impact_summary": upgrade_audit._impact_summary(reports)[:4],
         "validation_summary": top_validation[:4],
         "group_summary": upgrade_audit._group_summary(reports)[:4],
         "source_summary": upgrade_audit._source_summary(reports)[:4],
         "release_freshness_summary": upgrade_audit._release_freshness_summary(reports)[:4],
         "recommended_commands": recommended_commands,
+    }
+
+
+def route_map_payload(
+    *,
+    root: Path,
+    query: str | None = None,
+    repo_usage_tier: str | None = None,
+    impact_area: str | None = None,
+    limit: int = 10,
+) -> dict[str, object]:
+    upgrade_inventory = _upgrade_inventory(root)
+    route_map = _payload_list(upgrade_inventory.get("route_map"))
+    query_terms = _tokenize(query or "")
+    normalized_repo_usage_tier = str(repo_usage_tier or "").strip().lower()
+    normalized_impact_area = str(impact_area or "").strip().lower()
+
+    matches: list[Payload] = []
+    for entry in route_map:
+        if normalized_repo_usage_tier and str(entry.get("repo_usage_tier", "")).lower() != normalized_repo_usage_tier:
+            continue
+        if normalized_impact_area and str(entry.get("impact_area", "")).lower() != normalized_impact_area:
+            continue
+
+        search_blob = " ".join(
+            [
+                str(entry.get("package", "")),
+                str(entry.get("impact_area", "")),
+                str(entry.get("repo_usage_tier", "")),
+                " ".join(_string_list(entry.get("groups"))),
+                " ".join(_string_list(entry.get("sources"))),
+                " ".join(_string_list(entry.get("validation_commands"))),
+                " ".join(_string_list(entry.get("repo_usage_files"))),
+                str(entry.get("next_action", "")),
+            ]
+        ).lower()
+
+        if query_terms and not all(term in search_blob for term in query_terms):
+            continue
+        matches.append(entry)
+
+    matches.sort(
+        key=lambda item: (
+            str(item.get("repo_usage_tier", "")) != "hot-path",
+            -int(item.get("repo_usage_count", 0)),
+            str(item.get("package", "")),
+        )
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": upgrade_inventory.get("status", "missing"),
+        "summary": (
+            "Searchable package-to-validation route map derived from the repo's manifest-aware "
+            "upgrade inventory."
+        ),
+        "query": query,
+        "repo_usage_tier": repo_usage_tier,
+        "impact_area": impact_area,
+        "matches": matches[: max(limit, 1)],
+        "total_matches": len(matches),
+        "recommended_commands": _string_list(upgrade_inventory.get("recommended_commands")),
     }
 
 
@@ -1628,7 +1712,7 @@ def main(argv: list[str] | None = None) -> int:
         "action",
         nargs="?",
         default="list",
-        choices=["list", "describe", "search", "blueprint", "optimize", "expand"],
+        choices=["list", "describe", "search", "blueprint", "optimize", "expand", "route-map"],
     )
     parser.add_argument("target", nargs="?", default=None)
     parser.add_argument("--format", choices=["json", "text"], default="text")
@@ -1642,6 +1726,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Explicit kit to include in `blueprint` (repeatable).",
     )
     parser.add_argument("--limit", type=int, default=4, help="Maximum search or blueprint results.")
+    parser.add_argument(
+        "--repo-usage-tier",
+        default=None,
+        help="Filter route-map results by repo usage tier (for example: hot-path, active, supporting).",
+    )
+    parser.add_argument(
+        "--impact-area",
+        default=None,
+        help="Filter route-map results by impact area (for example: runtime-core, quality-tooling).",
+    )
     parser.add_argument(
         "--repo-root",
         default=".",
@@ -1825,6 +1919,43 @@ def main(argv: list[str] | None = None) -> int:
             ids = ", ".join(_string_list(item.get("candidate_ids"))) or "none"
             print(f"- {item['track']}: {item['focus']}")
             print(f"  candidates: {ids}")
+        return 0
+
+    if ns.action == "route-map":
+        query = str(ns.query or ns.target or "").strip() or None
+        route_map_result = route_map_payload(
+            root=Path(str(ns.repo_root)).resolve(),
+            query=query,
+            repo_usage_tier=ns.repo_usage_tier,
+            impact_area=ns.impact_area,
+            limit=ns.limit,
+        )
+        if ns.format == "json":
+            sys.stdout.write(canonical_json_dumps(route_map_result))
+            return 0
+        print("Validation route map")
+        if query:
+            print(f"query: {query}")
+        if ns.repo_usage_tier:
+            print(f"repo usage tier: {ns.repo_usage_tier}")
+        if ns.impact_area:
+            print(f"impact area: {ns.impact_area}")
+        print(f"matches: {route_map_result['total_matches']}")
+        for item in _payload_list(route_map_result.get("matches")):
+            print(
+                f"- {item['package']} [{item['impact_area']} / {item['repo_usage_tier']}] "
+                f"count={item['repo_usage_count']}"
+            )
+            print(f"  primary validation: {item['primary_validation']}")
+            for command in _string_list(item.get("validation_commands"))[1:3]:
+                print(f"  alternate validation: {command}")
+            for source in _string_list(item.get("sources")):
+                print(f"  source: {source}")
+            for group in _string_list(item.get("groups")):
+                print(f"  group: {group}")
+            for path in _string_list(item.get("repo_usage_files"))[:2]:
+                print(f"  usage: {path}")
+            print(f"  next action: {item['next_action']}")
         return 0
 
     if ns.target:

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -127,3 +127,36 @@ def test_expand_payload_turns_optimize_signals_into_feature_candidates(tmp_path:
     assert "dependency-radar" in mission_topics
     assert "validation-route-map" in mission_topics
     assert track_names == {"now", "next", "later"}
+
+
+def test_route_map_payload_surfaces_primary_validation_routes(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        "name='x'\n"
+        "version='0.1.0'\n"
+        "dependencies=['httpx>=0.28.1,<1']\n"
+        "[project.optional-dependencies]\n"
+        "docs=['mkdocs==1.6.1']\n",
+        encoding="utf-8",
+    )
+    src_dir = tmp_path / "src" / "demo"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    (src_dir / "api.py").write_text("import httpx\n", encoding="utf-8")
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    (tests_dir / "test_docs.py").write_text("import mkdocs\n", encoding="utf-8")
+
+    payload = kits.route_map_payload(
+        root=tmp_path,
+        query="httpx runtime",
+        repo_usage_tier="edge",
+        impact_area="runtime-core",
+        limit=5,
+    )
+
+    assert payload["status"] == "ready"
+    assert payload["total_matches"] == 1
+    match = payload["matches"][0]
+    assert match["package"] == "httpx"
+    assert match["primary_validation"]
+    assert "src/demo/api.py" in match["repo_usage_files"]

--- a/tests/test_kits_umbrella_cli.py
+++ b/tests/test_kits_umbrella_cli.py
@@ -138,3 +138,14 @@ def test_kits_expand_emits_feature_candidates_and_search_missions() -> None:
     candidate_ids = {item["id"] for item in payload["feature_candidates"]}
     assert "dependency-radar-dashboard" in candidate_ids
     assert payload["optimize"]["blueprint"]["control_plane"]["name"] == "agentos-control-plane"
+
+
+def test_kits_route_map_emits_searchable_validation_routes() -> None:
+    result = _run("kits", "route-map", "httpx", "--repo-usage-tier", "hot-path", "--format", "json")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "sdetkit.kits.catalog.v1"
+    assert payload["matches"]
+    top = payload["matches"][0]
+    assert top["package"] == "httpx"
+    assert top["primary_validation"]


### PR DESCRIPTION
### Motivation
- Provide a narrow, searchable route from packages to the smallest safe validation commands so refactors and upgrade work avoid running broad, expensive validation lanes. 
- Surface upgrade-inventory signals (impact area, repo-usage tier, validation commands, next action) as a first-class lookup for maintenance and triage workflows. 

### Description
- Add a new payload builder `route_map_payload` and include `route_map` in the manifest-aware inventory so package -> validation mappings are derived from the existing upgrade inventory (`src/sdetkit/kits.py`).
- Add a CLI surface `sdetkit kits route-map` with `--repo-usage-tier`, `--impact-area`, `--query`, `--limit`, and JSON/text output, and wire text rendering into the existing `kits` command (`src/sdetkit/kits.py`).
- Add a docs page describing the feature and examples, update MkDocs nav, and add README examples to surface the command to users (`docs/kits/validation-route-map.md`, `docs/kits/expansion-lab.md`, `mkdocs.yml`, `README.md`).
- Add tests for the payload and CLI coverage and small adjustments to existing tests to validate behavior (`tests/test_kits_blueprint.py`, `tests/test_kits_umbrella_cli.py`).

### Testing
- Ran targeted unit/CLI tests with `python -m pytest -q tests/test_kits_blueprint.py tests/test_kits_umbrella_cli.py` and all tests passed (13 passed). 
- Ran static checks with `python -m ruff check src/sdetkit/kits.py tests/test_kits_blueprint.py tests/test_kits_umbrella_cli.py` and linting passed. 
- Verified the CLI output with `python -m sdetkit kits route-map httpx --repo-usage-tier hot-path --format json` and the command returned the expected JSON payload. 
- Built the documentation with `python -m mkdocs build -q`; the build completed successfully but MkDocs material emitted a compatibility warning about MkDocs 2.0 upstream changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bcbff1a954832084b48ef4f3df97db)