### PR TITLE
Add `kits radar` dependency radar dashboard (payload, CLI, docs, tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ python -m sdetkit kits search topology
 python -m sdetkit kits blueprint --goal "agentized release upgrade search"
 python -m sdetkit kits optimize --goal "upgrade umbrella architecture with agentos optimization"
 python -m sdetkit kits expand --goal "upgrade umbrella architecture with agentos optimization"
+python -m sdetkit kits radar --repo-usage-tier hot-path --format json
 python -m sdetkit kits route-map httpx --repo-usage-tier hot-path --format json
 python -m sdetkit intelligence upgrade-audit --format json --top 5
 ```
@@ -157,7 +158,12 @@ It now also emits an alignment score so the umbrella architecture has a single n
 
 When you want the repo to go beyond alignment planning and explicitly suggest what to add next, `sdetkit kits expand --goal "..."` turns those optimize signals into prioritized feature candidates, targeted search missions, and rollout tracks. That makes it easier to decide which new addition should land now, which should be queued next, and which search direction is most likely to unlock the next repo-wide upgrade.
 
-One of those additions is now implemented directly as `sdetkit kits route-map`, which turns the dependency inventory into a searchable package-to-validation route map. That gives refactors and upgrade work a smaller proof loop by surfacing the best-fit validation command, impact area, repo usage tier, and next action for each package instead of forcing operators to guess which broad lane to run first.
+Two of those additions are now implemented directly:
+
+- `sdetkit kits radar`, which turns the dependency inventory into a dashboard-style maintenance radar with hotspot cards, watchlists, and recommended execution lanes,
+- and `sdetkit kits route-map`, which turns the same inventory into a searchable package-to-validation route map.
+
+Together they give refactors and upgrade work both a **macro view** of what is hottest in the repo and a **micro view** of the smallest safe validation command to run next.
 
 The premium gate intelligence layer now goes further as well: it ranks remediation scripts by observed hotspot severity, can merge in repo-local smart fix scripts from `.sdetkit/premium-remediation-scripts.json`, emits a first-class `premium-remediation-plan.json` artifact, refreshes integration topology when contract drift is detected, and supports focused search across rendered findings plus learned guideline lookup from the premium insights database.
 

--- a/docs/kits/dependency-radar-dashboard.md
+++ b/docs/kits/dependency-radar-dashboard.md
@@ -1,0 +1,43 @@
+# Dependency radar dashboard
+
+`sdetkit kits radar` turns the repo's upgrade inventory into a dashboard-friendly maintenance view.
+
+Use it when you want more than a raw dependency report and need a sharper answer to:
+
+> Which dependency areas are hottest right now, and what should we validate first?
+
+## What it emits
+
+The radar payload builds on the manifest-aware upgrade inventory and the validation route map, then adds:
+
+- **headline metrics** for the maintenance surface,
+- **dashboard cards** for hot-path, runtime-core, and quality-tooling watchlists,
+- **hotspots** that expose the strongest package-to-validation routes,
+- **watchlists** for recurring review slices,
+- and **maintenance lanes** that suggest what to run next.
+
+That makes it easier to move from “we should probably upgrade things” to a concrete operating review with smaller proof loops.
+
+## Example commands
+
+```bash
+python -m sdetkit kits radar --format json
+python -m sdetkit kits radar httpx --repo-usage-tier hot-path --format json
+python -m sdetkit kits radar --impact-area runtime-core --limit 5
+python -m sdetkit kits radar docs --impact-area quality-tooling
+```
+
+## Typical workflow
+
+1. Run `python -m sdetkit kits optimize --goal "upgrade umbrella architecture with agentos optimization"` to understand the umbrella posture.
+2. Run `python -m sdetkit kits radar ...` to turn the upgrade surface into a review-ready dashboard.
+3. Use the **hotspots** section to pick the first package-specific validation loop.
+4. Use the **maintenance lanes** section to schedule recurring review or AgentOS export.
+
+## Why this is useful
+
+The expansion lab already identified a **dependency radar dashboard** as one of the best next additions for the repo. This command productizes that idea directly, so the upgrade conversation becomes:
+
+- visible,
+- prioritized,
+- and tied to specific validation commands rather than broad maintenance intuition.

--- a/docs/kits/expansion-lab.md
+++ b/docs/kits/expansion-lab.md
@@ -35,6 +35,7 @@ The validation route map is now available directly via `sdetkit kits route-map`,
 
 ```bash
 python -m sdetkit kits expand --goal "upgrade umbrella architecture with agentos optimization"
+python -m sdetkit kits radar --repo-usage-tier hot-path --format json
 python -m sdetkit kits route-map --impact-area runtime-core --limit 5
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Test Intelligence Kit: kits/test-intelligence.md
       - Integration Assurance Kit: kits/integration-assurance.md
       - Failure Forensics Kit: kits/failure-forensics.md
+      - Dependency radar dashboard: kits/dependency-radar-dashboard.md
       - Validation route map: kits/validation-route-map.md
       - Expansion lab: kits/expansion-lab.md
   - Team adoption:

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -865,6 +865,178 @@ def route_map_payload(
     }
 
 
+def radar_payload(
+    *,
+    root: Path,
+    query: str | None = None,
+    repo_usage_tier: str | None = None,
+    impact_area: str | None = None,
+    limit: int = 5,
+) -> dict[str, object]:
+    upgrade_inventory = _upgrade_inventory(root)
+    route_map = _payload_list(upgrade_inventory.get("route_map"))
+    route_result = route_map_payload(
+        root=root,
+        query=query,
+        repo_usage_tier=repo_usage_tier,
+        impact_area=impact_area,
+        limit=limit,
+    )
+    filtered_matches = _payload_list(route_result.get("matches"))
+    release_freshness_summary = _payload_list(upgrade_inventory.get("release_freshness_summary"))
+
+    hot_path_packages = sum(
+        1 for item in route_map if str(item.get("repo_usage_tier", "")).lower() == "hot-path"
+    )
+    runtime_core_packages = sum(
+        1 for item in route_map if str(item.get("impact_area", "")).lower() == "runtime-core"
+    )
+    quality_tooling_packages = sum(
+        1 for item in route_map if str(item.get("impact_area", "")).lower() == "quality-tooling"
+    )
+    fresh_release_packages = sum(
+        int(item.get("count", 0))
+        for item in release_freshness_summary
+        if str(item.get("release_freshness", "")).lower() == "fresh-release"
+    )
+
+    watchlists = {
+        "hot_path": [
+            item for item in route_map if str(item.get("repo_usage_tier", "")).lower() == "hot-path"
+        ][: max(limit, 1)],
+        "runtime_core": [
+            item for item in route_map if str(item.get("impact_area", "")).lower() == "runtime-core"
+        ][: max(limit, 1)],
+        "quality_tooling": [
+            item
+            for item in route_map
+            if str(item.get("impact_area", "")).lower() == "quality-tooling"
+        ][: max(limit, 1)],
+        "fresh_releases": release_freshness_summary[: max(limit, 1)],
+    }
+
+    recommended_commands = _string_list(upgrade_inventory.get("recommended_commands"))
+    if repo_usage_tier:
+        recommended_commands.append(
+            "python -m sdetkit kits route-map "
+            f"--repo-usage-tier {repo_usage_tier} --format json"
+        )
+    if impact_area:
+        recommended_commands.append(
+            f"python -m sdetkit kits route-map --impact-area {impact_area} --format json"
+        )
+
+    dashboard_cards = [
+        {
+            "id": "maintenance-surface",
+            "title": "Maintenance surface",
+            "metric": int(upgrade_inventory.get("packages_audited", 0)),
+            "summary": "Total packages in the manifest-aware upgrade inventory.",
+            "commands": recommended_commands[:2],
+        },
+        {
+            "id": "hot-path-watchlist",
+            "title": "Hot-path watchlist",
+            "metric": hot_path_packages,
+            "summary": "Packages with the highest observed repo usage and the smallest safe proof loops.",
+            "commands": [
+                "python -m sdetkit intelligence upgrade-audit --used-in-repo-only "
+                "--repo-usage-tier hot-path --top 5 --format md",
+                "python -m sdetkit kits route-map --repo-usage-tier hot-path --format json",
+            ],
+        },
+        {
+            "id": "runtime-core-watchlist",
+            "title": "Runtime-core watchlist",
+            "metric": runtime_core_packages,
+            "summary": "Release-critical runtime packages that deserve a tighter maintenance cadence.",
+            "commands": [
+                "python -m sdetkit intelligence upgrade-audit --impact-area runtime-core --format md",
+                "bash quality.sh ci",
+            ],
+        },
+        {
+            "id": "quality-tooling-watchlist",
+            "title": "Quality-tooling watchlist",
+            "metric": quality_tooling_packages,
+            "summary": "Tooling packages that influence local/CI proof speed and repo confidence.",
+            "commands": [
+                "python -m sdetkit intelligence upgrade-audit --impact-area quality-tooling --format md",
+                "bash quality.sh type",
+            ],
+        },
+    ]
+
+    if fresh_release_packages:
+        dashboard_cards.append(
+            {
+                "id": "fresh-release-fast-lane",
+                "title": "Fresh-release fast lane",
+                "metric": fresh_release_packages,
+                "summary": "Recently published releases that are cheap to validate before they age into backlog noise.",
+                "commands": [
+                    "python -m sdetkit intelligence upgrade-audit --max-release-age-days 14 --format md",
+                    "bash quality.sh ci",
+                ],
+            }
+        )
+
+    maintenance_lanes = [
+        {
+            "id": "route-hotspots",
+            "title": "Route the hottest packages first",
+            "summary": (
+                "Use repo usage tier and impact area to shrink upgrade verification to the "
+                "smallest safe proof loop."
+            ),
+            "commands": [
+                "python -m sdetkit kits route-map --repo-usage-tier hot-path --format json",
+                "python -m sdetkit kits route-map --impact-area runtime-core --format json",
+            ],
+        },
+        {
+            "id": "audit-maintenance",
+            "title": "Audit and prioritize dependency maintenance",
+            "summary": "Review the highest-signal upgrade queue before broader umbrella optimization work.",
+            "commands": recommended_commands[:3],
+        },
+        {
+            "id": "governance-export",
+            "title": "Export recurring radar reviews through AgentOS",
+            "summary": "Capture the dependency radar as a recurring review artifact instead of a one-off report.",
+            "commands": [
+                'sdetkit agent run "template:dependency-outdated-report" --approve',
+                "sdetkit agent dashboard build --format html",
+            ],
+        },
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": route_result.get("status", upgrade_inventory.get("status", "missing")),
+        "summary": (
+            "Dependency radar dashboard derived from the repo's manifest-aware upgrade inventory, "
+            "route map, and maintenance watchlists."
+        ),
+        "query": query,
+        "repo_usage_tier": repo_usage_tier,
+        "impact_area": impact_area,
+        "headline_metrics": {
+            "packages_audited": int(upgrade_inventory.get("packages_audited", 0)),
+            "filtered_matches": len(filtered_matches),
+            "hot_path_packages": hot_path_packages,
+            "runtime_core_packages": runtime_core_packages,
+            "quality_tooling_packages": quality_tooling_packages,
+            "fresh_release_packages": fresh_release_packages,
+        },
+        "dashboard_cards": dashboard_cards,
+        "hotspots": filtered_matches[: max(limit, 1)],
+        "watchlists": watchlists,
+        "maintenance_lanes": maintenance_lanes,
+        "recommended_commands": recommended_commands,
+    }
+
+
 def _upgrade_execution_lane(upgrade_inventory: Payload) -> Payload:
     recommended_commands = [str(item) for item in _string_list(upgrade_inventory.get("recommended_commands"))]
     priority_packages = _payload_list(upgrade_inventory.get("priority_packages"))
@@ -1712,7 +1884,16 @@ def main(argv: list[str] | None = None) -> int:
         "action",
         nargs="?",
         default="list",
-        choices=["list", "describe", "search", "blueprint", "optimize", "expand", "route-map"],
+        choices=[
+            "list",
+            "describe",
+            "search",
+            "blueprint",
+            "optimize",
+            "expand",
+            "route-map",
+            "radar",
+        ],
     )
     parser.add_argument("target", nargs="?", default=None)
     parser.add_argument("--format", choices=["json", "text"], default="text")
@@ -1956,6 +2137,54 @@ def main(argv: list[str] | None = None) -> int:
             for path in _string_list(item.get("repo_usage_files"))[:2]:
                 print(f"  usage: {path}")
             print(f"  next action: {item['next_action']}")
+        return 0
+
+    if ns.action == "radar":
+        query = str(ns.query or ns.target or "").strip() or None
+        radar_result = radar_payload(
+            root=Path(str(ns.repo_root)).resolve(),
+            query=query,
+            repo_usage_tier=ns.repo_usage_tier,
+            impact_area=ns.impact_area,
+            limit=ns.limit,
+        )
+        if ns.format == "json":
+            sys.stdout.write(canonical_json_dumps(radar_result))
+            return 0
+        print("Dependency radar dashboard")
+        if query:
+            print(f"query: {query}")
+        if ns.repo_usage_tier:
+            print(f"repo usage tier: {ns.repo_usage_tier}")
+        if ns.impact_area:
+            print(f"impact area: {ns.impact_area}")
+        headline_metrics = _payload_dict(radar_result.get("headline_metrics"))
+        print(
+            "headline metrics: "
+            f"packages={headline_metrics.get('packages_audited', 0)}, "
+            f"filtered={headline_metrics.get('filtered_matches', 0)}, "
+            f"hot-path={headline_metrics.get('hot_path_packages', 0)}, "
+            f"runtime-core={headline_metrics.get('runtime_core_packages', 0)}"
+        )
+        print("dashboard cards:")
+        for item in _payload_list(radar_result.get("dashboard_cards")):
+            print(f"- {item['title']}: metric={item['metric']}")
+            print(f"  {item['summary']}")
+            for command in _string_list(item.get("commands"))[:2]:
+                print(f"  - command: {command}")
+        print("hotspots:")
+        for item in _payload_list(radar_result.get("hotspots")):
+            print(
+                f"- {item['package']} [{item['impact_area']} / {item['repo_usage_tier']}] "
+                f"count={item['repo_usage_count']}"
+            )
+            print(f"  primary validation: {item['primary_validation']}")
+            print(f"  next action: {item['next_action']}")
+        print("maintenance lanes:")
+        for item in _payload_list(radar_result.get("maintenance_lanes")):
+            print(f"- {item['title']}: {item['summary']}")
+            for command in _string_list(item.get("commands"))[:2]:
+                print(f"  - command: {command}")
         return 0
 
     if ns.target:

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -160,3 +160,38 @@ def test_route_map_payload_surfaces_primary_validation_routes(tmp_path: Path) ->
     assert match["package"] == "httpx"
     assert match["primary_validation"]
     assert "src/demo/api.py" in match["repo_usage_files"]
+
+
+def test_radar_payload_exposes_dashboard_cards_and_watchlists(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        "name='x'\n"
+        "version='0.1.0'\n"
+        "dependencies=['httpx>=0.28.1,<1', 'rich>=13,<14']\n"
+        "[project.optional-dependencies]\n"
+        "docs=['mkdocs==1.6.1']\n",
+        encoding="utf-8",
+    )
+    src_dir = tmp_path / "src" / "demo"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    (src_dir / "api.py").write_text("import httpx\nimport rich\n", encoding="utf-8")
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    (tests_dir / "test_docs.py").write_text("import mkdocs\n", encoding="utf-8")
+
+    payload = kits.radar_payload(
+        root=tmp_path,
+        query="httpx",
+        repo_usage_tier="edge",
+        impact_area="runtime-core",
+        limit=5,
+    )
+
+    assert payload["status"] == "ready"
+    assert payload["headline_metrics"]["packages_audited"] == 3
+    assert payload["headline_metrics"]["filtered_matches"] == 1
+    assert payload["headline_metrics"]["runtime_core_packages"] >= 1
+    assert payload["dashboard_cards"]
+    assert payload["hotspots"][0]["package"] == "httpx"
+    assert payload["watchlists"]["runtime_core"]
+    assert payload["maintenance_lanes"][0]["id"] == "route-hotspots"

--- a/tests/test_kits_umbrella_cli.py
+++ b/tests/test_kits_umbrella_cli.py
@@ -149,3 +149,13 @@ def test_kits_route_map_emits_searchable_validation_routes() -> None:
     top = payload["matches"][0]
     assert top["package"] == "httpx"
     assert top["primary_validation"]
+
+
+def test_kits_radar_emits_dependency_dashboard_json() -> None:
+    result = _run("kits", "radar", "httpx", "--repo-usage-tier", "hot-path", "--format", "json")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "sdetkit.kits.catalog.v1"
+    assert payload["headline_metrics"]["packages_audited"] >= 1
+    assert payload["dashboard_cards"]
+    assert payload["maintenance_lanes"]


### PR DESCRIPTION
### Motivation

- The expansion/optimize surfaces suggested a "dependency radar" but there was no first-class command to materialize it; teams need a dashboard-style maintenance view to prioritize upgrade work. 
- Provide a compact macro+micro surface that turns the manifest-aware upgrade inventory into watchlists, hotspots, and recommended execution lanes. 
- Ship the feature as a discoverable CLI action with docs and tests so it’s safe to use in CI and contributed workflows.

### Description

- Added `radar_payload()` in `src/sdkit/kits.py` which combines the upgrade inventory and route-map into headline metrics, dashboard cards, watchlists, hotspots, and maintenance lanes. 
- Exposed a new CLI action `sdetkit kits radar` by adding `radar` to the `kits` command choices and printing JSON/text output consistent with existing kit surfaces. 
- Documented the feature with `docs/kits/dependency-radar-dashboard.md`, wired it into `mkdocs.yml`, updated `docs/kits/expansion-lab.md`, and added a README example line showing the new command. 
- Added tests covering the payload and CLI: `tests/test_kits_blueprint.py` includes `test_radar_payload_exposes_dashboard_cards_and_watchlists`, and `tests/test_kits_umbrella_cli.py` includes `test_kits_radar_emits_dependency_dashboard_json`.

### Testing

- Ran `python -m pytest -q tests/test_kits_blueprint.py tests/test_kits_umbrella_cli.py` and all tests passed (`15 passed`).
- Ran static checks with `python -m ruff check src/sdetkit/kits.py tests/test_kits_blueprint.py tests/test_kits_umbrella_cli.py` and linting succeeded. 
- Exercised the new CLI end-to-end with `python -m sdetkit kits radar httpx --repo-usage-tier hot-path --format json` and validated JSON payload fields (headline metrics, dashboard cards, maintenance lanes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bcc562bde08320803ace6648de07e5)