### PR TITLE
Add platform problem authoring workflow (sdetkit author problem)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ doctor.json
 !.sdetkit/gate.fast.snapshot.json
 !.sdetkit/gate.release.snapshot.json
 !.sdetkit/premium-remediation-scripts.json
+!.sdetkit/workflows/
+!.sdetkit/workflows/platform_problem.yaml
 
 # docs build output
 site/

--- a/.sdetkit/workflows/platform_problem.yaml
+++ b/.sdetkit/workflows/platform_problem.yaml
@@ -1,0 +1,99 @@
+{
+  "name": "platform_problem_authoring",
+  "version": "1",
+  "gating_order": [
+    "baseline_environment",
+    "repo_long_horizon_fit",
+    "candidate_long_horizon_fit",
+    "novelty_gate",
+    "co_develop_until_stable",
+    "freeze_tests",
+    "production_only_finishing_pass",
+    "clean_tree_verification",
+    "base_new_triad"
+  ],
+  "required_artifacts": [
+    "/work/test.patch",
+    "/work/solution.patch",
+    "/work/docker.file",
+    "/work/final_title.txt",
+    "/work/final_description.txt",
+    "/work/run_summary.json"
+  ],
+  "size_gates": {
+    "test_patch_min_bytes": 204800,
+    "solution_patch_min_bytes": 29696
+  },
+  "allowed_test_patch_paths": [
+    "test.sh",
+    "tests/test_<topic>_problem.py",
+    "tests/conftest.py"
+  ],
+  "allowed_solution_patch_paths": [
+    "production_files_only"
+  ],
+  "preferred_production_file_scope": {
+    "warning_below": 3,
+    "preferred_min": 3,
+    "preferred_max": 6,
+    "fail_below": 2
+  },
+  "runner_contract": {
+    "shape": "minimal",
+    "entrypoint": "test.sh",
+    "modes": ["base", "new"],
+    "install_steps_allowed": false
+  },
+  "clean_tree_verification_sequence": [
+    "git_apply_check_test_patch",
+    "git_apply_check_solution_patch",
+    "fresh_tree_base_pass",
+    "fresh_tree_plus_test_patch_new_fail",
+    "fresh_tree_plus_test_patch_plus_solution_patch_base_pass",
+    "fresh_tree_plus_test_patch_plus_solution_patch_new_pass"
+  ],
+  "triad_expectations": {
+    "starter_base": "pass",
+    "starter_plus_test_patch_new": "fail",
+    "starter_plus_solution_patch_base": "pass",
+    "starter_plus_solution_patch_new": "pass"
+  },
+  "novelty_gate_sections": [
+    "candidate",
+    "public-surface scan",
+    "anti-shortcut traps",
+    "breadth expectation"
+  ],
+  "gate_metadata": {
+    "baseline_environment": ["metadata inspection", "dependency inference", "baseline green requirement"],
+    "repo_long_horizon_fit": ["public entrypoints", "cross-module state", "rollback/retry/parity semantics"],
+    "candidate_long_horizon_fit": ["downstream consequences", "anti-shortcut traps", "multi-file production impact"],
+    "novelty_gate": ["structured notes", "machine-readable outcome"],
+    "freeze_rules": ["tests freeze before production-only finishing pass"]
+  },
+  "final_title_constraints": {
+    "ascii_only": true,
+    "stored_outside_description": true
+  },
+  "final_description_constraints": {
+    "ascii_only": true,
+    "word_min": 77,
+    "word_max": 88,
+    "contract_only": true,
+    "no_solution_hints": true,
+    "no_test_references": true,
+    "code_like_bullet_block": true
+  },
+  "failure_summary_fields": [
+    "success",
+    "failure_reason",
+    "repo_url",
+    "pinned_sha",
+    "artifact_paths",
+    "patch_sizes",
+    "size_gate_status",
+    "clean_tree_replay_status",
+    "base_new_triad_status",
+    "metadata_presence"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,30 @@ It turns CI and test signals into deterministic contracts, machine-readable arti
 - **Release Confidence Kit** — `sdetkit release ...`
 - **Test Intelligence Kit** — `sdetkit intelligence ...`
 - **Integration Assurance Kit** — `sdetkit integration ...`
+- **Platform Problem Authoring Lane** — `sdetkit author problem ...`
 - **Failure Forensics Kit** — `sdetkit forensics ...`
 - **Catalog** — `sdetkit kits list` / `sdetkit kits describe <kit>`
+
+## Platform-style Python problem authoring
+
+SDETKit now ships a first-class, repo-owned workflow for platform-style Python problem authoring. This lane is environment-first: it bootstraps `/work`, renders `Dockerfile.problem`, builds and runs the authoring container, scaffolds novelty-gate notes, generates the minimal `test.sh` contract, and verifies artifact boundaries, clean-tree replay, and the base/new triad without asking the operator to paste logs or hand-assemble patches.
+
+This lane is distinct from the existing release-confidence, doctor, evidence, and gate commands. Those surfaces assess this repository or another codebase for readiness. The authoring lane prepares a pinned target repo for future platform-style problem creation and validates the stable artifact bundle expected by downstream reviewers:
+
+```bash
+python -m sdetkit author problem init --workdir /work --topic refresh-contract
+python -m sdetkit author problem doctor --repo-root . --workdir /work --format json
+python -m sdetkit author problem render-dockerfile --repo-root .
+python -m sdetkit author problem verify --repo-root . --workdir /work --format json
+python -m sdetkit author problem run \
+  --repo https://github.com/example/project.git \
+  --sha 0123456789abcdef0123456789abcdef01234567 \
+  --workdir /work \
+  --min-test-patch-bytes 204800 \
+  --min-solution-patch-bytes 29696
+```
+
+The repo-owned workflow contract lives in `.sdetkit/workflows/platform_problem.yaml`, and the end-to-end behavior is documented in `docs/platform-problem-authoring.md`.
 
 ## Choose your SDET lane fast
 

--- a/docs/platform-problem-authoring.md
+++ b/docs/platform-problem-authoring.md
@@ -1,0 +1,235 @@
+# Platform-style Python problem authoring
+
+## What this lane is
+
+`python -m sdetkit author problem ...` is the repo-owned workflow for preparing and validating platform-style Python problem authoring runs against a pinned target repository.
+
+This lane is designed for later prompts that only provide:
+
+- `REPO_URL`
+- `PINNED_SHA`
+
+The workflow owns the environment-first setup itself:
+
+- bootstraps `/work` and fallback ledger files,
+- renders `Dockerfile.problem` from target-repo metadata,
+- drives `docker build` and `docker run` through Python helpers,
+- scaffolds novelty-gate and candidate-notes templates,
+- creates the stable artifact targets,
+- verifies patch boundaries and configured size gates,
+- verifies clean-tree replay with `git apply --check`,
+- verifies the base/new triad,
+- emits machine-readable doctor, run, and failure summaries.
+
+## How this differs from gate / doctor / evidence / release
+
+The existing product lanes remain focused on release confidence, repo readiness, deterministic evidence, and CI-facing go/no-go checks.
+
+The authoring lane is different:
+
+- it prepares a *target repository* for future problem authoring work,
+- it enforces the artifact contract expected by platform-style review,
+- it validates authoring-specific policies such as `test.patch` vs `solution.patch` boundaries,
+- it centers the Dockerfile/problem-container workflow rather than release-report output.
+
+This is a productized extension of the repo, not a replacement for the release-confidence surfaces.
+
+## Command family
+
+### Initialize `/work`
+
+```bash
+python -m sdetkit author problem init --workdir /work --topic refresh-contract
+```
+
+Creates or repairs:
+
+- `/work/current_problem.txt`
+- `/work/current_slug.txt`
+- `/work/problem_history.md`
+- `/work/novelty_gate/`
+- `/work/novelty_gate.txt`
+- `/work/candidate_notes.md`
+- `/work/submission_<ID>/`
+- `/work/test.patch`
+- `/work/solution.patch`
+- `/work/docker.file`
+- `/work/final_title.txt`
+- `/work/final_description.txt`
+
+### Run the authoring doctor
+
+```bash
+python -m sdetkit author problem doctor --repo-root . --workdir /work --format json
+```
+
+Doctor checks:
+
+- `git` availability,
+- `docker` availability,
+- writable `/work`,
+- fallback ledger creation,
+- target-repo metadata presence,
+- inferred pytest/plugin dependency risks,
+- likely long-horizon repo fit.
+
+It writes `/work/author_doctor.json`.
+
+### Render `Dockerfile.problem`
+
+```bash
+python -m sdetkit author problem render-dockerfile --repo-root .
+```
+
+The renderer inspects, when present:
+
+- `pyproject.toml`
+- `tox.ini`
+- `noxfile.py`
+- `requirements*.txt`
+- CI files
+
+The generated Dockerfile always uses:
+
+- `FROM public.ecr.aws/x8v8d7g8/mars-base:latest`
+- `CMD ["/bin/bash"]`
+
+Install steps are emitted at build time only. The lane does **not** depend on runtime `pip install`, `uv`, or opportunistic dependency mutation inside the container.
+
+### Verify the artifact bundle
+
+```bash
+python -m sdetkit author problem verify --repo-root . --workdir /work --format json
+```
+
+Verification covers:
+
+- required artifacts and metadata,
+- `test.patch` boundary rules,
+- `solution.patch` production-only rules,
+- configured size gates,
+- `docker.file` parity with `Dockerfile.problem`,
+- clean-tree replay with `git apply --check`,
+- base/new triad expectations.
+
+### Run the full repo-owned workflow
+
+```bash
+python -m sdetkit author problem run \
+  --repo https://github.com/example/project.git \
+  --sha 0123456789abcdef0123456789abcdef01234567 \
+  --workdir /work \
+  --min-test-patch-bytes 204800 \
+  --min-solution-patch-bytes 29696
+```
+
+Current `run` behavior:
+
+1. bootstraps `/work`,
+2. clones the target repo into `/work/app`,
+3. checks out the pinned SHA,
+4. inspects metadata and environment fit,
+5. renders `Dockerfile.problem`,
+6. copies the rendered Dockerfile into `/work/docker.file`,
+7. generates the minimal repo-root `test.sh`,
+8. runs the authoring doctor,
+9. optionally runs `docker build` and `docker run`,
+10. verifies the artifact bundle and emits summaries.
+
+If the artifact bundle is incomplete, the workflow fails honestly and writes `/work/final_failure.json` with the concrete reason.
+
+## Stable artifact contract
+
+The workflow targets these stable paths:
+
+- `/work/test.patch`
+- `/work/solution.patch`
+- `/work/docker.file`
+- `/work/final_title.txt`
+- `/work/final_description.txt`
+- `/work/run_summary.json`
+
+Additional machine-readable outputs:
+
+- `/work/author_doctor.json`
+- `/work/final_failure.json` on failure
+
+## Workflow contract and policy file
+
+The machine-readable workflow contract lives at:
+
+- `.sdetkit/workflows/platform_problem.yaml`
+
+It records:
+
+- gating order,
+- required artifacts,
+- default size gates,
+- allowed `test.patch` paths,
+- allowed `solution.patch` scope,
+- preferred production-file breadth,
+- runner contract,
+- clean-tree replay sequence,
+- base/new triad sequence,
+- novelty-gate sections,
+- final title / description constraints,
+- failure-summary fields.
+
+## Patch-boundary policy
+
+`test.patch` is expected to contain only:
+
+- repo-root `test.sh`,
+- exactly one new `tests/test_<topic>_problem.py`,
+- the rare allowed test-side metadata edit when explicitly reviewed.
+
+`solution.patch` is expected to contain only production files.
+
+The verifier rejects leaked production files in `test.patch`, and rejects leaked tests, metadata, or Docker assets in `solution.patch`.
+
+## Minimal runner contract
+
+Generated `test.sh` follows the platform shape in spirit:
+
+```bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mode=${1:-}
+case "$mode" in
+  new) python3 -m pytest tests/test_<topic>_problem.py ;;
+  base) python3 -m pytest tests --ignore=tests/test_<topic>_problem.py ;;
+  *) echo "Usage: $0 {base|new}" >&2; exit 2 ;;
+esac
+```
+
+The verifier then checks:
+
+- base passes on the starter tree,
+- the new suite fails before the solution is applied,
+- base and new both pass after the solution is applied.
+
+## What is implemented today vs. what still depends on the later real task
+
+Implemented now:
+
+- the command family,
+- machine-readable workflow config,
+- workdir bootstrap and ledger fallback,
+- Dockerfile.problem rendering,
+- Docker build/run helpers,
+- patch-boundary verification,
+- size-gate enforcement,
+- clean-tree replay and triad verification,
+- machine-readable doctor/run/failure summaries,
+- smoke-style tests for the new subsystem.
+
+Still dependent on the later real authoring run:
+
+- choosing a strong candidate contract in the cloned target repo,
+- co-developing the final `test.patch` and `solution.patch`,
+- producing the final title and constrained description for the actual target repository,
+- reaching the final verified artifact bundle for that repo.
+
+That separation is intentional and honest: this repo now owns the workflow engine and validation contract, while the later real-task run still supplies the concrete target-repo authoring decisions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
       - Evidence showcase: evidence-showcase.md
   - Advanced and reference:
       - CLI reference: cli.md
+      - Platform problem authoring: platform-problem-authoring.md
       - Command surface inventory: command-surface.md
       - Capability map and command taxonomy: command-taxonomy.md
       - API: api.md

--- a/src/sdetkit/author_problem.py
+++ b/src/sdetkit/author_problem.py
@@ -1,0 +1,1147 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import _toml
+from .atomicio import atomic_write_text, canonical_json_dumps
+
+_BASE_IMAGE = "public.ecr.aws/x8v8d7g8/mars-base:latest"
+_DEFAULT_WORKFLOW_PATH = Path(".sdetkit/workflows/platform_problem.yaml")
+_ALLOWED_TEST_METADATA_EDIT = "tests/conftest.py"
+_KNOWN_PYTEST_PACKAGES = (
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-xdist",
+    "pytest-rerunfailures",
+    "pytest-timeout",
+    "hypothesis",
+    "requests-mock",
+    "freezegun",
+)
+
+
+@dataclass(frozen=True)
+class DockerInvocation:
+    argv: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "argv": list(self.argv),
+            "returncode": self.returncode,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+        }
+
+
+class DockerCommandRunner:
+    def run(self, argv: list[str], *, cwd: Path | None = None) -> DockerInvocation:
+        proc = subprocess.run(argv, cwd=str(cwd) if cwd else None, text=True, capture_output=True)
+        return DockerInvocation(argv=argv, returncode=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+
+    def which(self, program: str) -> str | None:
+        return shutil.which(program)
+
+
+@dataclass(frozen=True)
+class WorkflowContract:
+    path: Path
+    payload: dict[str, Any]
+
+    @property
+    def required_artifacts(self) -> list[str]:
+        return list(self.payload.get("required_artifacts", []))
+
+    @property
+    def size_gates(self) -> dict[str, int]:
+        gates = self.payload.get("size_gates", {})
+        return {
+            "test_patch_min_bytes": int(gates.get("test_patch_min_bytes", 204800)),
+            "solution_patch_min_bytes": int(gates.get("solution_patch_min_bytes", 29696)),
+        }
+
+    @property
+    def preferred_production_file_scope(self) -> dict[str, int]:
+        scope = self.payload.get("preferred_production_file_scope", {})
+        return {
+            "warning_below": int(scope.get("warning_below", 3)),
+            "preferred_min": int(scope.get("preferred_min", 3)),
+            "preferred_max": int(scope.get("preferred_max", 6)),
+            "fail_below": int(scope.get("fail_below", 2)),
+        }
+
+
+@dataclass(frozen=True)
+class RepoInspection:
+    root: Path
+    repo_name: str
+    metadata_files: list[str]
+    requirements_files: list[str]
+    ci_files: list[str]
+    dependency_risks: list[str]
+    baseline_commands: list[str]
+    likely_long_horizon_fit: bool
+    long_horizon_notes: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "root": self.root.as_posix(),
+            "repo_name": self.repo_name,
+            "metadata_files": list(self.metadata_files),
+            "requirements_files": list(self.requirements_files),
+            "ci_files": list(self.ci_files),
+            "dependency_risks": list(self.dependency_risks),
+            "baseline_commands": list(self.baseline_commands),
+            "likely_long_horizon_fit": self.likely_long_horizon_fit,
+            "long_horizon_notes": list(self.long_horizon_notes),
+        }
+
+
+@dataclass(frozen=True)
+class PatchAnalysis:
+    path: Path
+    exists: bool
+    size_bytes: int
+    files: list[str]
+    status: str
+    errors: list[str]
+    warnings: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path.as_posix(),
+            "exists": self.exists,
+            "size_bytes": self.size_bytes,
+            "files": list(self.files),
+            "status": self.status,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class TriadPhase:
+    name: str
+    command: str
+    expected: str
+    returncode: int
+    stdout: str
+    stderr: str
+    ok: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "command": self.command,
+            "expected": self.expected,
+            "returncode": self.returncode,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "ok": self.ok,
+        }
+
+
+@dataclass(frozen=True)
+class TriadResult:
+    ok: bool
+    phases: list[TriadPhase]
+    clean_tree_ok: bool
+    clean_tree_details: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "phases": [phase.to_dict() for phase in self.phases],
+            "clean_tree_ok": self.clean_tree_ok,
+            "clean_tree_details": list(self.clean_tree_details),
+        }
+
+
+@dataclass(frozen=True)
+class WorkBootstrap:
+    workdir: Path
+    submission_dir: Path
+    created: list[str]
+    artifact_paths: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workdir": self.workdir.as_posix(),
+            "submission_dir": self.submission_dir.as_posix(),
+            "created": list(self.created),
+            "artifact_paths": dict(self.artifact_paths),
+        }
+
+
+@dataclass(frozen=True)
+class RunContext:
+    repo_url: str
+    sha: str
+    workdir: Path
+    app_dir: Path
+    topic: str
+    contract: WorkflowContract
+    bootstrap: WorkBootstrap
+
+
+@dataclass(frozen=True)
+class RunResult:
+    ok: bool
+    summary: dict[str, Any]
+    failure: dict[str, Any] | None = None
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def load_workflow_contract(path: Path | None = None) -> WorkflowContract:
+    candidates: list[Path] = []
+    if path is not None:
+        candidates.append(Path(path))
+    cwd_candidate = Path.cwd() / _DEFAULT_WORKFLOW_PATH
+    repo_candidate = _repo_root() / _DEFAULT_WORKFLOW_PATH
+    candidates.extend([cwd_candidate, repo_candidate])
+    for candidate in candidates:
+        if candidate.exists():
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+            return WorkflowContract(path=candidate, payload=payload)
+    raise FileNotFoundError(f"workflow contract not found: {_DEFAULT_WORKFLOW_PATH.as_posix()}")
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", value.strip().lower()).strip("_")
+    return slug or "platform_problem"
+
+
+def _next_submission_dir(workdir: Path) -> Path:
+    existing = sorted(workdir.glob("submission_*"))
+    max_id = 0
+    for item in existing:
+        match = re.fullmatch(r"submission_(\d+)", item.name)
+        if match:
+            max_id = max(max_id, int(match.group(1)))
+    return workdir / f"submission_{max_id + 1:03d}"
+
+
+def _write_if_missing(path: Path, text: str, created: list[str]) -> None:
+    if path.exists():
+        return
+    atomic_write_text(path, text)
+    created.append(path.as_posix())
+
+
+def bootstrap_workdir(workdir: Path, *, topic: str | None = None) -> WorkBootstrap:
+    workdir = Path(workdir).resolve()
+    workdir.mkdir(parents=True, exist_ok=True)
+    created: list[str] = []
+    slug = _slugify(topic or "platform-problem")
+    _write_if_missing(workdir / "current_problem.txt", "Pending problem selection.\n", created)
+    _write_if_missing(workdir / "current_slug.txt", slug + "\n", created)
+    _write_if_missing(
+        workdir / "problem_history.md",
+        "# Problem history\n\n- bootstrap created by sdetkit author problem\n",
+        created,
+    )
+    novelty_dir = workdir / "novelty_gate"
+    if not novelty_dir.exists():
+        novelty_dir.mkdir(parents=True, exist_ok=True)
+        created.append(novelty_dir.as_posix())
+    _write_if_missing(
+        workdir / "novelty_gate.txt",
+        (
+            "# novelty gate\n\n"
+            "## candidate\n- describe the proposed contract and target behavior.\n\n"
+            "## public-surface scan\n- list existing tests, docs, and CLI/contracts reviewed.\n\n"
+            "## anti-shortcut traps\n- note why a tiny local fix should not satisfy the contract.\n\n"
+            "## breadth expectation\n- identify 3-6 production files likely to move.\n"
+        ),
+        created,
+    )
+    _write_if_missing(
+        workdir / "candidate_notes.md",
+        (
+            "# Candidate notes\n\n"
+            "## baseline environment\n- commands and outcomes\n\n"
+            "## repo long-horizon fit\n- public entrypoints\n- cross-module behavior\n\n"
+            "## candidate fit\n- downstream consequences\n- rollback/retry/parity/sequencing semantics\n"
+        ),
+        created,
+    )
+    submission_dir = _next_submission_dir(workdir)
+    submission_dir.mkdir(parents=True, exist_ok=True)
+    created.append(submission_dir.as_posix())
+    for name in [
+        "test.patch",
+        "solution.patch",
+        "docker.file",
+        "final_title.txt",
+        "final_description.txt",
+    ]:
+        artifact = workdir / name
+        _write_if_missing(artifact, "", created)
+    artifact_paths = {
+        "test_patch": (workdir / "test.patch").as_posix(),
+        "solution_patch": (workdir / "solution.patch").as_posix(),
+        "docker_file": (workdir / "docker.file").as_posix(),
+        "final_title": (workdir / "final_title.txt").as_posix(),
+        "final_description": (workdir / "final_description.txt").as_posix(),
+        "run_summary": (workdir / "run_summary.json").as_posix(),
+        "author_doctor": (workdir / "author_doctor.json").as_posix(),
+        "final_failure": (workdir / "final_failure.json").as_posix(),
+    }
+    return WorkBootstrap(
+        workdir=workdir, submission_dir=submission_dir, created=created, artifact_paths=artifact_paths
+    )
+
+
+def generate_test_runner(topic: str) -> str:
+    slug = _slugify(topic)
+    return (
+        "#!/usr/bin/env bash\n\n"
+        "set -euo pipefail\n\n"
+        'mode=${1:-}\n'
+        'case "$mode" in\n'
+        f'  new) python3 -m pytest tests/test_{slug}_problem.py ;;\n'
+        f'  base) python3 -m pytest tests --ignore=tests/test_{slug}_problem.py ;;\n'
+        '  *) echo "Usage: $0 {base|new}" >&2; exit 2 ;;\n'
+        "esac\n"
+    )
+
+
+def ensure_minimal_test_runner(repo_root: Path, *, topic: str) -> Path:
+    path = Path(repo_root) / "test.sh"
+    atomic_write_text(path, generate_test_runner(topic))
+    path.chmod(0o755)
+    return path
+
+
+def inspect_repo_metadata(repo_root: Path) -> RepoInspection:
+    repo_root = Path(repo_root).resolve()
+    metadata_files: list[str] = []
+    requirements_files: list[str] = []
+    ci_files: list[str] = []
+    for rel in ["pyproject.toml", "tox.ini", "noxfile.py", "setup.py", "setup.cfg"]:
+        if (repo_root / rel).exists():
+            metadata_files.append(rel)
+    for path in sorted(repo_root.glob("requirements*.txt")):
+        requirements_files.append(path.name)
+    for rel in [
+        ".github/workflows",
+        ".gitlab-ci.yml",
+        "azure-pipelines.yml",
+        "tox.ini",
+        "noxfile.py",
+    ]:
+        if (repo_root / rel).exists():
+            ci_files.append(rel)
+    risks: list[str] = []
+    baseline_commands: list[str] = []
+    if "pyproject.toml" in metadata_files:
+        baseline_commands.append("python3 -m pytest")
+    elif requirements_files:
+        baseline_commands.append("python3 -m pytest")
+        risks.append("pytest dependencies inferred from requirements*.txt rather than pyproject metadata")
+    else:
+        baseline_commands.append("python3 -m pytest")
+        risks.append("no pyproject.toml or requirements*.txt found; Dockerfile.problem may need inferred deps")
+    if "tox.ini" in metadata_files:
+        baseline_commands.append("python3 -m tox -q")
+    if "noxfile.py" in metadata_files:
+        baseline_commands.append("python3 -m nox -s tests")
+    long_horizon_notes: list[str] = []
+    py_files = list(repo_root.glob("src/**/*.py")) + list(repo_root.glob("**/*.py"))
+    top_level_public = 0
+    for package_dir in [repo_root / "src", repo_root]:
+        if package_dir.exists():
+            top_level_public += len([p for p in package_dir.iterdir() if p.suffix == ".py"])
+    if top_level_public >= 3:
+        long_horizon_notes.append("multiple public Python entrypoints detected")
+    tests_dir = repo_root / "tests"
+    if tests_dir.exists() and len(list(tests_dir.glob("test_*.py"))) >= 10:
+        long_horizon_notes.append("broad existing test surface suggests richer behavioral contracts")
+    if len(py_files) >= 20:
+        long_horizon_notes.append("cross-module production surface appears large enough for multi-file fixes")
+    likely_long_horizon_fit = len(long_horizon_notes) >= 2
+    if not likely_long_horizon_fit:
+        risks.append("repo may not satisfy long-horizon multi-file authoring goals")
+    return RepoInspection(
+        root=repo_root,
+        repo_name=repo_root.name,
+        metadata_files=metadata_files,
+        requirements_files=requirements_files,
+        ci_files=ci_files,
+        dependency_risks=risks,
+        baseline_commands=baseline_commands,
+        likely_long_horizon_fit=likely_long_horizon_fit,
+        long_horizon_notes=long_horizon_notes,
+    )
+
+
+def _read_optional_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _discover_install_inputs(repo_root: Path) -> dict[str, Any]:
+    repo_root = Path(repo_root)
+    requirements_files = [p.name for p in sorted(repo_root.glob("requirements*.txt")) if p.is_file()]
+    inferred_packages: set[str] = set()
+    pyproject = repo_root / "pyproject.toml"
+    pyproject_payload: dict[str, Any] = {}
+    project_dependencies: list[str] = []
+    extras: list[str] = []
+    if pyproject.exists():
+        pyproject_payload = _toml.loads(pyproject.read_text(encoding="utf-8"))
+        project = pyproject_payload.get("project", {})
+        deps = project.get("dependencies", [])
+        if isinstance(deps, list):
+            project_dependencies = [str(item) for item in deps]
+        optional_deps = project.get("optional-dependencies", {})
+        if isinstance(optional_deps, dict):
+            extras = sorted([key for key in optional_deps if key in {"test", "tests", "dev"}])
+            for values in optional_deps.values():
+                if isinstance(values, list):
+                    for value in values:
+                        lowered = str(value).lower()
+                        for known in _KNOWN_PYTEST_PACKAGES:
+                            if known in lowered:
+                                inferred_packages.add(known)
+    for rel in ["tox.ini", "noxfile.py", ".github/workflows", ".gitlab-ci.yml", "azure-pipelines.yml"]:
+        target = repo_root / rel
+        if target.is_dir():
+            for file in sorted(target.rglob("*.yml")) + sorted(target.rglob("*.yaml")):
+                text = _read_optional_text(file).lower()
+                for known in _KNOWN_PYTEST_PACKAGES:
+                    if known in text:
+                        inferred_packages.add(known)
+        else:
+            text = _read_optional_text(target).lower()
+            for known in _KNOWN_PYTEST_PACKAGES:
+                if known in text:
+                    inferred_packages.add(known)
+    for req in requirements_files:
+        text = _read_optional_text(repo_root / req).lower()
+        for known in _KNOWN_PYTEST_PACKAGES:
+            if known in text:
+                inferred_packages.add(known)
+    if not inferred_packages:
+        inferred_packages.add("pytest")
+    return {
+        "requirements_files": requirements_files,
+        "project_dependencies": project_dependencies,
+        "extras": extras,
+        "inferred_packages": sorted(inferred_packages),
+    }
+
+
+def render_dockerfile_problem(repo_root: Path, output_path: Path | None = None) -> str:
+    repo_root = Path(repo_root).resolve()
+    install_inputs = _discover_install_inputs(repo_root)
+    lines = [
+        f"FROM {_BASE_IMAGE}",
+        "WORKDIR /app",
+        "COPY . /app",
+    ]
+    for req in install_inputs["requirements_files"]:
+        lines.append(f"RUN python3 -m pip install --no-cache-dir -r {req}")
+    if (repo_root / "pyproject.toml").exists():
+        if install_inputs["extras"]:
+            extra_text = ",".join(install_inputs["extras"])
+            lines.append(f'RUN python3 -m pip install --no-cache-dir ".[{extra_text}]"')
+        else:
+            lines.append("RUN python3 -m pip install --no-cache-dir .")
+    elif install_inputs["project_dependencies"]:
+        joined = " ".join(sorted(install_inputs["project_dependencies"]))
+        lines.append(f"RUN python3 -m pip install --no-cache-dir {joined}")
+    if install_inputs["inferred_packages"]:
+        lines.append(
+            "RUN python3 -m pip install --no-cache-dir "
+            + " ".join(sorted(install_inputs["inferred_packages"]))
+        )
+    lines.append('CMD ["/bin/bash"]')
+    text = "\n".join(lines) + "\n"
+    target = output_path or (repo_root / "Dockerfile.problem")
+    atomic_write_text(target, text)
+    return text
+
+
+def build_docker_image(
+    repo_root: Path,
+    *,
+    dockerfile: Path | None = None,
+    tag: str | None = None,
+    runner: DockerCommandRunner | None = None,
+) -> DockerInvocation:
+    runner = runner or DockerCommandRunner()
+    dockerfile = dockerfile or (Path(repo_root) / "Dockerfile.problem")
+    tag = tag or f"sdetkit-author-{_slugify(Path(repo_root).name)}"
+    return runner.run(
+        ["docker", "build", "-f", str(dockerfile), "-t", tag, "."], cwd=Path(repo_root)
+    )
+
+
+def run_authoring_container(
+    repo_root: Path,
+    workdir: Path,
+    *,
+    image: str,
+    command: list[str] | None = None,
+    runner: DockerCommandRunner | None = None,
+) -> DockerInvocation:
+    runner = runner or DockerCommandRunner()
+    command = command or ["/bin/bash"]
+    argv = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{Path(repo_root).resolve()}:/app",
+        "-v",
+        f"{Path(workdir).resolve()}:/work",
+        "-w",
+        "/app",
+        image,
+        *command,
+    ]
+    return runner.run(argv)
+
+
+def _patch_paths(patch_path: Path) -> list[str]:
+    files: list[str] = []
+    if not patch_path.exists():
+        return files
+    for line in patch_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("+++ "):
+            value = line[4:].strip()
+            if value == "/dev/null":
+                continue
+            if value.startswith("b/"):
+                value = value[2:]
+            files.append(value)
+    return sorted(set(files))
+
+
+def analyze_test_patch(patch_path: Path) -> PatchAnalysis:
+    exists = patch_path.exists()
+    size_bytes = patch_path.stat().st_size if exists else 0
+    files = _patch_paths(patch_path)
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not exists:
+        errors.append("test.patch is missing")
+        return PatchAnalysis(patch_path, exists, size_bytes, files, "fail", errors, warnings)
+    allowed_test_files = [path for path in files if path.startswith("tests/test_") and path.endswith("_problem.py")]
+    disallowed = []
+    for file in files:
+        if file == "test.sh":
+            continue
+        if file in allowed_test_files:
+            continue
+        if file == _ALLOWED_TEST_METADATA_EDIT:
+            warnings.append("tests/conftest.py changed; review against workflow allowlist")
+            continue
+        disallowed.append(file)
+    if len(allowed_test_files) != 1:
+        errors.append("test.patch must touch exactly one tests/test_<topic>_problem.py file")
+    if disallowed:
+        errors.append("test.patch contains disallowed paths: " + ", ".join(disallowed))
+    status = "pass" if not errors else "fail"
+    return PatchAnalysis(patch_path, exists, size_bytes, files, status, errors, warnings)
+
+
+def analyze_solution_patch(patch_path: Path, *, contract: WorkflowContract) -> PatchAnalysis:
+    exists = patch_path.exists()
+    size_bytes = patch_path.stat().st_size if exists else 0
+    files = _patch_paths(patch_path)
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not exists:
+        errors.append("solution.patch is missing")
+        return PatchAnalysis(patch_path, exists, size_bytes, files, "fail", errors, warnings)
+    forbidden = [
+        file
+        for file in files
+        if file == "test.sh"
+        or file.startswith("tests/")
+        or file in {"Dockerfile", "Dockerfile.problem", "docker.file", "final_title.txt", "final_description.txt"}
+    ]
+    if forbidden:
+        errors.append("solution.patch contains non-production paths: " + ", ".join(forbidden))
+    scope = contract.preferred_production_file_scope
+    prod_count = len(files)
+    if prod_count < scope["fail_below"]:
+        errors.append(
+            f"solution.patch touches {prod_count} production files; minimum enforced breadth is {scope['fail_below']}"
+        )
+    elif prod_count < scope["warning_below"]:
+        warnings.append(
+            f"solution.patch touches {prod_count} production files; preferred range is {scope['preferred_min']}-{scope['preferred_max']}"
+        )
+    status = "pass" if not errors else "fail"
+    return PatchAnalysis(patch_path, exists, size_bytes, files, status, errors, warnings)
+
+
+def _copy_tree(src: Path, dest: Path) -> None:
+    shutil.copytree(src, dest, symlinks=False, ignore=shutil.ignore_patterns(".git"))
+
+
+def _run_test_mode(mode: str, *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["bash", "test.sh", mode], cwd=str(cwd), text=True, capture_output=True)
+
+
+def _apply_patch(repo_root: Path, patch_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "apply", str(patch_path)], cwd=str(repo_root), text=True, capture_output=True
+    )
+
+
+def _apply_patch_check(repo_root: Path, patch_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "apply", "--check", str(patch_path)], cwd=str(repo_root), text=True, capture_output=True
+    )
+
+
+def _materialize_starter_tree(repo_root: Path, destination: Path) -> tuple[bool, list[str]]:
+    details: list[str] = []
+    git_dir = repo_root / ".git"
+    if git_dir.exists():
+        sha_proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(repo_root), text=True, capture_output=True
+        )
+        if sha_proc.returncode == 0:
+            sha = sha_proc.stdout.strip()
+            clone_proc = subprocess.run(
+                ["git", "clone", "--quiet", str(repo_root), str(destination)],
+                text=True,
+                capture_output=True,
+            )
+            details.append(clone_proc.stderr.strip())
+            if clone_proc.returncode == 0:
+                checkout_proc = subprocess.run(
+                    ["git", "checkout", "--quiet", sha],
+                    cwd=str(destination),
+                    text=True,
+                    capture_output=True,
+                )
+                details.append(checkout_proc.stderr.strip())
+                return checkout_proc.returncode == 0, [item for item in details if item]
+    _copy_tree(repo_root, destination)
+    details.append("starter tree copied without git metadata")
+    return True, details
+
+
+def verify_clean_tree_and_triad(
+    repo_root: Path,
+    *,
+    test_patch: Path,
+    solution_patch: Path,
+) -> TriadResult:
+    phases: list[TriadPhase] = []
+    clean_tree_details: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="sdetkit-triad-") as tmp:
+        starter = Path(tmp) / "starter"
+        clean_tree_ok, details = _materialize_starter_tree(Path(repo_root).resolve(), starter)
+        clean_tree_details.extend(details)
+        if not clean_tree_ok:
+            return TriadResult(ok=False, phases=phases, clean_tree_ok=False, clean_tree_details=clean_tree_details)
+        checks = [
+            _apply_patch_check(starter, test_patch),
+            _apply_patch_check(starter, solution_patch),
+        ]
+        for proc in checks:
+            if proc.returncode != 0:
+                clean_tree_ok = False
+                clean_tree_details.append(proc.stderr.strip() or proc.stdout.strip())
+        test_patch_already_applied = False
+        base_tree = starter
+        if not (starter / "test.sh").exists():
+            apply_test_for_runner = _apply_patch(starter, test_patch)
+            if apply_test_for_runner.returncode != 0:
+                clean_tree_ok = False
+                clean_tree_details.append(
+                    apply_test_for_runner.stderr.strip() or apply_test_for_runner.stdout.strip()
+                )
+                return TriadResult(
+                    ok=False,
+                    phases=phases,
+                    clean_tree_ok=clean_tree_ok,
+                    clean_tree_details=clean_tree_details,
+                )
+            test_patch_already_applied = True
+        base_proc = _run_test_mode("base", cwd=base_tree)
+        phases.append(
+            TriadPhase(
+                name="starter_base",
+                command="bash test.sh base",
+                expected="pass",
+                returncode=base_proc.returncode,
+                stdout=base_proc.stdout,
+                stderr=base_proc.stderr,
+                ok=base_proc.returncode == 0,
+            )
+        )
+        if not test_patch_already_applied:
+            apply_test = _apply_patch(starter, test_patch)
+            if apply_test.returncode != 0:
+                clean_tree_ok = False
+                clean_tree_details.append(apply_test.stderr.strip() or apply_test.stdout.strip())
+                return TriadResult(
+                    ok=False,
+                    phases=phases,
+                    clean_tree_ok=clean_tree_ok,
+                    clean_tree_details=clean_tree_details,
+                )
+        new_proc = _run_test_mode("new", cwd=starter)
+        phases.append(
+            TriadPhase(
+                name="test_patch_new",
+                command="bash test.sh new",
+                expected="fail",
+                returncode=new_proc.returncode,
+                stdout=new_proc.stdout,
+                stderr=new_proc.stderr,
+                ok=new_proc.returncode != 0,
+            )
+        )
+        apply_solution = _apply_patch(starter, solution_patch)
+        if apply_solution.returncode != 0:
+            clean_tree_ok = False
+            clean_tree_details.append(apply_solution.stderr.strip() or apply_solution.stdout.strip())
+            return TriadResult(ok=False, phases=phases, clean_tree_ok=clean_tree_ok, clean_tree_details=clean_tree_details)
+        final_base = _run_test_mode("base", cwd=starter)
+        phases.append(
+            TriadPhase(
+                name="solution_base",
+                command="bash test.sh base",
+                expected="pass",
+                returncode=final_base.returncode,
+                stdout=final_base.stdout,
+                stderr=final_base.stderr,
+                ok=final_base.returncode == 0,
+            )
+        )
+        final_new = _run_test_mode("new", cwd=starter)
+        phases.append(
+            TriadPhase(
+                name="solution_new",
+                command="bash test.sh new",
+                expected="pass",
+                returncode=final_new.returncode,
+                stdout=final_new.stdout,
+                stderr=final_new.stderr,
+                ok=final_new.returncode == 0,
+            )
+        )
+    ok = clean_tree_ok and all(phase.ok for phase in phases)
+    return TriadResult(ok=ok, phases=phases, clean_tree_ok=clean_tree_ok, clean_tree_details=clean_tree_details)
+
+
+def _check_ascii_title(title: str) -> list[str]:
+    errors: list[str] = []
+    if not title.strip():
+        errors.append("final_title.txt is empty")
+    if not title.isascii():
+        errors.append("final_title.txt must be ASCII-only")
+    return errors
+
+
+def _check_final_description(description: str) -> list[str]:
+    errors: list[str] = []
+    words = [word for word in re.split(r"\s+", description.strip()) if word]
+    if not description.strip():
+        errors.append("final_description.txt is empty")
+        return errors
+    if not description.isascii():
+        errors.append("final_description.txt must be ASCII-only")
+    if len(words) < 77 or len(words) > 88:
+        errors.append("final_description.txt must contain 77-88 words")
+    if "test" in description.lower() or "pytest" in description.lower():
+        errors.append("final_description.txt must not reference tests")
+    if "solution" in description.lower() or "fix" in description.lower():
+        errors.append("final_description.txt must not include solution hints")
+    if "- " not in description and "* " not in description:
+        errors.append("final_description.txt must contain a code-like bullet block")
+    return errors
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    atomic_write_text(path, canonical_json_dumps(payload))
+
+
+def _write_failure(workdir: Path, *, reason: str, context: dict[str, Any]) -> dict[str, Any]:
+    payload = {"ok": False, "reason": reason, **context}
+    _write_json(workdir / "final_failure.json", payload)
+    return payload
+
+
+def run_author_doctor(
+    repo_root: Path,
+    workdir: Path,
+    *,
+    contract: WorkflowContract | None = None,
+    runner: DockerCommandRunner | None = None,
+) -> dict[str, Any]:
+    runner = runner or DockerCommandRunner()
+    contract = contract or load_workflow_contract()
+    bootstrap = bootstrap_workdir(workdir)
+    inspection = inspect_repo_metadata(repo_root)
+    checks: list[dict[str, Any]] = []
+    writable = os.access(workdir, os.W_OK)
+    checks.append({"id": "git_available", "ok": runner.which("git") is not None})
+    checks.append({"id": "docker_available", "ok": runner.which("docker") is not None})
+    checks.append({"id": "workdir_writable", "ok": writable})
+    checks.append({"id": "ledger_bootstrap", "ok": bool(bootstrap.created) or workdir.exists()})
+    checks.append({"id": "metadata_present", "ok": bool(inspection.metadata_files or inspection.requirements_files)})
+    checks.append({"id": "repo_long_horizon_fit", "ok": inspection.likely_long_horizon_fit})
+    payload = {
+        "ok": all(item["ok"] for item in checks[:-1]),
+        "repo_root": Path(repo_root).resolve().as_posix(),
+        "workdir": Path(workdir).resolve().as_posix(),
+        "workflow_contract": contract.path.as_posix(),
+        "checks": checks,
+        "inspection": inspection.to_dict(),
+        "bootstrap": bootstrap.to_dict(),
+        "size_gates": contract.size_gates,
+    }
+    _write_json(Path(workdir) / "author_doctor.json", payload)
+    return payload
+
+
+def verify_artifacts(
+    repo_root: Path,
+    workdir: Path,
+    *,
+    contract: WorkflowContract | None = None,
+    verify_triad: bool = True,
+) -> dict[str, Any]:
+    contract = contract or load_workflow_contract()
+    workdir = Path(workdir).resolve()
+    repo_root = Path(repo_root).resolve()
+    test_patch = analyze_test_patch(workdir / "test.patch")
+    solution_patch = analyze_solution_patch(workdir / "solution.patch", contract=contract)
+    size_gates = contract.size_gates
+    size_status = {
+        "test_patch_min_bytes": size_gates["test_patch_min_bytes"],
+        "test_patch_size_bytes": test_patch.size_bytes,
+        "test_patch_ok": test_patch.size_bytes >= size_gates["test_patch_min_bytes"],
+        "solution_patch_min_bytes": size_gates["solution_patch_min_bytes"],
+        "solution_patch_size_bytes": solution_patch.size_bytes,
+        "solution_patch_ok": solution_patch.size_bytes >= size_gates["solution_patch_min_bytes"],
+    }
+    docker_problem = repo_root / "Dockerfile.problem"
+    docker_copy = workdir / "docker.file"
+    docker_sync_ok = docker_problem.exists() and docker_copy.exists() and docker_problem.read_text(encoding="utf-8") == docker_copy.read_text(encoding="utf-8")
+    metadata_errors: list[str] = []
+    final_title = (workdir / "final_title.txt").read_text(encoding="utf-8") if (workdir / "final_title.txt").exists() else ""
+    final_description = (workdir / "final_description.txt").read_text(encoding="utf-8") if (workdir / "final_description.txt").exists() else ""
+    metadata_errors.extend(_check_ascii_title(final_title))
+    metadata_errors.extend(_check_final_description(final_description))
+    triad = None
+    if verify_triad:
+        triad = verify_clean_tree_and_triad(
+            repo_root,
+            test_patch=workdir / "test.patch",
+            solution_patch=workdir / "solution.patch",
+        )
+    ok = (
+        test_patch.status == "pass"
+        and solution_patch.status == "pass"
+        and size_status["test_patch_ok"]
+        and size_status["solution_patch_ok"]
+        and docker_sync_ok
+        and not metadata_errors
+        and (triad.ok if triad is not None else True)
+    )
+    payload = {
+        "ok": ok,
+        "repo_root": repo_root.as_posix(),
+        "workdir": workdir.as_posix(),
+        "test_patch": test_patch.to_dict(),
+        "solution_patch": solution_patch.to_dict(),
+        "size_gates": size_status,
+        "docker_file": {
+            "dockerfile_problem": docker_problem.as_posix(),
+            "copied_artifact": docker_copy.as_posix(),
+            "ok": docker_sync_ok,
+        },
+        "metadata": {
+            "title_path": (workdir / "final_title.txt").as_posix(),
+            "description_path": (workdir / "final_description.txt").as_posix(),
+            "errors": metadata_errors,
+        },
+        "triad": triad.to_dict() if triad is not None else None,
+    }
+    _write_json(workdir / "run_summary.json", payload)
+    if not ok:
+        _write_failure(workdir, reason="artifact verification failed", context=payload)
+    return payload
+
+
+def _git_clone_and_checkout(repo_url: str, sha: str, destination: Path) -> list[dict[str, Any]]:
+    steps: list[dict[str, Any]] = []
+    clone = subprocess.run(
+        ["git", "clone", repo_url, str(destination)], text=True, capture_output=True
+    )
+    steps.append(
+        {
+            "name": "git_clone",
+            "argv": ["git", "clone", repo_url, str(destination)],
+            "returncode": clone.returncode,
+            "stdout": clone.stdout,
+            "stderr": clone.stderr,
+        }
+    )
+    if clone.returncode != 0:
+        return steps
+    checkout = subprocess.run(
+        ["git", "checkout", sha], cwd=str(destination), text=True, capture_output=True
+    )
+    steps.append(
+        {
+            "name": "git_checkout",
+            "argv": ["git", "checkout", sha],
+            "returncode": checkout.returncode,
+            "stdout": checkout.stdout,
+            "stderr": checkout.stderr,
+        }
+    )
+    return steps
+
+
+def _copy_docker_artifact(app_dir: Path, workdir: Path) -> None:
+    dockerfile_problem = Path(app_dir) / "Dockerfile.problem"
+    if dockerfile_problem.exists():
+        atomic_write_text(workdir / "docker.file", dockerfile_problem.read_text(encoding="utf-8"))
+
+
+def run_problem_workflow(
+    repo_url: str,
+    sha: str,
+    workdir: Path,
+    *,
+    contract: WorkflowContract | None = None,
+    topic: str | None = None,
+    runner: DockerCommandRunner | None = None,
+    container_command: list[str] | None = None,
+    skip_docker: bool = False,
+    min_test_patch_bytes: int | None = None,
+    min_solution_patch_bytes: int | None = None,
+) -> RunResult:
+    runner = runner or DockerCommandRunner()
+    contract = contract or load_workflow_contract()
+    if min_test_patch_bytes is not None:
+        contract.payload.setdefault("size_gates", {})["test_patch_min_bytes"] = min_test_patch_bytes
+    if min_solution_patch_bytes is not None:
+        contract.payload.setdefault("size_gates", {})["solution_patch_min_bytes"] = min_solution_patch_bytes
+    bootstrap = bootstrap_workdir(workdir, topic=topic)
+    app_dir = Path(workdir).resolve() / "app"
+    if app_dir.exists() and any(app_dir.iterdir()):
+        failure = _write_failure(Path(workdir), reason="/work/app already exists and is not empty", context={"app_dir": app_dir.as_posix()})
+        return RunResult(ok=False, summary=failure, failure=failure)
+    clone_steps = _git_clone_and_checkout(repo_url, sha, app_dir)
+    if any(step["returncode"] != 0 for step in clone_steps):
+        failure = _write_failure(Path(workdir), reason="git clone or checkout failed", context={"steps": clone_steps})
+        return RunResult(ok=False, summary=failure, failure=failure)
+    topic_slug = _slugify(topic or app_dir.name)
+    inspection = inspect_repo_metadata(app_dir)
+    render_dockerfile_problem(app_dir)
+    _copy_docker_artifact(app_dir, Path(workdir))
+    ensure_minimal_test_runner(app_dir, topic=topic_slug)
+    doctor_payload = run_author_doctor(app_dir, Path(workdir), contract=contract, runner=runner)
+    docker_build = None
+    docker_run = None
+    image_tag = f"sdetkit-author-{topic_slug}"
+    if not skip_docker:
+        docker_build = build_docker_image(app_dir, tag=image_tag, runner=runner).to_dict()
+        if docker_build["returncode"] == 0:
+            docker_run = run_authoring_container(
+                app_dir,
+                Path(workdir),
+                image=image_tag,
+                command=container_command,
+                runner=runner,
+            ).to_dict()
+    summary = {
+        "ok": False,
+        "repo_url": repo_url,
+        "pinned_sha": sha,
+        "workflow_contract": contract.path.as_posix(),
+        "workdir": Path(workdir).resolve().as_posix(),
+        "app_dir": app_dir.as_posix(),
+        "artifacts": bootstrap.artifact_paths,
+        "bootstrap": bootstrap.to_dict(),
+        "doctor": doctor_payload,
+        "inspection": inspection.to_dict(),
+        "docker": {
+            "rendered": (app_dir / "Dockerfile.problem").as_posix(),
+            "build": docker_build,
+            "run": docker_run,
+            "skipped": skip_docker,
+        },
+        "gating_order": contract.payload.get("gating_order", []),
+        "notes": {
+            "novelty_gate": (Path(workdir) / "novelty_gate.txt").as_posix(),
+            "candidate_notes": (Path(workdir) / "candidate_notes.md").as_posix(),
+        },
+    }
+    verification = verify_artifacts(app_dir, Path(workdir), contract=contract, verify_triad=False)
+    summary["verification"] = verification
+    summary["patch_sizes"] = {
+        "test_patch_bytes": Path(workdir, "test.patch").stat().st_size,
+        "solution_patch_bytes": Path(workdir, "solution.patch").stat().st_size,
+    }
+    summary["ok"] = bool(
+        doctor_payload.get("ok")
+        and (skip_docker or (docker_build and docker_build.get("returncode") == 0))
+        and verification.get("ok")
+    )
+    _write_json(Path(workdir) / "run_summary.json", summary)
+    if not summary["ok"]:
+        failure = _write_failure(Path(workdir), reason="run did not reach a verified artifact bundle", context=summary)
+        return RunResult(ok=False, summary=summary, failure=failure)
+    return RunResult(ok=True, summary=summary, failure=None)
+
+
+def _format_human_doctor(payload: dict[str, Any]) -> str:
+    lines = ["Author problem doctor"]
+    for check in payload.get("checks", []):
+        marker = "OK" if check.get("ok") else "FAIL"
+        lines.append(f"[{marker}] {check.get('id')}")
+    inspection = payload.get("inspection", {})
+    lines.append(f"Repo: {inspection.get('repo_name', '')}")
+    lines.append("Metadata files: " + ", ".join(inspection.get("metadata_files", [])))
+    lines.append("Dependency risks: " + ", ".join(inspection.get("dependency_risks", [])))
+    return "\n".join(lines) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="sdetkit author")
+    sub = parser.add_subparsers(dest="surface", required=True)
+    problem = sub.add_parser("problem", help="Platform-style Python problem authoring lane")
+    psub = problem.add_subparsers(dest="action", required=True)
+
+    initp = psub.add_parser("init", help="Bootstrap /work ledger state and artifact targets")
+    initp.add_argument("--workdir", default="/work")
+    initp.add_argument("--topic", default="platform-problem")
+    initp.add_argument("--format", choices=["text", "json"], default="text")
+
+    doctorp = psub.add_parser("doctor", help="Inspect host tools, /work, and target repo readiness")
+    doctorp.add_argument("--repo-root", default=".")
+    doctorp.add_argument("--workdir", default="/work")
+    doctorp.add_argument("--format", choices=["text", "json"], default="text")
+
+    renderp = psub.add_parser("render-dockerfile", help="Render Dockerfile.problem from repo metadata")
+    renderp.add_argument("--repo-root", default=".")
+    renderp.add_argument("--output", default=None)
+
+    verifyp = psub.add_parser("verify", help="Verify artifact boundaries, size gates, and triad replay")
+    verifyp.add_argument("--repo-root", default=".")
+    verifyp.add_argument("--workdir", default="/work")
+    verifyp.add_argument("--skip-triad", action="store_true")
+    verifyp.add_argument("--format", choices=["text", "json"], default="text")
+
+    runp = psub.add_parser("run", help="Clone, pin, bootstrap, render Dockerfile, and verify artifacts")
+    runp.add_argument("--repo", required=True)
+    runp.add_argument("--sha", required=True)
+    runp.add_argument("--workdir", default="/work")
+    runp.add_argument("--topic", default=None)
+    runp.add_argument("--skip-docker", action="store_true")
+    runp.add_argument("--container-command", action="append", default=[])
+    runp.add_argument("--min-test-patch-bytes", type=int, default=204800)
+    runp.add_argument("--min-solution-patch-bytes", type=int, default=29696)
+    runp.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    ns = parser.parse_args(argv)
+    if ns.surface != "problem":
+        raise SystemExit(2)
+
+    if ns.action == "init":
+        bootstrap = bootstrap_workdir(Path(ns.workdir), topic=str(ns.topic))
+        if ns.format == "json":
+            sys.stdout.write(canonical_json_dumps(bootstrap.to_dict()))
+        else:
+            sys.stdout.write(f"Bootstrapped {bootstrap.workdir.as_posix()}\n")
+            for item in bootstrap.created:
+                sys.stdout.write(f"- {item}\n")
+        return 0
+
+    if ns.action == "doctor":
+        payload = run_author_doctor(Path(ns.repo_root), Path(ns.workdir))
+        if ns.format == "json":
+            sys.stdout.write(canonical_json_dumps(payload))
+        else:
+            sys.stdout.write(_format_human_doctor(payload))
+        return 0 if payload.get("ok") else 1
+
+    if ns.action == "render-dockerfile":
+        output = Path(ns.output) if ns.output else None
+        text = render_dockerfile_problem(Path(ns.repo_root), output)
+        sys.stdout.write(text)
+        return 0
+
+    if ns.action == "verify":
+        payload = verify_artifacts(
+            Path(ns.repo_root),
+            Path(ns.workdir),
+            verify_triad=not bool(ns.skip_triad),
+        )
+        if ns.format == "json":
+            sys.stdout.write(canonical_json_dumps(payload))
+        else:
+            sys.stdout.write(f"verification: {'OK' if payload.get('ok') else 'FAIL'}\n")
+            sys.stdout.write(f"test.patch: {payload['test_patch']['status']}\n")
+            sys.stdout.write(f"solution.patch: {payload['solution_patch']['status']}\n")
+            sys.stdout.write(
+                f"size gates: test={payload['size_gates']['test_patch_ok']} solution={payload['size_gates']['solution_patch_ok']}\n"
+            )
+        return 0 if payload.get("ok") else 1
+
+    if ns.action == "run":
+        container_command = list(ns.container_command) or None
+        result = run_problem_workflow(
+            ns.repo,
+            ns.sha,
+            Path(ns.workdir),
+            topic=ns.topic,
+            skip_docker=bool(ns.skip_docker),
+            container_command=container_command,
+            min_test_patch_bytes=int(ns.min_test_patch_bytes),
+            min_solution_patch_bytes=int(ns.min_solution_patch_bytes),
+        )
+        if ns.format == "json":
+            sys.stdout.write(canonical_json_dumps(result.summary))
+        else:
+            sys.stdout.write(
+                f"run: {'OK' if result.ok else 'FAIL'}\nworkdir: {Path(ns.workdir).resolve().as_posix()}\n"
+            )
+            sys.stdout.write(f"app_dir: {result.summary.get('app_dir', '')}\n")
+            if result.failure:
+                sys.stdout.write(f"failure_reason: {result.failure.get('reason', '')}\n")
+        return 0 if result.ok else 1
+
+    raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from importlib import metadata
 
 from . import (
+    author_problem,
     apiget,
     community_activation,
     continuous_upgrade_cycle8_closeout,
@@ -265,6 +266,11 @@ Start here:
     )
     _add_passthrough_subcommand(
         sub, "integration", help_text="[Stable/Core] Integration Assurance Kit (primary surface)"
+    )
+    _add_passthrough_subcommand(
+        sub,
+        "author",
+        help_text="[Stable/Core] Platform-style Python problem authoring workflow",
     )
     _add_passthrough_subcommand(
         sub,
@@ -1264,6 +1270,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "integration":
         return integration.main(ns.args)
+
+    if ns.cmd == "author":
+        return author_problem.main(ns.args)
 
     if ns.cmd == "forensics":
         return forensics.main(ns.args)

--- a/tests/test_author_problem.py
+++ b/tests/test_author_problem.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from sdetkit import cli
+from sdetkit.author_problem import (
+    DockerCommandRunner,
+    WorkflowContract,
+    bootstrap_workdir,
+    build_docker_image,
+    load_workflow_contract,
+    render_dockerfile_problem,
+    run_author_doctor,
+    run_authoring_container,
+    run_problem_workflow,
+    verify_artifacts,
+)
+
+
+class _FakeRunner(DockerCommandRunner):
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def run(self, argv: list[str], *, cwd: Path | None = None):  # type: ignore[override]
+        self.calls.append(list(argv))
+        return type(
+            "Invocation",
+            (),
+            {"argv": argv, "returncode": 0, "stdout": "ok", "stderr": "", "to_dict": lambda self: {"argv": argv, "returncode": 0, "stdout": "ok", "stderr": ""}},
+        )()
+
+    def which(self, program: str) -> str | None:  # type: ignore[override]
+        return f"/usr/bin/{program}"
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "author@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Author"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"], cwd=path, check=True, capture_output=True, text=True
+    )
+
+
+def _write_demo_repo(path: Path) -> None:
+    (path / "src/demoapp").mkdir(parents=True)
+    (path / "tests").mkdir(parents=True)
+    (path / "pyproject.toml").write_text(
+        """
+[project]
+name = "demoapp"
+version = "0.1.0"
+dependencies = []
+[project.optional-dependencies]
+test = ["pytest>=8"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (path / "src/demoapp/__init__.py").write_text("", encoding="utf-8")
+    (path / "src/demoapp/service.py").write_text(
+        """
+def refresh_state(snapshot):
+    return {"value": snapshot["value"], "sequence": snapshot["sequence"]}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (path / "src/demoapp/storage.py").write_text(
+        """
+def normalize_snapshot(snapshot):
+    return dict(snapshot)
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (path / "src/demoapp/api.py").write_text(
+        """
+from demoapp.service import refresh_state
+from demoapp.storage import normalize_snapshot
+
+
+def perform_refresh(snapshot):
+    return normalize_snapshot(refresh_state(snapshot))
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (path / "tests/test_existing.py").write_text(
+        """
+from demoapp.api import perform_refresh
+
+
+def test_existing_behavior():
+    assert perform_refresh({"value": "x", "sequence": 1}) == {"value": "x", "sequence": 1}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _make_problem_patches(repo_root: Path, workdir: Path) -> None:
+    (repo_root / "test.sh").write_text(
+        "#!/usr/bin/env bash\n\nset -euo pipefail\n\nmode=${1:-}\ncase \"$mode\" in\n  new) PYTHONPATH=src python3 -m pytest tests/test_refresh_problem.py ;;\n  base) PYTHONPATH=src python3 -m pytest tests --ignore=tests/test_refresh_problem.py ;;\n  *) echo \"Usage: $0 {base|new}\" >&2; exit 2 ;;\nesac\n",
+        encoding="utf-8",
+    )
+    (repo_root / "tests/test_refresh_problem.py").write_text(
+        """
+from demoapp.api import perform_refresh
+
+
+def test_refresh_contract_tracks_history_and_checkpoint():
+    snapshot = {
+        "value": "new",
+        "sequence": 5,
+        "history": ["old"],
+        "rotated": True,
+        "source": "sync",
+    }
+    assert perform_refresh(snapshot) == {
+        "value": "new",
+        "sequence": 5,
+        "history": ("old", "new"),
+        "rotated": True,
+        "source": "sync",
+        "checkpoint": "seq:5",
+    }
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "add", "-N", "test.sh", "tests/test_refresh_problem.py"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    test_patch = subprocess.run(
+        ["git", "diff", "--binary", "--", "test.sh", "tests/test_refresh_problem.py"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    (workdir / "test.patch").write_text(test_patch, encoding="utf-8")
+    subprocess.run(
+        ["git", "reset", "--", "test.sh", "tests/test_refresh_problem.py"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (repo_root / "test.sh").unlink()
+    (repo_root / "tests/test_refresh_problem.py").unlink()
+
+    (repo_root / "src/demoapp/service.py").write_text(
+        """
+def refresh_state(snapshot):
+    state = {"value": snapshot["value"], "sequence": snapshot["sequence"]}
+    if any(key in snapshot for key in ("history", "rotated", "source")):
+        history = list(snapshot.get("history", []))
+        history.append(snapshot["value"])
+        state.update(
+            {
+                "history": history,
+                "rotated": bool(snapshot.get("rotated", False)),
+                "source": snapshot.get("source", "direct"),
+                "checkpoint": f"seq:{snapshot['sequence']}",
+            }
+        )
+    return state
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (repo_root / "src/demoapp/storage.py").write_text(
+        """
+def normalize_snapshot(snapshot):
+    normalized = dict(snapshot)
+    if "history" in snapshot:
+        normalized["history"] = tuple(snapshot.get("history", []))
+    return normalized
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (repo_root / "src/demoapp/api.py").write_text(
+        """
+from demoapp.service import refresh_state
+from demoapp.storage import normalize_snapshot
+
+
+def perform_refresh(snapshot):
+    refreshed = refresh_state(snapshot)
+    return normalize_snapshot(refreshed)
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    solution_patch = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--binary",
+            "--",
+            "src/demoapp/api.py",
+            "src/demoapp/service.py",
+            "src/demoapp/storage.py",
+        ],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    (workdir / "solution.patch").write_text(solution_patch, encoding="utf-8")
+    subprocess.run(["git", "checkout", "--", "src/demoapp/api.py", "src/demoapp/service.py", "src/demoapp/storage.py"], cwd=repo_root, check=True, capture_output=True, text=True)
+
+
+def _write_final_metadata(workdir: Path) -> None:
+    (workdir / "final_title.txt").write_text(
+        "Durable session refresh contract\n", encoding="utf-8"
+    )
+    (workdir / "final_description.txt").write_text(
+        "Implement the repository contract for durable session refresh behavior.\n"
+        "- preserve rotation metadata across repeated refresh operations\n"
+        "- keep checkpoint sequencing monotonic when stale snapshots arrive late\n"
+        "- maintain parity between direct service entrypoints and storage-backed helpers\n"
+        "The update must protect rollback-safe state propagation, reject older snapshots once newer sequence markers exist, and ensure normalized refresh payloads keep history, source, and checkpoint details aligned across the public API surface. Repeated calls must remain deterministic even when callers replay previously seen state.\n",
+        encoding="utf-8",
+    )
+
+
+def _low_threshold_contract(tmp_path: Path) -> WorkflowContract:
+    payload = load_workflow_contract().payload
+    copied = json.loads(json.dumps(payload))
+    copied["size_gates"]["test_patch_min_bytes"] = 1
+    copied["size_gates"]["solution_patch_min_bytes"] = 1
+    return WorkflowContract(path=tmp_path / "contract.json", payload=copied)
+
+
+def test_author_problem_bootstrap_and_contract_load(tmp_path: Path) -> None:
+    bootstrap = bootstrap_workdir(tmp_path / "work", topic="Refresh Problem")
+    contract = load_workflow_contract()
+
+    assert (tmp_path / "work/current_problem.txt").exists()
+    assert (tmp_path / "work/novelty_gate.txt").exists()
+    assert (tmp_path / "work/candidate_notes.md").exists()
+    assert (tmp_path / "work/test.patch").exists()
+    assert contract.size_gates["test_patch_min_bytes"] == 204800
+    assert any(item.endswith("submission_001") for item in bootstrap.created)
+
+
+def test_render_dockerfile_and_docker_helpers(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_demo_repo(repo_root)
+    text = render_dockerfile_problem(repo_root)
+    runner = _FakeRunner()
+
+    build = build_docker_image(repo_root, runner=runner)
+    run = run_authoring_container(repo_root, tmp_path / "work", image="demo-image", runner=runner)
+
+    assert "FROM public.ecr.aws/x8v8d7g8/mars-base:latest" in text
+    assert 'CMD ["/bin/bash"]' in text
+    assert any("pytest" in line for line in text.splitlines())
+    assert build.returncode == 0
+    assert run.returncode == 0
+    assert runner.calls[0][:3] == ["docker", "build", "-f"]
+    assert runner.calls[1][:3] == ["docker", "run", "--rm"]
+
+
+def test_author_problem_doctor_verify_and_triad(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_demo_repo(repo_root)
+    _init_git_repo(repo_root)
+
+    workdir = tmp_path / "work"
+    bootstrap_workdir(workdir, topic="refresh")
+    _make_problem_patches(repo_root, workdir)
+    _write_final_metadata(workdir)
+    render_dockerfile_problem(repo_root)
+    (workdir / "docker.file").write_text(
+        (repo_root / "Dockerfile.problem").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    doctor = run_author_doctor(repo_root, workdir, contract=_low_threshold_contract(tmp_path), runner=_FakeRunner())
+    summary = verify_artifacts(
+        repo_root,
+        workdir,
+        contract=_low_threshold_contract(tmp_path),
+        verify_triad=True,
+    )
+
+    assert doctor["inspection"]["repo_name"] == "repo"
+    assert summary["ok"] is True
+    assert summary["test_patch"]["status"] == "pass"
+    assert summary["solution_patch"]["status"] == "pass"
+    assert summary["triad"]["ok"] is True
+    assert summary["triad"]["phases"][1]["expected"] == "fail"
+
+
+def test_author_problem_run_emits_failure_summary_when_artifacts_missing(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _write_demo_repo(source)
+    _init_git_repo(source)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=source, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    result = run_problem_workflow(
+        str(source),
+        sha,
+        tmp_path / "work",
+        skip_docker=True,
+        min_test_patch_bytes=1,
+        min_solution_patch_bytes=1,
+    )
+
+    assert result.ok is False
+    failure = json.loads((tmp_path / "work/final_failure.json").read_text(encoding="utf-8"))
+    summary = json.loads((tmp_path / "work/run_summary.json").read_text(encoding="utf-8"))
+    assert failure["reason"] == "run did not reach a verified artifact bundle"
+    assert summary["docker"]["skipped"] is True
+    assert summary["repo_url"] == str(source)
+
+
+def test_main_cli_dispatches_author_problem_init_and_help_lists_author(capsys) -> None:
+    rc = cli.main(["author", "problem", "init", "--workdir", "build/work", "--format", "json"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["artifact_paths"]["test_patch"].endswith("test.patch")
+
+    help_text = cli._build_root_parser()[0].format_help()
+    assert "author" in help_text

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -24,6 +24,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "playbooks" in out
 
     assert "report" in out
+    assert "author" in out
     assert "maintenance" in out
     assert "agent" in out
     assert "proof" in out


### PR DESCRIPTION
### Motivation

- Provide a repo-owned, environment-first authoring lane so future runs can be driven with only `REPO_URL` + `PINNED_SHA` and a writable `/work` without manual patch assembly. 
- Encode the full authoring contract (Dockerfile.problem rendering, /work bootstrap, size gates, patch-boundary rules, clean-tree replay, base/new triad) so later platform-style problem runs are deterministic and reviewer-safe. 
- Surface honest doctor/run/failure summaries and templates so the repo can autonomously prepare, validate, and emit the stable artifact bundle expected by reviewers.

### Description

- Add a new authoring subsystem in `src/sdetkit/author_problem.py` implementing: workdir bootstrap, novelty/candidate templates, `Dockerfile.problem` renderer, Docker build/run helpers, `test.sh` generator, patch analyzers, patch-boundary and size-gate enforcement, clean-tree replay and triad verification, and machine-readable summaries. 
- Expose the new lane via the root CLI as `python -m sdetkit author problem` with subcommands `init`, `doctor`, `render-dockerfile`, `verify`, and `run`. 
- Add a machine-readable workflow contract at `.sdetkit/workflows/platform_problem.yaml` encoding gating order, required artifact paths, size defaults, allowed test/solution patch scopes, triad expectations, and final-title/description constraints. 
- Add docs and navigation: `docs/platform-problem-authoring.md`, README updates, and `mkdocs.yml` entry describing usage and constraints. 
- Add smoke-style tests in `tests/test_author_problem.py` validating bootstrap, contract loading, Dockerfile rendering planning, artifact verification, triad replay, and `run` failure behavior, and update CLI help test to include `author`. 
- Allow the workflow contract to be tracked by adjusting `.gitignore` to keep `.sdetkit/workflows/platform_problem.yaml` committed.

### Testing

- Ran `pytest -q tests/test_author_problem.py tests/test_cli_help_lists_subcommands.py tests/test_entrypoints_smoke.py` with all tests passing (`12 passed`).
- Verified CLI surface: `python -m sdetkit author problem --help` shows the subcommands. 
- Smoke bootstrap: `python -m sdetkit author problem init --workdir "$TMPDIR" --topic smoke --format json` produced the expected `/work` artifact paths and created ledger files.
- The repo commit includes the new module, tests, contract, docs, README and CLI wiring; these automated checks succeeded in the local test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bcee36e6c48320b2fc211bf9238ae0)