### PR TITLE
Map host UID/GID into authoring container and make checkout reset robust to permission errors

### DIFF
--- a/src/sdetkit/author_problem.py
+++ b/src/sdetkit/author_problem.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import re
+import stat
 import shutil
 import subprocess
 import sys
@@ -63,6 +64,18 @@ class DockerCommandRunner:
 
     def which(self, program: str) -> str | None:
         return shutil.which(program)
+
+
+def _current_host_uid_gid() -> tuple[int, int] | None:
+    getuid = getattr(os, "getuid", None)
+    getgid = getattr(os, "getgid", None)
+    if not callable(getuid) or not callable(getgid):
+        return None
+    uid = int(getuid())
+    gid = int(getgid())
+    if uid < 0 or gid < 0:
+        return None
+    return uid, gid
 
 
 @dataclass(frozen=True)
@@ -644,6 +657,7 @@ def run_authoring_container(
 ) -> DockerInvocation:
     runner = runner or DockerCommandRunner()
     toolkit_root = (toolkit_root or _repo_root()).resolve()
+    host_identity = _current_host_uid_gid()
     command = command or [
         "python3",
         "-m",
@@ -660,6 +674,10 @@ def run_authoring_container(
         "docker",
         "run",
         "--rm",
+    ]
+    if host_identity is not None:
+        argv.extend(["--user", f"{host_identity[0]}:{host_identity[1]}"])
+    argv.extend([
         "-v",
         f"{Path(repo_root).resolve()}:/app",
         "-v",
@@ -672,7 +690,7 @@ def run_authoring_container(
         f"PYTHONPATH={_TOOLKIT_MOUNT}/src",
         image,
         *command,
-    ]
+    ])
     return runner.run(argv)
 
 
@@ -1097,12 +1115,61 @@ def _copy_docker_artifact(app_dir: Path, workdir: Path) -> None:
         atomic_write_text(workdir / "docker.file", dockerfile_problem.read_text(encoding="utf-8"))
 
 
+def _repair_remove_path(path: str) -> None:
+    target = Path(path)
+    identity = _current_host_uid_gid()
+    if identity is not None:
+        try:
+            os.chown(target, identity[0], identity[1], follow_symlinks=False)
+        except OSError:
+            pass
+    try:
+        mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+        if target.is_dir():
+            mode |= stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP
+        os.chmod(target, mode, follow_symlinks=False)
+    except OSError:
+        pass
+
+
+def _handle_rmtree_error(func: Any, path: str, exc_info: Any) -> None:
+    _repair_remove_path(path)
+    parent = Path(path).parent
+    if parent.exists():
+        _repair_remove_path(str(parent))
+    func(path)
+
+
+def _quarantine_checkout_dir(app_dir: Path) -> Path:
+    app_dir = Path(app_dir)
+    for index in range(1, 1000):
+        candidate = app_dir.with_name(f"{app_dir.name}.stale.{index:03d}")
+        if not candidate.exists():
+            app_dir.rename(candidate)
+            return candidate
+    raise RuntimeError(f"could not quarantine stale checkout: {app_dir.as_posix()}")
+
+
 def _reset_checkout_dir(app_dir: Path) -> None:
     if app_dir.is_symlink() or app_dir.is_file():
-        app_dir.unlink()
+        try:
+            app_dir.unlink()
+        except PermissionError:
+            quarantined = _quarantine_checkout_dir(app_dir)
+            try:
+                quarantined.unlink()
+            except OSError:
+                pass
         return
     if app_dir.exists():
-        shutil.rmtree(app_dir)
+        try:
+            shutil.rmtree(app_dir, onerror=_handle_rmtree_error)
+        except OSError:
+            quarantined = _quarantine_checkout_dir(app_dir)
+            try:
+                shutil.rmtree(quarantined, onerror=_handle_rmtree_error)
+            except OSError:
+                pass
 
 
 def _shell_command(name: str, command: str, *, cwd: Path) -> StageCommand:

--- a/tests/test_author_problem.py
+++ b/tests/test_author_problem.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from sdetkit.author_problem import (
     DockerCommandRunner,
     WorkflowContract,
     _git_restore_paths,
+    _reset_checkout_dir,
     _rich_strategy_matches,
     bootstrap_workdir,
     build_docker_image,
@@ -327,6 +329,9 @@ def test_render_dockerfile_and_docker_helpers(tmp_path: Path) -> None:
     assert run.returncode == 0
     assert runner.calls[0][:3] == ["docker", "build", "-f"]
     assert runner.calls[1][:3] == ["docker", "run", "--rm"]
+    assert "--user" in runner.calls[1]
+    user_index = runner.calls[1].index("--user")
+    assert runner.calls[1][user_index + 1] == f"{os.getuid()}:{os.getgid()}"
 
 
 def test_author_problem_doctor_verify_and_triad(tmp_path: Path) -> None:
@@ -613,6 +618,31 @@ def test_git_restore_paths_restores_tracked_and_deletes_untracked(tmp_path: Path
 
     assert (repo / "tracked.py").read_text(encoding="utf-8") == "value = 1\n"
     assert not (repo / "new_helper.py").exists()
+
+
+def test_reset_checkout_dir_quarantines_stale_tree_when_rmtree_hits_permission_error(
+    tmp_path: Path, monkeypatch
+) -> None:
+    app_dir = tmp_path / "app"
+    (app_dir / "__pycache__").mkdir(parents=True)
+    (app_dir / "__pycache__" / "test_progress.cpython-312-pytest-9.0.2.pyc").write_bytes(b"pyc")
+    original_rmtree = shutil.rmtree
+    seen_paths: list[str] = []
+
+    def fake_rmtree(path, *args, **kwargs):
+        target = Path(path)
+        seen_paths.append(target.name)
+        if target == app_dir:
+            raise PermissionError("stale root-owned pycache")
+        return original_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "rmtree", fake_rmtree)
+
+    _reset_checkout_dir(app_dir)
+
+    assert not app_dir.exists()
+    assert any(name.startswith("app.stale.") for name in seen_paths)
+    assert not any(tmp_path.glob("app.stale.*"))
 
 
 def test_main_cli_dispatches_author_problem_init_and_help_lists_author(capsys) -> None:


### PR DESCRIPTION
### Motivation

- Ensure files created by containers are owned by the invoking host user by passing the host `UID:GID` into `docker run` when available.
- Make repository checkout cleanup resilient to permission errors (e.g., root-owned files) by attempting to repair permissions and quarantining stale directories for later removal.

### Description

- Added `_current_host_uid_gid()` to detect the host `uid`/`gid` and pass `--user UID:GID` into `run_authoring_container` when available. 
- Introduced `_repair_remove_path()` and `_handle_rmtree_error()` to try to `chown`/`chmod` targets before retrying removals, and added `_quarantine_checkout_dir()` to rename stale checkouts to `*.stale.###` when removal fails. 
- Updated `_reset_checkout_dir()` to handle `PermissionError` and `OSError` from `unlink`/`rmtree` by quarantining and attempting recovery removals with the new handlers. 
- Updated tests to assert the `--user` flag is included in the docker invocation and added `test_reset_checkout_dir_quarantines_stale_tree_when_rmtree_hits_permission_error` to validate quarantine behavior.

### Testing

- Ran the modified test module with `pytest tests/test_author_problem.py -q`, and all tests including the new `test_reset_checkout_dir_quarantines_stale_tree_when_rmtree_hits_permission_error` passed. 
- Verified `test_render_dockerfile_and_docker_helpers` asserts for the `--user` argument and correct `UID:GID` mapping succeeded. 
- Exercised the checkout-reset logic via the new unit test which simulates `rmtree` raising `PermissionError` and validated that the directory is quarantined and cleaned as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bd1a297e188320b4d71bb24e15bc17)