### PR TITLE
Fix author problem workdir artifact handling

### DIFF
--- a/src/sdetkit/author_problem.py
+++ b/src/sdetkit/author_problem.py
@@ -322,6 +322,31 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     atomic_write_text(path, canonical_json_dumps(payload))
 
 
+def _read_workfile_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _clear_run_artifacts(workdir: Path, preserve: tuple[str, ...] = ()) -> None:
+    for name in (
+        "test.patch",
+        "solution.patch",
+        "docker.file",
+        "final_title.txt",
+        "final_description.txt",
+        "run_summary.json",
+        "final_failure.json",
+        "author_doctor.json",
+    ):
+        if name in preserve:
+            continue
+        (workdir / name).unlink(missing_ok=True)
+
+
 def bootstrap_workdir(workdir: Path, *, topic: str | None = None) -> WorkBootstrap:
     workdir = Path(workdir).resolve()
     workdir.mkdir(parents=True, exist_ok=True)
@@ -404,6 +429,12 @@ def _export_final_artifacts(
     export_dir = _artifact_export_root(export_root)
     export_dir.mkdir(parents=True, exist_ok=True)
     exported: dict[str, dict[str, str]] = {}
+    placeholder_sensitive = {
+        "test.patch",
+        "solution.patch",
+        "final_title.txt",
+        "final_description.txt",
+    }
     for name in [
         "test.patch",
         "solution.patch",
@@ -414,6 +445,8 @@ def _export_final_artifacts(
     ]:
         source = workdir / name
         if not source.exists():
+            continue
+        if not success and name in placeholder_sensitive and source.stat().st_size == 0:
             continue
         destination = export_dir / name
         shutil.copy2(source, destination)
@@ -1178,7 +1211,7 @@ def _shell_command(name: str, command: str, *, cwd: Path) -> StageCommand:
 
 
 def _append_note(path: Path, heading: str, lines: list[str]) -> None:
-    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    text = _read_workfile_text(path)
     addition = heading + "\n" + "\n".join(lines) + "\n"
     atomic_write_text(path, text.rstrip() + "\n\n" + addition)
 
@@ -1519,6 +1552,7 @@ def run_container_authoring(
     workdir = Path(workdir).resolve()
     repo_root = Path(repo_root).resolve()
     bootstrap = bootstrap_workdir(workdir, topic=topic)
+    _clear_run_artifacts(workdir, preserve=("docker.file", "author_doctor.json"))
     inspection = inspect_repo_metadata(repo_root)
     topic_slug = _slugify(topic or inspection.repo_name)
     novelty = _scaffold_novelty_gate(workdir, inspection, topic_slug)

--- a/tests/test_author_problem.py
+++ b/tests/test_author_problem.py
@@ -13,8 +13,10 @@ from sdetkit.author_problem import (
     _git_restore_paths,
     _reset_checkout_dir,
     _rich_strategy_matches,
+    _scaffold_novelty_gate,
     bootstrap_workdir,
     build_docker_image,
+    inspect_repo_metadata,
     load_workflow_contract,
     render_dockerfile_problem,
     run_author_doctor,
@@ -365,6 +367,29 @@ def test_author_problem_doctor_verify_and_triad(tmp_path: Path) -> None:
     assert summary["triad"]["phases"][1]["expected"] == "fail"
 
 
+def test_author_problem_recovers_from_unreadable_novelty_gate(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_demo_repo(repo_root)
+    _init_git_repo(repo_root)
+
+    workdir = tmp_path / "work"
+    bootstrap_workdir(workdir, topic="refresh")
+    novelty_gate = workdir / "novelty_gate.txt"
+    novelty_gate.write_text("# novelty gate\n", encoding="utf-8")
+    novelty_gate.chmod(0)
+
+    try:
+        novelty = _scaffold_novelty_gate(workdir, inspect_repo_metadata(repo_root), "refresh")
+    finally:
+        novelty_gate.chmod(0o644)
+
+    assert novelty["status"] == "scaffolded"
+    text = novelty_gate.read_text(encoding="utf-8")
+    assert "## machine-notes" in text
+    assert "candidate topic: refresh" in text
+
+
 def test_author_problem_run_emits_failure_summary_when_artifacts_missing(tmp_path: Path) -> None:
     source = tmp_path / "source"
     source.mkdir()
@@ -412,6 +437,52 @@ test = ["pytest>=8"]
     assert (_export_dir(tmp_path) / "final_failure.json").exists()
     assert manifest["success"] is False
     assert manifest["exports"]["final_failure.json"]["source"].endswith("/work/final_failure.json")
+
+
+def test_author_problem_failed_run_export_omits_stale_success_artifacts(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "pkg").mkdir()
+    (source / "tests").mkdir()
+    (source / "pyproject.toml").write_text(
+        """
+[project]
+name = "minimal"
+version = "0.1.0"
+dependencies = []
+[project.optional-dependencies]
+test = ["pytest>=8"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (source / "pkg/__init__.py").write_text("", encoding="utf-8")
+    (source / "pkg/core.py").write_text("def value():\n    return 1\n", encoding="utf-8")
+    (source / "tests/test_existing.py").write_text(
+        "from pkg.core import value\n\ndef test_value():\n    assert value() == 1\n",
+        encoding="utf-8",
+    )
+    _init_git_repo(source)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=source, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    result = run_problem_workflow(
+        str(source),
+        sha,
+        tmp_path / "work",
+        skip_docker=True,
+        min_test_patch_bytes=1,
+        min_solution_patch_bytes=1,
+        artifact_export_root=tmp_path,
+    )
+
+    assert result.ok is False
+    manifest = json.loads((_export_dir(tmp_path) / "export_manifest.json").read_text(encoding="utf-8"))
+    for name in ("test.patch", "solution.patch", "final_title.txt", "final_description.txt"):
+        assert name not in manifest["exports"]
+        assert not (_export_dir(tmp_path) / name).exists()
+
 
 
 def test_author_problem_run_can_succeed_end_to_end_with_demo_fixture(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Prevent authoring from crashing when work-managed files (like `novelty_gate.txt`) are unreadable, avoid exporting stale placeholder artifacts after failed runs, and ensure doctor-created placeholders do not persist into authoring.

### Description
- Add `_read_workfile_text(path: Path)` and switch `_append_note()` to use it so unreadable work files are treated as empty instead of raising.
- Add `_clear_run_artifacts(workdir, preserve=("docker.file","author_doctor.json"))` and invoke it at the start of `run_container_authoring()` to remove leftover placeholder artifacts before authoring begins.
- Update `_export_final_artifacts()` to skip exporting zero-byte placeholder success files (e.g., `test.patch`, `solution.patch`, `final_title.txt`, `final_description.txt`) when `success` is `False` so stale empty success artifacts are not exported after failures.
- Add regression tests in `tests/test_author_problem.py` for unreadable `novelty_gate.txt` recovery (`test_author_problem_recovers_from_unreadable_novelty_gate`) and failed-run export filtering (`test_author_problem_failed_run_export_omits_stale_success_artifacts`).

### Testing
- Ran the focused unit suite with `python -m pytest tests/test_author_problem.py` and all tests passed (`14 passed`), confirming the new behaviors and preventing regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bd2f6c35a48320b1eecb47490a9ada)