### PR TITLE
Add worker-oriented expansion control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,21 @@ The security auto-remediation lane is stronger too: premium gate can now priorit
 
 The GitHub-native maintenance layer is stronger too: beyond the existing GHAS digest, campaign planner, and configuration audit bots, the repo now carries a weekly **GHAS alert SLA tracker** for 7/14/30-day backlog enforcement, a weekly **GHAS metrics export bot** that publishes reusable JSON evidence for dashboards, audits, and roadmap reviews, a weekly **secret protection review bot** for push protection / delegated bypass / validity-check posture, a weekly **repo optimization control-loop bot** that turns `kits optimize`, `kits expand`, and automation coverage into actionable backlog slices, a weekly **docs experience radar bot** that keeps flagship docs, navigation, and search discoverability healthy, and a weekly **release readiness radar bot** that keeps doctor output, release assets, and publishing workflows visible in one operating lane.
 
+The worker layer is stronger too: `sdetkit kits expand --goal "..." --format json` now recommends **worker roles** plus a **worker launch pack** so teams can turn expansion ideas into deterministic AgentOS runs instead of leaving them as backlog text. The repo also ships three aligned worker templates out of the box:
+
+- `repo-expansion-control` for optimize/expand control-loop artifacts,
+- `docs-search-radar` for strict docs/search validation with bundled evidence,
+- `release-readiness-worker` for doctor + automation-readiness snapshots before publish windows.
+
+You can run them directly with:
+
+```bash
+python -m sdetkit kits expand --goal "add more bots workers search and repo expansion" --format json
+python -m sdetkit agent templates run repo-expansion-control
+python -m sdetkit agent templates run docs-search-radar
+python -m sdetkit agent templates run release-readiness-worker
+```
+
 To make those upgrade lanes reproducible in CI, the repo now pins the validated toolchain in `constraints-ci.txt` while leaving `pyproject.toml` flexible enough for package consumers.
 
 ## Sample artifacts

--- a/docs/automation-bots.md
+++ b/docs/automation-bots.md
@@ -19,6 +19,23 @@ The bots turn those same maintenance signals into a recurring GitHub-native oper
 
 ## Current bot inventory
 
+## Worker templates that align with the bot surface
+
+In addition to scheduled GitHub bots, the repo now ships **AgentOS worker templates** that let maintainers run the same expansion/review loops on demand and keep the outputs deterministic:
+
+- **`repo-expansion-control`** — runs `kits optimize` + `kits expand`, writes JSON artifacts, and bundles them for roadmap / dashboard follow-up.
+- **`docs-search-radar`** — runs a strict MkDocs build, captures the build log, and bundles docs-search evidence for later review.
+- **`release-readiness-worker`** — snapshots `doctor` plus `github_automation_check` so release-readiness follow-up can happen outside of a publish crunch.
+
+Recommended local launches:
+
+```bash
+python -m sdetkit agent templates run repo-expansion-control
+python -m sdetkit agent templates run docs-search-radar
+python -m sdetkit agent templates run release-readiness-worker
+python -m sdetkit kits expand --goal "add more bots workers search and repo expansion" --format json
+```
+
 ### Security and GitHub Advanced Security bots
 
 - **`security.yml`** — runs CodeQL.

--- a/src/sdetkit/agent/actions.py
+++ b/src/sdetkit/agent/actions.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from sdetkit import repo
 from sdetkit.atomicio import atomic_write_text
-from sdetkit.kits import blueprint_payload, optimize_payload
+from sdetkit.kits import blueprint_payload, expand_payload, optimize_payload
 from sdetkit.report import build_dashboard
 
 
@@ -60,6 +60,7 @@ class ActionRegistry:
             "report.build": self._report_build,
             "kits.blueprint": self._kits_blueprint,
             "kits.optimize": self._kits_optimize,
+            "kits.expand": self._kits_expand,
         }
 
     def run(self, name: str, params: dict[str, Any]) -> ActionResult:
@@ -251,6 +252,49 @@ class ActionRegistry:
                 "missing_domains": [
                     str(item) for item in _value_list(payload.get("missing_domains"))
                 ],
+            },
+        )
+
+    def _kits_expand(self, params: dict[str, Any]) -> ActionResult:
+        goal = str(params.get("goal", "")).strip() or None
+        output = str(params.get("output", ".sdetkit/agent/workdir/umbrella-expand.json"))
+        limit = int(params.get("limit", 3) or 3)
+        selected = params.get("kits") or []
+        selected_kits = [str(item) for item in selected] if isinstance(selected, list) else []
+        if not self._is_write_allowed(output):
+            return ActionResult(
+                "kits.expand",
+                False,
+                {
+                    "error": "write denied by allowlist",
+                    "path": output,
+                    "allowlist": list(self.write_allowlist),
+                },
+            )
+        try:
+            target = self._safe_rel(output)
+            payload = expand_payload(
+                root=self.root,
+                goal=goal,
+                selected_kits=selected_kits,
+                limit=limit,
+            )
+            atomic_write_text(
+                target, json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2) + "\n"
+            )
+        except (OSError, ValueError) as exc:
+            return ActionResult("kits.expand", False, {"error": str(exc), "path": output})
+        return ActionResult(
+            "kits.expand",
+            True,
+            {
+                "goal": goal,
+                "output": output,
+                "selected_kits": [
+                    str(kit["id"]) for kit in _dict_list(payload.get("selected_kits"))
+                ],
+                "feature_candidates": len(_dict_list(payload.get("feature_candidates"))),
+                "recommended_workers": len(_dict_list(payload.get("recommended_workers"))),
             },
         )
 

--- a/src/sdetkit/agent/core.py
+++ b/src/sdetkit/agent/core.py
@@ -284,6 +284,17 @@ def _rule_based_plan(task: str, *, max_actions: int) -> list[tuple[str, dict[str
                 },
             )
         ][:max_actions]
+    if any(term in normalized for term in ("expand", "feature", "worker", "workers", "bot", "bots", "search")):
+        return [
+            (
+                "kits.expand",
+                {
+                    "goal": task,
+                    "output": ".sdetkit/agent/workdir/umbrella-expand.json",
+                    "limit": 3,
+                },
+            )
+        ][:max_actions]
     if any(term in normalized for term in ("umbrella", "architecture", "blueprint")):
         return [
             (

--- a/src/sdetkit/agent/templates.py
+++ b/src/sdetkit/agent/templates.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from sdetkit.kits import expand_payload, optimize_payload
 from sdetkit import repo
 from sdetkit.atomicio import atomic_write_text, canonical_json_bytes, canonical_json_dumps
 from sdetkit.report import build_dashboard
@@ -367,6 +368,47 @@ def run_template(
             if isinstance(params.get("output_sarif"), str):
                 target = Path(str(params["output_sarif"]))
                 _write_json(target, repo._to_sarif(audit))
+                artifacts.append(target.as_posix())
+        elif step.action == "kits.optimize":
+            goal = str(params.get("goal", "")).strip() or None
+            limit = int(params.get("limit", 3) or 3)
+            selected = params.get("kits") or []
+            selected_kits = [str(item) for item in selected] if isinstance(selected, list) else []
+            payload = optimize_payload(
+                root=root,
+                goal=goal,
+                selected_kits=selected_kits,
+                limit=limit,
+            )
+            result = {
+                "goal": goal,
+                "alignment_score": payload["alignment_score"],
+                "missing_domains": payload["missing_domains"],
+            }
+            if isinstance(params.get("output"), str):
+                target = Path(str(params["output"]))
+                _write_json(target, payload)
+                artifacts.append(target.as_posix())
+            payload = result
+        elif step.action == "kits.expand":
+            goal = str(params.get("goal", "")).strip() or None
+            limit = int(params.get("limit", 3) or 3)
+            selected = params.get("kits") or []
+            selected_kits = [str(item) for item in selected] if isinstance(selected, list) else []
+            expand_result = expand_payload(
+                root=root,
+                goal=goal,
+                selected_kits=selected_kits,
+                limit=limit,
+            )
+            payload = {
+                "goal": goal,
+                "feature_candidates": len(expand_result.get("feature_candidates", [])),
+                "recommended_workers": len(expand_result.get("recommended_workers", [])),
+            }
+            if isinstance(params.get("output"), str):
+                target = Path(str(params["output"]))
+                _write_json(target, expand_result)
                 artifacts.append(target.as_posix())
         elif step.action == "report.build":
             fmt = str(params.get("format", "html"))

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -1530,6 +1530,145 @@ def _search_missions(goal: str | None, feature_candidates: list[Payload]) -> lis
     return missions[:7]
 
 
+def _recommended_workers(
+    goal: str | None, optimize_result: Payload, feature_candidates: list[Payload]
+) -> list[Payload]:
+    goal_text = goal or "umbrella optimization"
+    repo_signals = _payload_dict(optimize_result.get("repo_signals"))
+    candidate_map = {
+        str(item.get("id", "")): item for item in feature_candidates if isinstance(item, dict)
+    }
+    workers: list[Payload] = []
+
+    if "dependency-radar-dashboard" in candidate_map:
+        workers.append(
+            {
+                "id": "worker-dependency-radar",
+                "role": "upgrade-scout",
+                "focus": "Turn dependency heat into a recurring maintenance watchlist.",
+                "template": "repo-expansion-control",
+                "outputs": [
+                    ".sdetkit/agent/template-runs/repo-expansion-control/expand.json",
+                    ".sdetkit/agent/template-runs/repo-expansion-control/bundle.tar",
+                ],
+                "commands": [
+                    "python -m sdetkit kits radar --repo-usage-tier hot-path --format json",
+                    "python -m sdetkit intelligence upgrade-audit --format json --top 10",
+                ],
+            }
+        )
+
+    if "validation-route-map" in candidate_map:
+        workers.append(
+            {
+                "id": "worker-validation-route",
+                "role": "refactor-router",
+                "focus": "Map refactors and upgrades to the smallest safe proof loop.",
+                "template": "repo-expansion-control",
+                "outputs": [
+                    ".sdetkit/agent/template-runs/repo-expansion-control/expand.json",
+                    ".sdetkit/agent/template-runs/repo-expansion-control/plan.md",
+                ],
+                "commands": [
+                    "python -m sdetkit kits route-map httpx --repo-usage-tier hot-path --format json",
+                    "python -m sdetkit doctor --upgrade-audit --format md",
+                ],
+            }
+        )
+
+    if repo_signals.get("docs_site"):
+        workers.append(
+            {
+                "id": "worker-docs-radar",
+                "role": "docs-navigator",
+                "focus": "Keep flagship docs, search posture, and nav coverage aligned as the repo grows.",
+                "template": "docs-search-radar",
+                "outputs": [
+                    ".sdetkit/agent/template-runs/docs-search-radar/mkdocs-build.log",
+                    ".sdetkit/agent/template-runs/docs-search-radar/bundle.tar",
+                ],
+                "commands": [
+                    "python -m mkdocs build --strict",
+                    "python -m sdetkit maintenance --include-check github_automation_check --format md",
+                ],
+            }
+        )
+
+    if repo_signals.get("release_playbook"):
+        workers.append(
+            {
+                "id": "worker-release-radar",
+                "role": "release-guardian",
+                "focus": "Keep release readiness visible before publish windows and docs pushes.",
+                "template": "release-readiness-worker",
+                "outputs": [
+                    ".sdetkit/agent/template-runs/release-readiness-worker/doctor.json",
+                    ".sdetkit/agent/template-runs/release-readiness-worker/bundle.tar",
+                ],
+                "commands": [
+                    "python -m sdetkit doctor --format json",
+                    "python -m sdetkit maintenance --include-check github_automation_check --format json",
+                ],
+            }
+        )
+
+    workers.append(
+        {
+            "id": "worker-optimization-control",
+            "role": "control-plane-operator",
+            "focus": "Join optimize, expand, and dashboard artifacts into one repeatable control loop.",
+            "template": "repo-expansion-control",
+            "outputs": [
+                ".sdetkit/agent/template-runs/repo-expansion-control/optimize.json",
+                ".sdetkit/agent/template-runs/repo-expansion-control/dashboard.html",
+            ],
+            "commands": [
+                f'sdetkit agent run "{goal_text}" --approve',
+                "sdetkit agent dashboard build --format html",
+            ],
+        }
+    )
+
+    return workers[:5]
+
+
+def _worker_launch_pack(
+    goal: str | None, recommended_workers: list[Payload], search_missions: list[Payload]
+) -> list[Payload]:
+    goal_text = goal or "umbrella optimization"
+    mission_map = {
+        str(item.get("topic", "")): str(item.get("query", ""))
+        for item in search_missions
+        if isinstance(item, dict)
+    }
+    pack: list[Payload] = []
+    for worker in recommended_workers:
+        worker_id = str(worker.get("id", ""))
+        template_id = str(worker.get("template", ""))
+        topic = worker_id.removeprefix("worker-").replace("-", " ")
+        search_query = next(
+            (
+                query
+                for key, query in mission_map.items()
+                if key in worker_id or worker_id.endswith(key.replace("_", "-"))
+            ),
+            f"{goal_text} {topic}",
+        )
+        pack.append(
+            {
+                "worker_id": worker_id,
+                "template": template_id,
+                "launch_command": (
+                    f"python -m sdetkit agent templates run {template_id} "
+                    f"--output-dir .sdetkit/agent/template-runs/{template_id}"
+                ),
+                "search_query": search_query,
+                "outputs": _string_list(worker.get("outputs")),
+            }
+        )
+    return pack
+
+
 def expand_payload(
     *,
     root: Path,
@@ -1545,6 +1684,8 @@ def expand_payload(
     )
     feature_candidates = _feature_candidates(goal, optimize_result)
     search_missions = _search_missions(goal, feature_candidates)
+    recommended_workers = _recommended_workers(goal, optimize_result, feature_candidates)
+    worker_launch_pack = _worker_launch_pack(goal, recommended_workers, search_missions)
     rollout_tracks = [
         {
             "track": "now",
@@ -1581,6 +1722,8 @@ def expand_payload(
         "optimize": optimize_result,
         "feature_candidates": feature_candidates,
         "search_missions": search_missions,
+        "recommended_workers": recommended_workers,
+        "worker_launch_pack": worker_launch_pack,
         "rollout_tracks": rollout_tracks,
     }
 
@@ -2210,6 +2353,16 @@ def main(argv: list[str] | None = None) -> int:
         for item in _payload_list(expand_result.get("search_missions")):
             print(f"- {item['topic']}: {item['query']}")
             print(f"  intent: {item['intent']}")
+        print("recommended workers:")
+        for item in _payload_list(expand_result.get("recommended_workers")):
+            print(f"- {item['id']} ({item['role']}): {item['focus']}")
+            print(f"  template: {item['template']}")
+            for command in _string_list(item.get("commands"))[:2]:
+                print(f"  command: {command}")
+        print("worker launch pack:")
+        for item in _payload_list(expand_result.get("worker_launch_pack")):
+            print(f"- {item['worker_id']}: {item['launch_command']}")
+            print(f"  search: {item['search_query']}")
         print("rollout tracks:")
         for item in _payload_list(expand_result.get("rollout_tracks")):
             ids = ", ".join(_string_list(item.get("candidate_ids"))) or "none"

--- a/templates/automations/docs-search-radar.yaml
+++ b/templates/automations/docs-search-radar.yaml
@@ -1,0 +1,21 @@
+metadata:
+  id: docs-search-radar
+  title: Docs Search Radar Worker
+  version: 1.0.0
+  description: Validate docs build/search posture and capture a deterministic worker artifact bundle.
+workflow:
+  - id: mkdocs-build
+    action: shell.run
+    with:
+      cmd: python -m mkdocs build --strict
+      save_stdout: ${{run.output_dir}}/mkdocs-build.log
+  - id: docs-summary
+    action: fs.write
+    with:
+      path: ${{run.output_dir}}/summary.md
+      content: "Docs search radar worker summary: strict MkDocs build log captured for search/navigation review."
+  - id: bundle
+    action: artifacts.bundle
+    with:
+      source_dir: ${{run.output_dir}}
+      output: ${{run.output_dir}}/bundle.tar

--- a/templates/automations/release-readiness-worker.yaml
+++ b/templates/automations/release-readiness-worker.yaml
@@ -1,0 +1,26 @@
+metadata:
+  id: release-readiness-worker
+  title: Release Readiness Worker
+  version: 1.0.0
+  description: Snapshot release readiness signals and package them for recurring release-ops review.
+workflow:
+  - id: doctor
+    action: shell.run
+    with:
+      cmd: python -m sdetkit doctor --format json
+      save_stdout: ${{run.output_dir}}/doctor.json
+  - id: automation-check
+    action: shell.run
+    with:
+      cmd: python -m sdetkit maintenance --include-check github_automation_check --format json
+      save_stdout: ${{run.output_dir}}/automation-check.json
+  - id: release-brief
+    action: fs.write
+    with:
+      path: ${{run.output_dir}}/release-brief.md
+      content: "Release readiness worker summary: generated doctor.json, automation-check.json, and bundle.tar."
+  - id: bundle
+    action: artifacts.bundle
+    with:
+      source_dir: ${{run.output_dir}}
+      output: ${{run.output_dir}}/bundle.tar

--- a/templates/automations/repo-expansion-control.yaml
+++ b/templates/automations/repo-expansion-control.yaml
@@ -1,0 +1,32 @@
+metadata:
+  id: repo-expansion-control
+  title: Repo Expansion Control Worker
+  version: 1.0.0
+  description: Generate optimize/expand worker artifacts and bundle them for recurring control-loop reviews.
+inputs:
+  goal:
+    default: add more bots workers search and repo expansion
+    description: Repo expansion goal statement to analyze.
+workflow:
+  - id: optimize
+    action: kits.optimize
+    with:
+      goal: ${{inputs.goal}}
+      output: ${{run.output_dir}}/optimize.json
+      limit: 4
+  - id: expand
+    action: kits.expand
+    with:
+      goal: ${{inputs.goal}}
+      output: ${{run.output_dir}}/expand.json
+      limit: 4
+  - id: plan-md
+    action: fs.write
+    with:
+      path: ${{run.output_dir}}/plan.md
+      content: "Repo expansion worker plan: goal=${{inputs.goal}}; artifacts=optimize.json, expand.json, bundle.tar"
+  - id: bundle
+    action: artifacts.bundle
+    with:
+      source_dir: ${{run.output_dir}}
+      output: ${{run.output_dir}}/bundle.tar

--- a/tests/test_agent_actions_extra.py
+++ b/tests/test_agent_actions_extra.py
@@ -137,3 +137,52 @@ def test_action_registry_can_write_optimize_artifact(tmp_path: Path) -> None:
     payload = json.loads(artifact.read_text(encoding="utf-8"))
     assert payload["alignment_score"]["status"] in {"strong", "maximized"}
     assert payload["operating_sequence"][0]["stage"] == "doctor-first"
+
+
+def test_action_registry_can_write_expand_artifact(tmp_path: Path) -> None:
+    reg = ActionRegistry(
+        root=tmp_path, write_allowlist=(".sdetkit/agent/workdir",), shell_allowlist=()
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "premium-gate.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "ci.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "constraints-ci.txt").write_text("ruff==0.15.7\n", encoding="utf-8")
+    (tmp_path / "mkdocs.yml").write_text("site_name: demo\n", encoding="utf-8")
+    (tmp_path / "RELEASE.md").write_text("# release\n", encoding="utf-8")
+    (tmp_path / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".github" / "workflows" / "pages.yml").write_text("name: pages\n", encoding="utf-8")
+    (tmp_path / "examples" / "kits" / "integration").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "examples" / "kits" / "integration" / "profile.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "examples" / "kits" / "integration" / "heterogeneous-topology.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "templates" / "automations").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "templates" / "automations" / "repo-health-audit.yaml").write_text(
+        "metadata:\n  id: repo-health-audit\n  title: x\n  version: 1\n  description: x\nworkflow:\n  - action: fs.write\n    with:\n      path: out.txt\n",
+        encoding="utf-8",
+    )
+
+    result = reg.run(
+        "kits.expand",
+        {
+            "goal": "add more bots workers search and repo expansion",
+            "output": ".sdetkit/agent/workdir/umbrella-expand.json",
+        },
+    )
+
+    assert result.ok is True
+    assert result.payload["recommended_workers"] > 0
+    artifact = tmp_path / ".sdetkit" / "agent" / "workdir" / "umbrella-expand.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["recommended_workers"]
+    assert payload["worker_launch_pack"][0]["launch_command"].startswith(
+        "python -m sdetkit agent templates run "
+    )

--- a/tests/test_agent_foundation.py
+++ b/tests/test_agent_foundation.py
@@ -86,6 +86,21 @@ def test_manager_plan_routes_optimize_tasks_to_optimize_action(tmp_path: Path) -
     assert plan[0].params["goal"].startswith("optimize umbrella architecture")
 
 
+def test_manager_plan_routes_expansion_worker_tasks_to_expand_action(tmp_path: Path) -> None:
+    init_agent(tmp_path, tmp_path / ".sdetkit/agent/config.yaml")
+    cfg = load_config(tmp_path / ".sdetkit/agent/config.yaml")
+
+    _message, plan = _manager_plan(
+        task="add more bots workers search and repo expansion",
+        config=cfg,
+        provider=CountingProvider(),
+        worker_ids=["worker-1", "worker-2"],
+    )
+
+    assert plan[0].action == "kits.expand"
+    assert plan[0].params["output"] == ".sdetkit/agent/workdir/umbrella-expand.json"
+
+
 def test_worker_action_execution_success(tmp_path: Path) -> None:
     registry = ActionRegistry(
         root=tmp_path,
@@ -167,6 +182,55 @@ def test_worker_can_write_umbrella_optimize_artifact(tmp_path: Path) -> None:
     payload = json.loads(artifact.read_text(encoding="utf-8"))
     assert payload["alignment_score"]["score"] > 0
     assert payload["doctor_quality_contract"]["entrypoint"].startswith("sdetkit doctor ")
+
+
+def test_worker_can_write_umbrella_expand_artifact(tmp_path: Path) -> None:
+    init_agent(tmp_path, tmp_path / ".sdetkit/agent/config.yaml")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "premium-gate.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "ci.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "constraints-ci.txt").write_text("ruff==0.15.7\n", encoding="utf-8")
+    (tmp_path / "mkdocs.yml").write_text("site_name: demo\n", encoding="utf-8")
+    (tmp_path / "RELEASE.md").write_text("# release\n", encoding="utf-8")
+    (tmp_path / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".github" / "workflows" / "pages.yml").write_text("name: pages\n", encoding="utf-8")
+    (tmp_path / "examples" / "kits" / "integration").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "examples" / "kits" / "integration" / "profile.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "examples" / "kits" / "integration" / "heterogeneous-topology.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "templates" / "automations").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "templates" / "automations" / "repo-health-audit.yaml").write_text(
+        "metadata:\n  id: repo-health-audit\n  title: x\n  version: 1\n  description: x\nworkflow:\n  - action: fs.write\n    with:\n      path: out.txt\n",
+        encoding="utf-8",
+    )
+    registry = ActionRegistry(
+        root=tmp_path,
+        write_allowlist=(".sdetkit/agent/workdir",),
+        shell_allowlist=(),
+    )
+
+    result = registry.run(
+        "kits.expand",
+        {
+            "goal": "add more bots workers search and repo expansion",
+            "output": ".sdetkit/agent/workdir/umbrella-expand.json",
+        },
+    )
+
+    assert result.ok is True
+    artifact = tmp_path / ".sdetkit/agent/workdir/umbrella-expand.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["recommended_workers"]
+    assert payload["worker_launch_pack"]
 
 
 def test_reviewer_rejects_failed_action(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_agent_templates_engine.py
+++ b/tests/test_agent_templates_engine.py
@@ -79,7 +79,7 @@ def test_deterministic_pack_output(tmp_path: Path) -> None:
 def test_template_run_produces_artifacts_for_two_real_templates(tmp_path: Path) -> None:
     repo_root = Path.cwd()
     templates = discover_templates(repo_root)
-    assert len(templates) >= 8
+    assert len(templates) >= 11
 
     audit_template = template_by_id(repo_root, "repo-health-audit")
     audit_out = tmp_path / "audit"
@@ -103,3 +103,33 @@ def test_template_run_produces_artifacts_for_two_real_templates(tmp_path: Path) 
     run_record = json.loads((bundle_out / "run-record.json").read_text(encoding="utf-8"))
     assert run_record["status"] == "ok"
     assert "hash" in run_record
+
+
+def test_template_run_supports_repo_expansion_and_release_workers(tmp_path: Path) -> None:
+    repo_root = Path.cwd()
+
+    expansion_template = template_by_id(repo_root, "repo-expansion-control")
+    expansion_out = tmp_path / "expansion"
+    expansion_record = run_template(
+        repo_root,
+        template=expansion_template,
+        set_values={"goal": "add more bots workers search and repo expansion"},
+        output_dir=expansion_out,
+    )
+    assert expansion_record["status"] == "ok"
+    assert (expansion_out / "optimize.json").exists()
+    assert (expansion_out / "expand.json").exists()
+    assert (expansion_out / "bundle.tar").exists()
+
+    release_template = template_by_id(repo_root, "release-readiness-worker")
+    release_out = tmp_path / "release"
+    release_record = run_template(
+        repo_root,
+        template=release_template,
+        set_values={},
+        output_dir=release_out,
+    )
+    assert release_record["status"] == "ok"
+    assert (release_out / "doctor.json").exists()
+    assert (release_out / "automation-check.json").exists()
+    assert (release_out / "bundle.tar").exists()

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -119,6 +119,8 @@ def test_expand_payload_turns_optimize_signals_into_feature_candidates(tmp_path:
     candidate_ids = {item["id"] for item in payload["feature_candidates"]}
     mission_topics = {item["topic"] for item in payload["search_missions"]}
     track_names = {item["track"] for item in payload["rollout_tracks"]}
+    worker_ids = {item["id"] for item in payload["recommended_workers"]}
+    launch_templates = {item["template"] for item in payload["worker_launch_pack"]}
 
     assert payload["optimize"]["alignment_score"]["status"] in {"strong", "maximized"}
     assert "dependency-radar-dashboard" in candidate_ids
@@ -126,6 +128,9 @@ def test_expand_payload_turns_optimize_signals_into_feature_candidates(tmp_path:
     assert "runtime-watchlist" in candidate_ids
     assert "dependency-radar" in mission_topics
     assert "validation-route-map" in mission_topics
+    assert "worker-optimization-control" in worker_ids
+    assert "repo-expansion-control" in launch_templates
+    assert payload["worker_launch_pack"]
     assert track_names == {"now", "next", "later"}
 
 


### PR DESCRIPTION
### Motivation
- The repo already has strong bot/workflow coverage, but expansion planning often stops at feature/backlog text instead of producing deterministic, runnable workers. 
- Provide a clear path from `kits expand` signals into AgentOS-ready worker roles and launch artifacts so maintainers can execute and iterate on expansion work deterministically. 
- Ship reusable worker templates that encapsulate common control-loop tasks (optimize/expand, docs validation, release readiness) to bootstrap operational runs. 

### Description
- Extend the `kits.expand` payload to include `recommended_workers` and a `worker_launch_pack` so expansion output recommends worker roles and concrete launch commands. 
- Implement `_recommended_workers` and `_worker_launch_pack` helpers and wire them into `expand_payload`, plus print-friendly CLI output for recommended workers and the launch pack. 
- Add AgentOS support for the new flow by: adding a `kits.expand` action to `ActionRegistry`, enabling rule-based manager routing to `kits.expand` in `agent.core`, and allowing templates to run `kits.optimize`/`kits.expand` in `agent.templates`. 
- Add three automation templates under `templates/automations`: `repo-expansion-control`, `docs-search-radar`, and `release-readiness-worker` that produce bundled artifacts and can be run via `sdetkit agent templates run`. 
- Update docs (`README.md`, `docs/automation-bots.md`) to document the worker layer and how to run the new templates, and add tests that cover expand artifacts, worker routing, and the new templates. 

### Testing
- Ran unit tests: `pytest -q tests/test_kits_blueprint.py tests/test_agent_actions_extra.py tests/test_agent_foundation.py tests/test_agent_templates_engine.py` which completed successfully with all tests passing (33 passed). 
- Exercised runtime flows: `python -m sdetkit kits expand --goal 'add more bots workers search and repo expansion' --format json` produced `recommended_workers` and `worker_launch_pack`; `python -m sdetkit agent templates run repo-expansion-control` and `python -m sdetkit agent templates run release-readiness-worker` both executed and produced expected artifacts; `python -m sdetkit maintenance --include-check github_automation_check --format json` returned OK coverage. 
- Added automated assertions in tests verifying artifacts, recommended worker entries, and that agent action handlers write the expand/optimize artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bdd2aac7ac83209284ca755cbe7bea)