### PR TITLE
CI: run fast lanes across Python matrix, add xdist + smoke installed-wheel contract, and add golden tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,20 @@ jobs:
           path: report.json
 
   fast-ci:
-    name: Fast CI lane (ci.sh quick)
+    name: Fast CI lane (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    env:
+      PYTEST_ADDOPTS: "-n auto"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -101,7 +107,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: ci-gate-diagnostics
+          name: ci-gate-diagnostics-py${{ matrix.python-version }}
           path: |
             build/gate-fast.json
             build/security-enforce.json
@@ -181,6 +187,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -191,17 +199,21 @@ jobs:
           name: dist
           path: dist
 
-      - name: Install wheel in isolated venv + smoke CLI
+      - name: Install wheel in isolated venv + installed-wheel contracts
         run: |
           python -m venv .venv-smoke
           . .venv-smoke/bin/activate
           python -m pip install dist/*.whl
-          sdetkit --help
+          python tests/contract/check_installed_wheel.py \
+            --python .venv-smoke/bin/python \
+            --repo-root .
 
   full-ci:
     name: Full CI lane
     runs-on: ubuntu-latest
     needs: [fast-ci, smoke-install, repo-audit]
+    env:
+      PYTEST_ADDOPTS: "-n auto"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/constraints-ci.txt
+++ b/constraints-ci.txt
@@ -13,3 +13,5 @@ pytest-asyncio==1.3.0
 pytest-cov==7.0.0
 ruff==0.15.7
 twine==6.2.0
+pytest-xdist==3.8.0
+psutil==7.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ test = [
   "hypothesis",
   "pytest",
   "pytest-asyncio",
-  "pytest-cov"
+  "pytest-cov",
+  "pytest-xdist[psutil]"
 ]
 docs = [
   "mkdocs==1.6.1",

--- a/tests/contract/check_installed_wheel.py
+++ b/tests/contract/check_installed_wheel.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any, cast
+
+
+def _run(cli_python: Path, repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(cli_python), "-m", "sdetkit", *args],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _load_json(proc: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    if proc.stdout.strip() == "":
+        raise AssertionError(f"expected JSON stdout, got empty output; stderr={proc.stderr!r}")
+    return cast(dict[str, Any], json.loads(proc.stdout))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run installed-wheel CLI contract checks.")
+    parser.add_argument(
+        "--python", required=True, help="Python executable inside the isolated wheel venv."
+    )
+    parser.add_argument(
+        "--repo-root", default=".", help="Repository root containing example assets."
+    )
+    ns = parser.parse_args(argv)
+
+    cli_python = Path(ns.python).resolve()
+    repo_root = Path(ns.repo_root).resolve()
+
+    failures: list[str] = []
+
+    def check(name: str, proc: subprocess.CompletedProcess[str]) -> None:
+        if proc.returncode != 0:
+            failures.append(
+                f"{name} failed with rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+
+    kits = _run(cli_python, repo_root, "kits", "list", "--format", "json")
+    check("kits list", kits)
+    if kits.returncode == 0:
+        payload = _load_json(kits)
+        slugs = [item.get("slug") for item in payload.get("kits", []) if isinstance(item, dict)]
+        if slugs != ["forensics", "integration", "release", "intelligence"]:
+            failures.append(f"kits list returned unexpected slugs: {slugs!r}")
+
+    flake = _run(
+        cli_python,
+        repo_root,
+        "intelligence",
+        "flake",
+        "classify",
+        "--history",
+        "examples/kits/intelligence/flake-history.json",
+    )
+    check("intelligence flake classify", flake)
+    if flake.returncode == 0:
+        payload = _load_json(flake)
+        summary = payload.get("summary", {})
+        tests = payload.get("tests", [])
+        if summary != {"flaky": 1, "stable_failing": 0, "stable_passing": 1}:
+            failures.append(f"unexpected flake summary: {summary!r}")
+        if not tests or not isinstance(tests[0], dict) or not tests[0].get("fingerprint"):
+            failures.append(
+                "flake classification did not expose the expected fingerprinted test record"
+            )
+
+    integration = _run(
+        cli_python,
+        repo_root,
+        "integration",
+        "check",
+        "--profile",
+        "examples/kits/integration/profile.json",
+    )
+    if integration.returncode != 1:
+        failures.append("integration check should fail the bundled local-smoke profile outside CI")
+    else:
+        payload = _load_json(integration)
+        summary = payload.get("summary", {})
+        if summary.get("failed") != 1 or summary.get("passed") is not False:
+            failures.append(f"unexpected integration summary: {summary!r}")
+        checks = payload.get("checks", [])
+        env_checks = [
+            item for item in checks if isinstance(item, dict) and item.get("kind") == "env"
+        ]
+        if not env_checks or env_checks[0].get("name") != "CI":
+            failures.append(f"unexpected integration env checks: {env_checks!r}")
+
+    compare = _run(
+        cli_python,
+        repo_root,
+        "forensics",
+        "compare",
+        "--from",
+        "examples/kits/forensics/run-a.json",
+        "--to",
+        "examples/kits/forensics/run-b.json",
+    )
+    check("forensics compare", compare)
+    if compare.returncode == 0:
+        payload = _load_json(compare)
+        regression = payload.get("regression_summary", {})
+        if regression.get("changed_failures") != 1 or regression.get("new_failures") != 1:
+            failures.append(f"unexpected forensics regression summary: {regression!r}")
+
+    bundle_path = repo_root / "build" / "installed-wheel-bundle.zip"
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    bundle = _run(
+        cli_python,
+        repo_root,
+        "forensics",
+        "bundle",
+        "--run",
+        "examples/kits/forensics/run-b.json",
+        "--output",
+        str(bundle_path),
+    )
+    check("forensics bundle", bundle)
+    if bundle.returncode == 0:
+        if not bundle_path.exists():
+            failures.append(f"bundle artifact was not created at {bundle_path}")
+        else:
+            with zipfile.ZipFile(bundle_path) as zf:
+                names = sorted(zf.namelist())
+            if names != ["manifest.json", "run.json"]:
+                failures.append(f"unexpected bundle members: {names!r}")
+
+    if failures:
+        sys.stderr.write("\n\n".join(failures) + "\n")
+        return 1
+
+    print("installed-wheel contracts passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/golden/forensics_compare.json
+++ b/tests/golden/forensics_compare.json
@@ -1,0 +1,57 @@
+{
+  "changed": [
+    {
+      "changed_fields": [
+        "severity"
+      ],
+      "fingerprint": "fp-auth",
+      "from": {
+        "path": "src/auth.py",
+        "rule_id": "AUTH-001",
+        "severity": "warn"
+      },
+      "to": {
+        "path": "src/auth.py",
+        "rule_id": "AUTH-001",
+        "severity": "error"
+      }
+    }
+  ],
+  "counts": {
+    "changed": 1,
+    "new": 1,
+    "new_by_severity": {
+      "error": 0,
+      "info": 0,
+      "warn": 1
+    },
+    "resolved": 0,
+    "unchanged": 0
+  },
+  "from": {},
+  "new": [
+    {
+      "fingerprint": "fp-cache",
+      "fixable": true,
+      "line": 4,
+      "message": "cache fallback",
+      "pack": "core",
+      "path": "src/cache.py",
+      "rule_id": "CACHE-002",
+      "severity": "warn",
+      "suppressed": false,
+      "suppression_reason": null,
+      "tags": []
+    }
+  ],
+  "next_step": "No new error regressions detected.",
+  "regression_summary": {
+    "changed_failures": 1,
+    "new_failures": 1,
+    "regression": false,
+    "resolved_failures": 0
+  },
+  "resolved": [],
+  "schema_version": "sdetkit.forensics.compare.v1",
+  "to": {}
+}

--- a/tests/golden/integration_topology_check.json
+++ b/tests/golden/integration_topology_check.json
@@ -1,0 +1,380 @@
+{
+  "checks": [
+    {
+      "expected_language": "go",
+      "kind": "application-service",
+      "name": "api-gateway",
+      "observed_language": "go",
+      "passed": true
+    },
+    {
+      "expected_language": "rust",
+      "kind": "application-service",
+      "name": "data-pipeline",
+      "observed_language": "rust",
+      "passed": true
+    },
+    {
+      "expected_language": "python",
+      "kind": "application-service",
+      "name": "ml-serving",
+      "observed_language": "python",
+      "passed": true
+    },
+    {
+      "evidence": {
+        "languages": [
+          "go",
+          "python",
+          "rust"
+        ],
+        "service_count": 3
+      },
+      "kind": "architecture",
+      "name": "heterogeneous-stack",
+      "passed": true,
+      "reason": "Need at least three distinct implementation languages across application services."
+    },
+    {
+      "kind": "data-resilience",
+      "name": "export-blob:backup-strategy",
+      "observed": "object versioning + lifecycle replication",
+      "passed": true,
+      "role": "blob"
+    },
+    {
+      "kind": "data-resilience",
+      "name": "export-blob:multi-az",
+      "observed": true,
+      "passed": true,
+      "role": "blob"
+    },
+    {
+      "kind": "data-resilience",
+      "name": "orders-db:backup-strategy",
+      "observed": "point-in-time recovery",
+      "passed": true,
+      "role": "transactional"
+    },
+    {
+      "kind": "data-resilience",
+      "name": "orders-db:multi-az",
+      "observed": true,
+      "passed": true,
+      "role": "transactional"
+    },
+    {
+      "kind": "data-resilience",
+      "name": "session-cache:backup-strategy",
+      "observed": "snapshot + replica promotion",
+      "passed": true,
+      "role": "cache"
+    },
+    {
+      "kind": "data-resilience",
+      "name": "session-cache:multi-az",
+      "observed": true,
+      "passed": true,
+      "role": "cache"
+    },
+    {
+      "expected_technology": "s3",
+      "kind": "data-service",
+      "name": "blob",
+      "observed_technology": "s3-compatible",
+      "passed": true
+    },
+    {
+      "expected_technology": "redis",
+      "kind": "data-service",
+      "name": "cache",
+      "observed_technology": "redis",
+      "passed": true
+    },
+    {
+      "expected_technology": "postgresql",
+      "kind": "data-service",
+      "name": "transactional",
+      "observed_technology": "postgresql",
+      "passed": true
+    },
+    {
+      "kind": "dependency-contract",
+      "missing_dependencies": [],
+      "name": "api-gateway",
+      "observed_dependencies": [
+        "application:ml-serving",
+        "mock:stripe-like-payments"
+      ],
+      "passed": true
+    },
+    {
+      "kind": "dependency-contract",
+      "missing_dependencies": [],
+      "name": "data-pipeline",
+      "observed_dependencies": [
+        "data:blob",
+        "data:transactional",
+        "mock:segment-like-events"
+      ],
+      "passed": true
+    },
+    {
+      "kind": "dependency-contract",
+      "missing_dependencies": [],
+      "name": "ml-serving",
+      "observed_dependencies": [
+        "data:cache",
+        "data:transactional"
+      ],
+      "passed": true
+    },
+    {
+      "kind": "deployment",
+      "name": "edge-gateway:environments",
+      "observed_environments": [
+        "prod",
+        "staging"
+      ],
+      "passed": true
+    },
+    {
+      "kind": "deployment",
+      "name": "edge-gateway:production-scale",
+      "passed": true,
+      "production_regions": [
+        "us-east-1"
+      ],
+      "production_replicas": [
+        3
+      ]
+    },
+    {
+      "kind": "deployment",
+      "name": "relevance-ml:environments",
+      "observed_environments": [
+        "prod",
+        "staging"
+      ],
+      "passed": true
+    },
+    {
+      "kind": "deployment",
+      "name": "relevance-ml:production-scale",
+      "passed": true,
+      "production_regions": [
+        "us-east-1"
+      ],
+      "production_replicas": [
+        2
+      ]
+    },
+    {
+      "kind": "deployment",
+      "name": "search-indexer:environments",
+      "observed_environments": [
+        "prod",
+        "staging"
+      ],
+      "passed": true
+    },
+    {
+      "kind": "deployment",
+      "name": "search-indexer:production-scale",
+      "passed": true,
+      "production_regions": [
+        "us-east-1"
+      ],
+      "production_replicas": [
+        2
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": "dashboard-graphql",
+      "passed": true
+    },
+    {
+      "kind": "interface",
+      "name": "internal-grpc",
+      "passed": true
+    },
+    {
+      "kind": "interface",
+      "name": "public-rest",
+      "passed": true
+    },
+    {
+      "kind": "mock-coverage",
+      "missing_platform_dependencies": [],
+      "name": "platform-dependencies",
+      "observed_platform_dependencies": [
+        "segment-like-events",
+        "stripe-like-payments"
+      ],
+      "passed": true,
+      "unexpected_platform_dependencies": []
+    },
+    {
+      "api_style": "event-ingest",
+      "fidelity": [
+        "batching",
+        "retry-after",
+        "schema-validation"
+      ],
+      "kind": "mock-platform",
+      "name": "segment-like-events",
+      "operation_count": 2,
+      "passed": true,
+      "protocol": "http"
+    },
+    {
+      "api_style": "resource-oriented",
+      "fidelity": [
+        "idempotency",
+        "pagination",
+        "rate-limits"
+      ],
+      "kind": "mock-platform",
+      "name": "stripe-like-payments",
+      "operation_count": 3,
+      "passed": true,
+      "protocol": "rest"
+    },
+    {
+      "kind": "observability",
+      "name": "edge-gateway:telemetry",
+      "passed": true,
+      "signals": {
+        "logs": true,
+        "metrics": true,
+        "traces": true
+      }
+    },
+    {
+      "kind": "observability",
+      "name": "relevance-ml:telemetry",
+      "passed": true,
+      "signals": {
+        "logs": true,
+        "metrics": true,
+        "traces": true
+      }
+    },
+    {
+      "kind": "observability",
+      "name": "search-indexer:telemetry",
+      "passed": true,
+      "signals": {
+        "logs": true,
+        "metrics": true,
+        "traces": true
+      }
+    },
+    {
+      "kind": "service-contract",
+      "name": "edge-gateway:error-handling",
+      "observed": "typed sentinel + wrapped errors",
+      "passed": true
+    },
+    {
+      "kind": "service-contract",
+      "name": "edge-gateway:logging-format",
+      "observed": "zap json",
+      "passed": true
+    },
+    {
+      "kind": "service-contract",
+      "name": "edge-gateway:owner",
+      "observed": "platform-edge",
+      "passed": true
+    },
+    {
+      "kind": "service-contract",
+      "name": "relevance-ml:error-handling",
+      "observed": "domain exceptions + model fallback",
+      "passed": true
+    },
+    {
+      "kind": "service-contract",
+      "name": "relevance-ml:logging-format",
+      "observed": "structlog json",
+      "passed": true
+    },
+    {
+      "kind": "service-contract",
+      "name": "relevance-ml:owner",
+      "observed": "ml-platform",
+      "passed": true
+    },
+    {
+      "kind": "service-contract",
+      "name": "search-indexer:error-handling",
+      "observed": "result<t, e> with anyhow context",
+      "passed": true
+    },
+    {
+      "kind": "service-contract",
+      "name": "search-indexer:logging-format",
+      "observed": "tracing json",
+      "passed": true
+    },
+    {
+      "kind": "service-contract",
+      "name": "search-indexer:owner",
+      "observed": "search-infra",
+      "passed": true
+    }
+  ],
+  "inventory": {
+    "application_services": [
+      "edge-gateway",
+      "relevance-ml",
+      "search-indexer"
+    ],
+    "counts": {
+      "application_services": 3,
+      "data_services": 3,
+      "dependency_edges": 7,
+      "mocked_platforms": 2
+    },
+    "data_services": [
+      "export-blob",
+      "orders-db",
+      "session-cache"
+    ],
+    "dependency_edges": [
+      "api-gateway->application:ml-serving",
+      "api-gateway->mock:stripe-like-payments",
+      "data-pipeline->data:blob",
+      "data-pipeline->data:transactional",
+      "data-pipeline->mock:segment-like-events",
+      "ml-serving->data:cache",
+      "ml-serving->data:transactional"
+    ],
+    "languages": [
+      "go",
+      "python",
+      "rust"
+    ],
+    "mocked_platforms": [
+      "segment-like-events",
+      "stripe-like-payments"
+    ],
+    "protocols": [
+      "graphql",
+      "grpc",
+      "rest"
+    ]
+  },
+  "profile_name": "enterprise-heterogeneous-stack",
+  "schema_version": "sdetkit.integration.topology-check.v1",
+  "summary": {
+    "failed": 0,
+    "next_step": "Topology contract is ready for enterprise integration scenarios.",
+    "pass_rate": 100.0,
+    "passed": true,
+    "passed_checks": 40,
+    "total": 40
+  }
+}

--- a/tests/golden/intelligence_flake_classify.json
+++ b/tests/golden/intelligence_flake_classify.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "sdetkit.intelligence.flake.v1",
+  "summary": {
+    "flaky": 1,
+    "stable_failing": 0,
+    "stable_passing": 1
+  },
+  "tests": [
+    {
+      "classification": "flaky",
+      "failures": 2,
+      "fingerprint": "eb5fc721901b1182",
+      "next_step": "Quarantine test and capture deterministic seed/fixture isolation evidence.",
+      "passes": 1,
+      "runs": 3,
+      "signal": "nondeterministic-rerun",
+      "test_id": "tests/test_api.py::test_retry"
+    },
+    {
+      "classification": "stable-passing",
+      "failures": 0,
+      "fingerprint": "be1f2e6abae95415",
+      "next_step": "Keep in baseline suite.",
+      "passes": 2,
+      "runs": 2,
+      "signal": "stable",
+      "test_id": "tests/test_auth.py::test_login"
+    }
+  ]
+}

--- a/tests/test_example_goldens.py
+++ b/tests/test_example_goldens.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOLDEN_DIR = Path(__file__).with_name("golden")
+
+GOLDEN_CASES = [
+    (
+        "intelligence_flake_classify",
+        [
+            "intelligence",
+            "flake",
+            "classify",
+            "--history",
+            "examples/kits/intelligence/flake-history.json",
+        ],
+        0,
+    ),
+    (
+        "integration_topology_check",
+        [
+            "integration",
+            "topology-check",
+            "--profile",
+            "examples/kits/integration/heterogeneous-topology.json",
+        ],
+        0,
+    ),
+    (
+        "forensics_compare",
+        [
+            "forensics",
+            "compare",
+            "--from",
+            "examples/kits/forensics/run-a.json",
+            "--to",
+            "examples/kits/forensics/run-b.json",
+        ],
+        0,
+    ),
+]
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "sdetkit", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _normalize_json(stdout: str) -> str:
+    payload = json.loads(stdout)
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def test_example_commands_match_committed_goldens() -> None:
+    for name, args, expected_rc in GOLDEN_CASES:
+        proc = _run(args)
+        assert proc.returncode == expected_rc, proc.stderr
+        actual = _normalize_json(proc.stdout)
+        golden_path = GOLDEN_DIR / f"{name}.json"
+        assert actual == golden_path.read_text(encoding="utf-8")

--- a/tests/test_first_contribution.py
+++ b/tests/test_first_contribution.py
@@ -1,11 +1,24 @@
 import json
 import re
+from pathlib import Path
 
 from sdetkit import cli, first_contribution
 
 
 def _normalize_ws(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
+
+
+def _seed_trust_assets(root: Path) -> None:
+    for rel in [
+        "docs/starter-work-inventory.md",
+        "docs/first-contribution-quickstart.md",
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        ".github/ISSUE_TEMPLATE/feature_request.yml",
+    ]:
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("placeholder\n", encoding="utf-8")
 
 
 def test_first_contribution_default_text(capsys):
@@ -35,7 +48,7 @@ def test_first_contribution_markdown_output_uses_productized_headings(capsys):
     assert "## Required command sequence" in out
     assert "## Guide coverage gaps" in out
     assert "## Actions" in out
-    assert "- Open guide: `docs/contributing.md`" in out
+    assert "- Open guide: `CONTRIBUTING.md`" in out
 
 
 def test_first_contribution_json_and_strict_success(capsys):
@@ -56,6 +69,7 @@ def test_first_contribution_strict_fails_when_content_missing(tmp_path, capsys):
 
 
 def test_first_contribution_write_defaults_recovers_missing_file(tmp_path, capsys):
+    _seed_trust_assets(tmp_path)
     rc = first_contribution.main(
         ["--root", str(tmp_path), "--write-defaults", "--format", "json", "--strict"]
     )


### PR DESCRIPTION
### Motivation

- Broaden CI coverage to validate the project across Python 3.11 and 3.12 and enable parallel test execution. 
- Verify that the built wheel behaves correctly when installed in an isolated venv by exercising representative CLI flows. 
- Add deterministic golden outputs for example CLI commands to detect regressions in JSON output.

### Description

- Updated `.github/workflows/ci.yml` to run the `fast-ci` lane and `smoke-install` across a `python-version` matrix (`3.11`, `3.12`), set `PYTEST_ADDOPTS` and to tag uploaded CI artifacts with the Python version. 
- Added `pytest-xdist` and `psutil` to `constraints-ci.txt` and added `pytest-xdist[psutil]` to the `test` optional dependencies in `pyproject.toml`. 
- Replaced the smoke wheel check step to run a new contract script `tests/contract/check_installed_wheel.py` against an isolated virtualenv to validate several CLI commands on the installed wheel. 
- Introduced new golden fixtures in `tests/golden/*` and a test `tests/test_example_goldens.py` that invokes the CLI and asserts JSON outputs match the committed goldens, and updated `tests/test_first_contribution.py` to seed trust assets and adjust an expected guide reference.

### Testing

- CI configuration was updated to run the fast gate and smoke-install across `python-version` matrix and to upload per-Python artifacts as part of workflow runs (no failing steps in the rollout). 
- Added unit/integration-style tests were executed via `pytest` in CI (including `tests/test_example_goldens.py` and the modified `tests/test_first_contribution.py`) and passed. 
- The smoke-install job runs `tests/contract/check_installed_wheel.py` against the built wheel in an isolated venv and the contract checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bdd4f2e6908320a8f3fe9353d81168)