### PR TITLE
Add aligned worker automation radar

### DIFF
--- a/.github/workflows/worker-alignment-bot.yml
+++ b/.github/workflows/worker-alignment-bot.yml
@@ -1,0 +1,152 @@
+name: Worker Alignment Bot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "45 7 * * 1"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  worker-alignment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-test.txt
+            requirements-docs.txt
+            constraints-ci.txt
+
+      - name: Install repo
+        run: python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
+
+      - name: Run aligned worker templates
+        run: |
+          set -euo pipefail
+          mkdir -p build .sdetkit/agent/template-runs
+          python -m sdetkit agent templates run dependency-radar-worker --output-dir .sdetkit/agent/template-runs/dependency-radar-worker > build/dependency-radar-worker-run.json
+          python -m sdetkit agent templates run docs-search-radar --output-dir .sdetkit/agent/template-runs/docs-search-radar > build/docs-search-radar-run.json
+          python -m sdetkit agent templates run release-readiness-worker --output-dir .sdetkit/agent/template-runs/release-readiness-worker > build/release-readiness-worker-run.json
+          python -m sdetkit agent templates run worker-alignment-radar --output-dir .sdetkit/agent/template-runs/worker-alignment-radar > build/worker-alignment-radar-run.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          build = Path("build")
+          runs = {
+              "dependency-radar-worker": json.loads((build / "dependency-radar-worker-run.json").read_text(encoding="utf-8")),
+              "docs-search-radar": json.loads((build / "docs-search-radar-run.json").read_text(encoding="utf-8")),
+              "release-readiness-worker": json.loads((build / "release-readiness-worker-run.json").read_text(encoding="utf-8")),
+              "worker-alignment-radar": json.loads((build / "worker-alignment-radar-run.json").read_text(encoding="utf-8")),
+          }
+
+          lines = [
+              "# Worker alignment radar",
+              "",
+              "This issue is auto-generated from the repo's aligned worker templates so dependency, docs, release, and expansion lanes stay in sync.",
+              "",
+              "## Worker run status",
+          ]
+
+          for worker_id, payload in runs.items():
+              artifacts = payload.get("artifacts", [])
+              lines.append(
+                  f"- **{worker_id}** · status `{payload.get('status', 'unknown')}` · artifacts `{len(artifacts)}`"
+              )
+              if artifacts:
+                  lines.append(f"  - First artifact: `{artifacts[0]}`")
+
+          lines.extend(
+              [
+                  "",
+                  "## Follow-up prompts",
+                  "- [ ] Review dependency-radar-worker outputs before large upgrade or refactor batches.",
+                  "- [ ] Use docs-search-radar and release-readiness-worker outputs before docs or release pushes.",
+                  "- [ ] Use worker-alignment-radar outputs to keep recommended workers matched to the repo's active automation surface.",
+                  "",
+                  "## Artifacts",
+                  "- `build/dependency-radar-worker-run.json`",
+                  "- `build/docs-search-radar-run.json`",
+                  "- `build/release-readiness-worker-run.json`",
+                  "- `build/worker-alignment-radar-run.json`",
+              ]
+          )
+
+          (build / "worker-alignment-radar.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload worker-alignment artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: worker-alignment-radar
+          path: |
+            build/dependency-radar-worker-run.json
+            build/docs-search-radar-run.json
+            build/release-readiness-worker-run.json
+            build/worker-alignment-radar-run.json
+            build/worker-alignment-radar.md
+            .sdetkit/agent/template-runs/dependency-radar-worker
+            .sdetkit/agent/template-runs/docs-search-radar
+            .sdetkit/agent/template-runs/release-readiness-worker
+            .sdetkit/agent/template-runs/worker-alignment-radar
+
+      - name: Create or update worker alignment issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const weekOf = new Date().toISOString().slice(0, 10);
+            const title = `🤖 Worker alignment radar (${weekOf})`;
+            const body = fs.readFileSync('build/worker-alignment-radar.md', 'utf8');
+            const labels = [
+              { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
+              { name: 'automation', color: '5319e7', description: 'Automation and worker alignment' },
+              { name: 'priority:medium', color: 'fbca04', description: 'Medium-priority work item' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+              } catch {
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              }
+            }
+
+            const openIssues = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'automation',
+              per_page: 100,
+            });
+            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('🤖 Worker alignment radar'));
+
+            for (const oldIssue of priorIssues) {
+              if (oldIssue.title !== title) {
+                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
+              }
+            }
+
+            const existing = priorIssues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['maintenance', 'automation', 'priority:medium'],
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ python -m sdetkit kits optimize --goal "upgrade umbrella architecture with agent
 python -m sdetkit kits expand --goal "upgrade umbrella architecture with agentos optimization"
 python -m sdetkit kits radar --repo-usage-tier hot-path --format json
 python -m sdetkit kits route-map httpx --repo-usage-tier hot-path --format json
+python -m sdetkit agent templates run dependency-radar-worker
+python -m sdetkit agent templates run validation-route-worker --set query=httpx
+python -m sdetkit agent templates run worker-alignment-radar
 python -m sdetkit intelligence upgrade-audit --format json --top 5
 python -m sdetkit maintenance --include-check github_automation_check --format md
 ```
@@ -173,19 +176,25 @@ The security auto-remediation lane is stronger too: premium gate can now priorit
 
 The GitHub-native maintenance layer is stronger too: beyond the existing GHAS digest, campaign planner, and configuration audit bots, the repo now carries a weekly **GHAS alert SLA tracker** for 7/14/30-day backlog enforcement, a weekly **GHAS metrics export bot** that publishes reusable JSON evidence for dashboards, audits, and roadmap reviews, a weekly **secret protection review bot** for push protection / delegated bypass / validity-check posture, a weekly **repo optimization control-loop bot** that turns `kits optimize`, `kits expand`, and automation coverage into actionable backlog slices, a weekly **docs experience radar bot** that keeps flagship docs, navigation, and search discoverability healthy, and a weekly **release readiness radar bot** that keeps doctor output, release assets, and publishing workflows visible in one operating lane.
 
-The worker layer is stronger too: `sdetkit kits expand --goal "..." --format json` now recommends **worker roles** plus a **worker launch pack** so teams can turn expansion ideas into deterministic AgentOS runs instead of leaving them as backlog text. The repo also ships three aligned worker templates out of the box:
+The worker layer is stronger too: `sdetkit kits expand --goal "..." --format json` now recommends **worker roles** plus a **worker launch pack** so teams can turn expansion ideas into deterministic AgentOS runs instead of leaving them as backlog text. The repo also ships multiple aligned worker templates out of the box:
 
 - `repo-expansion-control` for optimize/expand control-loop artifacts,
+- `dependency-radar-worker` for upgrade inventory, hotspot radar, and validation-route evidence,
+- `validation-route-worker` for refactor-safe route mapping tied to doctor upgrade guidance,
 - `docs-search-radar` for strict docs/search validation with bundled evidence,
 - `release-readiness-worker` for doctor + automation-readiness snapshots before publish windows.
+- `worker-alignment-radar` for keeping the worker pack aligned with automation inventory and expansion signals.
 
 You can run them directly with:
 
 ```bash
 python -m sdetkit kits expand --goal "add more bots workers search and repo expansion" --format json
 python -m sdetkit agent templates run repo-expansion-control
+python -m sdetkit agent templates run dependency-radar-worker
+python -m sdetkit agent templates run validation-route-worker --set query=httpx
 python -m sdetkit agent templates run docs-search-radar
 python -m sdetkit agent templates run release-readiness-worker
+python -m sdetkit agent templates run worker-alignment-radar
 ```
 
 To make those upgrade lanes reproducible in CI, the repo now pins the validated toolchain in `constraints-ci.txt` while leaving `pyproject.toml` flexible enough for package consumers.

--- a/docs/automation-bots.md
+++ b/docs/automation-bots.md
@@ -24,15 +24,21 @@ The bots turn those same maintenance signals into a recurring GitHub-native oper
 In addition to scheduled GitHub bots, the repo now ships **AgentOS worker templates** that let maintainers run the same expansion/review loops on demand and keep the outputs deterministic:
 
 - **`repo-expansion-control`** — runs `kits optimize` + `kits expand`, writes JSON artifacts, and bundles them for roadmap / dashboard follow-up.
+- **`dependency-radar-worker`** — captures an offline-safe upgrade inventory, radar snapshot, and validation route map for refactor / dependency review.
+- **`validation-route-worker`** — turns a package or domain query into a route map plus doctor-linked upgrade guidance.
 - **`docs-search-radar`** — runs a strict MkDocs build, captures the build log, and bundles docs-search evidence for later review.
 - **`release-readiness-worker`** — snapshots `doctor` plus `github_automation_check` so release-readiness follow-up can happen outside of a publish crunch.
+- **`worker-alignment-radar`** — keeps expansion recommendations, automation coverage, and template inventory aligned with the repo's active worker surface.
 
 Recommended local launches:
 
 ```bash
 python -m sdetkit agent templates run repo-expansion-control
+python -m sdetkit agent templates run dependency-radar-worker
+python -m sdetkit agent templates run validation-route-worker --set query=httpx
 python -m sdetkit agent templates run docs-search-radar
 python -m sdetkit agent templates run release-readiness-worker
+python -m sdetkit agent templates run worker-alignment-radar
 python -m sdetkit kits expand --goal "add more bots workers search and repo expansion" --format json
 ```
 
@@ -61,6 +67,7 @@ python -m sdetkit kits expand --goal "add more bots workers search and repo expa
 - **`workflow-governance-bot.yml`** — publishes a monthly workflow-governance audit for permissions, SHA pinning, and manual recovery posture.
 - **`docs-experience-bot.yml`** — publishes a weekly docs-experience radar issue plus JSON artifact covering navigation coverage, search posture, and flagship-doc visibility.
 - **`release-readiness-radar-bot.yml`** — publishes a weekly release-readiness radar issue with doctor output, release asset freshness, and release-workflow coverage.
+- **`worker-alignment-bot.yml`** — runs the aligned worker templates together and publishes a weekly worker/radar issue with deterministic artifact links.
 - **`contributor-onboarding-bot.yml`** — keeps contributor guidance discoverable.
 - **`pr-helper-bot.yml` / `pr-quality-comment.yml`** — keep pull requests reviewable and actionable.
 
@@ -211,6 +218,17 @@ It now:
 - opens a date-scoped `🚀 Release readiness radar (...)` issue,
 - uploads `build/release-readiness-radar.json` plus the raw doctor/maintenance payloads as workflow artifacts.
 
+### `worker-alignment-bot.yml`
+
+This bot turns the worker layer into a first-class operating lane instead of leaving the templates as individual commands maintainers have to remember.
+
+It now:
+
+- runs `dependency-radar-worker`, `docs-search-radar`, `release-readiness-worker`, and `worker-alignment-radar` on a weekly cadence,
+- uploads both the per-worker run records and the template output directories as reusable artifacts,
+- opens a date-scoped `🤖 Worker alignment radar (...)` issue,
+- keeps the worker surface aligned with dependency, docs, release, and automation-review loops.
+
 ## Recommended weekly maintainer flow
 
 1. Open the latest **GHAS digest** issue.
@@ -224,8 +242,9 @@ It now:
 9. Open the latest **repo optimization control loop** issue and pick one `now` candidate or search mission.
 10. Open the latest **docs experience radar** issue and fold the highest-value orphan docs or missing flagship links back into the canonical journeys.
 11. Open the latest **release readiness radar** issue before a publish window or docs release push.
-12. Review the monthly **workflow governance audit** issue and close any pinning/permissions drift.
-13. Record implementation follow-up in `docs/roadmap.md` and the weekly maintenance issue.
+12. Open the latest **worker alignment radar** issue and refresh any stale worker/template lanes before they drift from the base automation surface.
+13. Review the monthly **workflow governance audit** issue and close any pinning/permissions drift.
+14. Record implementation follow-up in `docs/roadmap.md` and the weekly maintenance issue.
 
 ## Optional local dry runs
 
@@ -238,6 +257,8 @@ python -m sdetkit kits optimize --goal "add more helpful automation bots and Git
 python -m sdetkit kits expand --goal "add more helpful automation bots and GitHub Advanced Security coverage" --format json
 python -m sdetkit maintenance --include-check github_automation_check --format md
 python -m sdetkit maintenance --include-check github_automation_check --format json | jq '.checks.github_automation_check.details.ghas_update_tracks'
+python -m sdetkit agent templates run dependency-radar-worker
+python -m sdetkit agent templates run worker-alignment-radar
 ```
 
 ## What this unlocks for the repo
@@ -254,6 +275,7 @@ These bots make the repo more than a set of commands; they turn it into a contin
 - **scheduled dependency prioritization**,
 - **a docs information-architecture control loop instead of ad hoc nav cleanup**,
 - **a recurring release-ops radar for trust-asset and workflow freshness**,
+- **a worker-alignment control loop that keeps template automation synchronized with the repo's strongest maintenance lanes**,
 - **clearer issue-driven follow-up**,
 - **smaller validation loops for upgrades and refactors**,
 - **less hidden drift between security posture and maintenance work**.

--- a/docs/automation-templates-engine.md
+++ b/docs/automation-templates-engine.md
@@ -54,3 +54,9 @@ Use `sdetkit agent templates pack` to create a deterministic tar archive of temp
 - `precommit-style-checks`
 - `dependency-outdated-report`
 - `ci-artifact-bundle`
+- `dependency-radar-worker`
+- `validation-route-worker`
+- `worker-alignment-radar`
+- `docs-search-radar`
+- `release-readiness-worker`
+- `repo-expansion-control`

--- a/docs/kits/expansion-lab.md
+++ b/docs/kits/expansion-lab.md
@@ -37,6 +37,8 @@ The validation route map is now available directly via `sdetkit kits route-map`,
 python -m sdetkit kits expand --goal "upgrade umbrella architecture with agentos optimization"
 python -m sdetkit kits radar --repo-usage-tier hot-path --format json
 python -m sdetkit kits route-map --impact-area runtime-core --limit 5
+python -m sdetkit agent templates run dependency-radar-worker
+python -m sdetkit agent templates run worker-alignment-radar
 ```
 
 ## How to use it well

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -1546,10 +1546,12 @@ def _recommended_workers(
                 "id": "worker-dependency-radar",
                 "role": "upgrade-scout",
                 "focus": "Turn dependency heat into a recurring maintenance watchlist.",
-                "template": "repo-expansion-control",
+                "template": "dependency-radar-worker",
                 "outputs": [
-                    ".sdetkit/agent/template-runs/repo-expansion-control/expand.json",
-                    ".sdetkit/agent/template-runs/repo-expansion-control/bundle.tar",
+                    ".sdetkit/agent/template-runs/dependency-radar-worker/dependency-radar.json",
+                    ".sdetkit/agent/template-runs/dependency-radar-worker/radar.json",
+                    ".sdetkit/agent/template-runs/dependency-radar-worker/route-map.json",
+                    ".sdetkit/agent/template-runs/dependency-radar-worker/bundle.tar",
                 ],
                 "commands": [
                     "python -m sdetkit kits radar --repo-usage-tier hot-path --format json",
@@ -1564,10 +1566,11 @@ def _recommended_workers(
                 "id": "worker-validation-route",
                 "role": "refactor-router",
                 "focus": "Map refactors and upgrades to the smallest safe proof loop.",
-                "template": "repo-expansion-control",
+                "template": "validation-route-worker",
                 "outputs": [
-                    ".sdetkit/agent/template-runs/repo-expansion-control/expand.json",
-                    ".sdetkit/agent/template-runs/repo-expansion-control/plan.md",
+                    ".sdetkit/agent/template-runs/validation-route-worker/route-map.json",
+                    ".sdetkit/agent/template-runs/validation-route-worker/doctor-upgrade-audit.md",
+                    ".sdetkit/agent/template-runs/validation-route-worker/bundle.tar",
                 ],
                 "commands": [
                     "python -m sdetkit kits route-map httpx --repo-usage-tier hot-path --format json",
@@ -1614,6 +1617,26 @@ def _recommended_workers(
 
     workers.append(
         {
+            "id": "worker-automation-alignment",
+            "role": "worker-orchestrator",
+            "focus": "Keep worker packs, automation inventory, and expansion recommendations aligned.",
+            "template": "worker-alignment-radar",
+            "outputs": [
+                ".sdetkit/agent/template-runs/worker-alignment-radar/expand.json",
+                ".sdetkit/agent/template-runs/worker-alignment-radar/automation-check.json",
+                ".sdetkit/agent/template-runs/worker-alignment-radar/templates.json",
+                ".sdetkit/agent/template-runs/worker-alignment-radar/bundle.tar",
+            ],
+            "commands": [
+                f'python -m sdetkit kits expand --goal "{goal_text}" --format json',
+                "python -m sdetkit maintenance --include-check github_automation_check --format json",
+                "python -m sdetkit agent templates list",
+            ],
+        }
+    )
+
+    workers.append(
+        {
             "id": "worker-optimization-control",
             "role": "control-plane-operator",
             "focus": "Join optimize, expand, and dashboard artifacts into one repeatable control loop.",
@@ -1629,7 +1652,7 @@ def _recommended_workers(
         }
     )
 
-    return workers[:5]
+    return workers[:6]
 
 
 def _worker_launch_pack(

--- a/src/sdetkit/maintenance/checks/github_automation_check.py
+++ b/src/sdetkit/maintenance/checks/github_automation_check.py
@@ -39,6 +39,7 @@ _WORKFLOW_GROUPS: dict[str, dict[str, tuple[str, bool]]] = {
     "expansion_bots": {
         "docs-experience-bot.yml": ("Docs experience radar bot", True),
         "release-readiness-radar-bot.yml": ("Release readiness radar bot", True),
+        "worker-alignment-bot.yml": ("Worker alignment bot", True),
     },
     "collaboration_bots": {
         "pr-helper-bot.yml": ("PR helper bot", False),
@@ -164,6 +165,15 @@ _EXPANSION_UPDATE_TRACKS: list[dict[str, str]] = [
             "freshness checks for roadmap, changelog, and release playbook assets."
         ),
         "workflow": "release-readiness-radar-bot.yml",
+    },
+    {
+        "id": "worker_alignment",
+        "title": "Worker alignment radar",
+        "description": (
+            "Run the aligned worker templates together so expansion guidance, dependency review, "
+            "docs posture, and release readiness stay synchronized with the repo's base code."
+        ),
+        "workflow": "worker-alignment-bot.yml",
     },
 ]
 

--- a/templates/automations/dependency-radar-worker.yaml
+++ b/templates/automations/dependency-radar-worker.yaml
@@ -1,0 +1,31 @@
+metadata:
+  id: dependency-radar-worker
+  title: Dependency Radar Worker
+  version: 1.0.0
+  description: Capture upgrade inventory, dependency radar, and validation routes as a deterministic worker bundle.
+workflow:
+  - id: dependency-audit
+    action: shell.run
+    with:
+      cmd: python -m sdetkit intelligence upgrade-audit --format json --used-in-repo-only --top 10 --offline
+      save_stdout: ${{run.output_dir}}/dependency-radar.json
+  - id: radar
+    action: shell.run
+    with:
+      cmd: python -m sdetkit kits radar --repo-usage-tier hot-path --format json
+      save_stdout: ${{run.output_dir}}/radar.json
+  - id: route-map
+    action: shell.run
+    with:
+      cmd: python -m sdetkit kits route-map --impact-area runtime-core --limit 5 --format json
+      save_stdout: ${{run.output_dir}}/route-map.json
+  - id: summary
+    action: fs.write
+    with:
+      path: ${{run.output_dir}}/summary.md
+      content: "Dependency radar worker summary: captured dependency-radar.json, radar.json, route-map.json, and bundle.tar."
+  - id: bundle
+    action: artifacts.bundle
+    with:
+      source_dir: ${{run.output_dir}}
+      output: ${{run.output_dir}}/bundle.tar

--- a/templates/automations/validation-route-worker.yaml
+++ b/templates/automations/validation-route-worker.yaml
@@ -1,0 +1,30 @@
+metadata:
+  id: validation-route-worker
+  title: Validation Route Worker
+  version: 1.0.0
+  description: Map a refactor or dependency target to the smallest safe validation route and bundle the evidence.
+inputs:
+  query:
+    default: httpx
+    description: Package or domain to route through validation lanes.
+workflow:
+  - id: route-map
+    action: shell.run
+    with:
+      cmd: python -m sdetkit kits route-map ${{inputs.query}} --repo-usage-tier hot-path --format json
+      save_stdout: ${{run.output_dir}}/route-map.json
+  - id: doctor-upgrade-audit
+    action: shell.run
+    with:
+      cmd: python -m sdetkit doctor --upgrade-audit --upgrade-audit-offline --format md
+      save_stdout: ${{run.output_dir}}/doctor-upgrade-audit.md
+  - id: summary
+    action: fs.write
+    with:
+      path: ${{run.output_dir}}/summary.md
+      content: "Validation route worker summary: captured route-map.json, doctor-upgrade-audit.md, and bundle.tar."
+  - id: bundle
+    action: artifacts.bundle
+    with:
+      source_dir: ${{run.output_dir}}
+      output: ${{run.output_dir}}/bundle.tar

--- a/templates/automations/worker-alignment-radar.yaml
+++ b/templates/automations/worker-alignment-radar.yaml
@@ -1,0 +1,35 @@
+metadata:
+  id: worker-alignment-radar
+  title: Worker Alignment Radar
+  version: 1.0.0
+  description: Keep worker templates aligned with the repo's expansion plan, automation coverage, and template inventory.
+inputs:
+  goal:
+    default: add more bots workers search and repo expansion
+    description: Goal statement for the alignment radar.
+workflow:
+  - id: expand
+    action: shell.run
+    with:
+      cmd: python -m sdetkit kits expand --goal "${{inputs.goal}}" --format json
+      save_stdout: ${{run.output_dir}}/expand.json
+  - id: automation-check
+    action: shell.run
+    with:
+      cmd: python -m sdetkit maintenance --include-check github_automation_check --format json
+      save_stdout: ${{run.output_dir}}/automation-check.json
+  - id: templates-list
+    action: shell.run
+    with:
+      cmd: python -m sdetkit agent templates list
+      save_stdout: ${{run.output_dir}}/templates.json
+  - id: summary
+    action: fs.write
+    with:
+      path: ${{run.output_dir}}/summary.md
+      content: "Worker alignment radar summary: captured expand.json, automation-check.json, templates.json, and bundle.tar."
+  - id: bundle
+    action: artifacts.bundle
+    with:
+      source_dir: ${{run.output_dir}}
+      output: ${{run.output_dir}}/bundle.tar

--- a/tests/test_agent_templates_engine.py
+++ b/tests/test_agent_templates_engine.py
@@ -133,3 +133,48 @@ def test_template_run_supports_repo_expansion_and_release_workers(tmp_path: Path
     assert (release_out / "doctor.json").exists()
     assert (release_out / "automation-check.json").exists()
     assert (release_out / "bundle.tar").exists()
+
+
+def test_template_run_supports_new_alignment_workers(tmp_path: Path) -> None:
+    repo_root = Path.cwd()
+
+    dependency_template = template_by_id(repo_root, "dependency-radar-worker")
+    dependency_out = tmp_path / "dependency"
+    dependency_record = run_template(
+        repo_root,
+        template=dependency_template,
+        set_values={},
+        output_dir=dependency_out,
+    )
+    assert dependency_record["status"] == "ok"
+    assert (dependency_out / "dependency-radar.json").exists()
+    assert (dependency_out / "radar.json").exists()
+    assert (dependency_out / "route-map.json").exists()
+    assert (dependency_out / "bundle.tar").exists()
+
+    validation_template = template_by_id(repo_root, "validation-route-worker")
+    validation_out = tmp_path / "validation"
+    validation_record = run_template(
+        repo_root,
+        template=validation_template,
+        set_values={"query": "httpx"},
+        output_dir=validation_out,
+    )
+    assert validation_record["status"] == "ok"
+    assert (validation_out / "route-map.json").exists()
+    assert (validation_out / "doctor-upgrade-audit.md").exists()
+    assert (validation_out / "bundle.tar").exists()
+
+    alignment_template = template_by_id(repo_root, "worker-alignment-radar")
+    alignment_out = tmp_path / "alignment"
+    alignment_record = run_template(
+        repo_root,
+        template=alignment_template,
+        set_values={},
+        output_dir=alignment_out,
+    )
+    assert alignment_record["status"] == "ok"
+    assert (alignment_out / "expand.json").exists()
+    assert (alignment_out / "automation-check.json").exists()
+    assert (alignment_out / "templates.json").exists()
+    assert (alignment_out / "bundle.tar").exists()

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -128,7 +128,11 @@ def test_expand_payload_turns_optimize_signals_into_feature_candidates(tmp_path:
     assert "runtime-watchlist" in candidate_ids
     assert "dependency-radar" in mission_topics
     assert "validation-route-map" in mission_topics
+    assert "worker-automation-alignment" in worker_ids
     assert "worker-optimization-control" in worker_ids
+    assert "dependency-radar-worker" in launch_templates
+    assert "validation-route-worker" in launch_templates
+    assert "worker-alignment-radar" in launch_templates
     assert "repo-expansion-control" in launch_templates
     assert payload["worker_launch_pack"]
     assert track_names == {"now", "next", "later"}

--- a/tests/test_maintenance_cli.py
+++ b/tests/test_maintenance_cli.py
@@ -719,6 +719,7 @@ def test_github_automation_check_reports_new_ghas_workflows(tmp_path: Path) -> N
         ".github/workflows/workflow-governance-bot.yml",
         ".github/workflows/docs-experience-bot.yml",
         ".github/workflows/release-readiness-radar-bot.yml",
+        ".github/workflows/worker-alignment-bot.yml",
         ".github/dependabot.yml",
         ".github/codeql-config.yml",
         ".github/pip-audit-baseline.json",
@@ -756,6 +757,7 @@ def test_github_automation_check_reports_new_ghas_workflows(tmp_path: Path) -> N
     expansion_tracks = {item["id"]: item for item in result.details["expansion_update_tracks"]}
     assert expansion_tracks["docs_experience_radar"]["present"] is True
     assert expansion_tracks["release_readiness_radar"]["present"] is True
+    assert expansion_tracks["worker_alignment"]["present"] is True
 
 
 def test_github_automation_check_flags_missing_workflows(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Provide dedicated, reusable worker templates and a coordinating bot to keep dependency, docs, release, and expansion automation aligned with the repo’s umbrella architecture and AgentOS worker model.

### Description
- Added three new AgentOS automation templates: `templates/automations/dependency-radar-worker.yaml`, `templates/automations/validation-route-worker.yaml`, and `templates/automations/worker-alignment-radar.yaml` that bundle dependency audits, route maps, doctor upgrade guidance, and alignment checks into deterministic worker runs.
- Added a new GitHub workflow ` .github/workflows/worker-alignment-bot.yml` that runs the aligned workers, uploads artifacts, and opens/refreshes a date-scoped `🤖 Worker alignment radar` issue.
- Updated the expansion/worker surfaces in `src/sdetkit/kits.py` to recommend the new worker templates (including a `worker-automation-alignment` role) and increase the recommended worker slice to include the new orchestration worker.
- Extended `src/sdetkit/maintenance/checks/github_automation_check.py` to track the new `worker-alignment-bot.yml` in the expansion update tracks and workflow inventory.
- Documentation updates to surface the new templates and bot: `README.md`, `docs/automation-bots.md`, `docs/automation-templates-engine.md`, and `docs/kits/expansion-lab.md`.
- Added/updated tests to cover the new templates and expansion recommendations: `tests/test_agent_templates_engine.py`, `tests/test_kits_blueprint.py`, and `tests/test_maintenance_cli.py`.

### Testing
- Ran targeted pytest suites: `python -m pytest -q tests/test_agent_templates_engine.py tests/test_kits_blueprint.py tests/test_maintenance_cli.py` and observed all tests passing (37 passed total for these suites).
- Ran lint checks with `ruff` against modified files and received no issues.
- Built docs with `python -m mkdocs build --strict`, which completed successfully (existing informational MkDocs notices are unrelated to these changes).
- Verified runtime templates surface with `python -m sdetkit agent templates list` and validated expansion output with `python -m sdetkit kits expand --goal "add more bots workers search and repo expansion" --format json`, confirming the new templates and recommended worker ids are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bddaf43b9483209d9fd8dbdbf4d42d)