### PR TITLE
Add adapter-smoke and runtime-watchlist workers, bots, and docs

### DIFF
--- a/.github/workflows/adapter-smoke-bot.yml
+++ b/.github/workflows/adapter-smoke-bot.yml
@@ -1,0 +1,124 @@
+name: Adapter Smoke Bot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "35 6 * * 4"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  adapter-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-test.txt
+            constraints-ci.txt
+
+      - name: Install repo
+        run: python -m pip install -c constraints-ci.txt -e .[test]
+
+      - name: Run adapter smoke worker
+        run: |
+          set -euo pipefail
+          mkdir -p build .sdetkit/agent/template-runs
+          python -m sdetkit agent templates run adapter-smoke-worker --output-dir .sdetkit/agent/template-runs/adapter-smoke-worker > build/adapter-smoke-worker-run.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("build/adapter-smoke-worker-run.json").read_text(encoding="utf-8"))
+          artifacts = payload.get("artifacts", [])
+
+          lines = [
+              "# Adapter smoke pack",
+              "",
+              "This issue is auto-generated to keep optional notification adapters productized, smoke-tested, and easy to expand.",
+              "",
+              "## Worker status",
+              f"- Status: **{payload.get('status', 'unknown')}**",
+              f"- Artifacts captured: **{len(artifacts)}**",
+              "",
+              "## Suggested follow-up",
+              "- [ ] Review adapter route-map output before changing optional integration dependencies.",
+              "- [ ] Keep adapter quickstarts aligned with environment variables and offline defaults.",
+              "- [ ] Use the worker bundle as the baseline before expanding notify channels or plugins.",
+              "",
+              "## Artifacts",
+              "- `build/adapter-smoke-worker-run.json`",
+              "- `.sdetkit/agent/template-runs/adapter-smoke-worker`",
+          ]
+
+          Path("build/adapter-smoke.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload adapter smoke artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: adapter-smoke-pack
+          path: |
+            build/adapter-smoke-worker-run.json
+            build/adapter-smoke.md
+            .sdetkit/agent/template-runs/adapter-smoke-worker
+
+      - name: Create or update adapter smoke issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const weekOf = new Date().toISOString().slice(0, 10);
+            const title = `📣 Adapter smoke pack (${weekOf})`;
+            const body = fs.readFileSync('build/adapter-smoke.md', 'utf8');
+            const labels = [
+              { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
+              { name: 'automation', color: '5319e7', description: 'Automation and worker alignment' },
+              { name: 'priority:medium', color: 'fbca04', description: 'Medium-priority work item' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+              } catch {
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              }
+            }
+
+            const openIssues = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'automation',
+              per_page: 100,
+            });
+            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('📣 Adapter smoke pack'));
+
+            for (const oldIssue of priorIssues) {
+              if (oldIssue.title !== title) {
+                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
+              }
+            }
+
+            const existing = priorIssues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['maintenance', 'automation', 'priority:medium'],
+              });
+            }

--- a/.github/workflows/runtime-watchlist-bot.yml
+++ b/.github/workflows/runtime-watchlist-bot.yml
@@ -1,0 +1,124 @@
+name: Runtime Watchlist Bot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "55 6 * * 5"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  runtime-watchlist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-test.txt
+            constraints-ci.txt
+
+      - name: Install repo
+        run: python -m pip install -c constraints-ci.txt -e .[test]
+
+      - name: Run runtime watchlist worker
+        run: |
+          set -euo pipefail
+          mkdir -p build .sdetkit/agent/template-runs
+          python -m sdetkit agent templates run runtime-watchlist-worker --output-dir .sdetkit/agent/template-runs/runtime-watchlist-worker > build/runtime-watchlist-worker-run.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("build/runtime-watchlist-worker-run.json").read_text(encoding="utf-8"))
+          artifacts = payload.get("artifacts", [])
+
+          lines = [
+              "# Runtime fast-follow watchlist",
+              "",
+              "This issue is auto-generated to keep runtime-core dependencies on a focused fast-follow review loop.",
+              "",
+              "## Worker status",
+              f"- Status: **{payload.get('status', 'unknown')}**",
+              f"- Artifacts captured: **{len(artifacts)}**",
+              "",
+              "## Suggested follow-up",
+              "- [ ] Review the runtime watchlist before broad dependency refreshes or transport changes.",
+              "- [ ] Route the hottest runtime-core package to the smallest validation command first.",
+              "- [ ] Promote any recurring runtime drift into a scoped maintenance issue or PR.",
+              "",
+              "## Artifacts",
+              "- `build/runtime-watchlist-worker-run.json`",
+              "- `.sdetkit/agent/template-runs/runtime-watchlist-worker`",
+          ]
+
+          Path("build/runtime-watchlist.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload runtime watchlist artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: runtime-watchlist
+          path: |
+            build/runtime-watchlist-worker-run.json
+            build/runtime-watchlist.md
+            .sdetkit/agent/template-runs/runtime-watchlist-worker
+
+      - name: Create or update runtime watchlist issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const weekOf = new Date().toISOString().slice(0, 10);
+            const title = `⚡ Runtime fast-follow watchlist (${weekOf})`;
+            const body = fs.readFileSync('build/runtime-watchlist.md', 'utf8');
+            const labels = [
+              { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
+              { name: 'dependencies', color: '1d76db', description: 'Dependency maintenance and upgrades' },
+              { name: 'priority:medium', color: 'fbca04', description: 'Medium-priority work item' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+              } catch {
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              }
+            }
+
+            const openIssues = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'dependencies',
+              per_page: 100,
+            });
+            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('⚡ Runtime fast-follow watchlist'));
+
+            for (const oldIssue of priorIssues) {
+              if (oldIssue.title !== title) {
+                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
+              }
+            }
+
+            const existing = priorIssues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['maintenance', 'dependencies', 'priority:medium'],
+              });
+            }

--- a/.github/workflows/worker-alignment-bot.yml
+++ b/.github/workflows/worker-alignment-bot.yml
@@ -33,9 +33,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p build .sdetkit/agent/template-runs
+          python -m sdetkit agent templates run adapter-smoke-worker --output-dir .sdetkit/agent/template-runs/adapter-smoke-worker > build/adapter-smoke-worker-run.json
           python -m sdetkit agent templates run dependency-radar-worker --output-dir .sdetkit/agent/template-runs/dependency-radar-worker > build/dependency-radar-worker-run.json
           python -m sdetkit agent templates run docs-search-radar --output-dir .sdetkit/agent/template-runs/docs-search-radar > build/docs-search-radar-run.json
           python -m sdetkit agent templates run release-readiness-worker --output-dir .sdetkit/agent/template-runs/release-readiness-worker > build/release-readiness-worker-run.json
+          python -m sdetkit agent templates run runtime-watchlist-worker --output-dir .sdetkit/agent/template-runs/runtime-watchlist-worker > build/runtime-watchlist-worker-run.json
           python -m sdetkit agent templates run worker-alignment-radar --output-dir .sdetkit/agent/template-runs/worker-alignment-radar > build/worker-alignment-radar-run.json
           python - <<'PY'
           import json
@@ -43,16 +45,18 @@ jobs:
 
           build = Path("build")
           runs = {
+              "adapter-smoke-worker": json.loads((build / "adapter-smoke-worker-run.json").read_text(encoding="utf-8")),
               "dependency-radar-worker": json.loads((build / "dependency-radar-worker-run.json").read_text(encoding="utf-8")),
               "docs-search-radar": json.loads((build / "docs-search-radar-run.json").read_text(encoding="utf-8")),
               "release-readiness-worker": json.loads((build / "release-readiness-worker-run.json").read_text(encoding="utf-8")),
+              "runtime-watchlist-worker": json.loads((build / "runtime-watchlist-worker-run.json").read_text(encoding="utf-8")),
               "worker-alignment-radar": json.loads((build / "worker-alignment-radar-run.json").read_text(encoding="utf-8")),
           }
 
           lines = [
               "# Worker alignment radar",
               "",
-              "This issue is auto-generated from the repo's aligned worker templates so dependency, docs, release, and expansion lanes stay in sync.",
+              "This issue is auto-generated from the repo's aligned worker templates so adapter, dependency, docs, release, runtime, and expansion lanes stay in sync.",
               "",
               "## Worker run status",
           ]
@@ -69,14 +73,18 @@ jobs:
               [
                   "",
                   "## Follow-up prompts",
+                  "- [ ] Review adapter-smoke-worker outputs before expanding notification adapters or integration plugins.",
                   "- [ ] Review dependency-radar-worker outputs before large upgrade or refactor batches.",
                   "- [ ] Use docs-search-radar and release-readiness-worker outputs before docs or release pushes.",
+                  "- [ ] Use runtime-watchlist-worker outputs to keep runtime-core upgrades on a fast-follow loop.",
                   "- [ ] Use worker-alignment-radar outputs to keep recommended workers matched to the repo's active automation surface.",
                   "",
                   "## Artifacts",
+                  "- `build/adapter-smoke-worker-run.json`",
                   "- `build/dependency-radar-worker-run.json`",
                   "- `build/docs-search-radar-run.json`",
                   "- `build/release-readiness-worker-run.json`",
+                  "- `build/runtime-watchlist-worker-run.json`",
                   "- `build/worker-alignment-radar-run.json`",
               ]
           )
@@ -89,14 +97,18 @@ jobs:
         with:
           name: worker-alignment-radar
           path: |
+            build/adapter-smoke-worker-run.json
             build/dependency-radar-worker-run.json
             build/docs-search-radar-run.json
             build/release-readiness-worker-run.json
+            build/runtime-watchlist-worker-run.json
             build/worker-alignment-radar-run.json
             build/worker-alignment-radar.md
+            .sdetkit/agent/template-runs/adapter-smoke-worker
             .sdetkit/agent/template-runs/dependency-radar-worker
             .sdetkit/agent/template-runs/docs-search-radar
             .sdetkit/agent/template-runs/release-readiness-worker
+            .sdetkit/agent/template-runs/runtime-watchlist-worker
             .sdetkit/agent/template-runs/worker-alignment-radar
 
       - name: Create or update worker alignment issue

--- a/README.md
+++ b/README.md
@@ -174,13 +174,15 @@ The premium gate intelligence layer now goes further as well: it ranks remediati
 
 The security auto-remediation lane is stronger too: premium gate can now prioritize a built-in `security_fix_apply` smart script before baseline-aware security re-triage, and the security fixer now safely rewrites `shell=True` to `shell=False` alongside request timeout injection and `yaml.safe_load` upgrades for deterministic repo-safe cleanup.
 
-The GitHub-native maintenance layer is stronger too: beyond the existing GHAS digest, campaign planner, and configuration audit bots, the repo now carries a weekly **GHAS alert SLA tracker** for 7/14/30-day backlog enforcement, a weekly **GHAS metrics export bot** that publishes reusable JSON evidence for dashboards, audits, and roadmap reviews, a weekly **secret protection review bot** for push protection / delegated bypass / validity-check posture, a weekly **repo optimization control-loop bot** that turns `kits optimize`, `kits expand`, and automation coverage into actionable backlog slices, a weekly **docs experience radar bot** that keeps flagship docs, navigation, and search discoverability healthy, and a weekly **release readiness radar bot** that keeps doctor output, release assets, and publishing workflows visible in one operating lane.
+The GitHub-native maintenance layer is stronger too: beyond the existing GHAS digest, campaign planner, and configuration audit bots, the repo now carries a weekly **GHAS alert SLA tracker** for 7/14/30-day backlog enforcement, a weekly **GHAS metrics export bot** that publishes reusable JSON evidence for dashboards, audits, and roadmap reviews, a weekly **secret protection review bot** for push protection / delegated bypass / validity-check posture, a weekly **repo optimization control-loop bot** that turns `kits optimize`, `kits expand`, and automation coverage into actionable backlog slices, a weekly **docs experience radar bot** that keeps flagship docs, navigation, and search discoverability healthy, a weekly **adapter smoke bot** that validates optional notification channels and route-map coverage, a weekly **runtime watchlist bot** that keeps runtime-core upgrades on a fast-follow lane, and a weekly **release readiness radar bot** that keeps doctor output, release assets, and publishing workflows visible in one operating lane.
 
 The worker layer is stronger too: `sdetkit kits expand --goal "..." --format json` now recommends **worker roles** plus a **worker launch pack** so teams can turn expansion ideas into deterministic AgentOS runs instead of leaving them as backlog text. The repo also ships multiple aligned worker templates out of the box:
 
 - `repo-expansion-control` for optimize/expand control-loop artifacts,
+- `adapter-smoke-worker` for optional notification adapter smoke coverage plus expansion-ready quickstarts,
 - `dependency-radar-worker` for upgrade inventory, hotspot radar, and validation-route evidence,
 - `validation-route-worker` for refactor-safe route mapping tied to doctor upgrade guidance,
+- `runtime-watchlist-worker` for runtime-core fast-follow watchlists plus route-map evidence,
 - `docs-search-radar` for strict docs/search validation with bundled evidence,
 - `release-readiness-worker` for doctor + automation-readiness snapshots before publish windows.
 - `worker-alignment-radar` for keeping the worker pack aligned with automation inventory and expansion signals.
@@ -190,8 +192,10 @@ You can run them directly with:
 ```bash
 python -m sdetkit kits expand --goal "add more bots workers search and repo expansion" --format json
 python -m sdetkit agent templates run repo-expansion-control
+python -m sdetkit agent templates run adapter-smoke-worker
 python -m sdetkit agent templates run dependency-radar-worker
 python -m sdetkit agent templates run validation-route-worker --set query=httpx
+python -m sdetkit agent templates run runtime-watchlist-worker
 python -m sdetkit agent templates run docs-search-radar
 python -m sdetkit agent templates run release-readiness-worker
 python -m sdetkit agent templates run worker-alignment-radar

--- a/docs/automation-bots.md
+++ b/docs/automation-bots.md
@@ -24,8 +24,10 @@ The bots turn those same maintenance signals into a recurring GitHub-native oper
 In addition to scheduled GitHub bots, the repo now ships **AgentOS worker templates** that let maintainers run the same expansion/review loops on demand and keep the outputs deterministic:
 
 - **`repo-expansion-control`** — runs `kits optimize` + `kits expand`, writes JSON artifacts, and bundles them for roadmap / dashboard follow-up.
+- **`adapter-smoke-worker`** — validates optional notification adapters, captures integration-adapter route maps, and packages a quickstart-ready bundle.
 - **`dependency-radar-worker`** — captures an offline-safe upgrade inventory, radar snapshot, and validation route map for refactor / dependency review.
 - **`validation-route-worker`** — turns a package or domain query into a route map plus doctor-linked upgrade guidance.
+- **`runtime-watchlist-worker`** — emits a runtime-core fast-follow watchlist plus a route map for the hottest runtime validation lanes.
 - **`docs-search-radar`** — runs a strict MkDocs build, captures the build log, and bundles docs-search evidence for later review.
 - **`release-readiness-worker`** — snapshots `doctor` plus `github_automation_check` so release-readiness follow-up can happen outside of a publish crunch.
 - **`worker-alignment-radar`** — keeps expansion recommendations, automation coverage, and template inventory aligned with the repo's active worker surface.
@@ -34,8 +36,10 @@ Recommended local launches:
 
 ```bash
 python -m sdetkit agent templates run repo-expansion-control
+python -m sdetkit agent templates run adapter-smoke-worker
 python -m sdetkit agent templates run dependency-radar-worker
 python -m sdetkit agent templates run validation-route-worker --set query=httpx
+python -m sdetkit agent templates run runtime-watchlist-worker
 python -m sdetkit agent templates run docs-search-radar
 python -m sdetkit agent templates run release-readiness-worker
 python -m sdetkit agent templates run worker-alignment-radar
@@ -63,10 +67,12 @@ python -m sdetkit kits expand --goal "add more bots workers search and repo expa
 - **`dependency-auto-merge.yml`** — auto-merges safe Dependabot updates after checks pass.
 - **`pre-commit-autoupdate.yml`** — refreshes pre-commit hook pins.
 - **`dependency-radar-bot.yml`** — publishes a recurring dependency radar issue plus a runtime fast-follow watchlist.
+- **`adapter-smoke-bot.yml`** — publishes a weekly adapter smoke issue and artifact bundle for notification adapter quality and expansion readiness.
 - **`repo-optimization-bot.yml`** — publishes a weekly repo-optimization control loop issue from `kits optimize`, `kits expand`, and the GitHub automation maintenance check.
 - **`workflow-governance-bot.yml`** — publishes a monthly workflow-governance audit for permissions, SHA pinning, and manual recovery posture.
 - **`docs-experience-bot.yml`** — publishes a weekly docs-experience radar issue plus JSON artifact covering navigation coverage, search posture, and flagship-doc visibility.
 - **`release-readiness-radar-bot.yml`** — publishes a weekly release-readiness radar issue with doctor output, release asset freshness, and release-workflow coverage.
+- **`runtime-watchlist-bot.yml`** — publishes a weekly runtime fast-follow issue and worker artifacts so hot-path runtime upgrades stay reviewable.
 - **`worker-alignment-bot.yml`** — runs the aligned worker templates together and publishes a weekly worker/radar issue with deterministic artifact links.
 - **`contributor-onboarding-bot.yml`** — keeps contributor guidance discoverable.
 - **`pr-helper-bot.yml` / `pr-quality-comment.yml`** — keep pull requests reviewable and actionable.

--- a/docs/recommended-ci-flow.md
+++ b/docs/recommended-ci-flow.md
@@ -181,8 +181,10 @@ If you want the hosted repo to keep surfacing upgrade and security work between 
 - `.github/workflows/secret-protection-review-bot.yml` for a weekly secret protection posture and backlog review.
 - `.github/workflows/dependency-review.yml` for a pull-request dependency guardrail before merge.
 - `.github/workflows/dependency-radar-bot.yml` for a weekly dependency radar and runtime fast-follow watchlist.
+- `.github/workflows/adapter-smoke-bot.yml` for a weekly adapter smoke pack over optional notification adapters and integration-adapter route-map coverage.
 - `.github/workflows/repo-optimization-bot.yml` for a weekly optimize/expand-driven feature and automation backlog.
 - `.github/workflows/docs-experience-bot.yml` for a weekly docs experience radar over nav coverage, search posture, and flagship entrypoints.
+- `.github/workflows/runtime-watchlist-bot.yml` for a weekly runtime fast-follow watchlist over hot-path runtime-core packages.
 - `.github/workflows/release-readiness-radar-bot.yml` for a weekly release readiness radar over doctor output, release assets, and publish workflows.
 - `.github/workflows/security-maintenance-bot.yml` for the broader weekly security checklist and weak-spot report.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,8 +15,10 @@ To keep security and maintenance work visible and actionable, the repo runs an a
 - Monthly GHAS configuration audit issue is maintained by `.github/workflows/security-configuration-audit-bot.yml`.
 - Weekly secret protection review issue is maintained by `.github/workflows/secret-protection-review-bot.yml`.
 - Weekly dependency radar issue is maintained by `.github/workflows/dependency-radar-bot.yml`.
+- Weekly adapter smoke issue/artifact is maintained by `.github/workflows/adapter-smoke-bot.yml`.
 - Weekly repo optimization control-loop issue is maintained by `.github/workflows/repo-optimization-bot.yml`.
 - Weekly docs experience radar issue/artifact is maintained by `.github/workflows/docs-experience-bot.yml`.
+- Weekly runtime fast-follow watchlist issue/artifact is maintained by `.github/workflows/runtime-watchlist-bot.yml`.
 - Weekly release readiness radar issue/artifact is maintained by `.github/workflows/release-readiness-radar-bot.yml`.
 - Monthly workflow governance audit issue/artifact is maintained by `.github/workflows/workflow-governance-bot.yml`.
 - Security triage should include Dependabot, Code Scanning, Secret Scanning, Dependency Audit, SBOM freshness, dependency review posture, security-configuration visibility, and Actions workflow status review.
@@ -50,7 +52,9 @@ The maintenance system now produces ten recurring artifacts:
 - A date-scoped GHAS CodeQL hotspot issue that groups the code-scanning queue by rule and path so fixes can be batched.
 - A monthly GHAS configuration audit issue that verifies the repo's workflow/config coverage and attached security-configuration context.
 - A date-scoped dependency radar issue that highlights validation-linked upgrade candidates and a runtime fast-follow watchlist.
+- A date-scoped adapter smoke issue that keeps optional notification channels and integration-adapter quickstarts healthy.
 - A date-scoped docs experience radar issue that keeps flagship docs, nav coverage, and search discoverability reviewable.
+- A date-scoped runtime fast-follow watchlist that keeps hot-path runtime-core packages on a tighter maintenance loop.
 - A date-scoped release readiness radar issue that joins doctor output, release assets, and publish-workflow coverage.
 - A monthly workflow governance audit issue that keeps workflow permissions, SHA pinning, and manual recovery visible.
 

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -1579,6 +1579,50 @@ def _recommended_workers(
             }
         )
 
+    if "adapter-smoke-pack" in candidate_map:
+        workers.append(
+            {
+                "id": "worker-adapter-smoke",
+                "role": "adapter-productizer",
+                "focus": (
+                    "Keep optional notification adapters discoverable, smoke-tested, and ready "
+                    "for expansion work."
+                ),
+                "template": "adapter-smoke-worker",
+                "outputs": [
+                    ".sdetkit/agent/template-runs/adapter-smoke-worker/adapter-smoke.json",
+                    ".sdetkit/agent/template-runs/adapter-smoke-worker/adapter-quickstart.md",
+                    ".sdetkit/agent/template-runs/adapter-smoke-worker/bundle.tar",
+                ],
+                "commands": [
+                    "python -m pytest -q tests/test_notify_plugins.py tests/test_notify_plugins_extra.py",
+                    "python -m sdetkit kits route-map --impact-area integration-adapters --format json",
+                ],
+            }
+        )
+
+    if "runtime-watchlist" in candidate_map:
+        workers.append(
+            {
+                "id": "worker-runtime-watchlist",
+                "role": "runtime-scout",
+                "focus": (
+                    "Keep runtime-core dependencies on a fast-follow review lane before larger "
+                    "upgrade batches land."
+                ),
+                "template": "runtime-watchlist-worker",
+                "outputs": [
+                    ".sdetkit/agent/template-runs/runtime-watchlist-worker/runtime-watchlist.md",
+                    ".sdetkit/agent/template-runs/runtime-watchlist-worker/route-map.json",
+                    ".sdetkit/agent/template-runs/runtime-watchlist-worker/bundle.tar",
+                ],
+                "commands": [
+                    "python -m sdetkit intelligence upgrade-audit --impact-area runtime-core --format md",
+                    "python -m sdetkit kits route-map --impact-area runtime-core --format json",
+                ],
+            }
+        )
+
     if repo_signals.get("docs_site"):
         workers.append(
             {
@@ -1652,7 +1696,7 @@ def _recommended_workers(
         }
     )
 
-    return workers[:6]
+    return workers[:8]
 
 
 def _worker_launch_pack(

--- a/src/sdetkit/maintenance/checks/github_automation_check.py
+++ b/src/sdetkit/maintenance/checks/github_automation_check.py
@@ -37,8 +37,10 @@ _WORKFLOW_GROUPS: dict[str, dict[str, tuple[str, bool]]] = {
         "pre-commit-autoupdate.yml": ("Pre-commit auto-update bot", False),
     },
     "expansion_bots": {
+        "adapter-smoke-bot.yml": ("Adapter smoke bot", True),
         "docs-experience-bot.yml": ("Docs experience radar bot", True),
         "release-readiness-radar-bot.yml": ("Release readiness radar bot", True),
+        "runtime-watchlist-bot.yml": ("Runtime watchlist bot", True),
         "worker-alignment-bot.yml": ("Worker alignment bot", True),
     },
     "collaboration_bots": {
@@ -149,6 +151,15 @@ _GHAS_UPDATE_TRACKS: list[dict[str, str]] = [
 
 _EXPANSION_UPDATE_TRACKS: list[dict[str, str]] = [
     {
+        "id": "adapter_smoke",
+        "title": "Adapter smoke pack",
+        "description": (
+            "Run the adapter worker lane so optional notification channels stay smoke-tested, "
+            "documented, and ready for contributor-friendly expansion."
+        ),
+        "workflow": "adapter-smoke-bot.yml",
+    },
+    {
         "id": "docs_experience_radar",
         "title": "Docs experience radar",
         "description": (
@@ -165,6 +176,15 @@ _EXPANSION_UPDATE_TRACKS: list[dict[str, str]] = [
             "freshness checks for roadmap, changelog, and release playbook assets."
         ),
         "workflow": "release-readiness-radar-bot.yml",
+    },
+    {
+        "id": "runtime_watchlist",
+        "title": "Runtime fast-follow watchlist",
+        "description": (
+            "Keep runtime-core dependencies on a recurring fast-follow lane so transport, API, "
+            "and security-critical upgrades do not age silently."
+        ),
+        "workflow": "runtime-watchlist-bot.yml",
     },
     {
         "id": "worker_alignment",

--- a/templates/automations/adapter-smoke-worker.yaml
+++ b/templates/automations/adapter-smoke-worker.yaml
@@ -1,0 +1,26 @@
+metadata:
+  id: adapter-smoke-worker
+  title: Adapter Smoke Worker
+  version: 1.0.0
+  description: Validate optional notification adapters and capture integration-ready quickstart artifacts.
+workflow:
+  - id: adapter-route-map
+    action: shell.run
+    with:
+      cmd: python -m sdetkit kits route-map --impact-area integration-adapters --limit 5 --format json
+      save_stdout: ${{run.output_dir}}/adapter-smoke.json
+  - id: adapter-tests
+    action: shell.run
+    with:
+      cmd: python -m pytest -q tests/test_notify_plugins.py tests/test_notify_plugins_extra.py tests/test_notify_core_extra.py tests/test_notify_plugins_control_plane.py
+      save_stdout: ${{run.output_dir}}/adapter-tests.log
+  - id: adapter-quickstart
+    action: fs.write
+    with:
+      path: ${{run.output_dir}}/adapter-quickstart.md
+      content: "Adapter smoke worker summary: validated notification adapters, captured adapter-smoke.json, adapter-tests.log, and bundle.tar."
+  - id: bundle
+    action: artifacts.bundle
+    with:
+      source_dir: ${{run.output_dir}}
+      output: ${{run.output_dir}}/bundle.tar

--- a/templates/automations/runtime-watchlist-worker.yaml
+++ b/templates/automations/runtime-watchlist-worker.yaml
@@ -1,0 +1,26 @@
+metadata:
+  id: runtime-watchlist-worker
+  title: Runtime Watchlist Worker
+  version: 1.0.0
+  description: Track runtime-core fast-follow upgrades and route them to the smallest safe validation loop.
+workflow:
+  - id: runtime-watchlist
+    action: shell.run
+    with:
+      cmd: python -m sdetkit intelligence upgrade-audit --impact-area runtime-core --format md --offline
+      save_stdout: ${{run.output_dir}}/runtime-watchlist.md
+  - id: runtime-route-map
+    action: shell.run
+    with:
+      cmd: python -m sdetkit kits route-map --impact-area runtime-core --limit 5 --format json
+      save_stdout: ${{run.output_dir}}/route-map.json
+  - id: summary
+    action: fs.write
+    with:
+      path: ${{run.output_dir}}/summary.md
+      content: "Runtime watchlist worker summary: captured runtime-watchlist.md, route-map.json, and bundle.tar."
+  - id: bundle
+    action: artifacts.bundle
+    with:
+      source_dir: ${{run.output_dir}}
+      output: ${{run.output_dir}}/bundle.tar

--- a/tests/test_agent_templates_engine.py
+++ b/tests/test_agent_templates_engine.py
@@ -165,6 +165,32 @@ def test_template_run_supports_new_alignment_workers(tmp_path: Path) -> None:
     assert (validation_out / "doctor-upgrade-audit.md").exists()
     assert (validation_out / "bundle.tar").exists()
 
+    adapter_template = template_by_id(repo_root, "adapter-smoke-worker")
+    adapter_out = tmp_path / "adapter"
+    adapter_record = run_template(
+        repo_root,
+        template=adapter_template,
+        set_values={},
+        output_dir=adapter_out,
+    )
+    assert adapter_record["status"] == "ok"
+    assert (adapter_out / "adapter-smoke.json").exists()
+    assert (adapter_out / "adapter-tests.log").exists()
+    assert (adapter_out / "bundle.tar").exists()
+
+    runtime_template = template_by_id(repo_root, "runtime-watchlist-worker")
+    runtime_out = tmp_path / "runtime"
+    runtime_record = run_template(
+        repo_root,
+        template=runtime_template,
+        set_values={},
+        output_dir=runtime_out,
+    )
+    assert runtime_record["status"] == "ok"
+    assert (runtime_out / "runtime-watchlist.md").exists()
+    assert (runtime_out / "route-map.json").exists()
+    assert (runtime_out / "bundle.tar").exists()
+
     alignment_template = template_by_id(repo_root, "worker-alignment-radar")
     alignment_out = tmp_path / "alignment"
     alignment_record = run_template(

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -88,7 +88,12 @@ def test_optimize_payload_aligns_doctor_quality_gate_agentos_and_topology(tmp_pa
 
 def test_expand_payload_turns_optimize_signals_into_feature_candidates(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text(
-        "[project]\nname='x'\nversion='0.1.0'\ndependencies=['httpx>=0.28.1,<1']\n",
+        "[project]\n"
+        "name='x'\n"
+        "version='0.1.0'\n"
+        "dependencies=['httpx>=0.28.1,<1']\n"
+        "[project.optional-dependencies]\n"
+        "telegram=['python-telegram-bot>=22.7,<23']\n",
         encoding="utf-8",
     )
     (tmp_path / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -125,11 +130,18 @@ def test_expand_payload_turns_optimize_signals_into_feature_candidates(tmp_path:
     assert payload["optimize"]["alignment_score"]["status"] in {"strong", "maximized"}
     assert "dependency-radar-dashboard" in candidate_ids
     assert "validation-route-map" in candidate_ids
+    assert "adapter-smoke-pack" in candidate_ids
     assert "runtime-watchlist" in candidate_ids
     assert "dependency-radar" in mission_topics
     assert "validation-route-map" in mission_topics
+    assert "adapter-activation" in mission_topics
+    assert "runtime-fast-follow" in mission_topics
+    assert "worker-adapter-smoke" in worker_ids
+    assert "worker-runtime-watchlist" in worker_ids
     assert "worker-automation-alignment" in worker_ids
     assert "worker-optimization-control" in worker_ids
+    assert "adapter-smoke-worker" in launch_templates
+    assert "runtime-watchlist-worker" in launch_templates
     assert "dependency-radar-worker" in launch_templates
     assert "validation-route-worker" in launch_templates
     assert "worker-alignment-radar" in launch_templates

--- a/tests/test_maintenance_cli.py
+++ b/tests/test_maintenance_cli.py
@@ -720,6 +720,8 @@ def test_github_automation_check_reports_new_ghas_workflows(tmp_path: Path) -> N
         ".github/workflows/docs-experience-bot.yml",
         ".github/workflows/release-readiness-radar-bot.yml",
         ".github/workflows/worker-alignment-bot.yml",
+        ".github/workflows/adapter-smoke-bot.yml",
+        ".github/workflows/runtime-watchlist-bot.yml",
         ".github/dependabot.yml",
         ".github/codeql-config.yml",
         ".github/pip-audit-baseline.json",
@@ -755,8 +757,10 @@ def test_github_automation_check_reports_new_ghas_workflows(tmp_path: Path) -> N
     assert tracks["repo_optimization_loop"]["present"] is True
     assert tracks["workflow_governance"]["present"] is True
     expansion_tracks = {item["id"]: item for item in result.details["expansion_update_tracks"]}
+    assert expansion_tracks["adapter_smoke"]["present"] is True
     assert expansion_tracks["docs_experience_radar"]["present"] is True
     assert expansion_tracks["release_readiness_radar"]["present"] is True
+    assert expansion_tracks["runtime_watchlist"]["present"] is True
     assert expansion_tracks["worker_alignment"]["present"] is True
 
 


### PR DESCRIPTION
### Motivation

- Productize two high-leverage expansion opportunities (adapter smoke pack and runtime fast-follow watchlist) discovered by the repo's optimize/expand surfaces so optional adapters and runtime-core upgrades become first-class, maintainable lanes. 
- Make the worker control loop and automation tracking aware of these lanes so maintainers get recurring artifacts, issues, and deterministic AgentOS runs for expansion work.

### Description

- Add two AgentOS automation templates: `templates/automations/adapter-smoke-worker.yaml` and `templates/automations/runtime-watchlist-worker.yaml` that produce deterministic bundles and route-map/test artifacts. 
- Extend worker recommendation logic in `src/sdetkit/kits.py` to include `worker-adapter-smoke` and `worker-runtime-watchlist`, increase the recommended worker slice, and ensure the worker launch pack exposes their `template` launch commands. 
- Add scheduled GitHub workflows `/.github/workflows/adapter-smoke-bot.yml` and `/.github/workflows/runtime-watchlist-bot.yml` and fold both workers into the existing `worker-alignment-bot.yml` run so alignment issues/artifacts include adapter/runtime outputs. 
- Update `src/sdetkit/maintenance/checks/github_automation_check.py`, README and docs to track the new workflows and expansion update tracks, and add/adjust tests to validate the new templates, recommendations, and workflow-presence logic. 

### Testing

- Ran `pytest` for the changed coverage targets: `tests/test_kits_blueprint.py`, `tests/test_agent_templates_engine.py`, and `tests/test_maintenance_cli.py`, and all tests passed. 
- Ran `PYTHONPATH=src python -m sdetkit kits expand "add more bots workers search and repo expansion" --format json` to validate the expand payload now lists the new `worker-adapter-smoke` and `worker-runtime-watchlist` in `recommended_workers` and the corresponding templates in `worker_launch_pack`, and the command succeeded. 
- Full local test batch covering the adjusted templates and maintenance checks completed successfully (unit tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bddde7dbe88320a059886fde278077)