### PR TITLE
Add integration topology worker and radar bot; integrate into kits/expand and maintenance

### DIFF
--- a/.github/workflows/integration-topology-radar-bot.yml
+++ b/.github/workflows/integration-topology-radar-bot.yml
@@ -1,0 +1,124 @@
+name: Integration Topology Radar Bot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 6 * * 4"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  integration-topology-radar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-test.txt
+            constraints-ci.txt
+
+      - name: Install repo
+        run: python -m pip install -c constraints-ci.txt -e .[test]
+
+      - name: Run integration topology worker
+        run: |
+          set -euo pipefail
+          mkdir -p build .sdetkit/agent/template-runs
+          python -m sdetkit agent templates run integration-topology-worker --output-dir .sdetkit/agent/template-runs/integration-topology-worker > build/integration-topology-worker-run.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("build/integration-topology-worker-run.json").read_text(encoding="utf-8"))
+          artifacts = payload.get("artifacts", [])
+
+          lines = [
+              "# Integration topology radar",
+              "",
+              "This issue is auto-generated to keep heterogeneous topology proof aligned with premium-gate-ready upgrade work.",
+              "",
+              "## Worker status",
+              f"- Status: **{payload.get('status', 'unknown')}**",
+              f"- Artifacts captured: **{len(artifacts)}**",
+              "",
+              "## Suggested follow-up",
+              "- [ ] Review topology-check.json before landing umbrella integration refactors or platform workflow changes.",
+              "- [ ] Compare the optimize snapshot against the current release and worker lanes for any premium-gate drift.",
+              "- [ ] Convert any service-owner, telemetry, or deployment gaps into scoped issues or PRs.",
+              "",
+              "## Artifacts",
+              "- `build/integration-topology-worker-run.json`",
+              "- `.sdetkit/agent/template-runs/integration-topology-worker`",
+          ]
+
+          Path("build/integration-topology-radar.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload integration topology artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: integration-topology-radar
+          path: |
+            build/integration-topology-worker-run.json
+            build/integration-topology-radar.md
+            .sdetkit/agent/template-runs/integration-topology-worker
+
+      - name: Create or update integration topology issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const weekOf = new Date().toISOString().slice(0, 10);
+            const title = `🕸️ Integration topology radar (${weekOf})`;
+            const body = fs.readFileSync('build/integration-topology-radar.md', 'utf8');
+            const labels = [
+              { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
+              { name: 'integration', color: '5319e7', description: 'Integration assurance and topology work' },
+              { name: 'priority:medium', color: 'fbca04', description: 'Medium-priority work item' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+              } catch {
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              }
+            }
+
+            const openIssues = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'integration',
+              per_page: 100,
+            });
+            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('🕸️ Integration topology radar'));
+
+            for (const oldIssue of priorIssues) {
+              if (oldIssue.title !== title) {
+                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
+              }
+            }
+
+            const existing = priorIssues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['maintenance', 'integration', 'priority:medium'],
+              });
+            }

--- a/.github/workflows/worker-alignment-bot.yml
+++ b/.github/workflows/worker-alignment-bot.yml
@@ -36,6 +36,7 @@ jobs:
           python -m sdetkit agent templates run adapter-smoke-worker --output-dir .sdetkit/agent/template-runs/adapter-smoke-worker > build/adapter-smoke-worker-run.json
           python -m sdetkit agent templates run dependency-radar-worker --output-dir .sdetkit/agent/template-runs/dependency-radar-worker > build/dependency-radar-worker-run.json
           python -m sdetkit agent templates run docs-search-radar --output-dir .sdetkit/agent/template-runs/docs-search-radar > build/docs-search-radar-run.json
+          python -m sdetkit agent templates run integration-topology-worker --output-dir .sdetkit/agent/template-runs/integration-topology-worker > build/integration-topology-worker-run.json
           python -m sdetkit agent templates run release-readiness-worker --output-dir .sdetkit/agent/template-runs/release-readiness-worker > build/release-readiness-worker-run.json
           python -m sdetkit agent templates run runtime-watchlist-worker --output-dir .sdetkit/agent/template-runs/runtime-watchlist-worker > build/runtime-watchlist-worker-run.json
           python -m sdetkit agent templates run worker-alignment-radar --output-dir .sdetkit/agent/template-runs/worker-alignment-radar > build/worker-alignment-radar-run.json
@@ -48,6 +49,7 @@ jobs:
               "adapter-smoke-worker": json.loads((build / "adapter-smoke-worker-run.json").read_text(encoding="utf-8")),
               "dependency-radar-worker": json.loads((build / "dependency-radar-worker-run.json").read_text(encoding="utf-8")),
               "docs-search-radar": json.loads((build / "docs-search-radar-run.json").read_text(encoding="utf-8")),
+              "integration-topology-worker": json.loads((build / "integration-topology-worker-run.json").read_text(encoding="utf-8")),
               "release-readiness-worker": json.loads((build / "release-readiness-worker-run.json").read_text(encoding="utf-8")),
               "runtime-watchlist-worker": json.loads((build / "runtime-watchlist-worker-run.json").read_text(encoding="utf-8")),
               "worker-alignment-radar": json.loads((build / "worker-alignment-radar-run.json").read_text(encoding="utf-8")),
@@ -56,7 +58,7 @@ jobs:
           lines = [
               "# Worker alignment radar",
               "",
-              "This issue is auto-generated from the repo's aligned worker templates so adapter, dependency, docs, release, runtime, and expansion lanes stay in sync.",
+              "This issue is auto-generated from the repo's aligned worker templates so adapter, dependency, docs, topology, release, runtime, and expansion lanes stay in sync.",
               "",
               "## Worker run status",
           ]
@@ -76,6 +78,7 @@ jobs:
                   "- [ ] Review adapter-smoke-worker outputs before expanding notification adapters or integration plugins.",
                   "- [ ] Review dependency-radar-worker outputs before large upgrade or refactor batches.",
                   "- [ ] Use docs-search-radar and release-readiness-worker outputs before docs or release pushes.",
+                  "- [ ] Use integration-topology-worker outputs before topology, platform, or premium-gate refactors.",
                   "- [ ] Use runtime-watchlist-worker outputs to keep runtime-core upgrades on a fast-follow loop.",
                   "- [ ] Use worker-alignment-radar outputs to keep recommended workers matched to the repo's active automation surface.",
                   "",
@@ -83,6 +86,7 @@ jobs:
                   "- `build/adapter-smoke-worker-run.json`",
                   "- `build/dependency-radar-worker-run.json`",
                   "- `build/docs-search-radar-run.json`",
+                  "- `build/integration-topology-worker-run.json`",
                   "- `build/release-readiness-worker-run.json`",
                   "- `build/runtime-watchlist-worker-run.json`",
                   "- `build/worker-alignment-radar-run.json`",
@@ -100,6 +104,7 @@ jobs:
             build/adapter-smoke-worker-run.json
             build/dependency-radar-worker-run.json
             build/docs-search-radar-run.json
+            build/integration-topology-worker-run.json
             build/release-readiness-worker-run.json
             build/runtime-watchlist-worker-run.json
             build/worker-alignment-radar-run.json
@@ -107,6 +112,7 @@ jobs:
             .sdetkit/agent/template-runs/adapter-smoke-worker
             .sdetkit/agent/template-runs/dependency-radar-worker
             .sdetkit/agent/template-runs/docs-search-radar
+            .sdetkit/agent/template-runs/integration-topology-worker
             .sdetkit/agent/template-runs/release-readiness-worker
             .sdetkit/agent/template-runs/runtime-watchlist-worker
             .sdetkit/agent/template-runs/worker-alignment-radar

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The worker layer is stronger too: `sdetkit kits expand --goal "..." --format jso
 - `validation-route-worker` for refactor-safe route mapping tied to doctor upgrade guidance,
 - `runtime-watchlist-worker` for runtime-core fast-follow watchlists plus route-map evidence,
 - `docs-search-radar` for strict docs/search validation with bundled evidence,
+- `integration-topology-worker` for heterogeneous topology proof plus optimize guidance before premium-gate-sensitive refactors,
 - `release-readiness-worker` for doctor + automation-readiness snapshots before publish windows.
 - `worker-alignment-radar` for keeping the worker pack aligned with automation inventory and expansion signals.
 
@@ -197,6 +198,7 @@ python -m sdetkit agent templates run dependency-radar-worker
 python -m sdetkit agent templates run validation-route-worker --set query=httpx
 python -m sdetkit agent templates run runtime-watchlist-worker
 python -m sdetkit agent templates run docs-search-radar
+python -m sdetkit agent templates run integration-topology-worker
 python -m sdetkit agent templates run release-readiness-worker
 python -m sdetkit agent templates run worker-alignment-radar
 ```

--- a/docs/automation-bots.md
+++ b/docs/automation-bots.md
@@ -29,6 +29,7 @@ In addition to scheduled GitHub bots, the repo now ships **AgentOS worker templa
 - **`validation-route-worker`** — turns a package or domain query into a route map plus doctor-linked upgrade guidance.
 - **`runtime-watchlist-worker`** — emits a runtime-core fast-follow watchlist plus a route map for the hottest runtime validation lanes.
 - **`docs-search-radar`** — runs a strict MkDocs build, captures the build log, and bundles docs-search evidence for later review.
+- **`integration-topology-worker`** — validates heterogeneous topology proof, snapshots optimize guidance, and bundles architecture-ready evidence for premium-gate follow-up.
 - **`release-readiness-worker`** — snapshots `doctor` plus `github_automation_check` so release-readiness follow-up can happen outside of a publish crunch.
 - **`worker-alignment-radar`** — keeps expansion recommendations, automation coverage, and template inventory aligned with the repo's active worker surface.
 
@@ -41,6 +42,7 @@ python -m sdetkit agent templates run dependency-radar-worker
 python -m sdetkit agent templates run validation-route-worker --set query=httpx
 python -m sdetkit agent templates run runtime-watchlist-worker
 python -m sdetkit agent templates run docs-search-radar
+python -m sdetkit agent templates run integration-topology-worker
 python -m sdetkit agent templates run release-readiness-worker
 python -m sdetkit agent templates run worker-alignment-radar
 python -m sdetkit kits expand --goal "add more bots workers search and repo expansion" --format json
@@ -71,9 +73,10 @@ python -m sdetkit kits expand --goal "add more bots workers search and repo expa
 - **`repo-optimization-bot.yml`** — publishes a weekly repo-optimization control loop issue from `kits optimize`, `kits expand`, and the GitHub automation maintenance check.
 - **`workflow-governance-bot.yml`** — publishes a monthly workflow-governance audit for permissions, SHA pinning, and manual recovery posture.
 - **`docs-experience-bot.yml`** — publishes a weekly docs-experience radar issue plus JSON artifact covering navigation coverage, search posture, and flagship-doc visibility.
+- **`integration-topology-radar-bot.yml`** — publishes a weekly integration-topology radar issue and worker artifacts so topology proof stays aligned with premium-gate-ready refactors.
 - **`release-readiness-radar-bot.yml`** — publishes a weekly release-readiness radar issue with doctor output, release asset freshness, and release-workflow coverage.
 - **`runtime-watchlist-bot.yml`** — publishes a weekly runtime fast-follow issue and worker artifacts so hot-path runtime upgrades stay reviewable.
-- **`worker-alignment-bot.yml`** — runs the aligned worker templates together and publishes a weekly worker/radar issue with deterministic artifact links.
+- **`worker-alignment-bot.yml`** — runs the aligned worker templates together and publishes a weekly worker/radar issue with deterministic artifact links, including topology coverage.
 - **`contributor-onboarding-bot.yml`** — keeps contributor guidance discoverable.
 - **`pr-helper-bot.yml` / `pr-quality-comment.yml`** — keep pull requests reviewable and actionable.
 
@@ -224,13 +227,24 @@ It now:
 - opens a date-scoped `🚀 Release readiness radar (...)` issue,
 - uploads `build/release-readiness-radar.json` plus the raw doctor/maintenance payloads as workflow artifacts.
 
+### `integration-topology-radar-bot.yml`
+
+This bot turns the repo's topology-aware integration proof into a recurring architecture review lane instead of something maintainers only inspect during large refactors.
+
+It now:
+
+- runs `integration-topology-worker` on a weekly cadence,
+- captures the bundled topology-check and optimize payloads as reusable worker artifacts,
+- opens a date-scoped `🕸️ Integration topology radar (...)` issue,
+- keeps heterogeneous service proof aligned with premium-gate-ready umbrella changes.
+
 ### `worker-alignment-bot.yml`
 
 This bot turns the worker layer into a first-class operating lane instead of leaving the templates as individual commands maintainers have to remember.
 
 It now:
 
-- runs `dependency-radar-worker`, `docs-search-radar`, `release-readiness-worker`, and `worker-alignment-radar` on a weekly cadence,
+- runs `dependency-radar-worker`, `docs-search-radar`, `integration-topology-worker`, `release-readiness-worker`, and `worker-alignment-radar` on a weekly cadence,
 - uploads both the per-worker run records and the template output directories as reusable artifacts,
 - opens a date-scoped `🤖 Worker alignment radar (...)` issue,
 - keeps the worker surface aligned with dependency, docs, release, and automation-review loops.
@@ -247,10 +261,11 @@ It now:
 8. Open the latest **dependency radar** issue.
 9. Open the latest **repo optimization control loop** issue and pick one `now` candidate or search mission.
 10. Open the latest **docs experience radar** issue and fold the highest-value orphan docs or missing flagship links back into the canonical journeys.
-11. Open the latest **release readiness radar** issue before a publish window or docs release push.
-12. Open the latest **worker alignment radar** issue and refresh any stale worker/template lanes before they drift from the base automation surface.
-13. Review the monthly **workflow governance audit** issue and close any pinning/permissions drift.
-14. Record implementation follow-up in `docs/roadmap.md` and the weekly maintenance issue.
+11. Open the latest **integration topology radar** issue before topology, platform, or premium-gate changes expand.
+12. Open the latest **release readiness radar** issue before a publish window or docs release push.
+13. Open the latest **worker alignment radar** issue and refresh any stale worker/template lanes before they drift from the base automation surface.
+14. Review the monthly **workflow governance audit** issue and close any pinning/permissions drift.
+15. Record implementation follow-up in `docs/roadmap.md` and the weekly maintenance issue.
 
 ## Optional local dry runs
 

--- a/docs/kits/expansion-lab.md
+++ b/docs/kits/expansion-lab.md
@@ -29,6 +29,7 @@ Depending on the repo signals and dependency inventory, the expansion lab can su
 - a **validation route map** that links packages to the smallest safe proof loop,
 - an **adapter smoke pack** that makes optional integrations feel productized,
 - a **runtime fast-follow watchlist** for hot-path dependencies,
+- an **integration topology control loop** for premium-gate-sensitive architecture changes,
 - or an **optimization control center** that collapses boost + AgentOS outputs into one recurring operating view.
 
 The validation route map is now available directly via `sdetkit kits route-map`, so one strong follow-up pattern is:

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -1213,6 +1213,27 @@ def _innovation_opportunities(
             }
         )
 
+    if repo_signals.get("topology_profile") and repo_signals.get("premium_gate"):
+        opportunities.append(
+            {
+                "id": "integration-topology-radar",
+                "title": "Create an integration topology radar",
+                "summary": (
+                    "Turn heterogeneous-topology proof into a recurring worker and issue lane so "
+                    "service graph drift, owner gaps, and premium-gate alignment stay reviewable."
+                ),
+                "why_now": (
+                    "The repo already ships topology-aware integration proof plus premium-gate "
+                    "orchestration, which makes topology drift a good candidate for its own "
+                    "deterministic review loop."
+                ),
+                "commands": [
+                    "python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json",
+                    'python -m sdetkit kits optimize --goal "integration topology premium gate alignment" --format json',
+                ],
+            }
+        )
+
     if repo_signals.get("constraints") and source_summary:
         opportunities.append(
             {
@@ -1253,7 +1274,7 @@ def _innovation_opportunities(
             }
         )
 
-    return opportunities[:6]
+    return opportunities[:7]
 
 
 def _feature_candidates(goal: str | None, optimize_result: Payload) -> list[Payload]:
@@ -1431,6 +1452,29 @@ def _feature_candidates(goal: str | None, optimize_result: Payload) -> list[Payl
             }
         )
 
+    if "integration-topology-radar" in innovation_ids:
+        candidates.append(
+            {
+                "id": "integration-topology-control-loop",
+                "title": "Integration topology control loop",
+                "priority": "now",
+                "effort": "small",
+                "summary": (
+                    "Keep topology proof, service ownership signals, and premium-gate alignment in "
+                    "one recurring control loop before larger umbrella refactors land."
+                ),
+                "deliverables": [
+                    "topology worker artifact bundle",
+                    "weekly topology drift issue",
+                    "premium-gate follow-up checklist",
+                ],
+                "commands": [
+                    "python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json",
+                    'python -m sdetkit kits optimize --goal "integration topology premium gate alignment" --format json',
+                ],
+            }
+        )
+
     if repo_signals.get("agent_templates") and repo_signals.get("quality_script"):
         candidates.append(
             {
@@ -1519,6 +1563,14 @@ def _search_missions(goal: str | None, feature_candidates: list[Payload]) -> lis
                     "intent": "Reduce pre-release drift by reviewing doctor, release assets, and publishing posture together.",
                 }
             )
+        elif candidate_id == "integration-topology-control-loop":
+            missions.append(
+                {
+                    "topic": "integration-topology-control",
+                    "query": f"{goal_text} integration topology drift premium gate service graph",
+                    "intent": "Keep topology-aware integration proof aligned with premium validation and worker automation.",
+                }
+            )
         elif candidate_id == "optimization-control-center":
             missions.append(
                 {
@@ -1527,7 +1579,7 @@ def _search_missions(goal: str | None, feature_candidates: list[Payload]) -> lis
                     "intent": "Combine optimize, boost, and AgentOS history into one operating view.",
                 }
             )
-    return missions[:7]
+    return missions[:8]
 
 
 def _recommended_workers(
@@ -1659,6 +1711,28 @@ def _recommended_workers(
             }
         )
 
+    if "integration-topology-control-loop" in candidate_map:
+        workers.append(
+            {
+                "id": "worker-integration-topology",
+                "role": "topology-guardian",
+                "focus": (
+                    "Keep service-topology proof, premium-gate alignment, and architecture drift "
+                    "visible before umbrella refactors or release pushes."
+                ),
+                "template": "integration-topology-worker",
+                "outputs": [
+                    ".sdetkit/agent/template-runs/integration-topology-worker/topology-check.json",
+                    ".sdetkit/agent/template-runs/integration-topology-worker/optimize.json",
+                    ".sdetkit/agent/template-runs/integration-topology-worker/bundle.tar",
+                ],
+                "commands": [
+                    "python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json",
+                    'python -m sdetkit kits optimize --goal "integration topology premium gate alignment" --format json',
+                ],
+            }
+        )
+
     workers.append(
         {
             "id": "worker-automation-alignment",
@@ -1696,7 +1770,7 @@ def _recommended_workers(
         }
     )
 
-    return workers[:8]
+    return workers[:9]
 
 
 def _worker_launch_pack(

--- a/src/sdetkit/maintenance/checks/github_automation_check.py
+++ b/src/sdetkit/maintenance/checks/github_automation_check.py
@@ -39,6 +39,7 @@ _WORKFLOW_GROUPS: dict[str, dict[str, tuple[str, bool]]] = {
     "expansion_bots": {
         "adapter-smoke-bot.yml": ("Adapter smoke bot", True),
         "docs-experience-bot.yml": ("Docs experience radar bot", True),
+        "integration-topology-radar-bot.yml": ("Integration topology radar bot", True),
         "release-readiness-radar-bot.yml": ("Release readiness radar bot", True),
         "runtime-watchlist-bot.yml": ("Runtime watchlist bot", True),
         "worker-alignment-bot.yml": ("Worker alignment bot", True),
@@ -176,6 +177,15 @@ _EXPANSION_UPDATE_TRACKS: list[dict[str, str]] = [
             "freshness checks for roadmap, changelog, and release playbook assets."
         ),
         "workflow": "release-readiness-radar-bot.yml",
+    },
+    {
+        "id": "integration_topology_radar",
+        "title": "Integration topology radar",
+        "description": (
+            "Run the topology worker lane so heterogeneous service proof and premium-gate follow-up "
+            "stay visible as the repo's architecture expands."
+        ),
+        "workflow": "integration-topology-radar-bot.yml",
     },
     {
         "id": "runtime_watchlist",

--- a/templates/automations/integration-topology-worker.yaml
+++ b/templates/automations/integration-topology-worker.yaml
@@ -1,0 +1,26 @@
+metadata:
+  id: integration-topology-worker
+  title: Integration Topology Worker
+  version: 1.0.0
+  description: Validate heterogeneous topology proof, capture optimize guidance, and bundle architecture-ready artifacts.
+workflow:
+  - id: topology-check
+    action: shell.run
+    with:
+      cmd: python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json
+      save_stdout: ${{run.output_dir}}/topology-check.json
+  - id: topology-optimize
+    action: shell.run
+    with:
+      cmd: python -m sdetkit kits optimize --goal "integration topology premium gate alignment" --format json
+      save_stdout: ${{run.output_dir}}/optimize.json
+  - id: topology-summary
+    action: fs.write
+    with:
+      path: ${{run.output_dir}}/summary.md
+      content: "Integration topology worker summary: captured topology-check.json, optimize.json, and bundle.tar."
+  - id: bundle
+    action: artifacts.bundle
+    with:
+      source_dir: ${{run.output_dir}}
+      output: ${{run.output_dir}}/bundle.tar

--- a/tests/test_agent_templates_engine.py
+++ b/tests/test_agent_templates_engine.py
@@ -79,7 +79,7 @@ def test_deterministic_pack_output(tmp_path: Path) -> None:
 def test_template_run_produces_artifacts_for_two_real_templates(tmp_path: Path) -> None:
     repo_root = Path.cwd()
     templates = discover_templates(repo_root)
-    assert len(templates) >= 11
+    assert len(templates) >= 12
 
     audit_template = template_by_id(repo_root, "repo-health-audit")
     audit_out = tmp_path / "audit"
@@ -190,6 +190,19 @@ def test_template_run_supports_new_alignment_workers(tmp_path: Path) -> None:
     assert (runtime_out / "runtime-watchlist.md").exists()
     assert (runtime_out / "route-map.json").exists()
     assert (runtime_out / "bundle.tar").exists()
+
+    topology_template = template_by_id(repo_root, "integration-topology-worker")
+    topology_out = tmp_path / "topology"
+    topology_record = run_template(
+        repo_root,
+        template=topology_template,
+        set_values={},
+        output_dir=topology_out,
+    )
+    assert topology_record["status"] == "ok"
+    assert (topology_out / "topology-check.json").exists()
+    assert (topology_out / "optimize.json").exists()
+    assert (topology_out / "bundle.tar").exists()
 
     alignment_template = template_by_id(repo_root, "worker-alignment-radar")
     alignment_out = tmp_path / "alignment"

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -70,6 +70,7 @@ def test_optimize_payload_aligns_doctor_quality_gate_agentos_and_topology(tmp_pa
     innovation_ids = {item["id"] for item in payload["innovation_opportunities"]}
     assert "dependency-radar" in innovation_ids
     assert "runtime-core-fast-follow" in innovation_ids
+    assert "integration-topology-radar" in innovation_ids
     assert (
         payload["agentos_lane"]["commands"][1]
         == "sdetkit agent run 'template:repo-health-audit' --approve"
@@ -132,16 +133,20 @@ def test_expand_payload_turns_optimize_signals_into_feature_candidates(tmp_path:
     assert "validation-route-map" in candidate_ids
     assert "adapter-smoke-pack" in candidate_ids
     assert "runtime-watchlist" in candidate_ids
+    assert "integration-topology-control-loop" in candidate_ids
     assert "dependency-radar" in mission_topics
     assert "validation-route-map" in mission_topics
     assert "adapter-activation" in mission_topics
     assert "runtime-fast-follow" in mission_topics
+    assert "integration-topology-control" in mission_topics
     assert "worker-adapter-smoke" in worker_ids
     assert "worker-runtime-watchlist" in worker_ids
+    assert "worker-integration-topology" in worker_ids
     assert "worker-automation-alignment" in worker_ids
     assert "worker-optimization-control" in worker_ids
     assert "adapter-smoke-worker" in launch_templates
     assert "runtime-watchlist-worker" in launch_templates
+    assert "integration-topology-worker" in launch_templates
     assert "dependency-radar-worker" in launch_templates
     assert "validation-route-worker" in launch_templates
     assert "worker-alignment-radar" in launch_templates

--- a/tests/test_maintenance_cli.py
+++ b/tests/test_maintenance_cli.py
@@ -718,6 +718,7 @@ def test_github_automation_check_reports_new_ghas_workflows(tmp_path: Path) -> N
         ".github/workflows/repo-optimization-bot.yml",
         ".github/workflows/workflow-governance-bot.yml",
         ".github/workflows/docs-experience-bot.yml",
+        ".github/workflows/integration-topology-radar-bot.yml",
         ".github/workflows/release-readiness-radar-bot.yml",
         ".github/workflows/worker-alignment-bot.yml",
         ".github/workflows/adapter-smoke-bot.yml",
@@ -760,6 +761,7 @@ def test_github_automation_check_reports_new_ghas_workflows(tmp_path: Path) -> N
     assert expansion_tracks["adapter_smoke"]["present"] is True
     assert expansion_tracks["docs_experience_radar"]["present"] is True
     assert expansion_tracks["release_readiness_radar"]["present"] is True
+    assert expansion_tracks["integration_topology_radar"]["present"] is True
     assert expansion_tracks["runtime_watchlist"]["present"] is True
     assert expansion_tracks["worker_alignment"]["present"] is True
 


### PR DESCRIPTION
### Motivation
- Make heterogeneous integration topology proof a first-class, recurring maintenance lane so topology drift and premium-gate alignment are continuously monitored.
- Surface topology-driven recommendations from the umbrella `optimize`/`expand` flows so teams can turn architecture signals into deterministic worker runs.
- Ensure worker alignment and GitHub automation reporting include topology evidence alongside dependency, docs, and release radars.

### Description
- Add a new AgentOS automation template `templates/automations/integration-topology-worker.yaml` that runs `sdetkit integration topology-check` and `sdetkit kits optimize` and bundles topology artifacts.
- Add a weekly workflow `.github/workflows/integration-topology-radar-bot.yml` that runs the new worker, uploads artifacts, and opens/refreshes a topology radar issue.
- Extend the umbrella surfaces in `src/sdetkit/kits.py` to emit an `integration-topology` innovation opportunity, an `integration-topology-control-loop` feature candidate, a `integration-topology-control` search mission, and a `worker-integration-topology` recommendation; also adjusted list/truncation sizes for opportunities/missions/workers.
- Update `src/sdetkit/maintenance/checks/github_automation_check.py` to treat the topology radar workflow as a required expansion bot and include it in expansion update tracks.
- Wire the new worker into the aligned runs by updating `.github/workflows/worker-alignment-bot.yml` to execute and publish `integration-topology-worker` outputs, and update docs (`README.md`, `docs/automation-bots.md`, `docs/kits/expansion-lab.md`) to document the new lane.
- Add template/workflow/tests updates: `tests/test_agent_templates_engine.py`, `tests/test_kits_blueprint.py`, and `tests/test_maintenance_cli.py` were updated to assert the new template, candidate, missions, and expansion tracking.

### Testing
- Ran unit/integration tests: `python -m pytest -q tests/test_kits_blueprint.py tests/test_agent_templates_engine.py tests/test_maintenance_cli.py` and all tests passed (`37 passed`).
- Static checks: `python -m ruff check src/sdetkit/kits.py src/sdetkit/maintenance/checks/github_automation_check.py tests/...` completed with no reported issues.
- Template/catalog verification: `python -m sdetkit agent templates list` shows the `integration-topology-worker` template present (returned in template listing).
- End-to-end expand output: `python -m sdetkit kits expand --goal "add more bots workers search and repo expansion" --format json` produced payloads containing `integration-topology-control-loop`, related search mission, and `integration-topology-worker` in the `worker_launch_pack`, confirming the new lane is surfaced by `expand`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bde3640dbc8320a3818624321cbd35)