### PR TITLE
docs: add repo structure and file placement guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ If this is your first PR to this repository, use this shortest safe path:
 
 For a condensed version, see `docs/first-contribution-quickstart.md`.
 For concrete, repo-grounded starter categories, use `docs/starter-work-inventory.md`.
+For file-placement and root-directory guidance, see `docs/project-structure.md`.
 
 ## Starter contribution types
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,42 @@ DevS69 SDETKit is a unified SDET platform for:
 
 It turns CI and test signals into deterministic contracts, machine-readable artifacts, and clear go/no-go guidance.
 
+## Repo at a glance
+
+If the repository feels busy at first, use this map:
+
+| Area | What belongs here | Start with |
+| --- | --- | --- |
+| `src/` | Python package code and CLI implementation | `src/sdetkit/cli.py` |
+| `tests/` | automated tests and behavioral coverage | `tests/` matching the changed feature |
+| `docs/` | user, operator, and maintainer documentation | `docs/index.md` |
+| `scripts/` | repo helper scripts and local workflows | `scripts/check.sh`, `scripts/bootstrap.sh` |
+| `templates/` | reusable templates and scaffolding assets | `templates/` |
+| `examples/` | runnable examples and sample input/output payloads | `examples/kits/` |
+| `.sdetkit/` | generated outputs and repo-local automation assets | `.sdetkit/out/` |
+| `.github/` | CI, issue templates, and GitHub automation | `.github/workflows/` |
+| `artifacts/` | generated problem/automation artifacts | `artifacts/platform_problem/latest/` |
+| Root files | project-wide policy, packaging, and entry docs | `pyproject.toml`, `mkdocs.yml`, `README.md` |
+
+For a fuller directory walkthrough, see [`docs/project-structure.md`](docs/project-structure.md).
+
+## Root file guide
+
+Keep the repository root focused on project-wide entrypoints only:
+
+- **Project entry docs**: `README.md`, `CONTRIBUTING.md`, `RELEASE.md`, `ROADMAP.md`, `CHANGELOG.md`
+- **Policy/trust docs**: `SECURITY.md`, `SUPPORT.md`, `CODE_OF_CONDUCT.md`, `LICENSE`
+- **Build/config files**: `pyproject.toml`, `poetry.lock`, `mkdocs.yml`, `noxfile.py`, `Makefile`
+- **Top-level runners**: `quality.sh`, `ci.sh`, `premium-gate.sh`, `security.sh`
+
+Prefer these placement rules when adding new files:
+
+1. Put **implementation** in `src/`, not in ad hoc root scripts.
+2. Put **deep documentation** in `docs/`, and link to it from the root instead of growing root markdown files indefinitely.
+3. Put **examples and fixtures** in `examples/` or `tests/fixtures/`, not beside product docs.
+4. Put **generated outputs** in `.sdetkit/out/` or `artifacts/`, not mixed with hand-written source.
+5. Add a **new top-level file only** when it affects the entire project.
+
 ## Umbrella kits (primary surface)
 
 - **Release Confidence Kit** — `sdetkit release ...`

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,29 +1,69 @@
 # Project structure
 
-This page is the quickest way to understand **where things are** and **where to start reading**.
+This page is the quickest way to understand **where things are**, **where new files should go**, and **which paths matter most first**.
 
 ## High-level layout
 
 ```text
 .
-├── src/sdetkit/     # application + library code
-├── tests/           # automated tests
-├── docs/            # mkdocs site pages
-├── scripts/         # developer shell/check/bootstrap helpers
-├── tools/           # extra tooling (including patch harness wrapper)
-├── pyproject.toml   # package metadata + tool configuration
-├── quality.sh       # local quality runner
-└── mkdocs.yml       # documentation site config
+├── .github/                 # CI, issue templates, automation workflows
+├── .sdetkit/                # repo-local generated outputs and automation assets
+├── artifacts/               # generated platform-problem artifacts and snapshots
+├── docs/                    # MkDocs site pages
+├── examples/                # sample inputs, outputs, and runnable examples
+├── plans/                   # planning artifacts and working plans
+├── scripts/                 # developer shell/check/bootstrap helpers
+├── src/sdetkit/             # application + library code
+├── templates/               # reusable templates and scaffolds
+├── tests/                   # automated tests
+├── tools/                   # extra tooling helpers
+├── pyproject.toml           # package metadata + tool configuration
+├── quality.sh               # local quality runner
+├── README.md                # top-level product and repo entrypoint
+└── mkdocs.yml               # documentation site config
 ```
 
 ## What to read first (by role)
 
 | If you are... | Start here | Then read |
-|---|---|---|
+| --- | --- | --- |
 | New contributor | `README.md` | `CONTRIBUTING.md`, `docs/project-structure.md` |
 | CLI user | `docs/cli.md` | `docs/doctor.md`, `docs/repo-audit.md` |
-| Maintainer | `scripts/check.sh` | `quality.sh`, `noxfile.py`, `Makefile` |
+| Maintainer | `quality.sh` | `scripts/check.sh`, `noxfile.py`, `Makefile` |
 | Release owner | `RELEASE.md` | `docs/releasing.md`, `CHANGELOG.md` |
+| Docs editor | `docs/index.md` | `mkdocs.yml`, `docs/contributing.md` |
+
+## Root directory guide
+
+The repository root should stay reserved for **project-wide entrypoints and policy**.
+
+### Keep at the root
+
+- project entry docs such as `README.md`, `CONTRIBUTING.md`, `RELEASE.md`, and `ROADMAP.md`
+- project-wide policy and trust files such as `SECURITY.md`, `SUPPORT.md`, and `CODE_OF_CONDUCT.md`
+- package/build configuration such as `pyproject.toml`, `mkdocs.yml`, `poetry.lock`, and `noxfile.py`
+- top-level workflow runners such as `quality.sh`, `ci.sh`, `premium-gate.sh`, and `security.sh`
+
+### Prefer subdirectories for everything else
+
+| Content type | Preferred location |
+| --- | --- |
+| Runtime Python code | `src/sdetkit/` |
+| Tests and fixtures | `tests/` |
+| Long-form documentation | `docs/` |
+| Examples and sample payloads | `examples/` |
+| Reusable templates | `templates/` |
+| Generated outputs/evidence | `.sdetkit/out/` or `artifacts/` |
+| One-off helper scripts | `scripts/` or `tools/` |
+| Planning material | `plans/` |
+
+## Placement rules of thumb
+
+1. Add a **new top-level file only** if it affects the entire project.
+2. Add **new code** under `src/sdetkit/` and mirror its coverage in `tests/`.
+3. Add **deep explanations** under `docs/` and link from `README.md` instead of expanding root docs forever.
+4. Put **generated content** in `.sdetkit/out/` or `artifacts/`, not beside hand-maintained source files.
+5. Put **templates/examples** in `templates/` and `examples/`, not mixed with production code.
 
 ## Key source modules (`src/sdetkit/`)
 
@@ -40,17 +80,23 @@ This page is the quickest way to understand **where things are** and **where to 
 
 ## Supporting directories
 
-- `tests/` — feature tests, CLI tests, module unit tests, mutation-test killer tests
-- `scripts/` — one-command workflows:
+- `tests/` — feature tests, CLI tests, module unit tests, and mutation-test killer tests
+- `scripts/` — one-command workflows such as:
   - `check.sh` (fmt/lint/types/tests/coverage/docs/all)
   - `bootstrap.sh` (create local environment + install dependencies)
   - `env.sh` / `shell.sh` (venv PATH convenience)
 - `docs/` — user and maintainer documentation published via MkDocs
+- `examples/` — sample profiles, example payloads, and walkthrough data
+- `templates/` — reusable scaffolding and authoring helpers
 - `tools/` — additional helper scripts for local development
+- `.github/` — Actions workflows, templates, and GitHub automation policy
 
-## Repo hygiene rules of thumb
+## Repo hygiene checklist
 
-- Keep top-level files focused on project-level workflows and policy.
-- Prefer adding technical detail under `docs/` rather than expanding root-level markdown files indefinitely.
-- Add new runtime code to `src/sdetkit/`; add tests under `tests/` with matching scope.
-- Keep scripts composable and CI-compatible (`scripts/` + `quality.sh`).
+Use this before introducing a new file or folder:
+
+- Is this file **project-wide**? If not, keep it out of the root.
+- Is this file **written by humans**? If not, prefer `.sdetkit/out/` or `artifacts/`.
+- Is this content **documentation**? If yes, prefer `docs/`.
+- Is this content **an example/template**? If yes, prefer `examples/` or `templates/`.
+- Can the change be explained by linking from an existing page instead of adding another root file?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Choose your path (30-second router): choose-your-path.md
       - Install (canonical): install.md
       - First run quickstart (canonical): ready-to-use.md
+      - Repo structure and file guide: project-structure.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
       - Release confidence (core commands): release-confidence.md
       - Doctor checks: doctor.md


### PR DESCRIPTION
### Motivation
- Improve discoverability and reduce the "everything everywhere" feeling by making it clear which files and directories belong at the project root versus subdirectories. 
- Provide explicit placement rules so new contributions land in consistent locations and avoid ad-hoc root-file growth. 
- Surface the guidance in the main README and docs navigation so newcomers can find file-placement rules quickly.

### Description
- Add a new "Repo at a glance" section to `README.md` that maps major areas (`src/`, `tests/`, `docs/`, `scripts/`, `templates/`, `examples/`, `.sdetkit/`, `.github/`, `artifacts/`, root files) to their intended purpose and quick-start pointers. 
- Expand `docs/project-structure.md` into a file-placement guide with a high-level tree, role-based reading order, root-directory rules, preferred locations by content type, placement rules of thumb, and a repo hygiene checklist. 
- Link the new structure guide from `CONTRIBUTING.md` so contributors see placement guidance during onboarding. 
- Add the project-structure page to the MkDocs beginner navigation (`mkdocs.yml`) so the guide is exposed early in the docs site.

### Testing
- Ran `python -m mkdocs build`, which completed successfully but reported pre-existing warnings about documentation files not included in the current `nav`; the build itself passed. 
- Ran targeted pre-commit checks with `python -m pre_commit run --files README.md CONTRIBUTING.md docs/project-structure.md mkdocs.yml`, and the hooks passed for the changed files. 
- Verified local formatting and basic doc/link edits via the repo's configured checks with no failures on the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be080683c48320a5c073f390b6f174)