### PR TITLE
Add `verify` mode to quality.sh; make premium-gate full use verify; ignore generated dirs in security scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ python -m sdetkit intelligence failure-fingerprint --failures examples/kits/inte
 python -m sdetkit integration check --profile examples/kits/integration/profile.json
 python -m sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json
 # validates service owners, dependency edges, mocked platform coverage, deployments, telemetry, and data resilience
+bash quality.sh ci        # fast/smoke confidence while iterating
+bash quality.sh verify    # full verification before merge
 bash premium-gate.sh --mode full
 # premium gate now emits .sdetkit/out/integration-topology.json as a first-class operational artifact
 # head-5 also auto-runs repo-safe remediation scripts unless you pass --no-auto-run-scripts

--- a/docs/premium-quality-gate.md
+++ b/docs/premium-quality-gate.md
@@ -71,7 +71,7 @@ The script emits:
 
 Useful flags:
 
-- `--mode full|fast|engine-only`
+- `--mode full|fast|engine-only` (`fast` = smoke confidence only, `full` = pre-merge verification)
 - `--continue-on-error` (collect all failures in one run)
 - `--engine-min-score <int>`
 - `--out-dir <path>`
@@ -83,6 +83,8 @@ Useful flags:
 Examples:
 
 ```bash
+bash quality.sh ci       # fast/smoke confidence while iterating
+bash quality.sh verify   # full verification before merge
 bash premium-gate.sh --mode full
 bash premium-gate.sh --mode full --continue-on-error
 bash premium-gate.sh --mode fast --engine-min-score 75

--- a/premium-gate.sh
+++ b/premium-gate.sh
@@ -18,7 +18,7 @@ usage() {
 Usage: bash premium-gate.sh [options]
 
 Options:
-  --mode <full|fast|engine-only>   Run profile (default: full)
+  --mode <full|fast|engine-only>   Run profile: fast=smoke confidence, full=pre-merge verification (default: full)
   --out-dir <path>                 Artifact/log directory (default: .sdetkit/out)
   --engine-min-score <int>         Minimum premium engine score (default: 70)
   --ops-jobs <int>                 Parallel jobs for ops run (default: 2)
@@ -93,7 +93,8 @@ runtime_recommendation() {
   local title="$1"
   local elapsed="$2"
   case "$title" in
-    "Quality") info "Recommendation: keep changed modules above baseline coverage to preserve premium quality." ;;
+    "Quality (fast/smoke)") info "Recommendation: use this fast/smoke lane for local confidence only; run full verification before merge." ;;
+    "Quality (full verification)") info "Recommendation: treat this full verification lane as the pre-merge truth path and fix failures before merge." ;;
     "Ruff (format check)"|"Ruff (lint)") info "Recommendation: wire pre-commit hooks so lint and formatting warnings are caught before CI." ;;
     "CI") info "Recommendation: if CI is slow, shard tests by module while preserving deterministic ordering." ;;
     "Doctor JSON") info "Recommendation: review doctor output for high-severity checks first, then medium recommendations." ;;
@@ -217,7 +218,16 @@ run_plan() {
     return
   fi
 
-  run_step "quality" "Head-1 Foundation & Quality" "Quality" "bash quality.sh ci"
+  local quality_title quality_cmd
+  if [[ "$MODE" == "full" ]]; then
+    quality_title="Quality (full verification)"
+    quality_cmd="bash quality.sh verify"
+  else
+    quality_title="Quality (fast/smoke)"
+    quality_cmd="bash quality.sh ci"
+  fi
+
+  run_step "quality" "Head-1 Foundation & Quality" "$quality_title" "$quality_cmd"
 
   if [[ "$MODE" == "full" ]]; then
     run_step "ruff_format" "Head-2 Source Truth & Style" "Ruff (format check)" "python3 -m ruff format --check ."

--- a/quality.sh
+++ b/quality.sh
@@ -19,6 +19,9 @@ ensure_venv
 python3 scripts/check_repo_layout.py
 
 mode=${1:-all}
+if [[ "$mode" == "-h" || "$mode" == "--help" || "$mode" == "help" ]]; then
+  mode=help
+fi
 # Keep the default gate realistic for full-repo runs, while still allowing
 # stricter enforcement in CI/release jobs via COV_FAIL_UNDER=95.
 cov_fail_under=${COV_FAIL_UNDER:-80}
@@ -30,7 +33,28 @@ need_cmd() {
   exit 127
 }
 
-valid_modes=(all ci fmt lint type doctor test full-test cov mut muthtml boost)
+valid_modes=(all ci verify fmt lint type doctor test full-test cov mut muthtml boost help)
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: bash quality.sh {all|ci|verify|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost}
+
+Modes:
+  ci         Fast/smoke lane for local confidence; not merge truth.
+  verify     Full verification lane before merge (format, lint, typing, full tests).
+  all        Auto-format plus lint, typing, pytest, and coverage.
+  fmt        Apply Ruff formatting.
+  lint       Run Ruff lint checks.
+  type       Run mypy typing checks.
+  doctor     Run the repo doctor report.
+  test       Run the fast smoke gate.
+  full-test  Run the full pytest -q suite.
+  cov        Run the coverage lane.
+  mut        Run mutation testing.
+  muthtml    Build mutation HTML output.
+  boost      Chain doctor, fast gate, premium fast gate, and optimization summary.
+USAGE
+}
 
 mode_suggestion() {
   python3 - "$1" "${valid_modes[@]}" <<'PY'
@@ -134,10 +158,18 @@ case "$mode" in
   muthtml) run_muthtml ;;
   boost) run_boost ;;
   ci)
+    echo "[quality] Fast/smoke lane for local confidence (not full merge verification)."
     run_fmt_check
     run_lint
     run_type
     run_gate_fast
+    ;;
+  verify)
+    echo "[quality] Full verification lane before merge (format, lint, typing, full tests)."
+    run_fmt_check
+    run_lint
+    run_type
+    run_full_test
     ;;
   all)
     run_fmt
@@ -146,8 +178,11 @@ case "$mode" in
     run_test
     run_cov
     ;;
+  help)
+    usage
+    ;;
   *)
-    echo "Usage: bash quality.sh {all|ci|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost}" >&2
+    usage
     suggestion="$(mode_suggestion "$mode" || true)"
     if [[ -n "$suggestion" ]]; then
       echo "Did you mean: bash quality.sh $suggestion" >&2

--- a/src/sdetkit/release_narrative.py
+++ b/src/sdetkit/release_narrative.py
@@ -279,15 +279,19 @@ def _emit_pack(root: Path, out_dir: Path, payload: dict[str, Any]) -> list[str]:
     ]
 
 
-def _execute_commands(commands: list[str], timeout_sec: int) -> list[dict[str, Any]]:
+def _execute_commands(root: Path, commands: list[str], timeout_sec: int) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
+    script_root = Path(__file__).resolve().parents[2]
     for idx, command in enumerate(commands, start=1):
         try:
             argv = shlex.split(command)
             if argv and argv[0] == "python":
                 argv[0] = sys.executable
+            if len(argv) >= 2 and argv[1] == "scripts/check_day20_release_narrative_contract.py":
+                argv[1] = str(script_root / "scripts" / "check_day20_release_narrative_contract.py")
             proc = subprocess.run(
                 argv,
+                cwd=str(root),
                 shell=False,
                 capture_output=True,
                 text=True,
@@ -437,7 +441,7 @@ def main(argv: list[str] | None = None) -> int:
         payload["execution_artifacts"] = _write_execution_evidence(
             root,
             ns.evidence_dir,
-            _execute_commands(_EXECUTION_COMMANDS, ns.timeout_sec),
+            _execute_commands(root, _EXECUTION_COMMANDS, ns.timeout_sec),
         )
 
     strict_failed = (

--- a/src/sdetkit/security_gate.py
+++ b/src/sdetkit/security_gate.py
@@ -33,7 +33,9 @@ INLINE_ALLOW_PREFIX = "# sdetkit: allow-security"
 
 SKIP_DIRS = {
     ".git",
+    ".nox",
     ".venv",
+    "__pycache__",
     "node_modules",
     "dist",
     "build",

--- a/tests/test_quality_script.py
+++ b/tests/test_quality_script.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 import subprocess
+from pathlib import Path
 
 
 def test_quality_script_unknown_mode_suggests_closest_match() -> None:
@@ -13,3 +15,25 @@ def test_quality_script_unknown_mode_suggests_closest_match() -> None:
 
     assert result.returncode == 2
     assert "Did you mean: bash quality.sh ci" in result.stderr
+
+
+def test_quality_script_help_documents_fast_and_full_lanes() -> None:
+    text = Path("quality.sh").read_text(encoding="utf-8")
+    assert (
+        "Usage: bash quality.sh {all|ci|verify|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost}"
+        in text
+    )
+    assert "Fast/smoke lane for local confidence; not merge truth." in text
+    assert "Full verification lane before merge (format, lint, typing, full tests)." in text
+
+
+def test_quality_script_verify_uses_full_test_path() -> None:
+    text = Path("quality.sh").read_text(encoding="utf-8")
+    match = re.search(r"verify\)\n(?P<body>.*?run_full_test\n    ;;)", text, re.DOTALL)
+    assert match is not None
+    body = match.group("body")
+    assert "run_fmt_check" in body
+    assert "run_lint" in body
+    assert "run_type" in body
+    assert "run_full_test" in body
+    assert "run_gate_fast" not in body

--- a/tests/test_release_narrative.py
+++ b/tests/test_release_narrative.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 from sdetkit import cli
@@ -134,3 +136,27 @@ def test_cli_dispatch(tmp_path: Path, capsys) -> None:
     )
     assert rc == 0
     assert "Day 20 release narrative" in capsys.readouterr().out
+
+
+def test_execute_commands_run_inside_requested_root(monkeypatch, tmp_path: Path) -> None:
+    calls: list[dict[str, object]] = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(rn.subprocess, "run", _fake_run)
+
+    rows = rn._execute_commands(
+        tmp_path,
+        [
+            "python -m sdetkit release-narrative --format json --strict",
+            "python scripts/check_day20_release_narrative_contract.py --skip-evidence",
+        ],
+        5,
+    )
+
+    assert len(rows) == 2
+    assert all(call["cwd"] == str(tmp_path) for call in calls)
+    assert calls[0]["argv"][0] == sys.executable
+    assert calls[1]["argv"][1].endswith("scripts/check_day20_release_narrative_contract.py")

--- a/tests/test_security_control_tower.py
+++ b/tests/test_security_control_tower.py
@@ -109,7 +109,11 @@ def test_security_fix_dry_run_previews_and_applies_shell_false(tmp_path: Path, c
 
 def test_premium_gate_script_smoke_contains_commands() -> None:
     text = Path("premium-gate.sh").read_text(encoding="utf-8")
+    assert "bash quality.sh verify" in text
     assert "bash quality.sh ci" in text
+    assert "Quality (full verification)" in text
+    assert "Quality (fast/smoke)" in text
+    assert "fast=smoke confidence, full=pre-merge verification" in text
     assert "bash ci.sh" in text
     assert "python3 -m sdetkit doctor --ascii" in text
     assert "python3 -m sdetkit doctor --json --out" in text

--- a/tests/test_security_gate_helpers_extra.py
+++ b/tests/test_security_gate_helpers_extra.py
@@ -172,3 +172,25 @@ def test_security_gate_fix_and_dep_helpers(tmp_path: Path, monkeypatch: pytest.M
     ok, msg = sg._run_ruff_fix(tmp_path)
     assert ok is False
     assert "not available" in msg
+
+
+def test_security_gate_iter_files_skips_generated_dirs(tmp_path: Path) -> None:
+    (tmp_path / ".nox" / "session").mkdir(parents=True)
+    (tmp_path / ".nox" / "session" / "bad.py").write_text(
+        "import os\nos.system('x')\n", encoding="utf-8"
+    )
+    (tmp_path / ".venv" / "bin").mkdir(parents=True)
+    (tmp_path / ".venv" / "bin" / "activate.py").write_text(
+        "import os\nos.system('x')\n", encoding="utf-8"
+    )
+    (tmp_path / "site").mkdir()
+    (tmp_path / "site" / "generated.py").write_text("import os\nos.system('x')\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "good.py").write_text("print('ok')\n", encoding="utf-8")
+
+    files = [p.relative_to(tmp_path).as_posix() for p in sg._iter_files(tmp_path)]
+
+    assert "src/good.py" in files
+    assert all(not item.startswith(".nox/") for item in files)
+    assert all(not item.startswith(".venv/") for item in files)
+    assert all(not item.startswith("site/") for item in files)


### PR DESCRIPTION
### Motivation
- Make the fast gate honest: keep `ci` as a fast/smoke lane for local confidence and add a dedicated `verify` lane that runs the full verification path used as pre-merge truth. 
- Ensure the premium gate’s `--mode full` executes the full verification path rather than the fast/smoke lane so merge-time checks align with the repository truth. 
- Reduce noise from security/maintenance scans by excluding generated environments and build artifacts from the actual scan path selection so scanners focus on repo-owned source.

### Description
- Added a real `verify` mode to `quality.sh` (usage/help updated) that runs format check, lint, typing, and the full test suite via existing helpers (`run_fmt_check`, `run_lint`, `run_type`, `run_full_test`), and preserved `ci` as the fast/smoke lane. 
- Updated `premium-gate.sh` so Head-1 runs `bash quality.sh verify` when `--mode full` and `bash quality.sh ci` when `--mode fast`, and clarified help/runtime messaging to distinguish fast/smoke vs full verification. 
- Extended `src/sdetkit/security_gate.py` SKIP_DIRS to ignore generated paths in the file walker (added `.nox`, `__pycache__`, ensured `.venv`/`site`/build/dist cache entries are excluded) so scan selection omits non-repo artifacts. 
- Fixed `src/sdetkit/release_narrative.py` `_execute_commands` to run commands inside the requested `root` and resolve the scripts path, preventing full-verification runs from mutating tracked day20 artifacts; added/updated unit tests and doc snippets to lock the contract (`tests/test_quality_script.py`, `tests/test_security_gate_helpers_extra.py`, `tests/test_security_control_tower.py`, `tests/test_release_narrative.py`, and docs updates in `docs/premium-quality-gate.md` and `README.md`).

### Testing
- Ran `pytest -q` and unit test suite which passed (final run: tests completed successfully). 
- Ran `python -m nox -s lint` which completed successfully (ruff checks and format checks passed). 
- Ran `python -m nox -s tests` which executed the full test matrix and completed successfully. 
- Executed the operational validations `bash quality.sh ci`, `bash quality.sh verify`, `bash premium-gate.sh --mode fast`, and `bash premium-gate.sh --mode full`, all of which completed successfully and produced the expected fast vs full behavior and artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c047e90c308320819e79610c18b402)