### PR TITLE
Unify gate profiles, add verify (merge-truth) lane, and introduce checks registry + final verdict contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ bash premium-gate.sh --mode full
 # premium gate now emits .sdetkit/out/integration-topology.json as a first-class operational artifact
 # head-5 also auto-runs repo-safe remediation scripts unless you pass --no-auto-run-scripts
 # and writes .sdetkit/out/premium-remediation-plan.json so PRs can review selected vs deferred fixes
+# quality.sh and premium-gate.sh also emit aligned final verdict artifacts in .sdetkit/out/
+# including quality-verdict.json / premium-verdict.json and matching markdown summaries
 python -m sdetkit.premium_gate_engine --out-dir .sdetkit/out --search doctor --format json
 python -m sdetkit.premium_gate_engine --db-path .sdetkit/out/premium-insights.db --list-guidelines --search security
 python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json --fail-on error
@@ -136,6 +138,37 @@ python -m sdetkit continuous-upgrade-cycle9-closeout --format json --strict
 python -m sdetkit continuous-upgrade-cycle10-closeout --format json --strict
 python -m sdetkit continuous-upgrade-cycle11-closeout --format json --strict
 ```
+
+
+## Unified gate architecture (phase 1 foundation)
+
+The repo now treats gate execution as honest profiles instead of ambiguous green lights:
+
+- `quick`: fast local confidence / smoke only.
+- `standard`: default repository validation.
+- `strict`: merge/release truth.
+- `adaptive`: planner-selected scaffold for targeted future execution.
+
+Operationally, that means:
+
+- `bash quality.sh ci` stays a smoke lane and explicitly says it is **not** merge truth.
+- `bash quality.sh verify` is the full truth path for merge/release decisions.
+- `bash premium-gate.sh --mode fast` stays honest smoke confidence.
+- `bash premium-gate.sh --mode full` delegates to `bash quality.sh verify` for the quality truth path.
+- both runners now emit a shared final verdict contract with profile used, checks run, checks skipped with reasons, blocking failures, advisory findings, confidence level, and merge/release recommendation.
+
+### What is implemented now
+
+- phase-1 gate/profile alignment and honest fast-vs-full wording.
+- generated-path exclusions for repo/security scanning (`.nox/`, `.venv/`, `site/`, `__pycache__/`, `.pytest_cache/`, `build/`, `dist/`).
+- a new `sdetkit.checks` foundation with a shared data model, registry metadata, and final-verdict model.
+
+### What is scaffolded for later phases
+
+- adaptive planning and scheduler-driven targeting/concurrency.
+- broader migration of every existing check into the shared registry.
+- enterprise artifact expansion beyond the initial verdict/summary contract.
+- external repo/zip/commit onboarding flows built on the same shared model.
 
 ## Upgrade planning (first step)
 

--- a/premium-gate.sh
+++ b/premium-gate.sh
@@ -18,7 +18,7 @@ usage() {
 Usage: bash premium-gate.sh [options]
 
 Options:
-  --mode <full|fast|engine-only>   Run profile: fast=smoke confidence, full=pre-merge verification (default: full)
+  --mode <full|fast|engine-only>   Run profile: fast=honest smoke confidence, full=merge/release truth via `bash quality.sh verify` (default: full)
   --out-dir <path>                 Artifact/log directory (default: .sdetkit/out)
   --engine-min-score <int>         Minimum premium engine score (default: 70)
   --ops-jobs <int>                 Parallel jobs for ops run (default: 2)
@@ -82,6 +82,8 @@ esac
 mkdir -p "$OUT_DIR"
 STEP_INDEX_JSON="$OUT_DIR/premium-step-index.json"
 STEP_RESULTS_NDJSON="$OUT_DIR/premium-step-results.ndjson"
+PREMIUM_VERDICT_JSON="$OUT_DIR/premium-verdict.json"
+PREMIUM_SUMMARY_MD="$OUT_DIR/premium-summary.md"
 : > "$STEP_RESULTS_NDJSON"
 
 section() { printf '\n==> %s\n' "$1"; }
@@ -125,8 +127,8 @@ preflight() {
 }
 
 record_result() {
-  local id="$1" head="$2" title="$3" cmd="$4" rc="$5" elapsed="$6" status="$7" log="$8"
-  python3 - "$STEP_RESULTS_NDJSON" "$id" "$head" "$title" "$cmd" "$rc" "$elapsed" "$status" "$log" <<'PY'
+  local id="$1" head="$2" title="$3" cmd="$4" rc="$5" elapsed="$6" status="$7" log="$8" blocking="$9" reason="${10}"
+  python3 - "$STEP_RESULTS_NDJSON" "$id" "$head" "$title" "$cmd" "$rc" "$elapsed" "$status" "$log" "$blocking" "$reason" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -141,19 +143,21 @@ entry = {
     "elapsed_s": int(sys.argv[7]),
     "status": sys.argv[8],
     "log": sys.argv[9],
+    "blocking": sys.argv[10] == "1",
+    "reason": sys.argv[11],
 }
 path.write_text(path.read_text(encoding="utf-8") + json.dumps(entry, sort_keys=True) + "\n", encoding="utf-8")
 PY
 }
 
 run_step() {
-  local id="$1" head="$2" title="$3" cmd="$4"
+  local id="$1" head="$2" title="$3" cmd="$4" blocking="${5:-1}"
   local safe_title
   safe_title="$(echo "$title" | tr ' /()' '_____' | tr -cd '[:alnum:]_.-')"
   local step_log="$OUT_DIR/premium-gate.${safe_title}.log"
   section "[$head] $title"
   info "cmd: $cmd"
-  local started ended elapsed rc status
+  local started ended elapsed rc status reason
   started="$(date +%s)"
   set +e
   bash -lc "$cmd" 2>&1 | tee "$step_log"
@@ -161,20 +165,29 @@ run_step() {
   set -e
   ended="$(date +%s)"
   elapsed="$((ended - started))"
+  reason=""
   if (( rc == 0 )); then
     status="passed"
     pass "$title"
     runtime_recommendation "$title" "$elapsed"
   else
     status="failed"
+    reason="command failed (rc=$rc)"
     echo "ERROR: step failed: $title"
     warn "How to fix: run the same command locally, inspect logs under $OUT_DIR, and remediate before re-running premium-gate.sh."
   fi
-  record_result "$id" "$head" "$title" "$cmd" "$rc" "$elapsed" "$status" "$step_log"
+  record_result "$id" "$head" "$title" "$cmd" "$rc" "$elapsed" "$status" "$step_log" "$blocking" "$reason"
   if (( rc != 0 && CONTINUE_ON_ERROR == 0 )); then
     exit "$rc"
   fi
   return 0
+}
+
+skip_step() {
+  local id="$1" head="$2" title="$3" reason="$4" blocking="${5:-0}"
+  section "[$head] $title"
+  info "skip: $reason"
+  record_result "$id" "$head" "$title" "" 0 0 "skipped" "" "$blocking" "$reason"
 }
 
 emit_step_index() {
@@ -204,7 +217,8 @@ summary = {
     "out_dir": os.environ["OUT_DIR"],
     "five_heads": head_order,
     "total_steps": len(steps),
-    "failed_steps": [s["id"] for s in steps if s.get("status") != "passed"],
+    "failed_steps": [s["id"] for s in steps if s.get("status") == "failed"],
+    "skipped_steps": [s["id"] for s in steps if s.get("status") == "skipped"],
     "steps": steps,
 }
 Path(sys.argv[1]).write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -212,9 +226,76 @@ print(f"wrote step index: {sys.argv[1]}")
 PY
 }
 
+emit_final_verdict() {
+  python3 - "$STEP_RESULTS_NDJSON" "$MODE" "$PREMIUM_VERDICT_JSON" "$PREMIUM_SUMMARY_MD" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from sdetkit.checks.results import CheckRecord, build_final_verdict
+
+mode = sys.argv[2]
+profile = {"fast": "quick", "full": "strict", "engine-only": "adaptive"}[mode]
+records = []
+for raw in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    item = json.loads(raw)
+    records.append(
+        CheckRecord(
+            id=str(item["id"]),
+            title=str(item["title"]),
+            status=str(item["status"]),
+            blocking=bool(item.get("blocking", True)),
+            reason=str(item.get("reason", "")),
+            command=str(item.get("cmd", "")),
+            log_path=str(item.get("log", "")),
+        )
+    )
+
+notes = {
+    "fast": "Honest smoke confidence lane. Passing here is not the merge truth.",
+    "full": "Full premium verification lane. This wraps bash quality.sh verify as the truth path.",
+    "engine-only": "Adaptive/planner scaffold lane that isolates premium engine evidence collection.",
+}[mode]
+verdict = build_final_verdict(
+    profile=profile,
+    checks=records,
+    profile_notes=notes,
+    metadata={"source": "premium-gate.sh", "mode": mode, "checks_recorded": len(records)},
+)
+Path(sys.argv[3]).write_text(verdict.to_json(), encoding="utf-8")
+Path(sys.argv[4]).write_text(verdict.to_markdown(), encoding="utf-8")
+print(f"[premium] final verdict contract: {verdict.verdict_contract}")
+print(f"[premium] profile used: {verdict.profile}")
+print(f"[premium] checks run: {len(verdict.checks_run)}")
+print(f"[premium] checks skipped: {len(verdict.checks_skipped)}")
+if verdict.blocking_failures:
+    print("[premium] blocking failures:")
+    for item in verdict.blocking_failures:
+        print(f"- {item}")
+else:
+    print("[premium] blocking failures: none")
+if verdict.advisory_findings:
+    print("[premium] advisory findings:")
+    for item in verdict.advisory_findings:
+        print(f"- {item}")
+else:
+    print("[premium] advisory findings: none")
+print(f"[premium] confidence level: {verdict.confidence_level}")
+print(f"[premium] merge/release recommendation: {verdict.recommendation}")
+print(f"[premium] verdict json: {sys.argv[3]}")
+print(f"[premium] summary md: {sys.argv[4]}")
+PY
+}
+
 run_plan() {
   if [[ "$MODE" == "engine-only" ]]; then
     info "Mode engine-only: skipping upstream steps and running Head-5 only."
+    skip_step "quality" "Head-1 Foundation & Quality" "Quality (engine-only skip)" "engine-only mode skips upstream quality lanes" 0
+    skip_step "doctor_json" "Head-3 Operational Confidence" "Doctor JSON" "engine-only mode skips upstream operational evidence" 0
+    skip_step "security_scan" "Head-4 Security & Compliance" "Security Scan (offline SARIF)" "engine-only mode skips upstream security scan" 0
     return
   fi
 
@@ -227,24 +308,28 @@ run_plan() {
     quality_cmd="bash quality.sh ci"
   fi
 
-  run_step "quality" "Head-1 Foundation & Quality" "$quality_title" "$quality_cmd"
+  run_step "quality" "Head-1 Foundation & Quality" "$quality_title" "$quality_cmd" 1
 
   if [[ "$MODE" == "full" ]]; then
-    run_step "ruff_format" "Head-2 Source Truth & Style" "Ruff (format check)" "python3 -m ruff format --check ."
-    run_step "ruff_lint" "Head-2 Source Truth & Style" "Ruff (lint)" "python3 -m ruff check ."
-    run_step "ci" "Head-3 Operational Confidence" "CI" "bash ci.sh"
-    run_step "doctor_ascii" "Head-3 Operational Confidence" "Doctor ASCII" "python3 -m sdetkit doctor --ascii"
-    run_step "doctor_json" "Head-3 Operational Confidence" "Doctor JSON" "python3 -m sdetkit doctor --json --out '$OUT_DIR/doctor.json'"
-    run_step "maintenance_full" "Head-3 Operational Confidence" "Maintenance Full" "python3 -m sdetkit maintenance --mode full --format json --out '$OUT_DIR/maintenance.json'"
-    run_step "integration_topology" "Head-3 Operational Confidence" "Integration Topology Contract" "python3 -m sdetkit integration topology-check --profile '$TOPOLOGY_PROFILE' > '$OUT_DIR/integration-topology.json'"
-    run_step "security_scan" "Head-4 Security & Compliance" "Security Scan (offline SARIF)" "python3 -m sdetkit security scan --fail-on none --format sarif --output '$OUT_DIR/security.sarif'"
-    run_step "security_triage" "Head-4 Security & Compliance" "Security Triage (baseline-aware)" "python3 tools/triage.py --mode security --run-security --security-baseline tools/security.baseline.json --max-items 20 --tee '$OUT_DIR/security-check.json'"
-    run_step "ops_ci" "Head-3 Operational Confidence" "Control Plane Ops (CI profile)" "python3 -m sdetkit ops run --profile ci --jobs '$OPS_JOBS'"
-    run_step "evidence" "Head-4 Security & Compliance" "Evidence Pack" "python3 -m sdetkit evidence pack --output '$OUT_DIR/evidence.zip'"
+    run_step "ruff_format" "Head-2 Source Truth & Style" "Ruff (format check)" "python3 -m ruff format --check ." 1
+    run_step "ruff_lint" "Head-2 Source Truth & Style" "Ruff (lint)" "python3 -m ruff check ." 1
+    run_step "ci" "Head-3 Operational Confidence" "CI" "bash ci.sh" 1
+    run_step "doctor_ascii" "Head-3 Operational Confidence" "Doctor ASCII" "python3 -m sdetkit doctor --ascii" 0
+    run_step "doctor_json" "Head-3 Operational Confidence" "Doctor JSON" "python3 -m sdetkit doctor --json --out '$OUT_DIR/doctor.json'" 0
+    run_step "maintenance_full" "Head-3 Operational Confidence" "Maintenance Full" "python3 -m sdetkit maintenance --mode full --format json --out '$OUT_DIR/maintenance.json'" 0
+    run_step "integration_topology" "Head-3 Operational Confidence" "Integration Topology Contract" "python3 -m sdetkit integration topology-check --profile '$TOPOLOGY_PROFILE' > '$OUT_DIR/integration-topology.json'" 0
+    run_step "security_scan" "Head-4 Security & Compliance" "Security Scan (offline SARIF)" "python3 -m sdetkit security scan --fail-on none --format sarif --output '$OUT_DIR/security.sarif'" 1
+    run_step "security_triage" "Head-4 Security & Compliance" "Security Triage (baseline-aware)" "python3 tools/triage.py --mode security --run-security --security-baseline tools/security.baseline.json --max-items 20 --tee '$OUT_DIR/security-check.json'" 0
+    run_step "ops_ci" "Head-3 Operational Confidence" "Control Plane Ops (CI profile)" "python3 -m sdetkit ops run --profile ci --jobs '$OPS_JOBS'" 0
+    run_step "evidence" "Head-4 Security & Compliance" "Evidence Pack" "python3 -m sdetkit evidence pack --output '$OUT_DIR/evidence.zip'" 0
   else
-    run_step "doctor_json" "Head-3 Operational Confidence" "Doctor JSON" "python3 -m sdetkit doctor --json --out '$OUT_DIR/doctor.json'"
-    run_step "integration_topology" "Head-3 Operational Confidence" "Integration Topology Contract" "python3 -m sdetkit integration topology-check --profile '$TOPOLOGY_PROFILE' > '$OUT_DIR/integration-topology.json'"
-    run_step "security_scan" "Head-4 Security & Compliance" "Security Scan (offline SARIF)" "python3 -m sdetkit security scan --fail-on none --format sarif --output '$OUT_DIR/security.sarif'"
+    skip_step "ruff_format" "Head-2 Source Truth & Style" "Ruff (format check)" "fast mode relies on quality.sh ci for smoke-level source checks" 0
+    skip_step "ruff_lint" "Head-2 Source Truth & Style" "Ruff (lint)" "fast mode relies on quality.sh ci for smoke-level source checks" 0
+    run_step "doctor_json" "Head-3 Operational Confidence" "Doctor JSON" "python3 -m sdetkit doctor --json --out '$OUT_DIR/doctor.json'" 0
+    run_step "integration_topology" "Head-3 Operational Confidence" "Integration Topology Contract" "python3 -m sdetkit integration topology-check --profile '$TOPOLOGY_PROFILE' > '$OUT_DIR/integration-topology.json'" 0
+    run_step "security_scan" "Head-4 Security & Compliance" "Security Scan (offline SARIF)" "python3 -m sdetkit security scan --fail-on none --format sarif --output '$OUT_DIR/security.sarif'" 0
+    skip_step "maintenance_full" "Head-3 Operational Confidence" "Maintenance Full" "fast mode omits the slower full maintenance lane" 0
+    skip_step "evidence" "Head-4 Security & Compliance" "Evidence Pack" "fast mode omits release-grade evidence packaging" 0
   fi
 }
 
@@ -258,11 +343,12 @@ run_engine() {
   if [[ "$AUTO_RUN_SCRIPTS" == "1" ]]; then
     engine_cmd+=" --auto-run-scripts"
   fi
-  run_step "premium_engine" "Head-5 Intelligence Brain" "Premium Gate Engine" "$engine_cmd"
+  run_step "premium_engine" "Head-5 Intelligence Brain" "Premium Gate Engine" "$engine_cmd" 0
 }
 
 final_report() {
   emit_step_index
+  emit_final_verdict
   section "Premium Gate Final Report"
   python3 - "$STEP_RESULTS_NDJSON" <<'PY'
 import json
@@ -275,14 +361,21 @@ for raw in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
     if not raw:
         continue
     rows.append(json.loads(raw))
-failed = [r for r in rows if r.get("status") != "passed"]
-print(f"steps: {len(rows)} | failed: {len(failed)}")
+failed = [r for r in rows if r.get("status") == "failed"]
+skipped = [r for r in rows if r.get("status") == "skipped"]
+print(f"steps: {len(rows)} | failed: {len(failed)} | skipped: {len(skipped)}")
 if failed:
     print("failed step details:")
     for row in failed:
         print(f"- {row['head']} :: {row['title']} (rc={row['rc']})")
         print(f"  log: {row['log']}")
-    print("next action: inspect logs and .sdetkit/out/premium-summary.json for prioritized remediation.")
+else:
+    print("failed step details: none")
+if skipped:
+    print("skipped step details:")
+    for row in skipped:
+        print(f"- {row['head']} :: {row['title']} -> {row['reason']}")
+print("next action: inspect logs and .sdetkit/out/premium-summary.json for prioritized remediation.")
 PY
 
   if [[ -f "$OUT_DIR/premium-summary.json" ]]; then
@@ -293,6 +386,8 @@ PY
   fi
   info "Step index: $STEP_INDEX_JSON"
   info "Step run ledger: $STEP_RESULTS_NDJSON"
+  info "Verdict JSON: $PREMIUM_VERDICT_JSON"
+  info "Summary MD: $PREMIUM_SUMMARY_MD"
 }
 
 export MODE OUT_DIR STEP_RESULTS_NDJSON TOPOLOGY_PROFILE

--- a/quality.sh
+++ b/quality.sh
@@ -39,10 +39,16 @@ usage() {
   cat <<'USAGE' >&2
 Usage: bash quality.sh {all|ci|verify|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost}
 
+Profiles:
+  quick     Fast local confidence / smoke profile.
+  standard  Default repository validation profile.
+  strict    Merge/release truth profile.
+  adaptive  Planner-selected profile scaffold for future targeted scheduling.
+
 Modes:
   ci         Fast/smoke lane for local confidence; not merge truth.
   verify     Full verification lane before merge (format, lint, typing, full tests).
-  all        Auto-format plus lint, typing, pytest, and coverage.
+  all        Standard repo validation lane (auto-format, lint, typing, pytest, coverage).
   fmt        Apply Ruff formatting.
   lint       Run Ruff lint checks.
   type       Run mypy typing checks.
@@ -69,11 +75,11 @@ if match:
 PY
 }
 
-run_fmt()     { need_cmd ruff; python -m ruff format .; }
+run_fmt() { need_cmd ruff; python -m ruff format .; }
 run_fmt_check() { need_cmd ruff; python -m ruff format --check .; }
-run_lint()    { need_cmd ruff; python -m ruff check .; }
-run_type()    { need_cmd mypy; python -m mypy --config-file pyproject.toml src; }
-run_doctor()  { python -m sdetkit doctor --dev --ci --deps --repo --upgrade-audit --format md; }
+run_lint() { need_cmd ruff; python -m ruff check .; }
+run_type() { need_cmd mypy; python -m mypy --config-file pyproject.toml src; }
+run_doctor() { python -m sdetkit doctor --dev --ci --deps --repo --upgrade-audit --format md; }
 run_gate_fast() { python -m sdetkit gate fast; }
 run_premium_autofix() {
   if [[ -f "premium-gate.sh" ]]; then
@@ -117,7 +123,7 @@ run_boost() {
   run_optimize_summary
 }
 run_full_test() { need_cmd pytest; python -m pytest -q -o addopts=; }
-run_test()    { need_cmd pytest; python -m pytest; }
+run_test() { need_cmd pytest; python -m pytest; }
 run_cov() {
   need_cmd pytest
   # Coverage profiles:
@@ -143,43 +149,236 @@ run_cov() {
     --cov-report=term-missing \
     --cov-fail-under="$cov_fail_under"
 }
-run_mut()     { need_cmd mutmut; mutmut run; }
+run_mut() { need_cmd mutmut; mutmut run; }
 run_muthtml() { need_cmd mutmut; mutmut html; }
 
+SDETKIT_OUT_DIR="${SDETKIT_OUT_DIR:-.sdetkit/out}"
+mkdir -p "$SDETKIT_OUT_DIR"
+QUALITY_STEP_RESULTS_NDJSON="$SDETKIT_OUT_DIR/quality-step-results.ndjson"
+QUALITY_VERDICT_JSON="$SDETKIT_OUT_DIR/quality-verdict.json"
+QUALITY_SUMMARY_MD="$SDETKIT_OUT_DIR/quality-summary.md"
+: > "$QUALITY_STEP_RESULTS_NDJSON"
+
+record_check() {
+  python3 - "$QUALITY_STEP_RESULTS_NDJSON" "$1" "$2" "$3" "$4" "$5" "$6" "$7" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+entry = {
+    "id": sys.argv[2],
+    "title": sys.argv[3],
+    "status": sys.argv[4],
+    "blocking": sys.argv[5] == "1",
+    "reason": sys.argv[6],
+    "command": sys.argv[7],
+    "log_path": sys.argv[8],
+}
+path.write_text(path.read_text(encoding="utf-8") + json.dumps(entry, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
+run_tracked() {
+  local check_id="$1"
+  local title="$2"
+  local blocking="$3"
+  local command_text="$4"
+  local safe_title
+  safe_title="$(echo "$check_id" | tr -cd '[:alnum:]_.-')"
+  local log_path="$SDETKIT_OUT_DIR/quality.${safe_title}.log"
+  echo "[quality] running $check_id :: $title"
+  set +e
+  eval "$command_text" 2>&1 | tee "$log_path"
+  local rc=${PIPESTATUS[0]}
+  set -e
+  if (( rc == 0 )); then
+    record_check "$check_id" "$title" "passed" "$blocking" "" "$command_text" "$log_path"
+  else
+    record_check "$check_id" "$title" "failed" "$blocking" "command failed (rc=$rc)" "$command_text" "$log_path"
+  fi
+  return "$rc"
+}
+
+skip_tracked() {
+  local check_id="$1"
+  local title="$2"
+  local blocking="$3"
+  local reason="$4"
+  record_check "$check_id" "$title" "skipped" "$blocking" "$reason" "" ""
+}
+
+emit_final_verdict() {
+  python3 - "$QUALITY_STEP_RESULTS_NDJSON" "$1" "$2" "$QUALITY_VERDICT_JSON" "$QUALITY_SUMMARY_MD" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from sdetkit.checks.results import CheckRecord, build_final_verdict
+
+records = []
+for raw in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    item = json.loads(raw)
+    records.append(
+        CheckRecord(
+            id=str(item["id"]),
+            title=str(item["title"]),
+            status=str(item["status"]),
+            blocking=bool(item.get("blocking", True)),
+            reason=str(item.get("reason", "")),
+            command=str(item.get("command", "")),
+            log_path=str(item.get("log_path", "")),
+        )
+    )
+
+profile = sys.argv[2]
+notes = sys.argv[3]
+verdict = build_final_verdict(
+    profile=profile,
+    checks=records,
+    profile_notes=notes,
+    metadata={"source": "quality.sh", "checks_recorded": len(records)},
+)
+Path(sys.argv[4]).write_text(verdict.to_json(), encoding="utf-8")
+Path(sys.argv[5]).write_text(verdict.to_markdown(), encoding="utf-8")
+print(f"[quality] final verdict contract: {verdict.verdict_contract}")
+print(f"[quality] profile used: {verdict.profile}")
+print(f"[quality] checks run: {len(verdict.checks_run)}")
+print(f"[quality] checks skipped: {len(verdict.checks_skipped)}")
+if verdict.blocking_failures:
+    print("[quality] blocking failures:")
+    for item in verdict.blocking_failures:
+        print(f"- {item}")
+else:
+    print("[quality] blocking failures: none")
+if verdict.advisory_findings:
+    print("[quality] advisory findings:")
+    for item in verdict.advisory_findings:
+        print(f"- {item}")
+else:
+    print("[quality] advisory findings: none")
+print(f"[quality] confidence level: {verdict.confidence_level}")
+print(f"[quality] merge/release recommendation: {verdict.recommendation}")
+print(f"[quality] verdict json: {sys.argv[4]}")
+print(f"[quality] summary md: {sys.argv[5]}")
+PY
+}
+
+final_rc=0
+profile_used="standard"
+profile_notes="Default repository validation profile."
+
+run_required() {
+  if ! run_tracked "$1" "$2" "$3" "$4"; then
+    final_rc=1
+  fi
+}
+
 case "$mode" in
-  fmt) run_fmt ;;
-  lint) run_lint ;;
-  type) run_type ;;
-  doctor) run_doctor ;;
-  test) run_gate_fast ;;
-  cov) run_cov ;;
-  full-test) run_full_test ;;
-  mut) run_mut ;;
-  muthtml) run_muthtml ;;
-  boost) run_boost ;;
-  ci)
+  fmt)
+    profile_used="standard"
+    profile_notes="Single-check maintenance lane for formatting application."
+    run_required "format_apply" "Ruff format apply" 0 "run_fmt"
+    skip_tracked "lint" "Ruff lint" 1 "not selected in fmt mode"
+    skip_tracked "typing" "Mypy typing" 1 "not selected in fmt mode"
+    skip_tracked "tests_full" "Full pytest suite" 1 "not selected in fmt mode"
+    ;;
+  lint)
+    profile_used="standard"
+    profile_notes="Single-check repository validation lane for lint only."
+    run_required "lint" "Ruff lint" 1 "run_lint"
+    skip_tracked "format_check" "Ruff format check" 1 "not selected in lint mode"
+    skip_tracked "typing" "Mypy typing" 1 "not selected in lint mode"
+    skip_tracked "tests_full" "Full pytest suite" 1 "not selected in lint mode"
+    ;;
+  type)
+    profile_used="standard"
+    profile_notes="Single-check repository validation lane for typing only."
+    run_required "typing" "Mypy typing" 1 "run_type"
+    skip_tracked "format_check" "Ruff format check" 1 "not selected in type mode"
+    skip_tracked "lint" "Ruff lint" 1 "not selected in type mode"
+    skip_tracked "tests_full" "Full pytest suite" 1 "not selected in type mode"
+    ;;
+  doctor)
+    profile_used="standard"
+    profile_notes="Advisory repository health report lane."
+    run_required "doctor" "Doctor report" 0 "run_doctor"
+    skip_tracked "format_check" "Ruff format check" 1 "not selected in doctor mode"
+    skip_tracked "lint" "Ruff lint" 1 "not selected in doctor mode"
+    skip_tracked "typing" "Mypy typing" 1 "not selected in doctor mode"
+    ;;
+  test)
+    profile_used="quick"
+    profile_notes="Smoke-only test lane; passing does not imply merge truth."
     echo "[quality] Fast/smoke lane for local confidence (not full merge verification)."
-    run_fmt_check
-    run_lint
-    run_type
-    run_gate_fast
+    run_required "tests_smoke" "Fast/smoke tests" 1 "run_gate_fast"
+    skip_tracked "tests_full" "Full pytest suite" 1 "smoke test mode only"
+    ;;
+  cov)
+    profile_used="standard"
+    profile_notes="Coverage lane for default repository validation."
+    run_required "coverage" "Coverage lane" 1 "run_cov"
+    skip_tracked "tests_full" "Full pytest suite" 1 "coverage mode focuses on coverage gate"
+    ;;
+  full-test)
+    profile_used="strict"
+    profile_notes="Full test truth lane without the surrounding non-test checks."
+    run_required "tests_full" "Full pytest suite" 1 "run_full_test"
+    skip_tracked "tests_smoke" "Fast/smoke tests" 1 "full test mode supersedes smoke path"
+    ;;
+  mut)
+    profile_used="standard"
+    profile_notes="Mutation analysis lane."
+    run_required "mutation" "Mutation testing" 1 "run_mut"
+    ;;
+  muthtml)
+    profile_used="standard"
+    profile_notes="Mutation HTML artifact lane."
+    run_required "mutation_html" "Mutation HTML output" 0 "run_muthtml"
+    ;;
+  boost)
+    profile_used="adaptive"
+    profile_notes="Planner-oriented boost lane that chains multiple platform surfaces."
+    run_required "boost" "Boost orchestration" 0 "run_boost"
+    ;;
+  ci)
+    profile_used="quick"
+    profile_notes="Fast local confidence / smoke profile. Honest smoke lane only; not merge truth."
+    echo "[quality] Fast/smoke lane for local confidence (not full merge verification)."
+    run_required "format_check" "Ruff format check" 1 "run_fmt_check"
+    run_required "lint" "Ruff lint" 1 "run_lint"
+    run_required "typing" "Mypy typing" 1 "run_type"
+    run_required "tests_smoke" "Fast/smoke tests" 1 "run_gate_fast"
+    skip_tracked "tests_full" "Full pytest suite" 1 "quick profile uses smoke gate only; run verify for merge truth"
+    skip_tracked "coverage" "Coverage lane" 0 "quick profile omits coverage to stay fast"
     ;;
   verify)
+    profile_used="strict"
+    profile_notes="Merge/release truth profile. Full verification before merge."
     echo "[quality] Full verification lane before merge (format, lint, typing, full tests)."
-    run_fmt_check
-    run_lint
-    run_type
-    run_full_test
+    run_required "format_check" "Ruff format check" 1 "run_fmt_check"
+    run_required "lint" "Ruff lint" 1 "run_lint"
+    run_required "typing" "Mypy typing" 1 "run_type"
+    run_required "tests_full" "Full pytest suite" 1 "run_full_test"
+    skip_tracked "tests_smoke" "Fast/smoke tests" 1 "strict profile uses full tests instead of smoke gate"
+    skip_tracked "coverage" "Coverage lane" 0 "verify focuses on merge-truth checks; coverage remains a separate standard lane"
     ;;
   all)
-    run_fmt
-    run_lint
-    run_type
-    run_test
-    run_cov
+    profile_used="standard"
+    profile_notes="Default repository validation profile. Broader than smoke, lighter than strict merge truth."
+    run_required "format_apply" "Ruff format apply" 0 "run_fmt"
+    run_required "lint" "Ruff lint" 1 "run_lint"
+    run_required "typing" "Mypy typing" 1 "run_type"
+    run_required "tests_standard" "Pytest default suite" 1 "run_test"
+    run_required "coverage" "Coverage lane" 0 "run_cov"
+    skip_tracked "tests_full" "Full pytest suite" 1 "standard profile is not the merge/release truth path; use verify"
     ;;
   help)
     usage
+    exit 0
     ;;
   *)
     usage
@@ -190,3 +389,6 @@ case "$mode" in
     exit 2
     ;;
 esac
+
+emit_final_verdict "$profile_used" "$profile_notes"
+exit "$final_rc"

--- a/src/sdetkit/checks/__init__.py
+++ b/src/sdetkit/checks/__init__.py
@@ -1,0 +1,23 @@
+from .base import CheckDefinition, CheckProfile, RegistrySnapshot
+from .registry import (
+    CheckRegistry,
+    default_registry,
+    planner_seed,
+    profile_definitions,
+    registry_snapshot,
+)
+from .results import CheckRecord, FinalVerdict, build_final_verdict
+
+__all__ = [
+    "CheckDefinition",
+    "CheckProfile",
+    "RegistrySnapshot",
+    "CheckRegistry",
+    "default_registry",
+    "planner_seed",
+    "profile_definitions",
+    "registry_snapshot",
+    "CheckRecord",
+    "FinalVerdict",
+    "build_final_verdict",
+]

--- a/src/sdetkit/checks/base.py
+++ b/src/sdetkit/checks/base.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+CheckCategory = Literal[
+    "repo",
+    "doctor",
+    "lint",
+    "format",
+    "typing",
+    "tests",
+    "security",
+    "dependency",
+    "packaging",
+    "docs",
+    "release",
+    "governance",
+    "ci",
+    "performance",
+    "artifacts",
+]
+CheckCost = Literal["cheap", "moderate", "expensive"]
+CheckTruthLevel = Literal["smoke", "standard", "merge", "adaptive"]
+CheckProfileName = Literal["quick", "standard", "strict", "adaptive"]
+CheckStatus = Literal["passed", "failed", "skipped"]
+CheckRunner = Callable[[], int | dict[str, Any] | None]
+
+
+@dataclass(frozen=True)
+class CheckDefinition:
+    id: str
+    title: str
+    category: CheckCategory
+    cost: CheckCost
+    truth_level: CheckTruthLevel
+    dependencies: tuple[str, ...] = ()
+    parallel_safe: bool = True
+    required_tools: tuple[str, ...] = ()
+    required_paths: tuple[str, ...] = ()
+    advisory_only: bool = False
+    profile_names: tuple[CheckProfileName, ...] = ("quick", "standard", "strict", "adaptive")
+    command: tuple[str, ...] = ()
+    evidence_outputs: tuple[str, ...] = ()
+    run: CheckRunner | None = None
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class CheckProfile:
+    name: CheckProfileName
+    description: str
+    default_truth_level: CheckTruthLevel
+    merge_truth: bool
+    check_ids: tuple[str, ...]
+    planner_selected: bool = False
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class PlannerHint:
+    profile: CheckProfileName
+    reasons: tuple[str, ...] = ()
+    changed_paths: tuple[str, ...] = ()
+    targeted: bool = False
+    cache_keys: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SchedulerPlan:
+    profile: CheckProfileName
+    selected_checks: tuple[str, ...]
+    concurrency: int
+    blocked_checks: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+
+@dataclass
+class RegistrySnapshot:
+    profiles: dict[CheckProfileName, CheckProfile] = field(default_factory=dict)
+    checks: dict[str, CheckDefinition] = field(default_factory=dict)
+
+    def profile(self, name: CheckProfileName) -> CheckProfile:
+        return self.profiles[name]
+
+    def check(self, check_id: str) -> CheckDefinition:
+        return self.checks[check_id]
+
+    def checks_for_profile(self, profile: CheckProfileName) -> tuple[CheckDefinition, ...]:
+        configured = self.profile(profile).check_ids
+        return tuple(self.check(check_id) for check_id in configured)
+
+    def categories(self) -> tuple[str, ...]:
+        return tuple(sorted({check.category for check in self.checks.values()}))
+
+
+def normalize_ids(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value).strip() for value in values if str(value).strip()))

--- a/src/sdetkit/checks/registry.py
+++ b/src/sdetkit/checks/registry.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from typing import cast
+
+from .base import CheckDefinition, CheckProfile, CheckProfileName, RegistrySnapshot, normalize_ids
+
+DEFAULT_CHECKS: tuple[CheckDefinition, ...] = (
+    CheckDefinition(
+        id="repo_layout",
+        title="Repository layout contract",
+        category="repo",
+        cost="cheap",
+        truth_level="smoke",
+        parallel_safe=True,
+        required_tools=("python3",),
+        required_paths=("scripts/check_repo_layout.py",),
+        command=("python3", "scripts/check_repo_layout.py"),
+        evidence_outputs=("stdout",),
+        notes="Protects baseline repo structure before deeper checks run.",
+    ),
+    CheckDefinition(
+        id="format_check",
+        title="Ruff format check",
+        category="format",
+        cost="cheap",
+        truth_level="standard",
+        parallel_safe=True,
+        required_tools=("ruff",),
+        command=("python", "-m", "ruff", "format", "--check", "."),
+        evidence_outputs=("stdout", "stderr"),
+    ),
+    CheckDefinition(
+        id="lint",
+        title="Ruff lint",
+        category="lint",
+        cost="cheap",
+        truth_level="standard",
+        parallel_safe=True,
+        required_tools=("ruff",),
+        command=("python", "-m", "ruff", "check", "."),
+        evidence_outputs=("stdout", "stderr"),
+    ),
+    CheckDefinition(
+        id="typing",
+        title="Mypy typing",
+        category="typing",
+        cost="moderate",
+        truth_level="standard",
+        parallel_safe=True,
+        required_tools=("mypy",),
+        required_paths=("pyproject.toml", "src"),
+        command=("python", "-m", "mypy", "--config-file", "pyproject.toml", "src"),
+        evidence_outputs=("stdout", "stderr"),
+    ),
+    CheckDefinition(
+        id="doctor",
+        title="Doctor report",
+        category="doctor",
+        cost="moderate",
+        truth_level="smoke",
+        parallel_safe=True,
+        required_tools=("python",),
+        command=(
+            "python",
+            "-m",
+            "sdetkit",
+            "doctor",
+            "--dev",
+            "--ci",
+            "--deps",
+            "--repo",
+            "--upgrade-audit",
+            "--format",
+            "md",
+        ),
+        evidence_outputs=("stdout",),
+    ),
+    CheckDefinition(
+        id="tests_smoke",
+        title="Fast/smoke tests",
+        category="tests",
+        cost="moderate",
+        truth_level="smoke",
+        parallel_safe=False,
+        required_tools=("pytest",),
+        command=("python", "-m", "sdetkit", "gate", "fast"),
+        evidence_outputs=("stdout", "stderr", ".sdetkit/gate.fast.snapshot.json"),
+        notes="Useful for local confidence only; never represents merge truth.",
+    ),
+    CheckDefinition(
+        id="tests_full",
+        title="Full pytest suite",
+        category="tests",
+        cost="expensive",
+        truth_level="merge",
+        dependencies=("format_check", "lint", "typing"),
+        parallel_safe=False,
+        required_tools=("pytest",),
+        command=("python", "-m", "pytest", "-q", "-o", "addopts="),
+        evidence_outputs=("stdout", "stderr"),
+        notes="This is the full truth path for merge and release verification.",
+    ),
+    CheckDefinition(
+        id="coverage",
+        title="Coverage lane",
+        category="tests",
+        cost="expensive",
+        truth_level="standard",
+        dependencies=("tests_smoke",),
+        parallel_safe=False,
+        required_tools=("pytest",),
+        command=("python", "-m", "pytest", "--cov=sdetkit"),
+        evidence_outputs=("stdout", "stderr"),
+    ),
+    CheckDefinition(
+        id="security_scan",
+        title="Offline security scan",
+        category="security",
+        cost="moderate",
+        truth_level="standard",
+        parallel_safe=True,
+        required_tools=("python",),
+        command=(
+            "python",
+            "-m",
+            "sdetkit",
+            "security",
+            "scan",
+            "--fail-on",
+            "none",
+            "--format",
+            "sarif",
+        ),
+        evidence_outputs=(".sdetkit/out/security.sarif",),
+        notes="Generated and non-owned paths are excluded to reduce noise.",
+    ),
+    CheckDefinition(
+        id="maintenance_full",
+        title="Maintenance full report",
+        category="dependency",
+        cost="moderate",
+        truth_level="standard",
+        parallel_safe=True,
+        required_tools=("python",),
+        command=(
+            "python",
+            "-m",
+            "sdetkit",
+            "maintenance",
+            "--mode",
+            "full",
+            "--format",
+            "json",
+        ),
+        evidence_outputs=(".sdetkit/out/maintenance.json",),
+    ),
+    CheckDefinition(
+        id="evidence_pack",
+        title="Evidence pack",
+        category="artifacts",
+        cost="moderate",
+        truth_level="merge",
+        dependencies=("tests_full", "security_scan", "maintenance_full"),
+        parallel_safe=True,
+        required_tools=("python",),
+        command=("python", "-m", "sdetkit", "evidence", "pack"),
+        evidence_outputs=(".sdetkit/out/evidence.zip",),
+    ),
+)
+
+DEFAULT_PROFILES: tuple[CheckProfile, ...] = (
+    CheckProfile(
+        name="quick",
+        description="Fast local confidence / smoke profile.",
+        default_truth_level="smoke",
+        merge_truth=False,
+        check_ids=("repo_layout", "format_check", "lint", "typing", "tests_smoke"),
+        notes="Honest smoke lane for developers; passing does not imply merge readiness.",
+    ),
+    CheckProfile(
+        name="standard",
+        description="Default repository validation profile.",
+        default_truth_level="standard",
+        merge_truth=False,
+        check_ids=("repo_layout", "format_check", "lint", "typing", "tests_smoke", "coverage"),
+        notes="Balanced default for regular repo validation and daily automation.",
+    ),
+    CheckProfile(
+        name="strict",
+        description="Merge/release truth profile.",
+        default_truth_level="merge",
+        merge_truth=True,
+        check_ids=(
+            "repo_layout",
+            "format_check",
+            "lint",
+            "typing",
+            "tests_full",
+            "security_scan",
+            "maintenance_full",
+            "evidence_pack",
+        ),
+        notes="Full verification lane used for merge and release decisions.",
+    ),
+    CheckProfile(
+        name="adaptive",
+        description="Planner-selected profile based on repo/input context.",
+        default_truth_level="adaptive",
+        merge_truth=False,
+        check_ids=("repo_layout", "format_check", "lint", "typing", "tests_smoke", "security_scan"),
+        planner_selected=True,
+        notes="Phase-2/3 foundation: planner and scheduler decide the final targeted set.",
+    ),
+)
+
+
+class CheckRegistry:
+    def __init__(
+        self,
+        checks: tuple[CheckDefinition, ...] = DEFAULT_CHECKS,
+        profiles: tuple[CheckProfile, ...] = DEFAULT_PROFILES,
+    ) -> None:
+        self._snapshot = RegistrySnapshot(
+            profiles={profile.name: profile for profile in profiles},
+            checks={check.id: check for check in checks},
+        )
+
+    def snapshot(self) -> RegistrySnapshot:
+        return self._snapshot
+
+    def profile_names(self) -> tuple[str, ...]:
+        return tuple(self._snapshot.profiles)
+
+    def profile_check_ids(self, profile: str) -> tuple[str, ...]:
+        return self._snapshot.profile(cast(CheckProfileName, profile)).check_ids
+
+    def check_ids(self) -> tuple[str, ...]:
+        return tuple(self._snapshot.checks)
+
+    def planner_seed(self, profile: str = "adaptive") -> dict[str, object]:
+        profile_def = self._snapshot.profile(cast(CheckProfileName, profile))
+        return {
+            "profile": profile_def.name,
+            "planner_selected": profile_def.planner_selected,
+            "check_ids": list(profile_def.check_ids),
+            "notes": profile_def.notes,
+            "categories": list(self._snapshot.categories()),
+        }
+
+
+def default_registry() -> CheckRegistry:
+    return CheckRegistry()
+
+
+def profile_definitions() -> tuple[CheckProfile, ...]:
+    return DEFAULT_PROFILES
+
+
+def registry_snapshot() -> RegistrySnapshot:
+    return default_registry().snapshot()
+
+
+def planner_seed(profile: str = "adaptive") -> dict[str, object]:
+    return default_registry().planner_seed(profile)
+
+
+def check_ids_for_profile(profile: str) -> tuple[str, ...]:
+    return normalize_ids(default_registry().profile_check_ids(profile))

--- a/src/sdetkit/checks/results.py
+++ b/src/sdetkit/checks/results.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+from .base import CheckProfileName, CheckStatus
+
+ConfidenceLevel = Literal[
+    "low (smoke-only)",
+    "medium (standard validation)",
+    "high (merge/release truth)",
+    "planned (adaptive selection)",
+]
+Recommendation = Literal[
+    "continue-local-iteration",
+    "run-standard-validation",
+    "run-full-verification-before-merge",
+    "ready-for-merge-review",
+    "do-not-merge",
+]
+
+_PROFILE_CONFIDENCE: dict[CheckProfileName, ConfidenceLevel] = {
+    "quick": "low (smoke-only)",
+    "standard": "medium (standard validation)",
+    "strict": "high (merge/release truth)",
+    "adaptive": "planned (adaptive selection)",
+}
+
+
+@dataclass(frozen=True)
+class CheckRecord:
+    id: str
+    title: str
+    status: CheckStatus
+    blocking: bool = True
+    reason: str = ""
+    command: str = ""
+    advisory: tuple[str, ...] = ()
+    log_path: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["advisory"] = list(self.advisory)
+        return payload
+
+
+@dataclass(frozen=True)
+class FinalVerdict:
+    profile: CheckProfileName
+    verdict_contract: str
+    checks_run: tuple[CheckRecord, ...]
+    checks_skipped: tuple[CheckRecord, ...]
+    blocking_failures: tuple[str, ...]
+    advisory_findings: tuple[str, ...]
+    confidence_level: ConfidenceLevel
+    recommendation: Recommendation
+    summary: str
+    ok: bool
+    merge_truth: bool
+    profile_notes: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "profile": self.profile,
+            "verdict_contract": self.verdict_contract,
+            "ok": self.ok,
+            "merge_truth": self.merge_truth,
+            "summary": self.summary,
+            "profile_notes": self.profile_notes,
+            "checks_run": [record.as_dict() for record in self.checks_run],
+            "checks_skipped": [record.as_dict() for record in self.checks_skipped],
+            "blocking_failures": list(self.blocking_failures),
+            "advisory_findings": list(self.advisory_findings),
+            "confidence_level": self.confidence_level,
+            "recommendation": self.recommendation,
+            "metadata": self.metadata,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), sort_keys=True, indent=2) + "\n"
+
+    def to_markdown(self) -> str:
+        lines = [
+            "## Final Verdict",
+            f"- profile used: `{self.profile}`",
+            f"- summary: {self.summary}",
+            f"- confidence level: {self.confidence_level}",
+            f"- merge/release recommendation: `{self.recommendation}`",
+            f"- merge truth: {'yes' if self.merge_truth else 'no'}",
+        ]
+        if self.profile_notes:
+            lines.append(f"- profile notes: {self.profile_notes}")
+        lines.extend(["", "### Checks run"])
+        for record in self.checks_run:
+            lines.append(
+                f"- `{record.id}` - {record.title}: **{record.status.upper()}**"
+                + (f" (`{record.reason}`)" if record.reason else "")
+            )
+        lines.extend(["", "### Checks skipped"])
+        if self.checks_skipped:
+            for record in self.checks_skipped:
+                lines.append(f"- `{record.id}` - {record.reason or 'skipped by profile'}")
+        else:
+            lines.append("- none")
+        lines.extend(["", "### Blocking failures"])
+        if self.blocking_failures:
+            for item in self.blocking_failures:
+                lines.append(f"- {item}")
+        else:
+            lines.append("- none")
+        lines.extend(["", "### Advisory findings"])
+        if self.advisory_findings:
+            for item in self.advisory_findings:
+                lines.append(f"- {item}")
+        else:
+            lines.append("- none")
+        return "\n".join(lines) + "\n"
+
+
+def build_final_verdict(
+    *,
+    profile: CheckProfileName,
+    checks: list[CheckRecord],
+    profile_notes: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> FinalVerdict:
+    checks_run = tuple(record for record in checks if record.status != "skipped")
+    checks_skipped = tuple(record for record in checks if record.status == "skipped")
+    blocking_failures = tuple(
+        f"{record.id}: {record.title}"
+        for record in checks_run
+        if record.status == "failed" and record.blocking
+    )
+    advisory_findings = tuple(
+        item
+        for record in checks
+        for item in (
+            list(record.advisory)
+            + ([record.reason] if record.status == "skipped" and record.reason else [])
+        )
+        if item
+    )
+    ok = not blocking_failures
+    merge_truth = profile == "strict"
+    recommendation: Recommendation
+    if ok and profile == "quick":
+        recommendation = "run-full-verification-before-merge"
+    elif ok and profile == "standard":
+        recommendation = "ready-for-merge-review"
+    elif ok and profile == "strict":
+        recommendation = "ready-for-merge-review"
+    elif ok:
+        recommendation = "run-standard-validation"
+    else:
+        recommendation = "do-not-merge"
+
+    summary = (
+        "All blocking checks passed."
+        if ok
+        else f"Blocking failures present: {', '.join(blocking_failures)}"
+    )
+    return FinalVerdict(
+        profile=profile,
+        verdict_contract="sdetkit.final-verdict.v1",
+        checks_run=checks_run,
+        checks_skipped=checks_skipped,
+        blocking_failures=blocking_failures,
+        advisory_findings=advisory_findings,
+        confidence_level=_PROFILE_CONFIDENCE[profile],
+        recommendation=recommendation,
+        summary=summary,
+        ok=ok,
+        merge_truth=merge_truth,
+        profile_notes=profile_notes,
+        metadata=metadata or {},
+    )

--- a/src/sdetkit/projects.py
+++ b/src/sdetkit/projects.py
@@ -123,11 +123,14 @@ _SKIP_DIRS: set[str] = {
     "node_modules",
     "__pycache__",
     ".tox",
+    ".nox",
     ".mypy_cache",
     ".pytest_cache",
+    ".ruff_cache",
     ".sdetkit",
     "dist",
     "build",
+    "site",
 }
 
 _AUTODISCOVER_BASES: tuple[str, ...] = ("packages", "apps", "services", "libs", "crates")

--- a/src/sdetkit/repo.py
+++ b/src/sdetkit/repo.py
@@ -61,6 +61,7 @@ SKIP_DIRS: frozenset[str] = frozenset(
         "node_modules",
         "dist",
         "build",
+        "site",
     }
 )
 

--- a/tests/test_checks_registry.py
+++ b/tests/test_checks_registry.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from sdetkit.checks import build_final_verdict, default_registry
+from sdetkit.checks.results import CheckRecord
+
+
+def test_registry_exposes_profiles_and_core_truth_checks() -> None:
+    registry = default_registry()
+
+    assert registry.profile_names() == ("quick", "standard", "strict", "adaptive")
+    assert "tests_smoke" in registry.profile_check_ids("quick")
+    assert "tests_full" in registry.profile_check_ids("strict")
+    assert "security_scan" in registry.profile_check_ids("adaptive")
+
+    planner = registry.planner_seed()
+    assert planner["profile"] == "adaptive"
+    assert planner["planner_selected"] is True
+    assert "tests_smoke" in planner["check_ids"]
+
+
+def test_final_verdict_contract_separates_run_skipped_and_failures() -> None:
+    verdict = build_final_verdict(
+        profile="quick",
+        profile_notes="Smoke only.",
+        checks=[
+            CheckRecord(id="format_check", title="Ruff format check", status="passed"),
+            CheckRecord(id="tests_smoke", title="Fast/smoke tests", status="failed"),
+            CheckRecord(
+                id="tests_full",
+                title="Full pytest suite",
+                status="skipped",
+                reason="quick profile uses smoke gate only; run verify for merge truth",
+            ),
+        ],
+    )
+
+    payload = verdict.as_dict()
+
+    assert payload["verdict_contract"] == "sdetkit.final-verdict.v1"
+    assert payload["profile"] == "quick"
+    assert payload["confidence_level"] == "low (smoke-only)"
+    assert payload["blocking_failures"] == ["tests_smoke: Fast/smoke tests"]
+    assert payload["checks_skipped"][0]["reason"] == (
+        "quick profile uses smoke gate only; run verify for merge truth"
+    )
+    assert payload["recommendation"] == "do-not-merge"

--- a/tests/test_quality_script.py
+++ b/tests/test_quality_script.py
@@ -23,17 +23,33 @@ def test_quality_script_help_documents_fast_and_full_lanes() -> None:
         "Usage: bash quality.sh {all|ci|verify|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost}"
         in text
     )
+    assert "quick     Fast local confidence / smoke profile." in text
+    assert "standard  Default repository validation profile." in text
+    assert "strict    Merge/release truth profile." in text
+    assert "adaptive  Planner-selected profile scaffold for future targeted scheduling." in text
     assert "Fast/smoke lane for local confidence; not merge truth." in text
     assert "Full verification lane before merge (format, lint, typing, full tests)." in text
 
 
 def test_quality_script_verify_uses_full_test_path() -> None:
     text = Path("quality.sh").read_text(encoding="utf-8")
-    match = re.search(r"verify\)\n(?P<body>.*?run_full_test\n    ;;)", text, re.DOTALL)
+    match = re.search(r"  verify\)\n(?P<body>.*?    ;;)", text, re.DOTALL)
     assert match is not None
     body = match.group("body")
-    assert "run_fmt_check" in body
-    assert "run_lint" in body
-    assert "run_type" in body
-    assert "run_full_test" in body
-    assert "run_gate_fast" not in body
+    assert 'profile_used="strict"' in body
+    assert 'run_required "format_check"' in body
+    assert 'run_required "lint"' in body
+    assert 'run_required "typing"' in body
+    assert 'run_required "tests_full" "Full pytest suite" 1 "run_full_test"' in body
+    assert 'run_required "tests_smoke"' not in body
+
+
+def test_quality_script_writes_final_verdict_contract() -> None:
+    text = Path("quality.sh").read_text(encoding="utf-8")
+    assert "quality-verdict.json" in text
+    assert "quality-summary.md" in text
+    assert "final verdict contract:" in text
+    assert "verdict.verdict_contract" in text
+    assert "profile used" in text
+    assert "checks skipped" in text
+    assert "merge/release recommendation" in text

--- a/tests/test_repo_audit.py
+++ b/tests/test_repo_audit.py
@@ -182,6 +182,21 @@ def test_repo_check_skips_venv_prefix_and_dist_build_dirs(tmp_path: Path) -> Non
     assert rc == 0
 
 
+def test_repo_check_skips_site_and_nox_generated_dirs(tmp_path: Path) -> None:
+    nox_dir = tmp_path / ".nox" / "py311"
+    nox_dir.mkdir(parents=True)
+    (nox_dir / "artifact.py").write_text("print('generated')\n", encoding="utf-8")
+
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+    (site_dir / "index.html").write_text("<html></html>", encoding="utf-8")
+
+    (tmp_path / "clean.txt").write_text("clean\n", encoding="utf-8")
+
+    rc = cli.main(["repo", "check", str(tmp_path), "--allow-absolute-path", "--format", "json"])
+    assert rc == 0
+
+
 def test_repo_scanner_helpers_cover_workflow_dependency_and_baseline(tmp_path: Path) -> None:
     py_text = """
 eval('1')

--- a/tests/test_repo_monorepo_projects.py
+++ b/tests/test_repo_monorepo_projects.py
@@ -232,3 +232,27 @@ def test_all_projects_audit_idempotent_json(tmp_path: Path) -> None:
         ]
     )
     assert first.stdout == second.stdout
+
+
+def test_projects_autodiscovery_skips_generated_site_and_nox_dirs(tmp_path: Path) -> None:
+    _seed_project(tmp_path / "services" / "api")
+    generated = tmp_path / "site" / "nested"
+    generated.mkdir(parents=True)
+    (generated / "pyproject.toml").write_text(
+        "[project]\nname='generated-site'\n", encoding="utf-8"
+    )
+    nox_dir = tmp_path / ".nox" / "pkg"
+    nox_dir.mkdir(parents=True)
+    (nox_dir / "pyproject.toml").write_text("[project]\nname='generated-nox'\n", encoding="utf-8")
+
+    runner = CliRunner()
+    out_json = runner.invoke(
+        ["repo", "projects", "list", str(tmp_path), "--allow-absolute-path", "--json"]
+    )
+
+    assert out_json.exit_code == 0
+    payload = json.loads(out_json.stdout)
+    names = [item["name"] for item in payload["projects"]]
+    assert "generated-site" not in names
+    assert "generated-nox" not in names
+    assert "x" in names

--- a/tests/test_security_control_tower.py
+++ b/tests/test_security_control_tower.py
@@ -113,7 +113,8 @@ def test_premium_gate_script_smoke_contains_commands() -> None:
     assert "bash quality.sh ci" in text
     assert "Quality (full verification)" in text
     assert "Quality (fast/smoke)" in text
-    assert "fast=smoke confidence, full=pre-merge verification" in text
+    assert "fast=honest smoke confidence" in text
+    assert "full=merge/release truth via `bash quality.sh verify`" in text
     assert "bash ci.sh" in text
     assert "python3 -m sdetkit doctor --ascii" in text
     assert "python3 -m sdetkit doctor --json --out" in text
@@ -127,7 +128,15 @@ def test_premium_gate_script_smoke_contains_commands() -> None:
     assert "Head-5 Intelligence Brain" in text
     assert "premium-step-index.json" in text
     assert "premium-step-results.ndjson" in text
+    assert "premium-verdict.json" in text
+    assert "premium-summary.md" in text
     assert "emit_step_index()" in text
+    assert "emit_final_verdict()" in text
+    assert "final verdict contract:" in text
+    assert "verdict.verdict_contract" in text
+    assert "profile used" in text
+    assert "checks skipped" in text
+    assert "merge/release recommendation" in text
     assert "import sys" in text
 
 


### PR DESCRIPTION
### Motivation
- Create an honest, profile-driven gate model so smoke/local runs cannot masquerade as merge truth and so a single final verdict contract can be produced.
- Provide a small, extensible registry foundation so checks can be represented as independent units with metadata for future planner/scheduler work.
- Reduce noise from generated/non-owned files during repo, security, and maintenance scans by excluding typical build/venv/cache paths.
- Wire premium gate fast/full modes to the aligned quality truth path and produce consistent machine-readable artifacts for reviews and automation.

### Description
- Added a checks platform spine under `src/sdetkit/checks` with `base.py`, `registry.py`, `results.py`, and `__init__.py` that define check/ profile models, a default registry, and a `FinalVerdict` contract.  This seeds Phase 2 planner/scheduler work. 
- Reworked `quality.sh` to expose honest profiles (`quick`, `standard`, `strict`, `adaptive`), implemented `verify` as the full/merge truth lane (format, lint, typing, full tests), and added tracked execution with `quality-verdict.json` and `quality-summary.md` outputs describing profile, checks run/skipped, blocking failures, advisory findings, confidence and recommendation.
- Updated `premium-gate.sh` so `--mode fast` remains an honest smoke lane and `--mode full` delegates to `bash quality.sh verify`; premium now emits aligned verdict artifacts plus the premium step index and markdown summary.
- Extended generated-path exclusions used by repo/scan helpers to ignore `.nox/`, `.venv/`, `site/`, `__pycache__`, `.pytest_cache`, `build/`, `dist/` and similar caches to avoid scan noise while preserving owned-source coverage.
- Added/updated tests and docs: new `tests/test_checks_registry.py`, adjustments to `tests/test_quality_script.py`, `tests/test_security_control_tower.py`, and repo/project discovery tests, and a short README section describing the phase-1 architecture and what's scaffolded for later phases.

### Testing
- Ran the full automated test suite with `pytest -q` and the targeted tests introduced/modified; the test runs completed successfully.
- Ran code quality pipelines: `python -m nox -s lint` and `python -m nox -s tests`; both sessions completed without blocking failures.
- Exercised runtime commands to validate behavior: `bash quality.sh ci`, `bash quality.sh verify`, `bash premium-gate.sh --mode fast`, and `bash premium-gate.sh --mode full`, and each produced the expected verdict JSON/MD artifacts and step indices.
- Applied `ruff` formatting and resolved minor typing issues; lints and type-checks were re-run as part of validation and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c080005ca483209c64301bb221f211)