### PR TITLE
Add stable Phase 4 artifact contracts to the checks platform

### DIFF
--- a/premium-gate.sh
+++ b/premium-gate.sh
@@ -84,6 +84,9 @@ STEP_INDEX_JSON="$OUT_DIR/premium-step-index.json"
 STEP_RESULTS_NDJSON="$OUT_DIR/premium-step-results.ndjson"
 PREMIUM_VERDICT_JSON="$OUT_DIR/premium-verdict.json"
 PREMIUM_SUMMARY_MD="$OUT_DIR/premium-summary.md"
+PREMIUM_FIX_PLAN_JSON="$OUT_DIR/premium-fix-plan.json"
+PREMIUM_RISK_SUMMARY_JSON="$OUT_DIR/premium-risk-summary.json"
+PREMIUM_EVIDENCE_ZIP="$OUT_DIR/premium-evidence.zip"
 : > "$STEP_RESULTS_NDJSON"
 
 section() { printf '\n==> %s\n' "$1"; }
@@ -227,67 +230,64 @@ PY
 }
 
 emit_final_verdict() {
-  python3 - "$STEP_RESULTS_NDJSON" "$MODE" "$PREMIUM_VERDICT_JSON" "$PREMIUM_SUMMARY_MD" <<'PY'
+  local profile requested_profile notes metadata_json
+  profile="adaptive"
+  requested_profile="adaptive"
+  case "$MODE" in
+    fast)
+      profile="quick"
+      requested_profile="quick"
+      notes="Honest smoke confidence lane. Passing here is not the merge truth."
+      ;;
+    full)
+      profile="strict"
+      requested_profile="strict"
+      notes="Full premium verification lane. This wraps bash quality.sh verify as the truth path."
+      ;;
+    engine-only)
+      profile="adaptive"
+      requested_profile="adaptive"
+      notes="Adaptive/planner scaffold lane that isolates premium engine evidence collection."
+      ;;
+  esac
+  metadata_json="$(python3 - "$MODE" "$STEP_RESULTS_NDJSON" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-from sdetkit.checks.results import CheckRecord, build_final_verdict
-
-mode = sys.argv[2]
-profile = {"fast": "quick", "full": "strict", "engine-only": "adaptive"}[mode]
-records = []
-for raw in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+rows = []
+for raw in Path(sys.argv[2]).read_text(encoding="utf-8").splitlines():
     raw = raw.strip()
     if not raw:
         continue
-    item = json.loads(raw)
-    records.append(
-        CheckRecord(
-            id=str(item["id"]),
-            title=str(item["title"]),
-            status=str(item["status"]),
-            blocking=bool(item.get("blocking", True)),
-            reason=str(item.get("reason", "")),
-            command=str(item.get("cmd", "")),
-            log_path=str(item.get("log", "")),
-        )
+    rows.append(json.loads(raw))
+print(
+    json.dumps(
+        {
+            "source": "premium-gate.sh",
+            "mode": sys.argv[1],
+            "checks_recorded": len(rows),
+            "execution": {"mode": "sequential", "workers": 1},
+        },
+        sort_keys=True,
     )
-
-notes = {
-    "fast": "Honest smoke confidence lane. Passing here is not the merge truth.",
-    "full": "Full premium verification lane. This wraps bash quality.sh verify as the truth path.",
-    "engine-only": "Adaptive/planner scaffold lane that isolates premium engine evidence collection.",
-}[mode]
-verdict = build_final_verdict(
-    profile=profile,
-    checks=records,
-    profile_notes=notes,
-    metadata={"source": "premium-gate.sh", "mode": mode, "checks_recorded": len(records)},
 )
-Path(sys.argv[3]).write_text(verdict.to_json(), encoding="utf-8")
-Path(sys.argv[4]).write_text(verdict.to_markdown(), encoding="utf-8")
-print(f"[premium] final verdict contract: {verdict.verdict_contract}")
-print(f"[premium] profile used: {verdict.profile}")
-print(f"[premium] checks run: {len(verdict.checks_run)}")
-print(f"[premium] checks skipped: {len(verdict.checks_skipped)}")
-if verdict.blocking_failures:
-    print("[premium] blocking failures:")
-    for item in verdict.blocking_failures:
-        print(f"- {item}")
-else:
-    print("[premium] blocking failures: none")
-if verdict.advisory_findings:
-    print("[premium] advisory findings:")
-    for item in verdict.advisory_findings:
-        print(f"- {item}")
-else:
-    print("[premium] advisory findings: none")
-print(f"[premium] confidence level: {verdict.confidence_level}")
-print(f"[premium] merge/release recommendation: {verdict.recommendation}")
-print(f"[premium] verdict json: {sys.argv[3]}")
-print(f"[premium] summary md: {sys.argv[4]}")
 PY
+)"
+  python3 -m sdetkit.checks render-ledger \
+    --profile "$profile" \
+    --requested-profile "$requested_profile" \
+    --ledger "$STEP_RESULTS_NDJSON" \
+    --repo-root "$ROOT_DIR" \
+    --out-dir "$OUT_DIR" \
+    --profile-notes "$notes" \
+    --metadata-json "$metadata_json" \
+    --format text \
+    --json-output "$PREMIUM_VERDICT_JSON" \
+    --markdown-output "$PREMIUM_SUMMARY_MD" \
+    --fix-plan-output "$PREMIUM_FIX_PLAN_JSON" \
+    --risk-summary-output "$PREMIUM_RISK_SUMMARY_JSON" \
+    --evidence-output "$PREMIUM_EVIDENCE_ZIP"
 }
 
 run_plan() {
@@ -388,6 +388,9 @@ PY
   info "Step run ledger: $STEP_RESULTS_NDJSON"
   info "Verdict JSON: $PREMIUM_VERDICT_JSON"
   info "Summary MD: $PREMIUM_SUMMARY_MD"
+  info "Fix plan JSON: $PREMIUM_FIX_PLAN_JSON"
+  info "Risk summary JSON: $PREMIUM_RISK_SUMMARY_JSON"
+  info "Evidence ZIP: $PREMIUM_EVIDENCE_ZIP"
 }
 
 export MODE OUT_DIR STEP_RESULTS_NDJSON TOPOLOGY_PROFILE
@@ -397,4 +400,4 @@ run_plan
 run_engine
 final_report
 
-echo "Premium gate passed. Artifacts: $OUT_DIR/doctor.json, $OUT_DIR/maintenance.json, $OUT_DIR/integration-topology.json, $OUT_DIR/security.sarif, $OUT_DIR/security-check.json, $OUT_DIR/premium-summary.json, $OUT_DIR/premium-remediation-plan.json, $OUT_DIR/evidence.zip"
+echo "Premium gate passed. Artifacts: $OUT_DIR/doctor.json, $OUT_DIR/maintenance.json, $OUT_DIR/integration-topology.json, $OUT_DIR/security.sarif, $OUT_DIR/security-check.json, $OUT_DIR/premium-summary.json, $OUT_DIR/premium-remediation-plan.json, $PREMIUM_VERDICT_JSON, $PREMIUM_SUMMARY_MD, $PREMIUM_FIX_PLAN_JSON, $PREMIUM_RISK_SUMMARY_JSON, $PREMIUM_EVIDENCE_ZIP, $OUT_DIR/evidence.zip"

--- a/src/sdetkit/checks/__init__.py
+++ b/src/sdetkit/checks/__init__.py
@@ -1,3 +1,4 @@
+from .artifacts import artifact_paths_for, render_record_artifacts, render_report_artifacts
 from .base import CheckContext, CheckDefinition, CheckProfile, PlannerHint, RegistrySnapshot
 from .cache import CheckCache
 from .planner import (
@@ -25,6 +26,9 @@ __all__ = [
     "CheckProfile",
     "PlannerHint",
     "RegistrySnapshot",
+    "artifact_paths_for",
+    "render_record_artifacts",
+    "render_report_artifacts",
     "CheckCache",
     "CheckPlan",
     "PlannedCheck",

--- a/src/sdetkit/checks/__main__.py
+++ b/src/sdetkit/checks/__main__.py
@@ -5,10 +5,18 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import cast
 
-from .base import PlannerHint
+from .artifacts import (
+    ArtifactPaths,
+    artifact_paths_for,
+    render_record_artifacts,
+    render_report_artifacts,
+)
+from .base import CheckStatus, PlannerHint
 from .planner import CheckPlanner
 from .registry import default_registry
+from .results import CheckRecord
 from .runner import CheckRunner
 
 
@@ -16,21 +24,36 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.checks")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    for name in ("plan", "run"):
+    for name in ("plan", "run", "render-ledger"):
         command = sub.add_parser(name)
-        command.add_argument(
-            "--profile", choices=["quick", "standard", "strict", "adaptive"], required=True
-        )
+        if name != "render-ledger":
+            command.add_argument(
+                "--profile", choices=["quick", "standard", "strict", "adaptive"], required=True
+            )
+        else:
+            command.add_argument(
+                "--profile", choices=["quick", "standard", "strict", "adaptive"], required=True
+            )
+            command.add_argument("--ledger", required=True)
+            command.add_argument("--requested-profile", default=None)
+            command.add_argument("--profile-notes", default="")
+            command.add_argument("--metadata-json", default=None)
         command.add_argument("--repo-root", default=".")
         command.add_argument("--out-dir", default=".sdetkit/out")
-        command.add_argument("--changed-path", action="append", default=None)
-        command.add_argument("--reason", action="append", default=None)
-        command.add_argument("--no-targeting", action="store_true")
+        if name != "render-ledger":
+            command.add_argument("--changed-path", action="append", default=None)
+            command.add_argument("--reason", action="append", default=None)
+            command.add_argument("--no-targeting", action="store_true")
         command.add_argument("--format", choices=["json", "text"], default="json")
-        if name == "run":
+        if name in {"run", "render-ledger"}:
             command.add_argument("--json-output", default=None)
             command.add_argument("--markdown-output", default=None)
+            command.add_argument("--fix-plan-output", default=None)
+            command.add_argument("--risk-summary-output", default=None)
+            command.add_argument("--evidence-output", default=None)
+            command.add_argument("--run-report-output", default=None)
             command.add_argument("--emit-legacy-summary", action="store_true")
+        if name == "run":
             command.add_argument("--no-cache", action="store_true")
             command.add_argument("--max-workers", type=int, default=None)
     return parser
@@ -47,7 +70,12 @@ def _planner_hint(ns: argparse.Namespace) -> PlannerHint:
 
 def _print_legacy_summary(payload: dict[str, object]) -> None:
     print(f"[quality] final verdict contract: {payload['verdict_contract']}")
-    print(f"[quality] profile used: {payload['profile']}")
+    profile_node = payload.get("profile")
+    if isinstance(profile_node, dict):
+        profile_used = profile_node.get("used") or profile_node.get("selected") or "unknown"
+    else:
+        profile_used = profile_node
+    print(f"[quality] profile used: {profile_used}")
     checks_run = payload.get("checks_run")
     checks_skipped = payload.get("checks_skipped")
     print(f"[quality] checks run: {len(checks_run) if isinstance(checks_run, list) else 0}")
@@ -68,11 +96,12 @@ def _print_legacy_summary(payload: dict[str, object]) -> None:
             print(f"- {item}")
     else:
         print("[quality] advisory findings: none")
-    print(f"[quality] confidence level: {payload['confidence_level']}")
+    confidence = payload.get("confidence_level", payload.get("confidence", "unknown"))
+    print(f"[quality] confidence level: {confidence}")
     print(f"[quality] merge/release recommendation: {payload['recommendation']}")
     metadata = payload.get("metadata", {})
     if isinstance(metadata, dict):
-        execution = metadata.get("execution", {})
+        execution = metadata.get("execution", payload.get("execution", {}))
         if isinstance(execution, dict):
             print(
                 f"[quality] execution: {execution.get('mode', 'sequential')} with {execution.get('workers', 1)} worker(s)"
@@ -83,13 +112,96 @@ def _print_legacy_summary(payload: dict[str, object]) -> None:
             print(f"[quality] verdict json: {json_out}")
         if md_out:
             print(f"[quality] summary md: {md_out}")
+        fix_plan_out = metadata.get("fix_plan_output")
+        risk_summary_out = metadata.get("risk_summary_output")
+        evidence_out = metadata.get("evidence_output")
+        if fix_plan_out:
+            print(f"[quality] fix plan json: {fix_plan_out}")
+        if risk_summary_out:
+            print(f"[quality] risk summary json: {risk_summary_out}")
+        if evidence_out:
+            print(f"[quality] evidence zip: {evidence_out}")
+
+
+def _artifact_paths(ns: argparse.Namespace, out_dir: Path) -> ArtifactPaths:
+    defaults = artifact_paths_for(out_dir)
+    return ArtifactPaths(
+        verdict_json=Path(ns.json_output) if ns.json_output else defaults.verdict_json,
+        summary_md=Path(ns.markdown_output) if ns.markdown_output else defaults.summary_md,
+        fix_plan_json=Path(ns.fix_plan_output) if ns.fix_plan_output else defaults.fix_plan_json,
+        risk_summary_json=Path(ns.risk_summary_output)
+        if ns.risk_summary_output
+        else defaults.risk_summary_json,
+        evidence_zip=Path(ns.evidence_output) if ns.evidence_output else defaults.evidence_zip,
+        run_report_json=Path(ns.run_report_output)
+        if ns.run_report_output
+        else defaults.run_report_json,
+    )
+
+
+def _load_records_from_ledger(path: Path) -> tuple[CheckRecord, ...]:
+    records: list[CheckRecord] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        item = json.loads(raw)
+        status = cast(CheckStatus, str(item["status"]))
+        records.append(
+            CheckRecord(
+                id=str(item["id"]),
+                title=str(item["title"]),
+                status=status,
+                blocking=bool(item.get("blocking", True)),
+                reason=str(item.get("reason", "")),
+                command=str(item.get("command") or item.get("cmd") or ""),
+                advisory=tuple(str(entry) for entry in item.get("advisory", []) if str(entry)),
+                log_path=str(item.get("log_path") or item.get("log") or ""),
+                evidence_paths=tuple(
+                    str(entry) for entry in item.get("evidence_paths", []) if str(entry)
+                ),
+                elapsed_seconds=float(item.get("elapsed_seconds") or item.get("elapsed_s") or 0.0),
+                metadata=dict(item.get("metadata", {})),
+            )
+        )
+    return tuple(records)
 
 
 def main(argv: list[str] | None = None) -> int:
     ns = _build_parser().parse_args(argv)
     repo_root = Path(ns.repo_root).resolve()
     out_dir = Path(ns.out_dir).resolve()
+    output_paths = _artifact_paths(ns, out_dir) if ns.cmd in {"run", "render-ledger"} else None
     registry = default_registry()
+    if ns.cmd == "render-ledger":
+        assert output_paths is not None
+        metadata = json.loads(ns.metadata_json) if ns.metadata_json else {}
+        payload = render_record_artifacts(
+            repo_root=repo_root,
+            out_dir=out_dir,
+            profile=ns.profile,
+            records=_load_records_from_ledger(Path(ns.ledger)),
+            requested_profile=ns.requested_profile,
+            profile_notes=ns.profile_notes,
+            metadata=metadata,
+            paths=output_paths,
+        )
+        verdict_payload = payload["verdict"]
+        verdict_payload.setdefault("metadata", {})
+        if isinstance(verdict_payload["metadata"], dict):
+            verdict_payload["metadata"]["json_output"] = str(output_paths.verdict_json)
+            verdict_payload["metadata"]["markdown_output"] = str(output_paths.summary_md)
+            verdict_payload["metadata"]["fix_plan_output"] = str(output_paths.fix_plan_json)
+            verdict_payload["metadata"]["risk_summary_output"] = str(output_paths.risk_summary_json)
+            verdict_payload["metadata"]["evidence_output"] = str(output_paths.evidence_zip)
+        if ns.format == "json":
+            sys.stdout.write(json.dumps(verdict_payload, sort_keys=True, indent=2) + "\n")
+        else:
+            _print_legacy_summary(verdict_payload)
+        if ns.emit_legacy_summary and ns.format == "json":
+            _print_legacy_summary(verdict_payload)
+        return 0 if verdict_payload["ok"] else 1
+
     planner = CheckPlanner(registry.snapshot())
     plan = planner.plan(ns.profile, repo_root=repo_root, hint=_planner_hint(ns))
 
@@ -131,15 +243,16 @@ def main(argv: list[str] | None = None) -> int:
         max_workers=ns.max_workers,
     )
     verdict_payload = report.as_dict()
-
-    json_output = ns.json_output or str(out_dir / "quality-verdict.json")
-    markdown_output = ns.markdown_output or str(out_dir / "quality-summary.md")
-    Path(json_output).write_text(report.verdict.to_json(), encoding="utf-8")
-    Path(markdown_output).write_text(report.verdict.to_markdown(), encoding="utf-8")
+    assert output_paths is not None
+    render_report_artifacts(report, repo_root=repo_root, out_dir=out_dir, paths=output_paths)
     verdict_payload.setdefault("metadata", {})
     if isinstance(verdict_payload["metadata"], dict):
-        verdict_payload["metadata"]["json_output"] = json_output
-        verdict_payload["metadata"]["markdown_output"] = markdown_output
+        verdict_payload["metadata"]["json_output"] = str(output_paths.verdict_json)
+        verdict_payload["metadata"]["markdown_output"] = str(output_paths.summary_md)
+        verdict_payload["metadata"]["fix_plan_output"] = str(output_paths.fix_plan_json)
+        verdict_payload["metadata"]["risk_summary_output"] = str(output_paths.risk_summary_json)
+        verdict_payload["metadata"]["evidence_output"] = str(output_paths.evidence_zip)
+        verdict_payload["metadata"]["run_report_output"] = str(output_paths.run_report_json)
 
     if ns.format == "json":
         sys.stdout.write(json.dumps(verdict_payload, sort_keys=True, indent=2) + "\n")

--- a/src/sdetkit/checks/artifacts.py
+++ b/src/sdetkit/checks/artifacts.py
@@ -1,0 +1,685 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from .base import CheckProfileName
+from .results import CheckRecord, FinalVerdict, build_final_verdict
+from .runner import CheckRunReport
+
+VERDICT_SCHEMA_VERSION = "sdetkit.artifacts.verdict.v1"
+FIX_PLAN_SCHEMA_VERSION = "sdetkit.artifacts.fix-plan.v1"
+RISK_SUMMARY_SCHEMA_VERSION = "sdetkit.artifacts.risk-summary.v1"
+EVIDENCE_SCHEMA_VERSION = "sdetkit.artifacts.evidence.v1"
+
+_SEVERITY_ORDER = {"critical": 4, "high": 3, "medium": 2, "low": 1}
+_OWNER_HINTS = {
+    "format": "developer-experience",
+    "lint": "developer-experience",
+    "typing": "python-platform",
+    "tests": "quality-engineering",
+    "security": "security",
+    "doctor": "platform-ops",
+    "repo": "repository-maintainers",
+    "artifacts": "release-engineering",
+}
+_ACTION_HINTS = {
+    "format_check": "Run `python -m ruff format .` and re-run validation.",
+    "lint": "Run `python -m ruff check . --fix` where safe, then re-run validation.",
+    "typing": "Repair mypy-reported typing issues and re-run the typing lane.",
+    "tests_smoke": "Fix the smoke gate failure and then re-run the quick lane.",
+    "tests_full": "Fix the failing test cases and re-run the full pytest truth path.",
+    "doctor_core": "Review the doctor report and address the highest-severity checks first.",
+    "security_source_scan": "Triage security findings and remediate high-risk items before merge.",
+}
+
+
+@dataclass(frozen=True)
+class ArtifactPaths:
+    verdict_json: Path
+    summary_md: Path
+    fix_plan_json: Path
+    risk_summary_json: Path
+    evidence_zip: Path
+    run_report_json: Path
+
+
+def artifact_paths_for(out_dir: Path) -> ArtifactPaths:
+    return ArtifactPaths(
+        verdict_json=out_dir / "verdict.json",
+        summary_md=out_dir / "summary.md",
+        fix_plan_json=out_dir / "fix-plan.json",
+        risk_summary_json=out_dir / "risk-summary.json",
+        evidence_zip=out_dir / "evidence.zip",
+        run_report_json=out_dir / "run-report.json",
+    )
+
+
+def render_report_artifacts(
+    report: CheckRunReport,
+    *,
+    repo_root: Path,
+    out_dir: Path,
+    paths: ArtifactPaths | None = None,
+) -> dict[str, Any]:
+    return _render_artifacts(
+        records=report.records,
+        verdict=report.verdict,
+        report_payload=report.as_dict(),
+        repo_root=repo_root,
+        out_dir=out_dir,
+        paths=paths or artifact_paths_for(out_dir),
+    )
+
+
+def render_record_artifacts(
+    *,
+    repo_root: Path,
+    out_dir: Path,
+    profile: str,
+    records: tuple[CheckRecord, ...] | list[CheckRecord],
+    requested_profile: str | None = None,
+    profile_notes: str = "",
+    metadata: dict[str, Any] | None = None,
+    paths: ArtifactPaths | None = None,
+) -> dict[str, Any]:
+    merged_metadata = dict(metadata or {})
+    if requested_profile is not None:
+        merged_metadata.setdefault("requested_profile", requested_profile)
+    verdict = build_final_verdict(
+        profile=cast(CheckProfileName, profile),
+        checks=list(records),
+        profile_notes=profile_notes,
+        metadata=merged_metadata,
+    )
+    report_payload = {
+        **verdict.as_dict(),
+        "plan": {
+            "profile": verdict.profile,
+            "requested_profile": requested_profile or verdict.profile,
+            "selected_checks": [],
+            "skipped_checks": [],
+            "notes": [profile_notes] if profile_notes else [],
+            "planner_selected": bool(requested_profile and requested_profile != verdict.profile),
+            "changed_files": list(merged_metadata.get("changed_files", [])),
+            "changed_areas": list(merged_metadata.get("changed_areas", [])),
+            "adaptive_reason": str(merged_metadata.get("adaptive_reason", "")),
+        },
+    }
+    return _render_artifacts(
+        records=tuple(records),
+        verdict=verdict,
+        report_payload=report_payload,
+        repo_root=repo_root,
+        out_dir=out_dir,
+        paths=paths or artifact_paths_for(out_dir),
+    )
+
+
+def _render_artifacts(
+    *,
+    records: tuple[CheckRecord, ...] | list[CheckRecord],
+    verdict: FinalVerdict,
+    report_payload: dict[str, Any],
+    repo_root: Path,
+    out_dir: Path,
+    paths: ArtifactPaths,
+) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ordered_records = tuple(records)
+    artifact_map = {
+        "verdict_json": str(paths.verdict_json),
+        "summary_md": str(paths.summary_md),
+        "fix_plan_json": str(paths.fix_plan_json),
+        "risk_summary_json": str(paths.risk_summary_json),
+        "evidence_zip": str(paths.evidence_zip),
+        "run_report_json": str(paths.run_report_json),
+    }
+    verdict_payload = build_verdict_payload(
+        verdict=verdict,
+        records=ordered_records,
+        artifact_paths=artifact_map,
+    )
+    fix_plan = build_fix_plan_payload(verdict_payload)
+    risk_summary = build_risk_summary_payload(verdict_payload, fix_plan)
+    summary_md = build_summary_markdown(verdict_payload, fix_plan)
+    run_report_payload = {
+        **report_payload,
+        "artifact_paths": artifact_map,
+    }
+
+    paths.verdict_json.write_text(_stable_json(verdict_payload), encoding="utf-8")
+    paths.summary_md.write_text(summary_md, encoding="utf-8")
+    paths.fix_plan_json.write_text(_stable_json(fix_plan), encoding="utf-8")
+    paths.risk_summary_json.write_text(_stable_json(risk_summary), encoding="utf-8")
+    paths.run_report_json.write_text(_stable_json(run_report_payload), encoding="utf-8")
+    write_evidence_zip(
+        repo_root=repo_root,
+        out_dir=out_dir,
+        paths=paths,
+        verdict_payload=verdict_payload,
+        fix_plan=fix_plan,
+        risk_summary=risk_summary,
+        summary_md=summary_md,
+        run_report_payload=run_report_payload,
+        records=ordered_records,
+    )
+    return {
+        "verdict": verdict_payload,
+        "fix_plan": fix_plan,
+        "risk_summary": risk_summary,
+        "summary_markdown": summary_md,
+        "artifact_paths": artifact_map,
+    }
+
+
+def build_verdict_payload(
+    *,
+    verdict: FinalVerdict,
+    records: tuple[CheckRecord, ...] | list[CheckRecord],
+    artifact_paths: dict[str, str],
+) -> dict[str, Any]:
+    record_items = [serialize_record(record) for record in records]
+    check_summary = _check_results_summary(record_items)
+    blockers = [
+        {
+            "check_id": item["id"],
+            "title": item["title"],
+            "category": item["category"],
+            "severity": _severity_for_record(item),
+            "reason": item["reason"] or "blocking failure",
+            "target_mode": item["target_mode"],
+            "related_files": item["related_files"],
+            "log_path": item["log_path"],
+            "evidence_paths": item["evidence_paths"],
+        }
+        for item in record_items
+        if item["status"] == "failed" and item["blocking"]
+    ]
+    advisories = _advisories_for_records(record_items)
+    metadata = verdict.metadata if isinstance(verdict.metadata, dict) else {}
+    requested_profile = str(metadata.get("requested_profile", verdict.profile))
+    selected_profile = verdict.profile
+    execution = metadata.get("execution", {})
+    changed_files = _string_list(metadata.get("changed_files"))
+    changed_areas = _string_list(metadata.get("changed_areas"))
+    return {
+        "schema_version": VERDICT_SCHEMA_VERSION,
+        "verdict_contract": verdict.verdict_contract,
+        "ok": verdict.ok,
+        "summary": verdict.summary,
+        "profile": {
+            "requested": requested_profile,
+            "selected": selected_profile,
+            "used": verdict.profile,
+            "adaptive_requested": requested_profile == "adaptive",
+            "adaptive_resolved": requested_profile == "adaptive" and selected_profile != "adaptive",
+            "adaptive_reason": str(metadata.get("adaptive_reason", "")),
+            "notes": verdict.profile_notes,
+        },
+        "merge_truth": verdict.merge_truth,
+        "confidence": verdict.confidence_level,
+        "recommendation": verdict.recommendation,
+        "targeting": {
+            "modes": check_summary["target_modes"],
+            "used_targeted_execution": bool(check_summary["target_modes"].get("targeted", 0)),
+            "used_smoke_execution": bool(check_summary["target_modes"].get("smoke", 0)),
+            "used_full_execution": bool(check_summary["target_modes"].get("full", 0)),
+        },
+        "cache": {
+            "enabled": bool(metadata.get("cache_enabled", False)),
+            "summary": check_summary["cache_status"],
+            "used_cache_hits": bool(check_summary["cache_status"].get("hit", 0)),
+        },
+        "execution": {
+            "mode": execution.get("mode", "sequential")
+            if isinstance(execution, dict)
+            else "sequential",
+            "workers": execution.get("workers", 1) if isinstance(execution, dict) else 1,
+            "checks_recorded": int(metadata.get("checks_recorded", len(record_items))),
+            "source": str(metadata.get("source", "")),
+        },
+        "changed_files": changed_files,
+        "changed_areas": changed_areas,
+        "changed_file_evidence_present": bool(changed_files),
+        "check_results_summary": check_summary,
+        "blockers": blockers,
+        "advisories": advisories,
+        "checks_run": [item for item in record_items if item["status"] != "skipped"],
+        "checks_skipped": [item for item in record_items if item["status"] == "skipped"],
+        "artifact_paths": artifact_paths,
+    }
+
+
+def build_fix_plan_payload(verdict_payload: dict[str, Any]) -> dict[str, Any]:
+    auto_fixable: list[dict[str, Any]] = []
+    manual_fixes: list[dict[str, Any]] = []
+    follow_up_checks: list[dict[str, Any]] = []
+    all_items = verdict_payload["checks_run"] + verdict_payload["checks_skipped"]
+    for item in all_items:
+        if item["status"] == "passed":
+            continue
+        issue = {
+            "issue_id": f"{item['id']}:{item['status']}",
+            "check_id": item["id"],
+            "title": item["title"],
+            "category": item["category"],
+            "severity": _severity_for_record(item),
+            "blocking": bool(item["blocking"]),
+            "status": item["status"],
+            "target_mode": item["target_mode"],
+            "suggested_action": _suggested_action(item),
+            "related_files": item["related_files"],
+            "recommended_owner": _owner_for_category(item["category"]),
+            "reason": item["reason"]
+            or ("advisory finding" if not item["blocking"] else "failed check"),
+        }
+        if item["status"] == "failed" and _is_auto_fixable(item):
+            auto_fixable.append(issue)
+        else:
+            manual_fixes.append(issue)
+        follow_up_checks.append(
+            {
+                "check_id": item["id"],
+                "category": item["category"],
+                "target_mode": "full" if item["target_mode"] != "full" else item["target_mode"],
+                "why": _follow_up_reason(item, verdict_payload),
+            }
+        )
+    auto_fixable.sort(key=_issue_sort_key)
+    manual_fixes.sort(key=_issue_sort_key)
+    follow_up_checks.sort(key=lambda item: (item["check_id"], item["target_mode"], item["why"]))
+    return {
+        "schema_version": FIX_PLAN_SCHEMA_VERSION,
+        "profile": verdict_payload["profile"],
+        "confidence": verdict_payload["confidence"],
+        "recommendation": verdict_payload["recommendation"],
+        "targeting": verdict_payload["targeting"],
+        "cache": verdict_payload["cache"],
+        "summary": {
+            "auto_fixable_candidates": len(auto_fixable),
+            "manual_fixes": len(manual_fixes),
+            "follow_up_checks": len(follow_up_checks),
+        },
+        "auto_fixable_candidates": auto_fixable,
+        "manual_fixes": manual_fixes,
+        "follow_up_checks": follow_up_checks,
+    }
+
+
+def build_risk_summary_payload(
+    verdict_payload: dict[str, Any], fix_plan: dict[str, Any]
+) -> dict[str, Any]:
+    issues = fix_plan["auto_fixable_candidates"] + fix_plan["manual_fixes"]
+    severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    by_category: dict[str, dict[str, Any]] = {}
+    hotspots: dict[str, int] = {}
+    for issue in issues:
+        severity_counts[issue["severity"]] += 1
+        category = issue["category"]
+        entry = by_category.setdefault(
+            category,
+            {"category": category, "count": 0, "blocking": 0, "top_severity": "low"},
+        )
+        entry["count"] += 1
+        if issue["blocking"]:
+            entry["blocking"] += 1
+        if _SEVERITY_ORDER[issue["severity"]] > _SEVERITY_ORDER[entry["top_severity"]]:
+            entry["top_severity"] = issue["severity"]
+        for path in issue["related_files"]:
+            hotspots[path] = hotspots.get(path, 0) + 1
+    for path in verdict_payload.get("changed_files", []):
+        hotspots[path] = hotspots.get(path, 0) + 1
+    hotspot_items = [
+        {"path": path, "count": count}
+        for path, count in sorted(hotspots.items(), key=lambda item: (-item[1], item[0]))
+    ]
+    return {
+        "schema_version": RISK_SUMMARY_SCHEMA_VERSION,
+        "profile": verdict_payload["profile"],
+        "confidence": verdict_payload["confidence"],
+        "merge_truth": verdict_payload["merge_truth"],
+        "execution_truth": {
+            "used_full_truth": verdict_payload["merge_truth"]
+            and not verdict_payload["targeting"]["used_smoke_execution"]
+            and not verdict_payload["targeting"]["used_targeted_execution"],
+            "used_smoke_execution": verdict_payload["targeting"]["used_smoke_execution"],
+            "used_targeted_execution": verdict_payload["targeting"]["used_targeted_execution"],
+            "used_cache_hits": verdict_payload["cache"]["used_cache_hits"],
+        },
+        "severity_counts": severity_counts,
+        "risk_by_category": sorted(
+            by_category.values(),
+            key=lambda item: (
+                -item["blocking"],
+                -_SEVERITY_ORDER[item["top_severity"]],
+                item["category"],
+            ),
+        ),
+        "top_blockers": verdict_payload["blockers"][:5],
+        "risk_hotspots": hotspot_items[:10],
+        "recommendation": verdict_payload["recommendation"],
+        "check_results_summary": verdict_payload["check_results_summary"],
+    }
+
+
+def build_summary_markdown(verdict_payload: dict[str, Any], fix_plan: dict[str, Any]) -> str:
+    profile = verdict_payload["profile"]
+    summary = verdict_payload["check_results_summary"]
+    blockers = verdict_payload["blockers"]
+    advisories = verdict_payload["advisories"]
+    next_actions = (fix_plan["auto_fixable_candidates"] + fix_plan["manual_fixes"])[:3]
+    lines = [
+        "# Validation Summary",
+        "",
+        f"- **Overall verdict:** {'PASS' if verdict_payload['ok'] else 'FAIL'}",
+        f"- **Confidence:** {verdict_payload['confidence']}",
+        f"- **Recommendation:** `{verdict_payload['recommendation']}`",
+        f"- **Profile used:** requested `{profile['requested']}`, selected `{profile['selected']}`",
+        f"- **Merge/release truth:** {'yes' if verdict_payload['merge_truth'] else 'no'}",
+    ]
+    if profile["adaptive_requested"]:
+        lines.append(
+            f"- **Adaptive resolution:** {profile['adaptive_reason'] or 'adaptive requested'}"
+        )
+    if verdict_payload["targeting"]["used_smoke_execution"]:
+        lines.append(
+            "- **Execution honesty:** smoke checks were used; this is not full verification."
+        )
+    if verdict_payload["targeting"]["used_targeted_execution"]:
+        lines.append("- **Execution honesty:** targeted execution was used for part of this run.")
+    if verdict_payload["cache"]["used_cache_hits"]:
+        lines.append("- **Cache honesty:** cached check results were reused where safe.")
+    lines.extend(
+        [
+            "",
+            "## Checks",
+            f"- Ran: {summary['run']} (`passed={summary['passed']}`, `failed={summary['failed']}`)",
+            f"- Skipped: {summary['skipped']}",
+            f"- Target modes: full={summary['target_modes']['full']}, smoke={summary['target_modes']['smoke']}, targeted={summary['target_modes']['targeted']}",
+            f"- Cache: hit={summary['cache_status']['hit']}, fresh={summary['cache_status']['fresh']}, not-applicable={summary['cache_status']['not-applicable']}",
+        ]
+    )
+    if blockers:
+        lines.extend(["", "## Blockers"])
+        for item in blockers[:5]:
+            lines.append(
+                f"- `{item['check_id']}` ({item['category']}, {item['severity']}): {item['reason']}"
+            )
+    else:
+        lines.extend(["", "## Blockers", "- None"])
+    if advisories:
+        lines.extend(["", "## Advisories"])
+        for item in advisories[:5]:
+            lines.append(f"- `{item['check_id']}`: {item['message']}")
+    else:
+        lines.extend(["", "## Advisories", "- None"])
+    lines.extend(["", "## Top next actions"])
+    if next_actions:
+        for item in next_actions:
+            lines.append(f"- `{item['check_id']}` ({item['severity']}): {item['suggested_action']}")
+    else:
+        lines.append("- No follow-up actions required.")
+    return "\n".join(lines) + "\n"
+
+
+def write_evidence_zip(
+    *,
+    repo_root: Path,
+    out_dir: Path,
+    paths: ArtifactPaths,
+    verdict_payload: dict[str, Any],
+    fix_plan: dict[str, Any],
+    risk_summary: dict[str, Any],
+    summary_md: str,
+    run_report_payload: dict[str, Any],
+    records: tuple[CheckRecord, ...] | list[CheckRecord],
+) -> None:
+    zip_entries: list[tuple[str, bytes, str, str]] = [
+        ("manifest.json", b"", "manifest", ""),
+        (
+            "verdict.json",
+            _stable_json(verdict_payload).encode("utf-8"),
+            "artifact",
+            str(paths.verdict_json),
+        ),
+        ("summary.md", summary_md.encode("utf-8"), "artifact", str(paths.summary_md)),
+        (
+            "fix-plan.json",
+            _stable_json(fix_plan).encode("utf-8"),
+            "artifact",
+            str(paths.fix_plan_json),
+        ),
+        (
+            "risk-summary.json",
+            _stable_json(risk_summary).encode("utf-8"),
+            "artifact",
+            str(paths.risk_summary_json),
+        ),
+        (
+            "run-report.json",
+            _stable_json(run_report_payload).encode("utf-8"),
+            "artifact",
+            str(paths.run_report_json),
+        ),
+    ]
+    seen_sources: set[str] = set()
+    for record in records:
+        for rel in [record.log_path, *record.evidence_paths]:
+            if not rel or rel in seen_sources:
+                continue
+            seen_sources.add(rel)
+            source = repo_root / rel
+            if not source.is_file():
+                continue
+            if _exclude_from_evidence(source, out_dir):
+                continue
+            arcname = (
+                f"raw/{source.relative_to(out_dir).as_posix()}"
+                if _is_relative_to(source, out_dir)
+                else f"repo/{source.relative_to(repo_root).as_posix()}"
+            )
+            zip_entries.append((arcname, source.read_bytes(), "raw-evidence", str(source)))
+    zip_entries.sort(key=lambda item: item[0])
+    manifest = {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "profile": verdict_payload["profile"],
+        "recommendation": verdict_payload["recommendation"],
+        "confidence": verdict_payload["confidence"],
+        "contents": [
+            {
+                "path": arcname,
+                "kind": kind,
+                "source_path": source_path,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for arcname, payload, kind, source_path in zip_entries
+            if arcname != "manifest.json"
+        ],
+        "excludes": ["cache/", ".venv/", ".pytest_cache/", ".ruff_cache/", "__pycache__/"],
+    }
+    zip_entries = [
+        (
+            "manifest.json",
+            _stable_json(manifest).encode("utf-8"),
+            "manifest",
+            str(paths.evidence_zip.with_name("manifest.json")),
+        ),
+        *[item for item in zip_entries if item[0] != "manifest.json"],
+    ]
+    paths.evidence_zip.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(paths.evidence_zip, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for arcname, payload, _, _ in zip_entries:
+            info = zipfile.ZipInfo(arcname)
+            info.date_time = (1980, 1, 1, 0, 0, 0)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            archive.writestr(info, payload)
+
+
+def serialize_record(record: CheckRecord) -> dict[str, Any]:
+    metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    related_files = sorted(
+        {
+            *(_string_list(metadata.get("changed_paths"))),
+            *(_string_list(metadata.get("selected_targets"))),
+            *(str(path) for path in record.evidence_paths),
+        }
+    )
+    return {
+        "id": record.id,
+        "title": record.title,
+        "status": record.status,
+        "blocking": record.blocking,
+        "reason": record.reason,
+        "command": record.command,
+        "category": str(metadata.get("category", "uncategorized")),
+        "truth_level": str(metadata.get("truth_level", "unknown")),
+        "target_mode": str(metadata.get("target_mode", "full")),
+        "target_reason": str(metadata.get("target_reason", "")),
+        "cache_status": _cache_status(metadata),
+        "log_path": record.log_path,
+        "evidence_paths": sorted(record.evidence_paths),
+        "elapsed_seconds": record.elapsed_seconds,
+        "advisory": list(record.advisory),
+        "related_files": related_files,
+    }
+
+
+def _check_results_summary(record_items: list[dict[str, Any]]) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "total": len(record_items),
+        "run": 0,
+        "skipped": 0,
+        "passed": 0,
+        "failed": 0,
+        "blocking_failures": 0,
+        "advisories": 0,
+        "target_modes": {"full": 0, "smoke": 0, "targeted": 0},
+        "cache_status": {"hit": 0, "fresh": 0, "not-applicable": 0},
+    }
+    target_modes = cast(dict[str, int], summary["target_modes"])
+    cache_statuses = cast(dict[str, int], summary["cache_status"])
+    for item in record_items:
+        status = item["status"]
+        if status == "skipped":
+            summary["skipped"] += 1
+        else:
+            summary["run"] += 1
+            summary[status] += 1
+        if status == "failed" and item["blocking"]:
+            summary["blocking_failures"] += 1
+        summary["advisories"] += len(item["advisory"])
+        target_mode = item["target_mode"] if item["target_mode"] in target_modes else "full"
+        target_modes[target_mode] += 1
+        cache_status = item["cache_status"]
+        if cache_status not in cache_statuses:
+            cache_status = "not-applicable"
+        cache_statuses[cache_status] += 1
+    return summary
+
+
+def _advisories_for_records(record_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    advisories: list[dict[str, Any]] = []
+    for item in record_items:
+        for advisory in item["advisory"]:
+            advisories.append(
+                {
+                    "check_id": item["id"],
+                    "title": item["title"],
+                    "category": item["category"],
+                    "message": advisory,
+                    "blocking": item["blocking"],
+                }
+            )
+        if item["status"] == "skipped" and item["reason"]:
+            advisories.append(
+                {
+                    "check_id": item["id"],
+                    "title": item["title"],
+                    "category": item["category"],
+                    "message": item["reason"],
+                    "blocking": item["blocking"],
+                }
+            )
+    return advisories
+
+
+def _severity_for_record(item: dict[str, Any]) -> str:
+    if item["category"] == "security":
+        return "high" if item["blocking"] else "medium"
+    if item["status"] == "failed" and item["blocking"]:
+        return "high" if item["target_mode"] == "full" else "medium"
+    if item["status"] == "failed":
+        return "low"
+    if item["status"] == "skipped" and item["blocking"]:
+        return "medium"
+    return "low"
+
+
+def _suggested_action(item: dict[str, Any]) -> str:
+    return _ACTION_HINTS.get(
+        item["id"],
+        f"Investigate the `{item['id']}` {item['category']} result and re-run the affected lane.",
+    )
+
+
+def _follow_up_reason(item: dict[str, Any], verdict_payload: dict[str, Any]) -> str:
+    if item["target_mode"] != "full":
+        return "Run the full truth path before merge/release."
+    if verdict_payload["cache"]["used_cache_hits"]:
+        return "Re-run after remediation to refresh any cached evidence."
+    return "Re-run after remediation to confirm the issue is resolved."
+
+
+def _is_auto_fixable(item: dict[str, Any]) -> bool:
+    return item["id"] in {"format_check", "lint"}
+
+
+def _owner_for_category(category: str) -> str:
+    return _OWNER_HINTS.get(category, "repository-maintainers")
+
+
+def _issue_sort_key(item: dict[str, Any]) -> tuple[int, int, str, tuple[str, ...]]:
+    return (
+        -_SEVERITY_ORDER[item["severity"]],
+        0 if item["blocking"] else 1,
+        item["check_id"],
+        tuple(item["related_files"]),
+    )
+
+
+def _exclude_from_evidence(path: Path, out_dir: Path) -> bool:
+    parts = set(path.parts)
+    if {"cache", ".venv", ".pytest_cache", ".ruff_cache", "__pycache__"} & parts:
+        return True
+    return _is_relative_to(path, out_dir / "cache")
+
+
+def _cache_status(metadata: dict[str, Any]) -> str:
+    cache = metadata.get("cache", {})
+    if isinstance(cache, dict):
+        return str(cache.get("status", "not-applicable"))
+    return "not-applicable"
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if str(item)]
+    return []
+
+
+def _stable_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, indent=2) + "\n"
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True

--- a/src/sdetkit/checks/builtin.py
+++ b/src/sdetkit/checks/builtin.py
@@ -53,6 +53,8 @@ def _run_subprocess(
     evidence_paths = _existing_evidence(ctx, check.evidence_outputs)
     metadata = {
         "returncode": proc.returncode,
+        "category": check.category,
+        "truth_level": check.truth_level,
         "target_mode": ctx.target_mode,
         "target_reason": ctx.target_reason,
         "changed_paths": list(ctx.changed_paths),
@@ -86,6 +88,8 @@ def _skip_missing_prereqs(check: CheckDefinition, ctx: CheckContext) -> CheckRec
             command=_stringify_command(check.command),
             advisory=("planner skipped a check with unavailable tools",),
             metadata={
+                "category": check.category,
+                "truth_level": check.truth_level,
                 "target_mode": ctx.target_mode,
                 "target_reason": ctx.target_reason,
                 "changed_paths": list(ctx.changed_paths),
@@ -105,6 +109,8 @@ def _skip_missing_prereqs(check: CheckDefinition, ctx: CheckContext) -> CheckRec
             command=_stringify_command(check.command),
             advisory=("planner skipped a check with missing required paths",),
             metadata={
+                "category": check.category,
+                "truth_level": check.truth_level,
                 "target_mode": ctx.target_mode,
                 "target_reason": ctx.target_reason,
                 "changed_paths": list(ctx.changed_paths),

--- a/src/sdetkit/checks/planner.py
+++ b/src/sdetkit/checks/planner.py
@@ -31,6 +31,8 @@ class SkippedCheck:
     title: str
     reason: str
     blocking: bool
+    category: str = "uncategorized"
+    truth_level: str = "adaptive"
 
 
 @dataclass(frozen=True)
@@ -151,6 +153,8 @@ class CheckPlanner:
                     title=check.title,
                     reason=reason,
                     blocking=not check.advisory_only,
+                    category=check.category,
+                    truth_level=check.truth_level,
                 )
             )
 
@@ -164,6 +168,8 @@ class CheckPlanner:
                         title=check.title,
                         reason=prereq_reason,
                         blocking=not check.advisory_only,
+                        category=check.category,
+                        truth_level=check.truth_level,
                     )
                 )
                 continue

--- a/src/sdetkit/checks/runner.py
+++ b/src/sdetkit/checks/runner.py
@@ -89,6 +89,8 @@ class CheckRunner:
                 blocking=skipped.blocking,
                 reason=skipped.reason,
                 metadata={
+                    "category": skipped.category,
+                    "truth_level": skipped.truth_level,
                     "target_mode": "full",
                     "cache": {"status": "not-applicable"},
                     "execution": {"status": "skipped"},
@@ -129,6 +131,8 @@ class CheckRunner:
                             reason=f"dependency not satisfied: {', '.join(blocked_by)}",
                             command=item.command,
                             metadata={
+                                "category": item.category,
+                                "truth_level": item.truth_level,
                                 "target_mode": item.target_mode,
                                 "target_reason": item.targeting_reason,
                                 "changed_paths": list(item.changed_evidence),
@@ -236,6 +240,8 @@ class CheckRunner:
             cached = cache.load(cache_key)
             if cached is not None:
                 metadata = dict(cached.metadata)
+                metadata.setdefault("category", item.category)
+                metadata.setdefault("truth_level", item.truth_level)
                 metadata.setdefault("target_mode", item.target_mode)
                 metadata.setdefault("target_reason", item.targeting_reason)
                 metadata.setdefault("changed_paths", list(item.changed_evidence))
@@ -251,6 +257,8 @@ class CheckRunner:
                 reason="check has no execution wiring yet",
                 command=item.command,
                 metadata={
+                    "category": item.category,
+                    "truth_level": item.truth_level,
                     "target_mode": item.target_mode,
                     "target_reason": item.targeting_reason,
                     "changed_paths": list(item.changed_evidence),
@@ -262,6 +270,8 @@ class CheckRunner:
         else:
             record = definition.run(ctx)
             metadata = dict(record.metadata)
+            metadata.setdefault("category", item.category)
+            metadata.setdefault("truth_level", item.truth_level)
             metadata.setdefault("target_mode", item.target_mode)
             metadata.setdefault("target_reason", item.targeting_reason)
             metadata.setdefault("changed_paths", list(item.changed_evidence))

--- a/tests/test_checks_artifacts.py
+++ b/tests/test_checks_artifacts.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from sdetkit.checks import __main__ as checks_main
+from sdetkit.checks.artifacts import render_record_artifacts
+from sdetkit.checks.results import CheckRecord
+
+
+def _sample_records(repo_root: Path) -> tuple[CheckRecord, ...]:
+    out_dir = repo_root / ".sdetkit" / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "check.tests_full.log").write_text("full test failure\n", encoding="utf-8")
+    (out_dir / "doctor.json").write_text('{"ok": false}\n', encoding="utf-8")
+    return (
+        CheckRecord(
+            id="tests_full",
+            title="Full pytest suite",
+            status="failed",
+            blocking=True,
+            reason="command failed (rc=1)",
+            command="python -m pytest -q -o addopts=",
+            log_path=".sdetkit/out/check.tests_full.log",
+            evidence_paths=(".sdetkit/out/doctor.json",),
+            metadata={
+                "category": "tests",
+                "truth_level": "merge",
+                "target_mode": "targeted",
+                "target_reason": "targeted pytest scope from changed files",
+                "changed_paths": ["src/sdetkit/demo.py"],
+                "selected_targets": ["tests/test_demo.py"],
+                "cache": {"status": "hit"},
+            },
+        ),
+        CheckRecord(
+            id="format_check",
+            title="Ruff format check",
+            status="failed",
+            blocking=True,
+            reason="command failed (rc=1)",
+            command="python -m ruff format --check .",
+            metadata={
+                "category": "format",
+                "truth_level": "standard",
+                "target_mode": "full",
+                "cache": {"status": "fresh"},
+            },
+        ),
+        CheckRecord(
+            id="doctor_core",
+            title="Doctor core report",
+            status="skipped",
+            blocking=False,
+            reason="adaptive selected a narrower validation slice",
+            advisory=("doctor signal omitted in this targeted lane",),
+            metadata={
+                "category": "doctor",
+                "truth_level": "standard",
+                "target_mode": "smoke",
+                "cache": {"status": "not-applicable"},
+            },
+        ),
+    )
+
+
+def test_render_record_artifacts_writes_stable_schema_outputs(tmp_path: Path) -> None:
+    payload = render_record_artifacts(
+        repo_root=tmp_path,
+        out_dir=tmp_path / ".sdetkit" / "out",
+        profile="standard",
+        requested_profile="adaptive",
+        profile_notes="Adaptive resolved to standard after targeted local planning.",
+        metadata={
+            "source": "unit-test",
+            "requested_profile": "adaptive",
+            "adaptive_reason": "small code change set keeps adaptive on standard validation",
+            "changed_files": ["src/sdetkit/demo.py"],
+            "changed_areas": ["source", "tests"],
+            "execution": {"mode": "parallel", "workers": 2},
+            "checks_recorded": 3,
+            "cache_enabled": True,
+        },
+        records=_sample_records(tmp_path),
+    )
+
+    verdict = json.loads(
+        (tmp_path / ".sdetkit" / "out" / "verdict.json").read_text(encoding="utf-8")
+    )
+    fix_plan = json.loads(
+        (tmp_path / ".sdetkit" / "out" / "fix-plan.json").read_text(encoding="utf-8")
+    )
+    risk = json.loads(
+        (tmp_path / ".sdetkit" / "out" / "risk-summary.json").read_text(encoding="utf-8")
+    )
+    summary_md = (tmp_path / ".sdetkit" / "out" / "summary.md").read_text(encoding="utf-8")
+
+    assert payload["verdict"]["schema_version"] == "sdetkit.artifacts.verdict.v1"
+    assert verdict["profile"]["requested"] == "adaptive"
+    assert verdict["profile"]["selected"] == "standard"
+    assert verdict["profile"]["adaptive_resolved"] is True
+    assert verdict["targeting"]["used_targeted_execution"] is True
+    assert verdict["cache"]["used_cache_hits"] is True
+    assert verdict["check_results_summary"]["target_modes"] == {
+        "full": 1,
+        "smoke": 1,
+        "targeted": 1,
+    }
+    assert fix_plan["schema_version"] == "sdetkit.artifacts.fix-plan.v1"
+    assert [item["check_id"] for item in fix_plan["auto_fixable_candidates"]] == ["format_check"]
+    assert [item["check_id"] for item in fix_plan["manual_fixes"]] == ["tests_full", "doctor_core"]
+    assert risk["schema_version"] == "sdetkit.artifacts.risk-summary.v1"
+    assert risk["execution_truth"]["used_targeted_execution"] is True
+    assert risk["execution_truth"]["used_cache_hits"] is True
+    assert "targeted execution was used" in summary_md
+    assert "cached check results were reused" in summary_md
+    assert "requested `adaptive`, selected `standard`" in summary_md
+
+
+def test_evidence_zip_manifest_and_contents_are_deterministic(tmp_path: Path) -> None:
+    out_dir = tmp_path / ".sdetkit" / "out"
+    render_record_artifacts(
+        repo_root=tmp_path,
+        out_dir=out_dir,
+        profile="strict",
+        requested_profile="strict",
+        metadata={
+            "source": "unit-test",
+            "execution": {"mode": "sequential", "workers": 1},
+            "checks_recorded": 3,
+            "cache_enabled": False,
+        },
+        records=_sample_records(tmp_path),
+    )
+    first_zip = out_dir / "evidence.zip"
+    first_bytes = first_zip.read_bytes()
+    render_record_artifacts(
+        repo_root=tmp_path,
+        out_dir=out_dir,
+        profile="strict",
+        requested_profile="strict",
+        metadata={
+            "source": "unit-test",
+            "execution": {"mode": "sequential", "workers": 1},
+            "checks_recorded": 3,
+            "cache_enabled": False,
+        },
+        records=_sample_records(tmp_path),
+    )
+
+    with zipfile.ZipFile(first_zip) as archive:
+        names = archive.namelist()
+        manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+    assert names[0] == "manifest.json"
+    assert names[1:] == sorted(names[1:])
+    assert names[1:6] == [
+        "fix-plan.json",
+        "raw/check.tests_full.log",
+        "raw/doctor.json",
+        "risk-summary.json",
+        "run-report.json",
+    ]
+    assert "summary.md" in names
+    assert "verdict.json" in names
+    assert manifest["schema_version"] == "sdetkit.artifacts.evidence.v1"
+    assert any(item["path"] == "raw/check.tests_full.log" for item in manifest["contents"])
+    assert any(item["path"] == "raw/doctor.json" for item in manifest["contents"])
+    assert first_bytes == first_zip.read_bytes()
+
+
+def test_render_ledger_cli_writes_artifacts_for_shell_wrappers(tmp_path: Path) -> None:
+    ledger = tmp_path / "premium-step-results.ndjson"
+    log = tmp_path / ".sdetkit" / "out" / "premium.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("premium lane\n", encoding="utf-8")
+    ledger.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "id": "quality",
+                        "title": "Quality (fast/smoke)",
+                        "status": "passed",
+                        "blocking": True,
+                        "cmd": "bash quality.sh ci",
+                        "log": ".sdetkit/out/premium.log",
+                    },
+                    sort_keys=True,
+                ),
+                json.dumps(
+                    {
+                        "id": "premium_engine",
+                        "title": "Premium Gate Engine",
+                        "status": "skipped",
+                        "blocking": False,
+                        "reason": "engine-only mode skips premium engine execution",
+                    },
+                    sort_keys=True,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rc = checks_main.main(
+        [
+            "render-ledger",
+            "--profile",
+            "quick",
+            "--requested-profile",
+            "adaptive",
+            "--ledger",
+            str(ledger),
+            "--repo-root",
+            str(tmp_path),
+            "--out-dir",
+            str(tmp_path / ".sdetkit" / "out"),
+            "--profile-notes",
+            "Smoke shell wrapper lane.",
+            "--metadata-json",
+            json.dumps(
+                {
+                    "source": "premium-gate.sh",
+                    "mode": "fast",
+                    "execution": {"mode": "sequential", "workers": 1},
+                    "checks_recorded": 2,
+                },
+                sort_keys=True,
+            ),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    verdict = json.loads(
+        (tmp_path / ".sdetkit" / "out" / "verdict.json").read_text(encoding="utf-8")
+    )
+    assert verdict["profile"]["requested"] == "adaptive"
+    assert verdict["execution"]["source"] == "premium-gate.sh"
+    assert (tmp_path / ".sdetkit" / "out" / "fix-plan.json").exists()
+    assert (tmp_path / ".sdetkit" / "out" / "risk-summary.json").exists()
+    assert (tmp_path / ".sdetkit" / "out" / "evidence.zip").exists()

--- a/tests/test_security_control_tower.py
+++ b/tests/test_security_control_tower.py
@@ -130,14 +130,12 @@ def test_premium_gate_script_smoke_contains_commands() -> None:
     assert "premium-step-results.ndjson" in text
     assert "premium-verdict.json" in text
     assert "premium-summary.md" in text
+    assert "premium-fix-plan.json" in text
+    assert "premium-risk-summary.json" in text
+    assert "premium-evidence.zip" in text
+    assert "python3 -m sdetkit.checks render-ledger" in text
     assert "emit_step_index()" in text
     assert "emit_final_verdict()" in text
-    assert "final verdict contract:" in text
-    assert "verdict.verdict_contract" in text
-    assert "profile used" in text
-    assert "checks skipped" in text
-    assert "merge/release recommendation" in text
-    assert "import sys" in text
 
 
 def test_scan_online_mode_without_cmd_falls_back(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
### Motivation
- Provide stable, versioned, machine-readable artifacts (`verdict.json`, `summary.md`, `fix-plan.json`, `risk-summary.json`, `run-report.json`, `evidence.zip`) produced from the shared checks result model so platform consumers get a single source of truth.
- Make artifacts profile-aware and honest about adaptive resolution, targeting (full/smoke/targeted), and cache usage so reviewers, release teams, dashboards, and automation can rely on deterministic contracts.
- Move artifact rendering into the Python checks core so shell wrappers become lightweight callers of the platform truth rather than duplicating verdict assembly logic.

### Description
- Add `src/sdetkit/checks/artifacts.py` implementing v1 schemas and stable renderers for `verdict.json`, `summary.md`, `fix-plan.json`, `risk-summary.json`, `run-report.json`, and deterministic `evidence.zip` with `manifest.json` and selected raw evidence.
- Enrich check metadata propagation so planned and executed checks include `category`, `truth_level`, `target_mode`, `cache` status, `changed_paths`/`selected_targets`, and execution info for honest artifacts (changes in `planner.py`, `builtin.py`, `runner.py`).
- Extend CLI `python -m sdetkit.checks` to write the shared artifacts for normal runs and add a `render-ledger` subcommand that renders artifacts from a recorded step ledger for shell wrappers to reuse the same contracts (`src/sdetkit/checks/__main__.py`).
- Wire `premium-gate.sh` to delegate final artifact rendering to the shared platform (`render-ledger`) and emit premium-level `premium-fix-plan.json`, `premium-risk-summary.json`, and `premium-evidence.zip` alongside the existing premium artifacts.
- Export artifact helpers via `src/sdetkit/checks/__init__.py` and add `tests/test_checks_artifacts.py` validating schema structure, markdown honesty, deterministic evidence manifest/contents, and CLI ledger rendering; adjust related tests to reflect new artifact names/paths.

### Testing
- Ran unit and integration suites: `pytest -q` — all tests passed (1567 passed, 1 skipped, 3 deselected in repo run).
- Linting: `python -m nox -s lint` — succeeded.
- Full tests matrix: `python -m nox -s tests` — succeeded.
- Quality flows: `bash quality.sh ci` and `bash quality.sh verify` — succeeded.
- Premium gate: `bash premium-gate.sh --mode fast` and `bash premium-gate.sh --mode full` — succeeded and produced the new premium artifacts.
- New artifact-focused tests in `tests/test_checks_artifacts.py` passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1ae27601883208a0f3ef95ef3d865)