### PR TITLE
Promote canonical reliability flags and scope day aliases to compatibility

### DIFF
--- a/docs/artifacts/reliability-evidence-pack/evidence/command-01.log
+++ b/docs/artifacts/reliability-evidence-pack/evidence/command-01.log
@@ -5,20 +5,20 @@ ok: True
 {
   "emitted_files": [],
   "inputs": {
-    "day15": {
-      "pass_rate": 100.0,
-      "score": 100.0,
-      "strict": true
-    },
-    "day16": {
-      "pass_rate": 100.0,
-      "score": 100.0,
-      "strict": true
-    },
-    "day17": {
+    "contribution_quality_report": {
       "stability_score": 100.0,
       "strict_failures": [],
       "velocity_score": 75.44
+    },
+    "github_actions_onboarding": {
+      "pass_rate": 100.0,
+      "score": 100.0,
+      "strict": true
+    },
+    "gitlab_ci_onboarding": {
+      "pass_rate": 100.0,
+      "score": 100.0,
+      "strict": true
     }
   },
   "missing": [],
@@ -38,3 +38,4 @@ ok: True
 }
 
 --- stderr ---
+

--- a/docs/artifacts/reliability-evidence-pack/evidence/command-02.log
+++ b/docs/artifacts/reliability-evidence-pack/evidence/command-02.log
@@ -1,7 +1,11 @@
 command: python scripts/check_reliability_evidence_pack_contract.py --skip-evidence
-returncode: 0
-ok: True
+returncode: 1
+ok: False
 --- stdout ---
-reliability-evidence-pack-contract check passed
 
 --- stderr ---
+reliability-evidence-pack-contract check failed:
+ - docs/index.md: missing 'Reliability evidence pack'
+ - docs/index.md: missing 'sdetkit reliability-evidence-pack --format json --strict'
+ - docs/index.md: missing 'artifacts/reliability-evidence-pack/reliability-evidence-summary.json'
+

--- a/docs/artifacts/reliability-evidence-pack/evidence/command-03.log
+++ b/docs/artifacts/reliability-evidence-pack/evidence/command-03.log
@@ -3,6 +3,7 @@ returncode: 0
 ok: True
 --- stdout ---
 ..                                                                       [100%]
-2 passed in 1.39s
+2 passed in 3.98s
 
 --- stderr ---
+

--- a/docs/artifacts/reliability-evidence-pack/evidence/reliability-evidence-execution-summary.json
+++ b/docs/artifacts/reliability-evidence-pack/evidence/reliability-evidence-execution-summary.json
@@ -1,31 +1,31 @@
 {
   "name": "reliability-evidence-execution",
   "total_commands": 3,
-  "passed_commands": 3,
-  "failed_commands": 0,
+  "passed_commands": 2,
+  "failed_commands": 1,
   "results": [
     {
       "index": 1,
       "command": "python -m sdetkit reliability-evidence-pack --format json --strict",
       "returncode": 0,
       "ok": true,
-      "stdout": "{\n  \"emitted_files\": [],\n  \"inputs\": {\n    \"day15\": {\n      \"pass_rate\": 100.0,\n      \"score\": 100.0,\n      \"strict\": true\n    },\n    \"day16\": {\n      \"pass_rate\": 100.0,\n      \"score\": 100.0,\n      \"strict\": true\n    },\n    \"day17\": {\n      \"stability_score\": 100.0,\n      \"strict_failures\": [],\n      \"velocity_score\": 75.44\n    }\n  },\n  \"missing\": [],\n  \"name\": \"reliability-evidence-pack\",\n  \"page\": \"docs/reliability-evidence-pack.md\",\n  \"recommendations\": [\n    \"Reliability posture is strong; keep current CI and review cadence.\"\n  ],\n  \"score\": 100.0,\n  \"strict_failures\": [],\n  \"summary\": {\n    \"gate_status\": \"pass\",\n    \"reliability_score\": 95.09,\n    \"strict_all_green\": true\n  },\n  \"touched_files\": []\n}\n",
+      "stdout": "{\n  \"emitted_files\": [],\n  \"inputs\": {\n    \"contribution_quality_report\": {\n      \"stability_score\": 100.0,\n      \"strict_failures\": [],\n      \"velocity_score\": 75.44\n    },\n    \"github_actions_onboarding\": {\n      \"pass_rate\": 100.0,\n      \"score\": 100.0,\n      \"strict\": true\n    },\n    \"gitlab_ci_onboarding\": {\n      \"pass_rate\": 100.0,\n      \"score\": 100.0,\n      \"strict\": true\n    }\n  },\n  \"missing\": [],\n  \"name\": \"reliability-evidence-pack\",\n  \"page\": \"docs/reliability-evidence-pack.md\",\n  \"recommendations\": [\n    \"Reliability posture is strong; keep current CI and review cadence.\"\n  ],\n  \"score\": 100.0,\n  \"strict_failures\": [],\n  \"summary\": {\n    \"gate_status\": \"pass\",\n    \"reliability_score\": 95.09,\n    \"strict_all_green\": true\n  },\n  \"touched_files\": []\n}\n",
       "stderr": ""
     },
     {
       "index": 2,
       "command": "python scripts/check_reliability_evidence_pack_contract.py --skip-evidence",
-      "returncode": 0,
-      "ok": true,
-      "stdout": "reliability-evidence-pack-contract check passed\n",
-      "stderr": ""
+      "returncode": 1,
+      "ok": false,
+      "stdout": "",
+      "stderr": "reliability-evidence-pack-contract check failed:\n - docs/index.md: missing 'Reliability evidence pack'\n - docs/index.md: missing 'sdetkit reliability-evidence-pack --format json --strict'\n - docs/index.md: missing 'artifacts/reliability-evidence-pack/reliability-evidence-summary.json'\n"
     },
     {
       "index": 3,
       "command": "python -m pytest -q tests/test_cli_help_lists_subcommands.py",
       "returncode": 0,
       "ok": true,
-      "stdout": "..                                                                       [100%]\n2 passed in 1.39s\n",
+      "stdout": "..                                                                       [100%]\n2 passed in 3.98s\n",
       "stderr": ""
     }
   ]

--- a/docs/artifacts/reliability-evidence-pack/reliability-evidence-checklist.md
+++ b/docs/artifacts/reliability-evidence-pack/reliability-evidence-checklist.md
@@ -1,7 +1,7 @@
 # Reliability evidence checklist
 
-- [ ] Day 15 GitHub Actions quickstart strict gate still green.
-- [ ] Day 16 GitLab CI quickstart strict gate still green.
+- [ ] GitHub Actions onboarding strict gate still green.
+- [ ] GitLab CI onboarding strict gate still green.
 - [ ] Contribution-quality-report strict gates are green.
 - [ ] Reliability score is reviewed in weekly review.
 - [ ] Recommendations are tracked in planning backlog.

--- a/docs/artifacts/reliability-evidence-pack/reliability-evidence-summary.json
+++ b/docs/artifacts/reliability-evidence-pack/reliability-evidence-summary.json
@@ -1,19 +1,19 @@
 {
   "inputs": {
-    "day15": {
-      "pass_rate": 100.0,
-      "score": 100.0,
-      "strict": true
-    },
-    "day16": {
-      "pass_rate": 100.0,
-      "score": 100.0,
-      "strict": true
-    },
-    "day17": {
+    "contribution_quality_report": {
       "stability_score": 100.0,
       "strict_failures": [],
       "velocity_score": 75.44
+    },
+    "github_actions_onboarding": {
+      "pass_rate": 100.0,
+      "score": 100.0,
+      "strict": true
+    },
+    "gitlab_ci_onboarding": {
+      "pass_rate": 100.0,
+      "score": 100.0,
+      "strict": true
     }
   },
   "missing": [],

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,9 +56,9 @@ Public kit commands are contract-oriented:
 
 ## reliability-evidence-pack
 
---day15-summary
---day16-summary
---day17-summary
+--github-actions-summary
+--gitlab-ci-summary
+--contribution-quality-summary
 --min-reliability-score
 --write-defaults
 --execute
@@ -124,4 +124,3 @@ sdetkit enterprise-readiness --execute --evidence-dir docs/artifacts/enterprise-
 --evidence-dir
 --timeout-sec
 --emit-pack-dir
-

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -49,6 +49,14 @@ case "$mode" in
   day4)
     python scripts/check_day4_skills_contract.py
     ;;
+  github-actions-onboarding)
+    python scripts/check_github_actions_onboarding_contract.py
+    ;;
+  gitlab-ci-onboarding)
+    python scripts/check_gitlab_ci_onboarding_contract.py
+    python scripts/check_reliability_evidence_pack_contract.py
+    ;;
+  # Legacy aliases retained for compatibility with transition-era lanes.
   day15)
     python scripts/check_github_actions_onboarding_contract.py
     ;;
@@ -78,7 +86,7 @@ case "$mode" in
     python scripts/check_release_communications_contract.py
     ;;
   *)
-    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|day3|day4|day15|day16|release-readiness|release-communications|all}" >&2
+    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|day3|day4|github-actions-onboarding|gitlab-ci-onboarding|release-readiness|release-communications|all}" >&2
     exit 2
     ;;
 esac

--- a/scripts/check_reliability_evidence_pack_contract.py
+++ b/scripts/check_reliability_evidence_pack_contract.py
@@ -44,9 +44,9 @@ INDEX_EXPECTED = [
 
 CLI_EXPECTED = [
     "## reliability-evidence-pack",
-    "--day15-summary",
-    "--day16-summary",
-    "--day17-summary",
+    "--github-actions-summary",
+    "--gitlab-ci-summary",
+    "--contribution-quality-summary",
     "--min-reliability-score",
     "--write-defaults",
     "--execute",

--- a/src/sdetkit/reliability_evidence_pack.py
+++ b/src/sdetkit/reliability_evidence_pack.py
@@ -26,7 +26,7 @@ _REQUIRED_COMMANDS = [
     "python scripts/check_reliability_evidence_pack_contract.py",
 ]
 
-_REQUIRED_DAY17_KEYS = ("name", "quality", "contributions")
+_REQUIRED_CONTRIBUTION_QUALITY_KEYS = ("name", "quality", "contributions")
 
 _DAY18_DEFAULT_PAGE = """# Reliability evidence pack
 
@@ -113,44 +113,55 @@ def _normalize_execution_summary(summary: dict[str, Any], label: str) -> dict[st
 
 
 def build_reliability_pack(
-    day15_summary: dict[str, Any],
-    day16_summary: dict[str, Any],
-    day17_summary: dict[str, Any],
+    github_actions_summary: dict[str, Any],
+    gitlab_ci_summary: dict[str, Any],
+    contribution_quality_summary: dict[str, Any],
 ) -> dict[str, Any]:
-    day15 = _normalize_execution_summary(day15_summary, "day15")
-    day16 = _normalize_execution_summary(day16_summary, "day16")
-    _require_keys(day17_summary, _REQUIRED_DAY17_KEYS, "day17 summary")
+    github_actions = _normalize_execution_summary(
+        github_actions_summary, "github-actions onboarding"
+    )
+    gitlab_ci = _normalize_execution_summary(gitlab_ci_summary, "gitlab-ci onboarding")
+    _require_keys(
+        contribution_quality_summary,
+        _REQUIRED_CONTRIBUTION_QUALITY_KEYS,
+        "contribution-quality summary",
+    )
 
-    day15_pass_rate = round((float(day15["checks_passed"]) / float(day15["checks_total"])) * 100, 2)
-    day16_pass_rate = round((float(day16["checks_passed"]) / float(day16["checks_total"])) * 100, 2)
-    day17_velocity = float(day17_summary["contributions"]["velocity_score"])
-    day17_stability = float(day17_summary["quality"]["stability_score"])
+    github_actions_pass_rate = round(
+        (float(github_actions["checks_passed"]) / float(github_actions["checks_total"])) * 100,
+        2,
+    )
+    gitlab_ci_pass_rate = round(
+        (float(gitlab_ci["checks_passed"]) / float(gitlab_ci["checks_total"])) * 100, 2
+    )
+    contribution_velocity = float(contribution_quality_summary["contributions"]["velocity_score"])
+    contribution_stability = float(contribution_quality_summary["quality"]["stability_score"])
 
     reliability_score = round(
-        (float(day15["score"]) * 0.25)
-        + (float(day16["score"]) * 0.25)
-        + (day17_velocity * 0.20)
-        + (day17_stability * 0.20)
-        + (day15_pass_rate * 0.05)
-        + (day16_pass_rate * 0.05),
+        (float(github_actions["score"]) * 0.25)
+        + (float(gitlab_ci["score"]) * 0.25)
+        + (contribution_velocity * 0.20)
+        + (contribution_stability * 0.20)
+        + (github_actions_pass_rate * 0.05)
+        + (gitlab_ci_pass_rate * 0.05),
         2,
     )
 
     strict_all_green = (
-        bool(day15["strict"])
-        and bool(day16["strict"])
-        and not bool(day17_summary.get("strict_failures"))
+        bool(github_actions["strict"])
+        and bool(gitlab_ci["strict"])
+        and not bool(contribution_quality_summary.get("strict_failures"))
     )
     recommendations: list[str] = []
     if not strict_all_green:
         recommendations.append(
             "Resolve strict-gate failures before publishing the weekly reliability update."
         )
-    if day17_velocity < 70:
+    if contribution_velocity < 70:
         recommendations.append(
             "Raise contribution velocity with targeted docs and release distribution this week."
         )
-    if day17_stability < 95:
+    if contribution_stability < 95:
         recommendations.append(
             "Recover quality stability by re-running quality deltas and closing artifact gaps."
         )
@@ -160,20 +171,20 @@ def build_reliability_pack(
     return {
         "name": "reliability-evidence-pack",
         "inputs": {
-            "day15": {
-                "score": float(day15["score"]),
-                "strict": bool(day15["strict"]),
-                "pass_rate": day15_pass_rate,
+            "github_actions_onboarding": {
+                "score": float(github_actions["score"]),
+                "strict": bool(github_actions["strict"]),
+                "pass_rate": github_actions_pass_rate,
             },
-            "day16": {
-                "score": float(day16["score"]),
-                "strict": bool(day16["strict"]),
-                "pass_rate": day16_pass_rate,
+            "gitlab_ci_onboarding": {
+                "score": float(gitlab_ci["score"]),
+                "strict": bool(gitlab_ci["strict"]),
+                "pass_rate": gitlab_ci_pass_rate,
             },
-            "day17": {
-                "velocity_score": day17_velocity,
-                "stability_score": day17_stability,
-                "strict_failures": list(day17_summary.get("strict_failures", [])),
+            "contribution_quality_report": {
+                "velocity_score": contribution_velocity,
+                "stability_score": contribution_stability,
+                "strict_failures": list(contribution_quality_summary.get("strict_failures", [])),
             },
         },
         "summary": {
@@ -231,8 +242,8 @@ def _emit_pack(path: str, payload: dict[str, Any], base: Path) -> list[str]:
             [
                 "# Reliability evidence checklist",
                 "",
-                "- [ ] Day 15 GitHub Actions quickstart strict gate still green.",
-                "- [ ] Day 16 GitLab CI quickstart strict gate still green.",
+                "- [ ] GitHub Actions onboarding strict gate still green.",
+                "- [ ] GitLab CI onboarding strict gate still green.",
                 "- [ ] Contribution-quality-report strict gates are green.",
                 "- [ ] Reliability score is reviewed in weekly review.",
                 "- [ ] Recommendations are tracked in planning backlog.",
@@ -358,16 +369,31 @@ def _build_parser() -> argparse.ArgumentParser:
         "--root", default=".", help="Repository root where docs and artifacts live."
     )
     parser.add_argument(
-        "--day15-summary",
+        "--github-actions-summary",
         default="docs/artifacts/github-actions-onboarding-pack/evidence/github-actions-onboarding-execution-summary.json",
     )
     parser.add_argument(
-        "--day16-summary",
+        "--gitlab-ci-summary",
         default="docs/artifacts/gitlab-ci-onboarding-pack/evidence/gitlab-ci-onboarding-execution-summary.json",
     )
     parser.add_argument(
-        "--day17-summary",
+        "--contribution-quality-summary",
         default="docs/artifacts/contribution-quality-report-pack/contribution-quality-report-summary.json",
+    )
+    parser.add_argument(
+        "--day15-summary",
+        dest="github_actions_summary",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--day16-summary",
+        dest="gitlab_ci_summary",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--day17-summary",
+        dest="contribution_quality_summary",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument("--min-reliability-score", type=float, default=90.0)
     parser.add_argument("--strict", action="store_true")
@@ -407,10 +433,14 @@ def main(argv: list[str] | None = None) -> int:
     missing.extend(cmd for cmd in _REQUIRED_COMMANDS if cmd not in page_text)
 
     try:
-        day15_summary = _load_json(str(base / ns.day15_summary))
-        day16_summary = _load_json(str(base / ns.day16_summary))
-        day17_summary = _load_json(str(base / ns.day17_summary))
-        payload = build_reliability_pack(day15_summary, day16_summary, day17_summary)
+        github_actions_summary = _load_json(str(base / ns.github_actions_summary))
+        gitlab_ci_summary = _load_json(str(base / ns.gitlab_ci_summary))
+        contribution_quality_summary = _load_json(str(base / ns.contribution_quality_summary))
+        payload = build_reliability_pack(
+            github_actions_summary,
+            gitlab_ci_summary,
+            contribution_quality_summary,
+        )
     except (OSError, ValueError, json.JSONDecodeError, KeyError, TypeError) as exc:
         print(str(exc))
         return 2
@@ -431,7 +461,9 @@ def main(argv: list[str] | None = None) -> int:
     if missing:
         strict_failures.append(f"reliability page missing {len(missing)} required items")
     if not payload["summary"]["strict_all_green"]:
-        strict_failures.append("strict status is not green across day15/day16/day17 inputs")
+        strict_failures.append(
+            "strict status is not green across github-actions/gitlab-ci/contribution-quality inputs"
+        )
     if float(payload["summary"]["reliability_score"]) < float(ns.min_reliability_score):
         strict_failures.append(
             f"reliability_score {payload['summary']['reliability_score']} is below minimum {ns.min_reliability_score}"

--- a/tests/test_reliability_evidence_pack.py
+++ b/tests/test_reliability_evidence_pack.py
@@ -51,11 +51,11 @@ def test_pack_builds_json(tmp_path: Path, capsys) -> None:
         [
             "--root",
             str(tmp_path),
-            "--day15-summary",
+            "--github-actions-summary",
             str(day15.relative_to(tmp_path)),
-            "--day16-summary",
+            "--gitlab-ci-summary",
             str(day16.relative_to(tmp_path)),
-            "--day17-summary",
+            "--contribution-quality-summary",
             str(day17.relative_to(tmp_path)),
             "--format",
             "json",
@@ -78,11 +78,11 @@ def test_pack_emits_bundle_and_evidence(tmp_path: Path) -> None:
         [
             "--root",
             str(tmp_path),
-            "--day15-summary",
+            "--github-actions-summary",
             str(day15.relative_to(tmp_path)),
-            "--day16-summary",
+            "--gitlab-ci-summary",
             str(day16.relative_to(tmp_path)),
-            "--day17-summary",
+            "--contribution-quality-summary",
             str(day17.relative_to(tmp_path)),
             "--emit-pack-dir",
             "artifacts/reliability-evidence-pack",
@@ -119,11 +119,11 @@ def test_write_defaults(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--write-defaults",
-            "--day15-summary",
+            "--github-actions-summary",
             str(day15.relative_to(tmp_path)),
-            "--day16-summary",
+            "--gitlab-ci-summary",
             str(day16.relative_to(tmp_path)),
-            "--day17-summary",
+            "--contribution-quality-summary",
             str(day17.relative_to(tmp_path)),
             "--format",
             "json",
@@ -142,11 +142,11 @@ def test_cli_dispatch(tmp_path: Path, capsys) -> None:
             "reliability-evidence-pack",
             "--root",
             str(tmp_path),
-            "--day15-summary",
+            "--github-actions-summary",
             str(day15.relative_to(tmp_path)),
-            "--day16-summary",
+            "--gitlab-ci-summary",
             str(day16.relative_to(tmp_path)),
-            "--day17-summary",
+            "--contribution-quality-summary",
             str(day17.relative_to(tmp_path)),
             "--format",
             "text",
@@ -155,6 +155,40 @@ def test_cli_dispatch(tmp_path: Path, capsys) -> None:
     assert rc == 0
     out = capsys.readouterr().out
     assert "Reliability evidence pack" in out
+
+
+def test_reliability_pack_help_prefers_canonical_summary_flags() -> None:
+    help_text = rep._build_parser().format_help()
+    assert "--github-actions-summary" in help_text
+    assert "--gitlab-ci-summary" in help_text
+    assert "--contribution-quality-summary" in help_text
+    assert "--day15-summary" not in help_text
+    assert "--day16-summary" not in help_text
+    assert "--day17-summary" not in help_text
+
+
+def test_reliability_pack_accepts_legacy_day_aliases(tmp_path: Path, capsys) -> None:
+    day15, day16, day17 = _write_inputs(tmp_path)
+    _write_page(tmp_path)
+
+    rc = rep.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--day15-summary",
+            str(day15.relative_to(tmp_path)),
+            "--day16-summary",
+            str(day16.relative_to(tmp_path)),
+            "--day17-summary",
+            str(day17.relative_to(tmp_path)),
+            "--format",
+            "json",
+            "--strict",
+        ]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["summary"]["strict_all_green"] is True
 
 
 def test_reliability_pack_load_json_requires_object(tmp_path: Path) -> None:
@@ -199,16 +233,16 @@ def test_reliability_pack_execute_commands_timeout_records_error(monkeypatch) ->
 
 
 def test_reliability_pack_main_returns_2_on_missing_inputs(tmp_path: Path, capsys) -> None:
-    # Missing day15/day16/day17 files should be caught and return rc=2.
+    # Missing summary files should be caught and return rc=2.
     rc = rep.main(
         [
             "--root",
             str(tmp_path),
-            "--day15-summary",
+            "--github-actions-summary",
             "missing15.json",
-            "--day16-summary",
+            "--gitlab-ci-summary",
             "missing16.json",
-            "--day17-summary",
+            "--contribution-quality-summary",
             "missing17.json",
             "--format",
             "text",
@@ -228,11 +262,11 @@ def test_reliability_pack_main_markdown_writes_output_file(tmp_path: Path) -> No
         [
             "--root",
             str(tmp_path),
-            "--day15-summary",
+            "--github-actions-summary",
             str(day15.relative_to(tmp_path)),
-            "--day16-summary",
+            "--gitlab-ci-summary",
             str(day16.relative_to(tmp_path)),
-            "--day17-summary",
+            "--contribution-quality-summary",
             str(day17.relative_to(tmp_path)),
             "--format",
             "markdown",
@@ -270,11 +304,11 @@ def test_reliability_pack_strict_fails_when_page_missing_and_score_low(
         [
             "--root",
             str(tmp_path),
-            "--day15-summary",
+            "--github-actions-summary",
             str(day15.relative_to(tmp_path)),
-            "--day16-summary",
+            "--gitlab-ci-summary",
             str(day16.relative_to(tmp_path)),
-            "--day17-summary",
+            "--contribution-quality-summary",
             str(day17.relative_to(tmp_path)),
             "--format",
             "json",


### PR DESCRIPTION
### Motivation
- Remove day-based labels from active public interfaces for the reliability evidence pack and prefer durable, descriptive names for onboarding and contribution signals.
- Preserve backward compatibility by keeping legacy day aliases but confining them as hidden compatibility mappings so users/scripts that still use them continue to work.

### Description
- Replaced public CLI flags for the reliability pack with canonical names: `--github-actions-summary`, `--gitlab-ci-summary`, and `--contribution-quality-summary` in `src/sdetkit/reliability_evidence_pack.py` and `docs/cli.md`.
- Added hidden compatibility aliases `--day15-summary`, `--day16-summary`, and `--day17-summary` (using `argparse.SUPPRESS`) so legacy calls still map to the canonical options.
- Updated emitted reliability pack payload keys to use canonical input names (`github_actions_onboarding`, `gitlab_ci_onboarding`, `contribution_quality_report`) and updated emitted checklist wording to remove primary “Day 15/16/17” labels.
- Updated `scripts/check.sh` to advertise canonical selectors (`github-actions-onboarding`, `gitlab-ci-onboarding`) while keeping `day15`/`day16` as explicit legacy alias branches and adjusted the usage help accordingly.
- Updated the contract checker `scripts/check_reliability_evidence_pack_contract.py`, `docs/cli.md`, and tests in `tests/test_reliability_evidence_pack.py` so canonical flags are the primary interface and legacy aliases are explicitly tested.
- Regenerated the active checked-in reliability artifacts under `docs/artifacts/reliability-evidence-pack/` to reflect canonical naming changes.

### Testing
- Ran code formatting: `ruff format` on modified files, which completed successfully.
- Unit tests: `python -m pytest -q tests/test_reliability_evidence_pack.py` — all tests passed (`14 passed`).
- Contract checks: `python scripts/check_github_actions_onboarding_contract.py` and `python scripts/check_gitlab_ci_onboarding_contract.py` — both passed.
- Script dispatcher tests: `bash scripts/check.sh github-actions-onboarding` and `bash scripts/check.sh day15` — both passed, proving canonical selector and legacy alias lanes work.
- End-to-end execution: `python -m sdetkit reliability-evidence-pack --format json --strict` — produced expected output using canonical input keys.
- Contract checker `python scripts/check_reliability_evidence_pack_contract.py --skip-evidence` — failed due to pre-existing missing entries in `docs/index.md` (this failure is unrelated to the day-compatibility interface changes made in this pass).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c6018803348320b2a4c54f0fcad2ae)