### PR TITLE
Batch cleanup: canonicalize remaining active day85–day89 public naming

### DIFF
--- a/docs/day-85-big-upgrade-report.md
+++ b/docs/day-85-big-upgrade-report.md
@@ -2,15 +2,15 @@
 
 ## What shipped
 
-- Added `day85-release-prioritization-closeout` command to score Day 85 readiness from Day 84 evidence narrative handoff artifacts.
+- Added `release-prioritization-closeout` command to score Day 85 readiness from Day 84 evidence narrative handoff artifacts.
 - Added deterministic pack emission and execution evidence generation for release prioritization closeout proof.
 - Added strict contract validation script and tests that enforce Day 85 closeout quality gates and handoff integrity.
 
 ## Command lane
 
 ```bash
-python -m sdetkit day85-release-prioritization-closeout --format json --strict
-python -m sdetkit day85-release-prioritization-closeout --emit-pack-dir docs/artifacts/day85-release-prioritization-closeout-pack --format json --strict
-python -m sdetkit day85-release-prioritization-closeout --execute --evidence-dir docs/artifacts/day85-release-prioritization-closeout-pack/evidence --format json --strict
+python -m sdetkit release-prioritization-closeout --format json --strict
+python -m sdetkit release-prioritization-closeout --emit-pack-dir docs/artifacts/release-prioritization-closeout-pack --format json --strict
+python -m sdetkit release-prioritization-closeout --execute --evidence-dir docs/artifacts/release-prioritization-closeout-pack/evidence --format json --strict
 python scripts/check_release_prioritization_closeout_contract.py
 ```

--- a/docs/day-86-big-upgrade-report.md
+++ b/docs/day-86-big-upgrade-report.md
@@ -2,15 +2,15 @@
 
 ## What shipped
 
-- Added `day86-launch-readiness-closeout` command to score Day 86 readiness from Day 85 release prioritization handoff artifacts.
+- Added `launch-readiness-closeout` command to score Day 86 readiness from Day 85 release prioritization handoff artifacts.
 - Added deterministic pack emission and execution evidence generation for launch readiness closeout proof.
 - Added strict contract validation script and tests that enforce Day 86 closeout quality gates and handoff integrity.
 
 ## Command lane
 
 ```bash
-python -m sdetkit day86-launch-readiness-closeout --format json --strict
-python -m sdetkit day86-launch-readiness-closeout --emit-pack-dir docs/artifacts/day86-launch-readiness-closeout-pack --format json --strict
-python -m sdetkit day86-launch-readiness-closeout --execute --evidence-dir docs/artifacts/day86-launch-readiness-closeout-pack/evidence --format json --strict
+python -m sdetkit launch-readiness-closeout --format json --strict
+python -m sdetkit launch-readiness-closeout --emit-pack-dir docs/artifacts/launch-readiness-closeout-pack --format json --strict
+python -m sdetkit launch-readiness-closeout --execute --evidence-dir docs/artifacts/launch-readiness-closeout-pack/evidence --format json --strict
 python scripts/check_launch_readiness_closeout_contract.py
 ```

--- a/docs/day-87-big-upgrade-report.md
+++ b/docs/day-87-big-upgrade-report.md
@@ -2,15 +2,15 @@
 
 ## What shipped
 
-- Added `day87-governance-handoff-closeout` command to score Day 87 readiness from Day 86 launch readiness handoff artifacts.
+- Added `governance-handoff-closeout` command to score Day 87 readiness from Day 86 launch readiness handoff artifacts.
 - Added deterministic pack emission and execution evidence generation for governance handoff closeout proof.
 - Added strict contract validation script and tests that enforce Day 87 closeout quality gates and handoff integrity.
 
 ## Command lane
 
 ```bash
-python -m sdetkit day87-governance-handoff-closeout --format json --strict
-python -m sdetkit day87-governance-handoff-closeout --emit-pack-dir docs/artifacts/day87-governance-handoff-closeout-pack --format json --strict
-python -m sdetkit day87-governance-handoff-closeout --execute --evidence-dir docs/artifacts/day87-governance-handoff-closeout-pack/evidence --format json --strict
-python scripts/check_day87_governance_handoff_closeout_contract.py
+python -m sdetkit governance-handoff-closeout --format json --strict
+python -m sdetkit governance-handoff-closeout --emit-pack-dir docs/artifacts/governance-handoff-closeout-pack --format json --strict
+python -m sdetkit governance-handoff-closeout --execute --evidence-dir docs/artifacts/governance-handoff-closeout-pack/evidence --format json --strict
+python scripts/check_governance_handoff_closeout_contract.py
 ```

--- a/docs/day-88-big-upgrade-report.md
+++ b/docs/day-88-big-upgrade-report.md
@@ -2,15 +2,15 @@
 
 ## What shipped
 
-- Added `day88-governance-priorities-closeout` command to score Day 88 readiness from Day 87 governance handoff artifacts.
+- Added `governance-priorities-closeout` command to score Day 88 readiness from Day 87 governance handoff artifacts.
 - Added deterministic pack emission and execution evidence generation for governance priorities closeout proof.
 - Added strict contract validation script and tests that enforce Day 88 closeout quality gates and handoff integrity.
 
 ## Command lane
 
 ```bash
-python -m sdetkit day88-governance-priorities-closeout --format json --strict
-python -m sdetkit day88-governance-priorities-closeout --emit-pack-dir docs/artifacts/day88-governance-priorities-closeout-pack --format json --strict
-python -m sdetkit day88-governance-priorities-closeout --execute --evidence-dir docs/artifacts/day88-governance-priorities-closeout-pack/evidence --format json --strict
-python scripts/check_day88_governance_priorities_closeout_contract.py
+python -m sdetkit governance-priorities-closeout --format json --strict
+python -m sdetkit governance-priorities-closeout --emit-pack-dir docs/artifacts/governance-priorities-closeout-pack --format json --strict
+python -m sdetkit governance-priorities-closeout --execute --evidence-dir docs/artifacts/governance-priorities-closeout-pack/evidence --format json --strict
+python scripts/check_governance_priorities_closeout_contract.py
 ```

--- a/docs/day-89-big-upgrade-report.md
+++ b/docs/day-89-big-upgrade-report.md
@@ -2,15 +2,15 @@
 
 ## What shipped
 
-- Added `day89-governance-scale-closeout` command to score Day 89 readiness from Day 88 governance handoff artifacts.
+- Added `governance-scale-closeout` command to score Day 89 readiness from Day 88 governance handoff artifacts.
 - Added deterministic pack emission and execution evidence generation for governance scale closeout proof.
 - Added strict contract validation script and tests that enforce Day 89 closeout quality gates and handoff integrity.
 
 ## Command lane
 
 ```bash
-python -m sdetkit day89-governance-scale-closeout --format json --strict
-python -m sdetkit day89-governance-scale-closeout --emit-pack-dir docs/artifacts/day89-governance-scale-closeout-pack --format json --strict
-python -m sdetkit day89-governance-scale-closeout --execute --evidence-dir docs/artifacts/day89-governance-scale-closeout-pack/evidence --format json --strict
-python scripts/check_day89_governance_scale_closeout_contract.py
+python -m sdetkit governance-scale-closeout --format json --strict
+python -m sdetkit governance-scale-closeout --emit-pack-dir docs/artifacts/governance-scale-closeout-pack --format json --strict
+python -m sdetkit governance-scale-closeout --execute --evidence-dir docs/artifacts/governance-scale-closeout-pack/evidence --format json --strict
+python scripts/check_governance_scale_closeout_contract.py
 ```

--- a/tests/test_governance_handoff_closeout.py
+++ b/tests/test_governance_handoff_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-governance-handoff-closeout.md\nday87-governance-handoff-closeout\n",
+        "docs/integrations-governance-handoff-closeout.md\ngovernance-handoff-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -43,7 +43,7 @@ def _seed_repo(root: Path) -> None:
 
     summary = (
         root
-        / "docs/artifacts/day86-launch-readiness-closeout-pack/day86-launch-readiness-closeout-summary.json"
+        / "docs/artifacts/launch-readiness-closeout-pack/launch-readiness-closeout-summary.json"
     )
     summary.parent.mkdir(parents=True, exist_ok=True)
     summary.write_text(
@@ -56,7 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/day86-launch-readiness-closeout-pack/day86-delivery-board.md"
+    board = root / "docs/artifacts/launch-readiness-closeout-pack/launch-readiness-delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -76,7 +76,7 @@ def _seed_repo(root: Path) -> None:
     plan.write_text(
         json.dumps(
             {
-                "plan_id": "day87-governance-handoff-001",
+                "plan_id": "governance-handoff-001",
                 "contributors": ["maintainers", "release-ops"],
                 "narrative_channels": ["launch-brief", "release-report", "faq"],
                 "baseline": {"launch_confidence": 0.64, "narrative_reuse": 0.42},
@@ -134,7 +134,7 @@ def test_day87_strict_fails_without_day86(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
-        / "docs/artifacts/day86-launch-readiness-closeout-pack/day86-launch-readiness-closeout-summary.json"
+        / "docs/artifacts/launch-readiness-closeout-pack/launch-readiness-closeout-summary.json"
     ).unlink()
     assert d87.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 

--- a/tests/test_governance_priorities_closeout.py
+++ b/tests/test_governance_priorities_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-governance-priorities-closeout.md\nday88-governance-priorities-closeout\n",
+        "docs/integrations-governance-priorities-closeout.md\ngovernance-priorities-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -76,7 +76,7 @@ def _seed_repo(root: Path) -> None:
     plan.write_text(
         json.dumps(
             {
-                "plan_id": "day88-governance-priorities-001",
+                "plan_id": "governance-priorities-001",
                 "contributors": ["maintainers", "release-ops"],
                 "narrative_channels": ["launch-brief", "release-report", "faq"],
                 "baseline": {"launch_confidence": 0.64, "narrative_reuse": 0.42},

--- a/tests/test_governance_scale_closeout.py
+++ b/tests/test_governance_scale_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-governance-scale-closeout.md\nday89-governance-scale-closeout\n",
+        "docs/integrations-governance-scale-closeout.md\ngovernance-scale-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -78,7 +78,7 @@ def _seed_repo(root: Path) -> None:
     plan.write_text(
         json.dumps(
             {
-                "plan_id": "day89-governance-scale-001",
+                "plan_id": "governance-scale-001",
                 "contributors": ["maintainers", "release-ops"],
                 "narrative_channels": ["launch-brief", "release-report", "faq"],
                 "baseline": {"launch_confidence": 0.64, "narrative_reuse": 0.42},


### PR DESCRIPTION
### Motivation

- Remove remaining active/public references that use legacy dayNN names for governance/release lanes (85–89) and make canonical command/artifact names primary. 
- Preserve narrow compatibility shims for legacy aliases and evidence fallbacks while avoiding speculative or broad renames outside the audited active/public surfaces.

### Description

- Updated top-level public upgrade report docs to use canonical commands and artifact pack paths instead of day-prefixed commands in `docs/day-85-big-upgrade-report.md` through `docs/day-89-big-upgrade-report.md`.
- Updated governance closeout tests to prefer canonical command names, canonical upstream artifact paths, and canonical plan IDs in fixtures in `tests/test_governance_handoff_closeout.py`, `tests/test_governance_priorities_closeout.py`, and `tests/test_governance_scale_closeout.py`.
- Left CLI parser aliases and checker fallback behavior intact so `day85`–`day89` names remain narrow compatibility aliases while canonical names are the primary public surface.
- Did not change unrelated dayNN modules/artifacts outside the scoped active/public surfaces and avoided touching already-clean lanes per the inventory rules.

### Testing

- Ran targeted pytest for the touched areas with `pytest -q tests/test_release_prioritization_closeout.py tests/test_launch_readiness_closeout.py tests/test_governance_handoff_closeout.py tests/test_governance_priorities_closeout.py tests/test_governance_scale_closeout.py`, which completed successfully (`20 passed`).
- Executed each affected contract checker against seeded temporary repos via a Python harness (invoking `scripts/check_release_prioritization_closeout_contract.py`, `scripts/check_launch_readiness_closeout_contract.py`, `scripts/check_governance_handoff_closeout_contract.py`, `scripts/check_governance_priorities_closeout_contract.py`, and `scripts/check_governance_scale_closeout_contract.py --skip-evidence`) and all checks passed against those seeded fixtures.
- A full serialized chain check against the current repository baseline failed due to existing baseline state, so checkers were validated against seeded fixtures to prove the canonicalization is correct and backward-compatible; no tests failed for the modified files in this pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c72db2701483209c7d7c915f22eba4)