### PR TITLE
Batch cleanup: canonicalize closeout summary builders and keep narrow day aliases

### DIFF
--- a/scripts/check_case_study_prep3_closeout_contract.py
+++ b/scripts/check_case_study_prep3_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d71.build_day71_case_study_prep3_closeout_summary(root)
+    payload = d71.build_case_study_prep3_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_community_touchpoint_closeout_contract.py
+++ b/scripts/check_community_touchpoint_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d77.build_day77_community_touchpoint_closeout_summary(root)
+    payload = d77.build_community_touchpoint_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day41_expansion_automation_contract.py
+++ b/scripts/check_day41_expansion_automation_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d41.build_day41_expansion_automation_summary(root)
+    payload = d41.build_expansion_automation_summary(root)
 
     strict_failures: list[str] = []
     page = root / d41._PAGE_PATH

--- a/scripts/check_day42_optimization_closeout_contract.py
+++ b/scripts/check_day42_optimization_closeout_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d42.build_day42_optimization_closeout_summary(root)
+    payload = d42.build_optimization_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d42._PAGE_PATH

--- a/scripts/check_day43_acceleration_closeout_contract.py
+++ b/scripts/check_day43_acceleration_closeout_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d43.build_day43_acceleration_closeout_summary(root)
+    payload = d43.build_acceleration_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d43._PAGE_PATH

--- a/scripts/check_day44_scale_closeout_contract.py
+++ b/scripts/check_day44_scale_closeout_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d43.build_day44_scale_closeout_summary(root)
+    payload = d43.build_scale_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d43._PAGE_PATH

--- a/scripts/check_day45_expansion_closeout_contract.py
+++ b/scripts/check_day45_expansion_closeout_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d45.build_day45_expansion_closeout_summary(root)
+    payload = d45.build_expansion_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d45._PAGE_PATH

--- a/scripts/check_day46_optimization_closeout_contract.py
+++ b/scripts/check_day46_optimization_closeout_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d46.build_day46_optimization_closeout_summary(root)
+    payload = d46.build_optimization_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d46._PAGE_PATH

--- a/scripts/check_day47_reliability_closeout_contract.py
+++ b/scripts/check_day47_reliability_closeout_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d47.build_day47_reliability_closeout_summary(root)
+    payload = d47.build_reliability_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d47._PAGE_PATH

--- a/scripts/check_day48_objection_closeout_contract.py
+++ b/scripts/check_day48_objection_closeout_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d48.build_day48_objection_closeout_summary(root)
+    payload = d48.build_objection_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d48._PAGE_PATH

--- a/scripts/check_day49_weekly_review_closeout_contract.py
+++ b/scripts/check_day49_weekly_review_closeout_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d49.build_day49_weekly_review_closeout_summary(root)
+    payload = d49.build_weekly_review_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d49._PAGE_PATH

--- a/scripts/check_day51_case_snippet_closeout_contract.py
+++ b/scripts/check_day51_case_snippet_closeout_contract.py
@@ -16,7 +16,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d51.build_day51_case_snippet_closeout_summary(root)
+    payload = d51.build_case_snippet_closeout_summary(root)
 
     errors: list[str] = []
 

--- a/scripts/check_day52_narrative_closeout_contract.py
+++ b/scripts/check_day52_narrative_closeout_contract.py
@@ -16,7 +16,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d52.build_day52_narrative_closeout_summary(root)
+    payload = d52.build_narrative_closeout_summary(root)
 
     errors: list[str] = []
 

--- a/scripts/check_day53_docs_loop_closeout_contract.py
+++ b/scripts/check_day53_docs_loop_closeout_contract.py
@@ -16,7 +16,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d53.build_day53_docs_loop_closeout_summary(root)
+    payload = d53.build_docs_loop_closeout_summary(root)
 
     errors: list[str] = []
 

--- a/scripts/check_day55_contributor_activation_closeout_contract.py
+++ b/scripts/check_day55_contributor_activation_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d55.build_day55_contributor_activation_closeout_summary(root)
+    payload = d55.build_contributor_activation_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day56_stabilization_closeout_contract.py
+++ b/scripts/check_day56_stabilization_closeout_contract.py
@@ -16,7 +16,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d56.build_day56_stabilization_closeout_summary(root)
+    payload = d56.build_stabilization_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day57_kpi_deep_audit_closeout_contract.py
+++ b/scripts/check_day57_kpi_deep_audit_closeout_contract.py
@@ -16,7 +16,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d57.build_day57_kpi_deep_audit_closeout_summary(root)
+    payload = d57.build_kpi_deep_audit_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day58_phase2_hardening_closeout_contract.py
+++ b/scripts/check_day58_phase2_hardening_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d58.build_day58_phase2_hardening_closeout_summary(root)
+    payload = d58.build_phase2_hardening_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day59_phase3_preplan_closeout_contract.py
+++ b/scripts/check_day59_phase3_preplan_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d59.build_day59_phase3_preplan_closeout_summary(root)
+    payload = d59.build_phase3_preplan_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day60_phase2_wrap_handoff_closeout_contract.py
+++ b/scripts/check_day60_phase2_wrap_handoff_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d60.build_day60_phase2_wrap_handoff_closeout_summary(root)
+    payload = d60.build_phase2_wrap_handoff_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day61_phase3_kickoff_closeout_contract.py
+++ b/scripts/check_day61_phase3_kickoff_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d61.build_day61_phase3_kickoff_closeout_summary(root)
+    payload = d61.build_phase3_kickoff_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day62_community_program_closeout_contract.py
+++ b/scripts/check_day62_community_program_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d62.build_day62_community_program_closeout_summary(root)
+    payload = d62.build_community_program_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day63_onboarding_activation_closeout_contract.py
+++ b/scripts/check_day63_onboarding_activation_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d63.build_day63_onboarding_activation_closeout_summary(root)
+    payload = d63.build_onboarding_activation_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day64_integration_expansion_closeout_contract.py
+++ b/scripts/check_day64_integration_expansion_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d64.build_day64_integration_expansion_closeout_summary(root)
+    payload = d64.build_integration_expansion_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day65_weekly_review_closeout_contract.py
+++ b/scripts/check_day65_weekly_review_closeout_contract.py
@@ -16,7 +16,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d65.build_day65_weekly_review_closeout_summary(root)
+    payload = d65.build_weekly_review_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day66_integration_expansion2_closeout_contract.py
+++ b/scripts/check_day66_integration_expansion2_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d66.build_day66_integration_expansion2_closeout_summary(root)
+    payload = d66.build_integration_expansion2_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day67_integration_expansion3_closeout_contract.py
+++ b/scripts/check_day67_integration_expansion3_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d67.build_day67_integration_expansion3_closeout_summary(root)
+    payload = d67.build_integration_expansion3_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day68_integration_expansion4_closeout_contract.py
+++ b/scripts/check_day68_integration_expansion4_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d68.build_day68_integration_expansion4_closeout_summary(root)
+    payload = d68.build_integration_expansion4_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day69_case_study_prep1_closeout_contract.py
+++ b/scripts/check_day69_case_study_prep1_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d69.build_day69_case_study_prep1_closeout_summary(root)
+    payload = d69.build_case_study_prep1_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day70_case_study_prep2_closeout_contract.py
+++ b/scripts/check_day70_case_study_prep2_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d70.build_day70_case_study_prep2_closeout_summary(root)
+    payload = d70.build_case_study_prep2_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day72_case_study_prep4_closeout_contract.py
+++ b/scripts/check_day72_case_study_prep4_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d72.build_day72_case_study_prep4_closeout_summary(root)
+    payload = d72.build_case_study_prep4_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day73_case_study_launch_closeout_contract.py
+++ b/scripts/check_day73_case_study_launch_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d73.build_day73_case_study_launch_closeout_summary(root)
+    payload = d73.build_case_study_launch_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day74_distribution_scaling_closeout_contract.py
+++ b/scripts/check_day74_distribution_scaling_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d74.build_day74_distribution_scaling_closeout_summary(root)
+    payload = d74.build_distribution_scaling_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day75_trust_assets_refresh_closeout_contract.py
+++ b/scripts/check_day75_trust_assets_refresh_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d75.build_day75_trust_assets_refresh_closeout_summary(root)
+    payload = d75.build_trust_assets_refresh_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day76_contributor_recognition_closeout_contract.py
+++ b/scripts/check_day76_contributor_recognition_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d76.build_day76_contributor_recognition_closeout_summary(root)
+    payload = d76.build_contributor_recognition_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day79_scale_upgrade_closeout_contract.py
+++ b/scripts/check_day79_scale_upgrade_closeout_contract.py
@@ -16,7 +16,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d79.build_day79_scale_upgrade_closeout_summary(root)
+    payload = d79.build_scale_upgrade_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_day90_phase3_wrap_publication_closeout_contract.py
+++ b/scripts/check_day90_phase3_wrap_publication_closeout_contract.py
@@ -23,7 +23,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d90.build_day90_phase3_wrap_publication_closeout_summary(root)
+    payload = d90.build_phase3_wrap_publication_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_ecosystem_priorities_closeout_contract.py
+++ b/scripts/check_ecosystem_priorities_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d78.build_day78_ecosystem_priorities_closeout_summary(root)
+    payload = d78.build_ecosystem_priorities_closeout_summary(root)
     errors: list[str] = []
 
     if payload["summary"]["activation_score"] < 95:

--- a/scripts/check_evidence_narrative_closeout_contract.py
+++ b/scripts/check_evidence_narrative_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = lane.build_day84_evidence_narrative_closeout_summary(root)
+    payload = lane.build_evidence_narrative_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_execution_prioritization_closeout_contract.py
+++ b/scripts/check_execution_prioritization_closeout_contract.py
@@ -32,7 +32,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d50.build_day50_execution_prioritization_closeout_summary(root)
+    payload = d50.build_execution_prioritization_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d50._PAGE_PATH

--- a/scripts/check_governance_handoff_closeout_contract.py
+++ b/scripts/check_governance_handoff_closeout_contract.py
@@ -20,7 +20,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d87.build_day87_governance_handoff_closeout_summary(root)
+    payload = d87.build_governance_handoff_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_governance_priorities_closeout_contract.py
+++ b/scripts/check_governance_priorities_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d88.build_day88_governance_priorities_closeout_summary(root)
+    payload = d88.build_governance_priorities_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_governance_scale_closeout_contract.py
+++ b/scripts/check_governance_scale_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d89.build_day89_governance_scale_closeout_summary(root)
+    payload = d89.build_governance_scale_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_growth_campaign_closeout_contract.py
+++ b/scripts/check_growth_campaign_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = lane.build_day81_growth_campaign_closeout_summary(root)
+    payload = lane.build_growth_campaign_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_integration_feedback_closeout_contract.py
+++ b/scripts/check_integration_feedback_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = lane.build_day82_integration_feedback_closeout_summary(root)
+    payload = lane.build_integration_feedback_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_launch_readiness_closeout_contract.py
+++ b/scripts/check_launch_readiness_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = lane.build_day86_launch_readiness_closeout_summary(root)
+    payload = lane.build_launch_readiness_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_partner_outreach_closeout_contract.py
+++ b/scripts/check_partner_outreach_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = lane.build_day80_partner_outreach_closeout_summary(root)
+    payload = lane.build_partner_outreach_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_release_prioritization_closeout_contract.py
+++ b/scripts/check_release_prioritization_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = lane.build_day85_release_prioritization_closeout_summary(root)
+    payload = lane.build_release_prioritization_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/scripts/check_trust_faq_expansion_closeout_contract.py
+++ b/scripts/check_trust_faq_expansion_closeout_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = lane.build_day83_trust_faq_expansion_closeout_summary(root)
+    payload = lane.build_trust_faq_expansion_closeout_summary(root)
     errors: list[str] = []
 
     if not payload.get("summary", {}).get("strict_pass", False):

--- a/src/sdetkit/day41_expansion_automation.py
+++ b/src/sdetkit/day41_expansion_automation.py
@@ -149,7 +149,7 @@ def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
     return [line for line in expected if line not in text]
 
 
-def build_day41_expansion_automation_summary(root: Path) -> dict[str, Any]:
+def build_expansion_automation_summary(root: Path) -> dict[str, Any]:
     page_path = root / _PAGE_PATH
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
@@ -510,6 +510,11 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day41_expansion_automation_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_expansion_automation_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     ns = parser.parse_args(argv)
@@ -520,7 +525,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY41_DEFAULT_PAGE)
 
-    payload = build_day41_expansion_automation_summary(root)
+    payload = build_expansion_automation_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day42_optimization_closeout.py
+++ b/src/sdetkit/day42_optimization_closeout.py
@@ -151,7 +151,7 @@ def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
     return [line for line in expected if line not in text]
 
 
-def build_day42_optimization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -471,6 +471,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day42_optimization_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_optimization_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -480,7 +485,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY42_DEFAULT_PAGE)
 
-    payload = build_day42_optimization_closeout_summary(root)
+    payload = build_optimization_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day43_acceleration_closeout.py
+++ b/src/sdetkit/day43_acceleration_closeout.py
@@ -151,7 +151,7 @@ def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
     return [line for line in expected if line not in text]
 
 
-def build_day43_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
+def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -464,6 +464,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day43_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_acceleration_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -473,7 +478,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY43_DEFAULT_PAGE)
 
-    payload = build_day43_acceleration_closeout_summary(root)
+    payload = build_acceleration_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day44_scale_closeout.py
+++ b/src/sdetkit/day44_scale_closeout.py
@@ -151,7 +151,7 @@ def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
     return [line for line in expected if line not in text]
 
 
-def build_day44_scale_closeout_summary(root: Path) -> dict[str, Any]:
+def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -458,6 +458,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day44_scale_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_scale_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -467,7 +472,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY44_DEFAULT_PAGE)
 
-    payload = build_day44_scale_closeout_summary(root)
+    payload = build_scale_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day45_expansion_closeout.py
+++ b/src/sdetkit/day45_expansion_closeout.py
@@ -149,7 +149,7 @@ def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
     return [line for line in expected if line not in text]
 
 
-def build_day45_expansion_closeout_summary(root: Path) -> dict[str, Any]:
+def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -460,6 +460,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day45_expansion_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_expansion_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -469,7 +474,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY45_DEFAULT_PAGE)
 
-    payload = build_day45_expansion_closeout_summary(root)
+    payload = build_expansion_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day46_optimization_closeout.py
+++ b/src/sdetkit/day46_optimization_closeout.py
@@ -150,7 +150,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day46_optimization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -463,6 +463,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day46_optimization_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_optimization_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -472,7 +477,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY46_DEFAULT_PAGE)
 
-    payload = build_day46_optimization_closeout_summary(root)
+    payload = build_optimization_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day47_reliability_closeout.py
+++ b/src/sdetkit/day47_reliability_closeout.py
@@ -150,7 +150,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day47_reliability_closeout_summary(root: Path) -> dict[str, Any]:
+def build_reliability_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -461,6 +461,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day47_reliability_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_reliability_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -470,7 +475,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY47_DEFAULT_PAGE)
 
-    payload = build_day47_reliability_closeout_summary(root)
+    payload = build_reliability_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day48_objection_closeout.py
+++ b/src/sdetkit/day48_objection_closeout.py
@@ -150,7 +150,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day48_objection_closeout_summary(root: Path) -> dict[str, Any]:
+def build_objection_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -461,6 +461,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day48_objection_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_objection_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -470,7 +475,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY48_DEFAULT_PAGE)
 
-    payload = build_day48_objection_closeout_summary(root)
+    payload = build_objection_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day49_weekly_review_closeout.py
+++ b/src/sdetkit/day49_weekly_review_closeout.py
@@ -150,7 +150,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day49_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
+def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -489,6 +489,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day49_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_weekly_review_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -498,7 +503,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY49_DEFAULT_PAGE)
 
-    payload = build_day49_weekly_review_closeout_summary(root)
+    payload = build_weekly_review_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day50_execution_prioritization_closeout.py
+++ b/src/sdetkit/day50_execution_prioritization_closeout.py
@@ -152,7 +152,7 @@ def _board_stats(path: Path) -> tuple[int, bool, bool]:
     return len(lines), ("Day 49" in text), ("Day 50" in text)
 
 
-def build_day50_execution_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_execution_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -470,6 +470,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day50_execution_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_execution_prioritization_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -479,7 +484,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY50_DEFAULT_PAGE)
 
-    payload = build_day50_execution_prioritization_closeout_summary(root)
+    payload = build_execution_prioritization_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day51_case_snippet_closeout.py
+++ b/src/sdetkit/day51_case_snippet_closeout.py
@@ -172,7 +172,7 @@ def _board_stats(path: Path) -> tuple[int, bool, bool]:
     return len(lines), ("Day 50" in text), ("Day 51" in text)
 
 
-def build_day51_case_snippet_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_snippet_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -486,6 +486,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day51_case_snippet_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_case_snippet_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -495,7 +500,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY51_DEFAULT_PAGE)
 
-    payload = build_day51_case_snippet_closeout_summary(root)
+    payload = build_case_snippet_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day52_narrative_closeout.py
+++ b/src/sdetkit/day52_narrative_closeout.py
@@ -152,7 +152,7 @@ def _board_stats(path: Path) -> tuple[int, bool, bool]:
     return len(lines), ("Day 51" in text), ("Day 52" in text)
 
 
-def build_day52_narrative_closeout_summary(root: Path) -> dict[str, Any]:
+def build_narrative_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -465,6 +465,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day52_narrative_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_narrative_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -474,7 +479,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY52_DEFAULT_PAGE)
 
-    payload = build_day52_narrative_closeout_summary(root)
+    payload = build_narrative_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day53_docs_loop_closeout.py
+++ b/src/sdetkit/day53_docs_loop_closeout.py
@@ -152,7 +152,7 @@ def _board_stats(path: Path) -> tuple[int, bool, bool]:
     return len(lines), ("Day 52" in text), ("Day 53" in text)
 
 
-def build_day53_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
+def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
     docs_page_path = _PAGE_PATH
@@ -465,6 +465,11 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+
+def build_day53_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_docs_loop_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     ns = build_parser().parse_args(argv)
     root = Path(ns.root).resolve()
@@ -474,7 +479,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY53_DEFAULT_PAGE)
 
-    payload = build_day53_docs_loop_closeout_summary(root)
+    payload = build_docs_loop_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))

--- a/src/sdetkit/day55_contributor_activation_closeout.py
+++ b/src/sdetkit/day55_contributor_activation_closeout.py
@@ -151,7 +151,7 @@ def _board_stats(path: Path) -> tuple[int, bool]:
     return len(lines), ("Day 53" in text)
 
 
-def build_day55_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
+def build_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_path = root / _PAGE_PATH
@@ -414,6 +414,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day55_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_contributor_activation_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Contributor Activation Closeout checks (legacy alias: day55-contributor-activation-closeout)"
@@ -431,7 +436,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY55_DEFAULT_PAGE)
 
-    payload = build_day55_contributor_activation_closeout_summary(root)
+    payload = build_contributor_activation_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day56_stabilization_closeout.py
+++ b/src/sdetkit/day56_stabilization_closeout.py
@@ -153,7 +153,7 @@ def _board_stats(path: Path) -> tuple[int, bool]:
     return len(lines), ("Day 55" in text)
 
 
-def build_day56_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_path = root / _PAGE_PATH
@@ -408,6 +408,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day56_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_stabilization_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Stabilization Closeout checks (legacy alias: day56-stabilization-closeout)"
@@ -425,7 +430,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY56_DEFAULT_PAGE)
 
-    payload = build_day56_stabilization_closeout_summary(root)
+    payload = build_stabilization_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day57_kpi_deep_audit_closeout.py
+++ b/src/sdetkit/day57_kpi_deep_audit_closeout.py
@@ -150,7 +150,7 @@ def _load_board(path: Path) -> tuple[int, bool]:
     return len(items), has_day56
 
 
-def build_day57_kpi_deep_audit_closeout_summary(root: Path) -> dict[str, Any]:
+def build_kpi_deep_audit_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_path = root / _PAGE_PATH
@@ -399,6 +399,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day57_kpi_deep_audit_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_kpi_deep_audit_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="KPI Deep Audit Closeout checks (legacy alias: day57-kpi-deep-audit-closeout)"
@@ -416,7 +421,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY57_DEFAULT_PAGE)
 
-    payload = build_day57_kpi_deep_audit_closeout_summary(root)
+    payload = build_kpi_deep_audit_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day58_phase2_hardening_closeout.py
+++ b/src/sdetkit/day58_phase2_hardening_closeout.py
@@ -151,7 +151,7 @@ def _load_board(path: Path) -> tuple[int, bool]:
     return len(items), has_day57
 
 
-def build_day58_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     top10_text = _read(root / _TOP10_PATH)
@@ -400,6 +400,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day58_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_phase2_hardening_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Phase 2 Hardening Closeout checks (legacy alias: day58-phase2-hardening-closeout)"
@@ -417,7 +422,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY58_DEFAULT_PAGE)
 
-    payload = build_day58_phase2_hardening_closeout_summary(root)
+    payload = build_phase2_hardening_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day59_phase3_preplan_closeout.py
+++ b/src/sdetkit/day59_phase3_preplan_closeout.py
@@ -146,7 +146,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day59_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -388,6 +388,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day59_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_phase3_preplan_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Phase3 Preplan Closeout checks (legacy alias: day59-phase3-preplan-closeout)"
@@ -405,7 +410,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY59_DEFAULT_PAGE)
 
-    payload = build_day59_phase3_preplan_closeout_summary(root)
+    payload = build_phase3_preplan_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day60_phase2_wrap_handoff_closeout.py
+++ b/src/sdetkit/day60_phase2_wrap_handoff_closeout.py
@@ -148,7 +148,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day60_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -393,6 +393,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day60_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_phase2_wrap_handoff_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Phase 2 Wrap Handoff Closeout checks (legacy alias: day60-phase2-wrap-handoff-closeout)"
@@ -410,7 +415,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY60_DEFAULT_PAGE)
 
-    payload = build_day60_phase2_wrap_handoff_closeout_summary(root)
+    payload = build_phase2_wrap_handoff_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day61_phase3_kickoff_closeout.py
+++ b/src/sdetkit/day61_phase3_kickoff_closeout.py
@@ -146,7 +146,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day61_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -389,6 +389,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day61_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_phase3_kickoff_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 61 Phase-3 kickoff closeout checks")
     parser.add_argument("--root", default=".")
@@ -404,7 +409,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY61_DEFAULT_PAGE)
 
-    payload = build_day61_phase3_kickoff_closeout_summary(root)
+    payload = build_phase3_kickoff_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day62_community_program_closeout.py
+++ b/src/sdetkit/day62_community_program_closeout.py
@@ -148,7 +148,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day62_community_program_closeout_summary(root: Path) -> dict[str, Any]:
+def build_community_program_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -396,6 +396,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day62_community_program_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_community_program_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 62 community program closeout checks")
     parser.add_argument("--root", default=".")
@@ -411,7 +416,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY62_DEFAULT_PAGE)
 
-    payload = build_day62_community_program_closeout_summary(root)
+    payload = build_community_program_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day63_onboarding_activation_closeout.py
+++ b/src/sdetkit/day63_onboarding_activation_closeout.py
@@ -146,7 +146,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day63_onboarding_activation_closeout_summary(root: Path) -> dict[str, Any]:
+def build_onboarding_activation_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -393,6 +393,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day63_onboarding_activation_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_onboarding_activation_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 63 onboarding activation closeout checks")
     parser.add_argument("--root", default=".")
@@ -408,7 +413,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY63_DEFAULT_PAGE)
 
-    payload = build_day63_onboarding_activation_closeout_summary(root)
+    payload = build_onboarding_activation_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day64_integration_expansion_closeout.py
+++ b/src/sdetkit/day64_integration_expansion_closeout.py
@@ -158,7 +158,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day64_integration_expansion_closeout_summary(root: Path) -> dict[str, Any]:
+def build_integration_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -409,6 +409,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day64_integration_expansion_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_integration_expansion_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 64 integration expansion closeout checks")
     parser.add_argument("--root", default=".")
@@ -424,7 +429,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY64_DEFAULT_PAGE)
 
-    payload = build_day64_integration_expansion_closeout_summary(root)
+    payload = build_integration_expansion_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day65_weekly_review_closeout.py
+++ b/src/sdetkit/day65_weekly_review_closeout.py
@@ -150,7 +150,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day65_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
+def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -402,6 +402,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day65_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_weekly_review_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 65 weekly review closeout checks")
     parser.add_argument("--root", default=".")
@@ -417,7 +422,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY65_DEFAULT_PAGE)
 
-    payload = build_day65_weekly_review_closeout_summary(root)
+    payload = build_weekly_review_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day66_integration_expansion2_closeout.py
+++ b/src/sdetkit/day66_integration_expansion2_closeout.py
@@ -158,7 +158,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day66_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
+def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -413,6 +413,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day66_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_integration_expansion2_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 66 integration expansion #2 closeout checks")
     parser.add_argument("--root", default=".")
@@ -428,7 +433,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY66_DEFAULT_PAGE)
 
-    payload = build_day66_integration_expansion2_closeout_summary(root)
+    payload = build_integration_expansion2_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day67_integration_expansion3_closeout.py
+++ b/src/sdetkit/day67_integration_expansion3_closeout.py
@@ -158,7 +158,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day67_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
+def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -413,6 +413,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day67_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_integration_expansion3_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 67 integration expansion #3 closeout checks")
     parser.add_argument("--root", default=".")
@@ -428,7 +433,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY67_DEFAULT_PAGE)
 
-    payload = build_day67_integration_expansion3_closeout_summary(root)
+    payload = build_integration_expansion3_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day68_integration_expansion4_closeout.py
+++ b/src/sdetkit/day68_integration_expansion4_closeout.py
@@ -158,7 +158,7 @@ def _count_board_items(path: Path, needle: str) -> tuple[int, bool]:
     return len(checks), (needle in text)
 
 
-def build_day68_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
+def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -413,6 +413,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day68_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_integration_expansion4_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 68 integration expansion #4 closeout checks")
     parser.add_argument("--root", default=".")
@@ -428,7 +433,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY68_DEFAULT_PAGE)
 
-    payload = build_day68_integration_expansion4_closeout_summary(root)
+    payload = build_integration_expansion4_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day69_case_study_prep1_closeout.py
+++ b/src/sdetkit/day69_case_study_prep1_closeout.py
@@ -153,7 +153,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day69_case_study_prep1_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_prep1_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -406,6 +406,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day69_case_study_prep1_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_case_study_prep1_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 69 case-study prep #1 closeout checks")
     parser.add_argument("--root", default=".")
@@ -421,7 +426,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY69_DEFAULT_PAGE)
 
-    payload = build_day69_case_study_prep1_closeout_summary(root)
+    payload = build_case_study_prep1_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day70_case_study_prep2_closeout.py
+++ b/src/sdetkit/day70_case_study_prep2_closeout.py
@@ -151,7 +151,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day70_case_study_prep2_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_prep2_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -404,6 +404,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day70_case_study_prep2_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_case_study_prep2_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 70 case-study prep #2 closeout checks")
     parser.add_argument("--root", default=".")
@@ -419,7 +424,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY70_DEFAULT_PAGE)
 
-    payload = build_day70_case_study_prep2_closeout_summary(root)
+    payload = build_case_study_prep2_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day71_case_study_prep3_closeout.py
+++ b/src/sdetkit/day71_case_study_prep3_closeout.py
@@ -151,7 +151,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day71_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -415,6 +415,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day71_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_case_study_prep3_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Case Study Prep3 Closeout checks")
     parser.add_argument("--root", default=".")
@@ -430,7 +435,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY71_DEFAULT_PAGE)
 
-    payload = build_day71_case_study_prep3_closeout_summary(root)
+    payload = build_case_study_prep3_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day72_case_study_prep4_closeout.py
+++ b/src/sdetkit/day72_case_study_prep4_closeout.py
@@ -155,7 +155,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day72_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -417,6 +417,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day72_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_case_study_prep4_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Case Study Prep4 Closeout checks")
     parser.add_argument("--root", default=".")
@@ -432,7 +437,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY72_DEFAULT_PAGE)
 
-    payload = build_day72_case_study_prep4_closeout_summary(root)
+    payload = build_case_study_prep4_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day73_case_study_launch_closeout.py
+++ b/src/sdetkit/day73_case_study_launch_closeout.py
@@ -151,7 +151,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day73_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -405,6 +405,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day73_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_case_study_launch_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Case Study Launch Closeout checks")
     parser.add_argument("--root", default=".")
@@ -420,7 +425,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY73_DEFAULT_PAGE)
 
-    payload = build_day73_case_study_launch_closeout_summary(root)
+    payload = build_case_study_launch_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day74_distribution_scaling_closeout.py
+++ b/src/sdetkit/day74_distribution_scaling_closeout.py
@@ -151,7 +151,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day74_distribution_scaling_closeout_summary(root: Path) -> dict[str, Any]:
+def build_distribution_scaling_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -407,6 +407,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day74_distribution_scaling_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_distribution_scaling_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Distribution Scaling Closeout checks")
     parser.add_argument("--root", default=".")
@@ -422,7 +427,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY74_DEFAULT_PAGE)
 
-    payload = build_day74_distribution_scaling_closeout_summary(root)
+    payload = build_distribution_scaling_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day75_trust_assets_refresh_closeout.py
+++ b/src/sdetkit/day75_trust_assets_refresh_closeout.py
@@ -150,7 +150,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day75_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, Any]:
+def build_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -404,6 +404,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day75_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_trust_assets_refresh_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Trust Assets Refresh Closeout checks")
     parser.add_argument("--root", default=".")
@@ -419,7 +424,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY75_DEFAULT_PAGE)
 
-    payload = build_day75_trust_assets_refresh_closeout_summary(root)
+    payload = build_trust_assets_refresh_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day76_contributor_recognition_closeout.py
+++ b/src/sdetkit/day76_contributor_recognition_closeout.py
@@ -150,7 +150,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day76_contributor_recognition_closeout_summary(root: Path) -> dict[str, Any]:
+def build_contributor_recognition_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -413,6 +413,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day76_contributor_recognition_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_contributor_recognition_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Contributor Recognition Closeout checks")
     parser.add_argument("--root", default=".")
@@ -428,7 +433,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY76_DEFAULT_PAGE)
 
-    payload = build_day76_contributor_recognition_closeout_summary(root)
+    payload = build_contributor_recognition_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day77_community_touchpoint_closeout.py
+++ b/src/sdetkit/day77_community_touchpoint_closeout.py
@@ -150,7 +150,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day77_community_touchpoint_closeout_summary(root: Path) -> dict[str, Any]:
+def build_community_touchpoint_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -417,6 +417,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day77_community_touchpoint_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_community_touchpoint_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Community Touchpoint Closeout checks")
     parser.add_argument("--root", default=".")
@@ -432,7 +437,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY77_DEFAULT_PAGE)
 
-    payload = build_day77_community_touchpoint_closeout_summary(root)
+    payload = build_community_touchpoint_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day78_ecosystem_priorities_closeout.py
+++ b/src/sdetkit/day78_ecosystem_priorities_closeout.py
@@ -152,7 +152,7 @@ def _count_board_items(board_path: Path, anchor: str) -> tuple[int, bool]:
     return len(items), (anchor in text)
 
 
-def build_day78_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, Any]:
+def build_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read(root / "README.md")
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
@@ -417,6 +417,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day78_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_ecosystem_priorities_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Ecosystem Priorities Closeout checks")
     parser.add_argument("--root", default=".")
@@ -432,7 +437,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY78_DEFAULT_PAGE)
 
-    payload = build_day78_ecosystem_priorities_closeout_summary(root)
+    payload = build_ecosystem_priorities_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day79_scale_upgrade_closeout.py
+++ b/src/sdetkit/day79_scale_upgrade_closeout.py
@@ -141,7 +141,7 @@ def _load_json(path: Path) -> dict[str, Any]:
         return {}
 
 
-def build_day79_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
+def build_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -403,6 +403,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day79_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_scale_upgrade_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Scale Upgrade Closeout checks")
     parser.add_argument("--root", default=".")
@@ -418,7 +423,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY79_DEFAULT_PAGE)
 
-    payload = build_day79_scale_upgrade_closeout_summary(root)
+    payload = build_scale_upgrade_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day80_partner_outreach_closeout.py
+++ b/src/sdetkit/day80_partner_outreach_closeout.py
@@ -139,7 +139,7 @@ def _load_json(path: Path) -> dict[str, Any]:
         return {}
 
 
-def build_day80_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
+def build_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -406,6 +406,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day80_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_partner_outreach_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Partner Outreach Closeout checks")
     parser.add_argument("--root", default=".")
@@ -421,7 +426,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY80_DEFAULT_PAGE)
 
-    payload = build_day80_partner_outreach_closeout_summary(root)
+    payload = build_partner_outreach_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day81_growth_campaign_closeout.py
+++ b/src/sdetkit/day81_growth_campaign_closeout.py
@@ -141,7 +141,7 @@ def _checklist_count(text: str) -> int:
     return sum(1 for line in text.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day81_growth_campaign_closeout_summary(root: Path) -> dict[str, Any]:
+def build_growth_campaign_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -400,6 +400,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day81_growth_campaign_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_growth_campaign_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 81 growth campaign closeout checks")
     parser.add_argument("--root", default=".")
@@ -415,7 +420,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY81_DEFAULT_PAGE)
 
-    payload = build_day81_growth_campaign_closeout_summary(root)
+    payload = build_growth_campaign_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day82_integration_feedback_closeout.py
+++ b/src/sdetkit/day82_integration_feedback_closeout.py
@@ -145,7 +145,7 @@ def _checklist_count(markdown: str) -> int:
     return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day82_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
+def build_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -413,6 +413,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day82_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_integration_feedback_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 82 integration feedback closeout checks")
     parser.add_argument("--root", default=".")
@@ -428,7 +433,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY82_DEFAULT_PAGE)
 
-    payload = build_day82_integration_feedback_closeout_summary(root)
+    payload = build_integration_feedback_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day83_trust_faq_expansion_closeout.py
+++ b/src/sdetkit/day83_trust_faq_expansion_closeout.py
@@ -145,7 +145,7 @@ def _checklist_count(markdown: str) -> int:
     return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day83_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
+def build_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -414,6 +414,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day83_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_trust_faq_expansion_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 83 trust FAQ expansion closeout checks")
     parser.add_argument("--root", default=".")
@@ -429,7 +434,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY83_DEFAULT_PAGE)
 
-    payload = build_day83_trust_faq_expansion_closeout_summary(root)
+    payload = build_trust_faq_expansion_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day84_evidence_narrative_closeout.py
+++ b/src/sdetkit/day84_evidence_narrative_closeout.py
@@ -135,7 +135,7 @@ def _checklist_count(markdown: str) -> int:
     return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day84_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
+def build_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -404,6 +404,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day84_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_evidence_narrative_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 84 evidence narrative closeout checks")
     parser.add_argument("--root", default=".")
@@ -419,7 +424,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY84_DEFAULT_PAGE)
 
-    payload = build_day84_evidence_narrative_closeout_summary(root)
+    payload = build_evidence_narrative_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day85_release_prioritization_closeout.py
+++ b/src/sdetkit/day85_release_prioritization_closeout.py
@@ -135,7 +135,7 @@ def _checklist_count(markdown: str) -> int:
     return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day85_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -408,6 +408,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day85_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_release_prioritization_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 85 release prioritization closeout checks")
     parser.add_argument("--root", default=".")
@@ -423,7 +428,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY85_DEFAULT_PAGE)
 
-    payload = build_day85_release_prioritization_closeout_summary(root)
+    payload = build_release_prioritization_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day86_launch_readiness_closeout.py
+++ b/src/sdetkit/day86_launch_readiness_closeout.py
@@ -137,7 +137,7 @@ def _checklist_count(markdown: str) -> int:
     return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day86_launch_readiness_closeout_summary(root: Path) -> dict[str, Any]:
+def build_launch_readiness_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -406,6 +406,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day86_launch_readiness_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_launch_readiness_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 86 launch readiness closeout checks")
     parser.add_argument("--root", default=".")
@@ -421,7 +426,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY86_DEFAULT_PAGE)
 
-    payload = build_day86_launch_readiness_closeout_summary(root)
+    payload = build_launch_readiness_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day87_governance_handoff_closeout.py
+++ b/src/sdetkit/day87_governance_handoff_closeout.py
@@ -135,7 +135,7 @@ def _checklist_count(markdown: str) -> int:
     return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day87_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
+def build_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -404,6 +404,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+
+def build_day87_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_governance_handoff_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 87 governance handoff closeout checks")
     parser.add_argument("--root", default=".")
@@ -419,7 +425,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY87_DEFAULT_PAGE)
 
-    payload = build_day87_governance_handoff_closeout_summary(root)
+    payload = build_governance_handoff_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day88_governance_priorities_closeout.py
+++ b/src/sdetkit/day88_governance_priorities_closeout.py
@@ -135,7 +135,7 @@ def _checklist_count(markdown: str) -> int:
     return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day88_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
+def build_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -404,6 +404,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+
+def build_day88_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_governance_priorities_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 88 governance priorities closeout checks")
     parser.add_argument("--root", default=".")
@@ -419,7 +425,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY88_DEFAULT_PAGE)
 
-    payload = build_day88_governance_priorities_closeout_summary(root)
+    payload = build_governance_priorities_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day89_governance_scale_closeout.py
+++ b/src/sdetkit/day89_governance_scale_closeout.py
@@ -137,7 +137,7 @@ def _checklist_count(markdown: str) -> int:
     return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day89_governance_scale_closeout_summary(root: Path) -> dict[str, Any]:
+def build_governance_scale_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -406,6 +406,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+
+def build_day89_governance_scale_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_governance_scale_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 89 governance scale closeout checks")
     parser.add_argument("--root", default=".")
@@ -421,7 +427,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY89_DEFAULT_PAGE)
 
-    payload = build_day89_governance_scale_closeout_summary(root)
+    payload = build_governance_scale_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)

--- a/src/sdetkit/day90_phase3_wrap_publication_closeout.py
+++ b/src/sdetkit/day90_phase3_wrap_publication_closeout.py
@@ -139,7 +139,7 @@ def _checklist_count(markdown: str) -> int:
     return sum(1 for line in markdown.splitlines() if line.strip().startswith("- ["))
 
 
-def build_day90_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]:
     readme_text = _read_text(root / "README.md")
     docs_index_text = _read_text(root / "docs/index.md")
     page_text = _read_text(root / _PAGE_PATH)
@@ -414,6 +414,11 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
+
+def build_day90_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]:
+    """Compatibility alias for legacy day-based builder name."""
+    return build_phase3_wrap_publication_closeout_summary(root)
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Day 90 phase-3 wrap publication closeout checks")
     parser.add_argument("--root", default=".")
@@ -429,7 +434,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.write_default_doc:
         _write(root / _PAGE_PATH, _DAY90_DEFAULT_PAGE)
 
-    payload = build_day90_phase3_wrap_publication_closeout_summary(root)
+    payload = build_phase3_wrap_publication_closeout_summary(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, Path(ns.emit_pack_dir), payload)


### PR DESCRIPTION
### Motivation
- Remove day-based builder names from active/public closeout surfaces by making canonical builder APIs primary while preserving narrow compatibility shims for legacy imports.
- Apply the change repo-wide across remaining active/public closeout lanes in a single batch instead of one-at-a-time to avoid partial fixes and lingering dayNN primary surfaces.
- Keep semantics and public behavior intact and avoid changing historical/artifact provenance in docs/artifacts or evidence logs.

### Description
- Renamed primary summary builder functions in closeout modules from `build_dayNN_*_summary` to canonical `build_*_summary`, and added small in-module compatibility wrappers `build_dayNN_*_summary -> build_*_summary` where appropriate so old imports still work.
- Updated contract checker scripts under `scripts/` to call the canonical `build_*_summary` functions instead of the legacy `build_dayNN_*_summary` names so public checkers prefer canonical APIs.
- Left historical dayNN references in checked-in artifacts, docs, and evidence logs untouched; compatibility aliases are intentionally narrow wrappers only in their original modules.
- Scope and impact: this batch touched ~98 files (closeout modules + checker scripts) to productize the canonical builder naming across day41…day90 closeout lanes.

### Testing
- Compiled code with `python -m compileall -q src/sdetkit scripts` and the build completed without import/compile errors.
- Ran focused pytest suites: `pytest -q tests/test_cli_productized_closeout_aliases.py tests/test_phase3_kickoff_closeout.py tests/test_integration_expansion_closeout.py tests/test_integration_expansion4_closeout.py tests/test_reliability_evidence_pack.py` which resulted in `36 passed` (all selected tests passed).
- Ran an additional smoke run: `pytest -q tests/test_cli_productized_closeout_aliases.py` which passed (`10 passed`).
- Ran governance contract checkers with `--skip-evidence`; they now call canonical builders successfully but surface legitimate contract failures (strict/activation score thresholds) rather than import or wiring errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c737c0f85483209a9679741fdb49d1)