### PR TITLE
Normalize Day 55–58 artifact pack names to canonical public pack names

### DIFF
--- a/docs/integrations-contributor-activation-closeout.md
+++ b/docs/integrations-contributor-activation-closeout.md
@@ -17,8 +17,8 @@ Day 55 closes with a major contributor activation upgrade that turns Day 53 docs
 
 ```bash
 python -m sdetkit contributor-activation-closeout --format json --strict
-python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict
-python -m sdetkit contributor-activation-closeout --execute --evidence-dir docs/artifacts/day55-contributor-activation-closeout-pack/evidence --format json --strict
+python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/contributor-activation-closeout-pack --format json --strict
+python -m sdetkit contributor-activation-closeout --execute --evidence-dir docs/artifacts/contributor-activation-closeout-pack/evidence --format json --strict
 python scripts/check_contributor_activation_closeout_contract.py
 ```
 

--- a/docs/integrations-kpi-deep-audit-closeout.md
+++ b/docs/integrations-kpi-deep-audit-closeout.md
@@ -10,15 +10,15 @@ Day 57 closes with a major KPI deep-audit upgrade that turns Day 56 stabilizatio
 
 ## Required inputs (Day 56)
 
-- `docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json`
-- `docs/artifacts/day56-stabilization-closeout-pack/day56-delivery-board.md`
+- `docs/artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json`
+- `docs/artifacts/stabilization-closeout-pack/stabilization-delivery-board.md`
 
 ## KPI Deep Audit Closeout command lane
 
 ```bash
 python -m sdetkit kpi-deep-audit-closeout --format json --strict
-python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict
-python -m sdetkit kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/kpi-deep-audit-closeout-pack --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/kpi-deep-audit-closeout-pack/evidence --format json --strict
 python scripts/check_kpi_deep_audit_closeout_contract.py
 ```
 

--- a/docs/integrations-phase2-hardening-closeout.md
+++ b/docs/integrations-phase2-hardening-closeout.md
@@ -10,15 +10,15 @@ Day 58 closes with a major Phase-2 hardening upgrade that turns Day 57 KPI deep-
 
 ## Required inputs (Day 57)
 
-- `docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-kpi-deep-audit-closeout-summary.json`
-- `docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-delivery-board.md`
+- `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json`
+- `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md`
 
 ## Phase 2 Hardening Closeout command lane
 
 ```bash
 python -m sdetkit phase2-hardening-closeout --format json --strict
-python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict
-python -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/day58-phase2-hardening-closeout-pack/evidence --format json --strict
+python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/phase2-hardening-closeout-pack --format json --strict
+python -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/phase2-hardening-closeout-pack/evidence --format json --strict
 python scripts/check_phase2_hardening_closeout_contract.py
 ```
 

--- a/docs/integrations-phase3-preplan-closeout.md
+++ b/docs/integrations-phase3-preplan-closeout.md
@@ -10,8 +10,8 @@ Day 59 closes with a major Phase-3 pre-plan upgrade that turns Day 58 hardening 
 
 ## Required inputs (Day 58)
 
-- `docs/artifacts/day58-phase2-hardening-closeout-pack/day58-phase2-hardening-closeout-summary.json`
-- `docs/artifacts/day58-phase2-hardening-closeout-pack/day58-delivery-board.md`
+- `docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json`
+- `docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md`
 
 ## Phase3 Preplan Closeout command lane
 

--- a/docs/integrations-stabilization-closeout.md
+++ b/docs/integrations-stabilization-closeout.md
@@ -10,15 +10,15 @@ Day 56 closes with a major stabilization upgrade that turns Day 55 contributor-a
 
 ## Required inputs (Day 55)
 
-- `docs/artifacts/day55-contributor-activation-closeout-pack/day55-contributor-activation-closeout-summary.json`
-- `docs/artifacts/day55-contributor-activation-closeout-pack/day55-delivery-board.md`
+- `docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json`
+- `docs/artifacts/contributor-activation-closeout-pack/contributor-activation-delivery-board.md`
 
 ## Stabilization Closeout command lane
 
 ```bash
 python -m sdetkit stabilization-closeout --format json --strict
-python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict
-python -m sdetkit stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict
+python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/stabilization-closeout-pack --format json --strict
+python -m sdetkit stabilization-closeout --execute --evidence-dir docs/artifacts/stabilization-closeout-pack/evidence --format json --strict
 python scripts/check_stabilization_closeout_contract.py
 ```
 

--- a/scripts/check_day55_contributor_activation_closeout_contract.py
+++ b/scripts/check_day55_contributor_activation_closeout_contract.py
@@ -33,7 +33,7 @@ def main() -> int:
     if not ns.skip_evidence:
         evidence = (
             root
-            / "docs/artifacts/day55-contributor-activation-closeout-pack/evidence/day55-execution-summary.json"
+            / "docs/artifacts/contributor-activation-closeout-pack/evidence/contributor-activation-execution-summary.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence summary: {evidence}")

--- a/scripts/check_day56_stabilization_closeout_contract.py
+++ b/scripts/check_day56_stabilization_closeout_contract.py
@@ -31,7 +31,7 @@ def main() -> int:
     if not ns.skip_evidence:
         evidence = (
             root
-            / "docs/artifacts/day56-stabilization-closeout-pack/evidence/day56-execution-summary.json"
+            / "docs/artifacts/stabilization-closeout-pack/evidence/stabilization-execution-summary.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence summary: {evidence}")

--- a/scripts/check_day57_kpi_deep_audit_closeout_contract.py
+++ b/scripts/check_day57_kpi_deep_audit_closeout_contract.py
@@ -31,7 +31,7 @@ def main() -> int:
     if not ns.skip_evidence:
         evidence = (
             root
-            / "docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence/day57-execution-summary.json"
+            / "docs/artifacts/kpi-deep-audit-closeout-pack/evidence/kpi-deep-audit-execution-summary.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence summary: {evidence}")

--- a/scripts/check_day58_phase2_hardening_closeout_contract.py
+++ b/scripts/check_day58_phase2_hardening_closeout_contract.py
@@ -33,7 +33,7 @@ def main() -> int:
     if not ns.skip_evidence:
         evidence = (
             root
-            / "docs/artifacts/day58-phase2-hardening-closeout-pack/evidence/day58-execution-summary.json"
+            / "docs/artifacts/phase2-hardening-closeout-pack/evidence/phase2-hardening-execution-summary.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence summary: {evidence}")

--- a/src/sdetkit/day55_contributor_activation_closeout.py
+++ b/src/sdetkit/day55_contributor_activation_closeout.py
@@ -26,13 +26,13 @@ _REQUIRED_SECTIONS = [
 ]
 _REQUIRED_COMMANDS = [
     "python -m sdetkit contributor-activation-closeout --format json --strict",
-    "python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict",
-    "python -m sdetkit contributor-activation-closeout --execute --evidence-dir docs/artifacts/day55-contributor-activation-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/contributor-activation-closeout-pack --format json --strict",
+    "python -m sdetkit contributor-activation-closeout --execute --evidence-dir docs/artifacts/contributor-activation-closeout-pack/evidence --format json --strict",
     "python scripts/check_contributor_activation_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
     "python -m sdetkit contributor-activation-closeout --format json --strict",
-    "python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict",
+    "python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/contributor-activation-closeout-pack --format json --strict",
     "python scripts/check_contributor_activation_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -75,8 +75,8 @@ Day 55 closes with a major contributor activation upgrade that turns Day 53 docs
 
 ```bash
 python -m sdetkit contributor-activation-closeout --format json --strict
-python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/day55-contributor-activation-closeout-pack --format json --strict
-python -m sdetkit contributor-activation-closeout --execute --evidence-dir docs/artifacts/day55-contributor-activation-closeout-pack/evidence --format json --strict
+python -m sdetkit contributor-activation-closeout --emit-pack-dir docs/artifacts/contributor-activation-closeout-pack --format json --strict
+python -m sdetkit contributor-activation-closeout --execute --evidence-dir docs/artifacts/contributor-activation-closeout-pack/evidence --format json --strict
 python scripts/check_contributor_activation_closeout_contract.py
 ```
 
@@ -366,27 +366,27 @@ def _write(path: Path, text: str) -> None:
 def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     target = pack_dir if pack_dir.is_absolute() else root / pack_dir
     _write(
-        target / "day55-contributor-activation-closeout-summary.json",
+        target / "contributor-activation-closeout-summary.json",
         json.dumps(payload, indent=2) + "\n",
     )
     _write(
-        target / "day55-contributor-activation-closeout-summary.md", _render_text(payload) + "\n"
+        target / "contributor-activation-closeout-summary.md", _render_text(payload) + "\n"
     )
     _write(
-        target / "day55-contributor-activation-brief.md", "# Day 55 contributor activation brief\n"
+        target / "contributor-activation-brief.md", "# Day 55 contributor activation brief\n"
     )
-    _write(target / "day55-contributor-ladder.csv", "stage,owner,kpi\n")
+    _write(target / "contributor-ladder.csv", "stage,owner,kpi\n")
     _write(
-        target / "day55-contributor-activation-kpi-scorecard.json",
+        target / "contributor-activation-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "day55-execution-log.md", "# Day 55 execution log\n")
+    _write(target / "contributor-activation-execution-log.md", "# Day 55 execution log\n")
     _write(
-        target / "day55-delivery-board.md",
+        target / "contributor-activation-delivery-board.md",
         "\n".join(["# Day 55 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
-        target / "day55-validation-commands.md",
+        target / "contributor-activation-validation-commands.md",
         "# Day 55 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
@@ -409,7 +409,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
         events.append(event)
         _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
     _write(
-        out_dir / "day55-execution-summary.json",
+        out_dir / "contributor-activation-execution-summary.json",
         json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
     )
 
@@ -444,7 +444,7 @@ def main(argv: list[str] | None = None) -> int:
         evidence_dir = (
             Path(ns.evidence_dir)
             if ns.evidence_dir
-            else Path("docs/artifacts/day55-contributor-activation-closeout-pack/evidence")
+            else Path("docs/artifacts/contributor-activation-closeout-pack/evidence")
         )
         _execute_commands(root, evidence_dir)
 

--- a/src/sdetkit/day56_stabilization_closeout.py
+++ b/src/sdetkit/day56_stabilization_closeout.py
@@ -10,9 +10,9 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-stabilization-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY55_SUMMARY_PATH = "docs/artifacts/day55-contributor-activation-closeout-pack/day55-contributor-activation-closeout-summary.json"
+_DAY55_SUMMARY_PATH = "docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json"
 _DAY55_BOARD_PATH = (
-    "docs/artifacts/day55-contributor-activation-closeout-pack/day55-delivery-board.md"
+    "docs/artifacts/contributor-activation-closeout-pack/contributor-activation-delivery-board.md"
 )
 _SECTION_HEADER = "# Day 56 \u2014 Stabilization closeout lane"
 _REQUIRED_SECTIONS = [
@@ -26,13 +26,13 @@ _REQUIRED_SECTIONS = [
 ]
 _REQUIRED_COMMANDS = [
     "python -m sdetkit stabilization-closeout --format json --strict",
-    "python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict",
-    "python -m sdetkit stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/stabilization-closeout-pack --format json --strict",
+    "python -m sdetkit stabilization-closeout --execute --evidence-dir docs/artifacts/stabilization-closeout-pack/evidence --format json --strict",
     "python scripts/check_stabilization_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
     "python -m sdetkit stabilization-closeout --format json --strict",
-    "python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict",
+    "python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/stabilization-closeout-pack --format json --strict",
     "python scripts/check_stabilization_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -68,15 +68,15 @@ Day 56 closes with a major stabilization upgrade that turns Day 55 contributor-a
 
 ## Required inputs (Day 55)
 
-- `docs/artifacts/day55-contributor-activation-closeout-pack/day55-contributor-activation-closeout-summary.json`
-- `docs/artifacts/day55-contributor-activation-closeout-pack/day55-delivery-board.md`
+- `docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json`
+- `docs/artifacts/contributor-activation-closeout-pack/contributor-activation-delivery-board.md`
 
 ## Day 56 command lane
 
 ```bash
 python -m sdetkit stabilization-closeout --format json --strict
-python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/day56-stabilization-closeout-pack --format json --strict
-python -m sdetkit stabilization-closeout --execute --evidence-dir docs/artifacts/day56-stabilization-closeout-pack/evidence --format json --strict
+python -m sdetkit stabilization-closeout --emit-pack-dir docs/artifacts/stabilization-closeout-pack --format json --strict
+python -m sdetkit stabilization-closeout --execute --evidence-dir docs/artifacts/stabilization-closeout-pack/evidence --format json --strict
 python scripts/check_stabilization_closeout_contract.py
 ```
 
@@ -366,21 +366,21 @@ def _write(path: Path, text: str) -> None:
 def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     target = pack_dir if pack_dir.is_absolute() else root / pack_dir
     _write(
-        target / "day56-stabilization-closeout-summary.json", json.dumps(payload, indent=2) + "\n"
+        target / "stabilization-closeout-summary.json", json.dumps(payload, indent=2) + "\n"
     )
-    _write(target / "day56-stabilization-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "day56-stabilization-brief.md", "# Day 56 stabilization brief\n")
-    _write(target / "day56-risk-ledger.csv", "risk,owner,mitigation,status\n")
+    _write(target / "stabilization-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "stabilization-brief.md", "# Day 56 stabilization brief\n")
+    _write(target / "stabilization-risk-ledger.csv", "risk,owner,mitigation,status\n")
     _write(
-        target / "day56-stabilization-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n"
+        target / "stabilization-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n"
     )
-    _write(target / "day56-execution-log.md", "# Day 56 execution log\n")
+    _write(target / "stabilization-execution-log.md", "# Day 56 execution log\n")
     _write(
-        target / "day56-delivery-board.md",
+        target / "stabilization-delivery-board.md",
         "\n".join(["# Day 56 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
-        target / "day56-validation-commands.md",
+        target / "stabilization-validation-commands.md",
         "# Day 56 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
@@ -403,7 +403,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
         events.append(event)
         _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
     _write(
-        out_dir / "day56-execution-summary.json",
+        out_dir / "stabilization-execution-summary.json",
         json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
     )
 
@@ -438,7 +438,7 @@ def main(argv: list[str] | None = None) -> int:
         evidence_dir = (
             Path(ns.evidence_dir)
             if ns.evidence_dir
-            else Path("docs/artifacts/day56-stabilization-closeout-pack/evidence")
+            else Path("docs/artifacts/stabilization-closeout-pack/evidence")
         )
         _execute_commands(root, evidence_dir)
 

--- a/src/sdetkit/day57_kpi_deep_audit_closeout.py
+++ b/src/sdetkit/day57_kpi_deep_audit_closeout.py
@@ -11,9 +11,9 @@ from typing import Any
 _PAGE_PATH = "docs/integrations-kpi-deep-audit-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY56_SUMMARY_PATH = (
-    "docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json"
+    "docs/artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json"
 )
-_DAY56_BOARD_PATH = "docs/artifacts/day56-stabilization-closeout-pack/day56-delivery-board.md"
+_DAY56_BOARD_PATH = "docs/artifacts/stabilization-closeout-pack/stabilization-delivery-board.md"
 _unused_SECTION_HEADER = "# Day 57 \u2014 KPI deep audit closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 57 matters",
@@ -26,13 +26,13 @@ _REQUIRED_SECTIONS = [
 ]
 _REQUIRED_COMMANDS = [
     "python -m sdetkit kpi-deep-audit-closeout --format json --strict",
-    "python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict",
-    "python -m sdetkit kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/kpi-deep-audit-closeout-pack --format json --strict",
+    "python -m sdetkit kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/kpi-deep-audit-closeout-pack/evidence --format json --strict",
     "python scripts/check_kpi_deep_audit_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
     "python -m sdetkit kpi-deep-audit-closeout --format json --strict",
-    "python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict",
+    "python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/kpi-deep-audit-closeout-pack --format json --strict",
     "python scripts/check_kpi_deep_audit_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -68,15 +68,15 @@ Day 57 closes with a major KPI deep-audit upgrade that turns Day 56 stabilizatio
 
 ## Required inputs (Day 56)
 
-- `docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json`
-- `docs/artifacts/day56-stabilization-closeout-pack/day56-delivery-board.md`
+- `docs/artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json`
+- `docs/artifacts/stabilization-closeout-pack/stabilization-delivery-board.md`
 
 ## Day 57 command lane
 
 ```bash
 python -m sdetkit kpi-deep-audit-closeout --format json --strict
-python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack --format json --strict
-python -m sdetkit kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --emit-pack-dir docs/artifacts/kpi-deep-audit-closeout-pack --format json --strict
+python -m sdetkit kpi-deep-audit-closeout --execute --evidence-dir docs/artifacts/kpi-deep-audit-closeout-pack/evidence --format json --strict
 python scripts/check_kpi_deep_audit_closeout_contract.py
 ```
 
@@ -359,19 +359,19 @@ def _write(path: Path, text: str) -> None:
 def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     target = pack_dir if pack_dir.is_absolute() else root / pack_dir
     _write(
-        target / "day57-kpi-deep-audit-closeout-summary.json", json.dumps(payload, indent=2) + "\n"
+        target / "kpi-deep-audit-closeout-summary.json", json.dumps(payload, indent=2) + "\n"
     )
-    _write(target / "day57-kpi-deep-audit-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "day57-kpi-deep-audit-brief.md", "# Day 57 KPI deep-audit brief\n")
-    _write(target / "day57-risk-ledger.csv", "risk,owner,mitigation,status\n")
-    _write(target / "day57-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
-    _write(target / "day57-execution-log.md", "# Day 57 execution log\n")
+    _write(target / "kpi-deep-audit-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "kpi-deep-audit-brief.md", "# Day 57 KPI deep-audit brief\n")
+    _write(target / "kpi-deep-audit-risk-ledger.csv", "risk,owner,mitigation,status\n")
+    _write(target / "kpi-deep-audit-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "kpi-deep-audit-execution-log.md", "# Day 57 execution log\n")
     _write(
-        target / "day57-delivery-board.md",
+        target / "kpi-deep-audit-delivery-board.md",
         "\n".join(["# Day 57 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
-        target / "day57-validation-commands.md",
+        target / "kpi-deep-audit-validation-commands.md",
         "# Day 57 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
@@ -394,7 +394,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
         events.append(event)
         _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
     _write(
-        out_dir / "day57-execution-summary.json",
+        out_dir / "kpi-deep-audit-execution-summary.json",
         json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
     )
 
@@ -429,7 +429,7 @@ def main(argv: list[str] | None = None) -> int:
         evidence_dir = (
             Path(ns.evidence_dir)
             if ns.evidence_dir
-            else Path("docs/artifacts/day57-kpi-deep-audit-closeout-pack/evidence")
+            else Path("docs/artifacts/kpi-deep-audit-closeout-pack/evidence")
         )
         _execute_commands(root, evidence_dir)
 

--- a/src/sdetkit/day58_phase2_hardening_closeout.py
+++ b/src/sdetkit/day58_phase2_hardening_closeout.py
@@ -11,9 +11,9 @@ from typing import Any
 _PAGE_PATH = "docs/integrations-phase2-hardening-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY57_SUMMARY_PATH = (
-    "docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-kpi-deep-audit-closeout-summary.json"
+    "docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json"
 )
-_DAY57_BOARD_PATH = "docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-delivery-board.md"
+_DAY57_BOARD_PATH = "docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md"
 _SECTION_HEADER = "# Day 58 \u2014 Phase-2 hardening closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 58 matters",
@@ -26,13 +26,13 @@ _REQUIRED_SECTIONS = [
 ]
 _REQUIRED_COMMANDS = [
     "python -m sdetkit phase2-hardening-closeout --format json --strict",
-    "python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict",
-    "python -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/day58-phase2-hardening-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/phase2-hardening-closeout-pack --format json --strict",
+    "python -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/phase2-hardening-closeout-pack/evidence --format json --strict",
     "python scripts/check_phase2_hardening_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
     "python -m sdetkit phase2-hardening-closeout --format json --strict",
-    "python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict",
+    "python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/phase2-hardening-closeout-pack --format json --strict",
     "python scripts/check_phase2_hardening_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -68,15 +68,15 @@ Day 58 closes with a major Phase-2 hardening upgrade that turns Day 57 KPI deep-
 
 ## Required inputs (Day 57)
 
-- `docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-kpi-deep-audit-closeout-summary.json`
-- `docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-delivery-board.md`
+- `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json`
+- `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md`
 
 ## Day 58 command lane
 
 ```bash
 python -m sdetkit phase2-hardening-closeout --format json --strict
-python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/day58-phase2-hardening-closeout-pack --format json --strict
-python -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/day58-phase2-hardening-closeout-pack/evidence --format json --strict
+python -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/phase2-hardening-closeout-pack --format json --strict
+python -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/phase2-hardening-closeout-pack/evidence --format json --strict
 python scripts/check_phase2_hardening_closeout_contract.py
 ```
 
@@ -359,20 +359,20 @@ def _write(path: Path, text: str) -> None:
 def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     target = pack_dir if pack_dir.is_absolute() else root / pack_dir
     _write(
-        target / "day58-phase2-hardening-closeout-summary.json",
+        target / "phase2-hardening-closeout-summary.json",
         json.dumps(payload, indent=2) + "\n",
     )
-    _write(target / "day58-phase2-hardening-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "day58-phase2-hardening-brief.md", "# Day 58 Phase-2 hardening brief\n")
-    _write(target / "day58-risk-ledger.csv", "risk,owner,mitigation,status\n")
-    _write(target / "day58-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
-    _write(target / "day58-execution-log.md", "# Day 58 execution log\n")
+    _write(target / "phase2-hardening-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "phase2-hardening-brief.md", "# Day 58 Phase-2 hardening brief\n")
+    _write(target / "phase2-hardening-risk-ledger.csv", "risk,owner,mitigation,status\n")
+    _write(target / "phase2-hardening-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
+    _write(target / "phase2-hardening-execution-log.md", "# Day 58 execution log\n")
     _write(
-        target / "day58-delivery-board.md",
+        target / "phase2-hardening-delivery-board.md",
         "\n".join(["# Day 58 delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
-        target / "day58-validation-commands.md",
+        target / "phase2-hardening-validation-commands.md",
         "# Day 58 validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
@@ -395,7 +395,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
         events.append(event)
         _write(out_dir / f"command-{idx:02d}.log", json.dumps(event, indent=2) + "\n")
     _write(
-        out_dir / "day58-execution-summary.json",
+        out_dir / "phase2-hardening-execution-summary.json",
         json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
     )
 
@@ -430,7 +430,7 @@ def main(argv: list[str] | None = None) -> int:
         evidence_dir = (
             Path(ns.evidence_dir)
             if ns.evidence_dir
-            else Path("docs/artifacts/day58-phase2-hardening-closeout-pack/evidence")
+            else Path("docs/artifacts/phase2-hardening-closeout-pack/evidence")
         )
         _execute_commands(root, evidence_dir)
 

--- a/src/sdetkit/day59_phase3_preplan_closeout.py
+++ b/src/sdetkit/day59_phase3_preplan_closeout.py
@@ -10,8 +10,8 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-phase3-preplan-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY58_SUMMARY_PATH = "docs/artifacts/day58-phase2-hardening-closeout-pack/day58-phase2-hardening-closeout-summary.json"
-_DAY58_BOARD_PATH = "docs/artifacts/day58-phase2-hardening-closeout-pack/day58-delivery-board.md"
+_DAY58_SUMMARY_PATH = "docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json"
+_DAY58_BOARD_PATH = "docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md"
 _SECTION_HEADER = "# Day 59 \u2014 Phase-3 pre-plan closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 59 matters",
@@ -66,8 +66,8 @@ Day 59 closes with a major Phase-3 pre-plan upgrade that turns Day 58 hardening 
 
 ## Required inputs (Day 58)
 
-- `docs/artifacts/day58-phase2-hardening-closeout-pack/day58-phase2-hardening-closeout-summary.json`
-- `docs/artifacts/day58-phase2-hardening-closeout-pack/day58-delivery-board.md`
+- `docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json`
+- `docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md`
 
 ## Day 59 command lane
 

--- a/tests/test_contributor_activation_closeout.py
+++ b/tests/test_contributor_activation_closeout.py
@@ -99,20 +99,20 @@ def test_day55_emit_pack_and_execute(tmp_path: Path) -> None:
     )
     assert rc == 0
     assert (
-        tmp_path / "artifacts/day55-pack/day55-contributor-activation-closeout-summary.json"
+        tmp_path / "artifacts/day55-pack/contributor-activation-closeout-summary.json"
     ).exists()
     assert (
-        tmp_path / "artifacts/day55-pack/day55-contributor-activation-closeout-summary.md"
+        tmp_path / "artifacts/day55-pack/contributor-activation-closeout-summary.md"
     ).exists()
-    assert (tmp_path / "artifacts/day55-pack/day55-contributor-activation-brief.md").exists()
-    assert (tmp_path / "artifacts/day55-pack/day55-contributor-ladder.csv").exists()
+    assert (tmp_path / "artifacts/day55-pack/contributor-activation-brief.md").exists()
+    assert (tmp_path / "artifacts/day55-pack/contributor-ladder.csv").exists()
     assert (
-        tmp_path / "artifacts/day55-pack/day55-contributor-activation-kpi-scorecard.json"
+        tmp_path / "artifacts/day55-pack/contributor-activation-kpi-scorecard.json"
     ).exists()
-    assert (tmp_path / "artifacts/day55-pack/day55-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day55-pack/day55-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day55-pack/day55-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day55-pack/evidence/day55-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/day55-pack/contributor-activation-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day55-pack/contributor-activation-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day55-pack/contributor-activation-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day55-pack/evidence/contributor-activation-execution-summary.json").exists()
 
 
 def test_day55_strict_fails_without_day53(tmp_path: Path) -> None:

--- a/tests/test_kpi_deep_audit_closeout.py
+++ b/tests/test_kpi_deep_audit_closeout.py
@@ -43,7 +43,7 @@ def _seed_repo(root: Path) -> None:
 
     summary = (
         root
-        / "docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json"
+        / "docs/artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json"
     )
     summary.parent.mkdir(parents=True, exist_ok=True)
     summary.write_text(
@@ -56,7 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/day56-stabilization-closeout-pack/day56-delivery-board.md"
+    board = root / "docs/artifacts/stabilization-closeout-pack/stabilization-delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -99,22 +99,22 @@ def test_day57_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day57-pack/day57-kpi-deep-audit-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day57-pack/day57-kpi-deep-audit-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day57-pack/day57-kpi-deep-audit-brief.md").exists()
-    assert (tmp_path / "artifacts/day57-pack/day57-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day57-pack/day57-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day57-pack/day57-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day57-pack/day57-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day57-pack/day57-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day57-pack/evidence/day57-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-brief.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day57-pack/evidence/kpi-deep-audit-execution-summary.json").exists()
 
 
 def test_day57_strict_fails_without_day56(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
-        / "docs/artifacts/day56-stabilization-closeout-pack/day56-stabilization-closeout-summary.json"
+        / "docs/artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json"
     ).unlink()
     assert d57.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 

--- a/tests/test_phase2_hardening_closeout.py
+++ b/tests/test_phase2_hardening_closeout.py
@@ -43,7 +43,7 @@ def _seed_repo(root: Path) -> None:
 
     summary = (
         root
-        / "docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-kpi-deep-audit-closeout-summary.json"
+        / "docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json"
     )
     summary.parent.mkdir(parents=True, exist_ok=True)
     summary.write_text(
@@ -56,7 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-delivery-board.md"
+    board = root / "docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -99,22 +99,22 @@ def test_day58_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day58-pack/day58-phase2-hardening-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day58-pack/day58-phase2-hardening-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day58-pack/day58-phase2-hardening-brief.md").exists()
-    assert (tmp_path / "artifacts/day58-pack/day58-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day58-pack/day58-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day58-pack/day58-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day58-pack/day58-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day58-pack/day58-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day58-pack/evidence/day58-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-brief.md").exists()
+    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day58-pack/evidence/phase2-hardening-execution-summary.json").exists()
 
 
 def test_day58_strict_fails_without_day57(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
-        / "docs/artifacts/day57-kpi-deep-audit-closeout-pack/day57-kpi-deep-audit-closeout-summary.json"
+        / "docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json"
     ).unlink()
     assert d58.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 

--- a/tests/test_phase3_preplan_closeout.py
+++ b/tests/test_phase3_preplan_closeout.py
@@ -43,7 +43,7 @@ def _seed_repo(root: Path) -> None:
 
     summary = (
         root
-        / "docs/artifacts/day58-phase2-hardening-closeout-pack/day58-phase2-hardening-closeout-summary.json"
+        / "docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json"
     )
     summary.parent.mkdir(parents=True, exist_ok=True)
     summary.write_text(
@@ -56,7 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/day58-phase2-hardening-closeout-pack/day58-delivery-board.md"
+    board = root / "docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -114,7 +114,7 @@ def test_day59_strict_fails_without_day58(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
-        / "docs/artifacts/day58-phase2-hardening-closeout-pack/day58-phase2-hardening-closeout-summary.json"
+        / "docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json"
     ).unlink()
     assert d59.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 

--- a/tests/test_stabilization_closeout.py
+++ b/tests/test_stabilization_closeout.py
@@ -43,7 +43,7 @@ def _seed_repo(root: Path) -> None:
 
     summary = (
         root
-        / "docs/artifacts/day55-contributor-activation-closeout-pack/day55-contributor-activation-closeout-summary.json"
+        / "docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json"
     )
     summary.parent.mkdir(parents=True, exist_ok=True)
     summary.write_text(
@@ -57,7 +57,7 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     board = (
-        root / "docs/artifacts/day55-contributor-activation-closeout-pack/day55-delivery-board.md"
+        root / "docs/artifacts/contributor-activation-closeout-pack/contributor-activation-delivery-board.md"
     )
     board.write_text(
         "\n".join(
@@ -101,22 +101,22 @@ def test_day56_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day56-pack/day56-stabilization-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day56-pack/day56-stabilization-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day56-pack/day56-stabilization-brief.md").exists()
-    assert (tmp_path / "artifacts/day56-pack/day56-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day56-pack/day56-stabilization-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day56-pack/day56-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day56-pack/day56-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day56-pack/day56-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day56-pack/evidence/day56-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/day56-pack/stabilization-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/day56-pack/stabilization-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/day56-pack/stabilization-brief.md").exists()
+    assert (tmp_path / "artifacts/day56-pack/stabilization-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/day56-pack/stabilization-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/day56-pack/stabilization-execution-log.md").exists()
+    assert (tmp_path / "artifacts/day56-pack/stabilization-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day56-pack/stabilization-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/day56-pack/evidence/stabilization-execution-summary.json").exists()
 
 
 def test_day56_strict_fails_without_day55(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
-        / "docs/artifacts/day55-contributor-activation-closeout-pack/day55-contributor-activation-closeout-summary.json"
+        / "docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json"
     ).unlink()
     assert d56.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 


### PR DESCRIPTION
### Motivation
- The active/public Day 55–58 closeout chain (and Day 59 downstream handoff) still used legacy `dayNN` pack names on public surfaces, causing inconsistent public interfaces and emitted artifact names.
- This change makes canonical pack names the primary public contract while preserving legacy `dayNN` aliases only where they act as explicit compatibility shims.

### Description
- Updated lane modules to emit and reference canonical pack directories and filenames: `contributor-activation-closeout-pack`, `stabilization-closeout-pack`, `kpi-deep-audit-closeout-pack`, and `phase2-hardening-closeout-pack`, and adjusted Day 59 inputs to prefer the canonical Day 58 pack paths (changes in `src/sdetkit/day55_*` → `day59_*`).
- Updated integration docs to show canonical pack paths/command examples instead of `day55`/`day56`/`day57`/`day58` pack paths (`docs/integrations-*.md`).
- Updated contract-check scripts to validate canonical evidence filenames/locations (changes in `scripts/check_day55_*`, `check_day56_*`, `check_day57_*`, `check_day58_*`).
- Updated tests to seed and assert emitted artifacts against the canonical filenames and pack locations under `tests/` so checked-in artifacts and test fixtures match the new public naming.

### Testing
- Ran targeted pytest: `pytest -q tests/test_contributor_activation_closeout.py tests/test_stabilization_closeout.py tests/test_kpi_deep_audit_closeout.py tests/test_phase2_hardening_closeout.py tests/test_phase3_preplan_closeout.py`, and all tests passed (`20 passed`).
- Executed the lane contract checkers with `--skip-evidence`; several contract checks still fail due to existing discoverability/strict-baseline issues unrelated to these naming changes (these failures are expected and not caused by this patch).
- No push was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c73dc2e1a8832096670d2c01c2b73e)