### PR TITLE
Prefer canonical CI template paths for integration-expansion closeout lanes

### DIFF
--- a/docs/integrations-integration-expansion2-closeout.md
+++ b/docs/integrations-integration-expansion2-closeout.md
@@ -12,7 +12,7 @@ Day 66 closes with a major integration upgrade that converts Day 65 weekly revie
 
 - `docs/artifacts/weekly-review-closeout-cycle2-pack/weekly-review-closeout-cycle2-summary.json`
 - `docs/artifacts/weekly-review-closeout-cycle2-pack/day65-delivery-board.md`
-- `templates/ci/gitlab/day66-advanced-reference.yml`
+- `templates/ci/gitlab/gitlab-advanced-reference.yml`
 
 ## Integration Expansion 2 Closeout command lane (legacy)
 

--- a/docs/integrations-integration-expansion3-closeout.md
+++ b/docs/integrations-integration-expansion3-closeout.md
@@ -12,7 +12,7 @@ Day 67 closes with a major integration upgrade that converts Day 66 integration 
 
 - `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json`
 - `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md`
-- `templates/ci/jenkins/day67-advanced-reference.Jenkinsfile`
+- `templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile`
 
 ## Integration Expansion3 Closeout command lane (legacy)
 

--- a/docs/integrations-integration-expansion4-closeout.md
+++ b/docs/integrations-integration-expansion4-closeout.md
@@ -12,7 +12,7 @@ Day 68 closes with a major integration upgrade that converts Day 67 outputs into
 
 - `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json`
 - `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md`
-- `templates/ci/tekton/day68-self-hosted-reference.yaml`
+- `templates/ci/tekton/tekton-self-hosted-reference.yaml`
 
 ## Integration Expansion4 Closeout command lane (legacy)
 

--- a/src/sdetkit/day66_integration_expansion2_closeout.py
+++ b/src/sdetkit/day66_integration_expansion2_closeout.py
@@ -14,7 +14,8 @@ _DAY65_SUMMARY_PATH = (
     "docs/artifacts/weekly-review-closeout-cycle2-pack/weekly-review-closeout-cycle2-summary.json"
 )
 _DAY65_BOARD_PATH = "docs/artifacts/weekly-review-closeout-cycle2-pack/day65-delivery-board.md"
-_GITLAB_PATH = "templates/ci/gitlab/day66-advanced-reference.yml"
+_GITLAB_PATH = "templates/ci/gitlab/gitlab-advanced-reference.yml"
+_LEGACY_GITLAB_PATH = "templates/ci/gitlab/day66-advanced-reference.yml"
 _SECTION_HEADER = "# Day 66 \u2014 Integration expansion #2 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Expansion 2 Closeout matters",
@@ -79,7 +80,8 @@ Day 66 closes with a major integration upgrade that converts Day 65 weekly revie
 
 - `docs/artifacts/weekly-review-closeout-cycle2-pack/weekly-review-closeout-cycle2-summary.json`
 - `docs/artifacts/weekly-review-closeout-cycle2-pack/day65-delivery-board.md`
-- `templates/ci/gitlab/day66-advanced-reference.yml`
+- `templates/ci/gitlab/gitlab-advanced-reference.yml`
+  - legacy compatibility alias: `templates/ci/gitlab/day66-advanced-reference.yml`
 
 ## Integration Expansion 2 Closeout command lane (Legacy Day 66)
 
@@ -128,6 +130,16 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
+def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
+    canonical_path = root / canonical
+    if canonical_path.exists():
+        return canonical_path
+    legacy_path = root / legacy
+    if legacy_path.exists():
+        return legacy_path
+    return canonical_path
+
+
 def _load_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -163,7 +175,8 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
-    gitlab_text = _read(root / _GITLAB_PATH)
+    gitlab_path = _resolve_input_path(root, _GITLAB_PATH, _LEGACY_GITLAB_PATH)
+    gitlab_text = _read(gitlab_path)
 
     day65_summary = root / _DAY65_SUMMARY_PATH
     day65_board = root / _DAY65_BOARD_PATH
@@ -267,7 +280,7 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
             "check_id": "gitlab_reference_present",
             "weight": 10,
             "passed": not missing_gitlab_lines,
-            "evidence": missing_gitlab_lines or _GITLAB_PATH,
+            "evidence": missing_gitlab_lines or str(gitlab_path.relative_to(root)),
         },
     ]
 
@@ -307,7 +320,7 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
     else:
         misses.append("Day 66 GitLab reference pipeline is missing required controls.")
         handoff_actions.append(
-            "Update templates/ci/gitlab/day66-advanced-reference.yml to restore required controls."
+            "Update templates/ci/gitlab/gitlab-advanced-reference.yml to restore required controls."
         )
 
     if not failed and not critical_failures:
@@ -329,7 +342,9 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
             "day65_delivery_board": str(day65_board.relative_to(root))
             if day65_board.exists()
             else str(day65_board),
-            "gitlab_reference": _GITLAB_PATH,
+            "gitlab_reference": str(gitlab_path.relative_to(root))
+            if gitlab_path.exists()
+            else _GITLAB_PATH,
         },
         "checks": checks,
         "rollup": {

--- a/src/sdetkit/day67_integration_expansion3_closeout.py
+++ b/src/sdetkit/day67_integration_expansion3_closeout.py
@@ -14,7 +14,8 @@ _DAY66_SUMMARY_PATH = "docs/artifacts/integration-expansion2-closeout-pack/integ
 _DAY66_BOARD_PATH = (
     "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md"
 )
-_JENKINS_PATH = "templates/ci/jenkins/day67-advanced-reference.Jenkinsfile"
+_JENKINS_PATH = "templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile"
+_LEGACY_JENKINS_PATH = "templates/ci/jenkins/day67-advanced-reference.Jenkinsfile"
 _SECTION_HEADER = "# Day 67 \u2014 Integration expansion #3 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Expansion3 Closeout matters",
@@ -79,7 +80,8 @@ Day 67 closes with a major integration upgrade that converts Day 66 integration 
 
 - `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json`
 - `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md`
-- `templates/ci/jenkins/day67-advanced-reference.Jenkinsfile`
+- `templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile`
+  - legacy compatibility alias: `templates/ci/jenkins/day67-advanced-reference.Jenkinsfile`
 
 ## Integration Expansion3 Closeout command lane (Legacy Day 67)
 
@@ -128,6 +130,16 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
+def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
+    canonical_path = root / canonical
+    if canonical_path.exists():
+        return canonical_path
+    legacy_path = root / legacy
+    if legacy_path.exists():
+        return legacy_path
+    return canonical_path
+
+
 def _load_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -163,7 +175,8 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
-    jenkins_text = _read(root / _JENKINS_PATH)
+    jenkins_path = _resolve_input_path(root, _JENKINS_PATH, _LEGACY_JENKINS_PATH)
+    jenkins_text = _read(jenkins_path)
 
     day66_summary = root / _DAY66_SUMMARY_PATH
     day66_board = root / _DAY66_BOARD_PATH
@@ -267,7 +280,7 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
             "check_id": "jenkins_reference_present",
             "weight": 10,
             "passed": not missing_jenkins_lines,
-            "evidence": missing_jenkins_lines or _JENKINS_PATH,
+            "evidence": missing_jenkins_lines or str(jenkins_path.relative_to(root)),
         },
     ]
 
@@ -307,7 +320,7 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
     else:
         misses.append("Day 67 Jenkins reference pipeline is missing required controls.")
         handoff_actions.append(
-            "Update templates/ci/jenkins/day67-advanced-reference.Jenkinsfile to restore required controls."
+            "Update templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile to restore required controls."
         )
 
     if not failed and not critical_failures:
@@ -329,7 +342,9 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
             "day66_delivery_board": str(day66_board.relative_to(root))
             if day66_board.exists()
             else str(day66_board),
-            "jenkins_reference": _JENKINS_PATH,
+            "jenkins_reference": str(jenkins_path.relative_to(root))
+            if jenkins_path.exists()
+            else _JENKINS_PATH,
         },
         "checks": checks,
         "rollup": {

--- a/src/sdetkit/day68_integration_expansion4_closeout.py
+++ b/src/sdetkit/day68_integration_expansion4_closeout.py
@@ -14,7 +14,8 @@ _DAY67_SUMMARY_PATH = "docs/artifacts/integration-expansion3-closeout-pack/integ
 _DAY67_BOARD_PATH = (
     "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md"
 )
-_REFERENCE_PATH = "templates/ci/tekton/day68-self-hosted-reference.yaml"
+_REFERENCE_PATH = "templates/ci/tekton/tekton-self-hosted-reference.yaml"
+_LEGACY_REFERENCE_PATH = "templates/ci/tekton/day68-self-hosted-reference.yaml"
 _SECTION_HEADER = "# Day 68 \u2014 Integration expansion #4 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Expansion4 Closeout matters",
@@ -79,7 +80,8 @@ Day 68 closes with a major integration upgrade that converts Day 67 outputs into
 
 - `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json`
 - `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md`
-- `templates/ci/tekton/day68-self-hosted-reference.yaml`
+- `templates/ci/tekton/tekton-self-hosted-reference.yaml`
+  - legacy compatibility alias: `templates/ci/tekton/day68-self-hosted-reference.yaml`
 
 ## Integration Expansion4 Closeout command lane (Legacy Day 68)
 
@@ -128,6 +130,16 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
+def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
+    canonical_path = root / canonical
+    if canonical_path.exists():
+        return canonical_path
+    legacy_path = root / legacy
+    if legacy_path.exists():
+        return legacy_path
+    return canonical_path
+
+
 def _load_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -163,7 +175,8 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
-    reference_text = _read(root / _REFERENCE_PATH)
+    reference_path = _resolve_input_path(root, _REFERENCE_PATH, _LEGACY_REFERENCE_PATH)
+    reference_text = _read(reference_path)
 
     day67_summary = root / _DAY67_SUMMARY_PATH
     day67_board = root / _DAY67_BOARD_PATH
@@ -267,7 +280,7 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
             "check_id": "self_hosted_reference_present",
             "weight": 10,
             "passed": not missing_reference_lines,
-            "evidence": missing_reference_lines or _REFERENCE_PATH,
+            "evidence": missing_reference_lines or str(reference_path.relative_to(root)),
         },
     ]
 
@@ -307,7 +320,7 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
     else:
         misses.append("Day 68 self-hosted reference pipeline is missing required controls.")
         handoff_actions.append(
-            "Update templates/ci/tekton/day68-self-hosted-reference.yaml to restore required controls."
+            "Update templates/ci/tekton/tekton-self-hosted-reference.yaml to restore required controls."
         )
 
     if not failed and not critical_failures:
@@ -329,7 +342,9 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
             "day67_delivery_board": str(day67_board.relative_to(root))
             if day67_board.exists()
             else str(day67_board),
-            "self_hosted_reference": _REFERENCE_PATH,
+            "self_hosted_reference": str(reference_path.relative_to(root))
+            if reference_path.exists()
+            else _REFERENCE_PATH,
         },
         "checks": checks,
         "rollup": {

--- a/tests/test_integration_expansion2_closeout.py
+++ b/tests/test_integration_expansion2_closeout.py
@@ -72,7 +72,7 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
 
-    gitlab = root / "templates/ci/gitlab/day66-advanced-reference.yml"
+    gitlab = root / "templates/ci/gitlab/gitlab-advanced-reference.yml"
     gitlab.write_text(
         "stages:\n"
         "  - lint\n"

--- a/tests/test_integration_expansion3_closeout.py
+++ b/tests/test_integration_expansion3_closeout.py
@@ -74,7 +74,7 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
 
-    jenkins = root / "templates/ci/jenkins/day67-advanced-reference.Jenkinsfile"
+    jenkins = root / "templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile"
     jenkins.write_text(
         "pipeline {\n"
         "  agent any\n"

--- a/tests/test_integration_expansion4_closeout.py
+++ b/tests/test_integration_expansion4_closeout.py
@@ -27,7 +27,7 @@ def _seed_repo(root: Path) -> None:
         d68._DAY68_DEFAULT_PAGE,
         encoding="utf-8",
     )
-    (root / "templates/ci/tekton/day68-self-hosted-reference.yaml").write_text(
+    (root / "templates/ci/tekton/tekton-self-hosted-reference.yaml").write_text(
         "\n".join(d68._REQUIRED_REFERENCE_LINES) + "\n",
         encoding="utf-8",
     )


### PR DESCRIPTION
### Motivation
- Inventory found active/public residue where integration-expansion lanes referenced day-based CI template filenames (`day66-...`, `day67-...`, `day68-...`) instead of the canonical templates. 
- The goal was to make canonical template names primary on active/public surfaces while retaining narrow compatibility fallbacks for legacy day-prefixed filenames. 
- Keep semantics and public contracts intact and avoid touching already-clean lanes or historical artifacts.

### Description
- Switched integration expansion closeout lanes to prefer canonical templates by updating `src/sdetkit/day66_integration_expansion2_closeout.py`, `src/sdetkit/day67_integration_expansion3_closeout.py`, and `src/sdetkit/day68_integration_expansion4_closeout.py` to use canonical paths (`templates/ci/gitlab/gitlab-advanced-reference.yml`, `templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile`, `templates/ci/tekton/tekton-self-hosted-reference.yaml`) and added `_LEGACY_*` aliases. 
- Added a `_resolve_input_path(root, canonical, legacy)` helper in each lane so the canonical path is used when present and the legacy `dayNN-...` file is used only as an explicit compatibility fallback. 
- Updated docs (`docs/integrations-integration-expansion2-closeout.md`, `docs/integrations-integration-expansion3-closeout.md`, `docs/integrations-integration-expansion4-closeout.md`) and the targeted tests (`tests/test_integration_expansion2_closeout.py`, `tests/test_integration_expansion3_closeout.py`, `tests/test_integration_expansion4_closeout.py`) to point at the canonical template paths; legacy day-prefixed filenames are retained only as documented fallback. 
- Committed the changes (commit created via local commit) without pushing.

### Testing
- Ran unit/functional tests with `pytest -q tests/test_integration_expansion2_closeout.py tests/test_integration_expansion3_closeout.py tests/test_integration_expansion4_closeout.py` and all tests passed (`12 passed`).
- Ran repo layout check with `python scripts/check_repo_layout.py` which succeeded (`ok: repo layout invariants hold`).
- Ran contract checkers `python scripts/check_integration_expansion2_closeout_contract.py --skip-evidence`, `python scripts/check_integration_expansion3_closeout_contract.py --skip-evidence`, and `python scripts/check_integration_expansion4_closeout_contract.py --skip-evidence` which report expected pre-existing baseline failures (activation/strict/index/header issues) and are not caused by this change. 
- Attempted strict pack generation with `python -m sdetkit integration-expansion* --emit-pack-dir ... --format json --strict` which fails on this checkout due to missing baseline artifacts; a non-strict emit was exercised and then cleaned to avoid adding day-prefixed artifacts to tracked packs. 
- Final `git status --short` shows a clean working tree for the committed changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c7c7ec68808320a53a6fd26a9c452a)