### PR TITLE
Batch-clean delivery-board names for day42/43/48/49/50 closeout lanes

### DIFF
--- a/docs/integrations-acceleration-closeout.md
+++ b/docs/integrations-acceleration-closeout.md
@@ -11,7 +11,7 @@ Day 43 closes with a major acceleration upgrade that converts Day 42 optimizatio
 ## Required inputs (Day 42)
 
 - `docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json`
-- `docs/artifacts/optimization-closeout-foundation-pack/day42-delivery-board.md`
+- `docs/artifacts/optimization-closeout-foundation-pack/optimization-delivery-board.md`
 
 ## Day 43 command lane
 

--- a/docs/integrations-execution-prioritization-closeout.md
+++ b/docs/integrations-execution-prioritization-closeout.md
@@ -11,7 +11,7 @@ Day 50 closes with a major execution-prioritization upgrade that converts Day 49
 ## Required inputs (Day 49)
 
 - `docs/artifacts/day49-weekly-review-closeout-pack/day49-weekly-review-closeout-summary.json`
-- `docs/artifacts/day49-weekly-review-closeout-pack/day49-delivery-board.md`
+- `docs/artifacts/day49-weekly-review-closeout-pack/weekly-review-delivery-board.md`
 
 ## Day 50 command lane
 

--- a/docs/integrations-optimization-closeout-foundation.md
+++ b/docs/integrations-optimization-closeout-foundation.md
@@ -11,7 +11,7 @@ Optimization Closeout Foundation closes the lane with a major optimization upgra
 ## Required inputs (Day 41)
 
 - `docs/artifacts/expansion-automation-pack/expansion-automation-summary.json`
-- `docs/artifacts/expansion-automation-pack/day41-delivery-board.md`
+- `docs/artifacts/expansion-automation-pack/expansion-automation-delivery-board.md`
 
 ## Optimization Closeout Foundation command lane
 

--- a/docs/integrations-scale-closeout.md
+++ b/docs/integrations-scale-closeout.md
@@ -11,7 +11,7 @@ Day 44 closes with a big scale upgrade that converts Day 43 acceleration evidenc
 ## Required inputs (Day 43)
 
 - `docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json`
-- `docs/artifacts/acceleration-closeout-pack/day43-delivery-board.md`
+- `docs/artifacts/acceleration-closeout-pack/acceleration-delivery-board.md`
 
 ## Day 44 command lane
 

--- a/docs/integrations-weekly-review-closeout.md
+++ b/docs/integrations-weekly-review-closeout.md
@@ -11,7 +11,7 @@ Day 49 closes with a major weekly-review upgrade that converts Day 48 objection 
 ## Required inputs (Day 48)
 
 - `docs/artifacts/objection-closeout-pack/objection-closeout-summary.json`
-- `docs/artifacts/objection-closeout-pack/day48-delivery-board.md`
+- `docs/artifacts/objection-closeout-pack/objection-delivery-board.md`
 
 ## Day 49 command lane
 

--- a/src/sdetkit/day42_optimization_closeout.py
+++ b/src/sdetkit/day42_optimization_closeout.py
@@ -13,7 +13,8 @@ _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY41_SUMMARY_PATH = (
     "docs/artifacts/expansion-automation-pack/expansion-automation-summary.json"
 )
-_DAY41_BOARD_PATH = "docs/artifacts/expansion-automation-pack/day41-delivery-board.md"
+_DAY41_BOARD_PATH = "docs/artifacts/expansion-automation-pack/expansion-automation-delivery-board.md"
+_DAY41_LEGACY_BOARD_PATH = "docs/artifacts/expansion-automation-pack/day41-delivery-board.md"
 _SECTION_HEADER = "# Optimization Closeout Foundation \u2014 Optimization closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Optimization Closeout Foundation matters",
@@ -69,7 +70,7 @@ Optimization Closeout Foundation closes with a major optimization upgrade that c
 ## Required inputs (Day 41)
 
 - `docs/artifacts/expansion-automation-pack/expansion-automation-summary.json`
-- `docs/artifacts/expansion-automation-pack/day41-delivery-board.md`
+- `docs/artifacts/expansion-automation-pack/expansion-automation-delivery-board.md`
 
 ## Optimization Closeout Foundation command lane
 
@@ -151,6 +152,13 @@ def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
     return [line for line in expected if line not in text]
 
 
+def _resolve_existing_path(root: Path, primary: str, legacy: str) -> Path:
+    primary_path = root / primary
+    if primary_path.exists():
+        return primary_path
+    return root / legacy
+
+
 def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
@@ -172,7 +180,7 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
     day41_summary = root / _DAY41_SUMMARY_PATH
-    day41_board = root / _DAY41_BOARD_PATH
+    day41_board = _resolve_existing_path(root, _DAY41_BOARD_PATH, _DAY41_LEGACY_BOARD_PATH)
     day41_score, day41_strict, day41_check_count = _load_day41(day41_summary)
     board_count, board_has_day41, board_has_day42 = _board_stats(day41_board)
 
@@ -419,6 +427,12 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(
         target / "day42-execution-log.md",
         "# Optimization Closeout Foundation Execution Log\n\n- [ ] 2026-03-12: Record misses, wins, and Day 43 acceleration priorities.\n",
+    )
+    _write(
+        target / "optimization-delivery-board.md",
+        "# Optimization Closeout Foundation Delivery Board\n\n"
+        + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES)
+        + "\n",
     )
     _write(
         target / "day42-delivery-board.md",

--- a/src/sdetkit/day43_acceleration_closeout.py
+++ b/src/sdetkit/day43_acceleration_closeout.py
@@ -13,7 +13,10 @@ _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY42_SUMMARY_PATH = (
     "docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json"
 )
-_DAY42_BOARD_PATH = "docs/artifacts/optimization-closeout-foundation-pack/day42-delivery-board.md"
+_DAY42_BOARD_PATH = (
+    "docs/artifacts/optimization-closeout-foundation-pack/optimization-delivery-board.md"
+)
+_DAY42_LEGACY_BOARD_PATH = "docs/artifacts/optimization-closeout-foundation-pack/day42-delivery-board.md"
 _SECTION_HEADER = "# Day 43 \u2014 Acceleration closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 43 matters",
@@ -69,7 +72,7 @@ Day 43 closes with a major acceleration upgrade that converts Day 42 optimizatio
 ## Required inputs (Day 42)
 
 - `docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json`
-- `docs/artifacts/optimization-closeout-foundation-pack/day42-delivery-board.md`
+- `docs/artifacts/optimization-closeout-foundation-pack/optimization-delivery-board.md`
 
 ## Day 43 command lane
 
@@ -151,6 +154,13 @@ def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
     return [line for line in expected if line not in text]
 
 
+def _resolve_existing_path(root: Path, primary: str, legacy: str) -> Path:
+    primary_path = root / primary
+    if primary_path.exists():
+        return primary_path
+    return root / legacy
+
+
 def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
@@ -172,7 +182,7 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
     day42_summary = root / _DAY42_SUMMARY_PATH
-    day42_board = root / _DAY42_BOARD_PATH
+    day42_board = _resolve_existing_path(root, _DAY42_BOARD_PATH, _DAY42_LEGACY_BOARD_PATH)
     day42_score, day42_strict, day42_check_count = _load_day42(day42_summary)
     board_count, board_has_day42, board_has_day43 = _board_stats(day42_board)
 
@@ -418,6 +428,10 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(
         target / "day43-execution-log.md",
         "# Day 43 Execution Log\n\n- [ ] 2026-03-12: Record misses, wins, and Day 44 scale priorities.\n",
+    )
+    _write(
+        target / "acceleration-delivery-board.md",
+        "# Day 43 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
         target / "day43-delivery-board.md",

--- a/src/sdetkit/day48_objection_closeout.py
+++ b/src/sdetkit/day48_objection_closeout.py
@@ -417,6 +417,10 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         "# Day 48 Execution Log\n\n- [ ] 2026-03-16: Record misses, wins, and Day 49 weekly-review priorities.\n",
     )
     _write(
+        target / "objection-delivery-board.md",
+        "# Day 48 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
+    )
+    _write(
         target / "day48-delivery-board.md",
         "# Day 48 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )

--- a/src/sdetkit/day49_weekly_review_closeout.py
+++ b/src/sdetkit/day49_weekly_review_closeout.py
@@ -13,7 +13,8 @@ _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY48_SUMMARY_PATH = (
     "docs/artifacts/objection-closeout-pack/objection-closeout-summary.json"
 )
-_DAY48_BOARD_PATH = "docs/artifacts/objection-closeout-pack/day48-delivery-board.md"
+_DAY48_BOARD_PATH = "docs/artifacts/objection-closeout-pack/objection-delivery-board.md"
+_DAY48_LEGACY_BOARD_PATH = "docs/artifacts/objection-closeout-pack/day48-delivery-board.md"
 _SECTION_HEADER = "# Day 49 \u2014 Weekly review closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 49 matters",
@@ -69,7 +70,7 @@ Day 49 closes with a major weekly-review upgrade that converts Day 48 objection 
 ## Required inputs (Day 48)
 
 - `docs/artifacts/objection-closeout-pack/objection-closeout-summary.json`
-- `docs/artifacts/objection-closeout-pack/day48-delivery-board.md`
+- `docs/artifacts/objection-closeout-pack/objection-delivery-board.md`
 
 ## Day 49 command lane
 
@@ -150,6 +151,13 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
+def _resolve_existing_path(root: Path, primary: str, legacy: str) -> Path:
+    primary_path = root / primary
+    if primary_path.exists():
+        return primary_path
+    return root / legacy
+
+
 def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
     readme_path = "README.md"
     docs_index_path = "docs/index.md"
@@ -171,7 +179,7 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
     day48_summary = root / _DAY48_SUMMARY_PATH
-    day48_board = root / _DAY48_BOARD_PATH
+    day48_board = _resolve_existing_path(root, _DAY48_BOARD_PATH, _DAY48_LEGACY_BOARD_PATH)
     day48_score, day48_strict, day48_check_count = _load_day48(day48_summary)
     board_count, board_has_day48, board_has_day49 = _board_stats(day48_board)
 
@@ -441,6 +449,10 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(
         target / "day49-execution-log.md",
         "# Day 49 Execution Log\n\n- [ ] 2026-03-17: Record misses, wins, and Day 50 execution priorities.\n",
+    )
+    _write(
+        target / "weekly-review-delivery-board.md",
+        "# Day 49 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
         target / "day49-delivery-board.md",

--- a/src/sdetkit/day50_execution_prioritization_closeout.py
+++ b/src/sdetkit/day50_execution_prioritization_closeout.py
@@ -13,7 +13,10 @@ _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY49_SUMMARY_PATH = (
     "docs/artifacts/day49-weekly-review-closeout-pack/day49-weekly-review-closeout-summary.json"
 )
-_DAY49_BOARD_PATH = "docs/artifacts/day49-weekly-review-closeout-pack/day49-delivery-board.md"
+_DAY49_BOARD_PATH = (
+    "docs/artifacts/day49-weekly-review-closeout-pack/weekly-review-delivery-board.md"
+)
+_DAY49_LEGACY_BOARD_PATH = "docs/artifacts/day49-weekly-review-closeout-pack/day49-delivery-board.md"
 _SECTION_HEADER = "# Day 50 \u2014 Execution prioritization closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 50 matters",
@@ -69,7 +72,7 @@ Day 50 closes with a major execution-prioritization upgrade that converts Day 49
 ## Required inputs (Day 49)
 
 - `docs/artifacts/day49-weekly-review-closeout-pack/day49-weekly-review-closeout-summary.json`
-- `docs/artifacts/day49-weekly-review-closeout-pack/day49-delivery-board.md`
+- `docs/artifacts/day49-weekly-review-closeout-pack/weekly-review-delivery-board.md`
 
 ## Day 50 command lane
 
@@ -146,6 +149,13 @@ def _contains_all_lines(text: str, required_lines: list[str]) -> list[str]:
     return [line for line in required_lines if line not in text]
 
 
+def _resolve_existing_path(root: Path, primary: str, legacy: str) -> Path:
+    primary_path = root / primary
+    if primary_path.exists():
+        return primary_path
+    return root / legacy
+
+
 def _board_stats(path: Path) -> tuple[int, bool, bool]:
     text = _read(path)
     lines = [line.strip() for line in text.splitlines() if line.strip().startswith("- [")]
@@ -175,7 +185,7 @@ def build_execution_prioritization_closeout_summary(root: Path) -> dict[str, Any
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
     day49_summary = root / _DAY49_SUMMARY_PATH
-    day49_board = root / _DAY49_BOARD_PATH
+    day49_board = _resolve_existing_path(root, _DAY49_BOARD_PATH, _DAY49_LEGACY_BOARD_PATH)
     day49_score, day49_strict, day49_check_count = _load_day49(day49_summary)
     board_count, board_has_day49, board_has_day50 = _board_stats(day49_board)
 

--- a/tests/test_acceleration_closeout.py
+++ b/tests/test_acceleration_closeout.py
@@ -56,7 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/optimization-closeout-foundation-pack/day42-delivery-board.md"
+    board = root / "docs/artifacts/optimization-closeout-foundation-pack/optimization-delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -105,7 +105,7 @@ def test_day43_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/day43-pack/day43-growth-matrix.csv").exists()
     assert (tmp_path / "artifacts/day43-pack/day43-acceleration-kpi-scorecard.json").exists()
     assert (tmp_path / "artifacts/day43-pack/day43-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day43-pack/day43-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day43-pack/acceleration-delivery-board.md").exists()
     assert (tmp_path / "artifacts/day43-pack/day43-validation-commands.md").exists()
     assert (tmp_path / "artifacts/day43-pack/evidence/day43-execution-summary.json").exists()
 

--- a/tests/test_execution_prioritization_closeout.py
+++ b/tests/test_execution_prioritization_closeout.py
@@ -56,7 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/day49-weekly-review-closeout-pack/day49-delivery-board.md"
+    board = root / "docs/artifacts/day49-weekly-review-closeout-pack/weekly-review-delivery-board.md"
     board.write_text(
         "\n".join(
             [

--- a/tests/test_objection_closeout.py
+++ b/tests/test_objection_closeout.py
@@ -100,7 +100,7 @@ def test_day48_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/day48-pack/day48-faq-objection-map.csv").exists()
     assert (tmp_path / "artifacts/day48-pack/day48-objection-kpi-scorecard.json").exists()
     assert (tmp_path / "artifacts/day48-pack/day48-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day48-pack/day48-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day48-pack/objection-delivery-board.md").exists()
     assert (tmp_path / "artifacts/day48-pack/day48-validation-commands.md").exists()
     assert (tmp_path / "artifacts/day48-pack/evidence/day48-execution-summary.json").exists()
 

--- a/tests/test_optimization_closeout_foundation.py
+++ b/tests/test_optimization_closeout_foundation.py
@@ -56,7 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/expansion-automation-pack/day41-delivery-board.md"
+    board = root / "docs/artifacts/expansion-automation-pack/expansion-automation-delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -107,7 +107,7 @@ def test_day42_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/day42-pack/day42-remediation-matrix.csv").exists()
     assert (tmp_path / "artifacts/day42-pack/day42-optimization-kpi-scorecard.json").exists()
     assert (tmp_path / "artifacts/day42-pack/day42-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day42-pack/day42-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day42-pack/optimization-delivery-board.md").exists()
     assert (tmp_path / "artifacts/day42-pack/day42-validation-commands.md").exists()
     assert (tmp_path / "artifacts/day42-pack/evidence/day42-execution-summary.json").exists()
 

--- a/tests/test_scale_closeout.py
+++ b/tests/test_scale_closeout.py
@@ -56,7 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/acceleration-closeout-pack/day43-delivery-board.md"
+    board = root / "docs/artifacts/acceleration-closeout-pack/acceleration-delivery-board.md"
     board.write_text(
         "\n".join(
             [

--- a/tests/test_weekly_review_closeout.py
+++ b/tests/test_weekly_review_closeout.py
@@ -50,7 +50,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/objection-closeout-pack/day48-delivery-board.md"
+    board = root / "docs/artifacts/objection-closeout-pack/objection-delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -101,7 +101,7 @@ def test_day49_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/day49-pack/day49-weekly-review-kpi-scorecard.json").exists()
     assert (tmp_path / "artifacts/day49-pack/day49-advanced-priority-matrix.json").exists()
     assert (tmp_path / "artifacts/day49-pack/day49-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day49-pack/day49-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/day49-pack/weekly-review-delivery-board.md").exists()
     assert (tmp_path / "artifacts/day49-pack/day49-validation-commands.md").exists()
     assert (tmp_path / "artifacts/day49-pack/evidence/day49-execution-summary.json").exists()
 


### PR DESCRIPTION
### Motivation
- Remove remaining active/public `dayNN` delivery-board naming on the closeout handoff chain and promote canonical artifact names across docs, emitters, and tests.
- Inventory showed the Day 42/43/48/49/50 handoff chain still used `dayNN-delivery-board.md` on active/public surfaces and required a single batch pass to clean all eligible lanes.

### Description
- Promoted canonical board filenames on public surfaces and docs: `expansion-automation-delivery-board.md`, `optimization-delivery-board.md`, `acceleration-delivery-board.md`, `objection-delivery-board.md`, and `weekly-review-delivery-board.md` (docs updated accordingly). 
- Added legacy fallback resolution (`_resolve_existing_path`) in affected closeout modules so downstream readers prefer canonical names but fall back to `dayNN-delivery-board.md` when the canonical file is absent. 
- Emitters now write the canonical board filename as primary and also still emit the legacy `dayNN-delivery-board.md` as a narrow compatibility shim so existing packs do not break. 
- Updated targeted tests to assert the canonical board filenames while preserving compatibility (tests now seed canonical-named boards), and updated a handful of integration docs to reference canonical artifacts. 

### Testing
- Ran the targeted pytest suite: `python -m pytest -q tests/test_optimization_closeout_foundation.py tests/test_acceleration_closeout.py tests/test_scale_closeout.py tests/test_objection_closeout.py tests/test_weekly_review_closeout.py tests/test_execution_prioritization_closeout.py` and all tests passed (`26 passed`).
- Ran contract checkers with `--skip-evidence`; most upstream contract checks returned expected baseline-input failures due to missing strict handoff inputs in this repo snapshot (not regressions from the rename), while `python scripts/check_execution_prioritization_closeout_contract.py --skip-evidence` completed successfully.
- Commit created for the batch change (no push performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c7cf095c488320954d2a65c19f27b7)