### PR TITLE
Reject unknown ops tasks and surface validation errors in CLI

### DIFF
--- a/src/sdetkit/ops_control.py
+++ b/src/sdetkit/ops_control.py
@@ -154,6 +154,11 @@ def _task_catalog() -> dict[str, TaskDef]:
 
 
 def _task_order(tasks: dict[str, TaskDef], selected: tuple[str, ...]) -> list[str]:
+    missing = sorted(name for name in selected if name not in tasks)
+    if missing:
+        joined = ", ".join(missing)
+        raise ValueError(f"Unknown ops task(s): {joined}")
+
     indegree = {name: 0 for name in selected}
     dependents: dict[str, list[str]] = {name: [] for name in selected}
     for name in selected:
@@ -322,6 +327,10 @@ def run(
 
 
 def cli(argv: list[str] | None = None) -> int:
+    def _validation_error(exc: ValueError) -> int:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+
     p = argparse.ArgumentParser(prog="sdetkit ops")
     sub = p.add_subparsers(dest="cmd", required=True)
     init_p = sub.add_parser("init")
@@ -345,7 +354,10 @@ def cli(argv: list[str] | None = None) -> int:
         return init_layout(force=bool(ns.force))
     if ns.cmd == "plan":
         init_layout(force=False)
-        payload = plan(ns.profile, apply=bool(ns.apply), no_cache=bool(ns.no_cache))
+        try:
+            payload = plan(ns.profile, apply=bool(ns.apply), no_cache=bool(ns.no_cache))
+        except ValueError as exc:
+            return _validation_error(exc)
         sys.stdout.write(
             json.dumps({"profile": ns.profile, "plan": payload}, sort_keys=True, indent=2) + "\n"
         )
@@ -353,4 +365,7 @@ def cli(argv: list[str] | None = None) -> int:
     init_layout(force=False)
     apply = bool(ns.apply) and not bool(ns.dry_run)
     ff = bool(ns.fail_fast) or (ns.profile == "ci" and not ns.keep_going)
-    return run(ns.profile, ns.jobs, apply, bool(ns.no_cache), ff, bool(ns.keep_going))
+    try:
+        return run(ns.profile, ns.jobs, apply, bool(ns.no_cache), ff, bool(ns.keep_going))
+    except ValueError as exc:
+        return _validation_error(exc)

--- a/tests/test_ops_control_branches_wave1.py
+++ b/tests/test_ops_control_branches_wave1.py
@@ -157,3 +157,40 @@ def test_cli_run_computes_apply_and_failfast(monkeypatch: pytest.MonkeyPatch) ->
     rc2 = oc.cli(["run", "--profile", "local", "--apply", "--dry-run"])
     assert rc2 == 0
     assert seen[-1] == ("local", 1, False, False, False, False)
+
+
+def test_task_order_rejects_unknown_selected_task() -> None:
+    with pytest.raises(ValueError, match="Unknown ops task"):
+        oc._task_order({"quality": TaskDef("quality", ("echo", "ok"))}, ("missing",))
+
+
+def test_cli_plan_reports_unknown_task_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(oc, "init_layout", lambda force=False: 0)
+    monkeypatch.setattr(
+        oc, "_task_catalog", lambda: {"quality": TaskDef("quality", ("echo", "ok"))}
+    )
+    monkeypatch.setattr(oc, "_profile_tasks", lambda _p: ("quality", "missing"))
+
+    rc = oc.cli(["plan", "--profile", "default"])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Unknown ops task(s): missing" in err
+
+
+def test_cli_run_reports_unknown_task_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(oc, "init_layout", lambda force=False: 0)
+    monkeypatch.setattr(
+        oc, "_task_catalog", lambda: {"quality": TaskDef("quality", ("echo", "ok"))}
+    )
+    monkeypatch.setattr(oc, "_profile_tasks", lambda _p: ("quality", "missing"))
+
+    rc = oc.cli(["run", "--profile", "default"])
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Unknown ops task(s): missing" in err


### PR DESCRIPTION
### Motivation
- Prevent silent/incorrect behavior when a requested task name is not present in the task catalog by failing early with a clear message.
- Ensure the CLI returns a non-zero exit code and emits a helpful error on invalid task selections during `plan` and `run` invocations.

### Description
- Added validation in `_task_order` to detect selected task names not present in the `tasks` map and raise `ValueError` listing missing names.
- Introduced a `_validation_error` helper in `cli` to write validation messages to stderr and return exit code `2`.
- Wrapped calls to `plan` and `run` in `cli` with `try/except ValueError` to invoke `_validation_error` and return a proper error code instead of crashing.
- Added unit tests `test_task_order_rejects_unknown_selected_task`, `test_cli_plan_reports_unknown_task_error`, and `test_cli_run_reports_unknown_task_error` to cover the new validation and CLI behavior.

### Testing
- Ran the updated unit tests in `tests/test_ops_control_branches_wave1.py` including the three new tests and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c9432ea5108320994c83378311455b)