### PR TITLE
chore: clarify scripts/check.sh completion output

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -91,4 +91,4 @@ case "$mode" in
     ;;
 esac
 
-echo "All checks passed!"
+echo "check.sh: $mode checks passed."


### PR DESCRIPTION
### Motivation
- Make the final status message from `scripts/check.sh` unambiguous when underlying tools also print a generic `All checks passed!` line.

### Description
- Replace the generic `echo "All checks passed!"` with `echo "check.sh: $mode checks passed."` in `scripts/check.sh` so the completion message includes the invoked mode.

### Testing
- Ran `python3 scripts/check_repo_layout.py` which returned OK, ran `bash scripts/check.sh lint` which completed successfully, and ran `bash scripts/check.sh tests` which finished with `1577 passed, 3 deselected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c947d5079c8320a7adb9dd89cb14c9)