### PR TITLE
Batch cleanup: canonicalize Day 47/48/49 public artifact names

### DIFF
--- a/scripts/check_objection_closeout_contract_48.py
+++ b/scripts/check_objection_closeout_contract_48.py
@@ -43,7 +43,7 @@ def main() -> int:
 
     if not ns.skip_evidence:
         evidence = (
-            root / "docs/artifacts/objection-closeout-pack/evidence/day48-execution-summary.json"
+            root / "docs/artifacts/objection-closeout-pack/evidence/objection-execution-summary-48.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")

--- a/scripts/check_weekly_review_closeout_contract_49.py
+++ b/scripts/check_weekly_review_closeout_contract_49.py
@@ -44,7 +44,7 @@ def main() -> int:
     if not ns.skip_evidence:
         evidence = (
             root
-            / "docs/artifacts/weekly-review-closeout-pack/evidence/day49-execution-summary.json"
+            / "docs/artifacts/weekly-review-closeout-pack/evidence/weekly-review-execution-summary-49.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")

--- a/src/sdetkit/execution_prioritization_closeout_50.py
+++ b/src/sdetkit/execution_prioritization_closeout_50.py
@@ -14,7 +14,7 @@ _DAY49_SUMMARY_PATH = (
     "docs/artifacts/weekly-review-closeout-pack-49/weekly-review-closeout-summary-49.json"
 )
 _DAY49_BOARD_PATH = (
-    "docs/artifacts/day49-weekly-review-closeout-pack/weekly-review-delivery-board.md"
+    "docs/artifacts/weekly-review-closeout-pack-49/delivery-board-49.md"
 )
 _DAY49_LEGACY_BOARD_PATH = "docs/artifacts/weekly-review-closeout-pack-49/delivery-board-49.md"
 _SECTION_HEADER = "# Day 50 \u2014 Execution prioritization closeout lane"
@@ -72,7 +72,7 @@ Day 50 closes with a major execution-prioritization upgrade that converts Day 49
 ## Required inputs (Day 49)
 
 - `docs/artifacts/weekly-review-closeout-pack-49/weekly-review-closeout-summary-49.json`
-- `docs/artifacts/day49-weekly-review-closeout-pack/weekly-review-delivery-board.md`
+- `docs/artifacts/weekly-review-closeout-pack-49/delivery-board-49.md`
 
 ## Day 50 command lane
 

--- a/src/sdetkit/objection_closeout_48.py
+++ b/src/sdetkit/objection_closeout_48.py
@@ -386,16 +386,16 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(target / "objection-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
     _write(target / "objection-closeout-summary.md", _render_text(payload) + "\n")
     _write(
-        target / "day48-objection-plan.md",
+        target / "objection-plan-48.md",
         "# Day 48 Objection Plan\n\n- Objective: close Day 48 with measurable objection-resolution and adoption gains.\n",
     )
     _write(
-        target / "day48-faq-objection-map.csv",
+        target / "faq-objection-map-48.csv",
         "stream,owner,backup,publish_window,docs_cta,command_cta,kpi_target,risk_flag\n"
         "objection-floor,qa-lead,docs-owner,2026-03-16T10:00:00Z,docs/integrations-objection-closeout.md,python -m sdetkit objection-closeout --format json --strict,failed-checks:0,faq-drift\n",
     )
     _write(
-        target / "day48-objection-kpi-scorecard.json",
+        target / "objection-kpi-scorecard-48.json",
         json.dumps(
             {
                 "kpis": [
@@ -413,7 +413,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         + "\n",
     )
     _write(
-        target / "day48-execution-log.md",
+        target / "execution-log-48.md",
         "# Day 48 Execution Log\n\n- [ ] 2026-03-16: Record misses, wins, and Day 49 weekly-review priorities.\n",
     )
     _write(
@@ -421,11 +421,11 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         "# Day 48 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
-        target / "day48-delivery-board.md",
+        target / "delivery-board-48.md",
         "# Day 48 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
-        target / "day48-validation-commands.md",
+        target / "validation-commands-48.md",
         "# Day 48 Validation Commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
@@ -448,13 +448,13 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
         events.append(event)
         _write(evidence_path / f"command-{index:02d}.log", json.dumps(event, indent=2) + "\n")
     _write(
-        evidence_path / "day48-execution-summary.json",
+        evidence_path / "objection-execution-summary-48.json",
         json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
     )
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Day 48 objection closeout checks")
+    parser = argparse.ArgumentParser(description="Objection closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/reliability_closeout_47.py
+++ b/src/sdetkit/reliability_closeout_47.py
@@ -28,13 +28,13 @@ _REQUIRED_SECTIONS = [
 ]
 _REQUIRED_COMMANDS = [
     "python -m sdetkit reliability-closeout --format json --strict",
-    "python -m sdetkit reliability-closeout --emit-pack-dir docs/artifacts/day47-reliability-closeout-pack --format json --strict",
-    "python -m sdetkit reliability-closeout --execute --evidence-dir docs/artifacts/day47-reliability-closeout-pack/evidence --format json --strict",
+    "python -m sdetkit reliability-closeout --emit-pack-dir docs/artifacts/reliability-closeout-pack-47 --format json --strict",
+    "python -m sdetkit reliability-closeout --execute --evidence-dir docs/artifacts/reliability-closeout-pack-47/evidence --format json --strict",
     "python scripts/check_reliability_closeout_contract.py",
 ]
 _EXECUTION_COMMANDS = [
     "python -m sdetkit reliability-closeout --format json --strict",
-    "python -m sdetkit reliability-closeout --emit-pack-dir docs/artifacts/day47-reliability-closeout-pack --format json --strict",
+    "python -m sdetkit reliability-closeout --emit-pack-dir docs/artifacts/reliability-closeout-pack-47 --format json --strict",
     "python scripts/check_reliability_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
@@ -77,8 +77,8 @@ Day 47 closes with a major reliability upgrade that converts Day 46 optimization
 
 ```bash
 python -m sdetkit reliability-closeout --format json --strict
-python -m sdetkit reliability-closeout --emit-pack-dir docs/artifacts/day47-reliability-closeout-pack --format json --strict
-python -m sdetkit reliability-closeout --execute --evidence-dir docs/artifacts/day47-reliability-closeout-pack/evidence --format json --strict
+python -m sdetkit reliability-closeout --emit-pack-dir docs/artifacts/reliability-closeout-pack-47 --format json --strict
+python -m sdetkit reliability-closeout --execute --evidence-dir docs/artifacts/reliability-closeout-pack-47/evidence --format json --strict
 python scripts/check_reliability_closeout_contract.py
 ```
 
@@ -338,7 +338,7 @@ def build_reliability_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     return {
-        "name": "day47-reliability-closeout",
+        "name": "reliability-closeout",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -400,19 +400,19 @@ def _write(path: Path, text: str) -> None:
 def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     target = root / pack_dir
     target.mkdir(parents=True, exist_ok=True)
-    _write(target / "day47-reliability-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
-    _write(target / "day47-reliability-closeout-summary.md", _render_text(payload) + "\n")
+    _write(target / "reliability-closeout-summary-47.json", json.dumps(payload, indent=2) + "\n")
+    _write(target / "reliability-closeout-summary-47.md", _render_text(payload) + "\n")
     _write(
-        target / "day47-reliability-plan.md",
+        target / "reliability-plan-47.md",
         "# Day 47 Reliability Plan\n\n- Objective: close Day 47 with measurable reliability and quality gains.\n",
     )
     _write(
-        target / "day47-incident-map.csv",
+        target / "incident-map-47.csv",
         "stream,owner,backup,publish_window,docs_cta,command_cta,kpi_target,risk_flag\n"
         "reliability-floor,qa-lead,platform-owner,2026-03-15T10:00:00Z,docs/integrations-reliability-closeout.md,python -m sdetkit reliability-closeout --format json --strict,failed-checks:0,reliability-drift\n",
     )
     _write(
-        target / "day47-reliability-kpi-scorecard.json",
+        target / "reliability-kpi-scorecard-47.json",
         json.dumps(
             {
                 "kpis": [
@@ -430,15 +430,15 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         + "\n",
     )
     _write(
-        target / "day47-execution-log.md",
+        target / "execution-log-47.md",
         "# Day 47 Execution Log\n\n- [ ] 2026-03-15: Record misses, wins, and Day 48 execution priorities.\n",
     )
     _write(
-        target / "day47-delivery-board.md",
+        target / "delivery-board-47.md",
         "# Day 47 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
-        target / "day47-validation-commands.md",
+        target / "validation-commands-47.md",
         "# Day 47 Validation Commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
@@ -461,13 +461,13 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
         events.append(event)
         _write(evidence_path / f"command-{index:02d}.log", json.dumps(event, indent=2) + "\n")
     _write(
-        evidence_path / "day47-execution-summary.json",
+        evidence_path / "reliability-execution-summary-47.json",
         json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
     )
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Day 47 reliability closeout checks")
+    parser = argparse.ArgumentParser(description="Reliability closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")
@@ -500,7 +500,7 @@ def main(argv: list[str] | None = None) -> int:
         evidence_dir = (
             Path(ns.evidence_dir)
             if ns.evidence_dir
-            else Path("docs/artifacts/day47-reliability-closeout-pack/evidence")
+            else Path("docs/artifacts/reliability-closeout-pack-47/evidence")
         )
         _execute_commands(root, evidence_dir)
 

--- a/src/sdetkit/weekly_review_closeout_49.py
+++ b/src/sdetkit/weekly_review_closeout_49.py
@@ -12,7 +12,7 @@ _PAGE_PATH = "docs/integrations-weekly-review-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY48_SUMMARY_PATH = "docs/artifacts/objection-closeout-pack/objection-closeout-summary.json"
 _DAY48_BOARD_PATH = "docs/artifacts/objection-closeout-pack/objection-delivery-board.md"
-_DAY48_LEGACY_BOARD_PATH = "docs/artifacts/objection-closeout-pack/day48-delivery-board.md"
+_DAY48_LEGACY_BOARD_PATH = "docs/artifacts/objection-closeout-pack/delivery-board-48.md"
 _SECTION_HEADER = "# Day 49 \u2014 Weekly review closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 49 matters",
@@ -329,8 +329,8 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     return {
-        "name": "day49-advanced-weekly-review-control-tower",
-        "legacy_name": "weekly-review-closeout",
+        "name": "weekly-review-closeout",
+        "legacy_name": "day49-advanced-weekly-review-control-tower",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -393,16 +393,16 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(target / "weekly-review-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
     _write(target / "weekly-review-closeout-summary.md", _render_text(payload) + "\n")
     _write(
-        target / "day49-weekly-review-brief.md",
+        target / "weekly-review-brief-49.md",
         "# Day 49 Weekly Review Brief\n\n- Objective: close Day 49 with measurable weekly-review discipline and prioritized execution gains.\n",
     )
     _write(
-        target / "day49-weekly-review-risk-register.csv",
+        target / "weekly-review-risk-register-49.csv",
         "stream,owner,backup,review_window,docs_cta,command_cta,kpi_target,risk_flag\n"
         "weekly-review-floor,qa-lead,docs-owner,2026-03-17T10:00:00Z,docs/integrations-weekly-review-closeout.md,python -m sdetkit weekly-review-closeout --format json --strict,failed-checks:0,priority-drift\n",
     )
     _write(
-        target / "day49-weekly-review-kpi-scorecard.json",
+        target / "weekly-review-kpi-scorecard-49.json",
         json.dumps(
             {
                 "kpis": [
@@ -420,7 +420,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         + "\n",
     )
     _write(
-        target / "day49-advanced-priority-matrix.json",
+        target / "advanced-priority-matrix-49.json",
         json.dumps(
             {
                 "priority_model": "weighted-weekly-review",
@@ -445,7 +445,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         + "\n",
     )
     _write(
-        target / "day49-execution-log.md",
+        target / "execution-log-49.md",
         "# Day 49 Execution Log\n\n- [ ] 2026-03-17: Record misses, wins, and Day 50 execution priorities.\n",
     )
     _write(
@@ -453,11 +453,11 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         "# Day 49 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
-        target / "day49-delivery-board.md",
+        target / "delivery-board-49.md",
         "# Day 49 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
-        target / "day49-validation-commands.md",
+        target / "validation-commands-49.md",
         "# Day 49 Validation Commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
@@ -480,14 +480,14 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
         events.append(event)
         _write(evidence_path / f"command-{index:02d}.log", json.dumps(event, indent=2) + "\n")
     _write(
-        evidence_path / "day49-execution-summary.json",
+        evidence_path / "weekly-review-execution-summary-49.json",
         json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
     )
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Day 49 advanced weekly review control tower checks"
+        description="Weekly review closeout checks (legacy alias: day49-advanced-weekly-review-control-tower)"
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")

--- a/tests/test_execution_prioritization_closeout.py
+++ b/tests/test_execution_prioritization_closeout.py
@@ -57,7 +57,7 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     board = (
-        root / "docs/artifacts/day49-weekly-review-closeout-pack/weekly-review-delivery-board.md"
+        root / "docs/artifacts/weekly-review-closeout-pack-49/delivery-board-49.md"
     )
     board.write_text(
         "\n".join(

--- a/tests/test_objection_closeout.py
+++ b/tests/test_objection_closeout.py
@@ -83,25 +83,25 @@ def test_day48_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day48-pack",
+            "artifacts/objection-pack-48",
             "--execute",
             "--evidence-dir",
-            "artifacts/day48-pack/evidence",
+            "artifacts/objection-pack-48/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day48-pack/objection-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day48-pack/objection-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day48-pack/day48-objection-plan.md").exists()
-    assert (tmp_path / "artifacts/day48-pack/day48-faq-objection-map.csv").exists()
-    assert (tmp_path / "artifacts/day48-pack/day48-objection-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day48-pack/day48-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day48-pack/objection-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day48-pack/day48-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day48-pack/evidence/day48-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/objection-pack-48/objection-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/objection-pack-48/objection-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/objection-pack-48/objection-plan-48.md").exists()
+    assert (tmp_path / "artifacts/objection-pack-48/faq-objection-map-48.csv").exists()
+    assert (tmp_path / "artifacts/objection-pack-48/objection-kpi-scorecard-48.json").exists()
+    assert (tmp_path / "artifacts/objection-pack-48/execution-log-48.md").exists()
+    assert (tmp_path / "artifacts/objection-pack-48/objection-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/objection-pack-48/validation-commands-48.md").exists()
+    assert (tmp_path / "artifacts/objection-pack-48/evidence/objection-execution-summary-48.json").exists()
 
 
 def test_day48_strict_fails_when_day47_inputs_missing(tmp_path: Path) -> None:

--- a/tests/test_reliability_closeout.py
+++ b/tests/test_reliability_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-reliability-closeout.md\nday47-reliability-closeout\n",
+        "docs/integrations-reliability-closeout.md\nreliability-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -75,7 +75,7 @@ def test_day47_reliability_closeout_json(tmp_path: Path, capsys) -> None:
     rc = d47.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day47-reliability-closeout"
+    assert out["name"] == "reliability-closeout"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -86,25 +86,25 @@ def test_day47_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day47-pack",
+            "artifacts/reliability-pack-47",
             "--execute",
             "--evidence-dir",
-            "artifacts/day47-pack/evidence",
+            "artifacts/reliability-pack-47/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day47-pack/day47-reliability-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day47-pack/day47-reliability-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day47-pack/day47-reliability-plan.md").exists()
-    assert (tmp_path / "artifacts/day47-pack/day47-incident-map.csv").exists()
-    assert (tmp_path / "artifacts/day47-pack/day47-reliability-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day47-pack/day47-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day47-pack/day47-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day47-pack/day47-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day47-pack/evidence/day47-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/reliability-pack-47/reliability-closeout-summary-47.json").exists()
+    assert (tmp_path / "artifacts/reliability-pack-47/reliability-closeout-summary-47.md").exists()
+    assert (tmp_path / "artifacts/reliability-pack-47/reliability-plan-47.md").exists()
+    assert (tmp_path / "artifacts/reliability-pack-47/incident-map-47.csv").exists()
+    assert (tmp_path / "artifacts/reliability-pack-47/reliability-kpi-scorecard-47.json").exists()
+    assert (tmp_path / "artifacts/reliability-pack-47/execution-log-47.md").exists()
+    assert (tmp_path / "artifacts/reliability-pack-47/delivery-board-47.md").exists()
+    assert (tmp_path / "artifacts/reliability-pack-47/validation-commands-47.md").exists()
+    assert (tmp_path / "artifacts/reliability-pack-47/evidence/reliability-execution-summary-47.json").exists()
 
 
 def test_day47_strict_fails_when_day46_inputs_missing(tmp_path: Path) -> None:

--- a/tests/test_weekly_review_closeout.py
+++ b/tests/test_weekly_review_closeout.py
@@ -70,8 +70,8 @@ def test_day49_weekly_review_closeout_json(tmp_path: Path, capsys) -> None:
     rc = d49.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
-    assert out["name"] == "day49-advanced-weekly-review-control-tower"
-    assert out["legacy_name"] == "weekly-review-closeout"
+    assert out["name"] == "weekly-review-closeout"
+    assert out["legacy_name"] == "day49-advanced-weekly-review-control-tower"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -82,26 +82,26 @@ def test_day49_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day49-pack",
+            "artifacts/weekly-review-pack-49",
             "--execute",
             "--evidence-dir",
-            "artifacts/day49-pack/evidence",
+            "artifacts/weekly-review-pack-49/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day49-pack/weekly-review-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day49-pack/weekly-review-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day49-pack/day49-weekly-review-brief.md").exists()
-    assert (tmp_path / "artifacts/day49-pack/day49-weekly-review-risk-register.csv").exists()
-    assert (tmp_path / "artifacts/day49-pack/day49-weekly-review-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day49-pack/day49-advanced-priority-matrix.json").exists()
-    assert (tmp_path / "artifacts/day49-pack/day49-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day49-pack/weekly-review-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day49-pack/day49-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day49-pack/evidence/day49-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-brief-49.md").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-risk-register-49.csv").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-kpi-scorecard-49.json").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/advanced-priority-matrix-49.json").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/execution-log-49.md").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/validation-commands-49.md").exists()
+    assert (tmp_path / "artifacts/weekly-review-pack-49/evidence/weekly-review-execution-summary-49.json").exists()
 
 
 def test_day49_strict_fails_when_day48_inputs_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- A repo-wide inventory identified remaining active/public `dayNN` residues in the Day 47/48/49 closeout family and a Day 50 handoff reference.
- The goal was to make canonical, productized artifact/evidence filenames primary on active/public surfaces (use `*-NN` suffixes) while keeping narrow legacy aliases only where intentionally required.
- This reduces confusing dual naming on emitted packs, docs, checkers and tests and ensures downstream lanes prefer canonical artifacts.

### Description
- Canonicalized Day 47 reliability outputs: payload `name`, README command examples, emitted pack filenames, evidence filename, parser description, and default evidence path were switched from `day47-*` to `*-47` naming while preserving `build_day47_*` compatibility alias.
- Canonicalized Day 48 objection outputs and evidence filenames from `day48-*` to `*-48` naming and simplified the parser description while keeping `build_day48_*` compatibility alias.
- Canonicalized Day 49 weekly-review outputs: primary payload name set to the canonical lane, emitted pack/artifact/evidence filenames moved to `*-49` suffixes, and the parser description updated while retaining an explicit legacy alias field for `day49-advanced-weekly-review-control-tower`.
- Fixed Day 50 downstream wiring to prefer the canonical Day 49 delivery-board path and updated the small set of contract-check scripts and targeted tests to assert the canonical outputs; touched files include the three closeout modules, Day 50 module, two check scripts and four targeted tests.

### Testing
- Ran targeted unit tests: `pytest -q tests/test_reliability_closeout.py tests/test_objection_closeout.py tests/test_weekly_review_closeout.py tests/test_execution_prioritization_closeout.py` which passed (18 passed).
- Executed the contract check scripts locally (`scripts/check_... --skip-evidence`) and they reported missing docs contract entries / strict-baseline failures, which are pre-existing repo doc/strict-state issues and not regressions from this rename pass.
- Validated emitted pack filepaths produced by the updated modules using the tests that exercise `--emit-pack-dir` + `--execute`, and those assertions succeeded in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca308a27dc8320ac94603d9edd1246)