### PR TITLE
Prefer canonical summary builders in remaining day28-day40 public checker lane

### DIFF
--- a/scripts/check_demo_asset2_contract.py
+++ b/scripts/check_demo_asset2_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d34.build_day34_demo_asset2_summary(root)
+    payload = d34.build_demo_asset2_summary(root)
 
     strict_failures: list[str] = []
     page = root / d34._PAGE_PATH

--- a/scripts/check_demo_asset_contract.py
+++ b/scripts/check_demo_asset_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d33.build_day33_demo_asset_summary(root)
+    payload = d33.build_demo_asset_summary(root)
 
     strict_failures: list[str] = []
     page = root / d33._PAGE_PATH

--- a/scripts/check_distribution_batch_contract_38.py
+++ b/scripts/check_distribution_batch_contract_38.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d38.build_day38_distribution_batch_summary(root)
+    payload = d38.build_distribution_batch_summary(root)
 
     strict_failures: list[str] = []
     page = root / d38._PAGE_PATH

--- a/scripts/check_distribution_closeout_contract_36.py
+++ b/scripts/check_distribution_closeout_contract_36.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d36.build_day36_distribution_closeout_summary(root)
+    payload = d36.build_distribution_closeout_summary(root)
 
     strict_failures: list[str] = []
     page = root / d36._PAGE_PATH

--- a/scripts/check_experiment_lane_contract_37.py
+++ b/scripts/check_experiment_lane_contract_37.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d37.build_day37_experiment_lane_summary(root)
+    payload = d37.build_experiment_lane_summary(root)
 
     strict_failures: list[str] = []
     page = root / d37._PAGE_PATH

--- a/scripts/check_kpi_instrumentation_contract_35.py
+++ b/scripts/check_kpi_instrumentation_contract_35.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d35.build_day35_kpi_instrumentation_summary(root)
+    payload = d35.build_kpi_instrumentation_summary(root)
 
     strict_failures: list[str] = []
     page = root / d35._PAGE_PATH

--- a/scripts/check_phase1_hardening_contract.py
+++ b/scripts/check_phase1_hardening_contract.py
@@ -21,7 +21,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d29.build_day29_phase1_hardening_summary(root)
+    payload = d29.build_phase1_hardening_summary(root)
 
     strict_failures: list[str] = []
     page = root / d29._PAGE_PATH

--- a/scripts/check_phase1_wrap_contract.py
+++ b/scripts/check_phase1_wrap_contract.py
@@ -18,7 +18,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d30.build_day30_phase1_wrap_summary(root)
+    payload = d30.build_phase1_wrap_summary(root)
 
     strict_failures: list[str] = []
     page = root / d30._PAGE_PATH

--- a/scripts/check_phase2_kickoff_contract.py
+++ b/scripts/check_phase2_kickoff_contract.py
@@ -20,7 +20,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d31.build_day31_phase2_kickoff_summary(root)
+    payload = d31.build_phase2_kickoff_summary(root)
 
     strict_failures: list[str] = []
     page = root / d31._PAGE_PATH

--- a/scripts/check_playbook_post_contract.py
+++ b/scripts/check_playbook_post_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d39.build_day39_playbook_post_summary(root)
+    payload = d39.build_playbook_post_summary(root)
 
     strict_failures: list[str] = []
     page = root / d39._PAGE_PATH

--- a/scripts/check_release_cadence_contract.py
+++ b/scripts/check_release_cadence_contract.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d32.build_day32_release_cadence_summary(root)
+    payload = d32.build_release_cadence_summary(root)
 
     strict_failures: list[str] = []
     page = root / d32._PAGE_PATH

--- a/scripts/check_scale_lane_contract_40.py
+++ b/scripts/check_scale_lane_contract_40.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d40.build_day40_scale_lane_summary(root)
+    payload = d40.build_scale_lane_summary(root)
 
     strict_failures: list[str] = []
     page = root / d40._PAGE_PATH

--- a/scripts/check_weekly_review_contract_28.py
+++ b/scripts/check_weekly_review_contract_28.py
@@ -14,7 +14,7 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = d28.build_day28_weekly_review_summary(root)
+    payload = d28.build_weekly_review_summary(root)
 
     strict_failures: list[str] = []
     page = root / d28._PAGE_PATH

--- a/src/sdetkit/demo_asset2_34.py
+++ b/src/sdetkit/demo_asset2_34.py
@@ -530,5 +530,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_demo_asset2_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day34_demo_asset2_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/demo_asset_33.py
+++ b/src/sdetkit/demo_asset_33.py
@@ -529,5 +529,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_demo_asset_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day33_demo_asset_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/distribution_batch_38.py
+++ b/src/sdetkit/distribution_batch_38.py
@@ -578,5 +578,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_distribution_batch_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day38_distribution_batch_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/distribution_closeout_36.py
+++ b/src/sdetkit/distribution_closeout_36.py
@@ -546,5 +546,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_distribution_closeout_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day36_distribution_closeout_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/experiment_lane_37.py
+++ b/src/sdetkit/experiment_lane_37.py
@@ -576,5 +576,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_experiment_lane_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day37_experiment_lane_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/kpi_instrumentation_35.py
+++ b/src/sdetkit/kpi_instrumentation_35.py
@@ -526,5 +526,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_kpi_instrumentation_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day35_kpi_instrumentation_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/phase1_hardening_29.py
+++ b/src/sdetkit/phase1_hardening_29.py
@@ -357,5 +357,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_phase1_hardening_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day29_phase1_hardening_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/phase1_wrap_30.py
+++ b/src/sdetkit/phase1_wrap_30.py
@@ -451,5 +451,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_phase1_wrap_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day30_phase1_wrap_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/phase2_kickoff_31.py
+++ b/src/sdetkit/phase2_kickoff_31.py
@@ -527,5 +527,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_phase2_kickoff_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day31_phase2_kickoff_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/playbook_post_39.py
+++ b/src/sdetkit/playbook_post_39.py
@@ -570,5 +570,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_playbook_post_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day39_playbook_post_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/release_cadence_32.py
+++ b/src/sdetkit/release_cadence_32.py
@@ -545,5 +545,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_release_cadence_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day32_release_cadence_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/scale_lane_40.py
+++ b/src/sdetkit/scale_lane_40.py
@@ -568,5 +568,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_scale_lane_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day40_scale_lane_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sdetkit/weekly_review_28.py
+++ b/src/sdetkit/weekly_review_28.py
@@ -438,5 +438,23 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def build_weekly_review_summary(
+    root: Path,
+    *,
+    readme_path: str = "README.md",
+    docs_index_path: str = "docs/index.md",
+    docs_page_path: str = _PAGE_PATH,
+    top10_path: str = _TOP10_PATH,
+) -> dict[str, Any]:
+    """Canonical summary builder (day-based name retained as compatibility alias)."""
+    return build_day28_weekly_review_summary(
+        root,
+        readme_path=readme_path,
+        docs_index_path=docs_index_path,
+        docs_page_path=docs_page_path,
+        top10_path=top10_path,
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Remove remaining active/public dayNN naming in the contract-checker family (day28–day40) by making canonical lane names primary while preserving compatibility shims. 
- Avoid one-off lane fixes by inventorying and cleaning the whole eligible family in a single pass. 

### Description
- Added canonical wrappers `build_<lane>_summary(...)` to the day28–day40 runtime modules and retained existing `build_dayNN_*` functions as narrow compatibility aliases. 
- Updated active contract checker scripts in `scripts/check_*` to call the new canonical builders (day28..day40) instead of the dayNN names. 
- Changed affected files across `src/sdetkit/` and `scripts/` (13 lanes: weekly_review/phase1_hardening/phase1_wrap/phase2_kickoff/release_cadence/demo_asset/demo_asset2/kpi_instrumentation/distribution_closeout/distribution_batch/playbook_post/experiment_lane/scale_lane). 
- Preserved semantics by forwarding canonical wrappers to existing implementations so public behavior and prior imports continue to work. 

### Testing
- Ran `pytest -q tests/test_cli_help_lists_subcommands.py` and it passed (2 passed). 
- Ran `python -m py_compile` over all touched modules and checker scripts and it passed (no syntax errors). 
- Executed touched checker scripts to validate wiring; they ran but returned pre-existing strict/score failures unrelated to this refactor (expected and unchanged by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca3df0f92483208eb22c8bdbe34284)