### PR TITLE
Standardize delivery-board/evidence filenames and genericize lane docs and pack outputs

### DIFF
--- a/docs/integrations-acceleration-closeout.md
+++ b/docs/integrations-acceleration-closeout.md
@@ -11,7 +11,7 @@ Lane closes with a major acceleration upgrade that converts Lane optimization ev
 ## Required inputs (Lane)
 
 - `docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json`
-- `docs/artifacts/optimization-closeout-foundation-pack/optimization-delivery-board.md`
+- `docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md`
 
 ## Lane command lane
 

--- a/docs/integrations-optimization-closeout-foundation.md
+++ b/docs/integrations-optimization-closeout-foundation.md
@@ -11,7 +11,7 @@ Optimization Closeout Foundation closes the lane with a major optimization upgra
 ## Required inputs (Lane)
 
 - `docs/artifacts/expansion-automation-pack/expansion-automation-summary.json`
-- `docs/artifacts/expansion-automation-pack/expansion-automation-delivery-board.md`
+- `docs/artifacts/expansion-automation-pack/delivery-board.md`
 
 ## Optimization Closeout Foundation command lane
 

--- a/docs/integrations-scale-closeout.md
+++ b/docs/integrations-scale-closeout.md
@@ -11,7 +11,7 @@ Lane closes with a big scale upgrade that converts Lane acceleration evidence in
 ## Required inputs (Lane)
 
 - `docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json`
-- `docs/artifacts/acceleration-closeout-pack/acceleration-delivery-board.md`
+- `docs/artifacts/acceleration-closeout-pack/delivery-board.md`
 
 ## Lane command lane
 

--- a/scripts/check_acceleration_closeout_contract_43.py
+++ b/scripts/check_acceleration_closeout_contract_43.py
@@ -43,7 +43,7 @@ def main() -> int:
 
     if not ns.skip_evidence:
         evidence = (
-            root / "docs/artifacts/acceleration-closeout-pack/evidence/day43-execution-summary.json"
+            root / "docs/artifacts/acceleration-closeout-pack/evidence/execution-summary.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")

--- a/scripts/check_docs_loop_closeout_contract_53.py
+++ b/scripts/check_docs_loop_closeout_contract_53.py
@@ -37,7 +37,7 @@ def main() -> int:
         if not evidence.exists():
             evidence = (
                 root
-                / "docs/artifacts/docs-loop-closeout-pack/evidence/day53-execution-summary.json"
+                / "docs/artifacts/docs-loop-closeout-pack/evidence/execution-summary.json"
             )
         if not evidence.exists():
             errors.append(f"missing evidence summary: {evidence}")

--- a/scripts/check_expansion_automation_contract_41.py
+++ b/scripts/check_expansion_automation_contract_41.py
@@ -43,7 +43,7 @@ def main() -> int:
 
     if not ns.skip_evidence:
         evidence = (
-            root / "docs/artifacts/expansion-automation-pack/evidence/day41-execution-summary.json"
+            root / "docs/artifacts/expansion-automation-pack/evidence/execution-summary.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")

--- a/scripts/check_narrative_closeout_contract_52.py
+++ b/scripts/check_narrative_closeout_contract_52.py
@@ -37,7 +37,7 @@ def main() -> int:
         if not evidence.exists():
             evidence = (
                 root
-                / "docs/artifacts/narrative-closeout-pack/evidence/day52-execution-summary.json"
+                / "docs/artifacts/narrative-closeout-pack/evidence/execution-summary.json"
             )
         if not evidence.exists():
             errors.append(f"missing evidence summary: {evidence}")

--- a/scripts/check_optimization_closeout_contract_42.py
+++ b/scripts/check_optimization_closeout_contract_42.py
@@ -44,7 +44,7 @@ def main() -> int:
     if not ns.skip_evidence:
         evidence = (
             root
-            / "docs/artifacts/optimization-closeout-foundation-pack/evidence/day42-execution-summary.json"
+            / "docs/artifacts/optimization-closeout-foundation-pack/evidence/execution-summary.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")

--- a/scripts/check_weekly_review_closeout_contract_65.py
+++ b/scripts/check_weekly_review_closeout_contract_65.py
@@ -38,7 +38,7 @@ def main() -> int:
         if not evidence.exists():
             legacy_evidence = (
                 root
-                / "docs/artifacts/weekly-review-closeout-2-pack/evidence/day65-execution-summary.json"
+                / "docs/artifacts/weekly-review-closeout-2-pack/evidence/execution-summary.json"
             )
             if legacy_evidence.exists():
                 evidence = legacy_evidence

--- a/src/sdetkit/acceleration_closeout_43.py
+++ b/src/sdetkit/acceleration_closeout_43.py
@@ -12,19 +12,19 @@ _PAGE_PATH = "docs/integrations-acceleration-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY42_SUMMARY_PATH = "docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json"
 _DAY42_BOARD_PATH = (
-    "docs/artifacts/optimization-closeout-foundation-pack/optimization-delivery-board.md"
+    "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
 )
 _DAY42_LEGACY_BOARD_PATH = (
-    "docs/artifacts/optimization-closeout-foundation-pack/day42-delivery-board.md"
+    "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
 )
 _SECTION_HEADER = "# Day 43 \u2014 Acceleration closeout lane"
 _REQUIRED_SECTIONS = [
-    "## Why Day 43 matters",
-    "## Required inputs (Day 42)",
-    "## Day 43 command lane",
+    "## Why this lane matters",
+    "## Required inputs (optimization closeout foundation)",
+    "## Command lane",
     "## Acceleration closeout contract",
     "## Acceleration quality checklist",
-    "## Day 43 delivery board",
+    "## Delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -61,20 +61,20 @@ _REQUIRED_DELIVERY_BOARD_LINES = [
 
 _DAY43_DEFAULT_PAGE = """# Day 43 \u2014 Acceleration closeout lane
 
-Day 43 closes with a major acceleration upgrade that converts Day 42 optimization evidence into deterministic improvement loops.
+This lane closes with a major acceleration upgrade that converts optimization evidence into deterministic improvement loops.
 
-## Why Day 43 matters
+## Why this lane matters
 
 - Converts Day 42 optimization proof into growth-first operating motion.
 - Protects quality with owner accountability, command proof, and KPI guardrails.
 - Produces a deterministic handoff from acceleration outcomes into Day 44 scale priorities.
 
-## Required inputs (Day 42)
+## Required inputs (optimization closeout foundation)
 
 - `docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json`
-- `docs/artifacts/optimization-closeout-foundation-pack/optimization-delivery-board.md`
+- `docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md`
 
-## Day 43 command lane
+## Command lane
 
 ```bash
 python -m sdetkit acceleration-closeout --format json --strict
@@ -98,7 +98,7 @@ python scripts/check_acceleration_closeout_contract.py
 - [ ] Scorecard captures baseline, current, delta, and confidence for each KPI
 - [ ] Artifact pack includes acceleration plan, growth matrix, KPI scorecard, and execution log
 
-## Day 43 delivery board
+## Delivery board
 
 - [ ] Day 43 acceleration plan draft committed
 - [ ] Day 43 review notes captured with owner + backup
@@ -206,19 +206,19 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day43_link",
+            "check_id": "readme_acceleration_closeout_link",
             "weight": 8,
             "passed": "docs/integrations-acceleration-closeout.md" in readme_text,
             "evidence": "docs/integrations-acceleration-closeout.md",
         },
         {
-            "check_id": "readme_day43_command",
+            "check_id": "readme_acceleration_closeout_command",
             "weight": 4,
             "passed": "acceleration-closeout" in readme_text,
             "evidence": "acceleration-closeout",
         },
         {
-            "check_id": "docs_index_day43_links",
+            "check_id": "docs_index_acceleration_closeout_links",
             "weight": 8,
             "passed": (
                 "impact-43-big-upgrade-report.md" in docs_index_text
@@ -227,7 +227,7 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "impact-43-big-upgrade-report.md + integrations-acceleration-closeout.md",
         },
         {
-            "check_id": "top10_day43_alignment",
+            "check_id": "top10_acceleration_closeout_alignment",
             "weight": 5,
             "passed": ("Day 43" in top10_text and "Day 44" in top10_text),
             "evidence": "Day 43 + Day 44 strategy chain",
@@ -368,7 +368,7 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 43 acceleration closeout summary",
+        "Acceleration closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -397,16 +397,16 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(target / "acceleration-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
     _write(target / "acceleration-closeout-summary.md", _render_text(payload) + "\n")
     _write(
-        target / "day43-acceleration-plan.md",
-        "# Day 43 Acceleration Plan\n\n- Objective: close Day 43 with measurable quality and throughput gains.\n",
+        target / "acceleration-plan.md",
+        "# Acceleration plan\n\n- Objective: close Day 43 with measurable quality and throughput gains.\n",
     )
     _write(
-        target / "day43-growth-matrix.csv",
+        target / "growth-matrix.csv",
         "stream,owner,backup,publish_window,docs_cta,command_cta,kpi_target,risk_flag\n"
         "quality-floor,qa-lead,platform-owner,2026-03-12T10:00:00Z,docs/integrations-acceleration-closeout.md,python -m sdetkit acceleration-closeout --format json --strict,failed-checks:0,baseline-drift\n",
     )
     _write(
-        target / "day43-acceleration-kpi-scorecard.json",
+        target / "acceleration-kpi-scorecard.json",
         json.dumps(
             {
                 "kpis": [
@@ -424,20 +424,16 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         + "\n",
     )
     _write(
-        target / "day43-execution-log.md",
-        "# Day 43 Execution Log\n\n- [ ] 2026-03-12: Record misses, wins, and Day 44 scale priorities.\n",
+        target / "execution-log.md",
+        "# Acceleration execution log\n\n- [ ] 2026-03-12: Record misses, wins, and Day 44 scale priorities.\n",
     )
     _write(
-        target / "acceleration-delivery-board.md",
-        "# Day 43 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
+        target / "delivery-board.md",
+        "# Acceleration delivery board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
-        target / "day43-delivery-board.md",
-        "# Day 43 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
-    )
-    _write(
-        target / "day43-validation-commands.md",
-        "# Day 43 Validation Commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        target / "validation-commands.md",
+        "# Acceleration validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -459,13 +455,13 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
         events.append(event)
         _write(evidence_path / f"command-{index:02d}.log", json.dumps(event, indent=2) + "\n")
     _write(
-        evidence_path / "day43-execution-summary.json",
+        evidence_path / "execution-summary.json",
         json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
     )
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Day 43 acceleration closeout checks")
+    parser = argparse.ArgumentParser(description="Acceleration closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/expansion_automation_41.py
+++ b/src/sdetkit/expansion_automation_41.py
@@ -16,12 +16,12 @@ _LEGACY_DAY40_SUMMARY_PATH = "docs/artifacts/day40-scale-lane-pack/day40-scale-l
 _LEGACY_DAY40_BOARD_PATH = "docs/artifacts/day40-scale-lane-pack/day40-delivery-board.md"
 _SECTION_HEADER = "# Day 41 \u2014 Expansion automation lane"
 _REQUIRED_SECTIONS = [
-    "## Why Day 41 matters",
-    "## Required inputs (Day 40)",
-    "## Day 41 command lane",
+    "## Why this lane matters",
+    "## Required inputs (prior scale lane)",
+    "## Command lane",
     "## Expansion automation contract",
     "## Expansion quality checklist",
-    "## Day 41 delivery board",
+    "## Delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -58,20 +58,20 @@ _REQUIRED_DELIVERY_BOARD_LINES = [
 
 _DAY41_DEFAULT_PAGE = """# Day 41 \u2014 Expansion automation lane
 
-Day 41 closes with a major expansion automation upgrade that converts Day 40 scale evidence into repeatable workflows.
+This lane closes with a major expansion automation upgrade that converts prior scale-lane evidence into repeatable workflows.
 
-## Why Day 41 matters
+## Why this lane matters
 
 - Converts Day 40 scale wins into automation-first operating motion.
 - Protects quality with owner accountability, command proof, and KPI guardrails.
 - Produces a deterministic handoff from expansion outcomes into Day 42 optimization priorities.
 
-## Required inputs (Day 40)
+## Required inputs (prior scale lane)
 
 - `docs/artifacts/scale-lane-pack/scale-lane-summary.json`
 - `docs/artifacts/scale-lane-pack/delivery-board.md`
 
-## Day 41 command lane
+## Command lane
 
 ```bash
 python -m sdetkit expansion-automation --format json --strict
@@ -95,7 +95,7 @@ python scripts/check_expansion_automation_contract.py
 - [ ] Scorecard captures baseline, current, delta, and confidence for each KPI
 - [ ] Artifact pack includes expansion plan, automation matrix, KPI scorecard, and execution log
 
-## Day 41 delivery board
+## Delivery board
 
 - [ ] Day 41 expansion plan draft committed
 - [ ] Day 41 review notes captured with owner + backup
@@ -105,7 +105,7 @@ python scripts/check_expansion_automation_contract.py
 
 ## Scoring model
 
-Day 41 weighted score (0-100):
+Weighted score (0-100):
 
 - Docs contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
@@ -204,19 +204,19 @@ def build_expansion_automation_summary(root: Path) -> dict[str, Any]:
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day41_link",
+            "check_id": "readme_expansion_automation_link",
             "weight": 8,
             "passed": "docs/integrations-expansion-automation.md" in readme_text,
             "evidence": "docs/integrations-expansion-automation.md",
         },
         {
-            "check_id": "readme_day41_command",
+            "check_id": "readme_expansion_automation_command",
             "weight": 4,
             "passed": "expansion-automation" in readme_text,
             "evidence": "expansion-automation",
         },
         {
-            "check_id": "docs_index_day41_links",
+            "check_id": "docs_index_expansion_automation_links",
             "weight": 8,
             "passed": (
                 "impact-41-big-upgrade-report.md" in docs_index_text
@@ -225,10 +225,10 @@ def build_expansion_automation_summary(root: Path) -> dict[str, Any]:
             "evidence": "impact-41-big-upgrade-report.md + integrations-expansion-automation.md",
         },
         {
-            "check_id": "top10_day41_alignment",
+            "check_id": "top10_expansion_automation_alignment",
             "weight": 5,
             "passed": ("Day 41" in top10_text and "Day 42" in top10_text),
-            "evidence": "Day 41 + Day 42 strategy chain",
+            "evidence": "Expansion automation + optimization strategy chain",
         },
         {
             "check_id": "day40_summary_present",
@@ -367,7 +367,7 @@ def build_expansion_automation_summary(root: Path) -> dict[str, Any]:
 def _to_text(payload: dict[str, Any]) -> str:
     summary = payload["summary"]
     return (
-        "Day 41 expansion automation summary\n"
+        "Expansion automation summary\n"
         f"Activation score: {summary['activation_score']}\n"
         f"Passed checks: {summary['passed_checks']}\n"
         f"Failed checks: {summary['failed_checks']}\n"
@@ -378,7 +378,7 @@ def _to_text(payload: dict[str, Any]) -> str:
 def _to_markdown(payload: dict[str, Any]) -> str:
     summary = payload["summary"]
     lines = [
-        "# Day 41 expansion automation summary",
+        "# Expansion automation summary",
         "",
         f"- Activation score: **{summary['activation_score']}**",
         f"- Passed checks: **{summary['passed_checks']}**",
@@ -414,8 +414,8 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(target / "expansion-automation-summary.json", json.dumps(payload, indent=2) + "\n")
     _write(target / "expansion-automation-summary.md", _to_markdown(payload))
     _write(
-        target / "day41-expansion-plan.md",
-        "# Day 41 expansion automation lane\n\n"
+        target / "expansion-plan.md",
+        "# Expansion automation lane\n\n"
         "## Automation summary\n"
         "- Day 40 scale winners were converted into reusable automation blocks.\n"
         "- Misses are paired with rollback-ready remediation loops.\n\n"
@@ -425,14 +425,14 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         "- [ ] Capture KPI pulses at 24h and 72h with confidence tag\n",
     )
     _write(
-        target / "day41-automation-matrix.csv",
+        target / "automation-matrix.csv",
         "workflow,owner,backup,publish_window_utc,docs_cta,command_cta,kpi_target,risk_guardrail\n"
         "expansion-summary,pm-owner,backup-pm,2026-03-09T09:00:00Z,docs/integrations-expansion-automation.md,python -m sdetkit expansion-automation --format json --strict,completion:+6%,rollback-doc-ready\n"
         "matrix-rollout,ops-owner,backup-ops,2026-03-09T12:00:00Z,docs/impact-41-big-upgrade-report.md,python scripts/check_expansion_automation_contract.py,adoption:+8%,dry-run-before-rollout\n"
         "kpi-review,growth-owner,backup-growth,2026-03-10T15:00:00Z,docs/top-10-github-strategy.md,python -m sdetkit expansion-automation --emit-pack-dir docs/artifacts/expansion-automation-pack --format json --strict,ctr:+3%,trigger-alert-on-regression\n",
     )
     _write(
-        target / "day41-expansion-kpi-scorecard.json",
+        target / "expansion-kpi-scorecard.json",
         json.dumps(
             {
                 "generated_for": "expansion-automation",
@@ -465,19 +465,19 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         + "\n",
     )
     _write(
-        target / "day41-execution-log.md",
-        "# Day 41 execution log\n\n"
+        target / "execution-log.md",
+        "# Expansion automation execution log\n\n"
         "- [ ] 2026-03-09: Publish expansion plan and collect internal review notes.\n"
         "- [ ] 2026-03-10: Execute automation matrix and capture first KPI pulse.\n"
         "- [ ] 2026-03-11: Record misses, wins, and Day 42 optimization priorities.\n",
     )
     _write(
-        target / "day41-delivery-board.md",
-        "# Day 41 delivery board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
+        target / "delivery-board.md",
+        "# Expansion automation delivery board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
-        target / "day41-validation-commands.md",
-        "# Day 41 validation commands\n\n```bash\n" + "\n".join(_REQUIRED_COMMANDS) + "\n```\n",
+        target / "validation-commands.md",
+        "# Expansion automation validation commands\n\n```bash\n" + "\n".join(_REQUIRED_COMMANDS) + "\n```\n",
     )
 
 
@@ -504,11 +504,11 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
         "failed_commands": [log["command"] for log in logs if log["returncode"] != 0],
         "commands": logs,
     }
-    _write(target / "day41-execution-summary.json", json.dumps(summary, indent=2) + "\n")
+    _write(target / "execution-summary.json", json.dumps(summary, indent=2) + "\n")
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Day 41 expansion automation scorer.")
+    parser = argparse.ArgumentParser(description="Expansion automation scorer.")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json", "markdown"], default="text")
     parser.add_argument("--output")

--- a/src/sdetkit/optimization_closeout_42.py
+++ b/src/sdetkit/optimization_closeout_42.py
@@ -12,13 +12,13 @@ _PAGE_PATH = "docs/integrations-optimization-closeout-foundation.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY41_SUMMARY_PATH = "docs/artifacts/expansion-automation-pack/expansion-automation-summary.json"
 _DAY41_BOARD_PATH = (
-    "docs/artifacts/expansion-automation-pack/expansion-automation-delivery-board.md"
+    "docs/artifacts/expansion-automation-pack/delivery-board.md"
 )
-_DAY41_LEGACY_BOARD_PATH = "docs/artifacts/expansion-automation-pack/day41-delivery-board.md"
+_DAY41_LEGACY_BOARD_PATH = "docs/artifacts/expansion-automation-pack/delivery-board.md"
 _SECTION_HEADER = "# Optimization Closeout Foundation \u2014 Optimization closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Optimization Closeout Foundation matters",
-    "## Required inputs (Day 41)",
+    "## Required inputs (expansion automation)",
     "## Optimization Closeout Foundation command lane",
     "## Optimization closeout contract",
     "## Optimization quality checklist",
@@ -67,10 +67,10 @@ Optimization Closeout Foundation closes with a major optimization upgrade that c
 - Protects quality with owner accountability, command proof, and KPI guardrails.
 - Produces a deterministic handoff from optimization outcomes into Day 43 acceleration priorities.
 
-## Required inputs (Day 41)
+## Required inputs (expansion automation)
 
 - `docs/artifacts/expansion-automation-pack/expansion-automation-summary.json`
-- `docs/artifacts/expansion-automation-pack/expansion-automation-delivery-board.md`
+- `docs/artifacts/expansion-automation-pack/delivery-board.md`
 
 ## Optimization Closeout Foundation command lane
 
@@ -110,7 +110,7 @@ Optimization Closeout Foundation weighted score (0-100):
 
 - Docs contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
-- Day 41 continuity and strict baseline carryover: 35 points.
+- Expansion automation continuity and strict baseline carryover: 35 points.
 - Optimization contract lock + delivery board readiness: 15 points.
 """
 
@@ -204,19 +204,19 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day42_link",
+            "check_id": "readme_optimization_closeout_foundation_link",
             "weight": 8,
             "passed": "docs/integrations-optimization-closeout-foundation.md" in readme_text,
             "evidence": "docs/integrations-optimization-closeout-foundation.md",
         },
         {
-            "check_id": "readme_day42_command",
+            "check_id": "readme_optimization_closeout_foundation_command",
             "weight": 4,
             "passed": "optimization-closeout-foundation" in readme_text,
             "evidence": "optimization-closeout-foundation",
         },
         {
-            "check_id": "docs_index_day42_links",
+            "check_id": "docs_index_optimization_closeout_foundation_links",
             "weight": 8,
             "passed": (
                 "impact-42-big-upgrade-report.md" in docs_index_text
@@ -225,10 +225,10 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "impact-42-big-upgrade-report.md + integrations-optimization-closeout-foundation.md",
         },
         {
-            "check_id": "top10_day42_alignment",
+            "check_id": "top10_optimization_closeout_foundation_alignment",
             "weight": 5,
             "passed": ("Optimization Closeout Foundation" in top10_text and "Day 43" in top10_text),
-            "evidence": "Optimization Closeout Foundation + Day 43 strategy chain",
+            "evidence": "Optimization Closeout Foundation + acceleration strategy chain",
         },
         {
             "check_id": "day41_summary_present",
@@ -371,9 +371,9 @@ def _render_text(payload: dict[str, Any]) -> str:
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
         f"- Critical failures: {payload['summary']['critical_failures']}",
-        f"- Day 41 activation score: `{payload['rollup']['day41_activation_score']}`",
-        f"- Day 41 checks evaluated: `{payload['rollup']['day41_checks']}`",
-        f"- Day 41 delivery board checklist items: `{payload['rollup']['day41_delivery_board_items']}`",
+        f"- Expansion automation activation score: `{payload['rollup']['day41_activation_score']}`",
+        f"- Expansion automation checks evaluated: `{payload['rollup']['day41_checks']}`",
+        f"- Expansion automation delivery board checklist items: `{payload['rollup']['day41_delivery_board_items']}`",
     ]
     if payload["wins"]:
         lines.append("- Wins:")
@@ -398,16 +398,16 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     )
     _write(target / "optimization-closeout-foundation-summary.md", _render_text(payload) + "\n")
     _write(
-        target / "day42-optimization-plan.md",
+        target / "optimization-plan.md",
         "# Optimization Closeout Foundation Optimization Plan\n\n- Objective: close Optimization Closeout Foundation with measurable quality and throughput gains.\n",
     )
     _write(
-        target / "day42-remediation-matrix.csv",
+        target / "remediation-matrix.csv",
         "stream,owner,backup,publish_window,docs_cta,command_cta,kpi_target,risk_flag\n"
         "quality-floor,qa-lead,platform-owner,2026-03-12T10:00:00Z,docs/integrations-optimization-closeout-foundation.md,python -m sdetkit optimization-closeout-foundation --format json --strict,failed-checks:0,baseline-drift\n",
     )
     _write(
-        target / "day42-optimization-kpi-scorecard.json",
+        target / "optimization-kpi-scorecard.json",
         json.dumps(
             {
                 "kpis": [
@@ -425,23 +425,17 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
         + "\n",
     )
     _write(
-        target / "day42-execution-log.md",
+        target / "execution-log.md",
         "# Optimization Closeout Foundation Execution Log\n\n- [ ] 2026-03-12: Record misses, wins, and Day 43 acceleration priorities.\n",
     )
     _write(
-        target / "optimization-delivery-board.md",
+        target / "delivery-board.md",
         "# Optimization Closeout Foundation Delivery Board\n\n"
         + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES)
         + "\n",
     )
     _write(
-        target / "day42-delivery-board.md",
-        "# Optimization Closeout Foundation Delivery Board\n\n"
-        + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES)
-        + "\n",
-    )
-    _write(
-        target / "day42-validation-commands.md",
+        target / "validation-commands.md",
         "# Optimization Closeout Foundation Validation Commands\n\n```bash\n"
         + "\n".join(_EXECUTION_COMMANDS)
         + "\n```\n",
@@ -466,7 +460,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
         events.append(event)
         _write(evidence_path / f"command-{index:02d}.log", json.dumps(event, indent=2) + "\n")
     _write(
-        evidence_path / "day42-execution-summary.json",
+        evidence_path / "execution-summary.json",
         json.dumps({"total_commands": len(events), "commands": events}, indent=2) + "\n",
     )
 

--- a/src/sdetkit/scale_closeout_44.py
+++ b/src/sdetkit/scale_closeout_44.py
@@ -11,15 +11,15 @@ from typing import Any
 _PAGE_PATH = "docs/integrations-scale-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY43_SUMMARY_PATH = "docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
-_DAY43_BOARD_PATH = "docs/artifacts/acceleration-closeout-pack/acceleration-delivery-board.md"
+_DAY43_BOARD_PATH = "docs/artifacts/acceleration-closeout-pack/delivery-board.md"
 _SECTION_HEADER = "# Day 44 \u2014 Scale closeout lane"
 _REQUIRED_SECTIONS = [
-    "## Why Day 44 matters",
-    "## Required inputs (Day 43)",
-    "## Day 44 command lane",
+    "## Why this lane matters",
+    "## Required inputs (acceleration closeout)",
+    "## Command lane",
     "## Scale closeout contract",
     "## Scale quality checklist",
-    "## Day 44 delivery board",
+    "## Delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -56,20 +56,20 @@ _REQUIRED_DELIVERY_BOARD_LINES = [
 
 _DAY44_DEFAULT_PAGE = """# Day 44 \u2014 Scale closeout lane
 
-Day 44 closes with a major scale upgrade that converts Day 43 acceleration evidence into deterministic improvement loops.
+This lane closes with a major scale upgrade that converts acceleration evidence into deterministic improvement loops.
 
-## Why Day 44 matters
+## Why this lane matters
 
 - Converts Day 43 acceleration proof into growth-first operating motion.
 - Protects quality with owner accountability, command proof, and KPI guardrails.
 - Produces a deterministic handoff from scale outcomes into Day 45 expansion priorities.
 
-## Required inputs (Day 43)
+## Required inputs (acceleration closeout)
 
 - `docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json`
-- `docs/artifacts/acceleration-closeout-pack/acceleration-delivery-board.md`
+- `docs/artifacts/acceleration-closeout-pack/delivery-board.md`
 
-## Day 44 command lane
+## Command lane
 
 ```bash
 python -m sdetkit scale-closeout --format json --strict
@@ -93,7 +93,7 @@ python scripts/check_scale_closeout_contract.py
 - [ ] Scorecard captures baseline, current, delta, and confidence for each KPI
 - [ ] Artifact pack includes scale plan, growth matrix, KPI scorecard, and execution log
 
-## Day 44 delivery board
+## Delivery board
 
 - [ ] Day 44 scale plan draft committed
 - [ ] Day 44 review notes captured with owner + backup
@@ -103,7 +103,7 @@ python scripts/check_scale_closeout_contract.py
 
 ## Scoring model
 
-Day 44 weighted score (0-100):
+Weighted score (0-100):
 
 - Docs contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
@@ -180,7 +180,7 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
     day43_board = _resolve_existing_path(
         root,
         _DAY43_BOARD_PATH,
-        "docs/artifacts/acceleration-closeout-pack/day43-delivery-board.md",
+        "docs/artifacts/acceleration-closeout-pack/acceleration-delivery-board.md",
     )
     day43_score, day43_strict, day43_check_count = _load_day43(day43_summary)
     board_count, board_has_day43, board_has_day44 = _board_stats(day43_board)
@@ -205,19 +205,19 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day44_link",
+            "check_id": "readme_scale_closeout_link",
             "weight": 8,
             "passed": "docs/integrations-scale-closeout.md" in readme_text,
             "evidence": "docs/integrations-scale-closeout.md",
         },
         {
-            "check_id": "readme_day44_command",
+            "check_id": "readme_scale_closeout_command",
             "weight": 4,
             "passed": "scale-closeout" in readme_text,
             "evidence": "scale-closeout",
         },
         {
-            "check_id": "docs_index_day44_links",
+            "check_id": "docs_index_scale_closeout_links",
             "weight": 8,
             "passed": (
                 "impact-44-big-upgrade-report.md" in docs_index_text
@@ -226,10 +226,10 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "impact-44-big-upgrade-report.md + integrations-scale-closeout.md",
         },
         {
-            "check_id": "top10_day44_alignment",
+            "check_id": "top10_scale_closeout_alignment",
             "weight": 5,
             "passed": ("Day 44" in top10_text and "Day 45" in top10_text),
-            "evidence": "Day 44 + Day 45 strategy chain",
+            "evidence": "Scale closeout + expansion closeout strategy chain",
         },
         {
             "check_id": "day43_summary_present",
@@ -363,7 +363,7 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        "Day 44 scale closeout summary",
+        "Scale closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -393,7 +393,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(target / "scale-closeout-summary.md", _render_text(payload) + "\n")
     _write(
         target / "scale-plan.md",
-        "# Day 44 Scale Plan\n\n- Objective: close Day 44 with measurable quality and throughput gains.\n",
+        "# Scale plan\n\n- Objective: close Day 44 with measurable quality and throughput gains.\n",
     )
     _write(
         target / "scale-growth-matrix.csv",
@@ -420,15 +420,15 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     )
     _write(
         target / "scale-execution-log.md",
-        "# Day 44 Execution Log\n\n- [ ] 2026-03-12: Record misses, wins, and Day 45 expansion priorities.\n",
+        "# Scale execution log\n\n- [ ] 2026-03-12: Record misses, wins, and Day 45 expansion priorities.\n",
     )
     _write(
         target / "scale-delivery-board.md",
-        "# Day 44 Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
+        "# Scale delivery board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
         target / "scale-validation-commands.md",
-        "# Day 44 Validation Commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "# Scale validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -456,7 +456,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Day 44 scale closeout checks")
+    parser = argparse.ArgumentParser(description="Scale closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/tests/test_acceleration_closeout.py
+++ b/tests/test_acceleration_closeout.py
@@ -57,7 +57,7 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     board = (
-        root / "docs/artifacts/optimization-closeout-foundation-pack/optimization-delivery-board.md"
+        root / "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
     )
     board.write_text(
         "\n".join(
@@ -91,25 +91,25 @@ def test_day43_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day43-pack",
+            "artifacts/acceleration-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day43-pack/evidence",
+            "artifacts/acceleration-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day43-pack/acceleration-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day43-pack/acceleration-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day43-pack/day43-acceleration-plan.md").exists()
-    assert (tmp_path / "artifacts/day43-pack/day43-growth-matrix.csv").exists()
-    assert (tmp_path / "artifacts/day43-pack/day43-acceleration-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day43-pack/day43-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day43-pack/acceleration-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day43-pack/day43-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day43-pack/evidence/day43-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/acceleration-closeout-pack/acceleration-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/acceleration-closeout-pack/acceleration-plan.md").exists()
+    assert (tmp_path / "artifacts/acceleration-closeout-pack/growth-matrix.csv").exists()
+    assert (tmp_path / "artifacts/acceleration-closeout-pack/acceleration-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/acceleration-closeout-pack/execution-log.md").exists()
+    assert (tmp_path / "artifacts/acceleration-closeout-pack/delivery-board.md").exists()
+    assert (tmp_path / "artifacts/acceleration-closeout-pack/validation-commands.md").exists()
+    assert (tmp_path / "artifacts/acceleration-closeout-pack/evidence/execution-summary.json").exists()
 
 
 def test_day43_strict_fails_when_day42_inputs_missing(tmp_path: Path) -> None:
@@ -126,4 +126,4 @@ def test_day43_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["acceleration-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 43 acceleration closeout summary" in capsys.readouterr().out
+    assert "Acceleration closeout summary" in capsys.readouterr().out

--- a/tests/test_expansion_automation.py
+++ b/tests/test_expansion_automation.py
@@ -86,25 +86,25 @@ def test_day41_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day41-pack",
+            "artifacts/expansion-automation-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day41-pack/evidence",
+            "artifacts/expansion-automation-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day41-pack/expansion-automation-summary.json").exists()
-    assert (tmp_path / "artifacts/day41-pack/expansion-automation-summary.md").exists()
-    assert (tmp_path / "artifacts/day41-pack/day41-expansion-plan.md").exists()
-    assert (tmp_path / "artifacts/day41-pack/day41-automation-matrix.csv").exists()
-    assert (tmp_path / "artifacts/day41-pack/day41-expansion-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day41-pack/day41-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day41-pack/day41-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day41-pack/day41-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day41-pack/evidence/day41-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/expansion-automation-pack/expansion-automation-summary.json").exists()
+    assert (tmp_path / "artifacts/expansion-automation-pack/expansion-automation-summary.md").exists()
+    assert (tmp_path / "artifacts/expansion-automation-pack/expansion-plan.md").exists()
+    assert (tmp_path / "artifacts/expansion-automation-pack/automation-matrix.csv").exists()
+    assert (tmp_path / "artifacts/expansion-automation-pack/expansion-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/expansion-automation-pack/execution-log.md").exists()
+    assert (tmp_path / "artifacts/expansion-automation-pack/delivery-board.md").exists()
+    assert (tmp_path / "artifacts/expansion-automation-pack/validation-commands.md").exists()
+    assert (tmp_path / "artifacts/expansion-automation-pack/evidence/execution-summary.json").exists()
 
 
 def test_day41_strict_fails_when_day40_inputs_missing(tmp_path: Path) -> None:
@@ -118,4 +118,4 @@ def test_day41_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["expansion-automation", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 41 expansion automation summary" in capsys.readouterr().out
+    assert "Expansion automation summary" in capsys.readouterr().out

--- a/tests/test_optimization_closeout_foundation.py
+++ b/tests/test_optimization_closeout_foundation.py
@@ -53,7 +53,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/expansion-automation-pack/expansion-automation-delivery-board.md"
+    board = root / "docs/artifacts/expansion-automation-pack/delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -86,10 +86,10 @@ def test_day42_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day42-pack",
+            "artifacts/optimization-closeout-foundation-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day42-pack/evidence",
+            "artifacts/optimization-closeout-foundation-pack/evidence",
             "--format",
             "json",
             "--strict",
@@ -97,16 +97,16 @@ def test_day42_emit_pack_and_execute(tmp_path: Path) -> None:
     )
     assert rc == 0
     assert (
-        tmp_path / "artifacts/day42-pack/optimization-closeout-foundation-summary.json"
+        tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json"
     ).exists()
-    assert (tmp_path / "artifacts/day42-pack/optimization-closeout-foundation-summary.md").exists()
-    assert (tmp_path / "artifacts/day42-pack/day42-optimization-plan.md").exists()
-    assert (tmp_path / "artifacts/day42-pack/day42-remediation-matrix.csv").exists()
-    assert (tmp_path / "artifacts/day42-pack/day42-optimization-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day42-pack/day42-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day42-pack/optimization-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day42-pack/day42-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day42-pack/evidence/day42-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-plan.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/remediation-matrix.csv").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/execution-log.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/delivery-board.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/validation-commands.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/evidence/execution-summary.json").exists()
 
 
 def test_day42_strict_fails_when_day41_inputs_missing(tmp_path: Path) -> None:

--- a/tests/test_scale_closeout.py
+++ b/tests/test_scale_closeout.py
@@ -53,7 +53,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = root / "docs/artifacts/acceleration-closeout-pack/acceleration-delivery-board.md"
+    board = root / "docs/artifacts/acceleration-closeout-pack/delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -86,25 +86,25 @@ def test_day44_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day44-pack",
+            "artifacts/scale-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day44-pack/evidence",
+            "artifacts/scale-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day44-pack/scale-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day44-pack/scale-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day44-pack/scale-plan.md").exists()
-    assert (tmp_path / "artifacts/day44-pack/scale-growth-matrix.csv").exists()
-    assert (tmp_path / "artifacts/day44-pack/scale-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day44-pack/scale-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day44-pack/scale-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day44-pack/scale-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day44-pack/evidence/scale-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/scale-closeout-pack/scale-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/scale-closeout-pack/scale-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/scale-closeout-pack/scale-plan.md").exists()
+    assert (tmp_path / "artifacts/scale-closeout-pack/scale-growth-matrix.csv").exists()
+    assert (tmp_path / "artifacts/scale-closeout-pack/scale-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/scale-closeout-pack/scale-execution-log.md").exists()
+    assert (tmp_path / "artifacts/scale-closeout-pack/scale-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/scale-closeout-pack/scale-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/scale-closeout-pack/evidence/scale-execution-summary.json").exists()
 
 
 def test_day44_strict_fails_when_day43_inputs_missing(tmp_path: Path) -> None:
@@ -120,4 +120,4 @@ def test_day44_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["scale-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert "Day 44 scale closeout summary" in capsys.readouterr().out
+    assert "Scale closeout summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation

- Normalize artifact and evidence filenames across lanes to remove day-specific prefixes and simplify discovery and validation.
- Make lane documentation headings and command CTAs more generic and consistent for reusable tooling and clearer readability.

### Description

- Updated docs to reference `delivery-board.md` (instead of `*-delivery-board.md`) and adjusted lane section headings to generic phrases like `## Why this lane matters` and `## Command lane`.
- Standardized execution evidence filenames to `execution-summary.json` (replacing `dayXX-execution-summary.json`) in check scripts and pack emitters.
- Renamed emitted pack files to generic names (for example `dayXX-*` -> `acceleration-plan.md`, `growth-matrix.csv`, `execution-log.md`, `validation-commands.md`, etc.) and updated the corresponding `src/sdetkit/*` builders to produce those names and updated check IDs and summary text to match the new naming.
- Updated validation scripts in `scripts/` to look for the new `execution-summary.json` and adjusted legacy path resolution where applicable, and updated unit tests in `tests/` to assert the new artifact names and summary content.

### Testing

- Ran unit tests with `pytest`, which executed the updated tests under `tests/` and all tests passed.
- Emission and execution code paths were exercised by the updated tests using the `--emit-pack-dir` and `--execute` flows and validated existence of new artifact and evidence filenames.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca3fa1355483208513408944743ec7)