### PR TITLE
tests: switch closeout pack assertions from dayNN to canonical pack names

### DIFF
--- a/tests/test_case_study_launch_closeout.py
+++ b/tests/test_case_study_launch_closeout.py
@@ -107,27 +107,27 @@ def test_day73_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day73-pack",
+            "artifacts/case-study-launch-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day73-pack/evidence",
+            "artifacts/case-study-launch-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day73-pack/case-study-launch-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day73-pack/case-study-launch-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day73-pack/case-study-launch-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/day73-pack/case-study-launch-case-study-narrative.md").exists()
-    assert (tmp_path / "artifacts/day73-pack/case-study-launch-controls-log.json").exists()
-    assert (tmp_path / "artifacts/day73-pack/case-study-launch-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day73-pack/case-study-launch-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day73-pack/case-study-launch-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day73-pack/case-study-launch-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-case-study-narrative.md").exists()
+    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-controls-log.json").exists()
+    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-execution-log.md").exists()
+    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day73-pack/evidence/case-study-launch-execution-summary.json"
+        tmp_path / "artifacts/case-study-launch-closeout-pack/evidence/case-study-launch-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_case_study_prep1_closeout.py
+++ b/tests/test_case_study_prep1_closeout.py
@@ -88,20 +88,20 @@ def test_day69_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day69-pack",
+            "artifacts/case-study-prep1-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day69-pack/evidence",
+            "artifacts/case-study-prep1-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day69-pack/case-study-prep1-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day69-pack/case-study-prep1-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/case-study-prep1-closeout-pack/case-study-prep1-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/case-study-prep1-closeout-pack/case-study-prep1-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/day69-pack/evidence/case-study-prep1-execution-summary.json"
+        tmp_path / "artifacts/case-study-prep1-closeout-pack/evidence/case-study-prep1-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_case_study_prep2_closeout.py
+++ b/tests/test_case_study_prep2_closeout.py
@@ -77,20 +77,20 @@ def test_day70_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day70-pack",
+            "artifacts/case-study-prep2-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day70-pack/evidence",
+            "artifacts/case-study-prep2-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day70-pack/case-study-prep2-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day70-pack/case-study-prep2-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/case-study-prep2-closeout-pack/case-study-prep2-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/case-study-prep2-closeout-pack/case-study-prep2-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/day70-pack/evidence/case-study-prep2-execution-summary.json"
+        tmp_path / "artifacts/case-study-prep2-closeout-pack/evidence/case-study-prep2-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_case_study_prep4_closeout.py
+++ b/tests/test_case_study_prep4_closeout.py
@@ -105,27 +105,27 @@ def test_day72_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day72-pack",
+            "artifacts/case-study-prep4-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day72-pack/evidence",
+            "artifacts/case-study-prep4-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day72-pack/case-study-prep4-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day72-pack/case-study-prep4-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day72-pack/case-study-prep4-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/day72-pack/case-study-prep4-case-study-narrative.md").exists()
-    assert (tmp_path / "artifacts/day72-pack/case-study-prep4-controls-log.json").exists()
-    assert (tmp_path / "artifacts/day72-pack/case-study-prep4-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day72-pack/case-study-prep4-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day72-pack/case-study-prep4-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day72-pack/case-study-prep4-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-case-study-narrative.md").exists()
+    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-controls-log.json").exists()
+    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-execution-log.md").exists()
+    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day72-pack/evidence/case-study-prep4-execution-summary.json"
+        tmp_path / "artifacts/case-study-prep4-closeout-pack/evidence/case-study-prep4-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_community_program_closeout.py
+++ b/tests/test_community_program_closeout.py
@@ -88,28 +88,28 @@ def test_day62_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day62-pack",
+            "artifacts/community-program-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day62-pack/evidence",
+            "artifacts/community-program-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day62-pack/community-program-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day62-pack/community-program-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day62-pack/community-program-community-launch-brief.md").exists()
-    assert (tmp_path / "artifacts/day62-pack/community-program-office-hours-cadence.md").exists()
-    assert (tmp_path / "artifacts/day62-pack/community-program-participation-policy.md").exists()
-    assert (tmp_path / "artifacts/day62-pack/community-program-moderation-runbook.md").exists()
-    assert (tmp_path / "artifacts/day62-pack/community-program-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day62-pack/community-program-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day62-pack/community-program-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day62-pack/community-program-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-community-launch-brief.md").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-office-hours-cadence.md").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-participation-policy.md").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-moderation-runbook.md").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-execution-log.md").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day62-pack/evidence/community-program-execution-summary.json"
+        tmp_path / "artifacts/community-program-closeout-pack/evidence/community-program-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_contributor_activation_closeout.py
+++ b/tests/test_contributor_activation_closeout.py
@@ -86,28 +86,28 @@ def test_day55_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day55-pack",
+            "artifacts/contributor-activation-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day55-pack/evidence",
+            "artifacts/contributor-activation-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day55-pack/contributor-activation-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day55-pack/contributor-activation-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day55-pack/contributor-activation-brief.md").exists()
-    assert (tmp_path / "artifacts/day55-pack/contributor-ladder.csv").exists()
-    assert (tmp_path / "artifacts/day55-pack/contributor-activation-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day55-pack/contributor-activation-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day55-pack/contributor-activation-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-brief.md").exists()
+    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-ladder.csv").exists()
+    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-execution-log.md").exists()
+    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/day55-pack/contributor-activation-validation-commands.md"
+        tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-validation-commands.md"
     ).exists()
     assert (
-        tmp_path / "artifacts/day55-pack/evidence/contributor-activation-execution-summary.json"
+        tmp_path / "artifacts/contributor-activation-closeout-pack/evidence/contributor-activation-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_contributor_recognition_closeout.py
+++ b/tests/test_contributor_recognition_closeout.py
@@ -79,10 +79,10 @@ def test_day76_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day76-pack",
+            "artifacts/contributor-recognition-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day76-pack/evidence",
+            "artifacts/contributor-recognition-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
@@ -90,11 +90,11 @@ def test_day76_emit_pack_and_execute(tmp_path: Path) -> None:
     )
     assert rc == 0
     assert (
-        tmp_path / "artifacts/day76-pack/contributor-recognition-closeout-summary.json"
+        tmp_path / "artifacts/contributor-recognition-closeout-pack/contributor-recognition-closeout-summary.json"
     ).exists()
-    assert (tmp_path / "artifacts/day76-pack/contributor-recognition-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/contributor-recognition-closeout-pack/contributor-recognition-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/day76-pack/evidence/contributor-recognition-execution-summary.json"
+        tmp_path / "artifacts/contributor-recognition-closeout-pack/evidence/contributor-recognition-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_distribution_scaling_closeout.py
+++ b/tests/test_distribution_scaling_closeout.py
@@ -107,29 +107,29 @@ def test_day74_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day74-pack",
+            "artifacts/distribution-scaling-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day74-pack/evidence",
+            "artifacts/distribution-scaling-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day74-pack/distribution-scaling-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day74-pack/distribution-scaling-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day74-pack/distribution-scaling-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/day74-pack/distribution-scaling-plan.md").exists()
+    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-plan.md").exists()
     assert (
-        tmp_path / "artifacts/day74-pack/distribution-scaling-channel-controls-log.json"
+        tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-channel-controls-log.json"
     ).exists()
-    assert (tmp_path / "artifacts/day74-pack/distribution-scaling-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day74-pack/distribution-scaling-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day74-pack/distribution-scaling-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day74-pack/distribution-scaling-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-execution-log.md").exists()
+    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day74-pack/evidence/distribution-scaling-execution-summary.json"
+        tmp_path / "artifacts/distribution-scaling-closeout-pack/evidence/distribution-scaling-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_docs_loop_closeout.py
+++ b/tests/test_docs_loop_closeout.py
@@ -86,25 +86,25 @@ def test_day53_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day53-pack",
+            "artifacts/docs-loop-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day53-pack/evidence",
+            "artifacts/docs-loop-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day53-pack/docs-loop-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day53-pack/docs-loop-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day53-pack/docs-loop-brief.md").exists()
-    assert (tmp_path / "artifacts/day53-pack/docs-loop-cross-link-map.csv").exists()
-    assert (tmp_path / "artifacts/day53-pack/docs-loop-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day53-pack/docs-loop-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day53-pack/docs-loop-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day53-pack/docs-loop-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day53-pack/evidence/docs-loop-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-brief.md").exists()
+    assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-cross-link-map.csv").exists()
+    assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-execution-log.md").exists()
+    assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/docs-loop-closeout-pack/evidence/docs-loop-execution-summary.json").exists()
 
 
 def test_day53_strict_fails_when_day52_inputs_missing(tmp_path: Path) -> None:

--- a/tests/test_expansion_closeout.py
+++ b/tests/test_expansion_closeout.py
@@ -86,25 +86,25 @@ def test_day45_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day45-pack",
+            "artifacts/expansion-closeout-pack-45",
             "--execute",
             "--evidence-dir",
-            "artifacts/day45-pack/evidence",
+            "artifacts/expansion-closeout-pack-45/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day45-pack/expansion-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day45-pack/expansion-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day45-pack/expansion-plan.md").exists()
-    assert (tmp_path / "artifacts/day45-pack/expansion-growth-matrix.csv").exists()
-    assert (tmp_path / "artifacts/day45-pack/expansion-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day45-pack/expansion-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day45-pack/expansion-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day45-pack/expansion-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day45-pack/evidence/expansion-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-plan.md").exists()
+    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-growth-matrix.csv").exists()
+    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-execution-log.md").exists()
+    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/expansion-closeout-pack-45/evidence/expansion-execution-summary.json").exists()
 
 
 def test_day45_strict_fails_when_day44_inputs_missing(tmp_path: Path) -> None:

--- a/tests/test_integration_expansion2_closeout.py
+++ b/tests/test_integration_expansion2_closeout.py
@@ -112,29 +112,29 @@ def test_day66_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day66-pack",
+            "artifacts/integration-expansion2-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day66-pack/evidence",
+            "artifacts/integration-expansion2-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day66-pack/integration-expansion2-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day66-pack/integration-expansion2-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day66-pack/integration-expansion2-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/day66-pack/integration-expansion2-pipeline-blueprint.md").exists()
-    assert (tmp_path / "artifacts/day66-pack/integration-expansion2-matrix-plan.json").exists()
-    assert (tmp_path / "artifacts/day66-pack/integration-expansion2-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day66-pack/integration-expansion2-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day66-pack/integration-expansion2-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-pipeline-blueprint.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-matrix-plan.json").exists()
+    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-execution-log.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/day66-pack/integration-expansion2-validation-commands.md"
+        tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-validation-commands.md"
     ).exists()
     assert (
-        tmp_path / "artifacts/day66-pack/evidence/integration-expansion2-execution-summary.json"
+        tmp_path / "artifacts/integration-expansion2-closeout-pack/evidence/integration-expansion2-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_integration_expansion3_closeout.py
+++ b/tests/test_integration_expansion3_closeout.py
@@ -117,29 +117,29 @@ def test_day67_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day67-pack",
+            "artifacts/integration-expansion3-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day67-pack/evidence",
+            "artifacts/integration-expansion3-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day67-pack/integration-expansion3-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day67-pack/integration-expansion3-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day67-pack/integration-expansion3-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/day67-pack/integration-expansion3-jenkins-blueprint.md").exists()
-    assert (tmp_path / "artifacts/day67-pack/integration-expansion3-matrix-plan.json").exists()
-    assert (tmp_path / "artifacts/day67-pack/integration-expansion3-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day67-pack/integration-expansion3-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day67-pack/integration-expansion3-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-jenkins-blueprint.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-matrix-plan.json").exists()
+    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-execution-log.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/day67-pack/integration-expansion3-validation-commands.md"
+        tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-validation-commands.md"
     ).exists()
     assert (
-        tmp_path / "artifacts/day67-pack/evidence/integration-expansion3-execution-summary.json"
+        tmp_path / "artifacts/integration-expansion3-closeout-pack/evidence/integration-expansion3-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_integration_expansion4_closeout.py
+++ b/tests/test_integration_expansion4_closeout.py
@@ -83,25 +83,25 @@ def test_day68_emit_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day68-pack",
+            "artifacts/integration-expansion4-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day68-pack/evidence",
+            "artifacts/integration-expansion4-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day68-pack/integration-expansion4-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day68-pack/integration-expansion4-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-integration-brief.md").exists()
     assert (
-        tmp_path / "artifacts/day68-pack/integration-expansion4-self-hosted-blueprint.md"
+        tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-self-hosted-blueprint.md"
     ).exists()
-    assert (tmp_path / "artifacts/day68-pack/integration-expansion4-policy-plan.json").exists()
-    assert (tmp_path / "artifacts/day68-pack/integration-expansion4-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-policy-plan.json").exists()
+    assert (tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-kpi-scorecard.json").exists()
     assert (
-        tmp_path / "artifacts/day68-pack/evidence/integration-expansion4-execution-summary.json"
+        tmp_path / "artifacts/integration-expansion4-closeout-pack/evidence/integration-expansion4-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_kpi_deep_audit_closeout.py
+++ b/tests/test_kpi_deep_audit_closeout.py
@@ -88,26 +88,26 @@ def test_day57_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day57-pack",
+            "artifacts/kpi-deep-audit-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day57-pack/evidence",
+            "artifacts/kpi-deep-audit-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-brief.md").exists()
-    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day57-pack/kpi-deep-audit-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-brief.md").exists()
+    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-scorecard.json").exists()
+    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-execution-log.md").exists()
+    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day57-pack/evidence/kpi-deep-audit-execution-summary.json"
+        tmp_path / "artifacts/kpi-deep-audit-closeout-pack/evidence/kpi-deep-audit-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_optimization_closeout.py
+++ b/tests/test_optimization_closeout.py
@@ -86,25 +86,25 @@ def test_day46_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day46-pack",
+            "artifacts/optimization-closeout-pack-46",
             "--execute",
             "--evidence-dir",
-            "artifacts/day46-pack/evidence",
+            "artifacts/optimization-closeout-pack-46/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day46-pack/optimization-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day46-pack/optimization-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day46-pack/optimization-plan.md").exists()
-    assert (tmp_path / "artifacts/day46-pack/optimization-bottleneck-map.csv").exists()
-    assert (tmp_path / "artifacts/day46-pack/optimization-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day46-pack/optimization-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day46-pack/optimization-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day46-pack/optimization-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day46-pack/evidence/optimization-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-plan.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-bottleneck-map.csv").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-execution-log.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/optimization-closeout-pack-46/evidence/optimization-execution-summary.json").exists()
 
 
 def test_day46_strict_fails_when_day45_inputs_missing(tmp_path: Path) -> None:

--- a/tests/test_phase1_hardening.py
+++ b/tests/test_phase1_hardening.py
@@ -60,22 +60,22 @@ def test_day29_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day29-pack",
+            "artifacts/phase1-hardening-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day29-pack/evidence",
+            "artifacts/phase1-hardening-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day29-pack/phase1-hardening-summary.json").exists()
-    assert (tmp_path / "artifacts/day29-pack/phase1-hardening-summary.md").exists()
-    assert (tmp_path / "artifacts/day29-pack/phase1-hardening-stale-gaps.json").exists()
-    assert (tmp_path / "artifacts/day29-pack/phase1-hardening-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/phase1-hardening-pack/phase1-hardening-summary.json").exists()
+    assert (tmp_path / "artifacts/phase1-hardening-pack/phase1-hardening-summary.md").exists()
+    assert (tmp_path / "artifacts/phase1-hardening-pack/phase1-hardening-stale-gaps.json").exists()
+    assert (tmp_path / "artifacts/phase1-hardening-pack/phase1-hardening-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day29-pack/evidence/phase1-hardening-execution-summary.json"
+        tmp_path / "artifacts/phase1-hardening-pack/evidence/phase1-hardening-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_phase1_wrap.py
+++ b/tests/test_phase1_wrap.py
@@ -67,22 +67,22 @@ def test_day30_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day30-pack",
+            "artifacts/phase1-wrap-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day30-pack/evidence",
+            "artifacts/phase1-wrap-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day30-pack/phase1-wrap-summary.json").exists()
-    assert (tmp_path / "artifacts/day30-pack/phase1-wrap-summary.md").exists()
-    assert (tmp_path / "artifacts/day30-pack/phase1-wrap-phase2-backlog.md").exists()
-    assert (tmp_path / "artifacts/day30-pack/phase1-wrap-handoff-actions.md").exists()
-    assert (tmp_path / "artifacts/day30-pack/phase1-wrap-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/day30-pack/evidence/phase1-wrap-execution-summary.json").exists()
+    assert (tmp_path / "artifacts/phase1-wrap-pack/phase1-wrap-summary.json").exists()
+    assert (tmp_path / "artifacts/phase1-wrap-pack/phase1-wrap-summary.md").exists()
+    assert (tmp_path / "artifacts/phase1-wrap-pack/phase1-wrap-phase2-backlog.md").exists()
+    assert (tmp_path / "artifacts/phase1-wrap-pack/phase1-wrap-handoff-actions.md").exists()
+    assert (tmp_path / "artifacts/phase1-wrap-pack/phase1-wrap-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/phase1-wrap-pack/evidence/phase1-wrap-execution-summary.json").exists()
 
 
 def test_day30_strict_fails_when_inputs_missing(tmp_path: Path) -> None:

--- a/tests/test_phase2_hardening_closeout.py
+++ b/tests/test_phase2_hardening_closeout.py
@@ -88,26 +88,26 @@ def test_day58_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day58-pack",
+            "artifacts/phase2-hardening-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day58-pack/evidence",
+            "artifacts/phase2-hardening-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-brief.md").exists()
-    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day58-pack/phase2-hardening-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-brief.md").exists()
+    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-scorecard.json").exists()
+    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-execution-log.md").exists()
+    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day58-pack/evidence/phase2-hardening-execution-summary.json"
+        tmp_path / "artifacts/phase2-hardening-closeout-pack/evidence/phase2-hardening-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_phase2_kickoff.py
+++ b/tests/test_phase2_kickoff.py
@@ -89,23 +89,23 @@ def test_day31_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day31-pack",
+            "artifacts/phase2-kickoff-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day31-pack/evidence",
+            "artifacts/phase2-kickoff-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day31-pack/phase2-kickoff-summary.json").exists()
-    assert (tmp_path / "artifacts/day31-pack/phase2-kickoff-summary.md").exists()
-    assert (tmp_path / "artifacts/day31-pack/phase2-kickoff-baseline-snapshot.json").exists()
-    assert (tmp_path / "artifacts/day31-pack/phase2-kickoff-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day31-pack/phase2-kickoff-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-summary.json").exists()
+    assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-summary.md").exists()
+    assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-baseline-snapshot.json").exists()
+    assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day31-pack/evidence/phase2-kickoff-execution-summary.json"
+        tmp_path / "artifacts/phase2-kickoff-pack/evidence/phase2-kickoff-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_phase2_wrap_handoff_closeout.py
+++ b/tests/test_phase2_wrap_handoff_closeout.py
@@ -88,26 +88,26 @@ def test_day60_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day60-pack",
+            "artifacts/phase2-wrap-handoff-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day60-pack/evidence",
+            "artifacts/phase2-wrap-handoff-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day60-pack/phase2-wrap-handoff-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day60-pack/phase2-wrap-handoff-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day60-pack/phase2-wrap-handoff-brief.md").exists()
-    assert (tmp_path / "artifacts/day60-pack/phase2-wrap-handoff-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day60-pack/phase2-wrap-handoff-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day60-pack/phase2-wrap-handoff-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day60-pack/phase2-wrap-handoff-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day60-pack/phase2-wrap-handoff-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-brief.md").exists()
+    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-execution-log.md").exists()
+    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day60-pack/evidence/phase2-wrap-handoff-execution-summary.json"
+        tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/evidence/phase2-wrap-handoff-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_phase3_kickoff_closeout.py
+++ b/tests/test_phase3_kickoff_closeout.py
@@ -92,26 +92,26 @@ def test_day61_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day61-pack",
+            "artifacts/phase3-kickoff-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day61-pack/evidence",
+            "artifacts/phase3-kickoff-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day61-pack/phase3-kickoff-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day61-pack/phase3-kickoff-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day61-pack/phase3-kickoff-brief.md").exists()
-    assert (tmp_path / "artifacts/day61-pack/phase3-kickoff-trust-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day61-pack/phase3-kickoff-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day61-pack/phase3-kickoff-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day61-pack/phase3-kickoff-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day61-pack/phase3-kickoff-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-brief.md").exists()
+    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-trust-ledger.csv").exists()
+    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-execution-log.md").exists()
+    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day61-pack/evidence/phase3-kickoff-execution-summary.json"
+        tmp_path / "artifacts/phase3-kickoff-closeout-pack/evidence/phase3-kickoff-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_phase3_preplan_closeout.py
+++ b/tests/test_phase3_preplan_closeout.py
@@ -91,26 +91,26 @@ def test_day59_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day59-pack",
+            "artifacts/phase3-preplan-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day59-pack/evidence",
+            "artifacts/phase3-preplan-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day59-pack/phase3-preplan-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day59-pack/phase3-preplan-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day59-pack/phase3-preplan-brief.md").exists()
-    assert (tmp_path / "artifacts/day59-pack/phase3-preplan-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day59-pack/phase3-preplan-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day59-pack/phase3-preplan-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day59-pack/phase3-preplan-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day59-pack/phase3-preplan-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-brief.md").exists()
+    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-execution-log.md").exists()
+    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day59-pack/evidence/phase3-preplan-execution-summary.json"
+        tmp_path / "artifacts/phase3-preplan-closeout-pack/evidence/phase3-preplan-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_stabilization_closeout.py
+++ b/tests/test_stabilization_closeout.py
@@ -92,26 +92,26 @@ def test_day56_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day56-pack",
+            "artifacts/stabilization-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day56-pack/evidence",
+            "artifacts/stabilization-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day56-pack/stabilization-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day56-pack/stabilization-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day56-pack/stabilization-brief.md").exists()
-    assert (tmp_path / "artifacts/day56-pack/stabilization-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day56-pack/stabilization-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day56-pack/stabilization-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day56-pack/stabilization-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day56-pack/stabilization-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-brief.md").exists()
+    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-execution-log.md").exists()
+    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day56-pack/evidence/stabilization-execution-summary.json"
+        tmp_path / "artifacts/stabilization-closeout-pack/evidence/stabilization-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_trust_assets_refresh_closeout.py
+++ b/tests/test_trust_assets_refresh_closeout.py
@@ -108,29 +108,29 @@ def test_day75_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day75-pack",
+            "artifacts/trust-assets-refresh-closeout-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day75-pack/evidence",
+            "artifacts/trust-assets-refresh-closeout-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day75-pack/trust-assets-refresh-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/day75-pack/trust-assets-refresh-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day75-pack/trust-assets-refresh-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/day75-pack/trust-assets-refresh-plan.md").exists()
-    assert (tmp_path / "artifacts/day75-pack/trust-assets-refresh-trust-controls-log.json").exists()
+    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.json").exists()
+    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-integration-brief.md").exists()
+    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-plan.md").exists()
+    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-trust-controls-log.json").exists()
     assert (
-        tmp_path / "artifacts/day75-pack/trust-assets-refresh-trust-kpi-scorecard.json"
+        tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-trust-kpi-scorecard.json"
     ).exists()
-    assert (tmp_path / "artifacts/day75-pack/trust-assets-refresh-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day75-pack/trust-assets-refresh-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/day75-pack/trust-assets-refresh-validation-commands.md").exists()
+    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-execution-log.md").exists()
+    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/day75-pack/evidence/trust-assets-refresh-execution-summary.json"
+        tmp_path / "artifacts/trust-assets-refresh-closeout-pack/evidence/trust-assets-refresh-execution-summary.json"
     ).exists()
 
 

--- a/tests/test_weekly_review_closeout_2.py
+++ b/tests/test_weekly_review_closeout_2.py
@@ -96,31 +96,31 @@ def test_day65_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day65-pack",
+            "artifacts/weekly-review-closeout-2-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day65-pack/evidence",
+            "artifacts/weekly-review-closeout-2-pack/evidence",
             "--format",
             "json",
             "--strict",
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/day65-pack/weekly-review-closeout-2-summary.json").exists()
-    assert (tmp_path / "artifacts/day65-pack/weekly-review-closeout-2-summary.md").exists()
-    assert (tmp_path / "artifacts/day65-pack/weekly-review-closeout-2-weekly-brief.md").exists()
-    assert (tmp_path / "artifacts/day65-pack/weekly-review-closeout-2-kpi-dashboard.json").exists()
+    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-summary.json").exists()
+    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-summary.md").exists()
+    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-weekly-brief.md").exists()
+    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-kpi-dashboard.json").exists()
     assert (
-        tmp_path / "artifacts/day65-pack/weekly-review-closeout-2-governance-decision-register.md"
+        tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-governance-decision-register.md"
     ).exists()
-    assert (tmp_path / "artifacts/day65-pack/weekly-review-closeout-2-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/day65-pack/weekly-review-closeout-2-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day65-pack/weekly-review-closeout-2-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-risk-ledger.csv").exists()
+    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-execution-log.md").exists()
+    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/day65-pack/weekly-review-closeout-2-validation-commands.md"
+        tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-validation-commands.md"
     ).exists()
     assert (
-        tmp_path / "artifacts/day65-pack/evidence/weekly-review-closeout-2-execution-summary.json"
+        tmp_path / "artifacts/weekly-review-closeout-2-pack/evidence/weekly-review-closeout-2-execution-summary.json"
     ).exists()
 
 


### PR DESCRIPTION
### Motivation
- Per a repo-wide audit of `DAY_PATTERN='day([0-9]{1,2})'` across `src`, `tests`, `docs`, and `scripts`, several active/public test contracts still asserted `artifacts/dayNN-pack` as the primary emitted pack path and needed canonicalization. 
- The goal of this pass was to inventory remaining active/public day-based lanes and fix all eligible lanes in one batch while preserving CLI compatibility aliases and leaving already-productized lanes alone. 

### Description
- Replaced `artifacts/dayNN-pack` occurrences in active/public test emit/assert paths with their canonical pack names across the closeout/pack test suite (updated 25 test files, canonical examples include `docs-loop-closeout-pack`, `phase1-hardening-pack`, `phase1-wrap-pack`, `phase2-kickoff-pack`, `integration-expansion*-closeout-pack`, `case-study-*-closeout-pack`, `trust-assets-refresh-closeout-pack`, `contributor-*closeout-pack`, and others). 
- This was applied as a single batch edit across remaining eligible lanes (phase, integration expansion, case-study, trust/distribution/community/contributor lanes) rather than one lane at a time. 
- Preserved intentionally-out-of-scope surfaces: the Day 50 test lane was left unchanged per constraints, CLI legacy day aliases were left as narrow compatibility shims, and previously productized phase/phase1/phase2/day90→cycle1 boundaries were not reworked. 
- Committed the batch changes with the message `tests: switch closeout pack assertions from dayNN to canonical pack names` (no push performed). 

### Testing
- Ran targeted pytest across the touched test modules with `pytest -q` and all touched tests passed: `101 passed`.
- Sampled contract checker scripts with `--skip-evidence`; several script checks failed due to pre-existing content/score baselines unrelated to the path changes (examples: `scripts/check_phase1_hardening_contract.py --skip-evidence`, `scripts/check_docs_loop_closeout_contract.py --skip-evidence`, `scripts/check_contributor_recognition_closeout_contract.py --skip-evidence`, `scripts/check_trust_assets_refresh_closeout_contract.py --skip-evidence`).
- Verified repository state and commit: `git status --short` shows a clean working tree after the commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca48ac5bb483208350e7590f8f72e5)