### PR TITLE
Remove stale dayNN fallback paths from active closeout lanes

### DIFF
--- a/src/sdetkit/contributor_activation_closeout_55.py
+++ b/src/sdetkit/contributor_activation_closeout_55.py
@@ -11,11 +11,7 @@ from typing import Any
 _PAGE_PATH = "docs/integrations-contributor-activation-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY53_SUMMARY_PATH = "docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json"
-_DAY53_SUMMARY_FALLBACK_PATH = (
-    "docs/artifacts/docs-loop-closeout-pack/day53-docs-loop-closeout-summary.json"
-)
 _DAY53_BOARD_PATH = "docs/artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md"
-_DAY53_BOARD_FALLBACK_PATH = "docs/artifacts/docs-loop-closeout-pack/day53-delivery-board.md"
 _SECTION_HEADER = "# Day 55 \u2014 Contributor activation closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 55 matters",
@@ -72,7 +68,6 @@ Day 55 closes with a major contributor activation upgrade that turns Day 53 docs
 
 - `docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json`
 - `docs/artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md`
-- Compatibility fallback: day53-named files remain accepted.
 
 ## Day 55 command lane
 
@@ -172,13 +167,9 @@ def build_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
     day53_summary_primary = root / _DAY53_SUMMARY_PATH
-    day53_summary_fallback = root / _DAY53_SUMMARY_FALLBACK_PATH
-    day53_summary = (
-        day53_summary_primary if day53_summary_primary.exists() else day53_summary_fallback
-    )
+    day53_summary = day53_summary_primary
     day53_board_primary = root / _DAY53_BOARD_PATH
-    day53_board_fallback = root / _DAY53_BOARD_FALLBACK_PATH
-    day53_board = day53_board_primary if day53_board_primary.exists() else day53_board_fallback
+    day53_board = day53_board_primary
     day53_score, day53_strict, day53_check_count = _load_day53(day53_summary)
     board_count, board_has_day53 = _board_stats(day53_board)
 

--- a/src/sdetkit/distribution_batch_38.py
+++ b/src/sdetkit/distribution_batch_38.py
@@ -12,10 +12,6 @@ _PAGE_PATH = "docs/integrations-distribution-batch.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY37_SUMMARY_PATH = "docs/artifacts/experiment-lane-pack/experiment-lane-summary.json"
 _DAY37_BOARD_PATH = "docs/artifacts/experiment-lane-pack/delivery-board.md"
-_LEGACY_DAY37_SUMMARY_PATH = (
-    "docs/artifacts/day37-experiment-lane-pack/day37-experiment-lane-summary.json"
-)
-_LEGACY_DAY37_BOARD_PATH = "docs/artifacts/day37-experiment-lane-pack/day37-delivery-board.md"
 _SECTION_HEADER = "# Day 38 \u2014 Distribution batch #1"
 _REQUIRED_SECTIONS = [
     "## Why Day 38 matters",
@@ -160,14 +156,6 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
-    canonical_path = root / canonical
-    if canonical_path.exists():
-        return canonical_path
-    legacy_path = root / legacy
-    return legacy_path if legacy_path.exists() else canonical_path
-
-
 def build_day38_distribution_batch_summary(
     root: Path,
     *,
@@ -190,8 +178,8 @@ def build_day38_distribution_batch_summary(
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day37_summary = _resolve_input_path(root, _DAY37_SUMMARY_PATH, _LEGACY_DAY37_SUMMARY_PATH)
-    day37_board = _resolve_input_path(root, _DAY37_BOARD_PATH, _LEGACY_DAY37_BOARD_PATH)
+    day37_summary = root / _DAY37_SUMMARY_PATH
+    day37_board = root / _DAY37_BOARD_PATH
     day37_score, day37_strict, day37_check_count = _load_day37(day37_summary)
     board_count, board_has_day37, board_has_day38 = _board_stats(day37_board)
 

--- a/src/sdetkit/distribution_closeout_36.py
+++ b/src/sdetkit/distribution_closeout_36.py
@@ -12,10 +12,6 @@ _PAGE_PATH = "docs/integrations-distribution-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY35_SUMMARY_PATH = "docs/artifacts/kpi-instrumentation-pack/kpi-instrumentation-summary.json"
 _DAY35_BOARD_PATH = "docs/artifacts/kpi-instrumentation-pack/delivery-board.md"
-_DAY35_SUMMARY_FALLBACK_PATH = (
-    "docs/artifacts/kpi-instrumentation-pack/day35-kpi-instrumentation-summary.json"
-)
-_DAY35_BOARD_FALLBACK_PATH = "docs/artifacts/kpi-instrumentation-pack/day35-delivery-board.md"
 _SECTION_HEADER = "# Day 36 \u2014 Community distribution closeout"
 _REQUIRED_SECTIONS = [
     "## Why Day 36 matters",
@@ -120,10 +116,6 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def _resolve_existing_path(primary: Path, fallback: Path) -> Path:
-    return primary if primary.exists() else fallback
-
-
 def _load_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -186,13 +178,8 @@ def build_day36_distribution_closeout_summary(
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day35_summary = _resolve_existing_path(
-        root / _DAY35_SUMMARY_PATH,
-        root / _DAY35_SUMMARY_FALLBACK_PATH,
-    )
-    day35_board = _resolve_existing_path(
-        root / _DAY35_BOARD_PATH, root / _DAY35_BOARD_FALLBACK_PATH
-    )
+    day35_summary = root / _DAY35_SUMMARY_PATH
+    day35_board = root / _DAY35_BOARD_PATH
     day35_score, day35_strict, day35_check_count = _load_day35(day35_summary)
     board_count, board_has_day36, board_has_day37 = _board_stats(day35_board)
 

--- a/src/sdetkit/docs_loop_closeout_53.py
+++ b/src/sdetkit/docs_loop_closeout_53.py
@@ -11,11 +11,7 @@ from typing import Any
 _PAGE_PATH = "docs/integrations-docs-loop-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY52_SUMMARY_PATH = "docs/artifacts/narrative-closeout-pack/narrative-closeout-summary.json"
-_DAY52_SUMMARY_FALLBACK_PATH = (
-    "docs/artifacts/narrative-closeout-pack/day52-narrative-closeout-summary.json"
-)
 _DAY52_BOARD_PATH = "docs/artifacts/narrative-closeout-pack/narrative-delivery-board.md"
-_DAY52_BOARD_FALLBACK_PATH = "docs/artifacts/narrative-closeout-pack/day52-delivery-board.md"
 _SECTION_HEADER = "# Day 53 \u2014 Docs loop optimization closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 53 matters",
@@ -72,7 +68,6 @@ Day 53 closes with a major docs loop optimization upgrade that converts Day 52 n
 
 - `docs/artifacts/narrative-closeout-pack/narrative-closeout-summary.json`
 - `docs/artifacts/narrative-closeout-pack/narrative-delivery-board.md`
-- Compatibility fallback: day52-named files remain accepted.
 
 ## Day 53 command lane
 
@@ -178,13 +173,9 @@ def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
     day52_summary_primary = root / _DAY52_SUMMARY_PATH
-    day52_summary_fallback = root / _DAY52_SUMMARY_FALLBACK_PATH
-    day52_summary = (
-        day52_summary_primary if day52_summary_primary.exists() else day52_summary_fallback
-    )
+    day52_summary = day52_summary_primary
     day52_board_primary = root / _DAY52_BOARD_PATH
-    day52_board_fallback = root / _DAY52_BOARD_FALLBACK_PATH
-    day52_board = day52_board_primary if day52_board_primary.exists() else day52_board_fallback
+    day52_board = day52_board_primary
     day52_score, day52_strict, day52_check_count = _load_day52(day52_summary)
     board_count, board_has_day52, board_has_day53 = _board_stats(day52_board)
 

--- a/src/sdetkit/expansion_automation_41.py
+++ b/src/sdetkit/expansion_automation_41.py
@@ -12,8 +12,6 @@ _PAGE_PATH = "docs/integrations-expansion-automation.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY40_SUMMARY_PATH = "docs/artifacts/scale-lane-pack/scale-lane-summary.json"
 _DAY40_BOARD_PATH = "docs/artifacts/scale-lane-pack/delivery-board.md"
-_LEGACY_DAY40_SUMMARY_PATH = "docs/artifacts/day40-scale-lane-pack/day40-scale-lane-summary.json"
-_LEGACY_DAY40_BOARD_PATH = "docs/artifacts/day40-scale-lane-pack/day40-delivery-board.md"
 _SECTION_HEADER = "# Day 41 \u2014 Expansion automation lane"
 _REQUIRED_SECTIONS = [
     "## Why this lane matters",
@@ -151,14 +149,6 @@ def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
     return [line for line in expected if line not in text]
 
 
-def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
-    canonical_path = root / canonical
-    if canonical_path.exists():
-        return canonical_path
-    legacy_path = root / legacy
-    return legacy_path if legacy_path.exists() else canonical_path
-
-
 def build_expansion_automation_summary(root: Path) -> dict[str, Any]:
     page_path = root / _PAGE_PATH
     readme_path = "README.md"
@@ -179,8 +169,8 @@ def build_expansion_automation_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day40_summary = _resolve_input_path(root, _DAY40_SUMMARY_PATH, _LEGACY_DAY40_SUMMARY_PATH)
-    day40_board = _resolve_input_path(root, _DAY40_BOARD_PATH, _LEGACY_DAY40_BOARD_PATH)
+    day40_summary = root / _DAY40_SUMMARY_PATH
+    day40_board = root / _DAY40_BOARD_PATH
     day40_score, day40_strict, day40_check_count = _load_day40(day40_summary)
     board_count, board_has_day40, board_has_day41 = _board_stats(day40_board)
 

--- a/src/sdetkit/expansion_closeout_45.py
+++ b/src/sdetkit/expansion_closeout_45.py
@@ -116,13 +116,6 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def _resolve_existing_path(root: Path, primary: str, legacy: str) -> Path:
-    primary_path = root / primary
-    if primary_path.exists():
-        return primary_path
-    return root / legacy
-
-
 def _load_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -177,11 +170,7 @@ def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
     day44_summary = root / _DAY44_SUMMARY_PATH
-    day44_board = _resolve_existing_path(
-        root,
-        _DAY44_BOARD_PATH,
-        "docs/artifacts/scale-closeout-pack/day44-delivery-board.md",
-    )
+    day44_board = root / _DAY44_BOARD_PATH
     day44_score, day44_strict, day44_check_count = _load_day44(day44_summary)
     board_count, board_has_day44, board_has_day45 = _board_stats(day44_board)
 

--- a/src/sdetkit/experiment_lane_37.py
+++ b/src/sdetkit/experiment_lane_37.py
@@ -12,10 +12,6 @@ _PAGE_PATH = "docs/integrations-experiment-lane.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY36_SUMMARY_PATH = "docs/artifacts/distribution-closeout-pack/distribution-closeout-summary.json"
 _DAY36_BOARD_PATH = "docs/artifacts/distribution-closeout-pack/delivery-board.md"
-_LEGACY_DAY36_SUMMARY_PATH = (
-    "docs/artifacts/day36-distribution-closeout-pack/day36-distribution-closeout-summary.json"
-)
-_LEGACY_DAY36_BOARD_PATH = "docs/artifacts/day36-distribution-closeout-pack/day36-delivery-board.md"
 _SECTION_HEADER = "# Day 37 \u2014 Experiment lane activation"
 _REQUIRED_SECTIONS = [
     "## Why Day 37 matters",
@@ -160,14 +156,6 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
-    canonical_path = root / canonical
-    if canonical_path.exists():
-        return canonical_path
-    legacy_path = root / legacy
-    return legacy_path if legacy_path.exists() else canonical_path
-
-
 def build_day37_experiment_lane_summary(
     root: Path,
     *,
@@ -190,8 +178,8 @@ def build_day37_experiment_lane_summary(
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day36_summary = _resolve_input_path(root, _DAY36_SUMMARY_PATH, _LEGACY_DAY36_SUMMARY_PATH)
-    day36_board = _resolve_input_path(root, _DAY36_BOARD_PATH, _LEGACY_DAY36_BOARD_PATH)
+    day36_summary = root / _DAY36_SUMMARY_PATH
+    day36_board = root / _DAY36_BOARD_PATH
     day36_score, day36_strict, day36_check_count = _load_day36(day36_summary)
     board_count, board_has_day36, board_has_day37 = _board_stats(day36_board)
 

--- a/src/sdetkit/integration_expansion2_closeout_66.py
+++ b/src/sdetkit/integration_expansion2_closeout_66.py
@@ -16,9 +16,7 @@ _DAY65_SUMMARY_PATH = (
 _DAY65_BOARD_PATH = (
     "docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-delivery-board-2.md"
 )
-_DAY65_LEGACY_BOARD_PATH = "docs/artifacts/weekly-review-closeout-2-pack/day65-delivery-board.md"
 _GITLAB_PATH = "templates/ci/gitlab/gitlab-advanced-reference.yml"
-_LEGACY_GITLAB_PATH = "templates/ci/gitlab/day66-advanced-reference.yml"
 _SECTION_HEADER = "# Day 66 \u2014 Integration expansion #2 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Expansion 2 Closeout matters",
@@ -84,7 +82,6 @@ Day 66 closes with a major integration upgrade that converts Day 65 weekly revie
 - `docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json`
 - `docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-delivery-board-2.md`
 - `templates/ci/gitlab/gitlab-advanced-reference.yml`
-  - legacy compatibility alias: `templates/ci/gitlab/day66-advanced-reference.yml`
 
 ## Integration Expansion 2 Closeout command lane (Legacy Day 66)
 
@@ -133,16 +130,6 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
-    canonical_path = root / canonical
-    if canonical_path.exists():
-        return canonical_path
-    legacy_path = root / legacy
-    if legacy_path.exists():
-        return legacy_path
-    return canonical_path
-
-
 def _load_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -178,15 +165,11 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
-    gitlab_path = _resolve_input_path(root, _GITLAB_PATH, _LEGACY_GITLAB_PATH)
+    gitlab_path = root / _GITLAB_PATH
     gitlab_text = _read(gitlab_path)
 
     day65_summary = root / _DAY65_SUMMARY_PATH
     day65_board = root / _DAY65_BOARD_PATH
-    if not day65_board.exists():
-        legacy_day65_board = root / _DAY65_LEGACY_BOARD_PATH
-        if legacy_day65_board.exists():
-            day65_board = legacy_day65_board
     day65_score, day65_strict, day65_check_count = _load_day65(day65_summary)
     board_count, board_has_day65 = _count_board_items(day65_board, "Day 65")
 

--- a/src/sdetkit/integration_expansion3_closeout_67.py
+++ b/src/sdetkit/integration_expansion3_closeout_67.py
@@ -15,7 +15,6 @@ _DAY66_BOARD_PATH = (
     "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md"
 )
 _JENKINS_PATH = "templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile"
-_LEGACY_JENKINS_PATH = "templates/ci/jenkins/day67-advanced-reference.Jenkinsfile"
 _SECTION_HEADER = "# Day 67 \u2014 Integration expansion #3 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Expansion3 Closeout matters",
@@ -81,7 +80,6 @@ Day 67 closes with a major integration upgrade that converts Day 66 integration 
 - `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json`
 - `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md`
 - `templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile`
-  - legacy compatibility alias: `templates/ci/jenkins/day67-advanced-reference.Jenkinsfile`
 
 ## Integration Expansion3 Closeout command lane (Legacy Day 67)
 
@@ -130,16 +128,6 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
-    canonical_path = root / canonical
-    if canonical_path.exists():
-        return canonical_path
-    legacy_path = root / legacy
-    if legacy_path.exists():
-        return legacy_path
-    return canonical_path
-
-
 def _load_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -175,7 +163,7 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
-    jenkins_path = _resolve_input_path(root, _JENKINS_PATH, _LEGACY_JENKINS_PATH)
+    jenkins_path = root / _JENKINS_PATH
     jenkins_text = _read(jenkins_path)
 
     day66_summary = root / _DAY66_SUMMARY_PATH

--- a/src/sdetkit/integration_expansion4_closeout_68.py
+++ b/src/sdetkit/integration_expansion4_closeout_68.py
@@ -15,7 +15,6 @@ _DAY67_BOARD_PATH = (
     "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md"
 )
 _REFERENCE_PATH = "templates/ci/tekton/tekton-self-hosted-reference.yaml"
-_LEGACY_REFERENCE_PATH = "templates/ci/tekton/day68-self-hosted-reference.yaml"
 _SECTION_HEADER = "# Day 68 \u2014 Integration expansion #4 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Expansion4 Closeout matters",
@@ -81,7 +80,6 @@ Day 68 closes with a major integration upgrade that converts Day 67 outputs into
 - `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json`
 - `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md`
 - `templates/ci/tekton/tekton-self-hosted-reference.yaml`
-  - legacy compatibility alias: `templates/ci/tekton/day68-self-hosted-reference.yaml`
 
 ## Integration Expansion4 Closeout command lane (Legacy Day 68)
 
@@ -130,16 +128,6 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
-    canonical_path = root / canonical
-    if canonical_path.exists():
-        return canonical_path
-    legacy_path = root / legacy
-    if legacy_path.exists():
-        return legacy_path
-    return canonical_path
-
-
 def _load_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -175,7 +163,7 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
-    reference_path = _resolve_input_path(root, _REFERENCE_PATH, _LEGACY_REFERENCE_PATH)
+    reference_path = root / _REFERENCE_PATH
     reference_text = _read(reference_path)
 
     day67_summary = root / _DAY67_SUMMARY_PATH

--- a/src/sdetkit/optimization_closeout_46.py
+++ b/src/sdetkit/optimization_closeout_46.py
@@ -116,13 +116,6 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def _resolve_existing_path(root: Path, primary: str, legacy: str) -> Path:
-    primary_path = root / primary
-    if primary_path.exists():
-        return primary_path
-    return root / legacy
-
-
 def _load_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
@@ -176,11 +169,7 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
     day45_summary = root / _DAY45_SUMMARY_PATH
-    day45_board = _resolve_existing_path(
-        root,
-        _DAY45_BOARD_PATH,
-        "docs/artifacts/expansion-closeout-pack/day45-delivery-board.md",
-    )
+    day45_board = root / _DAY45_BOARD_PATH
     day45_score, day45_strict, day45_check_count = _load_day45(day45_summary)
     board_count, board_has_day45, board_has_day46 = _board_stats(day45_board)
 

--- a/src/sdetkit/playbook_post_39.py
+++ b/src/sdetkit/playbook_post_39.py
@@ -12,10 +12,6 @@ _PAGE_PATH = "docs/integrations-playbook-post.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY38_SUMMARY_PATH = "docs/artifacts/distribution-batch-pack/distribution-batch-summary.json"
 _DAY38_BOARD_PATH = "docs/artifacts/distribution-batch-pack/delivery-board.md"
-_LEGACY_DAY38_SUMMARY_PATH = (
-    "docs/artifacts/day38-distribution-batch-pack/day38-distribution-batch-summary.json"
-)
-_LEGACY_DAY38_BOARD_PATH = "docs/artifacts/day38-distribution-batch-pack/day38-delivery-board.md"
 _SECTION_HEADER = "# Day 39 \u2014 Playbook post #1"
 _REQUIRED_SECTIONS = [
     "## Why Day 39 matters",
@@ -160,14 +156,6 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
-    canonical_path = root / canonical
-    if canonical_path.exists():
-        return canonical_path
-    legacy_path = root / legacy
-    return legacy_path if legacy_path.exists() else canonical_path
-
-
 def build_day39_playbook_post_summary(
     root: Path,
     *,
@@ -190,8 +178,8 @@ def build_day39_playbook_post_summary(
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day38_summary = _resolve_input_path(root, _DAY38_SUMMARY_PATH, _LEGACY_DAY38_SUMMARY_PATH)
-    day38_board = _resolve_input_path(root, _DAY38_BOARD_PATH, _LEGACY_DAY38_BOARD_PATH)
+    day38_summary = root / _DAY38_SUMMARY_PATH
+    day38_board = root / _DAY38_BOARD_PATH
     day38_score, day38_strict, day38_check_count = _load_day38(day38_summary)
     board_count, board_has_day38, board_has_day39 = _board_stats(day38_board)
 

--- a/src/sdetkit/scale_lane_40.py
+++ b/src/sdetkit/scale_lane_40.py
@@ -12,10 +12,6 @@ _PAGE_PATH = "docs/integrations-scale-lane.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY39_SUMMARY_PATH = "docs/artifacts/playbook-post-pack/playbook-post-summary.json"
 _DAY39_BOARD_PATH = "docs/artifacts/playbook-post-pack/delivery-board.md"
-_LEGACY_DAY39_SUMMARY_PATH = (
-    "docs/artifacts/day39-playbook-post-pack/day39-playbook-post-summary.json"
-)
-_LEGACY_DAY39_BOARD_PATH = "docs/artifacts/day39-playbook-post-pack/day39-delivery-board.md"
 _SECTION_HEADER = "# Day 40 \u2014 Scale lane #1"
 _REQUIRED_SECTIONS = [
     "## Why Day 40 matters",
@@ -160,14 +156,6 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def _resolve_input_path(root: Path, canonical: str, legacy: str) -> Path:
-    canonical_path = root / canonical
-    if canonical_path.exists():
-        return canonical_path
-    legacy_path = root / legacy
-    return legacy_path if legacy_path.exists() else canonical_path
-
-
 def build_day40_scale_lane_summary(
     root: Path,
     *,
@@ -190,8 +178,8 @@ def build_day40_scale_lane_summary(
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day39_summary = _resolve_input_path(root, _DAY39_SUMMARY_PATH, _LEGACY_DAY39_SUMMARY_PATH)
-    day39_board = _resolve_input_path(root, _DAY39_BOARD_PATH, _LEGACY_DAY39_BOARD_PATH)
+    day39_summary = root / _DAY39_SUMMARY_PATH
+    day39_board = root / _DAY39_BOARD_PATH
     day39_score, day39_strict, day39_check_count = _load_day39(day39_summary)
     board_count, board_has_day39, board_has_day40 = _board_stats(day39_board)
 

--- a/src/sdetkit/weekly_review_28.py
+++ b/src/sdetkit/weekly_review_28.py
@@ -73,10 +73,6 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def _resolve_existing_path(primary: Path, fallback: Path) -> Path:
-    return primary if primary.exists() else fallback
-
-
 def _load_score(path: Path) -> tuple[float, bool]:
     if not path.exists():
         return 0.0, False
@@ -111,14 +107,12 @@ def build_day28_weekly_review_summary(
     day25_primary = (
         root / "docs/artifacts/community-activation-pack/community-activation-summary.json"
     )
-    day25_fallback = root / "docs/artifacts/community-activation-pack/day25-community-summary.json"
-    day25_path = _resolve_existing_path(day25_primary, day25_fallback)
+    day25_path = day25_primary
     external_contribution_path = (
         root / "docs/artifacts/external-contribution-pack/external-contribution-summary.json"
     )
     day27_primary = root / "docs/artifacts/kpi-audit-pack/kpi-audit-summary.json"
-    day27_fallback = root / "docs/artifacts/kpi-audit-pack/day27-kpi-summary.json"
-    day27_path = _resolve_existing_path(day27_primary, day27_fallback)
+    day27_path = day27_primary
 
     day25_score, day25_ok = _load_score(day25_path)
     external_contribution_score, external_contribution_ok = _load_score(external_contribution_path)


### PR DESCRIPTION
### Motivation
- I performed a repo-wide search for remaining `dayNN` residues and discovered active/public occurrences for these lanes: day1, day2, day3, day4, day5, day6, day7, day8, day9, day10, day11, day12, day13, day14, day15, day16, day17, day18, day20, day21, day22, day23, day24, day25, day26, day27, day28, day29, day30, day31, day32, day33, day34, day35, day36, day37, day38, day39, day40, day41, day42, day43, day44, day45, day46, day47, day48, day49, day50, day51, day52, day53, day55, day56, day57, day58, day59, day60, day61, day62, day63, day64, day65, day66, day67, day68, day69, day70, day71, day72, day73, day74, day75, day76, day77, day78, day79, day80, day81, day82, day83, day84, day85, day86, day87, day88, day89, day90, day92, day93, day95, day97, day99.  The intent of this change is to remove stale `dayNN` fallback wiring from active/public surfaces and prefer canonical artifact and CI reference paths.

### Description
- Removed legacy `dayNN` fallback constants and resolver helpers and made canonical artifact/reference paths primary across active closeout lanes by eliminating fallback resolution and fallback-text in module doc strings. Files changed include `src/sdetkit/distribution_closeout_36.py`, `src/sdetkit/experiment_lane_37.py`, `src/sdetkit/distribution_batch_38.py`, `src/sdetkit/playbook_post_39.py`, `src/sdetkit/scale_lane_40.py`, `src/sdetkit/expansion_automation_41.py`, `src/sdetkit/expansion_closeout_45.py`, `src/sdetkit/optimization_closeout_46.py`, `src/sdetkit/docs_loop_closeout_53.py`, `src/sdetkit/contributor_activation_closeout_55.py`, `src/sdetkit/integration_expansion2_closeout_66.py`, `src/sdetkit/integration_expansion3_closeout_67.py`, `src/sdetkit/integration_expansion4_closeout_68.py`, and `src/sdetkit/weekly_review_28.py`.
- Concretely replaced code paths that used `_resolve_input_path`/`_resolve_existing_path` or `*_FALLBACK_PATH` with direct canonical paths (e.g. `day37_summary = root / _DAY37_SUMMARY_PATH`), and removed legacy `templates/ci/day66-...`/`day67-...`/`day68-...` aliases from these active modules.
- Preserved out-of-scope / intentionally retained legacy identifiers in excluded lanes (e.g. `phase1_hardening_29` legacy pack identifiers) and left historical test/evidence artifacts and contract-check scripts unchanged except where they referenced the active fallback wiring.

### Testing
- Ran the targeted pytest suite covering the touched lanes with `pytest -q` (final run included tests referenced in this PR) and observed test success: `74 passed` in the final run. 
- Ran `python -m compileall -q` on the modified modules and it completed without syntax errors. 
- Ran the lane contract checker scripts with `--skip-evidence`; these produced failures reflecting pre-existing docs/strict-baseline drift in the repository, not regressions introduced by this cleanup (their failures are unrelated to the removal of stale fallback paths). 
- Created a single commit for the batch change and the working tree is clean after committing (`git status --short` shows no uncommitted changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d0858e20c8832091ad9bbc770a222d)