### PR TITLE
Narrow day36–40 contract checkers to canonical artifact evidence paths

### DIFF
--- a/scripts/check_distribution_batch_contract_38.py
+++ b/scripts/check_distribution_batch_contract_38.py
@@ -42,14 +42,7 @@ def main() -> int:
         errors.append(f"critical failures: {payload['summary']['critical_failures']}")
 
     if not ns.skip_evidence:
-        evidence_candidates = [
-            root / "docs/artifacts/distribution-batch-pack/evidence/execution-summary.json",
-            root
-            / "docs/artifacts/day38-distribution-batch-pack/evidence/day38-execution-summary.json",
-        ]
-        evidence = next(
-            (path for path in evidence_candidates if path.exists()), evidence_candidates[0]
-        )
+        evidence = root / "docs/artifacts/distribution-batch-pack/evidence/execution-summary.json"
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")
         else:

--- a/scripts/check_distribution_closeout_contract_36.py
+++ b/scripts/check_distribution_closeout_contract_36.py
@@ -42,14 +42,7 @@ def main() -> int:
         errors.append(f"critical failures: {payload['summary']['critical_failures']}")
 
     if not ns.skip_evidence:
-        evidence_candidates = [
-            root / "docs/artifacts/distribution-closeout-pack/evidence/execution-summary.json",
-            root
-            / "docs/artifacts/day36-distribution-closeout-pack/evidence/day36-execution-summary.json",
-        ]
-        evidence = next(
-            (path for path in evidence_candidates if path.exists()), evidence_candidates[0]
-        )
+        evidence = root / "docs/artifacts/distribution-closeout-pack/evidence/execution-summary.json"
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")
         else:

--- a/scripts/check_experiment_lane_contract_37.py
+++ b/scripts/check_experiment_lane_contract_37.py
@@ -42,14 +42,7 @@ def main() -> int:
         errors.append(f"critical failures: {payload['summary']['critical_failures']}")
 
     if not ns.skip_evidence:
-        evidence_candidates = [
-            root / "docs/artifacts/experiment-lane-pack/evidence/execution-summary.json",
-            root
-            / "docs/artifacts/day37-experiment-lane-pack/evidence/day37-execution-summary.json",
-        ]
-        evidence = next(
-            (path for path in evidence_candidates if path.exists()), evidence_candidates[0]
-        )
+        evidence = root / "docs/artifacts/experiment-lane-pack/evidence/execution-summary.json"
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")
         else:

--- a/scripts/check_playbook_post_contract.py
+++ b/scripts/check_playbook_post_contract.py
@@ -42,13 +42,7 @@ def main() -> int:
         errors.append(f"critical failures: {payload['summary']['critical_failures']}")
 
     if not ns.skip_evidence:
-        evidence_candidates = [
-            root / "docs/artifacts/playbook-post-pack/evidence/execution-summary.json",
-            root / "docs/artifacts/day39-playbook-post-pack/evidence/day39-execution-summary.json",
-        ]
-        evidence = next(
-            (path for path in evidence_candidates if path.exists()), evidence_candidates[0]
-        )
+        evidence = root / "docs/artifacts/playbook-post-pack/evidence/execution-summary.json"
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")
         else:

--- a/scripts/check_scale_lane_contract_40.py
+++ b/scripts/check_scale_lane_contract_40.py
@@ -42,13 +42,7 @@ def main() -> int:
         errors.append(f"critical failures: {payload['summary']['critical_failures']}")
 
     if not ns.skip_evidence:
-        evidence_candidates = [
-            root / "docs/artifacts/scale-lane-pack/evidence/execution-summary.json",
-            root / "docs/artifacts/day40-scale-lane-pack/evidence/day40-execution-summary.json",
-        ]
-        evidence = next(
-            (path for path in evidence_candidates if path.exists()), evidence_candidates[0]
-        )
+        evidence = root / "docs/artifacts/scale-lane-pack/evidence/execution-summary.json"
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")
         else:


### PR DESCRIPTION
### Motivation
- Remove remaining active/public dayNN residue where contract-checker scripts used broad dayNN fallback evidence paths while canonical pack locations are the current public sources. 
- The scan showed the day36–day40 contract-checker evidence fallbacks were the live public surface mismatches that could be safely narrowed without breaking compatibility.

### Description
- Replaced ambiguous evidence-candidate logic with a single canonical evidence path in five active checker scripts so they only read the current pack evidence file: `docs/artifacts/*-pack/evidence/execution-summary.json`.
- Files updated: `scripts/check_distribution_closeout_contract_36.py`, `scripts/check_experiment_lane_contract_37.py`, `scripts/check_distribution_batch_contract_38.py`, `scripts/check_playbook_post_contract.py`, and `scripts/check_scale_lane_contract_40.py`.
- This change removes stale `docs/artifacts/dayNN-*-pack` fallback candidates and leaves canonical pack names as the primary public contract surface while preserving existing checks and semantics.
- Intentional legacy aliases and compatibility lanes (e.g., day50 CLI alias, reliability day15/day16/day17 flags, and the Day 90 / phase3 boundary) were left untouched.

### Testing
- Ran targeted pytest: `tests/test_distribution_closeout.py`, `tests/test_experiment_lane.py`, `tests/test_distribution_batch.py`, `tests/test_playbook_post.py`, and `tests/test_scale_lane.py`, which completed successfully (`23 passed`).
- Executed the updated contract checker scripts end-to-end; they returned non-zero due to pre-existing strict/docs baseline failures in repository content, not due to the evidence-path narrowing logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d08cbfa3b48320839936c23df57333)