### PR TITLE
Refactor day-based builder aliases, normalize artifact paths/formatting, and update tests

### DIFF
--- a/scripts/check_distribution_closeout_contract_36.py
+++ b/scripts/check_distribution_closeout_contract_36.py
@@ -42,7 +42,9 @@ def main() -> int:
         errors.append(f"critical failures: {payload['summary']['critical_failures']}")
 
     if not ns.skip_evidence:
-        evidence = root / "docs/artifacts/distribution-closeout-pack/evidence/execution-summary.json"
+        evidence = (
+            root / "docs/artifacts/distribution-closeout-pack/evidence/execution-summary.json"
+        )
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")
         else:

--- a/scripts/check_docs_loop_closeout_contract_53.py
+++ b/scripts/check_docs_loop_closeout_contract_53.py
@@ -36,8 +36,7 @@ def main() -> int:
         )
         if not evidence.exists():
             evidence = (
-                root
-                / "docs/artifacts/docs-loop-closeout-pack/evidence/execution-summary.json"
+                root / "docs/artifacts/docs-loop-closeout-pack/evidence/execution-summary.json"
             )
         if not evidence.exists():
             errors.append(f"missing evidence summary: {evidence}")

--- a/scripts/check_expansion_automation_contract_41.py
+++ b/scripts/check_expansion_automation_contract_41.py
@@ -42,9 +42,7 @@ def main() -> int:
         errors.append(f"critical failures: {payload['summary']['critical_failures']}")
 
     if not ns.skip_evidence:
-        evidence = (
-            root / "docs/artifacts/expansion-automation-pack/evidence/execution-summary.json"
-        )
+        evidence = root / "docs/artifacts/expansion-automation-pack/evidence/execution-summary.json"
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")
         else:

--- a/scripts/check_narrative_closeout_contract_52.py
+++ b/scripts/check_narrative_closeout_contract_52.py
@@ -36,8 +36,7 @@ def main() -> int:
         )
         if not evidence.exists():
             evidence = (
-                root
-                / "docs/artifacts/narrative-closeout-pack/evidence/execution-summary.json"
+                root / "docs/artifacts/narrative-closeout-pack/evidence/execution-summary.json"
             )
         if not evidence.exists():
             errors.append(f"missing evidence summary: {evidence}")

--- a/scripts/check_objection_closeout_contract_48.py
+++ b/scripts/check_objection_closeout_contract_48.py
@@ -43,7 +43,8 @@ def main() -> int:
 
     if not ns.skip_evidence:
         evidence = (
-            root / "docs/artifacts/objection-closeout-pack/evidence/objection-execution-summary-48.json"
+            root
+            / "docs/artifacts/objection-closeout-pack/evidence/objection-execution-summary-48.json"
         )
         if not evidence.exists():
             errors.append(f"missing evidence file: {evidence}")

--- a/src/sdetkit/acceleration_closeout_43.py
+++ b/src/sdetkit/acceleration_closeout_43.py
@@ -11,12 +11,8 @@ from typing import Any
 _PAGE_PATH = "docs/integrations-acceleration-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY42_SUMMARY_PATH = "docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json"
-_DAY42_BOARD_PATH = (
-    "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
-)
-_DAY42_LEGACY_BOARD_PATH = (
-    "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
-)
+_DAY42_BOARD_PATH = "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
+_DAY42_LEGACY_BOARD_PATH = "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
 _SECTION_HEADER = "# Day 43 \u2014 Acceleration closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why this lane matters",
@@ -433,7 +429,9 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     )
     _write(
         target / "validation-commands.md",
-        "# Acceleration validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "# Acceleration validation commands\n\n```bash\n"
+        + "\n".join(_EXECUTION_COMMANDS)
+        + "\n```\n",
     )
 
 
@@ -472,7 +470,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day43_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
+def build_acceleration_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_acceleration_closeout_summary(root)
 

--- a/src/sdetkit/case_study_launch_closeout_73.py
+++ b/src/sdetkit/case_study_launch_closeout_73.py
@@ -414,7 +414,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day73_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_launch_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_case_study_launch_closeout_summary(root)
 

--- a/src/sdetkit/case_study_prep1_closeout_69.py
+++ b/src/sdetkit/case_study_prep1_closeout_69.py
@@ -410,7 +410,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day69_case_study_prep1_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_prep1_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_case_study_prep1_closeout_summary(root)
 

--- a/src/sdetkit/case_study_prep2_closeout_70.py
+++ b/src/sdetkit/case_study_prep2_closeout_70.py
@@ -412,7 +412,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day70_case_study_prep2_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_prep2_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_case_study_prep2_closeout_summary(root)
 

--- a/src/sdetkit/case_study_prep3_closeout_71.py
+++ b/src/sdetkit/case_study_prep3_closeout_71.py
@@ -416,7 +416,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day71_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_prep3_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_case_study_prep3_closeout_summary(root)
 

--- a/src/sdetkit/case_study_prep4_closeout_72.py
+++ b/src/sdetkit/case_study_prep4_closeout_72.py
@@ -431,7 +431,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day72_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
+def build_case_study_prep4_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_case_study_prep4_closeout_summary(root)
 

--- a/src/sdetkit/community_program_closeout_62.py
+++ b/src/sdetkit/community_program_closeout_62.py
@@ -400,7 +400,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day62_community_program_closeout_summary(root: Path) -> dict[str, Any]:
+def build_community_program_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_community_program_closeout_summary(root)
 

--- a/src/sdetkit/community_touchpoint_closeout_77.py
+++ b/src/sdetkit/community_touchpoint_closeout_77.py
@@ -417,7 +417,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day77_community_touchpoint_closeout_summary(root: Path) -> dict[str, Any]:
+def build_community_touchpoint_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_community_touchpoint_closeout_summary(root)
 

--- a/src/sdetkit/contributor_activation_closeout_55.py
+++ b/src/sdetkit/contributor_activation_closeout_55.py
@@ -412,7 +412,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day55_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
+def build_contributor_activation_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_contributor_activation_closeout_summary(root)
 

--- a/src/sdetkit/contributor_recognition_closeout_76.py
+++ b/src/sdetkit/contributor_recognition_closeout_76.py
@@ -412,7 +412,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day76_contributor_recognition_closeout_summary(root: Path) -> dict[str, Any]:
+def build_contributor_recognition_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_contributor_recognition_closeout_summary(root)
 

--- a/src/sdetkit/demo_asset2_34.py
+++ b/src/sdetkit/demo_asset2_34.py
@@ -156,7 +156,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day34_demo_asset2_summary(
+def build_demo_asset2_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -496,7 +496,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY34_DEFAULT_PAGE)
 
-    payload = build_day34_demo_asset2_summary(root)
+    payload = build_demo_asset2_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -539,7 +539,7 @@ def build_demo_asset2_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day34_demo_asset2_summary(
+    return build_demo_asset2_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/demo_asset_33.py
+++ b/src/sdetkit/demo_asset_33.py
@@ -156,7 +156,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day33_demo_asset_summary(
+def build_demo_asset_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -205,19 +205,19 @@ def build_day33_demo_asset_summary(
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day33_link",
+            "check_id": "readme_demo_asset_link",
             "weight": 8,
             "passed": "docs/integrations-demo-asset.md" in readme_text,
             "evidence": "docs/integrations-demo-asset.md",
         },
         {
-            "check_id": "readme_day33_command",
+            "check_id": "readme_demo_asset_command",
             "weight": 4,
             "passed": "demo-asset" in readme_text,
             "evidence": "demo-asset",
         },
         {
-            "check_id": "docs_index_day33_links",
+            "check_id": "docs_index_demo_asset_links",
             "weight": 8,
             "passed": (
                 "impact-33-ultra-upgrade-report.md" in docs_index_text
@@ -226,7 +226,7 @@ def build_day33_demo_asset_summary(
             "evidence": "impact-33-ultra-upgrade-report.md + integrations-demo-asset.md",
         },
         {
-            "check_id": "top10_day33_alignment",
+            "check_id": "top10_demo_asset_alignment",
             "weight": 5,
             "passed": (
                 "Day 33 \u2014 Demo asset #1" in top10_text
@@ -495,7 +495,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY33_DEFAULT_PAGE)
 
-    payload = build_day33_demo_asset_summary(root)
+    payload = build_demo_asset_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -538,7 +538,7 @@ def build_demo_asset_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day33_demo_asset_summary(
+    return build_demo_asset_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/distribution_batch_38.py
+++ b/src/sdetkit/distribution_batch_38.py
@@ -156,7 +156,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day38_distribution_batch_summary(
+def build_distribution_batch_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -203,19 +203,19 @@ def build_day38_distribution_batch_summary(
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day38_link",
+            "check_id": "readme_distribution_batch_link",
             "weight": 8,
             "passed": "docs/integrations-distribution-batch.md" in readme_text,
             "evidence": "docs/integrations-distribution-batch.md",
         },
         {
-            "check_id": "readme_day38_command",
+            "check_id": "readme_distribution_batch_command",
             "weight": 4,
             "passed": "distribution-batch" in readme_text,
             "evidence": "distribution-batch",
         },
         {
-            "check_id": "docs_index_day38_links",
+            "check_id": "docs_index_distribution_batch_links",
             "weight": 8,
             "passed": (
                 "impact-38-big-upgrade-report.md" in docs_index_text
@@ -224,7 +224,7 @@ def build_day38_distribution_batch_summary(
             "evidence": "impact-38-big-upgrade-report.md + integrations-distribution-batch.md",
         },
         {
-            "check_id": "top10_day38_alignment",
+            "check_id": "top10_distribution_batch_alignment",
             "weight": 5,
             "passed": ("Day 38" in top10_text and "Day 39" in top10_text),
             "evidence": "Day 38 + Day 39 strategy chain",
@@ -532,7 +532,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY38_DEFAULT_PAGE)
 
-    payload = build_day38_distribution_batch_summary(root)
+    payload = build_distribution_batch_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -575,7 +575,7 @@ def build_distribution_batch_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day38_distribution_batch_summary(
+    return build_distribution_batch_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/distribution_closeout_36.py
+++ b/src/sdetkit/distribution_closeout_36.py
@@ -156,7 +156,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day36_distribution_closeout_summary(
+def build_distribution_closeout_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -499,7 +499,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY36_DEFAULT_PAGE)
 
-    payload = build_day36_distribution_closeout_summary(root)
+    payload = build_distribution_closeout_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -542,7 +542,7 @@ def build_distribution_closeout_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day36_distribution_closeout_summary(
+    return build_distribution_closeout_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/distribution_scaling_closeout_74.py
+++ b/src/sdetkit/distribution_scaling_closeout_74.py
@@ -415,7 +415,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day74_distribution_scaling_closeout_summary(root: Path) -> dict[str, Any]:
+def build_distribution_scaling_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_distribution_scaling_closeout_summary(root)
 

--- a/src/sdetkit/docs_loop_closeout_53.py
+++ b/src/sdetkit/docs_loop_closeout_53.py
@@ -470,7 +470,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day53_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
+def build_docs_loop_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_docs_loop_closeout_summary(root)
 

--- a/src/sdetkit/ecosystem_priorities_closeout_78.py
+++ b/src/sdetkit/ecosystem_priorities_closeout_78.py
@@ -417,7 +417,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day78_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, Any]:
+def build_ecosystem_priorities_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_ecosystem_priorities_closeout_summary(root)
 

--- a/src/sdetkit/evidence_narrative_closeout_84.py
+++ b/src/sdetkit/evidence_narrative_closeout_84.py
@@ -411,7 +411,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day84_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
+def build_evidence_narrative_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_evidence_narrative_closeout_summary(root)
 

--- a/src/sdetkit/execution_prioritization_closeout_50.py
+++ b/src/sdetkit/execution_prioritization_closeout_50.py
@@ -13,9 +13,7 @@ _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY49_SUMMARY_PATH = (
     "docs/artifacts/weekly-review-closeout-pack-49/weekly-review-closeout-summary-49.json"
 )
-_DAY49_BOARD_PATH = (
-    "docs/artifacts/weekly-review-closeout-pack-49/delivery-board-49.md"
-)
+_DAY49_BOARD_PATH = "docs/artifacts/weekly-review-closeout-pack-49/delivery-board-49.md"
 _DAY49_LEGACY_BOARD_PATH = "docs/artifacts/weekly-review-closeout-pack-49/delivery-board-49.md"
 _SECTION_HEADER = "# Day 50 \u2014 Execution prioritization closeout lane"
 _REQUIRED_SECTIONS = [
@@ -480,7 +478,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day50_execution_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_execution_prioritization_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_execution_prioritization_closeout_summary(root)
 

--- a/src/sdetkit/expansion_automation_41.py
+++ b/src/sdetkit/expansion_automation_41.py
@@ -463,11 +463,15 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     )
     _write(
         target / "delivery-board.md",
-        "# Expansion automation delivery board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
+        "# Expansion automation delivery board\n\n"
+        + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES)
+        + "\n",
     )
     _write(
         target / "validation-commands.md",
-        "# Expansion automation validation commands\n\n```bash\n" + "\n".join(_REQUIRED_COMMANDS) + "\n```\n",
+        "# Expansion automation validation commands\n\n```bash\n"
+        + "\n".join(_REQUIRED_COMMANDS)
+        + "\n```\n",
     )
 
 
@@ -510,7 +514,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day41_expansion_automation_summary(root: Path) -> dict[str, Any]:
+def build_expansion_automation_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_expansion_automation_summary(root)
 

--- a/src/sdetkit/expansion_closeout_45.py
+++ b/src/sdetkit/expansion_closeout_45.py
@@ -460,7 +460,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day45_expansion_closeout_summary(root: Path) -> dict[str, Any]:
+def build_expansion_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_expansion_closeout_summary(root)
 

--- a/src/sdetkit/experiment_lane_37.py
+++ b/src/sdetkit/experiment_lane_37.py
@@ -156,7 +156,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day37_experiment_lane_summary(
+def build_experiment_lane_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -530,7 +530,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY37_DEFAULT_PAGE)
 
-    payload = build_day37_experiment_lane_summary(root)
+    payload = build_experiment_lane_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -573,7 +573,7 @@ def build_experiment_lane_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day37_experiment_lane_summary(
+    return build_experiment_lane_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/governance_handoff_closeout_87.py
+++ b/src/sdetkit/governance_handoff_closeout_87.py
@@ -411,7 +411,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day87_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
+def build_governance_handoff_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_governance_handoff_closeout_summary(root)
 

--- a/src/sdetkit/governance_priorities_closeout_88.py
+++ b/src/sdetkit/governance_priorities_closeout_88.py
@@ -413,7 +413,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day88_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
+def build_governance_priorities_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_governance_priorities_closeout_summary(root)
 

--- a/src/sdetkit/governance_scale_closeout_89.py
+++ b/src/sdetkit/governance_scale_closeout_89.py
@@ -411,7 +411,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day89_governance_scale_closeout_summary(root: Path) -> dict[str, Any]:
+def build_governance_scale_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_governance_scale_closeout_summary(root)
 

--- a/src/sdetkit/growth_campaign_closeout_81.py
+++ b/src/sdetkit/growth_campaign_closeout_81.py
@@ -405,7 +405,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day81_growth_campaign_closeout_summary(root: Path) -> dict[str, Any]:
+def build_growth_campaign_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_growth_campaign_closeout_summary(root)
 

--- a/src/sdetkit/integration_expansion2_closeout_66.py
+++ b/src/sdetkit/integration_expansion2_closeout_66.py
@@ -422,7 +422,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day66_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
+def build_integration_expansion2_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_integration_expansion2_closeout_summary(root)
 

--- a/src/sdetkit/integration_expansion3_closeout_67.py
+++ b/src/sdetkit/integration_expansion3_closeout_67.py
@@ -420,7 +420,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day67_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
+def build_integration_expansion3_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_integration_expansion3_closeout_summary(root)
 

--- a/src/sdetkit/integration_expansion4_closeout_68.py
+++ b/src/sdetkit/integration_expansion4_closeout_68.py
@@ -423,7 +423,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day68_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
+def build_integration_expansion4_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_integration_expansion4_closeout_summary(root)
 

--- a/src/sdetkit/integration_feedback_closeout_82.py
+++ b/src/sdetkit/integration_feedback_closeout_82.py
@@ -417,7 +417,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day82_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
+def build_integration_feedback_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_integration_feedback_closeout_summary(root)
 

--- a/src/sdetkit/kpi_deep_audit_closeout_57.py
+++ b/src/sdetkit/kpi_deep_audit_closeout_57.py
@@ -397,7 +397,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day57_kpi_deep_audit_closeout_summary(root: Path) -> dict[str, Any]:
+def build_kpi_deep_audit_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_kpi_deep_audit_closeout_summary(root)
 

--- a/src/sdetkit/kpi_instrumentation_35.py
+++ b/src/sdetkit/kpi_instrumentation_35.py
@@ -156,7 +156,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day35_kpi_instrumentation_summary(
+def build_kpi_instrumentation_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -205,19 +205,19 @@ def build_day35_kpi_instrumentation_summary(
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day35_link",
+            "check_id": "readme_kpi_instrumentation_link",
             "weight": 8,
             "passed": "docs/integrations-kpi-instrumentation.md" in readme_text,
             "evidence": "docs/integrations-kpi-instrumentation.md",
         },
         {
-            "check_id": "readme_day35_command",
+            "check_id": "readme_kpi_instrumentation_command",
             "weight": 4,
             "passed": "kpi-instrumentation" in readme_text,
             "evidence": "README kpi-instrumentation command lane",
         },
         {
-            "check_id": "docs_index_day35_links",
+            "check_id": "docs_index_kpi_instrumentation_links",
             "weight": 8,
             "passed": (
                 "impact-35-big-upgrade-report.md" in docs_index_text
@@ -226,7 +226,7 @@ def build_day35_kpi_instrumentation_summary(
             "evidence": "impact-35-big-upgrade-report.md + integrations-kpi-instrumentation.md",
         },
         {
-            "check_id": "top10_day35_alignment",
+            "check_id": "top10_kpi_instrumentation_alignment",
             "weight": 5,
             "passed": ("Day 35" in top10_text and "Day 36" in top10_text),
             "evidence": "Day 35 + Day 36 strategy chain",
@@ -492,7 +492,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY35_DEFAULT_PAGE)
 
-    payload = build_day35_kpi_instrumentation_summary(root)
+    payload = build_kpi_instrumentation_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -535,7 +535,7 @@ def build_kpi_instrumentation_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day35_kpi_instrumentation_summary(
+    return build_kpi_instrumentation_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/launch_readiness_closeout_86.py
+++ b/src/sdetkit/launch_readiness_closeout_86.py
@@ -409,7 +409,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day86_launch_readiness_closeout_summary(root: Path) -> dict[str, Any]:
+def build_launch_readiness_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_launch_readiness_closeout_summary(root)
 

--- a/src/sdetkit/objection_closeout_48.py
+++ b/src/sdetkit/objection_closeout_48.py
@@ -465,7 +465,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day48_objection_closeout_summary(root: Path) -> dict[str, Any]:
+def build_objection_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_objection_closeout_summary(root)
 

--- a/src/sdetkit/optimization_closeout_42.py
+++ b/src/sdetkit/optimization_closeout_42.py
@@ -11,9 +11,7 @@ from typing import Any
 _PAGE_PATH = "docs/integrations-optimization-closeout-foundation.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY41_SUMMARY_PATH = "docs/artifacts/expansion-automation-pack/expansion-automation-summary.json"
-_DAY41_BOARD_PATH = (
-    "docs/artifacts/expansion-automation-pack/delivery-board.md"
-)
+_DAY41_BOARD_PATH = "docs/artifacts/expansion-automation-pack/delivery-board.md"
 _DAY41_LEGACY_BOARD_PATH = "docs/artifacts/expansion-automation-pack/delivery-board.md"
 _SECTION_HEADER = "# Optimization Closeout Foundation \u2014 Optimization closeout lane"
 _REQUIRED_SECTIONS = [
@@ -479,7 +477,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day42_optimization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_optimization_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_optimization_closeout_summary(root)
 

--- a/src/sdetkit/optimization_closeout_46.py
+++ b/src/sdetkit/optimization_closeout_46.py
@@ -459,7 +459,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day46_optimization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_optimization_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_optimization_closeout_summary(root)
 

--- a/src/sdetkit/partner_outreach_closeout_80.py
+++ b/src/sdetkit/partner_outreach_closeout_80.py
@@ -409,7 +409,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day80_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
+def build_partner_outreach_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_partner_outreach_closeout_summary(root)
 

--- a/src/sdetkit/phase1_hardening_29.py
+++ b/src/sdetkit/phase1_hardening_29.py
@@ -11,9 +11,9 @@ from typing import Any
 _PAGE_PATH = "docs/integrations-phase1-hardening.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _CANONICAL_LANE_NAME = "phase1-hardening"
-_LEGACY_LANE_NAME = "day29-phase1-hardening"
+_LEGACY_LANE_NAME = "legacy-phase1-hardening"
 _CANONICAL_PACK_DIR = "docs/artifacts/phase1-hardening-pack"
-_LEGACY_PACK_DIR = "docs/artifacts/day29-hardening-pack"
+_LEGACY_PACK_DIR = "docs/artifacts/legacy-phase1-hardening-pack"
 _CANONICAL_SUMMARY_JSON = "phase1-hardening-summary.json"
 _CANONICAL_SUMMARY_MD = "phase1-hardening-summary.md"
 _CANONICAL_STALE_GAPS = "phase1-hardening-stale-gaps.json"
@@ -87,7 +87,7 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def build_day29_phase1_hardening_summary(
+def build_phase1_hardening_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -142,13 +142,13 @@ def build_day29_phase1_hardening_summary(
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day29_link",
+            "check_id": "readme_phase1_hardening_link",
             "weight": 12,
             "passed": "docs/integrations-phase1-hardening.md" in readme_text,
             "evidence": "docs/integrations-phase1-hardening.md",
         },
         {
-            "check_id": "docs_index_day29_links",
+            "check_id": "docs_index_phase1_hardening_links",
             "weight": 12,
             "passed": all(
                 token in docs_index_text
@@ -160,7 +160,7 @@ def build_day29_phase1_hardening_summary(
             "evidence": "impact-29-ultra-upgrade-report.md + integrations-phase1-hardening.md",
         },
         {
-            "check_id": "top10_day29_alignment",
+            "check_id": "top10_phase1_hardening_alignment",
             "weight": 11,
             "passed": "Day 29 \u2014 Phase-1 hardening" in top10_text,
             "evidence": "Day 29 \u2014 Phase-1 hardening",
@@ -291,7 +291,7 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
         )
     summary = {
         "name": "phase1-hardening-execution",
-        "legacy_name": "day29-phase1-hardening-execution",
+        "legacy_name": "legacy-phase1-hardening-execution",
         "total_commands": len(logs),
         "failed_commands": [log["command"] for log in logs if log["returncode"] != 0],
         "commands": logs,
@@ -323,7 +323,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY29_DEFAULT_PAGE)
 
-    payload = build_day29_phase1_hardening_summary(root)
+    payload = build_phase1_hardening_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -366,7 +366,7 @@ def build_phase1_hardening_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day29_phase1_hardening_summary(
+    return build_phase1_hardening_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/phase1_wrap_30.py
+++ b/src/sdetkit/phase1_wrap_30.py
@@ -11,7 +11,7 @@ from typing import Any
 _PAGE_PATH = "docs/integrations-phase1-wrap.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _CANONICAL_LANE_NAME = "phase1-wrap"
-_LEGACY_LANE_NAME = "day30-phase1-wrap"
+_LEGACY_LANE_NAME = "legacy-phase1-wrap"
 _DAY29_CANONICAL_SUMMARY_PATH = "docs/artifacts/phase1-hardening-pack/phase1-hardening-summary.json"
 _CANONICAL_EXECUTION_SUMMARY = "phase1-wrap-execution-summary.json"
 _SECTION_HEADER = "# Day 30 \u2014 Phase-1 wrap and Phase-2 handoff"
@@ -98,7 +98,7 @@ def _load_score(path: Path) -> tuple[float, bool]:
     return 0.0, False
 
 
-def build_day30_phase1_wrap_summary(
+def build_phase1_wrap_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -151,19 +151,19 @@ def build_day30_phase1_wrap_summary(
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day30_link",
+            "check_id": "readme_phase1_wrap_link",
             "weight": 10,
             "passed": "docs/integrations-phase1-wrap.md" in readme_text,
             "evidence": "docs/integrations-phase1-wrap.md",
         },
         {
-            "check_id": "readme_day30_command",
+            "check_id": "readme_phase1_wrap_command",
             "weight": 5,
-            "passed": ("phase1-wrap" in readme_text) or ("day30-phase1-wrap" in readme_text),
-            "evidence": "phase1-wrap (legacy: day30-phase1-wrap)",
+            "passed": ("phase1-wrap" in readme_text) or ("legacy-phase1-wrap" in readme_text),
+            "evidence": "phase1-wrap (legacy: legacy-phase1-wrap)",
         },
         {
-            "check_id": "docs_index_day30_links",
+            "check_id": "docs_index_phase1_wrap_links",
             "weight": 10,
             "passed": (
                 "impact-30-ultra-upgrade-report.md" in docs_index_text
@@ -172,7 +172,7 @@ def build_day30_phase1_wrap_summary(
             "evidence": "impact-30-ultra-upgrade-report.md + integrations-phase1-wrap.md",
         },
         {
-            "check_id": "top10_day30_alignment",
+            "check_id": "top10_phase1_wrap_alignment",
             "weight": 5,
             "passed": (
                 "Day 30 \u2014 Phase-1 wrap + handoff" in top10_text
@@ -385,7 +385,7 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
         )
     summary = {
         "name": "phase1-wrap-execution",
-        "legacy_name": "day30-phase1-wrap-execution",
+        "legacy_name": "legacy-phase1-wrap-execution",
         "total_commands": len(logs),
         "failed_commands": [log["command"] for log in logs if log["returncode"] != 0],
         "commands": logs,
@@ -417,7 +417,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY30_DEFAULT_PAGE)
 
-    payload = build_day30_phase1_wrap_summary(root)
+    payload = build_phase1_wrap_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -460,7 +460,7 @@ def build_phase1_wrap_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day30_phase1_wrap_summary(
+    return build_phase1_wrap_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/phase2_hardening_closeout_58.py
+++ b/src/sdetkit/phase2_hardening_closeout_58.py
@@ -400,7 +400,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day58_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase2_hardening_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_phase2_hardening_closeout_summary(root)
 

--- a/src/sdetkit/phase2_kickoff_31.py
+++ b/src/sdetkit/phase2_kickoff_31.py
@@ -144,7 +144,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day31_phase2_kickoff_summary(
+def build_phase2_kickoff_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -493,7 +493,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY31_DEFAULT_PAGE)
 
-    payload = build_day31_phase2_kickoff_summary(root)
+    payload = build_phase2_kickoff_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -536,7 +536,7 @@ def build_phase2_kickoff_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day31_phase2_kickoff_summary(
+    return build_phase2_kickoff_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/phase2_wrap_handoff_closeout_60.py
+++ b/src/sdetkit/phase2_wrap_handoff_closeout_60.py
@@ -395,7 +395,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day60_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase2_wrap_handoff_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_phase2_wrap_handoff_closeout_summary(root)
 

--- a/src/sdetkit/phase3_kickoff_closeout_61.py
+++ b/src/sdetkit/phase3_kickoff_closeout_61.py
@@ -393,7 +393,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day61_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase3_kickoff_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_phase3_kickoff_closeout_summary(root)
 

--- a/src/sdetkit/phase3_preplan_closeout_59.py
+++ b/src/sdetkit/phase3_preplan_closeout_59.py
@@ -390,7 +390,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day59_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase3_preplan_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_phase3_preplan_closeout_summary(root)
 

--- a/src/sdetkit/phase3_wrap_publication_closeout_90.py
+++ b/src/sdetkit/phase3_wrap_publication_closeout_90.py
@@ -420,7 +420,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day90_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]:
+def build_phase3_wrap_publication_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_phase3_wrap_publication_closeout_summary(root)
 

--- a/src/sdetkit/playbook_post_39.py
+++ b/src/sdetkit/playbook_post_39.py
@@ -156,7 +156,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day39_playbook_post_summary(
+def build_playbook_post_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -524,7 +524,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY39_DEFAULT_PAGE)
 
-    payload = build_day39_playbook_post_summary(root)
+    payload = build_playbook_post_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -567,7 +567,7 @@ def build_playbook_post_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day39_playbook_post_summary(
+    return build_playbook_post_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/release_cadence_32.py
+++ b/src/sdetkit/release_cadence_32.py
@@ -156,7 +156,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day32_release_cadence_summary(
+def build_release_cadence_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -205,19 +205,19 @@ def build_day32_release_cadence_summary(
             "evidence": {"missing_commands": missing_commands},
         },
         {
-            "check_id": "readme_day32_link",
+            "check_id": "readme_release_cadence_link",
             "weight": 8,
             "passed": "docs/integrations-release-cadence.md" in readme_text,
             "evidence": "docs/integrations-release-cadence.md",
         },
         {
-            "check_id": "readme_day32_command",
+            "check_id": "readme_release_cadence_command",
             "weight": 4,
             "passed": "release-cadence" in readme_text,
             "evidence": "release-cadence",
         },
         {
-            "check_id": "docs_index_day32_links",
+            "check_id": "docs_index_release_cadence_links",
             "weight": 8,
             "passed": (
                 "impact-32-ultra-upgrade-report.md" in docs_index_text
@@ -226,7 +226,7 @@ def build_day32_release_cadence_summary(
             "evidence": "impact-32-ultra-upgrade-report.md + integrations-release-cadence.md",
         },
         {
-            "check_id": "top10_day32_alignment",
+            "check_id": "top10_release_cadence_alignment",
             "weight": 5,
             "passed": (
                 "Day 32 \u2014 Release cadence setup" in top10_text
@@ -511,7 +511,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY32_DEFAULT_PAGE)
 
-    payload = build_day32_release_cadence_summary(root)
+    payload = build_release_cadence_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -554,7 +554,7 @@ def build_release_cadence_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day32_release_cadence_summary(
+    return build_release_cadence_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/release_prioritization_closeout_85.py
+++ b/src/sdetkit/release_prioritization_closeout_85.py
@@ -414,7 +414,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day85_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_release_prioritization_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_release_prioritization_closeout_summary(root)
 

--- a/src/sdetkit/reliability_closeout_47.py
+++ b/src/sdetkit/reliability_closeout_47.py
@@ -478,7 +478,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day47_reliability_closeout_summary(root: Path) -> dict[str, Any]:
+def build_reliability_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_reliability_closeout_summary(root)
 

--- a/src/sdetkit/scale_closeout_44.py
+++ b/src/sdetkit/scale_closeout_44.py
@@ -467,7 +467,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day44_scale_closeout_summary(root: Path) -> dict[str, Any]:
+def build_scale_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_scale_closeout_summary(root)
 

--- a/src/sdetkit/scale_lane_40.py
+++ b/src/sdetkit/scale_lane_40.py
@@ -156,7 +156,7 @@ def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
     return [line for line in lines if line not in text]
 
 
-def build_day40_scale_lane_summary(
+def build_scale_lane_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -522,7 +522,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY40_DEFAULT_PAGE)
 
-    payload = build_day40_scale_lane_summary(root)
+    payload = build_scale_lane_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -565,7 +565,7 @@ def build_scale_lane_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day40_scale_lane_summary(
+    return build_scale_lane_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/scale_upgrade_closeout_79.py
+++ b/src/sdetkit/scale_upgrade_closeout_79.py
@@ -404,7 +404,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day79_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
+def build_scale_upgrade_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_scale_upgrade_closeout_summary(root)
 

--- a/src/sdetkit/stabilization_closeout_56.py
+++ b/src/sdetkit/stabilization_closeout_56.py
@@ -404,7 +404,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day56_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
+def build_stabilization_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_stabilization_closeout_summary(root)
 

--- a/src/sdetkit/trust_assets_refresh_closeout_75.py
+++ b/src/sdetkit/trust_assets_refresh_closeout_75.py
@@ -412,7 +412,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day75_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, Any]:
+def build_trust_assets_refresh_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_trust_assets_refresh_closeout_summary(root)
 

--- a/src/sdetkit/trust_faq_expansion_closeout_83.py
+++ b/src/sdetkit/trust_faq_expansion_closeout_83.py
@@ -419,7 +419,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day83_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
+def build_trust_faq_expansion_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_trust_faq_expansion_closeout_summary(root)
 

--- a/src/sdetkit/weekly_review_28.py
+++ b/src/sdetkit/weekly_review_28.py
@@ -87,7 +87,7 @@ def _load_score(path: Path) -> tuple[float, bool]:
     return 0.0, False
 
 
-def build_day28_weekly_review_summary(
+def build_weekly_review_summary_impl(
     root: Path,
     *,
     readme_path: str = "README.md",
@@ -400,7 +400,7 @@ def main(argv: list[str] | None = None) -> int:
         if not page.exists():
             _write(page, _DAY28_DEFAULT_PAGE)
 
-    payload = build_day28_weekly_review_summary(root)
+    payload = build_weekly_review_summary_impl(root)
 
     if ns.emit_pack_dir:
         _emit_pack(root, payload, Path(ns.emit_pack_dir))
@@ -443,7 +443,7 @@ def build_weekly_review_summary(
     top10_path: str = _TOP10_PATH,
 ) -> dict[str, Any]:
     """Canonical summary builder (day-based name retained as compatibility alias)."""
-    return build_day28_weekly_review_summary(
+    return build_weekly_review_summary_impl(
         root,
         readme_path=readme_path,
         docs_index_path=docs_index_path,

--- a/src/sdetkit/weekly_review_closeout_49.py
+++ b/src/sdetkit/weekly_review_closeout_49.py
@@ -499,7 +499,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_day49_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
+def build_weekly_review_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_weekly_review_closeout_summary(root)
 

--- a/src/sdetkit/weekly_review_closeout_65.py
+++ b/src/sdetkit/weekly_review_closeout_65.py
@@ -414,7 +414,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
     )
 
 
-def build_day65_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
+def build_weekly_review_closeout_summary_impl(root: Path) -> dict[str, Any]:
     """Compatibility alias for legacy day-based builder name."""
     return build_weekly_review_closeout_summary(root)
 

--- a/tests/test_acceleration_closeout.py
+++ b/tests/test_acceleration_closeout.py
@@ -56,9 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = (
-        root / "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
-    )
+    board = root / "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
     board.write_text(
         "\n".join(
             [
@@ -75,7 +73,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day43_acceleration_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane43_acceleration_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d42.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -84,7 +82,7 @@ def test_day43_acceleration_closeout_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day43_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane43_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d42.main(
         [
@@ -101,18 +99,26 @@ def test_day43_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/acceleration-closeout-pack/acceleration-closeout-summary.md").exists()
+    assert (
+        tmp_path / "artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/acceleration-closeout-pack/acceleration-closeout-summary.md"
+    ).exists()
     assert (tmp_path / "artifacts/acceleration-closeout-pack/acceleration-plan.md").exists()
     assert (tmp_path / "artifacts/acceleration-closeout-pack/growth-matrix.csv").exists()
-    assert (tmp_path / "artifacts/acceleration-closeout-pack/acceleration-kpi-scorecard.json").exists()
+    assert (
+        tmp_path / "artifacts/acceleration-closeout-pack/acceleration-kpi-scorecard.json"
+    ).exists()
     assert (tmp_path / "artifacts/acceleration-closeout-pack/execution-log.md").exists()
     assert (tmp_path / "artifacts/acceleration-closeout-pack/delivery-board.md").exists()
     assert (tmp_path / "artifacts/acceleration-closeout-pack/validation-commands.md").exists()
-    assert (tmp_path / "artifacts/acceleration-closeout-pack/evidence/execution-summary.json").exists()
+    assert (
+        tmp_path / "artifacts/acceleration-closeout-pack/evidence/execution-summary.json"
+    ).exists()
 
 
-def test_day43_strict_fails_when_day42_inputs_missing(tmp_path: Path) -> None:
+def test_lane43_strict_fails_when_lane42_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -122,7 +128,7 @@ def test_day43_strict_fails_when_day42_inputs_missing(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day43_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane43_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["acceleration-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_case_snippet_closeout.py
+++ b/tests/test_case_snippet_closeout.py
@@ -121,7 +121,7 @@ def test_cycle51_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_cycle51_strict_fails_when_day50_inputs_missing(tmp_path: Path) -> None:
+def test_cycle51_strict_fails_when_lane50_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path

--- a/tests/test_case_study_launch_closeout.py
+++ b/tests/test_case_study_launch_closeout.py
@@ -91,7 +91,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day73_json(tmp_path: Path, capsys) -> None:
+def test_lane73_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d73.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -100,7 +100,7 @@ def test_day73_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day73_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane73_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d73.main(
         [
@@ -117,21 +117,44 @@ def test_day73_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-case-study-narrative.md").exists()
-    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-controls-log.json").exists()
-    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-execution-log.md").exists()
-    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/case-study-launch-closeout-pack/evidence/case-study-launch-execution-summary.json"
+        tmp_path
+        / "artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/case-study-launch-closeout-pack/case-study-launch-integration-brief.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/case-study-launch-closeout-pack/case-study-launch-case-study-narrative.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-controls-log.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-launch-closeout-pack/case-study-launch-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/case-study-launch-closeout-pack/case-study-launch-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/case-study-launch-closeout-pack/evidence/case-study-launch-execution-summary.json"
     ).exists()
 
 
-def test_day73_strict_fails_without_day72(tmp_path: Path) -> None:
+def test_lane73_strict_fails_without_day72(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -140,7 +163,7 @@ def test_day73_strict_fails_without_day72(tmp_path: Path) -> None:
     assert d73.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day73_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane73_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["case-study-launch-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_case_study_prep1_closeout.py
+++ b/tests/test_case_study_prep1_closeout.py
@@ -72,7 +72,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day69_json(tmp_path: Path, capsys) -> None:
+def test_lane69_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d69.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -81,7 +81,7 @@ def test_day69_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["strict_pass"] is True
 
 
-def test_day69_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane69_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d69.main(
         [
@@ -98,14 +98,19 @@ def test_day69_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/case-study-prep1-closeout-pack/case-study-prep1-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/case-study-prep1-closeout-pack/case-study-prep1-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/case-study-prep1-closeout-pack/evidence/case-study-prep1-execution-summary.json"
+        tmp_path / "artifacts/case-study-prep1-closeout-pack/case-study-prep1-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-prep1-closeout-pack/case-study-prep1-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/case-study-prep1-closeout-pack/evidence/case-study-prep1-execution-summary.json"
     ).exists()
 
 
-def test_day69_strict_fails_without_day68_summary(tmp_path: Path) -> None:
+def test_lane69_strict_fails_without_lane68_summary(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -114,7 +119,7 @@ def test_day69_strict_fails_without_day68_summary(tmp_path: Path) -> None:
     assert d69.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day69_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane69_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["case-study-prep1-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_case_study_prep2_closeout.py
+++ b/tests/test_case_study_prep2_closeout.py
@@ -61,7 +61,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day70_json(tmp_path: Path, capsys) -> None:
+def test_lane70_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d70.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -70,7 +70,7 @@ def test_day70_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["strict_pass"] is True
 
 
-def test_day70_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane70_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d70.main(
         [
@@ -87,14 +87,19 @@ def test_day70_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/case-study-prep2-closeout-pack/case-study-prep2-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/case-study-prep2-closeout-pack/case-study-prep2-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/case-study-prep2-closeout-pack/evidence/case-study-prep2-execution-summary.json"
+        tmp_path / "artifacts/case-study-prep2-closeout-pack/case-study-prep2-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-prep2-closeout-pack/case-study-prep2-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/case-study-prep2-closeout-pack/evidence/case-study-prep2-execution-summary.json"
     ).exists()
 
 
-def test_day70_strict_fails_without_day69_summary(tmp_path: Path) -> None:
+def test_lane70_strict_fails_without_lane69_summary(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -103,7 +108,7 @@ def test_day70_strict_fails_without_day69_summary(tmp_path: Path) -> None:
     assert d70.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day70_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane70_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["case-study-prep2-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_case_study_prep3_closeout.py
+++ b/tests/test_case_study_prep3_closeout.py
@@ -89,7 +89,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day71_json(tmp_path: Path, capsys) -> None:
+def test_lane71_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d71.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -98,7 +98,7 @@ def test_day71_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day71_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane71_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d71.main(
         [
@@ -146,7 +146,7 @@ def test_day71_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day71_strict_fails_without_day70(tmp_path: Path) -> None:
+def test_lane71_strict_fails_without_day70(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -155,7 +155,7 @@ def test_day71_strict_fails_without_day70(tmp_path: Path) -> None:
     assert d71.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day71_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane71_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["case-study-prep3-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_case_study_prep4_closeout.py
+++ b/tests/test_case_study_prep4_closeout.py
@@ -89,7 +89,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day72_json(tmp_path: Path, capsys) -> None:
+def test_lane72_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d72.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -98,7 +98,7 @@ def test_day72_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day72_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane72_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d72.main(
         [
@@ -115,21 +115,42 @@ def test_day72_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-case-study-narrative.md").exists()
-    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-controls-log.json").exists()
-    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-execution-log.md").exists()
-    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/case-study-prep4-closeout-pack/evidence/case-study-prep4-execution-summary.json"
+        tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-integration-brief.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-case-study-narrative.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-controls-log.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/case-study-prep4-closeout-pack/case-study-prep4-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/case-study-prep4-closeout-pack/evidence/case-study-prep4-execution-summary.json"
     ).exists()
 
 
-def test_day72_strict_fails_without_day71(tmp_path: Path) -> None:
+def test_lane72_strict_fails_without_day71(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -138,7 +159,7 @@ def test_day72_strict_fails_without_day71(tmp_path: Path) -> None:
     assert d72.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day72_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane72_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["case-study-prep4-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_community_program_closeout.py
+++ b/tests/test_community_program_closeout.py
@@ -72,7 +72,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day62_json(tmp_path: Path, capsys) -> None:
+def test_lane62_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d62.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -81,7 +81,7 @@ def test_day62_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day62_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane62_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d62.main(
         [
@@ -98,22 +98,49 @@ def test_day62_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-community-launch-brief.md").exists()
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-office-hours-cadence.md").exists()
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-participation-policy.md").exists()
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-moderation-runbook.md").exists()
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-execution-log.md").exists()
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/community-program-closeout-pack/community-program-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/community-program-closeout-pack/evidence/community-program-execution-summary.json"
+        tmp_path
+        / "artifacts/community-program-closeout-pack/community-program-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/community-program-closeout-pack/community-program-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/community-program-closeout-pack/community-program-community-launch-brief.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/community-program-closeout-pack/community-program-office-hours-cadence.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/community-program-closeout-pack/community-program-participation-policy.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/community-program-closeout-pack/community-program-moderation-runbook.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/community-program-closeout-pack/community-program-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/community-program-closeout-pack/community-program-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/community-program-closeout-pack/community-program-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/community-program-closeout-pack/community-program-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/community-program-closeout-pack/evidence/community-program-execution-summary.json"
     ).exists()
 
 
-def test_day62_strict_fails_without_day61(tmp_path: Path) -> None:
+def test_lane62_strict_fails_without_day61(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -122,12 +149,10 @@ def test_day62_strict_fails_without_day61(tmp_path: Path) -> None:
     assert d62.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day62_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane62_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["community-program-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    alias_rc = cli.main(
-        ["community-program-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    alias_rc = cli.main(["community-program-closeout", "--root", str(tmp_path), "--format", "text"])
     assert alias_rc == 0
     assert "Community Program Closeout summary" in capsys.readouterr().out

--- a/tests/test_community_touchpoint_closeout.py
+++ b/tests/test_community_touchpoint_closeout.py
@@ -91,7 +91,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day77_json(tmp_path: Path, capsys) -> None:
+def test_lane77_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d77.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -100,7 +100,7 @@ def test_day77_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day77_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane77_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d77.main(
         [
@@ -148,7 +148,7 @@ def test_day77_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day77_strict_fails_without_day76(tmp_path: Path) -> None:
+def test_lane77_strict_fails_without_day76(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -157,7 +157,7 @@ def test_day77_strict_fails_without_day76(tmp_path: Path) -> None:
     assert d77.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day77_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane77_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["community-touchpoint-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_contributor_activation_closeout.py
+++ b/tests/test_contributor_activation_closeout.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day55_json(tmp_path: Path, capsys) -> None:
+def test_lane55_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d55.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day55_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day55_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane55_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d55.main(
         [
@@ -96,31 +96,50 @@ def test_day55_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-brief.md").exists()
-    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-ladder.csv").exists()
-    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-execution-log.md").exists()
-    assert (tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-validation-commands.md"
+        tmp_path
+        / "artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json"
     ).exists()
     assert (
-        tmp_path / "artifacts/contributor-activation-closeout-pack/evidence/contributor-activation-execution-summary.json"
+        tmp_path
+        / "artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-activation-brief.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/contributor-activation-closeout-pack/contributor-ladder.csv"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/contributor-activation-closeout-pack/contributor-activation-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/contributor-activation-closeout-pack/contributor-activation-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/contributor-activation-closeout-pack/contributor-activation-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/contributor-activation-closeout-pack/contributor-activation-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/contributor-activation-closeout-pack/evidence/contributor-activation-execution-summary.json"
     ).exists()
 
 
-def test_day55_strict_fails_without_day53(tmp_path: Path) -> None:
+def test_lane55_strict_fails_without_day53(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json").unlink()
     assert d55.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day55_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane55_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["contributor-activation-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["contributor-activation-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Contributor Activation Closeout summary" in capsys.readouterr().out

--- a/tests/test_contributor_funnel.py
+++ b/tests/test_contributor_funnel.py
@@ -8,7 +8,7 @@ import pytest
 from sdetkit import contributor_funnel
 
 
-def test_day8_backlog_has_ten_curated_issues() -> None:
+def test_lane8_backlog_has_ten_curated_issues() -> None:
     payload = json.loads(contributor_funnel._render_json(contributor_funnel.build_backlog()))
     assert payload["name"] == "contributor-funnel"
     assert payload["kpis"]["issue_count"] == 10

--- a/tests/test_contributor_recognition_closeout.py
+++ b/tests/test_contributor_recognition_closeout.py
@@ -63,7 +63,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day76_json(tmp_path: Path, capsys) -> None:
+def test_lane76_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d76.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -72,7 +72,7 @@ def test_day76_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["strict_pass"] is True
 
 
-def test_day76_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane76_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d76.main(
         [
@@ -90,15 +90,20 @@ def test_day76_emit_pack_and_execute(tmp_path: Path) -> None:
     )
     assert rc == 0
     assert (
-        tmp_path / "artifacts/contributor-recognition-closeout-pack/contributor-recognition-closeout-summary.json"
+        tmp_path
+        / "artifacts/contributor-recognition-closeout-pack/contributor-recognition-closeout-summary.json"
     ).exists()
-    assert (tmp_path / "artifacts/contributor-recognition-closeout-pack/contributor-recognition-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/contributor-recognition-closeout-pack/evidence/contributor-recognition-execution-summary.json"
+        tmp_path
+        / "artifacts/contributor-recognition-closeout-pack/contributor-recognition-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/contributor-recognition-closeout-pack/evidence/contributor-recognition-execution-summary.json"
     ).exists()
 
 
-def test_day76_strict_fails_without_day75_summary(tmp_path: Path) -> None:
+def test_lane76_strict_fails_without_lane75_summary(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -107,7 +112,7 @@ def test_day76_strict_fails_without_day75_summary(tmp_path: Path) -> None:
     assert d76.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day76_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane76_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["contributor-recognition-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_demo_asset.py
+++ b/tests/test_demo_asset.py
@@ -68,7 +68,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day33_demo_asset_json(tmp_path: Path, capsys) -> None:
+def test_demo_asset_demo_asset_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d33.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -77,7 +77,7 @@ def test_day33_demo_asset_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day33_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_demo_asset_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d33.main(
         [
@@ -103,14 +103,14 @@ def test_day33_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/demo-asset-pack/evidence/demo-execution-summary.json").exists()
 
 
-def test_day33_strict_fails_when_day32_inputs_missing(tmp_path: Path) -> None:
+def test_demo_asset_strict_fails_when_lane32_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/release-cadence-pack/release-cadence-summary.json").unlink()
     rc = d33.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day33_strict_fails_when_day32_board_is_not_ready(tmp_path: Path) -> None:
+def test_demo_asset_strict_fails_when_lane32_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/release-cadence-pack/release-delivery-board.md").write_text(
         "- [ ] Day 33 demo asset #1 scope frozen\n", encoding="utf-8"
@@ -119,7 +119,7 @@ def test_day33_strict_fails_when_day32_board_is_not_ready(tmp_path: Path) -> Non
     assert rc == 1
 
 
-def test_day33_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_demo_asset_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["demo-asset", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_demo_asset2.py
+++ b/tests/test_demo_asset2.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day34_demo_asset2_json(tmp_path: Path, capsys) -> None:
+def test_lane34_demo_asset2_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d34.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day34_demo_asset2_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day34_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane34_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d34.main(
         [
@@ -107,14 +107,14 @@ def test_day34_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day34_strict_fails_when_day33_inputs_missing(tmp_path: Path) -> None:
+def test_lane34_strict_fails_when_lane33_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/demo-asset-pack/demo-asset-summary.json").unlink()
     rc = d34.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day34_strict_fails_when_day33_board_is_not_ready(tmp_path: Path) -> None:
+def test_lane34_strict_fails_when_lane33_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/demo-asset-pack/demo-delivery-board.md").write_text(
         "- [ ] Day 34 demo asset #2 backlog pre-scoped\n", encoding="utf-8"
@@ -123,7 +123,7 @@ def test_day34_strict_fails_when_day33_board_is_not_ready(tmp_path: Path) -> Non
     assert rc == 1
 
 
-def test_day34_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane34_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["demo-asset2", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_distribution_batch.py
+++ b/tests/test_distribution_batch.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day38_distribution_json(tmp_path: Path, capsys) -> None:
+def test_distribution_batch_distribution_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d38.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day38_distribution_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day38_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_distribution_batch_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d38.main(
         [
@@ -107,14 +107,14 @@ def test_day38_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/distribution-batch-pack/evidence/execution-summary.json").exists()
 
 
-def test_day38_strict_fails_when_day37_inputs_missing(tmp_path: Path) -> None:
+def test_distribution_batch_strict_fails_when_lane37_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/experiment-lane-pack/experiment-lane-summary.json").unlink()
     rc = d38.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day38_strict_fails_when_day37_board_is_not_ready(tmp_path: Path) -> None:
+def test_distribution_batch_strict_fails_when_lane37_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/experiment-lane-pack/delivery-board.md").write_text(
         "- [ ] Day 38 distribution batch actions selected from winners\n", encoding="utf-8"
@@ -123,7 +123,7 @@ def test_day38_strict_fails_when_day37_board_is_not_ready(tmp_path: Path) -> Non
     assert rc == 1
 
 
-def test_day38_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_distribution_batch_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["distribution-batch", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_distribution_closeout.py
+++ b/tests/test_distribution_closeout.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day36_distribution_json(tmp_path: Path, capsys) -> None:
+def test_lane36_distribution_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d36.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day36_distribution_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day36_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane36_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d36.main(
         [
@@ -112,14 +112,14 @@ def test_day36_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day36_strict_fails_when_day35_inputs_missing(tmp_path: Path) -> None:
+def test_lane36_strict_fails_when_lane35_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/kpi-instrumentation-pack/kpi-instrumentation-summary.json").unlink()
     rc = d36.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day36_strict_fails_when_day35_board_is_not_ready(tmp_path: Path) -> None:
+def test_lane36_strict_fails_when_lane35_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/kpi-instrumentation-pack/delivery-board.md").write_text(
         "- [ ] Day 36 distribution message references KPI shifts\n", encoding="utf-8"
@@ -128,7 +128,7 @@ def test_day36_strict_fails_when_day35_board_is_not_ready(tmp_path: Path) -> Non
     assert rc == 1
 
 
-def test_day36_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane36_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["distribution-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_distribution_scaling_closeout.py
+++ b/tests/test_distribution_scaling_closeout.py
@@ -91,7 +91,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day74_json(tmp_path: Path, capsys) -> None:
+def test_lane74_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d74.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -100,7 +100,7 @@ def test_day74_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day74_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane74_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d74.main(
         [
@@ -117,23 +117,48 @@ def test_day74_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-plan.md").exists()
     assert (
-        tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-channel-controls-log.json"
+        tmp_path
+        / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.json"
     ).exists()
-    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-execution-log.md").exists()
-    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/distribution-scaling-closeout-pack/evidence/distribution-scaling-execution-summary.json"
+        tmp_path
+        / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-integration-brief.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-plan.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-channel-controls-log.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/distribution-scaling-closeout-pack/distribution-scaling-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/distribution-scaling-closeout-pack/evidence/distribution-scaling-execution-summary.json"
     ).exists()
 
 
-def test_day74_strict_fails_without_day73(tmp_path: Path) -> None:
+def test_lane74_strict_fails_without_day73(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -142,7 +167,7 @@ def test_day74_strict_fails_without_day73(tmp_path: Path) -> None:
     assert d74.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day74_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane74_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["distribution-scaling-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_docs_loop_closeout.py
+++ b/tests/test_docs_loop_closeout.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day53_docs_loop_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane53_docs_loop_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d53.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day53_docs_loop_closeout_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day53_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane53_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d53.main(
         [
@@ -103,18 +103,22 @@ def test_day53_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-kpi-scorecard.json").exists()
     assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-execution-log.md").exists()
     assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/docs-loop-closeout-pack/evidence/docs-loop-execution-summary.json").exists()
+    assert (
+        tmp_path / "artifacts/docs-loop-closeout-pack/docs-loop-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/docs-loop-closeout-pack/evidence/docs-loop-execution-summary.json"
+    ).exists()
 
 
-def test_day53_strict_fails_when_day52_inputs_missing(tmp_path: Path) -> None:
+def test_lane53_strict_fails_when_lane52_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/narrative-closeout-pack/narrative-closeout-summary.json").unlink()
     rc = d53.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day53_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane53_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["docs-loop-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_ecosystem_priorities_closeout.py
+++ b/tests/test_ecosystem_priorities_closeout.py
@@ -66,7 +66,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day78_json(tmp_path: Path, capsys) -> None:
+def test_lane78_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d78.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -75,7 +75,7 @@ def test_day78_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["strict_pass"] is True
 
 
-def test_day78_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane78_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d78.main(
         [
@@ -116,7 +116,7 @@ def test_day78_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day78_strict_fails_without_day77_summary(tmp_path: Path) -> None:
+def test_lane78_strict_fails_without_lane77_summary(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -125,7 +125,7 @@ def test_day78_strict_fails_without_day77_summary(tmp_path: Path) -> None:
     assert d78.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day78_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane78_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["ecosystem-priorities-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_evidence_narrative_closeout.py
+++ b/tests/test_evidence_narrative_closeout.py
@@ -92,7 +92,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day84_json(tmp_path: Path, capsys) -> None:
+def test_lane84_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d84.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -101,7 +101,7 @@ def test_day84_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day84_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane84_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d84.main(
         [
@@ -155,7 +155,7 @@ def test_day84_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day84_strict_fails_without_day83(tmp_path: Path) -> None:
+def test_lane84_strict_fails_without_day83(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -164,7 +164,7 @@ def test_day84_strict_fails_without_day83(tmp_path: Path) -> None:
     assert d84.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day84_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane84_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["evidence-narrative-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_execution_prioritization_closeout.py
+++ b/tests/test_execution_prioritization_closeout.py
@@ -56,9 +56,7 @@ def _seed_repo(root: Path) -> None:
         ),
         encoding="utf-8",
     )
-    board = (
-        root / "docs/artifacts/weekly-review-closeout-pack-49/delivery-board-49.md"
-    )
+    board = root / "docs/artifacts/weekly-review-closeout-pack-49/delivery-board-49.md"
     board.write_text(
         "\n".join(
             [
@@ -75,7 +73,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day50_execution_prioritization_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane50_execution_prioritization_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d50.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -84,7 +82,7 @@ def test_day50_execution_prioritization_closeout_json(tmp_path: Path, capsys) ->
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day50_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane50_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d50.main(
         [
@@ -118,7 +116,7 @@ def test_day50_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day50_strict_fails_when_day49_inputs_missing(tmp_path: Path) -> None:
+def test_lane50_strict_fails_when_lane49_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -128,7 +126,7 @@ def test_day50_strict_fails_when_day49_inputs_missing(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day50_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane50_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(
         ["execution-prioritization-closeout", "--root", str(tmp_path), "--format", "text"]

--- a/tests/test_expansion_automation.py
+++ b/tests/test_expansion_automation.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day41_expansion_automation_json(tmp_path: Path, capsys) -> None:
+def test_lane41_expansion_automation_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d41.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day41_expansion_automation_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day41_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane41_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d41.main(
         [
@@ -96,25 +96,31 @@ def test_day41_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/expansion-automation-pack/expansion-automation-summary.json").exists()
-    assert (tmp_path / "artifacts/expansion-automation-pack/expansion-automation-summary.md").exists()
+    assert (
+        tmp_path / "artifacts/expansion-automation-pack/expansion-automation-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/expansion-automation-pack/expansion-automation-summary.md"
+    ).exists()
     assert (tmp_path / "artifacts/expansion-automation-pack/expansion-plan.md").exists()
     assert (tmp_path / "artifacts/expansion-automation-pack/automation-matrix.csv").exists()
     assert (tmp_path / "artifacts/expansion-automation-pack/expansion-kpi-scorecard.json").exists()
     assert (tmp_path / "artifacts/expansion-automation-pack/execution-log.md").exists()
     assert (tmp_path / "artifacts/expansion-automation-pack/delivery-board.md").exists()
     assert (tmp_path / "artifacts/expansion-automation-pack/validation-commands.md").exists()
-    assert (tmp_path / "artifacts/expansion-automation-pack/evidence/execution-summary.json").exists()
+    assert (
+        tmp_path / "artifacts/expansion-automation-pack/evidence/execution-summary.json"
+    ).exists()
 
 
-def test_day41_strict_fails_when_day40_inputs_missing(tmp_path: Path) -> None:
+def test_lane41_strict_fails_when_lane40_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/scale-lane-pack/scale-lane-summary.json").unlink()
     rc = d41.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day41_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane41_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["expansion-automation", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_expansion_closeout.py
+++ b/tests/test_expansion_closeout.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day45_expansion_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane45_expansion_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d45.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day45_expansion_closeout_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day45_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane45_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d45.main(
         [
@@ -96,25 +96,33 @@ def test_day45_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-closeout-summary.md").exists()
+    assert (
+        tmp_path / "artifacts/expansion-closeout-pack-45/expansion-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/expansion-closeout-pack-45/expansion-closeout-summary.md"
+    ).exists()
     assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-plan.md").exists()
     assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-growth-matrix.csv").exists()
     assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-kpi-scorecard.json").exists()
     assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-execution-log.md").exists()
     assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/expansion-closeout-pack-45/expansion-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/expansion-closeout-pack-45/evidence/expansion-execution-summary.json").exists()
+    assert (
+        tmp_path / "artifacts/expansion-closeout-pack-45/expansion-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/expansion-closeout-pack-45/evidence/expansion-execution-summary.json"
+    ).exists()
 
 
-def test_day45_strict_fails_when_day44_inputs_missing(tmp_path: Path) -> None:
+def test_lane45_strict_fails_when_lane44_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/scale-closeout-pack/scale-closeout-summary.json").unlink()
     rc = d45.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day45_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane45_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["expansion-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_experiment_lane.py
+++ b/tests/test_experiment_lane.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day37_distribution_json(tmp_path: Path, capsys) -> None:
+def test_lane37_distribution_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d37.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day37_distribution_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day37_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane37_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d37.main(
         [
@@ -107,7 +107,7 @@ def test_day37_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/experiment-lane-pack/evidence/execution-summary.json").exists()
 
 
-def test_day37_strict_fails_when_day36_inputs_missing(tmp_path: Path) -> None:
+def test_lane37_strict_fails_when_lane36_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path / "docs/artifacts/distribution-closeout-pack/distribution-closeout-summary.json"
@@ -116,7 +116,7 @@ def test_day37_strict_fails_when_day36_inputs_missing(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day37_strict_fails_when_day36_board_is_not_ready(tmp_path: Path) -> None:
+def test_lane37_strict_fails_when_lane36_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/distribution-closeout-pack/delivery-board.md").write_text(
         "- [ ] Day 37 experiment backlog seeded from channel misses\n", encoding="utf-8"
@@ -125,7 +125,7 @@ def test_day37_strict_fails_when_day36_board_is_not_ready(tmp_path: Path) -> Non
     assert rc == 1
 
 
-def test_day37_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane37_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["experiment-lane", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_gate_release.py
+++ b/tests/test_gate_release.py
@@ -97,7 +97,7 @@ def test_gate_release_passes_named_playbooks(monkeypatch, tmp_path: Path, capsys
             "--playbook-name",
             "weekly-review-lane",
             "--playbook-name",
-            "day29-phase1-hardening",
+            "legacy-phase1-hardening",
         ]
     )
     assert rc == 0
@@ -108,7 +108,7 @@ def test_gate_release_passes_named_playbooks(monkeypatch, tmp_path: Path, capsys
         "--name",
         "weekly-review-lane",
         "--name",
-        "day29-phase1-hardening",
+        "legacy-phase1-hardening",
         "--format",
         "json",
     ]

--- a/tests/test_governance_handoff_closeout.py
+++ b/tests/test_governance_handoff_closeout.py
@@ -91,7 +91,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day87_json(tmp_path: Path, capsys) -> None:
+def test_lane87_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d87.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -100,7 +100,7 @@ def test_day87_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day87_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane87_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d87.main(
         [
@@ -154,7 +154,7 @@ def test_day87_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day87_strict_fails_without_day86(tmp_path: Path) -> None:
+def test_lane87_strict_fails_without_day86(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -163,7 +163,7 @@ def test_day87_strict_fails_without_day86(tmp_path: Path) -> None:
     assert d87.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day87_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane87_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["governance-handoff-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_governance_priorities_closeout.py
+++ b/tests/test_governance_priorities_closeout.py
@@ -92,7 +92,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day88_json(tmp_path: Path, capsys) -> None:
+def test_lane88_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d88.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -101,7 +101,7 @@ def test_day88_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day88_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane88_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d88.main(
         [
@@ -159,7 +159,7 @@ def test_day88_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day88_strict_fails_without_day87(tmp_path: Path) -> None:
+def test_lane88_strict_fails_without_day87(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -168,7 +168,7 @@ def test_day88_strict_fails_without_day87(tmp_path: Path) -> None:
     assert d88.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day88_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane88_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["governance-priorities-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_governance_scale_closeout.py
+++ b/tests/test_governance_scale_closeout.py
@@ -92,7 +92,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day89_json(tmp_path: Path, capsys) -> None:
+def test_lane89_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d89.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -101,7 +101,7 @@ def test_day89_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day89_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane89_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d89.main(
         [
@@ -151,7 +151,7 @@ def test_day89_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day89_strict_fails_without_day88(tmp_path: Path) -> None:
+def test_lane89_strict_fails_without_day88(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -160,7 +160,7 @@ def test_day89_strict_fails_without_day88(tmp_path: Path) -> None:
     assert d89.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day89_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane89_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["governance-scale-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_growth_campaign_closeout.py
+++ b/tests/test_growth_campaign_closeout.py
@@ -91,7 +91,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day81_json(tmp_path: Path, capsys) -> None:
+def test_lane81_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d81.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -100,7 +100,7 @@ def test_day81_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day81_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane81_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d81.main(
         [
@@ -143,7 +143,7 @@ def test_day81_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day81_strict_fails_without_day80(tmp_path: Path) -> None:
+def test_lane81_strict_fails_without_day80(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -152,7 +152,7 @@ def test_day81_strict_fails_without_day80(tmp_path: Path) -> None:
     assert d81.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day81_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane81_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["growth-campaign-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_integration_expansion2_closeout.py
+++ b/tests/test_integration_expansion2_closeout.py
@@ -96,7 +96,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day66_json(tmp_path: Path, capsys) -> None:
+def test_lane66_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d66.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -105,7 +105,7 @@ def test_day66_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day66_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane66_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d66.main(
         [
@@ -122,23 +122,49 @@ def test_day66_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-pipeline-blueprint.md").exists()
-    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-matrix-plan.json").exists()
-    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-execution-log.md").exists()
-    assert (tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-validation-commands.md"
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json"
     ).exists()
     assert (
-        tmp_path / "artifacts/integration-expansion2-closeout-pack/evidence/integration-expansion2-execution-summary.json"
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-integration-brief.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-pipeline-blueprint.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-matrix-plan.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/integration-expansion2-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion2-closeout-pack/evidence/integration-expansion2-execution-summary.json"
     ).exists()
 
 
-def test_day66_strict_fails_without_day65(tmp_path: Path) -> None:
+def test_lane66_strict_fails_without_day65(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -147,10 +173,8 @@ def test_day66_strict_fails_without_day65(tmp_path: Path) -> None:
     assert d66.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day66_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane66_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["integration-expansion2-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["integration-expansion2-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Integration Expansion 2 Closeout summary" in capsys.readouterr().out

--- a/tests/test_integration_expansion3_closeout.py
+++ b/tests/test_integration_expansion3_closeout.py
@@ -101,7 +101,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day67_json(tmp_path: Path, capsys) -> None:
+def test_lane67_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d67.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -110,7 +110,7 @@ def test_day67_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day67_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane67_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d67.main(
         [
@@ -127,23 +127,49 @@ def test_day67_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-jenkins-blueprint.md").exists()
-    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-matrix-plan.json").exists()
-    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-execution-log.md").exists()
-    assert (tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-validation-commands.md"
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json"
     ).exists()
     assert (
-        tmp_path / "artifacts/integration-expansion3-closeout-pack/evidence/integration-expansion3-execution-summary.json"
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-integration-brief.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-jenkins-blueprint.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-matrix-plan.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/integration-expansion3-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion3-closeout-pack/evidence/integration-expansion3-execution-summary.json"
     ).exists()
 
 
-def test_day67_strict_fails_without_day66(tmp_path: Path) -> None:
+def test_lane67_strict_fails_without_day66(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -152,10 +178,8 @@ def test_day67_strict_fails_without_day66(tmp_path: Path) -> None:
     assert d67.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day67_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane67_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["integration-expansion3-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["integration-expansion3-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Integration Expansion3 Closeout summary" in capsys.readouterr().out

--- a/tests/test_integration_expansion4_closeout.py
+++ b/tests/test_integration_expansion4_closeout.py
@@ -67,7 +67,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day68_json_strict(tmp_path: Path, capsys) -> None:
+def test_lane68_json_strict(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d68.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -76,7 +76,7 @@ def test_day68_json_strict(tmp_path: Path, capsys) -> None:
     assert payload["summary"]["activation_score"] >= 95
 
 
-def test_day68_emit_and_execute(tmp_path: Path) -> None:
+def test_lane68_emit_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d68.main(
         [
@@ -93,19 +93,33 @@ def test_day68_emit_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-integration-brief.md").exists()
     assert (
-        tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-self-hosted-blueprint.md"
+        tmp_path
+        / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.json"
     ).exists()
-    assert (tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-policy-plan.json").exists()
-    assert (tmp_path / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-kpi-scorecard.json").exists()
     assert (
-        tmp_path / "artifacts/integration-expansion4-closeout-pack/evidence/integration-expansion4-execution-summary.json"
+        tmp_path
+        / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-integration-brief.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-self-hosted-blueprint.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-policy-plan.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion4-closeout-pack/integration-expansion4-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/integration-expansion4-closeout-pack/evidence/integration-expansion4-execution-summary.json"
     ).exists()
 
 
-def test_day68_strict_fails_without_day67_summary(tmp_path: Path) -> None:
+def test_lane68_strict_fails_without_lane67_summary(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -115,7 +129,7 @@ def test_day68_strict_fails_without_day67_summary(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day68_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane68_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["integration-expansion4-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_integration_feedback_closeout.py
+++ b/tests/test_integration_feedback_closeout.py
@@ -88,7 +88,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day82_json(tmp_path: Path, capsys) -> None:
+def test_lane82_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d82.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -97,7 +97,7 @@ def test_day82_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day82_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane82_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d82.main(
         [
@@ -150,7 +150,7 @@ def test_day82_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day82_strict_fails_without_day81(tmp_path: Path) -> None:
+def test_lane82_strict_fails_without_day81(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -159,7 +159,7 @@ def test_day82_strict_fails_without_day81(tmp_path: Path) -> None:
     assert d82.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day82_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane82_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["integration-feedback-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_kpi_deep_audit_closeout.py
+++ b/tests/test_kpi_deep_audit_closeout.py
@@ -72,7 +72,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day57_json(tmp_path: Path, capsys) -> None:
+def test_lane57_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d57.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -81,7 +81,7 @@ def test_day57_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day57_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane57_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d57.main(
         [
@@ -98,20 +98,35 @@ def test_day57_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-brief.md").exists()
-    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-scorecard.json").exists()
-    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-execution-log.md").exists()
-    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/kpi-deep-audit-closeout-pack/evidence/kpi-deep-audit-execution-summary.json"
+        tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.md"
+    ).exists()
+    assert (tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-brief.md").exists()
+    assert (
+        tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-risk-ledger.csv"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/kpi-deep-audit-closeout-pack/evidence/kpi-deep-audit-execution-summary.json"
     ).exists()
 
 
-def test_day57_strict_fails_without_day56(tmp_path: Path) -> None:
+def test_lane57_strict_fails_without_day56(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path / "docs/artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json"
@@ -119,7 +134,7 @@ def test_day57_strict_fails_without_day56(tmp_path: Path) -> None:
     assert d57.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day57_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane57_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["kpi-deep-audit-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_kpi_instrumentation.py
+++ b/tests/test_kpi_instrumentation.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day35_kpi_json(tmp_path: Path, capsys) -> None:
+def test_kpi_instrumentation_kpi_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d35.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day35_kpi_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day35_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_kpi_instrumentation_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d35.main(
         [
@@ -112,14 +112,14 @@ def test_day35_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day35_strict_fails_when_day34_inputs_missing(tmp_path: Path) -> None:
+def test_kpi_instrumentation_strict_fails_when_lane34_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/demo-asset2-pack/demo-asset2-summary.json").unlink()
     rc = d35.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day35_strict_fails_when_day34_board_is_not_ready(tmp_path: Path) -> None:
+def test_kpi_instrumentation_strict_fails_when_lane34_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/demo-asset2-pack/demo-asset2-delivery-board.md").write_text(
         "- [ ] Day 35 KPI instrumentation backlog pre-scoped\n", encoding="utf-8"
@@ -128,7 +128,7 @@ def test_day35_strict_fails_when_day34_board_is_not_ready(tmp_path: Path) -> Non
     assert rc == 1
 
 
-def test_day35_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_kpi_instrumentation_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["kpi-instrumentation", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_launch_readiness_closeout.py
+++ b/tests/test_launch_readiness_closeout.py
@@ -92,7 +92,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day86_json(tmp_path: Path, capsys) -> None:
+def test_lane86_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d86.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -101,7 +101,7 @@ def test_day86_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day86_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane86_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d86.main(
         [
@@ -151,7 +151,7 @@ def test_day86_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day86_strict_fails_without_day85(tmp_path: Path) -> None:
+def test_lane86_strict_fails_without_day85(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -160,7 +160,7 @@ def test_day86_strict_fails_without_day85(tmp_path: Path) -> None:
     assert d86.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day86_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane86_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["launch-readiness-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_objection_closeout.py
+++ b/tests/test_objection_closeout.py
@@ -67,7 +67,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day48_objection_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane48_objection_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d48.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -76,7 +76,7 @@ def test_day48_objection_closeout_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day48_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane48_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d48.main(
         [
@@ -101,10 +101,12 @@ def test_day48_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/objection-pack-48/execution-log-48.md").exists()
     assert (tmp_path / "artifacts/objection-pack-48/objection-delivery-board.md").exists()
     assert (tmp_path / "artifacts/objection-pack-48/validation-commands-48.md").exists()
-    assert (tmp_path / "artifacts/objection-pack-48/evidence/objection-execution-summary-48.json").exists()
+    assert (
+        tmp_path / "artifacts/objection-pack-48/evidence/objection-execution-summary-48.json"
+    ).exists()
 
 
-def test_day48_strict_fails_when_day47_inputs_missing(tmp_path: Path) -> None:
+def test_lane48_strict_fails_when_lane47_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -114,7 +116,7 @@ def test_day48_strict_fails_when_day47_inputs_missing(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day48_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane48_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["objection-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_optimization_closeout.py
+++ b/tests/test_optimization_closeout.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day46_optimization_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane46_optimization_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d46.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day46_optimization_closeout_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day46_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane46_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d46.main(
         [
@@ -96,25 +96,42 @@ def test_day46_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-closeout-summary.md").exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-pack-46/optimization-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-pack-46/optimization-closeout-summary.md"
+    ).exists()
     assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-plan.md").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-bottleneck-map.csv").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-execution-log.md").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-pack-46/optimization-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-pack-46/evidence/optimization-execution-summary.json").exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-pack-46/optimization-bottleneck-map.csv"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-pack-46/optimization-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-pack-46/optimization-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-pack-46/optimization-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-pack-46/optimization-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/optimization-closeout-pack-46/evidence/optimization-execution-summary.json"
+    ).exists()
 
 
-def test_day46_strict_fails_when_day45_inputs_missing(tmp_path: Path) -> None:
+def test_lane46_strict_fails_when_lane45_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/expansion-closeout-pack/expansion-closeout-summary.json").unlink()
     rc = d46.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day46_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane46_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["optimization-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_optimization_closeout_foundation.py
+++ b/tests/test_optimization_closeout_foundation.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day42_optimization_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane42_optimization_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d42.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day42_optimization_closeout_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day42_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane42_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d42.main(
         [
@@ -97,19 +97,33 @@ def test_day42_emit_pack_and_execute(tmp_path: Path) -> None:
     )
     assert rc == 0
     assert (
-        tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json"
+        tmp_path
+        / "artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json"
     ).exists()
-    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.md").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-plan.md").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/remediation-matrix.csv").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-kpi-scorecard.json").exists()
+    assert (
+        tmp_path
+        / "artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-plan.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-foundation-pack/remediation-matrix.csv"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-foundation-pack/optimization-kpi-scorecard.json"
+    ).exists()
     assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/execution-log.md").exists()
     assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/delivery-board.md").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/validation-commands.md").exists()
-    assert (tmp_path / "artifacts/optimization-closeout-foundation-pack/evidence/execution-summary.json").exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-foundation-pack/validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/optimization-closeout-foundation-pack/evidence/execution-summary.json"
+    ).exists()
 
 
-def test_day42_strict_fails_when_day41_inputs_missing(tmp_path: Path) -> None:
+def test_lane42_strict_fails_when_lane41_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path / "docs/artifacts/expansion-automation-pack/expansion-automation-summary.json"
@@ -118,7 +132,7 @@ def test_day42_strict_fails_when_day41_inputs_missing(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day42_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane42_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["optimization-closeout-foundation", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_partner_outreach_closeout.py
+++ b/tests/test_partner_outreach_closeout.py
@@ -86,7 +86,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day80_json(tmp_path: Path, capsys) -> None:
+def test_lane80_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d80.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -95,7 +95,7 @@ def test_day80_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day80_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane80_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d80.main(
         [
@@ -141,7 +141,7 @@ def test_day80_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day80_strict_fails_without_day79(tmp_path: Path) -> None:
+def test_lane80_strict_fails_without_day79(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path / "docs/artifacts/scale-upgrade-closeout-pack/scale-upgrade-closeout-summary.json"
@@ -149,7 +149,7 @@ def test_day80_strict_fails_without_day79(tmp_path: Path) -> None:
     assert d80.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day80_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane80_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["partner-outreach-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_phase1_hardening.py
+++ b/tests/test_phase1_hardening.py
@@ -44,7 +44,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day29_hardening_json(tmp_path: Path, capsys) -> None:
+def test_phase1_hardening_hardening_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d29.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -53,7 +53,7 @@ def test_day29_hardening_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 90
 
 
-def test_day29_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_phase1_hardening_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d29.main(
         [
@@ -73,13 +73,16 @@ def test_day29_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/phase1-hardening-pack/phase1-hardening-summary.json").exists()
     assert (tmp_path / "artifacts/phase1-hardening-pack/phase1-hardening-summary.md").exists()
     assert (tmp_path / "artifacts/phase1-hardening-pack/phase1-hardening-stale-gaps.json").exists()
-    assert (tmp_path / "artifacts/phase1-hardening-pack/phase1-hardening-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/phase1-hardening-pack/evidence/phase1-hardening-execution-summary.json"
+        tmp_path / "artifacts/phase1-hardening-pack/phase1-hardening-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase1-hardening-pack/evidence/phase1-hardening-execution-summary.json"
     ).exists()
 
 
-def test_day29_strict_fails_when_sections_missing(tmp_path: Path) -> None:
+def test_phase1_hardening_strict_fails_when_sections_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/integrations-phase1-hardening.md").write_text(
         "# Day 29 — Phase-1 hardening\n", encoding="utf-8"
@@ -88,7 +91,7 @@ def test_day29_strict_fails_when_sections_missing(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day29_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_phase1_hardening_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase1-hardening", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_phase1_wrap.py
+++ b/tests/test_phase1_wrap.py
@@ -51,7 +51,7 @@ def _seed_repo(root: Path) -> None:
         p.write_text(json.dumps({"summary": {"activation_score": 93}}, indent=2), encoding="utf-8")
 
 
-def test_day30_wrap_json(tmp_path: Path, capsys) -> None:
+def test_phase1_wrap_wrap_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d30.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -60,7 +60,7 @@ def test_day30_wrap_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 90
 
 
-def test_day30_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_phase1_wrap_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d30.main(
         [
@@ -82,17 +82,19 @@ def test_day30_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/phase1-wrap-pack/phase1-wrap-phase2-backlog.md").exists()
     assert (tmp_path / "artifacts/phase1-wrap-pack/phase1-wrap-handoff-actions.md").exists()
     assert (tmp_path / "artifacts/phase1-wrap-pack/phase1-wrap-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/phase1-wrap-pack/evidence/phase1-wrap-execution-summary.json").exists()
+    assert (
+        tmp_path / "artifacts/phase1-wrap-pack/evidence/phase1-wrap-execution-summary.json"
+    ).exists()
 
 
-def test_day30_strict_fails_when_inputs_missing(tmp_path: Path) -> None:
+def test_phase1_wrap_strict_fails_when_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/phase1-hardening-pack/phase1-hardening-summary.json").unlink()
     rc = d30.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day30_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_phase1_wrap_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase1-wrap", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_phase2_hardening_closeout.py
+++ b/tests/test_phase2_hardening_closeout.py
@@ -72,7 +72,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day58_json(tmp_path: Path, capsys) -> None:
+def test_lane58_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d58.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -81,7 +81,7 @@ def test_day58_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day58_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane58_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d58.main(
         [
@@ -98,20 +98,38 @@ def test_day58_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-brief.md").exists()
-    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-scorecard.json").exists()
-    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-execution-log.md").exists()
-    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/phase2-hardening-closeout-pack/evidence/phase2-hardening-execution-summary.json"
+        tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-brief.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-risk-ledger.csv"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase2-hardening-closeout-pack/phase2-hardening-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase2-hardening-closeout-pack/evidence/phase2-hardening-execution-summary.json"
     ).exists()
 
 
-def test_day58_strict_fails_without_day57(tmp_path: Path) -> None:
+def test_lane58_strict_fails_without_day57(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -120,7 +138,7 @@ def test_day58_strict_fails_without_day57(tmp_path: Path) -> None:
     assert d58.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day58_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane58_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase2-hardening-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_phase2_kickoff.py
+++ b/tests/test_phase2_kickoff.py
@@ -73,7 +73,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day31_kickoff_json(tmp_path: Path, capsys) -> None:
+def test_lane31_kickoff_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d31.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -82,7 +82,7 @@ def test_day31_kickoff_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day31_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane31_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d31.main(
         [
@@ -101,22 +101,26 @@ def test_day31_emit_pack_and_execute(tmp_path: Path) -> None:
     assert rc == 0
     assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-summary.json").exists()
     assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-summary.md").exists()
-    assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-baseline-snapshot.json").exists()
+    assert (
+        tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-baseline-snapshot.json"
+    ).exists()
     assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-validation-commands.md").exists()
+    assert (
+        tmp_path / "artifacts/phase2-kickoff-pack/phase2-kickoff-validation-commands.md"
+    ).exists()
     assert (
         tmp_path / "artifacts/phase2-kickoff-pack/evidence/phase2-kickoff-execution-summary.json"
     ).exists()
 
 
-def test_day31_strict_fails_when_day30_inputs_missing(tmp_path: Path) -> None:
+def test_lane31_strict_fails_when_lane30_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/phase1-wrap-pack/phase1-wrap-summary.json").unlink()
     rc = d31.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day31_strict_fails_when_backlog_is_not_phase2_ready(tmp_path: Path) -> None:
+def test_lane31_strict_fails_when_backlog_is_not_phase2_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/phase1-wrap-pack/phase1-wrap-phase2-backlog.md").write_text(
         "- [ ] Day 31 baseline\n", encoding="utf-8"
@@ -125,7 +129,7 @@ def test_day31_strict_fails_when_backlog_is_not_phase2_ready(tmp_path: Path) -> 
     assert rc == 1
 
 
-def test_day31_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane31_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase2-kickoff", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_phase2_wrap_handoff_closeout.py
+++ b/tests/test_phase2_wrap_handoff_closeout.py
@@ -72,7 +72,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day60_json(tmp_path: Path, capsys) -> None:
+def test_lane60_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d60.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -81,7 +81,7 @@ def test_day60_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day60_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane60_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d60.main(
         [
@@ -98,20 +98,43 @@ def test_day60_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-brief.md").exists()
-    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-execution-log.md").exists()
-    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/evidence/phase2-wrap-handoff-execution-summary.json"
+        tmp_path
+        / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-brief.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-risk-ledger.csv"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase2-wrap-handoff-closeout-pack/evidence/phase2-wrap-handoff-execution-summary.json"
     ).exists()
 
 
-def test_day60_strict_fails_without_day59(tmp_path: Path) -> None:
+def test_lane60_strict_fails_without_day59(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -120,10 +143,8 @@ def test_day60_strict_fails_without_day59(tmp_path: Path) -> None:
     assert d60.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day60_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane60_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["phase2-wrap-handoff-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    rc = cli.main(["phase2-wrap-handoff-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Phase 2 Wrap Handoff Closeout summary" in capsys.readouterr().out

--- a/tests/test_phase3_kickoff_closeout.py
+++ b/tests/test_phase3_kickoff_closeout.py
@@ -76,7 +76,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day61_json(tmp_path: Path, capsys) -> None:
+def test_lane61_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d61.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -85,7 +85,7 @@ def test_day61_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day61_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane61_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d61.main(
         [
@@ -102,20 +102,35 @@ def test_day61_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-brief.md").exists()
-    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-trust-ledger.csv").exists()
-    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-execution-log.md").exists()
-    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/phase3-kickoff-closeout-pack/evidence/phase3-kickoff-execution-summary.json"
+        tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.md"
+    ).exists()
+    assert (tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-brief.md").exists()
+    assert (
+        tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-trust-ledger.csv"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase3-kickoff-closeout-pack/evidence/phase3-kickoff-execution-summary.json"
     ).exists()
 
 
-def test_day61_strict_fails_without_day60(tmp_path: Path) -> None:
+def test_lane61_strict_fails_without_day60(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -124,12 +139,10 @@ def test_day61_strict_fails_without_day60(tmp_path: Path) -> None:
     assert d61.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day61_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane61_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase3-kickoff-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    alias_rc = cli.main(
-        ["phase3-kickoff-closeout", "--root", str(tmp_path), "--format", "text"]
-    )
+    alias_rc = cli.main(["phase3-kickoff-closeout", "--root", str(tmp_path), "--format", "text"])
     assert alias_rc == 0
     assert "Phase3 Kickoff Closeout summary" in capsys.readouterr().out

--- a/tests/test_phase3_preplan_closeout.py
+++ b/tests/test_phase3_preplan_closeout.py
@@ -75,7 +75,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day59_json(tmp_path: Path, capsys) -> None:
+def test_lane59_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d59.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -84,7 +84,7 @@ def test_day59_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day59_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane59_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d59.main(
         [
@@ -101,20 +101,35 @@ def test_day59_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-brief.md").exists()
-    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-execution-log.md").exists()
-    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/phase3-preplan-closeout-pack/evidence/phase3-preplan-execution-summary.json"
+        tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.md"
+    ).exists()
+    assert (tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-brief.md").exists()
+    assert (
+        tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-risk-ledger.csv"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/phase3-preplan-closeout-pack/phase3-preplan-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/phase3-preplan-closeout-pack/evidence/phase3-preplan-execution-summary.json"
     ).exists()
 
 
-def test_day59_strict_fails_without_day58(tmp_path: Path) -> None:
+def test_lane59_strict_fails_without_day58(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -123,7 +138,7 @@ def test_day59_strict_fails_without_day58(tmp_path: Path) -> None:
     assert d59.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day59_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane59_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase3-preplan-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_phase3_wrap_publication_closeout.py
+++ b/tests/test_phase3_wrap_publication_closeout.py
@@ -91,7 +91,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day90_json(tmp_path: Path, capsys) -> None:
+def test_lane90_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d90.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -100,7 +100,7 @@ def test_day90_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day90_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane90_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d90.main(
         [
@@ -161,7 +161,7 @@ def test_day90_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day90_strict_fails_without_day89(tmp_path: Path) -> None:
+def test_lane90_strict_fails_without_day89(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -170,7 +170,7 @@ def test_day90_strict_fails_without_day89(tmp_path: Path) -> None:
     assert d90.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day90_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane90_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase3-wrap-publication-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_playbook_post.py
+++ b/tests/test_playbook_post.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day39_playbook_post_json(tmp_path: Path, capsys) -> None:
+def test_lane39_playbook_post_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d39.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day39_playbook_post_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day39_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane39_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d39.main(
         [
@@ -107,14 +107,14 @@ def test_day39_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/playbook-post-pack/evidence/execution-summary.json").exists()
 
 
-def test_day39_strict_fails_when_day38_inputs_missing(tmp_path: Path) -> None:
+def test_lane39_strict_fails_when_lane38_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/distribution-batch-pack/distribution-batch-summary.json").unlink()
     rc = d39.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day39_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane39_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["playbook-post", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_release_cadence.py
+++ b/tests/test_release_cadence.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day32_release_cadence_json(tmp_path: Path, capsys) -> None:
+def test_release_cadence_release_cadence_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d32.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day32_release_cadence_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day32_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_release_cadence_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d32.main(
         [
@@ -107,14 +107,14 @@ def test_day32_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day32_strict_fails_when_day31_inputs_missing(tmp_path: Path) -> None:
+def test_release_cadence_strict_fails_when_lane31_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/phase2-kickoff-pack/phase2-kickoff-summary.json").unlink()
     rc = d32.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day32_strict_fails_when_day31_board_is_not_ready(tmp_path: Path) -> None:
+def test_release_cadence_strict_fails_when_lane31_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/phase2-kickoff-pack/phase2-kickoff-delivery-board.md").write_text(
         "- [ ] Day 32 release cadence checklist drafted\n", encoding="utf-8"
@@ -123,7 +123,7 @@ def test_day32_strict_fails_when_day31_board_is_not_ready(tmp_path: Path) -> Non
     assert rc == 1
 
 
-def test_day32_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_release_cadence_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["release-cadence", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_release_prioritization_closeout.py
+++ b/tests/test_release_prioritization_closeout.py
@@ -92,7 +92,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day85_json(tmp_path: Path, capsys) -> None:
+def test_lane85_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d85.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -101,7 +101,7 @@ def test_day85_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day85_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane85_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d85.main(
         [
@@ -160,7 +160,7 @@ def test_day85_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day85_strict_fails_without_day84(tmp_path: Path) -> None:
+def test_lane85_strict_fails_without_day84(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -169,7 +169,7 @@ def test_day85_strict_fails_without_day84(tmp_path: Path) -> None:
     assert d85.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day85_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane85_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["release-prioritization-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_reliability_closeout.py
+++ b/tests/test_reliability_closeout.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day47_reliability_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane47_reliability_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d47.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day47_reliability_closeout_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day47_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane47_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d47.main(
         [
@@ -96,7 +96,9 @@ def test_day47_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/reliability-pack-47/reliability-closeout-summary-47.json").exists()
+    assert (
+        tmp_path / "artifacts/reliability-pack-47/reliability-closeout-summary-47.json"
+    ).exists()
     assert (tmp_path / "artifacts/reliability-pack-47/reliability-closeout-summary-47.md").exists()
     assert (tmp_path / "artifacts/reliability-pack-47/reliability-plan-47.md").exists()
     assert (tmp_path / "artifacts/reliability-pack-47/incident-map-47.csv").exists()
@@ -104,10 +106,12 @@ def test_day47_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/reliability-pack-47/execution-log-47.md").exists()
     assert (tmp_path / "artifacts/reliability-pack-47/delivery-board-47.md").exists()
     assert (tmp_path / "artifacts/reliability-pack-47/validation-commands-47.md").exists()
-    assert (tmp_path / "artifacts/reliability-pack-47/evidence/reliability-execution-summary-47.json").exists()
+    assert (
+        tmp_path / "artifacts/reliability-pack-47/evidence/reliability-execution-summary-47.json"
+    ).exists()
 
 
-def test_day47_strict_fails_when_day46_inputs_missing(tmp_path: Path) -> None:
+def test_lane47_strict_fails_when_lane46_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path / "docs/artifacts/optimization-closeout-pack/optimization-closeout-summary.json"
@@ -116,7 +120,7 @@ def test_day47_strict_fails_when_day46_inputs_missing(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day47_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane47_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["reliability-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_scale_closeout.py
+++ b/tests/test_scale_closeout.py
@@ -70,7 +70,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day44_scale_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane44_scale_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d44.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -79,7 +79,7 @@ def test_day44_scale_closeout_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day44_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane44_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d44.main(
         [
@@ -104,10 +104,12 @@ def test_day44_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/scale-closeout-pack/scale-execution-log.md").exists()
     assert (tmp_path / "artifacts/scale-closeout-pack/scale-delivery-board.md").exists()
     assert (tmp_path / "artifacts/scale-closeout-pack/scale-validation-commands.md").exists()
-    assert (tmp_path / "artifacts/scale-closeout-pack/evidence/scale-execution-summary.json").exists()
+    assert (
+        tmp_path / "artifacts/scale-closeout-pack/evidence/scale-execution-summary.json"
+    ).exists()
 
 
-def test_day44_strict_fails_when_day43_inputs_missing(tmp_path: Path) -> None:
+def test_lane44_strict_fails_when_lane43_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path / "docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
@@ -116,7 +118,7 @@ def test_day44_strict_fails_when_day43_inputs_missing(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day44_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane44_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["scale-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_scale_lane.py
+++ b/tests/test_scale_lane.py
@@ -68,7 +68,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day40_scale_lane_json(tmp_path: Path, capsys) -> None:
+def test_lane40_scale_lane_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d40.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -77,7 +77,7 @@ def test_day40_scale_lane_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day40_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane40_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d40.main(
         [
@@ -105,14 +105,14 @@ def test_day40_emit_pack_and_execute(tmp_path: Path) -> None:
     assert (tmp_path / "artifacts/scale-lane-pack/evidence/execution-summary.json").exists()
 
 
-def test_day40_strict_fails_when_day39_inputs_missing(tmp_path: Path) -> None:
+def test_lane40_strict_fails_when_lane39_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/playbook-post-pack/playbook-post-summary.json").unlink()
     rc = d40.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day40_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane40_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["scale-lane", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_scale_upgrade_closeout.py
+++ b/tests/test_scale_upgrade_closeout.py
@@ -89,7 +89,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day79_json(tmp_path: Path, capsys) -> None:
+def test_lane79_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d79.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -98,7 +98,7 @@ def test_day79_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day79_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane79_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d79.main(
         [
@@ -133,7 +133,7 @@ def test_day79_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day79_strict_fails_without_day78(tmp_path: Path) -> None:
+def test_lane79_strict_fails_without_day78(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -142,7 +142,7 @@ def test_day79_strict_fails_without_day78(tmp_path: Path) -> None:
     assert d79.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day79_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane79_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["scale-upgrade-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_stabilization_closeout.py
+++ b/tests/test_stabilization_closeout.py
@@ -76,7 +76,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day56_json(tmp_path: Path, capsys) -> None:
+def test_lane56_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d56.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -85,7 +85,7 @@ def test_day56_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day56_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane56_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d56.main(
         [
@@ -102,20 +102,35 @@ def test_day56_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-brief.md").exists()
-    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-execution-log.md").exists()
-    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/stabilization-closeout-pack/evidence/stabilization-execution-summary.json"
+        tmp_path / "artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/stabilization-closeout-pack/stabilization-closeout-summary.md"
+    ).exists()
+    assert (tmp_path / "artifacts/stabilization-closeout-pack/stabilization-brief.md").exists()
+    assert (
+        tmp_path / "artifacts/stabilization-closeout-pack/stabilization-risk-ledger.csv"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/stabilization-closeout-pack/stabilization-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/stabilization-closeout-pack/stabilization-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/stabilization-closeout-pack/stabilization-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/stabilization-closeout-pack/stabilization-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/stabilization-closeout-pack/evidence/stabilization-execution-summary.json"
     ).exists()
 
 
-def test_day56_strict_fails_without_day55(tmp_path: Path) -> None:
+def test_lane56_strict_fails_without_day55(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -124,7 +139,7 @@ def test_day56_strict_fails_without_day55(tmp_path: Path) -> None:
     assert d56.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day56_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane56_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["stabilization-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_triage_templates.py
+++ b/tests/test_triage_templates.py
@@ -24,7 +24,7 @@ def _seed_templates(root: Path) -> None:
     )
 
 
-def test_day9_template_health_payload_is_complete(tmp_path: Path) -> None:
+def test_lane9_template_health_payload_is_complete(tmp_path: Path) -> None:
     _seed_templates(tmp_path)
     payload = triage_templates.build_template_health(str(tmp_path))
     assert payload["name"] == "triage-templates"
@@ -33,7 +33,7 @@ def test_day9_template_health_payload_is_complete(tmp_path: Path) -> None:
     assert len(payload["templates"]) == 4
 
 
-def test_markdown_export_writes_day9_artifact(tmp_path: Path) -> None:
+def test_markdown_export_writes_lane9_artifact(tmp_path: Path) -> None:
     _seed_templates(tmp_path)
     out = tmp_path / "day9.md"
     rc = triage_templates.main(

--- a/tests/test_trust_assets_refresh_closeout.py
+++ b/tests/test_trust_assets_refresh_closeout.py
@@ -92,7 +92,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day75_json(tmp_path: Path, capsys) -> None:
+def test_lane75_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d75.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -101,7 +101,7 @@ def test_day75_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day75_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane75_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d75.main(
         [
@@ -118,23 +118,48 @@ def test_day75_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.json").exists()
-    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-integration-brief.md").exists()
-    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-plan.md").exists()
-    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-trust-controls-log.json").exists()
     assert (
-        tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-trust-kpi-scorecard.json"
+        tmp_path
+        / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.json"
     ).exists()
-    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-execution-log.md").exists()
-    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-delivery-board.md").exists()
-    assert (tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-validation-commands.md").exists()
     assert (
-        tmp_path / "artifacts/trust-assets-refresh-closeout-pack/evidence/trust-assets-refresh-execution-summary.json"
+        tmp_path
+        / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-integration-brief.md"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-plan.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-trust-controls-log.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-trust-kpi-scorecard.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/trust-assets-refresh-closeout-pack/evidence/trust-assets-refresh-execution-summary.json"
     ).exists()
 
 
-def test_day75_strict_fails_without_day74(tmp_path: Path) -> None:
+def test_lane75_strict_fails_without_day74(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -143,7 +168,7 @@ def test_day75_strict_fails_without_day74(tmp_path: Path) -> None:
     assert d75.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day75_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane75_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["trust-assets-refresh-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_trust_faq_expansion_closeout.py
+++ b/tests/test_trust_faq_expansion_closeout.py
@@ -92,7 +92,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day83_json(tmp_path: Path, capsys) -> None:
+def test_lane83_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d83.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -101,7 +101,7 @@ def test_day83_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day83_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane83_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d83.main(
         [
@@ -154,7 +154,7 @@ def test_day83_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day83_strict_fails_without_day82(tmp_path: Path) -> None:
+def test_lane83_strict_fails_without_day82(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -163,7 +163,7 @@ def test_day83_strict_fails_without_day82(tmp_path: Path) -> None:
     assert d83.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day83_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane83_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["trust-faq-expansion-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_weekly_review_closeout.py
+++ b/tests/test_weekly_review_closeout.py
@@ -65,7 +65,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day49_weekly_review_closeout_json(tmp_path: Path, capsys) -> None:
+def test_lane49_weekly_review_closeout_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d49.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -75,7 +75,7 @@ def test_day49_weekly_review_closeout_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day49_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane49_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d49.main(
         [
@@ -92,33 +92,42 @@ def test_day49_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-closeout-summary.json").exists()
+    assert (
+        tmp_path / "artifacts/weekly-review-pack-49/weekly-review-closeout-summary.json"
+    ).exists()
     assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-closeout-summary.md").exists()
     assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-brief-49.md").exists()
-    assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-risk-register-49.csv").exists()
-    assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-kpi-scorecard-49.json").exists()
+    assert (
+        tmp_path / "artifacts/weekly-review-pack-49/weekly-review-risk-register-49.csv"
+    ).exists()
+    assert (
+        tmp_path / "artifacts/weekly-review-pack-49/weekly-review-kpi-scorecard-49.json"
+    ).exists()
     assert (tmp_path / "artifacts/weekly-review-pack-49/advanced-priority-matrix-49.json").exists()
     assert (tmp_path / "artifacts/weekly-review-pack-49/execution-log-49.md").exists()
     assert (tmp_path / "artifacts/weekly-review-pack-49/weekly-review-delivery-board.md").exists()
     assert (tmp_path / "artifacts/weekly-review-pack-49/validation-commands-49.md").exists()
-    assert (tmp_path / "artifacts/weekly-review-pack-49/evidence/weekly-review-execution-summary-49.json").exists()
+    assert (
+        tmp_path
+        / "artifacts/weekly-review-pack-49/evidence/weekly-review-execution-summary-49.json"
+    ).exists()
 
 
-def test_day49_strict_fails_when_day48_inputs_missing(tmp_path: Path) -> None:
+def test_lane49_strict_fails_when_lane48_inputs_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/objection-closeout-pack/objection-closeout-summary.json").unlink()
     rc = d49.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
 
-def test_day49_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane49_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Day 49 advanced weekly review control tower summary" in capsys.readouterr().out
 
 
-def test_day49_advanced_alias_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane49_advanced_alias_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(
         ["day49-advanced-weekly-review-control-tower", "--root", str(tmp_path), "--format", "text"]
@@ -127,7 +136,7 @@ def test_day49_advanced_alias_cli_dispatch(tmp_path: Path, capsys) -> None:
     assert "advanced weekly review control tower" in capsys.readouterr().out
 
 
-def test_day49_non_day_alias_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane49_non_day_alias_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_weekly_review_closeout_2.py
+++ b/tests/test_weekly_review_closeout_2.py
@@ -80,7 +80,7 @@ def _seed_repo(root: Path) -> None:
     workflow.write_text("name: Day64 Advanced GitHub Actions Reference\n", encoding="utf-8")
 
 
-def test_day65_json(tmp_path: Path, capsys) -> None:
+def test_lane65_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d65.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -89,7 +89,7 @@ def test_day65_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 95
 
 
-def test_day65_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane65_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d65.main(
         [
@@ -106,25 +106,47 @@ def test_day65_emit_pack_and_execute(tmp_path: Path) -> None:
         ]
     )
     assert rc == 0
-    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-summary.json").exists()
-    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-summary.md").exists()
-    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-weekly-brief.md").exists()
-    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-kpi-dashboard.json").exists()
     assert (
-        tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-governance-decision-register.md"
-    ).exists()
-    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-risk-ledger.csv").exists()
-    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-execution-log.md").exists()
-    assert (tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-delivery-board.md").exists()
-    assert (
-        tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-validation-commands.md"
+        tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-summary.json"
     ).exists()
     assert (
-        tmp_path / "artifacts/weekly-review-closeout-2-pack/evidence/weekly-review-closeout-2-execution-summary.json"
+        tmp_path / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-summary.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-weekly-brief.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-kpi-dashboard.json"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-governance-decision-register.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-risk-ledger.csv"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-execution-log.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-delivery-board.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/weekly-review-closeout-2-pack/weekly-review-closeout-2-validation-commands.md"
+    ).exists()
+    assert (
+        tmp_path
+        / "artifacts/weekly-review-closeout-2-pack/evidence/weekly-review-closeout-2-execution-summary.json"
     ).exists()
 
 
-def test_day65_strict_fails_without_day64(tmp_path: Path) -> None:
+def test_lane65_strict_fails_without_day64(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path
@@ -133,7 +155,7 @@ def test_day65_strict_fails_without_day64(tmp_path: Path) -> None:
     assert d65.main(["--root", str(tmp_path), "--strict", "--format", "json"]) == 1
 
 
-def test_day65_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane65_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0

--- a/tests/test_weekly_review_lane.py
+++ b/tests/test_weekly_review_lane.py
@@ -51,7 +51,7 @@ def _seed_repo(root: Path) -> None:
     )
 
 
-def test_day28_weekly_review_json(tmp_path: Path, capsys) -> None:
+def test_lane28_weekly_review_json(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = d28.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
@@ -60,7 +60,7 @@ def test_day28_weekly_review_json(tmp_path: Path, capsys) -> None:
     assert out["summary"]["activation_score"] >= 90
 
 
-def test_day28_emit_pack_and_execute(tmp_path: Path) -> None:
+def test_lane28_emit_pack_and_execute(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     rc = d28.main(
         [
@@ -86,7 +86,7 @@ def test_day28_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_day28_strict_fails_when_sections_missing(tmp_path: Path) -> None:
+def test_lane28_strict_fails_when_sections_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/integrations-weekly-review.md").write_text(
         "# Weekly review #4 (Day 28)\n", encoding="utf-8"
@@ -95,7 +95,7 @@ def test_day28_strict_fails_when_sections_missing(tmp_path: Path) -> None:
     assert rc == 1
 
 
-def test_day28_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane28_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["weekly-review-lane", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0


### PR DESCRIPTION
### Motivation
- Migrate legacy day-based builder names to canonical implementation aliases to simplify API while preserving compatibility. 
- Normalize multi-line string/Path concatenation and artifact/evidence file paths for consistent output across modules. 
- Adjust a few legacy identifiers and pack directory names to remove day-prefixed legacy tokens. 

### Description
- Introduced `*_impl` compatibility aliases (e.g. `build_acceleration_closeout_summary_impl`) replacing many `build_dayNN_*` builder function names and kept existing public `build_*` wrappers to call the new impl functions. 
- Normalized string concatenation and `Path` expressions in several modules to avoid awkward parentheses and ensure generated pack files and validation commands are written consistently. 
- Replaced some legacy lane/pack names (notably in Phase-1 hardening/wrap) to use `legacy-` prefixes and updated canonical pack filenames produced by `_run_execution`/emit routines. 
- Updated the test suite expectations and renamed many tests (e.g. `test_dayXX_*` → `test_laneXX_*`), and adjusted assertions to the new artifact paths and filenames generated by the refactored code. 

### Testing
- Ran the automated unit test suite with `pytest -q` after the changes. 
- Updated tests were executed against the modified modules and the test run completed successfully. 
- The modified tests assert the presence of the normalized artifact files and updated JSON/MD outputs and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d091d771708320808e0d2b91f4a92d)