### PR TITLE
Productize phase2/phase3 continuity keys (replace dayNN continuity with canonical predecessor names)

### DIFF
--- a/docs/artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.json
+++ b/docs/artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-phase2-wrap-handoff-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day59_summary": "docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json",
-    "day59_delivery_board": "docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-delivery-board.md"
+    "phase3_preplan_summary": "docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json",
+    "phase3_preplan_delivery_board": "docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-delivery-board.md"
   },
   "checks": [
     {
@@ -28,34 +28,34 @@
       "evidence": "Day 60 + Day 61 strategy chain"
     },
     {
-      "check_id": "day59_summary_present",
+      "check_id": "phase3_preplan_summary_present",
       "weight": 10,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json"
     },
     {
-      "check_id": "day59_delivery_board_present",
+      "check_id": "phase3_preplan_delivery_board_present",
       "weight": 8,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-delivery-board.md"
     },
     {
-      "check_id": "day59_quality_floor",
+      "check_id": "phase3_preplan_quality_floor",
       "weight": 15,
       "passed": false,
       "evidence": {
-        "day59_score": 18,
+        "phase3_preplan_score": 18,
         "strict_pass": false,
-        "day59_checks": 13
+        "phase3_preplan_checks": 13
       }
     },
     {
-      "check_id": "day59_board_integrity",
+      "check_id": "phase3_preplan_board_integrity",
       "weight": 7,
       "passed": true,
       "evidence": {
         "board_items": 5,
-        "contains_day59": true
+        "contains_phase3_preplan": true
       }
     },
     {
@@ -98,16 +98,16 @@
     }
   ],
   "rollup": {
-    "day59_activation_score": 18,
-    "day59_checks": 13,
-    "day59_delivery_board_items": 5
+    "phase3_preplan_activation_score": 18,
+    "phase3_preplan_checks": 13,
+    "phase3_preplan_delivery_board_items": 5
   },
   "summary": {
     "activation_score": 43,
     "passed_checks": 7,
     "failed_checks": 6,
     "critical_failures": [
-      "day59_strict_baseline"
+      "phase3_preplan_strict_baseline"
     ],
     "strict_pass": false
   },

--- a/docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json
+++ b/docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-phase3-preplan-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day58_summary": "/workspace/DevS69-sdetkit/docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json",
-    "day58_delivery_board": "/workspace/DevS69-sdetkit/docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md"
+    "phase2_hardening_summary": "/workspace/DevS69-sdetkit/docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json",
+    "phase2_hardening_delivery_board": "/workspace/DevS69-sdetkit/docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md"
   },
   "checks": [
     {
@@ -28,34 +28,34 @@
       "evidence": "Day 59 + Day 60 strategy chain"
     },
     {
-      "check_id": "day58_summary_present",
+      "check_id": "phase2_hardening_summary_present",
       "weight": 10,
       "passed": false,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json"
     },
     {
-      "check_id": "day58_delivery_board_present",
+      "check_id": "phase2_hardening_delivery_board_present",
       "weight": 8,
       "passed": false,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md"
     },
     {
-      "check_id": "day58_quality_floor",
+      "check_id": "phase2_hardening_quality_floor",
       "weight": 15,
       "passed": false,
       "evidence": {
-        "day58_score": 0,
+        "phase2_hardening_score": 0,
         "strict_pass": false,
-        "day58_checks": 0
+        "phase2_hardening_checks": 0
       }
     },
     {
-      "check_id": "day58_board_integrity",
+      "check_id": "phase2_hardening_board_integrity",
       "weight": 7,
       "passed": false,
       "evidence": {
         "board_items": 0,
-        "contains_day58": false
+        "contains_phase2_hardening": false
       }
     },
     {
@@ -98,17 +98,17 @@
     }
   ],
   "rollup": {
-    "day58_activation_score": 0,
-    "day58_checks": 0,
-    "day58_delivery_board_items": 0
+    "phase2_hardening_activation_score": 0,
+    "phase2_hardening_checks": 0,
+    "phase2_hardening_delivery_board_items": 0
   },
   "summary": {
     "activation_score": 18,
     "passed_checks": 4,
     "failed_checks": 9,
     "critical_failures": [
-      "day58_handoff_inputs",
-      "day58_strict_baseline"
+      "phase2_hardening_handoff_inputs",
+      "phase2_hardening_strict_baseline"
     ],
     "strict_pass": false
   },

--- a/src/sdetkit/phase2_hardening_closeout_58.py
+++ b/src/sdetkit/phase2_hardening_closeout_58.py
@@ -128,7 +128,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day57(path: Path) -> tuple[int, bool, int]:
+def _load_kpi_deep_audit(path: Path) -> tuple[int, bool, int]:
     payload_obj = _load_json(path)
     if not isinstance(payload_obj, dict):
         return 0, False, 0
@@ -147,8 +147,8 @@ def _load_board(path: Path) -> tuple[int, bool]:
     text = _read(path)
     lines = [line.strip() for line in text.splitlines()]
     items = [line for line in lines if line.startswith("- [")]
-    has_day57 = any("Day 57" in line for line in lines)
-    return len(items), has_day57
+    has_kpi_deep_audit = any("Day 57" in line for line in lines)
+    return len(items), has_kpi_deep_audit
 
 
 def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
@@ -156,11 +156,11 @@ def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
     docs_index_text = _read(root / "docs/index.md")
     top10_text = _read(root / _TOP10_PATH)
     page_text = _read(root / _PAGE_PATH)
-    day57_summary = root / _DAY57_SUMMARY_PATH
-    day57_board = root / _DAY57_BOARD_PATH
+    kpi_deep_audit_summary = root / _DAY57_SUMMARY_PATH
+    kpi_deep_audit_board = root / _DAY57_BOARD_PATH
 
-    day57_score, day57_strict, day57_check_count = _load_day57(day57_summary)
-    board_count, board_has_day57 = _load_board(day57_board)
+    kpi_deep_audit_score, kpi_deep_audit_strict, kpi_deep_audit_check_count = _load_kpi_deep_audit(kpi_deep_audit_summary)
+    board_count, board_has_kpi_deep_audit = _load_board(kpi_deep_audit_board)
 
     missing_sections = [s for s in _REQUIRED_SECTIONS if s not in page_text]
     missing_commands = [c for c in _REQUIRED_COMMANDS if c not in page_text]
@@ -197,32 +197,32 @@ def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 58 + Day 59 strategy chain",
         },
         {
-            "check_id": "day57_summary_present",
+            "check_id": "kpi_deep_audit_summary_present",
             "weight": 10,
-            "passed": day57_summary.exists(),
-            "evidence": str(day57_summary),
+            "passed": kpi_deep_audit_summary.exists(),
+            "evidence": str(kpi_deep_audit_summary),
         },
         {
-            "check_id": "day57_delivery_board_present",
+            "check_id": "kpi_deep_audit_delivery_board_present",
             "weight": 8,
-            "passed": day57_board.exists(),
-            "evidence": str(day57_board),
+            "passed": kpi_deep_audit_board.exists(),
+            "evidence": str(kpi_deep_audit_board),
         },
         {
-            "check_id": "day57_quality_floor",
+            "check_id": "kpi_deep_audit_quality_floor",
             "weight": 15,
-            "passed": day57_strict and day57_score >= 95,
+            "passed": kpi_deep_audit_strict and kpi_deep_audit_score >= 95,
             "evidence": {
-                "day57_score": day57_score,
-                "strict_pass": day57_strict,
-                "day57_checks": day57_check_count,
+                "kpi_deep_audit_score": kpi_deep_audit_score,
+                "strict_pass": kpi_deep_audit_strict,
+                "kpi_deep_audit_checks": kpi_deep_audit_check_count,
             },
         },
         {
-            "check_id": "day57_board_integrity",
+            "check_id": "kpi_deep_audit_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day57,
-            "evidence": {"board_items": board_count, "contains_day57": board_has_day57},
+            "passed": board_count >= 5 and board_has_kpi_deep_audit,
+            "evidence": {"board_items": board_count, "contains_kpi_deep_audit": board_has_kpi_deep_audit},
         },
         {
             "check_id": "page_header",
@@ -264,24 +264,24 @@ def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day57_summary.exists() or not day57_board.exists():
-        critical_failures.append("day57_handoff_inputs")
-    if not day57_strict:
-        critical_failures.append("day57_strict_baseline")
+    if not kpi_deep_audit_summary.exists() or not kpi_deep_audit_board.exists():
+        critical_failures.append("kpi_deep_audit_handoff_inputs")
+    if not kpi_deep_audit_strict:
+        critical_failures.append("kpi_deep_audit_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day57_strict:
-        wins.append(f"Day 57 continuity is strict-pass with activation score={day57_score}.")
+    if kpi_deep_audit_strict:
+        wins.append(f"Day 57 continuity is strict-pass with activation score={kpi_deep_audit_score}.")
     else:
         misses.append("Day 57 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 57 KPI deep-audit closeout command and restore strict baseline before Day 58 lock."
         )
 
-    if board_count >= 5 and board_has_day57:
+    if board_count >= 5 and board_has_kpi_deep_audit:
         wins.append(
             f"Day 57 delivery board integrity validated with {board_count} checklist items."
         )
@@ -314,18 +314,18 @@ def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day57_summary": str(day57_summary.relative_to(root))
-            if day57_summary.exists()
-            else str(day57_summary),
-            "day57_delivery_board": str(day57_board.relative_to(root))
-            if day57_board.exists()
-            else str(day57_board),
+            "kpi_deep_audit_summary": str(kpi_deep_audit_summary.relative_to(root))
+            if kpi_deep_audit_summary.exists()
+            else str(kpi_deep_audit_summary),
+            "kpi_deep_audit_delivery_board": str(kpi_deep_audit_board.relative_to(root))
+            if kpi_deep_audit_board.exists()
+            else str(kpi_deep_audit_board),
         },
         "checks": checks,
         "rollup": {
-            "day57_activation_score": day57_score,
-            "day57_checks": day57_check_count,
-            "day57_delivery_board_items": board_count,
+            "kpi_deep_audit_activation_score": kpi_deep_audit_score,
+            "kpi_deep_audit_checks": kpi_deep_audit_check_count,
+            "kpi_deep_audit_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,

--- a/src/sdetkit/phase2_wrap_handoff_closeout_60.py
+++ b/src/sdetkit/phase2_wrap_handoff_closeout_60.py
@@ -128,7 +128,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day59(path: Path) -> tuple[int, bool, int]:
+def _load_phase3_preplan(path: Path) -> tuple[int, bool, int]:
     payload_obj = _load_json(path)
     if not isinstance(payload_obj, dict):
         return 0, False, 0
@@ -154,10 +154,10 @@ def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
 
-    day59_summary = root / _DAY58_SUMMARY_PATH
-    day59_board = root / _DAY58_BOARD_PATH
-    day59_score, day59_strict, day59_check_count = _load_day59(day59_summary)
-    board_count, board_has_day59 = _count_board_items(day59_board, "Day 59")
+    phase3_preplan_summary = root / _DAY58_SUMMARY_PATH
+    phase3_preplan_board = root / _DAY58_BOARD_PATH
+    phase3_preplan_score, phase3_preplan_strict, phase3_preplan_check_count = _load_phase3_preplan(phase3_preplan_summary)
+    board_count, board_has_phase3_preplan = _count_board_items(phase3_preplan_board, "Day 59")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -188,32 +188,32 @@ def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 60 + Day 61 strategy chain",
         },
         {
-            "check_id": "day59_summary_present",
+            "check_id": "phase3_preplan_summary_present",
             "weight": 10,
-            "passed": day59_summary.exists(),
-            "evidence": str(day59_summary),
+            "passed": phase3_preplan_summary.exists(),
+            "evidence": str(phase3_preplan_summary),
         },
         {
-            "check_id": "day59_delivery_board_present",
+            "check_id": "phase3_preplan_delivery_board_present",
             "weight": 8,
-            "passed": day59_board.exists(),
-            "evidence": str(day59_board),
+            "passed": phase3_preplan_board.exists(),
+            "evidence": str(phase3_preplan_board),
         },
         {
-            "check_id": "day59_quality_floor",
+            "check_id": "phase3_preplan_quality_floor",
             "weight": 15,
-            "passed": day59_strict and day59_score >= 95,
+            "passed": phase3_preplan_strict and phase3_preplan_score >= 95,
             "evidence": {
-                "day59_score": day59_score,
-                "strict_pass": day59_strict,
-                "day59_checks": day59_check_count,
+                "phase3_preplan_score": phase3_preplan_score,
+                "strict_pass": phase3_preplan_strict,
+                "phase3_preplan_checks": phase3_preplan_check_count,
             },
         },
         {
-            "check_id": "day59_board_integrity",
+            "check_id": "phase3_preplan_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day59,
-            "evidence": {"board_items": board_count, "contains_day59": board_has_day59},
+            "passed": board_count >= 5 and board_has_phase3_preplan,
+            "evidence": {"board_items": board_count, "contains_phase3_preplan": board_has_phase3_preplan},
         },
         {
             "check_id": "page_header",
@@ -255,24 +255,24 @@ def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day59_summary.exists() or not day59_board.exists():
-        critical_failures.append("day59_handoff_inputs")
-    if not day59_strict:
-        critical_failures.append("day59_strict_baseline")
+    if not phase3_preplan_summary.exists() or not phase3_preplan_board.exists():
+        critical_failures.append("phase3_preplan_handoff_inputs")
+    if not phase3_preplan_strict:
+        critical_failures.append("phase3_preplan_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day59_strict:
-        wins.append(f"Day 59 continuity is strict-pass with activation score={day59_score}.")
+    if phase3_preplan_strict:
+        wins.append(f"Day 59 continuity is strict-pass with activation score={phase3_preplan_score}.")
     else:
         misses.append("Day 59 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 59 Phase-3 pre-plan closeout command and restore strict baseline before Day 60 lock."
         )
 
-    if board_count >= 5 and board_has_day59:
+    if board_count >= 5 and board_has_phase3_preplan:
         wins.append(
             f"Day 59 delivery board integrity validated with {board_count} checklist items."
         )
@@ -307,18 +307,18 @@ def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day59_summary": str(day59_summary.relative_to(root))
-            if day59_summary.exists()
-            else str(day59_summary),
-            "day59_delivery_board": str(day59_board.relative_to(root))
-            if day59_board.exists()
-            else str(day59_board),
+            "phase3_preplan_summary": str(phase3_preplan_summary.relative_to(root))
+            if phase3_preplan_summary.exists()
+            else str(phase3_preplan_summary),
+            "phase3_preplan_delivery_board": str(phase3_preplan_board.relative_to(root))
+            if phase3_preplan_board.exists()
+            else str(phase3_preplan_board),
         },
         "checks": checks,
         "rollup": {
-            "day59_activation_score": day59_score,
-            "day59_checks": day59_check_count,
-            "day59_delivery_board_items": board_count,
+            "phase3_preplan_activation_score": phase3_preplan_score,
+            "phase3_preplan_checks": phase3_preplan_check_count,
+            "phase3_preplan_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,

--- a/src/sdetkit/phase3_preplan_closeout_59.py
+++ b/src/sdetkit/phase3_preplan_closeout_59.py
@@ -130,7 +130,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day58(path: Path) -> tuple[int, bool, int]:
+def _load_phase2_hardening(path: Path) -> tuple[int, bool, int]:
     payload_obj = _load_json(path)
     if not isinstance(payload_obj, dict):
         return 0, False, 0
@@ -156,10 +156,10 @@ def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
 
-    day58_summary = root / _DAY58_SUMMARY_PATH
-    day58_board = root / _DAY58_BOARD_PATH
-    day58_score, day58_strict, day58_check_count = _load_day58(day58_summary)
-    board_count, board_has_day58 = _count_board_items(day58_board, "Day 58")
+    phase2_hardening_summary = root / _DAY58_SUMMARY_PATH
+    phase2_hardening_board = root / _DAY58_BOARD_PATH
+    phase2_hardening_score, phase2_hardening_strict, phase2_hardening_check_count = _load_phase2_hardening(phase2_hardening_summary)
+    board_count, board_has_phase2_hardening = _count_board_items(phase2_hardening_board, "Day 58")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -190,32 +190,32 @@ def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 59 + Day 60 strategy chain",
         },
         {
-            "check_id": "day58_summary_present",
+            "check_id": "phase2_hardening_summary_present",
             "weight": 10,
-            "passed": day58_summary.exists(),
-            "evidence": str(day58_summary),
+            "passed": phase2_hardening_summary.exists(),
+            "evidence": str(phase2_hardening_summary),
         },
         {
-            "check_id": "day58_delivery_board_present",
+            "check_id": "phase2_hardening_delivery_board_present",
             "weight": 8,
-            "passed": day58_board.exists(),
-            "evidence": str(day58_board),
+            "passed": phase2_hardening_board.exists(),
+            "evidence": str(phase2_hardening_board),
         },
         {
-            "check_id": "day58_quality_floor",
+            "check_id": "phase2_hardening_quality_floor",
             "weight": 15,
-            "passed": day58_strict and day58_score >= 95,
+            "passed": phase2_hardening_strict and phase2_hardening_score >= 95,
             "evidence": {
-                "day58_score": day58_score,
-                "strict_pass": day58_strict,
-                "day58_checks": day58_check_count,
+                "phase2_hardening_score": phase2_hardening_score,
+                "strict_pass": phase2_hardening_strict,
+                "phase2_hardening_checks": phase2_hardening_check_count,
             },
         },
         {
-            "check_id": "day58_board_integrity",
+            "check_id": "phase2_hardening_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day58,
-            "evidence": {"board_items": board_count, "contains_day58": board_has_day58},
+            "passed": board_count >= 5 and board_has_phase2_hardening,
+            "evidence": {"board_items": board_count, "contains_phase2_hardening": board_has_phase2_hardening},
         },
         {
             "check_id": "page_header",
@@ -257,24 +257,24 @@ def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day58_summary.exists() or not day58_board.exists():
-        critical_failures.append("day58_handoff_inputs")
-    if not day58_strict:
-        critical_failures.append("day58_strict_baseline")
+    if not phase2_hardening_summary.exists() or not phase2_hardening_board.exists():
+        critical_failures.append("phase2_hardening_handoff_inputs")
+    if not phase2_hardening_strict:
+        critical_failures.append("phase2_hardening_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day58_strict:
-        wins.append(f"Day 58 continuity is strict-pass with activation score={day58_score}.")
+    if phase2_hardening_strict:
+        wins.append(f"Day 58 continuity is strict-pass with activation score={phase2_hardening_score}.")
     else:
         misses.append("Day 58 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 58 Phase-2 hardening closeout command and restore strict baseline before Day 59 lock."
         )
 
-    if board_count >= 5 and board_has_day58:
+    if board_count >= 5 and board_has_phase2_hardening:
         wins.append(
             f"Day 58 delivery board integrity validated with {board_count} checklist items."
         )
@@ -307,18 +307,18 @@ def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day58_summary": str(day58_summary.relative_to(root))
-            if day58_summary.exists()
-            else str(day58_summary),
-            "day58_delivery_board": str(day58_board.relative_to(root))
-            if day58_board.exists()
-            else str(day58_board),
+            "phase2_hardening_summary": str(phase2_hardening_summary.relative_to(root))
+            if phase2_hardening_summary.exists()
+            else str(phase2_hardening_summary),
+            "phase2_hardening_delivery_board": str(phase2_hardening_board.relative_to(root))
+            if phase2_hardening_board.exists()
+            else str(phase2_hardening_board),
         },
         "checks": checks,
         "rollup": {
-            "day58_activation_score": day58_score,
-            "day58_checks": day58_check_count,
-            "day58_delivery_board_items": board_count,
+            "phase2_hardening_activation_score": phase2_hardening_score,
+            "phase2_hardening_checks": phase2_hardening_check_count,
+            "phase2_hardening_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,

--- a/tests/test_phase2_hardening_closeout.py
+++ b/tests/test_phase2_hardening_closeout.py
@@ -129,7 +129,7 @@ def test_lane58_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_lane58_strict_fails_without_day57(tmp_path: Path) -> None:
+def test_lane58_strict_fails_without_kpi_deep_audit(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path

--- a/tests/test_phase2_wrap_handoff_closeout.py
+++ b/tests/test_phase2_wrap_handoff_closeout.py
@@ -134,7 +134,7 @@ def test_lane60_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_lane60_strict_fails_without_day59(tmp_path: Path) -> None:
+def test_lane60_strict_fails_without_phase3_preplan(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path

--- a/tests/test_phase3_preplan_closeout.py
+++ b/tests/test_phase3_preplan_closeout.py
@@ -129,7 +129,7 @@ def test_lane59_emit_pack_and_execute(tmp_path: Path) -> None:
     ).exists()
 
 
-def test_lane59_strict_fails_without_day58(tmp_path: Path) -> None:
+def test_lane59_strict_fails_without_phase2_hardening(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path


### PR DESCRIPTION
### Motivation
- Remove remaining active/public day-based continuity keys on the phase2→phase3→phase2-wrap chain and make canonical predecessor-lane names the primary continuity identifiers.
- Keep public semantics and compatibility intact while narrowing legacy dayNN aliases to compatibility-only surfaces where appropriate.

### Description
- Replaced day-based continuity fields/check IDs in the active closeout emitters to canonical predecessor names: `day57_*` → `kpi_deep_audit_*` in `phase2_hardening_closeout_58`, `day58_*` → `phase2_hardening_*` in `phase3_preplan_closeout_59`, and `day59_*` → `phase3_preplan_*` in `phase2_wrap_handoff_closeout_60`.
- Updated corresponding checked-in active artifact summaries under `docs/artifacts/*` so the emitted JSON keys and rollup/check IDs prefer the canonical continuity names instead of dayNN keys.
- Renamed local loader functions/variables and check IDs (e.g., `_load_day57` → `_load_kpi_deep_audit`, `_load_day58` → `_load_phase2_hardening`, `_load_day59` → `_load_phase3_preplan`) and adjusted related evidence strings to match the canonical names.
- Updated tests to use canonical predecessor-lane wording in assertions/test names while preserving their behavior, and retained existing CLI legacy aliases for backward compatibility.

### Testing
- Ran targeted pytest: `pytest -q tests/test_phase2_hardening_closeout.py tests/test_phase3_preplan_closeout.py tests/test_phase2_wrap_handoff_closeout.py`, and all tests passed (`12 passed`).
- Verified syntax by compiling the modified modules with `python -m py_compile src/sdetkit/phase2_hardening_closeout_58.py src/sdetkit/phase3_preplan_closeout_59.py src/sdetkit/phase2_wrap_handoff_closeout_60.py` (successful).
- Ran the contract checker scripts for the touched lanes (`scripts/check_*_contract.py --skip-evidence`), which surfaced existing baseline content failures unrelated to these naming refactors; those failures are pre-existing and not caused by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d099cd535883209c16df02ac0f4cab)