### PR TITLE
Batch cleanup dayNN public names for early contract lanes

### DIFF
--- a/scripts/check_contribution_templates_contract_9.py
+++ b/scripts/check_contribution_templates_contract_9.py
@@ -21,7 +21,7 @@ DOCS_INDEX_EXPECTED = [
     "## Day 9 ultra upgrades (contribution templates)",
     "sdetkit triage-templates --format text --strict",
     "sdetkit triage-templates --write-defaults --format json --strict",
-    "artifacts/day9-triage-templates-sample.md",
+    "artifacts/triage-templates-sample-9.md",
 ]
 
 DOCS_CLI_EXPECTED = [

--- a/scripts/check_contributor_funnel_contract_8.py
+++ b/scripts/check_contributor_funnel_contract_8.py
@@ -8,20 +8,20 @@ README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DAY8_REPORT = Path("docs/impact-8-ultra-upgrade-report.md")
 DAY8_ARTIFACT = Path("docs/artifacts/good-first-issues-sample-8.md")
-DAY8_ISSUE_PACK = Path("docs/artifacts/day8-issue-pack")
+ISSUE_PACK = Path("docs/artifacts/contributor-issue-pack")
 DAY8_MODULE = Path("src/sdetkit/contributor_funnel.py")
 
 REQUIRED_README_SNIPPETS = [
     "## 🧲 Day 8 ultra: contributor funnel backlog",
     "python -m sdetkit contributor-funnel --format text --strict",
-    "python -m sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/day8-issue-pack",
+    "python -m sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/contributor-issue-pack",
     "docs/impact-8-ultra-upgrade-report.md",
 ]
 
 REQUIRED_INDEX_SNIPPETS = [
     "Day 8 ultra upgrade report",
     "sdetkit contributor-funnel --format text --strict",
-    "sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/day8-issue-pack",
+    "sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/contributor-issue-pack",
 ]
 
 REQUIRED_REPORT_SNIPPETS = [
@@ -61,7 +61,7 @@ def main() -> int:
         if not p.exists():
             errors.append(f"missing required file: {p}")
 
-    issue_pack_files = sorted(DAY8_ISSUE_PACK.glob("gfi-*.md")) if DAY8_ISSUE_PACK.exists() else []
+    issue_pack_files = sorted(ISSUE_PACK.glob("gfi-*.md")) if ISSUE_PACK.exists() else []
     if len(issue_pack_files) < 5:
         errors.append("missing issue-pack artifacts: expected at least 5 gfi-*.md files")
 

--- a/scripts/check_docs_navigation_contract_11.py
+++ b/scripts/check_docs_navigation_contract_11.py
@@ -7,7 +7,7 @@ README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
 DAY11_REPORT = Path("docs/impact-11-ultra-upgrade-report.md")
-DAY11_ARTIFACT = Path("docs/artifacts/day11-docs-navigation-sample.md")
+DOCS_NAV_ARTIFACT = Path("docs/artifacts/docs-governance-sample.md")
 
 README_EXPECTED = [
     "## 🧭 Day 11 ultra: docs navigation tune-up",
@@ -29,7 +29,7 @@ DOCS_INDEX_EXPECTED = [
 
 DOCS_CLI_EXPECTED = [
     "## docs-nav",
-    "sdetkit docs-nav --format markdown --output docs/artifacts/day11-docs-navigation-sample.md",
+    "sdetkit docs-nav --format markdown --output docs/artifacts/docs-governance-sample.md",
     "--strict",
     "--write-defaults",
 ]
@@ -54,7 +54,7 @@ def _missing(path: Path, expected: list[str]) -> list[str]:
 
 def main() -> int:
     errors: list[str] = []
-    required = [README, DOCS_INDEX, DOCS_CLI, DAY11_REPORT, DAY11_ARTIFACT]
+    required = [README, DOCS_INDEX, DOCS_CLI, DAY11_REPORT, DOCS_NAV_ARTIFACT]
     for path in required:
         if not path.exists():
             errors.append(f"missing required file: {path}")
@@ -69,7 +69,8 @@ def main() -> int:
             f'{DAY11_REPORT}: missing "{m}"' for m in _missing(DAY11_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
-            f'{DAY11_ARTIFACT}: missing "{m}"' for m in _missing(DAY11_ARTIFACT, ARTIFACT_EXPECTED)
+            f'{DOCS_NAV_ARTIFACT}: missing "{m}"'
+            for m in _missing(DOCS_NAV_ARTIFACT, ARTIFACT_EXPECTED)
         )
 
     if errors:

--- a/scripts/check_first_contribution_contract_10.py
+++ b/scripts/check_first_contribution_contract_10.py
@@ -9,7 +9,7 @@ DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
 DOCS_CONTRIBUTING = Path("docs/contributing.md")
 DAY10_REPORT = Path("docs/impact-10-ultra-upgrade-report.md")
-DAY10_ARTIFACT = Path("docs/artifacts/first-contribution-checklist-sample-10.md")
+FIRST_CONTRIBUTION_ARTIFACT = Path("docs/artifacts/first-contribution-checklist-sample.md")
 
 README_EXPECTED = [
     "## ✅ Day 10 ultra: first-contribution checklist",
@@ -30,12 +30,12 @@ DOCS_INDEX_EXPECTED = [
     "## Day 10 ultra upgrades (first-contribution checklist)",
     "sdetkit first-contribution --format text --strict",
     "sdetkit first-contribution --write-defaults --format json --strict",
-    "artifacts/day10-first-contribution-checklist-sample.md",
+    "artifacts/first-contribution-checklist-sample.md",
 ]
 
 DOCS_CLI_EXPECTED = [
     "## first-contribution",
-    "sdetkit first-contribution --format markdown --output docs/artifacts/first-contribution-checklist-sample-10.md",
+    "sdetkit first-contribution --format markdown --output docs/artifacts/first-contribution-checklist-sample.md",
     "--strict",
     "--write-defaults",
 ]
@@ -73,7 +73,7 @@ def main() -> int:
         DOCS_CLI,
         DOCS_CONTRIBUTING,
         DAY10_REPORT,
-        DAY10_ARTIFACT,
+        FIRST_CONTRIBUTION_ARTIFACT,
     ]
     for path in required:
         if not path.exists():
@@ -96,7 +96,8 @@ def main() -> int:
             f'{DAY10_REPORT}: missing "{m}"' for m in _missing(DAY10_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
-            f'{DAY10_ARTIFACT}: missing "{m}"' for m in _missing(DAY10_ARTIFACT, ARTIFACT_EXPECTED)
+            f'{FIRST_CONTRIBUTION_ARTIFACT}: missing "{m}"'
+            for m in _missing(FIRST_CONTRIBUTION_ARTIFACT, ARTIFACT_EXPECTED)
         )
 
     if errors:

--- a/src/sdetkit/contributor_funnel.py
+++ b/src/sdetkit/contributor_funnel.py
@@ -216,7 +216,6 @@ def _render_json(backlog: list[dict[str, Any]]) -> str:
     area_counts = Counter(str(i["area"]) for i in backlog)
     payload = {
         "name": "contributor-funnel",
-        "legacy_name": "day8-contributor-funnel",
         "issues": backlog,
         "kpis": {
             "issue_count": len(backlog),
@@ -273,7 +272,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if errors and args.strict:
         for err in errors:
-            print(f"[day8-validation] {err}")
+            print(f"[contributor-funnel-validation] {err}")
         return 1
     return 0
 

--- a/src/sdetkit/triage_templates.py
+++ b/src/sdetkit/triage_templates.py
@@ -292,7 +292,6 @@ def build_template_health(root: str = ".") -> dict[str, Any]:
 
     return {
         "name": "triage-templates",
-        "legacy_name": "day9-contribution-templates",
         "score": score,
         "total_checks": total_checks,
         "passed_checks": passed_checks,

--- a/tests/test_contributor_funnel.py
+++ b/tests/test_contributor_funnel.py
@@ -17,7 +17,7 @@ def test_lane8_backlog_has_ten_curated_issues() -> None:
 
 
 def test_markdown_output_and_issue_pack_written(tmp_path: Path) -> None:
-    out = tmp_path / "day8.md"
+    out = tmp_path / "contributor-funnel.md"
     pack_dir = tmp_path / "issue-pack"
     rc = contributor_funnel.main(
         [

--- a/tests/test_contributor_funnel_extra.py
+++ b/tests/test_contributor_funnel_extra.py
@@ -25,4 +25,4 @@ def test_main_strict_fails_when_full_backlog_invalid(monkeypatch, capsys) -> Non
     )
     rc = cf.main(["--strict", "--format", "json"])
     assert rc == 1
-    assert "day8-validation" in capsys.readouterr().out
+    assert "contributor-funnel-validation" in capsys.readouterr().out

--- a/tests/test_first_contribution_extra.py
+++ b/tests/test_first_contribution_extra.py
@@ -17,7 +17,7 @@ def test_write_defaults_and_main_markdown_output(tmp_path: Path) -> None:
     (tmp_path / ".github" / "ISSUE_TEMPLATE" / "feature_request.yml").write_text(
         "name: feature\n", encoding="utf-8"
     )
-    out = tmp_path / "artifacts/day10.md"
+    out = tmp_path / "artifacts/first-contribution.md"
     rc = fc.main(
         [
             "--root",

--- a/tests/test_triage_templates.py
+++ b/tests/test_triage_templates.py
@@ -35,7 +35,7 @@ def test_lane9_template_health_payload_is_complete(tmp_path: Path) -> None:
 
 def test_markdown_export_writes_lane9_artifact(tmp_path: Path) -> None:
     _seed_templates(tmp_path)
-    out = tmp_path / "day9.md"
+    out = tmp_path / "triage-templates.md"
     rc = triage_templates.main(
         [
             "--root",


### PR DESCRIPTION
### Motivation
- Remove remaining active/public `dayNN` naming on early contract surfaces so canonical product names are primary and legacy day aliases are narrowed.  
- Focus this pass on early contract/reporting lanes (contributor-funnel, triage-templates, first-contribution, docs navigation) while leaving previously productized boundaries untouched.  

### Description
- Removed `legacy_name` day-prefixed key from the contributor-funnel JSON output and replaced the strict-mode error tag from `day8-validation` to `contributor-funnel-validation` in `src/sdetkit/contributor_funnel.py`.  
- Removed `legacy_name` day-prefixed key from triage-templates public payload in `src/sdetkit/triage_templates.py`.  
- Updated active contract checker scripts to prefer canonical artifact/pack paths: `docs/artifacts/contributor-issue-pack` (was `day8-issue-pack`) in `scripts/check_contributor_funnel_contract_8.py`, `docs/artifacts/docs-governance-sample.md` (was day11 sample name) in `scripts/check_docs_navigation_contract_11.py`, and `docs/artifacts/first-contribution-checklist-sample.md` (normalized path) in `scripts/check_first_contribution_contract_10.py`, and adjusted triage templates sample path expectation in `scripts/check_contribution_templates_contract_9.py`.  
- Updated tests to match canonicalized outputs and temporary artifact filenames in `tests/test_contributor_funnel.py`, `tests/test_contributor_funnel_extra.py`, `tests/test_triage_templates.py`, and `tests/test_first_contribution_extra.py`.  
- Files changed (high-level): `src/sdetkit/contributor_funnel.py`, `src/sdetkit/triage_templates.py`, `scripts/check_*_contract_*.py` (four scripts), and four test modules.  

### Testing
- Ran targeted unit tests with `pytest -q tests/test_contributor_funnel.py tests/test_contributor_funnel_extra.py tests/test_triage_templates.py tests/test_first_contribution_extra.py tests/test_docs_navigation.py` which passed (`31 passed`).  
- Executed contract checker scripts: `scripts/check_contributor_funnel_contract_8.py`, `scripts/check_contribution_templates_contract_9.py`, `scripts/check_first_contribution_contract_10.py`, and `scripts/check_docs_navigation_contract_11.py`, which report expected failures only because baseline `docs/impact-*-ultra-upgrade-report.md` artifacts are not present in this checkout and are therefore out-of-scope for the rename pass.  
- No changes were made to previously productized lanes (reliability, day50/day51, phase1/phase2, day90 boundary) after confirming they are already canonical.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d149f649d48320b65e5fd566859b54)