### PR TITLE
Narrow day-based legacy CLI aliases on active closeout lanes

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -497,10 +497,7 @@ Start here:
     d53.set_defaults(cmd="docs-loop-closeout")
     d53.add_argument("args", nargs=argparse.REMAINDER)
 
-    d55 = sub.add_parser(
-        "contributor-activation-closeout",
-        aliases=["day55-contributor-activation-closeout"],
-    )
+    d55 = sub.add_parser("contributor-activation-closeout")
     d55.set_defaults(cmd="contributor-activation-closeout")
     d55.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -520,18 +517,15 @@ Start here:
     d59.set_defaults(cmd="phase3-preplan-closeout")
     d59.add_argument("args", nargs=argparse.REMAINDER)
 
-    d60 = sub.add_parser(
-        "phase2-wrap-handoff-closeout",
-        aliases=["day60-phase2-wrap-handoff-closeout"],
-    )
+    d60 = sub.add_parser("phase2-wrap-handoff-closeout")
     d60.set_defaults(cmd="phase2-wrap-handoff-closeout")
     d60.add_argument("args", nargs=argparse.REMAINDER)
 
-    d61 = sub.add_parser("phase3-kickoff-closeout", aliases=["day61-phase3-kickoff-closeout"])
+    d61 = sub.add_parser("phase3-kickoff-closeout")
     d61.set_defaults(cmd="phase3-kickoff-closeout")
     d61.add_argument("args", nargs=argparse.REMAINDER)
 
-    d62 = sub.add_parser("community-program-closeout", aliases=["day62-community-program-closeout"])
+    d62 = sub.add_parser("community-program-closeout")
     d62.set_defaults(cmd="community-program-closeout")
     d62.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -547,17 +541,11 @@ Start here:
     d65.set_defaults(cmd="weekly-review-closeout-2")
     d65.add_argument("args", nargs=argparse.REMAINDER)
 
-    d66 = sub.add_parser(
-        "integration-expansion2-closeout",
-        aliases=["day66-integration-expansion2-closeout"],
-    )
+    d66 = sub.add_parser("integration-expansion2-closeout")
     d66.set_defaults(cmd="integration-expansion2-closeout")
     d66.add_argument("args", nargs=argparse.REMAINDER)
 
-    d67 = sub.add_parser(
-        "integration-expansion3-closeout",
-        aliases=["day67-integration-expansion3-closeout"],
-    )
+    d67 = sub.add_parser("integration-expansion3-closeout")
     d67.set_defaults(cmd="integration-expansion3-closeout")
     d67.add_argument("args", nargs=argparse.REMAINDER)
 
@@ -776,12 +764,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             "day47-reliability-closeout": "reliability-closeout",
             "day49-advanced-weekly-review-control-tower": "weekly-review-closeout",
             "day50-execution-prioritization-closeout": "execution-prioritization-closeout",
-            "day55-contributor-activation-closeout": "contributor-activation-closeout",
-            "day60-phase2-wrap-handoff-closeout": "phase2-wrap-handoff-closeout",
-            "day61-phase3-kickoff-closeout": "phase3-kickoff-closeout",
-            "day62-community-program-closeout": "community-program-closeout",
-            "day66-integration-expansion2-closeout": "integration-expansion2-closeout",
-            "day67-integration-expansion3-closeout": "integration-expansion3-closeout",
         }
         argv[0] = legacy_aliases.get(str(argv[0]), str(argv[0]))
 

--- a/src/sdetkit/contributor_activation_closeout_55.py
+++ b/src/sdetkit/contributor_activation_closeout_55.py
@@ -419,7 +419,7 @@ def build_contributor_activation_closeout_summary_impl(root: Path) -> dict[str, 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Contributor Activation Closeout checks (legacy alias: day55-contributor-activation-closeout)"
+        description="Contributor Activation Closeout checks"
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")

--- a/src/sdetkit/phase2_wrap_handoff_closeout_60.py
+++ b/src/sdetkit/phase2_wrap_handoff_closeout_60.py
@@ -402,7 +402,7 @@ def build_phase2_wrap_handoff_closeout_summary_impl(root: Path) -> dict[str, Any
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Phase 2 Wrap Handoff Closeout checks (legacy alias: day60-phase2-wrap-handoff-closeout)"
+        description="Phase 2 Wrap Handoff Closeout checks"
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")


### PR DESCRIPTION
### Motivation
- Remove remaining active/public `dayNN` CLI aliases so canonical closeout command names are primary while preserving compatibility-only aliases where explicitly required.
- Avoid modifying already-clean lanes or historical checked-in evidence; keep provenance in `docs/artifacts/**/evidence` as archival trace data.

### Description
- Removed public day-based CLI aliases for lanes `day55`, `day60`, `day61`, `day62`, `day66`, and `day67` in `src/sdetkit/cli.py` so the canonical commands (`contributor-activation-closeout`, `phase2-wrap-handoff-closeout`, `phase3-kickoff-closeout`, `community-program-closeout`, `integration-expansion2-closeout`, `integration-expansion3-closeout`) are primary-only.
- Cleared the corresponding entries from the `legacy_aliases` mapping in `src/sdetkit/cli.py`.
- Removed stale "legacy alias" wording from argparse `description` in `src/sdetkit/contributor_activation_closeout_55.py` and `src/sdetkit/phase2_wrap_handoff_closeout_60.py` so help text no longer promotes day aliases.
- Intentionally left explicitly-protected compatibility aliases (e.g., `day47`, `day49`, `day50`) and all historical evidence under `docs/artifacts/**/evidence` unchanged.

### Testing
- Ran targeted pytest for touched areas with `pytest -q tests/test_cli_productized_closeout_aliases.py tests/test_cli_help_lists_subcommands.py tests/test_contributor_activation_closeout.py tests/test_phase3_kickoff_closeout.py tests/test_community_program_closeout.py tests/test_integration_expansion2_closeout.py tests/test_integration_expansion3_closeout.py tests/test_phase2_wrap_handoff_closeout.py` and all tests passed (`36 passed`).
- Ran `python scripts/check_repo_layout.py` which reported the repo layout invariants hold.
- Executed `python -m sdetkit --help >/tmp/sdet_help.txt` and verified the removed aliases do not appear using `rg -n "day(55|60|61|62|66|67)-" /tmp/sdet_help.txt`.
- Confirmed working tree was committed and clean via `git status --short` after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d14e5c58f88320aa7377fc043edfe5)