### PR TITLE
Normalize execution-prioritization public names in tests and hide legacy day aliases from check usage

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -93,7 +93,7 @@ case "$mode" in
     python scripts/check_release_communications_contract.py
     ;;
   *)
-    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|cycle3-proof|cycle4-skills|day3|day4|github-actions-onboarding|gitlab-ci-onboarding|release-readiness|release-communications|all}" >&2
+    echo "Usage: bash scripts/check.sh {fmt|lint|types|tests|coverage|docs|onboarding|cycle3-proof|cycle4-skills|github-actions-onboarding|gitlab-ci-onboarding|release-readiness|release-communications|all}" >&2
     exit 2
     ;;
 esac

--- a/tests/test_execution_prioritization_closeout.py
+++ b/tests/test_execution_prioritization_closeout.py
@@ -21,7 +21,7 @@ def _seed_repo(root: Path) -> None:
 
     (root / "docs/artifacts").mkdir(parents=True, exist_ok=True)
     (root / "README.md").write_text(
-        "docs/integrations-execution-prioritization-closeout.md\nday50-execution-prioritization-closeout\n",
+        "docs/integrations-execution-prioritization-closeout.md\nexecution-prioritization-closeout\n",
         encoding="utf-8",
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
@@ -89,10 +89,10 @@ def test_lane50_emit_pack_and_execute(tmp_path: Path) -> None:
             "--root",
             str(tmp_path),
             "--emit-pack-dir",
-            "artifacts/day50-pack",
+            "artifacts/execution-prioritization-pack",
             "--execute",
             "--evidence-dir",
-            "artifacts/day50-pack/evidence",
+            "artifacts/execution-prioritization-pack/evidence",
             "--format",
             "json",
             "--strict",
@@ -100,19 +100,19 @@ def test_lane50_emit_pack_and_execute(tmp_path: Path) -> None:
     )
     assert rc == 0
     assert (
-        tmp_path / "artifacts/day50-pack/execution-prioritization-closeout-summary.json"
+        tmp_path / "artifacts/execution-prioritization-pack/execution-prioritization-closeout-summary.json"
     ).exists()
-    assert (tmp_path / "artifacts/day50-pack/execution-prioritization-closeout-summary.md").exists()
-    assert (tmp_path / "artifacts/day50-pack/execution-prioritization-brief.md").exists()
-    assert (tmp_path / "artifacts/day50-pack/execution-prioritization-risk-register.csv").exists()
-    assert (tmp_path / "artifacts/day50-pack/execution-prioritization-kpi-scorecard.json").exists()
-    assert (tmp_path / "artifacts/day50-pack/execution-prioritization-execution-log.md").exists()
-    assert (tmp_path / "artifacts/day50-pack/execution-prioritization-delivery-board.md").exists()
+    assert (tmp_path / "artifacts/execution-prioritization-pack/execution-prioritization-closeout-summary.md").exists()
+    assert (tmp_path / "artifacts/execution-prioritization-pack/execution-prioritization-brief.md").exists()
+    assert (tmp_path / "artifacts/execution-prioritization-pack/execution-prioritization-risk-register.csv").exists()
+    assert (tmp_path / "artifacts/execution-prioritization-pack/execution-prioritization-kpi-scorecard.json").exists()
+    assert (tmp_path / "artifacts/execution-prioritization-pack/execution-prioritization-execution-log.md").exists()
+    assert (tmp_path / "artifacts/execution-prioritization-pack/execution-prioritization-delivery-board.md").exists()
     assert (
-        tmp_path / "artifacts/day50-pack/execution-prioritization-validation-commands.md"
+        tmp_path / "artifacts/execution-prioritization-pack/execution-prioritization-validation-commands.md"
     ).exists()
     assert (
-        tmp_path / "artifacts/day50-pack/evidence/execution-prioritization-execution-summary.json"
+        tmp_path / "artifacts/execution-prioritization-pack/evidence/execution-prioritization-execution-summary.json"
     ).exists()
 
 


### PR DESCRIPTION
### Motivation
- A repo-wide inventory showed active/public residue where tests and helper UX still promoted `day50` naming; canonical names should be primary on public surfaces.
- Avoid advertising legacy onboarding aliases in user-facing helper scripts while preserving narrow compatibility shims implemented elsewhere.

### Description
- Replaced `day50-execution-prioritization-closeout` with canonical `execution-prioritization-closeout` in `tests/test_execution_prioritization_closeout.py` and changed emitted artifact paths from `artifacts/day50-pack/...` to `artifacts/execution-prioritization-pack/...` so tests seed and assert the canonical public pack names.
- Shortened the `scripts/check.sh` usage string to stop advertising `day3`/`day4` legacy modes while preserving the case branches (compatibility behavior remains unchanged).
- Intentionally left existing CLI compatibility aliases (`day47`, `day49`, `day50`) and hidden reliability flags (`--day15/--day16/--day17`) as narrow compatibility shims and did not alter checked-in artifact snapshots or historical evidence files.

### Testing
- Ran `pytest -q tests/test_execution_prioritization_closeout.py tests/test_cli_productized_closeout_aliases.py tests/test_cli_help_lists_subcommands.py` and all tests passed (`16 passed`).
- Ran `python scripts/check_repo_layout.py` which passed (`ok: repo layout invariants hold`).
- Ran `python scripts/check_execution_prioritization_closeout_contract.py --skip-evidence` which reported existing docs contract errors unrelated to these changes (left as baseline failure, not introduced by this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d15392314083208322f19ded32b654)