### PR TITLE
Remove stale day-based legacy alias labels from closeout parser help

### DIFF
--- a/src/sdetkit/docs_loop_closeout_53.py
+++ b/src/sdetkit/docs_loop_closeout_53.py
@@ -458,7 +458,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Docs Loop Closeout checks (legacy alias: day53-docs-loop-closeout)"
+        description="Docs Loop Closeout checks"
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")

--- a/src/sdetkit/kpi_deep_audit_closeout_57.py
+++ b/src/sdetkit/kpi_deep_audit_closeout_57.py
@@ -404,7 +404,7 @@ def build_kpi_deep_audit_closeout_summary_impl(root: Path) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="KPI Deep Audit Closeout checks (legacy alias: day57-kpi-deep-audit-closeout)"
+        description="KPI Deep Audit Closeout checks"
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")

--- a/src/sdetkit/phase2_hardening_closeout_58.py
+++ b/src/sdetkit/phase2_hardening_closeout_58.py
@@ -407,7 +407,7 @@ def build_phase2_hardening_closeout_summary_impl(root: Path) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Phase 2 Hardening Closeout checks (legacy alias: day58-phase2-hardening-closeout)"
+        description="Phase 2 Hardening Closeout checks"
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")

--- a/src/sdetkit/phase3_preplan_closeout_59.py
+++ b/src/sdetkit/phase3_preplan_closeout_59.py
@@ -397,7 +397,7 @@ def build_phase3_preplan_closeout_summary_impl(root: Path) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Phase3 Preplan Closeout checks (legacy alias: day59-phase3-preplan-closeout)"
+        description="Phase3 Preplan Closeout checks"
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")

--- a/src/sdetkit/stabilization_closeout_56.py
+++ b/src/sdetkit/stabilization_closeout_56.py
@@ -411,7 +411,7 @@ def build_stabilization_closeout_summary_impl(root: Path) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Stabilization Closeout checks (legacy alias: day56-stabilization-closeout)"
+        description="Stabilization Closeout checks"
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")


### PR DESCRIPTION
### Motivation
- Clean up remaining active/public dayNN legacy labels that were still advertised in CLI parser help so canonical lane names are primary in user-facing help.

### Description
- Removed the ` (legacy alias: dayNN-...)` suffix from the parser `description` strings in `src/sdetkit/docs_loop_closeout_53.py`, `src/sdetkit/stabilization_closeout_56.py`, `src/sdetkit/kpi_deep_audit_closeout_57.py`, `src/sdetkit/phase2_hardening_closeout_58.py`, and `src/sdetkit/phase3_preplan_closeout_59.py` so help output shows canonical lane names only.

### Testing
- Ran the repo inventory and targeted scans and executed `pytest -q tests/test_docs_loop_closeout.py tests/test_stabilization_closeout.py tests/test_kpi_deep_audit_closeout.py tests/test_phase2_hardening_closeout.py tests/test_phase3_preplan_closeout.py`, which passed (`20 passed`), and spot-checked `python -m sdetkit <command> --help` for the modified lanes and confirmed `git status --short` is clean.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d15de1e3e883209d3db9f97db07fff)