### PR TITLE
Batch-clean dayNN naming in active contract checker scripts

### DIFF
--- a/scripts/check_contribution_templates_contract_9.py
+++ b/scripts/check_contribution_templates_contract_9.py
@@ -6,8 +6,8 @@ from pathlib import Path
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
-DAY9_REPORT = Path("docs/impact-9-ultra-upgrade-report.md")
-DAY9_ARTIFACT = Path("docs/artifacts/triage-templates-sample-9.md")
+LANE_REPORT = Path("docs/impact-9-ultra-upgrade-report.md")
+LANE_ARTIFACT = Path("docs/artifacts/triage-templates-sample-9.md")
 ISSUE_CONFIG = Path(".github/ISSUE_TEMPLATE/config.yml")
 
 README_EXPECTED = [
@@ -53,7 +53,7 @@ def _missing(path: Path, expected: list[str]) -> list[str]:
 
 def main() -> int:
     errors: list[str] = []
-    for path in [README, DOCS_INDEX, DOCS_CLI, DAY9_REPORT, DAY9_ARTIFACT, ISSUE_CONFIG]:
+    for path in [README, DOCS_INDEX, DOCS_CLI, LANE_REPORT, LANE_ARTIFACT, ISSUE_CONFIG]:
         if not path.exists():
             errors.append(f"missing required file: {path}")
 
@@ -64,7 +64,7 @@ def main() -> int:
         )
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
         errors.extend(
-            f'{DAY9_REPORT}: missing "{m}"' for m in _missing(DAY9_REPORT, REPORT_EXPECTED)
+            f'{LANE_REPORT}: missing "{m}"' for m in _missing(LANE_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
             f'{ISSUE_CONFIG}: missing "{m}"' for m in _missing(ISSUE_CONFIG, ISSUE_CONFIG_EXPECTED)

--- a/scripts/check_contributor_funnel_contract_8.py
+++ b/scripts/check_contributor_funnel_contract_8.py
@@ -6,10 +6,10 @@ from pathlib import Path
 
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
-DAY8_REPORT = Path("docs/impact-8-ultra-upgrade-report.md")
-DAY8_ARTIFACT = Path("docs/artifacts/good-first-issues-sample-8.md")
+LANE_REPORT = Path("docs/impact-8-ultra-upgrade-report.md")
+LANE_ARTIFACT = Path("docs/artifacts/good-first-issues-sample-8.md")
 ISSUE_PACK = Path("docs/artifacts/contributor-issue-pack")
-DAY8_MODULE = Path("src/sdetkit/contributor_funnel.py")
+LANE_MODULE = Path("src/sdetkit/contributor_funnel.py")
 
 REQUIRED_README_SNIPPETS = [
     "## 🧲 Day 8 ultra: contributor funnel backlog",
@@ -43,7 +43,7 @@ def main() -> int:
 
     readme = _read(README)
     docs_index = _read(DOCS_INDEX)
-    report = _read(DAY8_REPORT)
+    report = _read(LANE_REPORT)
 
     for s in REQUIRED_README_SNIPPETS:
         if s not in readme:
@@ -57,7 +57,7 @@ def main() -> int:
         if s not in report:
             errors.append(f"missing Day 8 report snippet: {s}")
 
-    for p in [DAY8_REPORT, DAY8_ARTIFACT, DAY8_MODULE]:
+    for p in [LANE_REPORT, LANE_ARTIFACT, LANE_MODULE]:
         if not p.exists():
             errors.append(f"missing required file: {p}")
 

--- a/scripts/check_conversion_contract_6.py
+++ b/scripts/check_conversion_contract_6.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
-DAY6_REPORT = Path("docs/impact-6-ultra-upgrade-report.md")
-DAY6_ARTIFACT = Path("docs/artifacts/conversion-qa-sample-6.md")
+LANE_REPORT = Path("docs/impact-6-ultra-upgrade-report.md")
+LANE_ARTIFACT = Path("docs/artifacts/conversion-qa-sample-6.md")
 DOCS_QA_MODULE = Path("src/sdetkit/docs_qa.py")
 
 REQUIRED_README_SNIPPETS = [
@@ -41,7 +41,7 @@ def main() -> int:
 
     readme = _read(README)
     docs_index = _read(DOCS_INDEX)
-    report = _read(DAY6_REPORT)
+    report = _read(LANE_REPORT)
 
     for s in REQUIRED_README_SNIPPETS:
         if s not in readme:
@@ -55,7 +55,7 @@ def main() -> int:
         if s not in report:
             errors.append(f"missing Day 6 report snippet: {s}")
 
-    for p in [DAY6_REPORT, DAY6_ARTIFACT, DOCS_QA_MODULE]:
+    for p in [LANE_REPORT, LANE_ARTIFACT, DOCS_QA_MODULE]:
         if not p.exists():
             errors.append(f"missing required file: {p}")
 

--- a/scripts/check_docs_navigation_contract_11.py
+++ b/scripts/check_docs_navigation_contract_11.py
@@ -6,7 +6,7 @@ from pathlib import Path
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
-DAY11_REPORT = Path("docs/impact-11-ultra-upgrade-report.md")
+LANE_REPORT = Path("docs/impact-11-ultra-upgrade-report.md")
 DOCS_NAV_ARTIFACT = Path("docs/artifacts/docs-governance-sample.md")
 
 README_EXPECTED = [
@@ -54,7 +54,7 @@ def _missing(path: Path, expected: list[str]) -> list[str]:
 
 def main() -> int:
     errors: list[str] = []
-    required = [README, DOCS_INDEX, DOCS_CLI, DAY11_REPORT, DOCS_NAV_ARTIFACT]
+    required = [README, DOCS_INDEX, DOCS_CLI, LANE_REPORT, DOCS_NAV_ARTIFACT]
     for path in required:
         if not path.exists():
             errors.append(f"missing required file: {path}")
@@ -66,7 +66,7 @@ def main() -> int:
         )
         errors.extend(f'{DOCS_CLI}: missing "{m}"' for m in _missing(DOCS_CLI, DOCS_CLI_EXPECTED))
         errors.extend(
-            f'{DAY11_REPORT}: missing "{m}"' for m in _missing(DAY11_REPORT, REPORT_EXPECTED)
+            f'{LANE_REPORT}: missing "{m}"' for m in _missing(LANE_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
             f'{DOCS_NAV_ARTIFACT}: missing "{m}"'

--- a/scripts/check_enterprise_readiness_contract.py
+++ b/scripts/check_enterprise_readiness_contract.py
@@ -7,8 +7,8 @@ README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
 USE_CASE_PAGE = Path("docs/use-cases-enterprise-regulated.md")
-DAY13_REPORT = Path("docs/enterprise-readiness-report.md")
-DAY13_ARTIFACT = Path("docs/artifacts/enterprise-readiness-sample.md")
+LANE_REPORT = Path("docs/enterprise-readiness-report.md")
+LANE_ARTIFACT = Path("docs/artifacts/enterprise-readiness-sample.md")
 ENTERPRISE_PACK_CI = Path("docs/artifacts/enterprise-readiness-pack/enterprise-readiness-ci.yml")
 ENTERPRISE_EVIDENCE = Path(
     "docs/artifacts/enterprise-readiness-pack/evidence/enterprise-readiness-execution-summary.json"
@@ -91,8 +91,8 @@ def main() -> int:
         DOCS_INDEX,
         DOCS_CLI,
         USE_CASE_PAGE,
-        DAY13_REPORT,
-        DAY13_ARTIFACT,
+        LANE_REPORT,
+        LANE_ARTIFACT,
         ENTERPRISE_PACK_CI,
         ENTERPRISE_EVIDENCE,
     ]
@@ -110,10 +110,10 @@ def main() -> int:
             f'{USE_CASE_PAGE}: missing "{m}"' for m in _missing(USE_CASE_PAGE, USE_CASE_EXPECTED)
         )
         errors.extend(
-            f'{DAY13_REPORT}: missing "{m}"' for m in _missing(DAY13_REPORT, REPORT_EXPECTED)
+            f'{LANE_REPORT}: missing "{m}"' for m in _missing(LANE_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
-            f'{DAY13_ARTIFACT}: missing "{m}"' for m in _missing(DAY13_ARTIFACT, ARTIFACT_EXPECTED)
+            f'{LANE_ARTIFACT}: missing "{m}"' for m in _missing(LANE_ARTIFACT, ARTIFACT_EXPECTED)
         )
         errors.extend(
             f'{ENTERPRISE_PACK_CI}: missing "{m}"'

--- a/scripts/check_first_contribution_contract_10.py
+++ b/scripts/check_first_contribution_contract_10.py
@@ -8,7 +8,7 @@ CONTRIBUTING = Path("CONTRIBUTING.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
 DOCS_CONTRIBUTING = Path("docs/contributing.md")
-DAY10_REPORT = Path("docs/impact-10-ultra-upgrade-report.md")
+LANE_REPORT = Path("docs/impact-10-ultra-upgrade-report.md")
 FIRST_CONTRIBUTION_ARTIFACT = Path("docs/artifacts/first-contribution-checklist-sample.md")
 
 README_EXPECTED = [
@@ -72,7 +72,7 @@ def main() -> int:
         DOCS_INDEX,
         DOCS_CLI,
         DOCS_CONTRIBUTING,
-        DAY10_REPORT,
+        LANE_REPORT,
         FIRST_CONTRIBUTION_ARTIFACT,
     ]
     for path in required:
@@ -93,7 +93,7 @@ def main() -> int:
             for m in _missing(DOCS_CONTRIBUTING, DOCS_CONTRIBUTING_EXPECTED)
         )
         errors.extend(
-            f'{DAY10_REPORT}: missing "{m}"' for m in _missing(DAY10_REPORT, REPORT_EXPECTED)
+            f'{LANE_REPORT}: missing "{m}"' for m in _missing(LANE_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
             f'{FIRST_CONTRIBUTION_ARTIFACT}: missing "{m}"'

--- a/scripts/check_objection_handling_contract.py
+++ b/scripts/check_objection_handling_contract.py
@@ -7,21 +7,21 @@ from pathlib import Path
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
-DAY23_PAGE = Path("docs/objection-handling.md")
-DAY23_REPORT = Path("docs/objection-handling-report.md")
-DAY23_ARTIFACT = Path("docs/objection-handling.md")
-DAY23_PACK_SUMMARY = Path("docs/artifacts/objection-handling-pack/objection-handling-summary.json")
-DAY23_PACK_SCORECARD = Path(
+LANE_PAGE = Path("docs/objection-handling.md")
+LANE_REPORT = Path("docs/objection-handling-report.md")
+LANE_ARTIFACT = Path("docs/objection-handling.md")
+LANE_PACK_SUMMARY = Path("docs/artifacts/objection-handling-pack/objection-handling-summary.json")
+LANE_PACK_SCORECARD = Path(
     "docs/artifacts/objection-handling-pack/objection-handling-scorecard.md"
 )
-DAY23_PACK_MATRIX = Path(
+LANE_PACK_MATRIX = Path(
     "docs/artifacts/objection-handling-pack/objection-handling-response-matrix.md"
 )
-DAY23_PACK_PLAYBOOK = Path("docs/artifacts/objection-handling-pack/objection-handling-playbook.md")
-DAY23_PACK_VALIDATION = Path(
+LANE_PACK_PLAYBOOK = Path("docs/artifacts/objection-handling-pack/objection-handling-playbook.md")
+LANE_PACK_VALIDATION = Path(
     "docs/artifacts/objection-handling-pack/objection-handling-validation-commands.md"
 )
-DAY23_EVIDENCE = Path(
+LANE_EVIDENCE = Path(
     "docs/artifacts/objection-handling-pack/evidence/objection-handling-execution-summary.json"
 )
 MODULE = Path("src/sdetkit/objection_handling.py")
@@ -78,18 +78,18 @@ def main(argv: list[str] | None = None) -> int:
         README,
         DOCS_INDEX,
         DOCS_CLI,
-        DAY23_PAGE,
-        DAY23_REPORT,
-        DAY23_ARTIFACT,
-        DAY23_PACK_SUMMARY,
-        DAY23_PACK_SCORECARD,
-        DAY23_PACK_MATRIX,
-        DAY23_PACK_PLAYBOOK,
-        DAY23_PACK_VALIDATION,
+        LANE_PAGE,
+        LANE_REPORT,
+        LANE_ARTIFACT,
+        LANE_PACK_SUMMARY,
+        LANE_PACK_SCORECARD,
+        LANE_PACK_MATRIX,
+        LANE_PACK_PLAYBOOK,
+        LANE_PACK_VALIDATION,
         MODULE,
     ]
     if not ns.skip_evidence:
-        required.append(DAY23_EVIDENCE)
+        required.append(LANE_EVIDENCE)
 
     errors: list[str] = []
     for path in required:
@@ -100,18 +100,18 @@ def main(argv: list[str] | None = None) -> int:
         errors.extend(f"{README}: missing '{m}'" for m in _missing(README, README_EXPECTED))
         errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
-        errors.extend(f"{DAY23_PAGE}: missing '{m}'" for m in _missing(DAY23_PAGE, PAGE_EXPECTED))
+        errors.extend(f"{LANE_PAGE}: missing '{m}'" for m in _missing(LANE_PAGE, PAGE_EXPECTED))
         errors.extend(
-            f"{DAY23_REPORT}: missing '{m}'" for m in _missing(DAY23_REPORT, REPORT_EXPECTED)
+            f"{LANE_REPORT}: missing '{m}'" for m in _missing(LANE_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
-            f"{DAY23_PACK_SUMMARY}: missing '{m}'"
-            for m in _missing(DAY23_PACK_SUMMARY, SUMMARY_EXPECTED)
+            f"{LANE_PACK_SUMMARY}: missing '{m}'"
+            for m in _missing(LANE_PACK_SUMMARY, SUMMARY_EXPECTED)
         )
         if not ns.skip_evidence:
             errors.extend(
-                f"{DAY23_EVIDENCE}: missing '{m}'"
-                for m in _missing(DAY23_EVIDENCE, EVIDENCE_EXPECTED)
+                f"{LANE_EVIDENCE}: missing '{m}'"
+                for m in _missing(LANE_EVIDENCE, EVIDENCE_EXPECTED)
             )
 
     if errors:

--- a/scripts/check_platform_contract_5.py
+++ b/scripts/check_platform_contract_5.py
@@ -6,8 +6,8 @@ import sys
 from pathlib import Path
 
 README = Path("README.md")
-DAY5_REPORT = Path("docs/impact-5-ultra-upgrade-report.md")
-DAY5_ARTIFACT = Path("docs/artifacts/platform-onboarding-sample-5.md")
+LANE_REPORT = Path("docs/impact-5-ultra-upgrade-report.md")
+LANE_ARTIFACT = Path("docs/artifacts/platform-onboarding-sample-5.md")
 
 REQUIRED_README_SNIPPETS = [
     "## 🖥️ Day 5 ultra: platform onboarding boost",
@@ -16,7 +16,7 @@ REQUIRED_README_SNIPPETS = [
     "docs/impact-5-ultra-upgrade-report.md",
 ]
 
-REQUIRED_DAY5_SECTION_LINKS = [
+REQUIRED_PLATFORM_SECTION_LINKS = [
     "docs/impact-5-ultra-upgrade-report.md",
     "docs/artifacts/platform-onboarding-sample-5.md",
 ]
@@ -29,7 +29,7 @@ REQUIRED_REPORT_SNIPPETS = [
 ]
 
 
-def _day5_section(text: str) -> str:
+def _platform_section(text: str) -> str:
     start = text.find("## 🖥️ Day 5 ultra: platform onboarding boost")
     if start == -1:
         return ""
@@ -48,30 +48,30 @@ def main() -> int:
         return 2
 
     readme_text = README.read_text(encoding="utf-8")
-    day5_section = _day5_section(readme_text)
+    platform_section = _platform_section(readme_text)
 
     for snippet in REQUIRED_README_SNIPPETS:
         if snippet not in readme_text:
             errors.append(f"missing README snippet: {snippet}")
 
-    if not day5_section:
+    if not platform_section:
         errors.append("missing Day 5 ultra section in README")
 
-    for link in REQUIRED_DAY5_SECTION_LINKS:
-        if link not in day5_section:
+    for link in REQUIRED_PLATFORM_SECTION_LINKS:
+        if link not in platform_section:
             errors.append(f"missing Day 5 section link: {link}")
         if not Path(link).exists():
             errors.append(f"missing link target: {link}")
 
-    if not DAY5_REPORT.exists():
+    if not LANE_REPORT.exists():
         errors.append("missing docs/impact-5-ultra-upgrade-report.md")
     else:
-        report_text = DAY5_REPORT.read_text(encoding="utf-8")
+        report_text = LANE_REPORT.read_text(encoding="utf-8")
         for snippet in REQUIRED_REPORT_SNIPPETS:
             if snippet not in report_text:
                 errors.append(f"missing Day 5 report snippet: {snippet}")
 
-    if not DAY5_ARTIFACT.exists():
+    if not LANE_ARTIFACT.exists():
         errors.append("missing docs/artifacts/platform-onboarding-sample-5.md")
 
     if errors:

--- a/scripts/check_release_communications_contract.py
+++ b/scripts/check_release_communications_contract.py
@@ -7,23 +7,23 @@ from pathlib import Path
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
-DAY20_PAGE = Path("docs/release-communications.md")
-DAY20_REPORT = Path("docs/release-communications-report.md")
-DAY20_ARTIFACT = Path("docs/artifacts/release-communications-sample.md")
-DAY20_PACK_SUMMARY = Path(
+LANE_PAGE = Path("docs/release-communications.md")
+LANE_REPORT = Path("docs/release-communications-report.md")
+LANE_ARTIFACT = Path("docs/artifacts/release-communications-sample.md")
+LANE_PACK_SUMMARY = Path(
     "docs/artifacts/release-communications-pack/release-communications-summary.json"
 )
-DAY20_PACK_MD = Path("docs/artifacts/release-communications-pack/release-communications.md")
-DAY20_PACK_BLURBS = Path(
+LANE_PACK_MD = Path("docs/artifacts/release-communications-pack/release-communications.md")
+LANE_PACK_BLURBS = Path(
     "docs/artifacts/release-communications-pack/release-communications-audience-blurbs.md"
 )
-DAY20_PACK_CHANNELS = Path(
+LANE_PACK_CHANNELS = Path(
     "docs/artifacts/release-communications-pack/release-communications-channel-posts.md"
 )
-DAY20_PACK_VALIDATION = Path(
+LANE_PACK_VALIDATION = Path(
     "docs/artifacts/release-communications-pack/release-communications-validation-commands.md"
 )
-DAY20_EVIDENCE = Path(
+LANE_EVIDENCE = Path(
     "docs/artifacts/release-communications-pack/evidence/release-communications-execution-summary.json"
 )
 MODULE = Path("src/sdetkit/release_communications.py")
@@ -79,18 +79,18 @@ def main(argv: list[str] | None = None) -> int:
         README,
         DOCS_INDEX,
         DOCS_CLI,
-        DAY20_PAGE,
-        DAY20_REPORT,
-        DAY20_ARTIFACT,
-        DAY20_PACK_SUMMARY,
-        DAY20_PACK_MD,
-        DAY20_PACK_BLURBS,
-        DAY20_PACK_CHANNELS,
-        DAY20_PACK_VALIDATION,
+        LANE_PAGE,
+        LANE_REPORT,
+        LANE_ARTIFACT,
+        LANE_PACK_SUMMARY,
+        LANE_PACK_MD,
+        LANE_PACK_BLURBS,
+        LANE_PACK_CHANNELS,
+        LANE_PACK_VALIDATION,
         MODULE,
     ]
     if not ns.skip_evidence:
-        required.append(DAY20_EVIDENCE)
+        required.append(LANE_EVIDENCE)
 
     errors: list[str] = []
     for path in required:
@@ -101,18 +101,18 @@ def main(argv: list[str] | None = None) -> int:
         errors.extend(f"{README}: missing '{m}'" for m in _missing(README, README_EXPECTED))
         errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
-        errors.extend(f"{DAY20_PAGE}: missing '{m}'" for m in _missing(DAY20_PAGE, PAGE_EXPECTED))
+        errors.extend(f"{LANE_PAGE}: missing '{m}'" for m in _missing(LANE_PAGE, PAGE_EXPECTED))
         errors.extend(
-            f"{DAY20_REPORT}: missing '{m}'" for m in _missing(DAY20_REPORT, REPORT_EXPECTED)
+            f"{LANE_REPORT}: missing '{m}'" for m in _missing(LANE_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
-            f"{DAY20_PACK_SUMMARY}: missing '{m}'"
-            for m in _missing(DAY20_PACK_SUMMARY, SUMMARY_EXPECTED)
+            f"{LANE_PACK_SUMMARY}: missing '{m}'"
+            for m in _missing(LANE_PACK_SUMMARY, SUMMARY_EXPECTED)
         )
         if not ns.skip_evidence:
             errors.extend(
-                f"{DAY20_EVIDENCE}: missing '{m}'"
-                for m in _missing(DAY20_EVIDENCE, EVIDENCE_EXPECTED)
+                f"{LANE_EVIDENCE}: missing '{m}'"
+                for m in _missing(LANE_EVIDENCE, EVIDENCE_EXPECTED)
             )
 
     if errors:

--- a/scripts/check_reliability_evidence_pack_contract.py
+++ b/scripts/check_reliability_evidence_pack_contract.py
@@ -7,22 +7,22 @@ from pathlib import Path
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
-DAY18_PAGE = Path("docs/reliability-evidence-pack.md")
-DAY18_REPORT = Path("docs/reliability-evidence-report.md")
-DAY18_ARTIFACT = Path("docs/reliability-evidence-pack.md")
-DAY18_PACK_SUMMARY = Path(
+LANE_PAGE = Path("docs/reliability-evidence-pack.md")
+LANE_REPORT = Path("docs/reliability-evidence-report.md")
+LANE_ARTIFACT = Path("docs/reliability-evidence-pack.md")
+LANE_PACK_SUMMARY = Path(
     "docs/artifacts/reliability-evidence-pack/reliability-evidence-summary.json"
 )
-DAY18_PACK_SCORECARD = Path(
+LANE_PACK_SCORECARD = Path(
     "docs/artifacts/reliability-evidence-pack/reliability-evidence-scorecard.md"
 )
-DAY18_PACK_CHECKLIST = Path(
+LANE_PACK_CHECKLIST = Path(
     "docs/artifacts/reliability-evidence-pack/reliability-evidence-checklist.md"
 )
-DAY18_PACK_VALIDATION = Path(
+LANE_PACK_VALIDATION = Path(
     "docs/artifacts/reliability-evidence-pack/reliability-evidence-validation-commands.md"
 )
-DAY18_EVIDENCE = Path(
+LANE_EVIDENCE = Path(
     "docs/artifacts/reliability-evidence-pack/evidence/reliability-evidence-execution-summary.json"
 )
 MODULE = Path("src/sdetkit/reliability_evidence_pack.py")
@@ -95,17 +95,17 @@ def main(argv: list[str] | None = None) -> int:
         README,
         DOCS_INDEX,
         DOCS_CLI,
-        DAY18_PAGE,
-        DAY18_REPORT,
-        DAY18_ARTIFACT,
-        DAY18_PACK_SUMMARY,
-        DAY18_PACK_SCORECARD,
-        DAY18_PACK_CHECKLIST,
-        DAY18_PACK_VALIDATION,
+        LANE_PAGE,
+        LANE_REPORT,
+        LANE_ARTIFACT,
+        LANE_PACK_SUMMARY,
+        LANE_PACK_SCORECARD,
+        LANE_PACK_CHECKLIST,
+        LANE_PACK_VALIDATION,
         MODULE,
     ]
     if not ns.skip_evidence:
-        required.append(DAY18_EVIDENCE)
+        required.append(LANE_EVIDENCE)
 
     errors: list[str] = []
     for path in required:
@@ -116,18 +116,18 @@ def main(argv: list[str] | None = None) -> int:
         errors.extend(f"{README}: missing '{m}'" for m in _missing(README, README_EXPECTED))
         errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
-        errors.extend(f"{DAY18_PAGE}: missing '{m}'" for m in _missing(DAY18_PAGE, PAGE_EXPECTED))
+        errors.extend(f"{LANE_PAGE}: missing '{m}'" for m in _missing(LANE_PAGE, PAGE_EXPECTED))
         errors.extend(
-            f"{DAY18_REPORT}: missing '{m}'" for m in _missing(DAY18_REPORT, REPORT_EXPECTED)
+            f"{LANE_REPORT}: missing '{m}'" for m in _missing(LANE_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
-            f"{DAY18_PACK_SUMMARY}: missing '{m}'"
-            for m in _missing(DAY18_PACK_SUMMARY, SUMMARY_EXPECTED)
+            f"{LANE_PACK_SUMMARY}: missing '{m}'"
+            for m in _missing(LANE_PACK_SUMMARY, SUMMARY_EXPECTED)
         )
         if not ns.skip_evidence:
             errors.extend(
-                f"{DAY18_EVIDENCE}: missing '{m}'"
-                for m in _missing(DAY18_EVIDENCE, EVIDENCE_EXPECTED)
+                f"{LANE_EVIDENCE}: missing '{m}'"
+                for m in _missing(LANE_EVIDENCE, EVIDENCE_EXPECTED)
             )
 
     if errors:

--- a/scripts/check_startup_readiness_contract.py
+++ b/scripts/check_startup_readiness_contract.py
@@ -7,8 +7,8 @@ README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
 USE_CASE_PAGE = Path("docs/use-cases-startup-small-team.md")
-DAY12_REPORT = Path("docs/startup-readiness-report.md")
-DAY12_ARTIFACT = Path("docs/artifacts/startup-readiness-sample.md")
+LANE_REPORT = Path("docs/startup-readiness-report.md")
+LANE_ARTIFACT = Path("docs/artifacts/startup-readiness-sample.md")
 STARTUP_PACK_CI = Path("docs/artifacts/startup-readiness-pack/startup-readiness-ci.yml")
 
 README_EXPECTED = [
@@ -76,8 +76,8 @@ def main() -> int:
         DOCS_INDEX,
         DOCS_CLI,
         USE_CASE_PAGE,
-        DAY12_REPORT,
-        DAY12_ARTIFACT,
+        LANE_REPORT,
+        LANE_ARTIFACT,
         STARTUP_PACK_CI,
     ]
     for path in required:
@@ -94,10 +94,10 @@ def main() -> int:
             f'{USE_CASE_PAGE}: missing "{m}"' for m in _missing(USE_CASE_PAGE, USE_CASE_EXPECTED)
         )
         errors.extend(
-            f'{DAY12_REPORT}: missing "{m}"' for m in _missing(DAY12_REPORT, REPORT_EXPECTED)
+            f'{LANE_REPORT}: missing "{m}"' for m in _missing(LANE_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
-            f'{DAY12_ARTIFACT}: missing "{m}"' for m in _missing(DAY12_ARTIFACT, ARTIFACT_EXPECTED)
+            f'{LANE_ARTIFACT}: missing "{m}"' for m in _missing(LANE_ARTIFACT, ARTIFACT_EXPECTED)
         )
         errors.extend(
             f'{STARTUP_PACK_CI}: missing "{m}"' for m in _missing(STARTUP_PACK_CI, PACK_CI_EXPECTED)

--- a/scripts/check_trust_assets_contract.py
+++ b/scripts/check_trust_assets_contract.py
@@ -7,15 +7,15 @@ from pathlib import Path
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")
-DAY22_PAGE = Path("docs/trust-assets.md")
-DAY22_REPORT = Path("docs/trust-assets-report.md")
-DAY22_ARTIFACT = Path("docs/trust-assets.md")
-DAY22_PACK_SUMMARY = Path("docs/artifacts/trust-assets-pack/trust-assets-summary.json")
-DAY22_PACK_SCORECARD = Path("docs/artifacts/trust-assets-pack/trust-assets-scorecard.md")
-DAY22_PACK_CHECKLIST = Path("docs/artifacts/trust-assets-pack/trust-assets-visibility-checklist.md")
-DAY22_PACK_VALIDATION = Path("docs/artifacts/trust-assets-pack/trust-assets-validation-commands.md")
-DAY22_PACK_ACTION_PLAN = Path("docs/artifacts/trust-assets-pack/trust-assets-action-plan.md")
-DAY22_EVIDENCE = Path(
+LANE_PAGE = Path("docs/trust-assets.md")
+LANE_REPORT = Path("docs/trust-assets-report.md")
+LANE_ARTIFACT = Path("docs/trust-assets.md")
+LANE_PACK_SUMMARY = Path("docs/artifacts/trust-assets-pack/trust-assets-summary.json")
+LANE_PACK_SCORECARD = Path("docs/artifacts/trust-assets-pack/trust-assets-scorecard.md")
+LANE_PACK_CHECKLIST = Path("docs/artifacts/trust-assets-pack/trust-assets-visibility-checklist.md")
+LANE_PACK_VALIDATION = Path("docs/artifacts/trust-assets-pack/trust-assets-validation-commands.md")
+LANE_PACK_ACTION_PLAN = Path("docs/artifacts/trust-assets-pack/trust-assets-action-plan.md")
+LANE_EVIDENCE = Path(
     "docs/artifacts/trust-assets-pack/evidence/trust-assets-execution-summary.json"
 )
 MODULE = Path("src/sdetkit/trust_assets.py")
@@ -73,18 +73,18 @@ def main(argv: list[str] | None = None) -> int:
         README,
         DOCS_INDEX,
         DOCS_CLI,
-        DAY22_PAGE,
-        DAY22_REPORT,
-        DAY22_ARTIFACT,
-        DAY22_PACK_SUMMARY,
-        DAY22_PACK_SCORECARD,
-        DAY22_PACK_CHECKLIST,
-        DAY22_PACK_VALIDATION,
-        DAY22_PACK_ACTION_PLAN,
+        LANE_PAGE,
+        LANE_REPORT,
+        LANE_ARTIFACT,
+        LANE_PACK_SUMMARY,
+        LANE_PACK_SCORECARD,
+        LANE_PACK_CHECKLIST,
+        LANE_PACK_VALIDATION,
+        LANE_PACK_ACTION_PLAN,
         MODULE,
     ]
     if not ns.skip_evidence:
-        required.append(DAY22_EVIDENCE)
+        required.append(LANE_EVIDENCE)
 
     errors: list[str] = []
     for path in required:
@@ -95,18 +95,18 @@ def main(argv: list[str] | None = None) -> int:
         errors.extend(f"{README}: missing '{m}'" for m in _missing(README, README_EXPECTED))
         errors.extend(f"{DOCS_INDEX}: missing '{m}'" for m in _missing(DOCS_INDEX, INDEX_EXPECTED))
         errors.extend(f"{DOCS_CLI}: missing '{m}'" for m in _missing(DOCS_CLI, CLI_EXPECTED))
-        errors.extend(f"{DAY22_PAGE}: missing '{m}'" for m in _missing(DAY22_PAGE, PAGE_EXPECTED))
+        errors.extend(f"{LANE_PAGE}: missing '{m}'" for m in _missing(LANE_PAGE, PAGE_EXPECTED))
         errors.extend(
-            f"{DAY22_REPORT}: missing '{m}'" for m in _missing(DAY22_REPORT, REPORT_EXPECTED)
+            f"{LANE_REPORT}: missing '{m}'" for m in _missing(LANE_REPORT, REPORT_EXPECTED)
         )
         errors.extend(
-            f"{DAY22_PACK_SUMMARY}: missing '{m}'"
-            for m in _missing(DAY22_PACK_SUMMARY, SUMMARY_EXPECTED)
+            f"{LANE_PACK_SUMMARY}: missing '{m}'"
+            for m in _missing(LANE_PACK_SUMMARY, SUMMARY_EXPECTED)
         )
         if not ns.skip_evidence:
             errors.extend(
-                f"{DAY22_EVIDENCE}: missing '{m}'"
-                for m in _missing(DAY22_EVIDENCE, EVIDENCE_EXPECTED)
+                f"{LANE_EVIDENCE}: missing '{m}'"
+                for m in _missing(LANE_EVIDENCE, EVIDENCE_EXPECTED)
             )
 
     if errors:

--- a/scripts/check_weekly_review_contract_7.py
+++ b/scripts/check_weekly_review_contract_7.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
-DAY7_REPORT = Path("docs/impact-7-ultra-upgrade-report.md")
-DAY7_ARTIFACT = Path("docs/artifacts/weekly-review-sample-7.md")
+LANE_REPORT = Path("docs/impact-7-ultra-upgrade-report.md")
+LANE_ARTIFACT = Path("docs/artifacts/weekly-review-sample-7.md")
 WEEKLY_MODULE = Path("src/sdetkit/weekly_review.py")
 
 REQUIRED_README_SNIPPETS = [
@@ -41,7 +41,7 @@ def main() -> int:
 
     readme = _read(README)
     docs_index = _read(DOCS_INDEX)
-    report = _read(DAY7_REPORT)
+    report = _read(LANE_REPORT)
 
     for s in REQUIRED_README_SNIPPETS:
         if s not in readme:
@@ -55,7 +55,7 @@ def main() -> int:
         if s not in report:
             errors.append(f"missing Day 7 report snippet: {s}")
 
-    for p in [DAY7_REPORT, DAY7_ARTIFACT, WEEKLY_MODULE]:
+    for p in [LANE_REPORT, LANE_ARTIFACT, WEEKLY_MODULE]:
         if not p.exists():
             errors.append(f"missing required file: {p}")
 


### PR DESCRIPTION
### Motivation
- Remove remaining active/public day-based identifier usage in contract checker scripts to make canonical lane naming consistent across active surfaces.  
- Perform a repo-wide, search-first cleanup of `day([0-9]{1,2})` residues on active checker surfaces rather than fixing a single lane.  
- Preserve semantics and narrow any compatibility-only references while avoiding blind changes to historical/test artifact content.

### Description
- Replaced day-numbered constant identifiers (`DAYNN_*`) with canonical neutral names (`LANE_*`) in 13 active contract checkers under `scripts/` to centralize public naming.  
- Updated related symbol names and small helpers where appropriate (for example `REQUIRED_DAY5_SECTION_LINKS` → `REQUIRED_PLATFORM_SECTION_LINKS` and `_day5_section` → `_platform_section`) to keep intent clear and avoid day-prefixed identifiers.  
- Kept intentionally scoped legacy references unchanged, including the explicit `day50` legacy alias mention in the execution-prioritization checker and the legacy root filename guards in the repo-layout checker.  
- All edits preserved file/path semantics and behavior (only identifier/constant names in active public checker scripts were canonicalized).

### Testing
- Ran Python compile checks with `python -m py_compile` against all touched `scripts/check_*.py` files and they passed.  
- Executed a targeted pytest suite for the touched areas with `pytest` and received `96 passed` tests.  
- Ran the updated contract checker scripts; several contract checks passed (`--skip-evidence` variants and others) while a number failed due to pre-existing missing docs/artifacts (e.g., missing `docs/impact-7-ultra-upgrade-report.md` and other lane report files), which are unrelated repo-content gaps and not caused by this refactor.  
- Verified with `rg -n -i "day([0-9]{1,2})" scripts/check_*.py` that only the two intentional compatibility/historical references remain (the `day50` alias note and the repo-layout legacy filename guard).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d16612545c8320b98029e2c081f4bf)