### PR TITLE
Remove day-based legacy_name fields from active early closeout lanes

### DIFF
--- a/docs/artifacts/community-activation-pack/community-activation-summary.json
+++ b/docs/artifacts/community-activation-pack/community-activation-summary.json
@@ -70,7 +70,6 @@
     "readme": "README.md",
     "top10": "docs/top-10-github-strategy.md"
   },
-  "legacy_name": "day25-community-activation",
   "name": "community-activation",
   "strict_failures": [
     "# Community activation (Day 25)",

--- a/docs/artifacts/kpi-audit-pack/kpi-audit-summary.json
+++ b/docs/artifacts/kpi-audit-pack/kpi-audit-summary.json
@@ -86,7 +86,6 @@
     "readme": "README.md",
     "top10": "docs/top-10-github-strategy.md"
   },
-  "legacy_name": "day27-kpi-audit",
   "metrics": {
     "baseline": {
       "discussions_per_week": 3.0,

--- a/docs/artifacts/weekly-review-pack/weekly-review-summary.json
+++ b/docs/artifacts/weekly-review-pack/weekly-review-summary.json
@@ -1,6 +1,5 @@
 {
   "name": "weekly-review-lane",
-  "legacy_name": "day28-weekly-review",
   "inputs": {
     "readme": "README.md",
     "docs_index": "docs/index.md",

--- a/src/sdetkit/community_activation.py
+++ b/src/sdetkit/community_activation.py
@@ -245,7 +245,6 @@ def build_community_activation_summary(
 
     return {
         "name": "community-activation",
-        "legacy_name": "day25-community-activation",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -360,7 +359,6 @@ def execute_commands(root: Path, evidence_dir: Path, timeout_sec: int) -> dict[s
         )
     payload = {
         "name": "community-activation-execution",
-        "legacy_name": "day25-community-activation-execution",
         "total_commands": len(_EXECUTION_COMMANDS),
         "results": results,
     }

--- a/src/sdetkit/kpi_audit.py
+++ b/src/sdetkit/kpi_audit.py
@@ -271,7 +271,6 @@ def build_kpi_audit_summary(
 
     return {
         "name": "kpi-audit",
-        "legacy_name": "day27-kpi-audit",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -394,7 +393,6 @@ def execute_commands(root: Path, evidence_dir: Path, timeout_sec: int) -> dict[s
 
     payload = {
         "name": "kpi-audit-execution",
-        "legacy_name": "day27-kpi-audit-execution",
         "total_commands": len(_EXECUTION_COMMANDS),
         "results": results,
     }

--- a/src/sdetkit/weekly_review_28.py
+++ b/src/sdetkit/weekly_review_28.py
@@ -243,7 +243,6 @@ def build_weekly_review_summary_impl(
 
     return {
         "name": "weekly-review-lane",
-        "legacy_name": "day28-weekly-review",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -369,7 +368,6 @@ def _run_execution(root: Path, evidence_dir: Path) -> None:
         )
     summary = {
         "name": "weekly-review-lane-execution",
-        "legacy_name": "day28-weekly-review-execution",
         "total_commands": len(logs),
         "failed_commands": [log["command"] for log in logs if log["returncode"] != 0],
         "commands": logs,


### PR DESCRIPTION
### Motivation
- Conducted a repo-wide inventory of `dayNN` residues on active/public surfaces and found remaining active/public `legacy_name` emissions for Day 25, Day 27 and Day 28 lanes. 
- The goal was to batch-clean remaining active/public day-based names and make canonical playbook names primary on outputs without touching already-productized compatibility shims. 
- Excluded already-clean lanes and intentional compatibility aliases (e.g. reliability/day47, weekly-review/day49, execution-prioritization/day50 and hidden reliability flags day15/day16/day17) from this pass.

### Description
- Removed day-based `legacy_name` fields from the return payloads and execution payloads in `src/sdetkit/community_activation.py`, `src/sdetkit/kpi_audit.py`, and `src/sdetkit/weekly_review_28.py` so canonical names (e.g. `community-activation`, `kpi-audit`, `weekly-review-lane`) are primary. 
- Regenerated the checked-in artifact summaries under `docs/artifacts/` to match the canonical payload shape by updating `docs/artifacts/community-activation-pack/community-activation-summary.json`, `docs/artifacts/kpi-audit-pack/kpi-audit-summary.json`, and `docs/artifacts/weekly-review-pack/weekly-review-summary.json`. 
- Preserved narrow compatibility shims and CLI routing aliases in `src/sdetkit/cli.py` (e.g. `day47-reliability-closeout`, `day49-advanced-weekly-review-control-tower`, `day50-execution-prioritization-closeout`) and hidden reliability flags in `src/sdetkit/reliability_evidence_pack.py`. 
- No behavioral logic changes were made beyond removing the emitted day-based `legacy_name` fields; all semantics and evidence/inputs remained intact.

### Testing
- Regenerated packs with `python -m sdetkit community-activation --format json --emit-pack-dir docs/artifacts/community-activation-pack`, `python -m sdetkit kpi-audit --format json --emit-pack-dir docs/artifacts/kpi-audit-pack`, and `python -m sdetkit weekly-review-lane --format json --emit-pack-dir docs/artifacts/weekly-review-pack`, and those commands completed successfully. 
- Ran targeted unit tests `pytest -q tests/test_community_activation.py tests/test_kpi_audit.py tests/test_weekly_review_lane.py` which passed (`12 passed`). 
- Ran `python scripts/check_repo_layout.py` which passed and confirms no forbidden legacy root CI filenames remain. 
- Performed strict-mode validation for the touched lanes and observed `python -m sdetkit community-activation --format json --strict` fails due to pre-existing docs/contract gaps unrelated to this cleanup (no strict-mode regressions were introduced by these edits).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d16f3158a883208601621c610049be)