### PR TITLE
Remove day97 legacy artifact aliases from Cycle 7 closeout test contract

### DIFF
--- a/tests/test_continuous_upgrade_closeout_7.py
+++ b/tests/test_continuous_upgrade_closeout_7.py
@@ -191,68 +191,57 @@ def test_cycle7_emit_pack_and_execute(tmp_path: Path) -> None:
     _find_existing(
         [
             pack / "continuous-upgrade-closeout-7-summary.json",
-            pack / "continuous-upgrade-closeout-7-summary.json",
         ]
     )
     _find_existing(
         [
-            pack / "continuous-upgrade-closeout-7-summary.md",
             pack / "continuous-upgrade-closeout-7-summary.md",
         ]
     )
     _find_existing(
         [
             pack / "continuous-upgrade-cycle7-evidence-brief.md",
-            pack / "day97-evidence-brief.md",
         ]
     )
     _find_existing(
         [
             pack / "continuous-upgrade-cycle7-plan.md",
-            pack / "day97-continuous-upgrade-plan.md",
         ]
     )
     _find_existing(
         [
             pack / "continuous-upgrade-cycle7-template-ledger.json",
-            pack / "day97-upgrade-template-upgrade-ledger.json",
         ]
     )
     _find_existing(
         [
             pack / "continuous-upgrade-cycle7-storyline-outcomes-ledger.json",
-            pack / "day97-storyline-outcomes-ledger.json",
         ]
     )
     _find_existing(
         [
             pack / "continuous-upgrade-cycle7-kpi-scorecard.json",
-            pack / "day97-upgrade-kpi-scorecard.json",
         ]
     )
     _find_existing(
         [
             pack / "continuous-upgrade-cycle7-execution-log.md",
-            pack / "day97-execution-log.md",
         ]
     )
     _find_existing(
         [
-            pack / "continuous-upgrade-cycle7-delivery-board.md",
             pack / "continuous-upgrade-cycle7-delivery-board.md",
         ]
     )
     _find_existing(
         [
             pack / "continuous-upgrade-cycle7-validation-commands.md",
-            pack / "day97-validation-commands.md",
         ]
     )
 
     execution_summary = _find_existing(
         [
             pack / "evidence/continuous-upgrade-cycle7-execution-summary.json",
-            pack / "evidence/day97-execution-summary.json",
         ]
     )
     execution_data = json.loads(execution_summary.read_text(encoding="utf-8"))
@@ -278,8 +267,6 @@ def test_cycle7_execute_strict_fails_on_command_error(tmp_path: Path, monkeypatc
     assert rc == 1
     execution_summary = _find_existing(
         [
-            tmp_path
-            / "artifacts/continuous-upgrade-cycle7-pack/evidence/continuous-upgrade-cycle7-execution-summary.json",
             tmp_path
             / "artifacts/continuous-upgrade-cycle7-pack/evidence/continuous-upgrade-cycle7-execution-summary.json",
         ]


### PR DESCRIPTION
### Motivation

- A repo scan for `day([0-9]{1,2})` showed remaining day-based residue used as fallback artifact names in the active Cycle 7 closeout test contract, which should prefer canonical cycle/closeout artifact names. 
- This change narrows public/test contract surfaces to canonical names while leaving intentional compatibility aliases and historical evidence logs untouched.

### Description

- Removed legacy `day97-*` fallback artifact assertions and duplicate-path assertions from `tests/test_continuous_upgrade_closeout_7.py`, so the test now only asserts canonical `continuous-upgrade-cycle7-*` / `continuous-upgrade-closeout-7-*` artifact paths. 
- Did not change emitter/runtime semantics or other compatibility aliases (`day15/day16/day17`, day50 legacy messaging, `check.sh` legacy aliases) which are intentionally retained or are historical artifacts. 
- Modified file: `tests/test_continuous_upgrade_closeout_7.py` (cleaned legacy assertions and duplicate checks).

### Testing

- Ran `pytest -q tests/test_continuous_upgrade_closeout_7.py`, which passed (`5 passed`).
- Ran the cycle contract checker `python scripts/check_continuous_upgrade_contract_7.py`, which failed due to a pre-existing import/module mismatch (`ModuleNotFoundError: No module named 'sdetkit.continuous_upgrade_cycle7_closeout'`) unrelated to this test cleanup. 
- Ran the CLI execution `python -m sdetkit continuous-upgrade-closeout-7 --format text --strict` which returned the existing baseline score outcome (strict fail) and is unchanged by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d190a1bc648320a4bf4a4065af1678)