### PR TITLE
Batch-clean legacy dayNN artifact paths for active closeout lanes

### DIFF
--- a/docs/artifacts/optimization-closeout-pack-42/optimization-closeout-summary-42.json
+++ b/docs/artifacts/optimization-closeout-pack-42/optimization-closeout-summary-42.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-optimization-closeout-foundation.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day41_summary": "docs/artifacts/expansion-automation-pack/expansion-automation-summary.json",
-    "day41_delivery_board": "docs/artifacts/expansion-automation-pack/day41-delivery-board.md"
+    "day41_summary": "docs/artifacts/expansion-automation-pack-41/expansion-automation-summary-41.json",
+    "day41_delivery_board": "docs/artifacts/expansion-automation-pack-41/delivery-board-41.md"
   },
   "checks": [
     {
@@ -59,13 +59,13 @@
       "check_id": "day41_summary_present",
       "weight": 10,
       "passed": true,
-      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/expansion-automation-pack/expansion-automation-summary.json"
+      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/expansion-automation-pack-41/expansion-automation-summary-41.json"
     },
     {
       "check_id": "day41_delivery_board_present",
       "weight": 8,
       "passed": true,
-      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/expansion-automation-pack/day41-delivery-board.md"
+      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/expansion-automation-pack-41/delivery-board-41.md"
     },
     {
       "check_id": "day41_quality_floor",

--- a/docs/artifacts/scale-closeout-pack-44/scale-closeout-summary-44.json
+++ b/docs/artifacts/scale-closeout-pack-44/scale-closeout-summary-44.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-scale-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day43_summary": "docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json",
-    "day43_delivery_board": "docs/artifacts/acceleration-closeout-pack/day43-delivery-board.md"
+    "day43_summary": "docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json",
+    "day43_delivery_board": "docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md"
   },
   "checks": [
     {
@@ -59,13 +59,13 @@
       "check_id": "day43_summary_present",
       "weight": 10,
       "passed": true,
-      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
+      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json"
     },
     {
       "check_id": "day43_delivery_board_present",
       "weight": 8,
       "passed": true,
-      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack/day43-delivery-board.md"
+      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md"
     },
     {
       "check_id": "day43_quality_floor",

--- a/docs/artifacts/scale-closeout-pack/scale-closeout-summary.json
+++ b/docs/artifacts/scale-closeout-pack/scale-closeout-summary.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-scale-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day43_summary": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json",
-    "day43_delivery_board": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack/day43-delivery-board.md"
+    "day43_summary": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json",
+    "day43_delivery_board": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md"
   },
   "checks": [
     {
@@ -59,13 +59,13 @@
       "check_id": "day43_summary_present",
       "weight": 10,
       "passed": false,
-      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
+      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json"
     },
     {
       "check_id": "day43_delivery_board_present",
       "weight": 8,
       "passed": false,
-      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack/day43-delivery-board.md"
+      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md"
     },
     {
       "check_id": "day43_quality_floor",

--- a/docs/artifacts/weekly-review-closeout-pack-49/weekly-review-closeout-summary-49.json
+++ b/docs/artifacts/weekly-review-closeout-pack-49/weekly-review-closeout-summary-49.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-weekly-review-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day48_summary": "docs/artifacts/objection-closeout-pack/objection-closeout-summary.json",
-    "day48_delivery_board": "docs/artifacts/objection-closeout-pack/day48-delivery-board.md"
+    "day48_summary": "docs/artifacts/objection-closeout-pack-48/objection-closeout-summary-48.json",
+    "day48_delivery_board": "docs/artifacts/objection-closeout-pack-48/delivery-board-48.md"
   },
   "checks": [
     {
@@ -59,13 +59,13 @@
       "check_id": "day48_summary_present",
       "weight": 10,
       "passed": true,
-      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/objection-closeout-pack/objection-closeout-summary.json"
+      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/objection-closeout-pack-48/objection-closeout-summary-48.json"
     },
     {
       "check_id": "day48_delivery_board_present",
       "weight": 8,
       "passed": true,
-      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/objection-closeout-pack/day48-delivery-board.md"
+      "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/objection-closeout-pack-48/delivery-board-48.md"
     },
     {
       "check_id": "day48_quality_floor",

--- a/src/sdetkit/acceleration_closeout_43.py
+++ b/src/sdetkit/acceleration_closeout_43.py
@@ -10,8 +10,9 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-acceleration-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY42_SUMMARY_PATH = "docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json"
-_DAY42_BOARD_PATH = "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
+_DAY42_SUMMARY_PATH = "docs/artifacts/optimization-closeout-pack-42/optimization-closeout-summary-42.json"
+_DAY42_BOARD_PATH = "docs/artifacts/optimization-closeout-pack-42/delivery-board-42.md"
+_DAY42_LEGACY_SUMMARY_PATH = "docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json"
 _DAY42_LEGACY_BOARD_PATH = "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
 _SECTION_HEADER = "# Day 43 \u2014 Acceleration closeout lane"
 _REQUIRED_SECTIONS = [
@@ -67,8 +68,8 @@ This lane closes with a major acceleration upgrade that converts optimization ev
 
 ## Required inputs (optimization closeout foundation)
 
-- `docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json`
-- `docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md`
+- `docs/artifacts/optimization-closeout-pack-42/optimization-closeout-summary-42.json`
+- `docs/artifacts/optimization-closeout-pack-42/delivery-board-42.md`
 
 ## Command lane
 
@@ -177,7 +178,7 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day42_summary = root / _DAY42_SUMMARY_PATH
+    day42_summary = _resolve_existing_path(root, _DAY42_SUMMARY_PATH, _DAY42_LEGACY_SUMMARY_PATH)
     day42_board = _resolve_existing_path(root, _DAY42_BOARD_PATH, _DAY42_LEGACY_BOARD_PATH)
     day42_score, day42_strict, day42_check_count = _load_day42(day42_summary)
     board_count, board_has_day42, board_has_day43 = _board_stats(day42_board)

--- a/src/sdetkit/optimization_closeout_42.py
+++ b/src/sdetkit/optimization_closeout_42.py
@@ -10,8 +10,9 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-optimization-closeout-foundation.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY41_SUMMARY_PATH = "docs/artifacts/expansion-automation-pack/expansion-automation-summary.json"
-_DAY41_BOARD_PATH = "docs/artifacts/expansion-automation-pack/delivery-board.md"
+_DAY41_SUMMARY_PATH = "docs/artifacts/expansion-automation-pack-41/expansion-automation-summary-41.json"
+_DAY41_BOARD_PATH = "docs/artifacts/expansion-automation-pack-41/delivery-board-41.md"
+_DAY41_LEGACY_SUMMARY_PATH = "docs/artifacts/expansion-automation-pack/expansion-automation-summary.json"
 _DAY41_LEGACY_BOARD_PATH = "docs/artifacts/expansion-automation-pack/delivery-board.md"
 _SECTION_HEADER = "# Optimization Closeout Foundation \u2014 Optimization closeout lane"
 _REQUIRED_SECTIONS = [
@@ -67,8 +68,8 @@ Optimization Closeout Foundation closes with a major optimization upgrade that c
 
 ## Required inputs (expansion automation)
 
-- `docs/artifacts/expansion-automation-pack/expansion-automation-summary.json`
-- `docs/artifacts/expansion-automation-pack/delivery-board.md`
+- `docs/artifacts/expansion-automation-pack-41/expansion-automation-summary-41.json`
+- `docs/artifacts/expansion-automation-pack-41/delivery-board-41.md`
 
 ## Optimization Closeout Foundation command lane
 
@@ -177,7 +178,7 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day41_summary = root / _DAY41_SUMMARY_PATH
+    day41_summary = _resolve_existing_path(root, _DAY41_SUMMARY_PATH, _DAY41_LEGACY_SUMMARY_PATH)
     day41_board = _resolve_existing_path(root, _DAY41_BOARD_PATH, _DAY41_LEGACY_BOARD_PATH)
     day41_score, day41_strict, day41_check_count = _load_day41(day41_summary)
     board_count, board_has_day41, board_has_day42 = _board_stats(day41_board)

--- a/src/sdetkit/scale_closeout_44.py
+++ b/src/sdetkit/scale_closeout_44.py
@@ -10,8 +10,10 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-scale-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY43_SUMMARY_PATH = "docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
-_DAY43_BOARD_PATH = "docs/artifacts/acceleration-closeout-pack/delivery-board.md"
+_DAY43_SUMMARY_PATH = "docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json"
+_DAY43_BOARD_PATH = "docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md"
+_DAY43_LEGACY_SUMMARY_PATH = "docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
+_DAY43_LEGACY_BOARD_PATH = "docs/artifacts/acceleration-closeout-pack/delivery-board.md"
 _SECTION_HEADER = "# Day 44 \u2014 Scale closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why this lane matters",
@@ -66,8 +68,8 @@ This lane closes with a major scale upgrade that converts acceleration evidence 
 
 ## Required inputs (acceleration closeout)
 
-- `docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json`
-- `docs/artifacts/acceleration-closeout-pack/delivery-board.md`
+- `docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json`
+- `docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md`
 
 ## Command lane
 
@@ -176,12 +178,8 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day43_summary = root / _DAY43_SUMMARY_PATH
-    day43_board = _resolve_existing_path(
-        root,
-        _DAY43_BOARD_PATH,
-        "docs/artifacts/acceleration-closeout-pack/acceleration-delivery-board.md",
-    )
+    day43_summary = _resolve_existing_path(root, _DAY43_SUMMARY_PATH, _DAY43_LEGACY_SUMMARY_PATH)
+    day43_board = _resolve_existing_path(root, _DAY43_BOARD_PATH, _DAY43_LEGACY_BOARD_PATH)
     day43_score, day43_strict, day43_check_count = _load_day43(day43_summary)
     board_count, board_has_day43, board_has_day44 = _board_stats(day43_board)
 

--- a/src/sdetkit/weekly_review_closeout_49.py
+++ b/src/sdetkit/weekly_review_closeout_49.py
@@ -10,9 +10,10 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-weekly-review-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY48_SUMMARY_PATH = "docs/artifacts/objection-closeout-pack/objection-closeout-summary.json"
-_DAY48_BOARD_PATH = "docs/artifacts/objection-closeout-pack/objection-delivery-board.md"
-_DAY48_LEGACY_BOARD_PATH = "docs/artifacts/objection-closeout-pack/delivery-board-48.md"
+_DAY48_SUMMARY_PATH = "docs/artifacts/objection-closeout-pack-48/objection-closeout-summary-48.json"
+_DAY48_BOARD_PATH = "docs/artifacts/objection-closeout-pack-48/delivery-board-48.md"
+_DAY48_LEGACY_SUMMARY_PATH = "docs/artifacts/objection-closeout-pack/objection-closeout-summary.json"
+_DAY48_LEGACY_BOARD_PATH = "docs/artifacts/objection-closeout-pack/objection-delivery-board.md"
 _SECTION_HEADER = "# Day 49 \u2014 Weekly review closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Day 49 matters",
@@ -67,8 +68,8 @@ Day 49 closes with a major weekly-review upgrade that converts Day 48 objection 
 
 ## Required inputs (Day 48)
 
-- `docs/artifacts/objection-closeout-pack/objection-closeout-summary.json`
-- `docs/artifacts/objection-closeout-pack/objection-delivery-board.md`
+- `docs/artifacts/objection-closeout-pack-48/objection-closeout-summary-48.json`
+- `docs/artifacts/objection-closeout-pack-48/delivery-board-48.md`
 
 ## Day 49 command lane
 
@@ -176,7 +177,7 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day48_summary = root / _DAY48_SUMMARY_PATH
+    day48_summary = _resolve_existing_path(root, _DAY48_SUMMARY_PATH, _DAY48_LEGACY_SUMMARY_PATH)
     day48_board = _resolve_existing_path(root, _DAY48_BOARD_PATH, _DAY48_LEGACY_BOARD_PATH)
     day48_score, day48_strict, day48_check_count = _load_day48(day48_summary)
     board_count, board_has_day48, board_has_day49 = _board_stats(day48_board)


### PR DESCRIPTION
### Motivation
- Remove remaining live dayNN-based artifact path residue on active/public surfaces and prefer canonical pack-named artifacts for current lanes. 
- Focus this pass on active closeout lanes where commands still resolved predecessor artifacts via stale legacy pack paths (avoid touching already-clean lanes or historical/test-only references). 
- Preserve narrow compatibility fallbacks so older fixtures and aliases continue to resolve when needed. 

### Description
- Updated four active closeout lane modules to prefer canonical predecessor pack paths and to resolve legacy paths only as explicit fallbacks by adding/adjusting `_DAY##_SUMMARY_PATH`, `_DAY##_BOARD_PATH` and `_DAY##_LEGACY_*` constants and using `_resolve_existing_path` where appropriate in `src/sdetkit/optimization_closeout_42.py`, `src/sdetkit/acceleration_closeout_43.py`, `src/sdetkit/scale_closeout_44.py`, and `src/sdetkit/weekly_review_closeout_49.py`.
- Rewrote checked-in active summary artifacts under `docs/artifacts/*` so the public/primary `inputs` now reference canonical `*-pack-<lane>` summary and delivery-board files instead of stale dayNN pack paths (e.g., optimization, scale, weekly-review summary JSON files were updated).
- Kept CLI legacy aliases and narrow compatibility shims intact (no promotion of dayNN legacy names to primary) and avoided changes to onboarding/reliability/day50/day51/phase1/phase2/day90 lanes as excluded by scope.
- Commit contains only the path/lookup and checked-in artifact reference updates described above and leaves historical/test-only day file references untouched.

### Testing
- Ran targeted pytest for the touched lanes with `pytest -q tests/test_optimization_closeout_foundation.py tests/test_acceleration_closeout.py tests/test_scale_closeout.py tests/test_weekly_review_closeout.py` and the final run succeeded: `18 passed`.
- Ran the lane contract checker scripts with `python scripts/check_optimization_closeout_contract.py --skip-evidence && python scripts/check_acceleration_closeout_contract.py --skip-evidence && python scripts/check_scale_closeout_contract.py --skip-evidence && python scripts/check_weekly_review_closeout_contract.py --skip-evidence` and observed the optimization contract check reporting missing docs contract entries (the optimization contract checker returned errors / score 51), indicating unrelated docs contract text drift that should be addressed separately.
- Iterative local validation was performed after each patch until the targeted pytest suite passed, and the repo was left with the intended canonical path wiring and compatibility fallbacks for the four active lanes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d1acb12a948320bb932e47a4bd4ed2)