### PR TITLE
Remove Day 49 legacy CLI alias and legacy_name emission for weekly-review-closeout

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -474,10 +474,7 @@ Start here:
     d48 = sub.add_parser("objection-closeout")
     d48.set_defaults(cmd="objection-closeout")
     d48.add_argument("args", nargs=argparse.REMAINDER)
-    d49 = sub.add_parser(
-        "weekly-review-closeout",
-        aliases=["day49-advanced-weekly-review-control-tower"],
-    )
+    d49 = sub.add_parser("weekly-review-closeout")
     d49.set_defaults(cmd="weekly-review-closeout")
     d49.add_argument("args", nargs=argparse.REMAINDER)
     d50 = sub.add_parser(
@@ -762,7 +759,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         argv[0] = _resolve_non_day_playbook_alias(str(argv[0]))
         legacy_aliases = {
             "day47-reliability-closeout": "reliability-closeout",
-            "day49-advanced-weekly-review-control-tower": "weekly-review-closeout",
             "day50-execution-prioritization-closeout": "execution-prioritization-closeout",
         }
         argv[0] = legacy_aliases.get(str(argv[0]), str(argv[0]))

--- a/src/sdetkit/weekly_review_closeout_49.py
+++ b/src/sdetkit/weekly_review_closeout_49.py
@@ -331,7 +331,6 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
 
     return {
         "name": "weekly-review-closeout",
-        "legacy_name": "day49-advanced-weekly-review-control-tower",
         "inputs": {
             "readme": readme_path,
             "docs_index": docs_index_path,
@@ -488,7 +487,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Weekly review closeout checks (legacy alias: day49-advanced-weekly-review-control-tower)"
+        description="Weekly review closeout checks"
     )
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")

--- a/tests/test_weekly_review_closeout.py
+++ b/tests/test_weekly_review_closeout.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from sdetkit import cli
 from sdetkit import weekly_review_closeout_49 as d49
 
@@ -71,7 +73,6 @@ def test_lane49_weekly_review_closeout_json(tmp_path: Path, capsys) -> None:
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
     assert out["name"] == "weekly-review-closeout"
-    assert out["legacy_name"] == "day49-advanced-weekly-review-control-tower"
     assert out["summary"]["activation_score"] >= 95
 
 
@@ -127,13 +128,14 @@ def test_lane49_cli_dispatch(tmp_path: Path, capsys) -> None:
     assert "Day 49 advanced weekly review control tower summary" in capsys.readouterr().out
 
 
-def test_lane49_advanced_alias_cli_dispatch(tmp_path: Path, capsys) -> None:
+def test_lane49_advanced_alias_cli_rejected(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
-    rc = cli.main(
-        ["day49-advanced-weekly-review-control-tower", "--root", str(tmp_path), "--format", "text"]
-    )
-    assert rc == 0
-    assert "advanced weekly review control tower" in capsys.readouterr().out
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(
+            ["day49-advanced-weekly-review-control-tower", "--root", str(tmp_path), "--format", "text"]
+        )
+    assert excinfo.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err
 
 
 def test_lane49_non_day_alias_cli_dispatch(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
### Motivation
- Narrow the active/public command surface by removing the Day 49 legacy alias so the canonical `weekly-review-closeout` name is the primary public interface and compatibility surface is reduced.

### Description
- Removed the `day49-advanced-weekly-review-control-tower` alias from the CLI parser and from the legacy alias remap so `weekly-review-closeout` is the only active public command (updated `src/sdetkit/cli.py`).
- Stopped emitting the Day 49 `legacy_name` in the weekly-review closeout JSON payload and simplified the parser description (updated `src/sdetkit/weekly_review_closeout_49.py`).
- Updated unit tests to assert canonical output and to verify the removed Day 49 alias is rejected (updated `tests/test_weekly_review_closeout.py`).
- Retained explicitly allowed compatibility aliases for Day 47 and Day 50 and left historical artifact/evidence packs and archive/test-only dayNN strings unchanged.

### Testing
- Ran targeted pytest: `pytest -q tests/test_weekly_review_closeout.py tests/test_cli_productized_closeout_aliases.py tests/test_cli_help_lists_subcommands.py`, which succeeded (18 passed).
- Ran `python scripts/check_weekly_review_closeout_contract.py` which failed due to missing docs contract entries and missing evidence in the baseline repository, and `python scripts/check_weekly_review_closeout_contract.py --skip-evidence` also reported missing docs contract entries; these failures reflect missing/legacy baseline artifacts rather than the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d257c58cfc8320b1f50823cfc26a6b)