### PR TITLE
Canonicalize dayNN continuity keys for Day 65–68 weekly/integration expansion chain

### DIFF
--- a/docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json
+++ b/docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-integration-expansion2-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day65_summary": "docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json",
-    "day65_delivery_board": "docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-delivery-board-2.md",
+    "weekly_review_summary": "docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json",
+    "weekly_review_delivery_board": "docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-delivery-board-2.md",
     "gitlab_reference": "templates/ci/gitlab/gitlab-advanced-reference.yml"
   },
   "checks": [
@@ -29,34 +29,34 @@
       "evidence": "Day 66 + Day 67 strategy chain"
     },
     {
-      "check_id": "day65_summary_present",
+      "check_id": "weekly_review_summary_present",
       "weight": 10,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json"
     },
     {
-      "check_id": "day65_delivery_board_present",
+      "check_id": "weekly_review_delivery_board_present",
       "weight": 7,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-delivery-board-2.md"
     },
     {
-      "check_id": "day65_quality_floor",
+      "check_id": "weekly_review_quality_floor",
       "weight": 13,
       "passed": false,
       "evidence": {
-        "day65_score": 55,
+        "weekly_review_score": 55,
         "strict_pass": false,
-        "day65_checks": 14
+        "weekly_review_checks": 14
       }
     },
     {
-      "check_id": "day65_board_integrity",
+      "check_id": "weekly_review_board_integrity",
       "weight": 5,
       "passed": false,
       "evidence": {
         "board_items": 5,
-        "contains_day65": false
+        "contains_weekly_review": false
       }
     },
     {
@@ -116,16 +116,16 @@
     }
   ],
   "rollup": {
-    "day65_activation_score": 55,
-    "day65_checks": 14,
-    "day65_delivery_board_items": 5
+    "weekly_review_activation_score": 55,
+    "weekly_review_checks": 14,
+    "weekly_review_delivery_board_items": 5
   },
   "summary": {
     "activation_score": 37,
     "passed_checks": 5,
     "failed_checks": 9,
     "critical_failures": [
-      "day65_strict_baseline"
+      "weekly_review_strict_baseline"
     ],
     "strict_pass": false
   },

--- a/docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.md
+++ b/docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.md
@@ -2,4 +2,4 @@ Integration Expansion 2 Closeout summary
 - Activation score: 37
 - Passed checks: 5
 - Failed checks: 9
-- Critical failures: ['day65_strict_baseline']
+- Critical failures: ['weekly_review_strict_baseline']

--- a/docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json
+++ b/docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-integration-expansion3-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day66_summary": "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json",
-    "day66_delivery_board": "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md",
+    "integration_expansion2_summary": "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json",
+    "integration_expansion2_delivery_board": "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md",
     "jenkins_reference": "templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile"
   },
   "checks": [
@@ -29,34 +29,34 @@
       "evidence": "Day 67 + Day 68 strategy chain"
     },
     {
-      "check_id": "day66_summary_present",
+      "check_id": "integration_expansion2_summary_present",
       "weight": 10,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json"
     },
     {
-      "check_id": "day66_delivery_board_present",
+      "check_id": "integration_expansion2_delivery_board_present",
       "weight": 7,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md"
     },
     {
-      "check_id": "day66_quality_floor",
+      "check_id": "integration_expansion2_quality_floor",
       "weight": 13,
       "passed": false,
       "evidence": {
-        "day66_score": 37,
+        "integration_expansion2_score": 37,
         "strict_pass": false,
-        "day66_checks": 14
+        "integration_expansion2_checks": 14
       }
     },
     {
-      "check_id": "day66_board_integrity",
+      "check_id": "integration_expansion2_board_integrity",
       "weight": 5,
       "passed": true,
       "evidence": {
         "board_items": 5,
-        "contains_day66": true
+        "contains_integration_expansion2": true
       }
     },
     {
@@ -116,16 +116,16 @@
     }
   ],
   "rollup": {
-    "day66_activation_score": 37,
-    "day66_checks": 14,
-    "day66_delivery_board_items": 5
+    "integration_expansion2_activation_score": 37,
+    "integration_expansion2_checks": 14,
+    "integration_expansion2_delivery_board_items": 5
   },
   "summary": {
     "activation_score": 42,
     "passed_checks": 6,
     "failed_checks": 8,
     "critical_failures": [
-      "day66_strict_baseline"
+      "integration_expansion2_strict_baseline"
     ],
     "strict_pass": false
   },

--- a/docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.md
+++ b/docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.md
@@ -2,4 +2,4 @@ Integration Expansion3 Closeout summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8
-- Critical failures: ['day66_strict_baseline']
+- Critical failures: ['integration_expansion2_strict_baseline']

--- a/docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.json
+++ b/docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-integration-expansion4-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day67_summary": "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json",
-    "day67_delivery_board": "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md",
+    "integration_expansion3_summary": "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json",
+    "integration_expansion3_delivery_board": "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md",
     "self_hosted_reference": "templates/ci/tekton/tekton-self-hosted-reference.yaml"
   },
   "checks": [
@@ -29,34 +29,34 @@
       "evidence": "Day 68 + Day 69 strategy chain"
     },
     {
-      "check_id": "day67_summary_present",
+      "check_id": "integration_expansion3_summary_present",
       "weight": 10,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json"
     },
     {
-      "check_id": "day67_delivery_board_present",
+      "check_id": "integration_expansion3_delivery_board_present",
       "weight": 7,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md"
     },
     {
-      "check_id": "day67_quality_floor",
+      "check_id": "integration_expansion3_quality_floor",
       "weight": 13,
       "passed": false,
       "evidence": {
-        "day67_score": 42,
+        "integration_expansion3_score": 42,
         "strict_pass": false,
-        "day67_checks": 14
+        "integration_expansion3_checks": 14
       }
     },
     {
-      "check_id": "day67_board_integrity",
+      "check_id": "integration_expansion3_board_integrity",
       "weight": 5,
       "passed": true,
       "evidence": {
         "board_items": 5,
-        "contains_day67": true
+        "contains_integration_expansion3": true
       }
     },
     {
@@ -116,16 +116,16 @@
     }
   ],
   "rollup": {
-    "day67_activation_score": 42,
-    "day67_checks": 14,
-    "day67_delivery_board_items": 5
+    "integration_expansion3_activation_score": 42,
+    "integration_expansion3_checks": 14,
+    "integration_expansion3_delivery_board_items": 5
   },
   "summary": {
     "activation_score": 42,
     "passed_checks": 6,
     "failed_checks": 8,
     "critical_failures": [
-      "day67_strict_baseline"
+      "integration_expansion3_strict_baseline"
     ],
     "strict_pass": false
   },

--- a/docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.md
+++ b/docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.md
@@ -2,4 +2,4 @@ Integration Expansion4 Closeout summary
 - Activation score: 42
 - Passed checks: 6
 - Failed checks: 8
-- Critical failures: ['day67_strict_baseline']
+- Critical failures: ['integration_expansion3_strict_baseline']

--- a/src/sdetkit/integration_expansion2_closeout_66.py
+++ b/src/sdetkit/integration_expansion2_closeout_66.py
@@ -10,10 +10,10 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-integration-expansion2-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY65_SUMMARY_PATH = (
+_WEEKLY_REVIEW_SUMMARY_PATH = (
     "docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json"
 )
-_DAY65_BOARD_PATH = (
+_WEEKLY_REVIEW_BOARD_PATH = (
     "docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-delivery-board-2.md"
 )
 _GITLAB_PATH = "templates/ci/gitlab/gitlab-advanced-reference.yml"
@@ -140,7 +140,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day65(path: Path) -> tuple[int, bool, int]:
+def _load_weekly_review(path: Path) -> tuple[int, bool, int]:
     payload_obj = _load_json(path)
     if not isinstance(payload_obj, dict):
         return 0, False, 0
@@ -168,10 +168,10 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
     gitlab_path = root / _GITLAB_PATH
     gitlab_text = _read(gitlab_path)
 
-    day65_summary = root / _DAY65_SUMMARY_PATH
-    day65_board = root / _DAY65_BOARD_PATH
-    day65_score, day65_strict, day65_check_count = _load_day65(day65_summary)
-    board_count, board_has_day65 = _count_board_items(day65_board, "Day 65")
+    weekly_review_summary = root / _WEEKLY_REVIEW_SUMMARY_PATH
+    weekly_review_board = root / _WEEKLY_REVIEW_BOARD_PATH
+    weekly_review_score, weekly_review_strict, weekly_review_check_count = _load_weekly_review(weekly_review_summary)
+    board_count, board_has_weekly_review = _count_board_items(weekly_review_board, "Day 65")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -203,32 +203,32 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 66 + Day 67 strategy chain",
         },
         {
-            "check_id": "day65_summary_present",
+            "check_id": "weekly_review_summary_present",
             "weight": 10,
-            "passed": day65_summary.exists(),
-            "evidence": str(day65_summary),
+            "passed": weekly_review_summary.exists(),
+            "evidence": str(weekly_review_summary),
         },
         {
-            "check_id": "day65_delivery_board_present",
+            "check_id": "weekly_review_delivery_board_present",
             "weight": 7,
-            "passed": day65_board.exists(),
-            "evidence": str(day65_board),
+            "passed": weekly_review_board.exists(),
+            "evidence": str(weekly_review_board),
         },
         {
-            "check_id": "day65_quality_floor",
+            "check_id": "weekly_review_quality_floor",
             "weight": 13,
-            "passed": day65_strict and day65_score >= 95,
+            "passed": weekly_review_strict and weekly_review_score >= 95,
             "evidence": {
-                "day65_score": day65_score,
-                "strict_pass": day65_strict,
-                "day65_checks": day65_check_count,
+                "weekly_review_score": weekly_review_score,
+                "strict_pass": weekly_review_strict,
+                "weekly_review_checks": weekly_review_check_count,
             },
         },
         {
-            "check_id": "day65_board_integrity",
+            "check_id": "weekly_review_board_integrity",
             "weight": 5,
-            "passed": board_count >= 5 and board_has_day65,
-            "evidence": {"board_items": board_count, "contains_day65": board_has_day65},
+            "passed": board_count >= 5 and board_has_weekly_review,
+            "evidence": {"board_items": board_count, "contains_weekly_review": board_has_weekly_review},
         },
         {
             "check_id": "page_header",
@@ -276,24 +276,24 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day65_summary.exists() or not day65_board.exists():
-        critical_failures.append("day65_handoff_inputs")
-    if not day65_strict:
-        critical_failures.append("day65_strict_baseline")
+    if not weekly_review_summary.exists() or not weekly_review_board.exists():
+        critical_failures.append("weekly_review_handoff_inputs")
+    if not weekly_review_strict:
+        critical_failures.append("weekly_review_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day65_strict:
-        wins.append(f"Day 65 continuity is strict-pass with activation score={day65_score}.")
+    if weekly_review_strict:
+        wins.append(f"Day 65 continuity is strict-pass with activation score={weekly_review_score}.")
     else:
         misses.append("Day 65 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 65 closeout command and restore strict baseline before Day 66 lock."
         )
 
-    if board_count >= 5 and board_has_day65:
+    if board_count >= 5 and board_has_weekly_review:
         wins.append(
             f"Day 65 delivery board integrity validated with {board_count} checklist items."
         )
@@ -326,21 +326,21 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day65_summary": str(day65_summary.relative_to(root))
-            if day65_summary.exists()
-            else str(day65_summary),
-            "day65_delivery_board": str(day65_board.relative_to(root))
-            if day65_board.exists()
-            else str(day65_board),
+            "weekly_review_summary": str(weekly_review_summary.relative_to(root))
+            if weekly_review_summary.exists()
+            else str(weekly_review_summary),
+            "weekly_review_delivery_board": str(weekly_review_board.relative_to(root))
+            if weekly_review_board.exists()
+            else str(weekly_review_board),
             "gitlab_reference": str(gitlab_path.relative_to(root))
             if gitlab_path.exists()
             else _GITLAB_PATH,
         },
         "checks": checks,
         "rollup": {
-            "day65_activation_score": day65_score,
-            "day65_checks": day65_check_count,
-            "day65_delivery_board_items": board_count,
+            "weekly_review_activation_score": weekly_review_score,
+            "weekly_review_checks": weekly_review_check_count,
+            "weekly_review_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,

--- a/src/sdetkit/integration_expansion3_closeout_67.py
+++ b/src/sdetkit/integration_expansion3_closeout_67.py
@@ -10,8 +10,8 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-integration-expansion3-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY66_SUMMARY_PATH = "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json"
-_DAY66_BOARD_PATH = (
+_INTEGRATION_EXPANSION2_SUMMARY_PATH = "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json"
+_INTEGRATION_EXPANSION2_BOARD_PATH = (
     "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md"
 )
 _JENKINS_PATH = "templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile"
@@ -138,7 +138,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day66(path: Path) -> tuple[int, bool, int]:
+def _load_integration_expansion2(path: Path) -> tuple[int, bool, int]:
     payload_obj = _load_json(path)
     if not isinstance(payload_obj, dict):
         return 0, False, 0
@@ -166,10 +166,10 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
     jenkins_path = root / _JENKINS_PATH
     jenkins_text = _read(jenkins_path)
 
-    day66_summary = root / _DAY66_SUMMARY_PATH
-    day66_board = root / _DAY66_BOARD_PATH
-    day66_score, day66_strict, day66_check_count = _load_day66(day66_summary)
-    board_count, board_has_day66 = _count_board_items(day66_board, "Day 66")
+    integration_expansion2_summary = root / _INTEGRATION_EXPANSION2_SUMMARY_PATH
+    integration_expansion2_board = root / _INTEGRATION_EXPANSION2_BOARD_PATH
+    integration_expansion2_score, integration_expansion2_strict, integration_expansion2_check_count = _load_integration_expansion2(integration_expansion2_summary)
+    board_count, board_has_integration_expansion2 = _count_board_items(integration_expansion2_board, "Day 66")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -201,32 +201,32 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 67 + Day 68 strategy chain",
         },
         {
-            "check_id": "day66_summary_present",
+            "check_id": "integration_expansion2_summary_present",
             "weight": 10,
-            "passed": day66_summary.exists(),
-            "evidence": str(day66_summary),
+            "passed": integration_expansion2_summary.exists(),
+            "evidence": str(integration_expansion2_summary),
         },
         {
-            "check_id": "day66_delivery_board_present",
+            "check_id": "integration_expansion2_delivery_board_present",
             "weight": 7,
-            "passed": day66_board.exists(),
-            "evidence": str(day66_board),
+            "passed": integration_expansion2_board.exists(),
+            "evidence": str(integration_expansion2_board),
         },
         {
-            "check_id": "day66_quality_floor",
+            "check_id": "integration_expansion2_quality_floor",
             "weight": 13,
-            "passed": day66_strict and day66_score >= 95,
+            "passed": integration_expansion2_strict and integration_expansion2_score >= 95,
             "evidence": {
-                "day66_score": day66_score,
-                "strict_pass": day66_strict,
-                "day66_checks": day66_check_count,
+                "integration_expansion2_score": integration_expansion2_score,
+                "strict_pass": integration_expansion2_strict,
+                "integration_expansion2_checks": integration_expansion2_check_count,
             },
         },
         {
-            "check_id": "day66_board_integrity",
+            "check_id": "integration_expansion2_board_integrity",
             "weight": 5,
-            "passed": board_count >= 5 and board_has_day66,
-            "evidence": {"board_items": board_count, "contains_day66": board_has_day66},
+            "passed": board_count >= 5 and board_has_integration_expansion2,
+            "evidence": {"board_items": board_count, "contains_integration_expansion2": board_has_integration_expansion2},
         },
         {
             "check_id": "page_header",
@@ -274,24 +274,24 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day66_summary.exists() or not day66_board.exists():
-        critical_failures.append("day66_handoff_inputs")
-    if not day66_strict:
-        critical_failures.append("day66_strict_baseline")
+    if not integration_expansion2_summary.exists() or not integration_expansion2_board.exists():
+        critical_failures.append("integration_expansion2_handoff_inputs")
+    if not integration_expansion2_strict:
+        critical_failures.append("integration_expansion2_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day66_strict:
-        wins.append(f"Day 66 continuity is strict-pass with activation score={day66_score}.")
+    if integration_expansion2_strict:
+        wins.append(f"Day 66 continuity is strict-pass with activation score={integration_expansion2_score}.")
     else:
         misses.append("Day 66 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 66 closeout command and restore strict baseline before Day 67 lock."
         )
 
-    if board_count >= 5 and board_has_day66:
+    if board_count >= 5 and board_has_integration_expansion2:
         wins.append(
             f"Day 66 delivery board integrity validated with {board_count} checklist items."
         )
@@ -324,21 +324,21 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day66_summary": str(day66_summary.relative_to(root))
-            if day66_summary.exists()
-            else str(day66_summary),
-            "day66_delivery_board": str(day66_board.relative_to(root))
-            if day66_board.exists()
-            else str(day66_board),
+            "integration_expansion2_summary": str(integration_expansion2_summary.relative_to(root))
+            if integration_expansion2_summary.exists()
+            else str(integration_expansion2_summary),
+            "integration_expansion2_delivery_board": str(integration_expansion2_board.relative_to(root))
+            if integration_expansion2_board.exists()
+            else str(integration_expansion2_board),
             "jenkins_reference": str(jenkins_path.relative_to(root))
             if jenkins_path.exists()
             else _JENKINS_PATH,
         },
         "checks": checks,
         "rollup": {
-            "day66_activation_score": day66_score,
-            "day66_checks": day66_check_count,
-            "day66_delivery_board_items": board_count,
+            "integration_expansion2_activation_score": integration_expansion2_score,
+            "integration_expansion2_checks": integration_expansion2_check_count,
+            "integration_expansion2_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,

--- a/src/sdetkit/integration_expansion4_closeout_68.py
+++ b/src/sdetkit/integration_expansion4_closeout_68.py
@@ -10,8 +10,8 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-integration-expansion4-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY67_SUMMARY_PATH = "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json"
-_DAY67_BOARD_PATH = (
+_INTEGRATION_EXPANSION3_SUMMARY_PATH = "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json"
+_INTEGRATION_EXPANSION3_BOARD_PATH = (
     "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md"
 )
 _REFERENCE_PATH = "templates/ci/tekton/tekton-self-hosted-reference.yaml"
@@ -138,7 +138,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day67(path: Path) -> tuple[int, bool, int]:
+def _load_integration_expansion3(path: Path) -> tuple[int, bool, int]:
     payload_obj = _load_json(path)
     if not isinstance(payload_obj, dict):
         return 0, False, 0
@@ -166,10 +166,10 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
     reference_path = root / _REFERENCE_PATH
     reference_text = _read(reference_path)
 
-    day67_summary = root / _DAY67_SUMMARY_PATH
-    day67_board = root / _DAY67_BOARD_PATH
-    day67_score, day67_strict, day67_check_count = _load_day67(day67_summary)
-    board_count, board_has_day67 = _count_board_items(day67_board, "Day 67")
+    integration_expansion3_summary = root / _INTEGRATION_EXPANSION3_SUMMARY_PATH
+    integration_expansion3_board = root / _INTEGRATION_EXPANSION3_BOARD_PATH
+    integration_expansion3_score, integration_expansion3_strict, integration_expansion3_check_count = _load_integration_expansion3(integration_expansion3_summary)
+    board_count, board_has_integration_expansion3 = _count_board_items(integration_expansion3_board, "Day 67")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -201,32 +201,32 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 68 + Day 69 strategy chain",
         },
         {
-            "check_id": "day67_summary_present",
+            "check_id": "integration_expansion3_summary_present",
             "weight": 10,
-            "passed": day67_summary.exists(),
-            "evidence": str(day67_summary),
+            "passed": integration_expansion3_summary.exists(),
+            "evidence": str(integration_expansion3_summary),
         },
         {
-            "check_id": "day67_delivery_board_present",
+            "check_id": "integration_expansion3_delivery_board_present",
             "weight": 7,
-            "passed": day67_board.exists(),
-            "evidence": str(day67_board),
+            "passed": integration_expansion3_board.exists(),
+            "evidence": str(integration_expansion3_board),
         },
         {
-            "check_id": "day67_quality_floor",
+            "check_id": "integration_expansion3_quality_floor",
             "weight": 13,
-            "passed": day67_strict and day67_score >= 95,
+            "passed": integration_expansion3_strict and integration_expansion3_score >= 95,
             "evidence": {
-                "day67_score": day67_score,
-                "strict_pass": day67_strict,
-                "day67_checks": day67_check_count,
+                "integration_expansion3_score": integration_expansion3_score,
+                "strict_pass": integration_expansion3_strict,
+                "integration_expansion3_checks": integration_expansion3_check_count,
             },
         },
         {
-            "check_id": "day67_board_integrity",
+            "check_id": "integration_expansion3_board_integrity",
             "weight": 5,
-            "passed": board_count >= 5 and board_has_day67,
-            "evidence": {"board_items": board_count, "contains_day67": board_has_day67},
+            "passed": board_count >= 5 and board_has_integration_expansion3,
+            "evidence": {"board_items": board_count, "contains_integration_expansion3": board_has_integration_expansion3},
         },
         {
             "check_id": "page_header",
@@ -274,24 +274,24 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day67_summary.exists() or not day67_board.exists():
-        critical_failures.append("day67_handoff_inputs")
-    if not day67_strict:
-        critical_failures.append("day67_strict_baseline")
+    if not integration_expansion3_summary.exists() or not integration_expansion3_board.exists():
+        critical_failures.append("integration_expansion3_handoff_inputs")
+    if not integration_expansion3_strict:
+        critical_failures.append("integration_expansion3_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day67_strict:
-        wins.append(f"Day 67 continuity is strict-pass with activation score={day67_score}.")
+    if integration_expansion3_strict:
+        wins.append(f"Day 67 continuity is strict-pass with activation score={integration_expansion3_score}.")
     else:
         misses.append("Day 67 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 67 closeout command and restore strict baseline before Day 68 lock."
         )
 
-    if board_count >= 5 and board_has_day67:
+    if board_count >= 5 and board_has_integration_expansion3:
         wins.append(
             f"Day 67 delivery board integrity validated with {board_count} checklist items."
         )
@@ -324,21 +324,21 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day67_summary": str(day67_summary.relative_to(root))
-            if day67_summary.exists()
-            else str(day67_summary),
-            "day67_delivery_board": str(day67_board.relative_to(root))
-            if day67_board.exists()
-            else str(day67_board),
+            "integration_expansion3_summary": str(integration_expansion3_summary.relative_to(root))
+            if integration_expansion3_summary.exists()
+            else str(integration_expansion3_summary),
+            "integration_expansion3_delivery_board": str(integration_expansion3_board.relative_to(root))
+            if integration_expansion3_board.exists()
+            else str(integration_expansion3_board),
             "self_hosted_reference": str(reference_path.relative_to(root))
             if reference_path.exists()
             else _REFERENCE_PATH,
         },
         "checks": checks,
         "rollup": {
-            "day67_activation_score": day67_score,
-            "day67_checks": day67_check_count,
-            "day67_delivery_board_items": board_count,
+            "integration_expansion3_activation_score": integration_expansion3_score,
+            "integration_expansion3_checks": integration_expansion3_check_count,
+            "integration_expansion3_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,

--- a/src/sdetkit/weekly_review_closeout_65.py
+++ b/src/sdetkit/weekly_review_closeout_65.py
@@ -10,13 +10,13 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-weekly-review-closeout-2.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_DAY64_SUMMARY_PATH = (
+_INTEGRATION_EXPANSION_SUMMARY_PATH = (
     "docs/artifacts/integration-expansion-closeout-pack/integration-expansion-closeout-summary.json"
 )
-_DAY64_BOARD_PATH = (
+_INTEGRATION_EXPANSION_BOARD_PATH = (
     "docs/artifacts/integration-expansion-closeout-pack/integration-expansion-delivery-board.md"
 )
-_DAY64_WORKFLOW_PATH = ".github/workflows/advanced-github-actions-reference-64.yml"
+_INTEGRATION_EXPANSION_WORKFLOW_PATH = ".github/workflows/advanced-github-actions-reference-64.yml"
 _SECTION_HEADER = "# Day 65 \u2014 Weekly review #9 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Weekly Review Closeout matters",
@@ -132,7 +132,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day64(path: Path) -> tuple[int, bool, int]:
+def _load_integration_expansion(path: Path) -> tuple[int, bool, int]:
     payload_obj = _load_json(path)
     if not isinstance(payload_obj, dict):
         return 0, False, 0
@@ -157,12 +157,12 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
     docs_index_text = _read(root / "docs/index.md")
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
-    day64_workflow_text = _read(root / _DAY64_WORKFLOW_PATH)
+    integration_expansion_workflow_text = _read(root / _INTEGRATION_EXPANSION_WORKFLOW_PATH)
 
-    day64_summary = root / _DAY64_SUMMARY_PATH
-    day64_board = root / _DAY64_BOARD_PATH
-    day64_score, day64_strict, day64_check_count = _load_day64(day64_summary)
-    board_count, board_has_day64 = _count_board_items(day64_board, "Day 64")
+    integration_expansion_summary = root / _INTEGRATION_EXPANSION_SUMMARY_PATH
+    integration_expansion_board = root / _INTEGRATION_EXPANSION_BOARD_PATH
+    integration_expansion_score, integration_expansion_strict, integration_expansion_check_count = _load_integration_expansion(integration_expansion_summary)
+    board_count, board_has_integration_expansion = _count_board_items(integration_expansion_board, "Day 64")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -193,32 +193,32 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 65 + Day 66 strategy chain",
         },
         {
-            "check_id": "day64_summary_present",
+            "check_id": "integration_expansion_summary_present",
             "weight": 10,
-            "passed": day64_summary.exists(),
-            "evidence": str(day64_summary),
+            "passed": integration_expansion_summary.exists(),
+            "evidence": str(integration_expansion_summary),
         },
         {
-            "check_id": "day64_delivery_board_present",
+            "check_id": "integration_expansion_delivery_board_present",
             "weight": 7,
-            "passed": day64_board.exists(),
-            "evidence": str(day64_board),
+            "passed": integration_expansion_board.exists(),
+            "evidence": str(integration_expansion_board),
         },
         {
-            "check_id": "day64_quality_floor",
+            "check_id": "integration_expansion_quality_floor",
             "weight": 13,
-            "passed": day64_strict and day64_score >= 95,
+            "passed": integration_expansion_strict and integration_expansion_score >= 95,
             "evidence": {
-                "day64_score": day64_score,
-                "strict_pass": day64_strict,
-                "day64_checks": day64_check_count,
+                "integration_expansion_score": integration_expansion_score,
+                "strict_pass": integration_expansion_strict,
+                "integration_expansion_checks": integration_expansion_check_count,
             },
         },
         {
-            "check_id": "day64_board_integrity",
+            "check_id": "integration_expansion_board_integrity",
             "weight": 5,
-            "passed": board_count >= 5 and board_has_day64,
-            "evidence": {"board_items": board_count, "contains_day64": board_has_day64},
+            "passed": board_count >= 5 and board_has_integration_expansion,
+            "evidence": {"board_items": board_count, "contains_integration_expansion": board_has_integration_expansion},
         },
         {
             "check_id": "page_header",
@@ -257,33 +257,33 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": missing_board_items or "delivery board locked",
         },
         {
-            "check_id": "day64_workflow_reference_present",
+            "check_id": "integration_expansion_workflow_reference_present",
             "weight": 10,
-            "passed": "Day64 Advanced GitHub Actions Reference" in day64_workflow_text,
+            "passed": "Day64 Advanced GitHub Actions Reference" in integration_expansion_workflow_text,
             "evidence": ".github/workflows/advanced-github-actions-reference-64.yml",
         },
     ]
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day64_summary.exists() or not day64_board.exists():
-        critical_failures.append("day64_handoff_inputs")
-    if not day64_strict:
-        critical_failures.append("day64_strict_baseline")
+    if not integration_expansion_summary.exists() or not integration_expansion_board.exists():
+        critical_failures.append("integration_expansion_handoff_inputs")
+    if not integration_expansion_strict:
+        critical_failures.append("integration_expansion_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day64_strict:
-        wins.append(f"Day 64 continuity is strict-pass with activation score={day64_score}.")
+    if integration_expansion_strict:
+        wins.append(f"Day 64 continuity is strict-pass with activation score={integration_expansion_score}.")
     else:
         misses.append("Day 64 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 64 closeout command and restore strict baseline before Day 65 lock."
         )
 
-    if board_count >= 5 and board_has_day64:
+    if board_count >= 5 and board_has_integration_expansion:
         wins.append(
             f"Day 64 delivery board integrity validated with {board_count} checklist items."
         )
@@ -293,12 +293,12 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
         )
         handoff_actions.append("Repair Day 64 delivery board entries to include Day 64 anchors.")
 
-    if "Day64 Advanced GitHub Actions Reference" in day64_workflow_text:
+    if "Day64 Advanced GitHub Actions Reference" in integration_expansion_workflow_text:
         wins.append("Day 64 workflow reference remains available for weekly KPI baseline review.")
     else:
         misses.append("Day 64 workflow reference is missing for weekly review context.")
         handoff_actions.append(
-            "Restore day64 workflow reference before publishing Day 65 outcomes."
+            "Restore integration_expansion workflow reference before publishing Day 65 outcomes."
         )
 
     if not failed and not critical_failures:
@@ -314,19 +314,19 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day64_summary": str(day64_summary.relative_to(root))
-            if day64_summary.exists()
-            else str(day64_summary),
-            "day64_delivery_board": str(day64_board.relative_to(root))
-            if day64_board.exists()
-            else str(day64_board),
-            "day64_workflow": _DAY64_WORKFLOW_PATH,
+            "integration_expansion_summary": str(integration_expansion_summary.relative_to(root))
+            if integration_expansion_summary.exists()
+            else str(integration_expansion_summary),
+            "integration_expansion_delivery_board": str(integration_expansion_board.relative_to(root))
+            if integration_expansion_board.exists()
+            else str(integration_expansion_board),
+            "integration_expansion_workflow": _INTEGRATION_EXPANSION_WORKFLOW_PATH,
         },
         "checks": checks,
         "rollup": {
-            "day64_activation_score": day64_score,
-            "day64_checks": day64_check_count,
-            "day64_delivery_board_items": board_count,
+            "integration_expansion_activation_score": integration_expansion_score,
+            "integration_expansion_checks": integration_expansion_check_count,
+            "integration_expansion_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,


### PR DESCRIPTION
### Motivation
- Remove remaining active/public day-based naming residue across the weekly → integration-expansion closeout chain so canonical lane names are primary on active surfaces. 
- This batch pass inventories the repo first (found 262 files matching `day([0-9]{1,2})`: 35 `src` active files, 35 `tests`, 185 `docs/artifacts`, 4 roadmap/report docs, 3 `scripts`) and then cleans all eligible active lanes in the same pass. 

### Description
- Replaced dayNN-oriented continuity keys/check IDs with canonical, lane-oriented names across the Day 65→68 chain: `day64_*` → `integration_expansion_*` in `weekly_review_closeout_65`, `day65_*` → `weekly_review_*` in `integration_expansion2_closeout_66`, `day66_*` → `integration_expansion2_*` in `integration_expansion3_closeout_67`, and `day67_*` → `integration_expansion3_*` in `integration_expansion4_closeout_68`.
- Normalized function/constant names and evidence keys to the new canonical names in the four source modules: `src/sdetkit/weekly_review_closeout_65.py`, `src/sdetkit/integration_expansion2_closeout_66.py`, `src/sdetkit/integration_expansion3_closeout_67.py`, and `src/sdetkit/integration_expansion4_closeout_68.py`.
- Regenerated and updated the checked-in active artifact summaries so emitted outputs use the canonical keys; modified artifact files under `docs/artifacts/` for the touched packs (`integration-expansion2/3/4` summary `.json` and `.md`).
- Left intentionally narrow compatibility aliases and other out-of-scope lanes untouched (notably existing CLI compatibility aliases such as `day47-*` and `day50-*`, onboarding/reliability lane boundaries, phase1/phase2 chains, and the recently productized day90/cycle boundary) after verifying no fresh mismatch existed.

### Testing
- Ran targeted pytest for the touched areas: `pytest -q tests/test_weekly_review_closeout_2.py tests/test_integration_expansion2_closeout.py tests/test_integration_expansion3_closeout.py tests/test_integration_expansion4_closeout.py tests/test_cli_productized_closeout_aliases.py`, all tests passed (`26 passed`).
- Ran the lane contract checker scripts for the affected lanes (`check_*_contract_*.py --skip-evidence`) to validate outputs and found failures in activation/strict checks; these are due to pre-existing low activation scores / missing strict baselines in the checked-in docs state and are not runtime or code errors introduced by this change.
- Verified the emitted/checked-in artifact summaries now contain the canonical keys and matching check IDs (examples: `weekly_review_*`, `integration_expansion2_*`, `integration_expansion3_*`) for downstream consumers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d25b01de7483208e6df6a1fcba93c9)