### PR TITLE
Cleanup: remove day-based wording from contributor-funnel backlog

### DIFF
--- a/src/sdetkit/contributor_funnel.py
+++ b/src/sdetkit/contributor_funnel.py
@@ -21,11 +21,11 @@ _DAY8_ISSUES = [
     },
     {
         "id": "GFI-02",
-        "title": "Add docs index quick link for day6 conversion QA sample",
+        "title": "Add docs index quick link for onboarding conversion QA sample",
         "area": "docs",
         "estimate": "S",
         "acceptance": [
-            "docs/index.md quick-jump section contains an anchor to Day 6 artifact guidance.",
+            "docs/index.md quick-jump section contains an anchor to onboarding artifact guidance.",
             "Anchor resolves in rendered markdown.",
             "docs-qa command output remains clean for modified files.",
         ],
@@ -58,7 +58,7 @@ _DAY8_ISSUES = [
         "area": "tests",
         "estimate": "M",
         "acceptance": [
-            "Test verifies markdown output starts with expected Day 6 heading.",
+            "Test verifies markdown output starts with expected onboarding heading.",
             "Test includes at least one failing-link fixture and checks report summary counts.",
             "Test suite stays deterministic (no network calls).",
         ],
@@ -69,7 +69,7 @@ _DAY8_ISSUES = [
         "area": "docs",
         "estimate": "S",
         "acceptance": [
-            "Contributing docs include explicit docs/artifacts/dayX-* naming guidance.",
+            "Contributing docs include explicit docs/artifacts/<capability>-* naming guidance.",
             "Examples include at least one markdown artifact path.",
             "Language remains beginner-friendly and concise.",
         ],
@@ -114,7 +114,7 @@ _DAY8_ISSUES = [
         "estimate": "S",
         "acceptance": [
             "Contributing or docs index includes a command block for impact contract scripts.",
-            "Snippet references at least day6 and day7 script examples.",
+            "Snippet references at least docs-qa and first-contribution script examples.",
             "Instructions remain compatible with bash on Linux/macOS.",
         ],
     },


### PR DESCRIPTION
### Motivation
- Remove remaining active/public day-based wording in the contributor-funnel backlog so canonical terminology (onboarding / docs-qa / first-contribution) is primary and non-technical copy does not promote legacy `dayNN` names.

### Description
- Edited `_DAY8_ISSUES` in `src/sdetkit/contributor_funnel.py` to replace `day6`/`day7`/`dayX` phrasing with canonical onboarding/docs-qa/first-contribution wording, preserving semantics and not changing runtime behavior.

### Testing
- Ran `python -m pytest -q tests/test_contributor_funnel.py tests/test_contributor_funnel_extra.py` and the tests passed (7 passed); running `python scripts/check_contributor_funnel_contract_8.py` failed due to pre-existing missing Day‑8 era README/docs/artifacts unrelated to this edit; the change was committed and the working tree is clean (`git status --short`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d2603517f083208e212ed1194aed80)