### PR TITLE
Batch-clean dayNN predecessor keys in active closeout lanes

### DIFF
--- a/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-brief.md
+++ b/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-brief.md
@@ -1,1 +1,1 @@
-# Cycle 55 contributor activation brief
+# Day 55 contributor activation brief

--- a/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json
+++ b/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json
@@ -5,10 +5,10 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-contributor-activation-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day53_summary": "docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json",
-    "day53_summary_primary": "docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json",
-    "day53_delivery_board": "docs/artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md",
-    "day53_delivery_board_primary": "docs/artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md"
+    "docs_loop_closeout_summary": "docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json",
+    "docs_loop_closeout_summary_primary": "docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json",
+    "docs_loop_closeout_delivery_board": "docs/artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md",
+    "docs_loop_closeout_delivery_board_primary": "docs/artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md"
   },
   "checks": [
     {
@@ -24,7 +24,10 @@
       "evidence": {
         "missing_sections": [
           "# Day 55 \u2014 Contributor activation closeout lane",
-          "## Day 55 command lane"
+          "## Why Day 55 matters",
+          "## Required inputs (Day 53)",
+          "## Day 55 command lane",
+          "## Day 55 delivery board"
         ]
       }
     },
@@ -46,7 +49,7 @@
       "check_id": "readme_command_lane",
       "weight": 4,
       "passed": false,
-      "evidence": "day55-contributor-activation-closeout"
+      "evidence": "README contributor-activation-closeout command lane"
     },
     {
       "check_id": "docs_index_links",
@@ -61,7 +64,7 @@
       "evidence": "Day 55 + Day 56 strategy chain"
     },
     {
-      "check_id": "day53_summary_present",
+      "check_id": "docs_loop_closeout_summary_present",
       "weight": 10,
       "passed": true,
       "evidence": {
@@ -70,7 +73,7 @@
       }
     },
     {
-      "check_id": "day53_delivery_board_present",
+      "check_id": "docs_loop_closeout_delivery_board_present",
       "weight": 8,
       "passed": true,
       "evidence": {
@@ -79,30 +82,35 @@
       }
     },
     {
-      "check_id": "day53_quality_floor",
+      "check_id": "docs_loop_closeout_quality_floor",
       "weight": 10,
       "passed": false,
       "evidence": {
-        "day53_score": 55.0,
+        "docs_loop_closeout_score": 41.0,
         "strict_pass": false,
-        "day53_checks": 14
+        "docs_loop_closeout_checks": 14
       }
     },
     {
-      "check_id": "day53_board_integrity",
+      "check_id": "docs_loop_closeout_board_integrity",
       "weight": 7,
       "passed": true,
       "evidence": {
         "board_items": 5,
-        "contains_day53": true
+        "contains_docs_loop_day53": true
       }
     },
     {
       "check_id": "activation_contract_locked",
       "weight": 5,
-      "passed": true,
+      "passed": false,
       "evidence": {
-        "missing_contract_lines": []
+        "missing_contract_lines": [
+          "- Single owner + backup reviewer are assigned for Day 55 contributor-activation execution and KPI follow-up.",
+          "- The Day 55 lane references Day 53 docs-loop wins and misses with deterministic contributor follow-up loops.",
+          "- Every Day 55 section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.",
+          "- Day 55 closeout records contributor-activation learnings and Day 56 prioritization inputs."
+        ]
       }
     },
     {
@@ -116,34 +124,41 @@
     {
       "check_id": "delivery_board_locked",
       "weight": 2,
-      "passed": true,
+      "passed": false,
       "evidence": {
-        "missing_board_items": []
+        "missing_board_items": [
+          "- [ ] Day 55 contributor brief committed",
+          "- [ ] Day 55 activation plan reviewed with owner + backup",
+          "- [ ] Day 55 contributor ladder exported",
+          "- [ ] Day 55 KPI scorecard snapshot exported",
+          "- [ ] Day 56 priorities drafted from Day 55 learnings"
+        ]
       }
     }
   ],
   "rollup": {
-    "day53_activation_score": 55.0,
-    "day53_checks": 14,
-    "day53_delivery_board_items": 5
+    "docs_loop_closeout_activation_score": 41.0,
+    "docs_loop_closeout_checks": 14,
+    "docs_loop_closeout_delivery_board_items": 5
   },
   "summary": {
-    "activation_score": 55,
-    "passed_checks": 8,
-    "failed_checks": 6,
+    "activation_score": 48,
+    "passed_checks": 6,
+    "failed_checks": 8,
     "critical_failures": [
-      "day53_strict_baseline"
+      "docs_loop_closeout_strict_baseline"
     ],
     "strict_pass": false
   },
   "wins": [
-    "Day 53 delivery board integrity validated with 5 checklist items.",
-    "Contributor activation contract + quality checklist is fully locked for execution."
+    "Day 53 delivery board integrity validated with 5 checklist items."
   ],
   "misses": [
-    "Day 53 strict continuity signal is missing."
+    "Day 53 strict continuity signal is missing.",
+    "Contributor activation contract, quality checklist, or delivery board entries are missing."
   ],
   "handoff_actions": [
-    "Re-run Day 53 docs-loop closeout command and restore strict baseline before Day 55 lock."
+    "Re-run Day 53 docs-loop closeout command and restore strict baseline before Day 55 lock.",
+    "Complete all Day 55 contract lines, quality checklist entries, and delivery board tasks in docs."
   ]
 }

--- a/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.md
+++ b/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.md
@@ -1,5 +1,5 @@
-Contributor Activation Closeout summary (legacy: Cycle 55)
-- Activation score: 55
-- Passed checks: 8
-- Failed checks: 6
-- Critical failures: ['day53_strict_baseline']
+Contributor Activation Closeout summary (legacy: Day 55)
+- Activation score: 48
+- Passed checks: 6
+- Failed checks: 8
+- Critical failures: ['docs_loop_closeout_strict_baseline']

--- a/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-delivery-board.md
+++ b/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-delivery-board.md
@@ -1,6 +1,6 @@
-# Cycle 55 delivery board
-- [ ] Cycle 55 contributor brief committed
-- [ ] Cycle 55 activation plan reviewed with owner + backup
-- [ ] Cycle 55 contributor ladder exported
-- [ ] Cycle 55 KPI scorecard snapshot exported
-- [ ] Cycle 56 priorities drafted from Cycle 55 learnings
+# Day 55 delivery board
+- [ ] Day 55 contributor brief committed
+- [ ] Day 55 activation plan reviewed with owner + backup
+- [ ] Day 55 contributor ladder exported
+- [ ] Day 55 KPI scorecard snapshot exported
+- [ ] Day 56 priorities drafted from Day 55 learnings

--- a/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-execution-log.md
+++ b/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-execution-log.md
@@ -1,1 +1,1 @@
-# Cycle 55 execution log
+# Day 55 execution log

--- a/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-validation-commands.md
+++ b/docs/artifacts/contributor-activation-closeout-pack/contributor-activation-validation-commands.md
@@ -1,4 +1,4 @@
-# Cycle 55 validation commands
+# Day 55 validation commands
 
 ```bash
 python -m sdetkit contributor-activation-closeout --format json --strict

--- a/docs/artifacts/demo-asset-pack/demo-asset-summary.json
+++ b/docs/artifacts/demo-asset-pack/demo-asset-summary.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-demo-asset.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day32_summary": "docs/artifacts/release-cadence-pack/release-cadence-summary.json",
-    "day32_delivery_board": "docs/artifacts/release-cadence-pack/release-delivery-board.md"
+    "release_cadence_summary": "docs/artifacts/release-cadence-pack/release-cadence-summary.json",
+    "release_cadence_delivery_board": "docs/artifacts/release-cadence-pack/release-delivery-board.md"
   },
   "checks": [
     {
@@ -18,9 +18,15 @@
     {
       "check_id": "required_sections_present",
       "weight": 10,
-      "passed": true,
+      "passed": false,
       "evidence": {
-        "missing_sections": []
+        "missing_sections": [
+          "# Day 33 \u2014 Demo asset #1 production",
+          "## Why Day 33 matters",
+          "## Required inputs (Day 32)",
+          "## Day 33 command lane",
+          "## Day 33 delivery board"
+        ]
       }
     },
     {
@@ -32,31 +38,31 @@
       }
     },
     {
-      "check_id": "readme_integration_link",
+      "check_id": "readme_demo_asset_link",
       "weight": 8,
       "passed": false,
       "evidence": "docs/integrations-demo-asset.md"
     },
     {
-      "check_id": "readme_command_lane",
+      "check_id": "readme_demo_asset_command",
       "weight": 4,
       "passed": false,
       "evidence": "demo-asset"
     },
     {
-      "check_id": "docs_index_links",
+      "check_id": "docs_index_demo_asset_links",
       "weight": 8,
       "passed": false,
       "evidence": "impact-33-ultra-upgrade-report.md + integrations-demo-asset.md"
     },
     {
-      "check_id": "top10_strategy_alignment",
+      "check_id": "top10_demo_asset_alignment",
       "weight": 5,
       "passed": false,
       "evidence": "Day 33 + Day 34 strategy chain"
     },
     {
-      "check_id": "day32_summary_present",
+      "check_id": "release_cadence_summary_present",
       "weight": 10,
       "passed": true,
       "evidence": {
@@ -65,7 +71,7 @@
       }
     },
     {
-      "check_id": "day32_delivery_board_present",
+      "check_id": "release_cadence_delivery_board_present",
       "weight": 8,
       "passed": true,
       "evidence": {
@@ -74,23 +80,23 @@
       }
     },
     {
-      "check_id": "day32_quality_floor",
+      "check_id": "release_cadence_quality_floor",
       "weight": 10,
       "passed": false,
       "evidence": {
-        "day32_score": 65.0,
+        "release_cadence_score": 65.0,
         "strict_pass": false,
-        "day32_checks": 14
+        "release_cadence_checks": 14
       }
     },
     {
-      "check_id": "day32_board_integrity",
+      "check_id": "release_cadence_board_integrity",
       "weight": 7,
-      "passed": true,
+      "passed": false,
       "evidence": {
         "board_items": 5,
-        "contains_day33": true,
-        "contains_day34": true
+        "contains_demo_asset_day33": false,
+        "contains_demo_asset_day34": false
       }
     },
     {
@@ -112,34 +118,41 @@
     {
       "check_id": "delivery_board_locked",
       "weight": 2,
-      "passed": true,
+      "passed": false,
       "evidence": {
-        "missing_board_items": []
+        "missing_board_items": [
+          "- [ ] Day 33 script draft committed",
+          "- [ ] Day 33 first cut rendered",
+          "- [ ] Day 33 final cut + caption copy approved",
+          "- [ ] Day 34 demo asset #2 backlog pre-scoped",
+          "- [ ] Day 35 KPI instrumentation plan updated"
+        ]
       }
     }
   ],
   "rollup": {
-    "day32_activation_score": 65.0,
-    "day32_checks": 14,
-    "day32_delivery_board_items": 5
+    "release_cadence_activation_score": 65.0,
+    "release_cadence_checks": 14,
+    "release_cadence_delivery_board_items": 5
   },
   "summary": {
-    "activation_score": 65,
-    "passed_checks": 9,
-    "failed_checks": 5,
+    "activation_score": 46,
+    "passed_checks": 6,
+    "failed_checks": 8,
     "critical_failures": [
-      "day32_strict_baseline"
+      "release_cadence_strict_baseline"
     ],
     "strict_pass": false
   },
-  "wins": [
-    "Day 32 delivery board integrity validated with 5 checklist items.",
-    "Demo production contract + quality checklist is fully locked for execution."
-  ],
+  "wins": [],
   "misses": [
-    "Day 32 strict continuity signal is missing."
+    "Day 32 strict continuity signal is missing.",
+    "Day 32 delivery board integrity is incomplete (needs >=5 items and Day 33/34 anchors).",
+    "Demo contract, quality checklist, or delivery board entries are missing."
   ],
   "handoff_actions": [
-    "Re-run Day 32 cadence command and restore strict pass baseline before demo lock."
+    "Re-run Day 32 cadence command and restore strict pass baseline before demo lock.",
+    "Repair Day 32 delivery board entries to include Day 33 and Day 34 anchors.",
+    "Complete all Day 33 contract lines, quality checklist entries, and delivery board tasks in docs."
   ]
 }

--- a/docs/artifacts/demo-asset-pack/demo-asset-summary.md
+++ b/docs/artifacts/demo-asset-pack/demo-asset-summary.md
@@ -1,22 +1,24 @@
-# Cycle 33 demo asset summary
+# Day 33 demo asset summary
 
-- Activation score: **65**
-- Passed checks: **9**
-- Failed checks: **5**
-- Critical failures: **day32_strict_baseline**
+- Activation score: **46**
+- Passed checks: **6**
+- Failed checks: **8**
+- Critical failures: **release_cadence_strict_baseline**
 
-## Cycle 32 continuity
+## Release-cadence continuity
 
-- Cycle 32 activation score: `65.0`
-- Cycle 32 checks evaluated: `14`
-- Cycle 32 delivery board checklist items: `5`
+- Day 32 activation score: `65.0`
+- Day 32 checks evaluated: `14`
+- Day 32 delivery board checklist items: `5`
 
 ## Wins
-- Cycle 32 delivery board integrity validated with 5 checklist items.
-- Demo production contract + quality checklist is fully locked for execution.
 
 ## Misses
-- Cycle 32 strict continuity signal is missing.
+- Day 32 strict continuity signal is missing.
+- Day 32 delivery board integrity is incomplete (needs >=5 items and Day 33/34 anchors).
+- Demo contract, quality checklist, or delivery board entries are missing.
 
 ## Handoff actions
-- [ ] Re-run Cycle 32 cadence command and restore strict pass baseline before demo lock.
+- [ ] Re-run Day 32 cadence command and restore strict pass baseline before demo lock.
+- [ ] Repair Day 32 delivery board entries to include Day 33 and Day 34 anchors.
+- [ ] Complete all Day 33 contract lines, quality checklist entries, and delivery board tasks in docs.

--- a/docs/artifacts/demo-asset-pack/demo-delivery-board.md
+++ b/docs/artifacts/demo-asset-pack/demo-delivery-board.md
@@ -1,7 +1,7 @@
-# Cycle 33 delivery board
+# Day 33 delivery board
 
-- [ ] Cycle 33 script draft committed
-- [ ] Cycle 33 first cut rendered
-- [ ] Cycle 33 final cut + caption copy approved
-- [ ] Cycle 34 demo asset #2 backlog pre-scoped
-- [ ] Cycle 35 KPI instrumentation plan updated
+- [ ] Day 33 script draft committed
+- [ ] Day 33 first cut rendered
+- [ ] Day 33 final cut + caption copy approved
+- [ ] Day 34 demo asset #2 backlog pre-scoped
+- [ ] Day 35 KPI instrumentation plan updated

--- a/docs/artifacts/demo-asset-pack/demo-script.md
+++ b/docs/artifacts/demo-asset-pack/demo-script.md
@@ -1,4 +1,4 @@
-# Cycle 33 demo script
+# Day 33 demo script
 
 ## Hook (0-10s)
 - Pain point + why this matters now

--- a/docs/artifacts/demo-asset-pack/demo-validation-commands.md
+++ b/docs/artifacts/demo-asset-pack/demo-validation-commands.md
@@ -1,4 +1,4 @@
-# Cycle 33 validation commands
+# Day 33 validation commands
 
 ```bash
 python -m sdetkit demo-asset --format json --strict

--- a/docs/artifacts/docs-loop-closeout-pack/docs-loop-brief.md
+++ b/docs/artifacts/docs-loop-closeout-pack/docs-loop-brief.md
@@ -1,3 +1,3 @@
-# Cycle 53 Docs-loop Brief
+# Day 53 Docs-loop Brief
 
-- Objective: close Cycle 53 with measurable docs-loop optimization gains and proof-backed cross-link quality.
+- Objective: close Day 53 with measurable docs-loop optimization gains and proof-backed cross-link quality.

--- a/docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json
+++ b/docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json
@@ -5,10 +5,10 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-docs-loop-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day52_summary": "docs/artifacts/narrative-closeout-pack/narrative-closeout-summary.json",
-    "day52_summary_primary": "docs/artifacts/narrative-closeout-pack/narrative-closeout-summary.json",
-    "day52_delivery_board": "docs/artifacts/narrative-closeout-pack/narrative-delivery-board.md",
-    "day52_delivery_board_primary": "docs/artifacts/narrative-closeout-pack/narrative-delivery-board.md"
+    "narrative_closeout_summary": "docs/artifacts/narrative-closeout-pack/narrative-closeout-summary.json",
+    "narrative_closeout_summary_primary": "docs/artifacts/narrative-closeout-pack/narrative-closeout-summary.json",
+    "narrative_closeout_delivery_board": "docs/artifacts/narrative-closeout-pack/narrative-delivery-board.md",
+    "narrative_closeout_delivery_board_primary": "docs/artifacts/narrative-closeout-pack/narrative-delivery-board.md"
   },
   "checks": [
     {
@@ -24,7 +24,10 @@
       "evidence": {
         "missing_sections": [
           "# Day 53 \u2014 Docs loop optimization closeout lane",
-          "## Day 53 command lane"
+          "## Why Day 53 matters",
+          "## Required inputs (Day 52)",
+          "## Day 53 command lane",
+          "## Day 53 delivery board"
         ]
       }
     },
@@ -46,7 +49,7 @@
       "check_id": "readme_command_lane",
       "weight": 4,
       "passed": false,
-      "evidence": "day53-docs-loop-closeout"
+      "evidence": "README docs-loop-closeout command lane"
     },
     {
       "check_id": "docs_index_links",
@@ -61,7 +64,7 @@
       "evidence": "Day 52 + Day 53 strategy chain"
     },
     {
-      "check_id": "day52_summary_present",
+      "check_id": "narrative_closeout_summary_present",
       "weight": 10,
       "passed": true,
       "evidence": {
@@ -70,7 +73,7 @@
       }
     },
     {
-      "check_id": "day52_delivery_board_present",
+      "check_id": "narrative_closeout_delivery_board_present",
       "weight": 8,
       "passed": true,
       "evidence": {
@@ -79,31 +82,36 @@
       }
     },
     {
-      "check_id": "day52_quality_floor",
+      "check_id": "narrative_closeout_quality_floor",
       "weight": 10,
       "passed": false,
       "evidence": {
-        "day52_score": 55.0,
+        "narrative_closeout_score": 55.0,
         "strict_pass": false,
-        "day52_checks": 14
+        "narrative_closeout_checks": 14
       }
     },
     {
-      "check_id": "day52_board_integrity",
+      "check_id": "narrative_closeout_board_integrity",
       "weight": 7,
-      "passed": true,
+      "passed": false,
       "evidence": {
         "board_items": 5,
-        "contains_day52": true,
-        "contains_day53": true
+        "contains_narrative_closeout_day52": false,
+        "contains_docs_loop_day53": false
       }
     },
     {
       "check_id": "docs_loop_contract_locked",
       "weight": 5,
-      "passed": true,
+      "passed": false,
       "evidence": {
-        "missing_contract_lines": []
+        "missing_contract_lines": [
+          "- Single owner + backup reviewer are assigned for Day 53 docs-loop execution and KPI follow-up.",
+          "- The Day 53 docs-loop lane references Day 52 narrative winners and misses with deterministic cross-link remediation loops.",
+          "- Every Day 53 section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.",
+          "- Day 53 closeout records docs-loop learnings and Day 54 re-engagement priorities."
+        ]
       }
     },
     {
@@ -117,34 +125,41 @@
     {
       "check_id": "delivery_board_locked",
       "weight": 2,
-      "passed": true,
+      "passed": false,
       "evidence": {
-        "missing_board_items": []
+        "missing_board_items": [
+          "- [ ] Day 53 docs-loop brief committed",
+          "- [ ] Day 53 docs-loop plan reviewed with owner + backup",
+          "- [ ] Day 53 cross-link map exported",
+          "- [ ] Day 53 KPI scorecard snapshot exported",
+          "- [ ] Day 54 re-engagement priorities drafted from Day 53 learnings"
+        ]
       }
     }
   ],
   "rollup": {
-    "day52_activation_score": 55.0,
-    "day52_checks": 14,
-    "day52_delivery_board_items": 5
+    "narrative_closeout_activation_score": 55.0,
+    "narrative_closeout_checks": 14,
+    "narrative_closeout_delivery_board_items": 5
   },
   "summary": {
-    "activation_score": 55,
-    "passed_checks": 8,
-    "failed_checks": 6,
+    "activation_score": 41,
+    "passed_checks": 5,
+    "failed_checks": 9,
     "critical_failures": [
-      "day52_strict_baseline"
+      "narrative_closeout_strict_baseline"
     ],
     "strict_pass": false
   },
-  "wins": [
-    "Day 52 delivery board integrity validated with 5 checklist items.",
-    "Docs-loop contract + quality checklist is fully locked for execution."
-  ],
+  "wins": [],
   "misses": [
-    "Day 52 strict continuity signal is missing."
+    "Day 52 strict continuity signal is missing.",
+    "Day 52 delivery board integrity is incomplete (needs >=5 items and Day 52/53 anchors).",
+    "Docs-loop contract, quality checklist, or delivery board entries are missing."
   ],
   "handoff_actions": [
-    "Re-run Day 52 narrative closeout command and restore strict pass baseline before Day 53 lock."
+    "Re-run Day 52 narrative closeout command and restore strict pass baseline before Day 53 lock.",
+    "Repair Day 52 delivery board entries to include Day 52 and Day 53 anchors.",
+    "Complete all Day 53 docs-loop contract lines, quality checklist entries, and delivery board tasks in docs."
   ]
 }

--- a/docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.md
+++ b/docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.md
@@ -1,13 +1,12 @@
-Docs Loop Closeout summary (legacy: Cycle 53)
-- Activation score: 55
-- Passed checks: 8
-- Failed checks: 6
-- Critical failures: ['day52_strict_baseline']
-- Cycle 52 activation score: `55.0`
-- Cycle 52 checks evaluated: `14`
-- Cycle 52 delivery board checklist items: `5`
-- Wins:
-  - Cycle 52 delivery board integrity validated with 5 checklist items.
-  - Docs-loop contract + quality checklist is fully locked for execution.
+Docs Loop Closeout summary (legacy: Day 53)
+- Activation score: 41
+- Passed checks: 5
+- Failed checks: 9
+- Critical failures: ['narrative_closeout_strict_baseline']
+- Day 52 activation score: `55.0`
+- Day 52 checks evaluated: `14`
+- Day 52 delivery board checklist items: `5`
 - Misses:
-  - Cycle 52 strict continuity signal is missing.
+  - Day 52 strict continuity signal is missing.
+  - Day 52 delivery board integrity is incomplete (needs >=5 items and Day 52/53 anchors).
+  - Docs-loop contract, quality checklist, or delivery board entries are missing.

--- a/docs/artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md
+++ b/docs/artifacts/docs-loop-closeout-pack/docs-loop-delivery-board.md
@@ -1,7 +1,7 @@
-# Cycle 53 Delivery Board
+# Day 53 Delivery Board
 
-- [ ] Cycle 53 docs-loop brief committed
-- [ ] Cycle 53 docs-loop plan reviewed with owner + backup
-- [ ] Cycle 53 cross-link map exported
-- [ ] Cycle 53 KPI scorecard snapshot exported
-- [ ] Cycle 54 re-engagement priorities drafted from Cycle 53 learnings
+- [ ] Day 53 docs-loop brief committed
+- [ ] Day 53 docs-loop plan reviewed with owner + backup
+- [ ] Day 53 cross-link map exported
+- [ ] Day 53 KPI scorecard snapshot exported
+- [ ] Day 54 re-engagement priorities drafted from Day 53 learnings

--- a/docs/artifacts/docs-loop-closeout-pack/docs-loop-execution-log.md
+++ b/docs/artifacts/docs-loop-closeout-pack/docs-loop-execution-log.md
@@ -1,3 +1,3 @@
-# Cycle 53 Execution Log
+# Day 53 Execution Log
 
-- [ ] 2026-03-20: Record misses, wins, and Cycle 54 re-engagement priorities.
+- [ ] 2026-03-20: Record misses, wins, and Day 54 re-engagement priorities.

--- a/docs/artifacts/docs-loop-closeout-pack/docs-loop-validation-commands.md
+++ b/docs/artifacts/docs-loop-closeout-pack/docs-loop-validation-commands.md
@@ -1,4 +1,4 @@
-# Cycle 53 Validation Commands
+# Day 53 Validation Commands
 
 ```bash
 python -m sdetkit docs-loop-closeout --format json --strict

--- a/docs/artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.json
+++ b/docs/artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.json
@@ -5,8 +5,8 @@
     "docs_index": "docs/index.md",
     "docs_page": "docs/integrations-phase3-kickoff-closeout.md",
     "top10": "docs/top-10-github-strategy.md",
-    "day60_summary": "docs/artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.json",
-    "day60_delivery_board": "docs/artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-delivery-board.md"
+    "phase2_wrap_handoff_summary": "docs/artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.json",
+    "phase2_wrap_handoff_delivery_board": "docs/artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-delivery-board.md"
   },
   "checks": [
     {
@@ -28,34 +28,34 @@
       "evidence": "Day 61 + Day 62 strategy chain"
     },
     {
-      "check_id": "day60_summary_present",
+      "check_id": "phase2_wrap_handoff_summary_present",
       "weight": 10,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-closeout-summary.json"
     },
     {
-      "check_id": "day60_delivery_board_present",
+      "check_id": "phase2_wrap_handoff_delivery_board_present",
       "weight": 8,
       "passed": true,
       "evidence": "/workspace/DevS69-sdetkit/docs/artifacts/phase2-wrap-handoff-closeout-pack/phase2-wrap-handoff-delivery-board.md"
     },
     {
-      "check_id": "day60_quality_floor",
+      "check_id": "phase2_wrap_handoff_quality_floor",
       "weight": 15,
       "passed": false,
       "evidence": {
-        "day60_score": 43,
+        "phase2_wrap_handoff_score": 43,
         "strict_pass": false,
-        "day60_checks": 13
+        "phase2_wrap_handoff_checks": 13
       }
     },
     {
-      "check_id": "day60_board_integrity",
+      "check_id": "phase2_wrap_handoff_board_integrity",
       "weight": 7,
       "passed": false,
       "evidence": {
         "board_items": 5,
-        "contains_day60": false
+        "contains_phase2_wrap_handoff_day60": false
       }
     },
     {
@@ -109,16 +109,16 @@
     }
   ],
   "rollup": {
-    "day60_activation_score": 43,
-    "day60_checks": 13,
-    "day60_delivery_board_items": 5
+    "phase2_wrap_handoff_activation_score": 43,
+    "phase2_wrap_handoff_checks": 13,
+    "phase2_wrap_handoff_delivery_board_items": 5
   },
   "summary": {
     "activation_score": 29,
     "passed_checks": 4,
     "failed_checks": 9,
     "critical_failures": [
-      "day60_strict_baseline"
+      "phase2_wrap_handoff_strict_baseline"
     ],
     "strict_pass": false
   },

--- a/docs/artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.md
+++ b/docs/artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.md
@@ -2,4 +2,4 @@ Phase3 Kickoff Closeout summary
 - Activation score: 29
 - Passed checks: 4
 - Failed checks: 9
-- Critical failures: ['day60_strict_baseline']
+- Critical failures: ['phase2_wrap_handoff_strict_baseline']

--- a/src/sdetkit/contributor_activation_closeout_55.py
+++ b/src/sdetkit/contributor_activation_closeout_55.py
@@ -107,7 +107,7 @@ Day 55 weighted score (0-100):
 
 - Contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
-- Day 53 continuity and strict baseline carryover: 35 points.
+- Docs-loop continuity and strict baseline carryover: 35 points.
 - Activation contract lock + delivery board readiness: 15 points.
 """
 
@@ -126,7 +126,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day53(path: Path) -> tuple[float, bool, int]:
+def _load_docs_loop_closeout_summary(path: Path) -> tuple[float, bool, int]:
     data = _load_json(path)
     if data is None:
         return 0.0, False, 0
@@ -166,12 +166,12 @@ def build_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day53_summary_primary = root / _DAY53_SUMMARY_PATH
-    day53_summary = day53_summary_primary
-    day53_board_primary = root / _DAY53_BOARD_PATH
-    day53_board = day53_board_primary
-    day53_score, day53_strict, day53_check_count = _load_day53(day53_summary)
-    board_count, board_has_day53 = _board_stats(day53_board)
+    docs_loop_closeout_summary_primary = root / _DAY53_SUMMARY_PATH
+    docs_loop_closeout_summary = docs_loop_closeout_summary_primary
+    docs_loop_closeout_board_primary = root / _DAY53_BOARD_PATH
+    docs_loop_closeout_board = docs_loop_closeout_board_primary
+    docs_loop_closeout_score, docs_loop_closeout_strict, docs_loop_closeout_check_count = _load_docs_loop_closeout_summary(docs_loop_closeout_summary)
+    board_count, board_has_docs_loop_day53 = _board_stats(docs_loop_closeout_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -220,32 +220,32 @@ def build_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 55 + Day 56 strategy chain",
         },
         {
-            "check_id": "day53_summary_present",
+            "check_id": "docs_loop_closeout_summary_present",
             "weight": 10,
-            "passed": day53_summary.exists(),
-            "evidence": {"resolved": str(day53_summary), "primary": str(day53_summary_primary)},
+            "passed": docs_loop_closeout_summary.exists(),
+            "evidence": {"resolved": str(docs_loop_closeout_summary), "primary": str(docs_loop_closeout_summary_primary)},
         },
         {
-            "check_id": "day53_delivery_board_present",
+            "check_id": "docs_loop_closeout_delivery_board_present",
             "weight": 8,
-            "passed": day53_board.exists(),
-            "evidence": {"resolved": str(day53_board), "primary": str(day53_board_primary)},
+            "passed": docs_loop_closeout_board.exists(),
+            "evidence": {"resolved": str(docs_loop_closeout_board), "primary": str(docs_loop_closeout_board_primary)},
         },
         {
-            "check_id": "day53_quality_floor",
+            "check_id": "docs_loop_closeout_quality_floor",
             "weight": 10,
-            "passed": day53_strict and day53_score >= 95,
+            "passed": docs_loop_closeout_strict and docs_loop_closeout_score >= 95,
             "evidence": {
-                "day53_score": day53_score,
-                "strict_pass": day53_strict,
-                "day53_checks": day53_check_count,
+                "docs_loop_closeout_score": docs_loop_closeout_score,
+                "strict_pass": docs_loop_closeout_strict,
+                "docs_loop_closeout_checks": docs_loop_closeout_check_count,
             },
         },
         {
-            "check_id": "day53_board_integrity",
+            "check_id": "docs_loop_closeout_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day53,
-            "evidence": {"board_items": board_count, "contains_day53": board_has_day53},
+            "passed": board_count >= 5 and board_has_docs_loop_day53,
+            "evidence": {"board_items": board_count, "contains_docs_loop_day53": board_has_docs_loop_day53},
         },
         {
             "check_id": "activation_contract_locked",
@@ -269,24 +269,24 @@ def build_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day53_summary.exists() or not day53_board.exists():
-        critical_failures.append("day53_handoff_inputs")
-    if not day53_strict:
-        critical_failures.append("day53_strict_baseline")
+    if not docs_loop_closeout_summary.exists() or not docs_loop_closeout_board.exists():
+        critical_failures.append("docs_loop_closeout_handoff_inputs")
+    if not docs_loop_closeout_strict:
+        critical_failures.append("docs_loop_closeout_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day53_strict:
-        wins.append(f"Day 53 continuity is strict-pass with activation score={day53_score}.")
+    if docs_loop_closeout_strict:
+        wins.append(f"Docs-loop continuity is strict-pass with activation score={docs_loop_closeout_score}.")
     else:
         misses.append("Day 53 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 53 docs-loop closeout command and restore strict baseline before Day 55 lock."
         )
 
-    if board_count >= 5 and board_has_day53:
+    if board_count >= 5 and board_has_docs_loop_day53:
         wins.append(
             f"Day 53 delivery board integrity validated with {board_count} checklist items."
         )
@@ -321,20 +321,20 @@ def build_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day53_summary": str(day53_summary.relative_to(root))
-            if day53_summary.exists()
-            else str(day53_summary),
-            "day53_summary_primary": str(day53_summary_primary.relative_to(root)),
-            "day53_delivery_board": str(day53_board.relative_to(root))
-            if day53_board.exists()
-            else str(day53_board),
-            "day53_delivery_board_primary": str(day53_board_primary.relative_to(root)),
+            "docs_loop_closeout_summary": str(docs_loop_closeout_summary.relative_to(root))
+            if docs_loop_closeout_summary.exists()
+            else str(docs_loop_closeout_summary),
+            "docs_loop_closeout_summary_primary": str(docs_loop_closeout_summary_primary.relative_to(root)),
+            "docs_loop_closeout_delivery_board": str(docs_loop_closeout_board.relative_to(root))
+            if docs_loop_closeout_board.exists()
+            else str(docs_loop_closeout_board),
+            "docs_loop_closeout_delivery_board_primary": str(docs_loop_closeout_board_primary.relative_to(root)),
         },
         "checks": checks,
         "rollup": {
-            "day53_activation_score": day53_score,
-            "day53_checks": day53_check_count,
-            "day53_delivery_board_items": board_count,
+            "docs_loop_closeout_activation_score": docs_loop_closeout_score,
+            "docs_loop_closeout_checks": docs_loop_closeout_check_count,
+            "docs_loop_closeout_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,

--- a/src/sdetkit/demo_asset_33.py
+++ b/src/sdetkit/demo_asset_33.py
@@ -107,7 +107,7 @@ Day 33 weighted score (0-100):
 
 - Docs contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
-- Day 32 continuity and strict baseline carryover: 35 points.
+- Release-cadence continuity and strict baseline carryover: 35 points.
 - Demo contract lock + delivery board readiness: 15 points.
 """
 
@@ -126,7 +126,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day32(path: Path) -> tuple[float, bool, int]:
+def _load_release_cadence_summary(path: Path) -> tuple[float, bool, int]:
     data = _load_json(path)
     if data is None:
         return 0.0, False, 0
@@ -143,13 +143,13 @@ def _board_stats(path: Path) -> tuple[int, bool, bool]:
     text = _read(path)
     lines = [line.strip().lower() for line in text.splitlines()]
     item_count = sum(1 for line in lines if line.startswith("- [ ]"))
-    has_day33 = any(
+    has_demo_asset_day33 = any(
         any(token in line for token in ("impact 33", "day 33", "name 33")) for line in lines
     )
-    has_day34 = any(
+    has_demo_asset_day34 = any(
         any(token in line for token in ("impact 34", "day 34", "name 34")) for line in lines
     )
-    return item_count, has_day33, has_day34
+    return item_count, has_demo_asset_day33, has_demo_asset_day34
 
 
 def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
@@ -178,12 +178,12 @@ def build_demo_asset_summary_impl(
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day32_summary_primary = root / _DAY32_SUMMARY_PATH
-    day32_board_primary = root / _DAY32_BOARD_PATH
-    day32_summary = day32_summary_primary
-    day32_board = day32_board_primary
-    day32_score, day32_strict, day32_check_count = _load_day32(day32_summary)
-    board_count, board_has_day33, board_has_day34 = _board_stats(day32_board)
+    release_cadence_summary_primary = root / _DAY32_SUMMARY_PATH
+    release_cadence_board_primary = root / _DAY32_BOARD_PATH
+    release_cadence_summary = release_cadence_summary_primary
+    release_cadence_board = release_cadence_board_primary
+    release_cadence_score, release_cadence_strict, release_cadence_check_count = _load_release_cadence_summary(release_cadence_summary)
+    board_count, board_has_demo_asset_day33, board_has_demo_asset_day34 = _board_stats(release_cadence_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -235,35 +235,35 @@ def build_demo_asset_summary_impl(
             "evidence": "Day 33 + Day 34 strategy chain",
         },
         {
-            "check_id": "day32_summary_present",
+            "check_id": "release_cadence_summary_present",
             "weight": 10,
-            "passed": day32_summary.exists(),
-            "evidence": {"resolved": str(day32_summary), "primary": str(day32_summary_primary)},
+            "passed": release_cadence_summary.exists(),
+            "evidence": {"resolved": str(release_cadence_summary), "primary": str(release_cadence_summary_primary)},
         },
         {
-            "check_id": "day32_delivery_board_present",
+            "check_id": "release_cadence_delivery_board_present",
             "weight": 8,
-            "passed": day32_board.exists(),
-            "evidence": {"resolved": str(day32_board), "primary": str(day32_board_primary)},
+            "passed": release_cadence_board.exists(),
+            "evidence": {"resolved": str(release_cadence_board), "primary": str(release_cadence_board_primary)},
         },
         {
-            "check_id": "day32_quality_floor",
+            "check_id": "release_cadence_quality_floor",
             "weight": 10,
-            "passed": day32_strict and day32_score >= 95,
+            "passed": release_cadence_strict and release_cadence_score >= 95,
             "evidence": {
-                "day32_score": day32_score,
-                "strict_pass": day32_strict,
-                "day32_checks": day32_check_count,
+                "release_cadence_score": release_cadence_score,
+                "strict_pass": release_cadence_strict,
+                "release_cadence_checks": release_cadence_check_count,
             },
         },
         {
-            "check_id": "day32_board_integrity",
+            "check_id": "release_cadence_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day33 and board_has_day34,
+            "passed": board_count >= 5 and board_has_demo_asset_day33 and board_has_demo_asset_day34,
             "evidence": {
                 "board_items": board_count,
-                "contains_day33": board_has_day33,
-                "contains_day34": board_has_day34,
+                "contains_demo_asset_day33": board_has_demo_asset_day33,
+                "contains_demo_asset_day34": board_has_demo_asset_day34,
             },
         },
         {
@@ -289,24 +289,24 @@ def build_demo_asset_summary_impl(
     failed = [c for c in checks if not c["passed"]]
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     critical_failures: list[str] = []
-    if not day32_summary.exists() or not day32_board.exists():
-        critical_failures.append("day32_handoff_inputs")
-    if not day32_strict:
-        critical_failures.append("day32_strict_baseline")
+    if not release_cadence_summary.exists() or not release_cadence_board.exists():
+        critical_failures.append("release_cadence_handoff_inputs")
+    if not release_cadence_strict:
+        critical_failures.append("release_cadence_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day32_strict:
-        wins.append(f"Day 32 continuity is strict-pass with activation score={day32_score}.")
+    if release_cadence_strict:
+        wins.append(f"Release-cadence continuity is strict-pass with activation score={release_cadence_score}.")
     else:
         misses.append("Day 32 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 32 cadence command and restore strict pass baseline before demo lock."
         )
 
-    if board_count >= 5 and board_has_day33 and board_has_day34:
+    if board_count >= 5 and board_has_demo_asset_day33 and board_has_demo_asset_day34:
         wins.append(
             f"Day 32 delivery board integrity validated with {board_count} checklist items."
         )
@@ -338,18 +338,18 @@ def build_demo_asset_summary_impl(
             "docs_index": docs_index_path,
             "docs_page": docs_page_path,
             "top10": top10_path,
-            "day32_summary": str(day32_summary.relative_to(root))
-            if day32_summary.exists()
-            else str(day32_summary),
-            "day32_delivery_board": str(day32_board.relative_to(root))
-            if day32_board.exists()
-            else str(day32_board),
+            "release_cadence_summary": str(release_cadence_summary.relative_to(root))
+            if release_cadence_summary.exists()
+            else str(release_cadence_summary),
+            "release_cadence_delivery_board": str(release_cadence_board.relative_to(root))
+            if release_cadence_board.exists()
+            else str(release_cadence_board),
         },
         "checks": checks,
         "rollup": {
-            "day32_activation_score": day32_score,
-            "day32_checks": day32_check_count,
-            "day32_delivery_board_items": board_count,
+            "release_cadence_activation_score": release_cadence_score,
+            "release_cadence_checks": release_cadence_check_count,
+            "release_cadence_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,
@@ -385,11 +385,11 @@ def _to_markdown(payload: dict[str, Any]) -> str:
         f"- Failed checks: **{summary['failed_checks']}**",
         f"- Critical failures: **{', '.join(summary['critical_failures']) if summary['critical_failures'] else 'none'}**",
         "",
-        "## Day 32 continuity",
+        "## Release-cadence continuity",
         "",
-        f"- Day 32 activation score: `{payload['rollup']['day32_activation_score']}`",
-        f"- Day 32 checks evaluated: `{payload['rollup']['day32_checks']}`",
-        f"- Day 32 delivery board checklist items: `{payload['rollup']['day32_delivery_board_items']}`",
+        f"- Day 32 activation score: `{payload['rollup']['release_cadence_activation_score']}`",
+        f"- Day 32 checks evaluated: `{payload['rollup']['release_cadence_checks']}`",
+        f"- Day 32 delivery board checklist items: `{payload['rollup']['release_cadence_delivery_board_items']}`",
         "",
         "## Wins",
     ]

--- a/src/sdetkit/docs_loop_closeout_53.py
+++ b/src/sdetkit/docs_loop_closeout_53.py
@@ -107,7 +107,7 @@ Day 53 weighted score (0-100):
 
 - Docs contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
-- Day 52 continuity and strict baseline carryover: 35 points.
+- Narrative-closeout continuity and strict baseline carryover: 35 points.
 - Docs-loop contract lock + delivery board readiness: 15 points.
 """
 
@@ -126,7 +126,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day52(path: Path) -> tuple[float, bool, int]:
+def _load_narrative_closeout_summary(path: Path) -> tuple[float, bool, int]:
     data_obj = _load_json(path)
     if not isinstance(data_obj, dict):
         return 0.0, False, 0
@@ -172,12 +172,12 @@ def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day52_summary_primary = root / _DAY52_SUMMARY_PATH
-    day52_summary = day52_summary_primary
-    day52_board_primary = root / _DAY52_BOARD_PATH
-    day52_board = day52_board_primary
-    day52_score, day52_strict, day52_check_count = _load_day52(day52_summary)
-    board_count, board_has_day52, board_has_day53 = _board_stats(day52_board)
+    narrative_closeout_summary_primary = root / _DAY52_SUMMARY_PATH
+    narrative_closeout_summary = narrative_closeout_summary_primary
+    narrative_closeout_board_primary = root / _DAY52_BOARD_PATH
+    narrative_closeout_board = narrative_closeout_board_primary
+    narrative_closeout_score, narrative_closeout_strict, narrative_closeout_check_count = _load_narrative_closeout_summary(narrative_closeout_summary)
+    board_count, board_has_narrative_closeout_day52, board_has_docs_loop_day53 = _board_stats(narrative_closeout_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -226,35 +226,35 @@ def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 52 + Day 53 strategy chain",
         },
         {
-            "check_id": "day52_summary_present",
+            "check_id": "narrative_closeout_summary_present",
             "weight": 10,
-            "passed": day52_summary.exists(),
-            "evidence": {"resolved": str(day52_summary), "primary": str(day52_summary_primary)},
+            "passed": narrative_closeout_summary.exists(),
+            "evidence": {"resolved": str(narrative_closeout_summary), "primary": str(narrative_closeout_summary_primary)},
         },
         {
-            "check_id": "day52_delivery_board_present",
+            "check_id": "narrative_closeout_delivery_board_present",
             "weight": 8,
-            "passed": day52_board.exists(),
-            "evidence": {"resolved": str(day52_board), "primary": str(day52_board_primary)},
+            "passed": narrative_closeout_board.exists(),
+            "evidence": {"resolved": str(narrative_closeout_board), "primary": str(narrative_closeout_board_primary)},
         },
         {
-            "check_id": "day52_quality_floor",
+            "check_id": "narrative_closeout_quality_floor",
             "weight": 10,
-            "passed": day52_strict and day52_score >= 95,
+            "passed": narrative_closeout_strict and narrative_closeout_score >= 95,
             "evidence": {
-                "day52_score": day52_score,
-                "strict_pass": day52_strict,
-                "day52_checks": day52_check_count,
+                "narrative_closeout_score": narrative_closeout_score,
+                "strict_pass": narrative_closeout_strict,
+                "narrative_closeout_checks": narrative_closeout_check_count,
             },
         },
         {
-            "check_id": "day52_board_integrity",
+            "check_id": "narrative_closeout_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day52 and board_has_day53,
+            "passed": board_count >= 5 and board_has_narrative_closeout_day52 and board_has_docs_loop_day53,
             "evidence": {
                 "board_items": board_count,
-                "contains_day52": board_has_day52,
-                "contains_day53": board_has_day53,
+                "contains_narrative_closeout_day52": board_has_narrative_closeout_day52,
+                "contains_docs_loop_day53": board_has_docs_loop_day53,
             },
         },
         {
@@ -280,24 +280,24 @@ def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
     failed = [c for c in checks if not c["passed"]]
     score = int(round(sum(c["weight"] for c in checks if bool(c["passed"]))))
     critical_failures: list[str] = []
-    if not day52_summary.exists() or not day52_board.exists():
-        critical_failures.append("day52_handoff_inputs")
-    if not day52_strict:
-        critical_failures.append("day52_strict_baseline")
+    if not narrative_closeout_summary.exists() or not narrative_closeout_board.exists():
+        critical_failures.append("narrative_closeout_handoff_inputs")
+    if not narrative_closeout_strict:
+        critical_failures.append("narrative_closeout_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day52_strict:
-        wins.append(f"Day 52 continuity is strict-pass with activation score={day52_score}.")
+    if narrative_closeout_strict:
+        wins.append(f"Narrative-closeout continuity is strict-pass with activation score={narrative_closeout_score}.")
     else:
         misses.append("Day 52 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 52 narrative closeout command and restore strict pass baseline before Day 53 lock."
         )
 
-    if board_count >= 5 and board_has_day52 and board_has_day53:
+    if board_count >= 5 and board_has_narrative_closeout_day52 and board_has_docs_loop_day53:
         wins.append(
             f"Day 52 delivery board integrity validated with {board_count} checklist items."
         )
@@ -331,20 +331,20 @@ def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": docs_index_path,
             "docs_page": docs_page_path,
             "top10": top10_path,
-            "day52_summary": str(day52_summary.relative_to(root))
-            if day52_summary.exists()
-            else str(day52_summary),
-            "day52_summary_primary": str(day52_summary_primary.relative_to(root)),
-            "day52_delivery_board": str(day52_board.relative_to(root))
-            if day52_board.exists()
-            else str(day52_board),
-            "day52_delivery_board_primary": str(day52_board_primary.relative_to(root)),
+            "narrative_closeout_summary": str(narrative_closeout_summary.relative_to(root))
+            if narrative_closeout_summary.exists()
+            else str(narrative_closeout_summary),
+            "narrative_closeout_summary_primary": str(narrative_closeout_summary_primary.relative_to(root)),
+            "narrative_closeout_delivery_board": str(narrative_closeout_board.relative_to(root))
+            if narrative_closeout_board.exists()
+            else str(narrative_closeout_board),
+            "narrative_closeout_delivery_board_primary": str(narrative_closeout_board_primary.relative_to(root)),
         },
         "checks": checks,
         "rollup": {
-            "day52_activation_score": day52_score,
-            "day52_checks": day52_check_count,
-            "day52_delivery_board_items": board_count,
+            "narrative_closeout_activation_score": narrative_closeout_score,
+            "narrative_closeout_checks": narrative_closeout_check_count,
+            "narrative_closeout_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,
@@ -366,9 +366,9 @@ def _render_text(payload: dict[str, Any]) -> str:
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
         f"- Critical failures: {payload['summary']['critical_failures']}",
-        f"- Day 52 activation score: `{payload['rollup']['day52_activation_score']}`",
-        f"- Day 52 checks evaluated: `{payload['rollup']['day52_checks']}`",
-        f"- Day 52 delivery board checklist items: `{payload['rollup']['day52_delivery_board_items']}`",
+        f"- Day 52 activation score: `{payload['rollup']['narrative_closeout_activation_score']}`",
+        f"- Day 52 checks evaluated: `{payload['rollup']['narrative_closeout_checks']}`",
+        f"- Day 52 delivery board checklist items: `{payload['rollup']['narrative_closeout_delivery_board_items']}`",
     ]
     if payload["wins"]:
         lines.append("- Wins:")

--- a/src/sdetkit/phase3_kickoff_closeout_61.py
+++ b/src/sdetkit/phase3_kickoff_closeout_61.py
@@ -111,7 +111,7 @@ Day 61 weighted score (0-100):
 
 - Contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
-- Day 60 continuity and strict baseline carryover: 35 points.
+- Phase2-wrap-handoff continuity and strict baseline carryover: 35 points.
 - Phase-3 kickoff contract lock + delivery board readiness: 15 points.
 """
 
@@ -130,7 +130,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day60(path: Path) -> tuple[int, bool, int]:
+def _load_phase2_wrap_handoff_summary(path: Path) -> tuple[int, bool, int]:
     payload_obj = _load_json(path)
     if not isinstance(payload_obj, dict):
         return 0, False, 0
@@ -156,10 +156,10 @@ def build_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
     page_text = _read(root / _PAGE_PATH)
     top10_text = _read(root / _TOP10_PATH)
 
-    day60_summary = root / _DAY60_SUMMARY_PATH
-    day60_board = root / _DAY60_BOARD_PATH
-    day60_score, day60_strict, day60_check_count = _load_day60(day60_summary)
-    board_count, board_has_day60 = _count_board_items(day60_board, "Day 60")
+    phase2_wrap_handoff_summary = root / _DAY60_SUMMARY_PATH
+    phase2_wrap_handoff_board = root / _DAY60_BOARD_PATH
+    phase2_wrap_handoff_score, phase2_wrap_handoff_strict, phase2_wrap_handoff_check_count = _load_phase2_wrap_handoff_summary(phase2_wrap_handoff_summary)
+    board_count, board_has_phase2_wrap_handoff_day60 = _count_board_items(phase2_wrap_handoff_board, "Day 60")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -190,32 +190,32 @@ def build_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 61 + Day 62 strategy chain",
         },
         {
-            "check_id": "day60_summary_present",
+            "check_id": "phase2_wrap_handoff_summary_present",
             "weight": 10,
-            "passed": day60_summary.exists(),
-            "evidence": str(day60_summary),
+            "passed": phase2_wrap_handoff_summary.exists(),
+            "evidence": str(phase2_wrap_handoff_summary),
         },
         {
-            "check_id": "day60_delivery_board_present",
+            "check_id": "phase2_wrap_handoff_delivery_board_present",
             "weight": 8,
-            "passed": day60_board.exists(),
-            "evidence": str(day60_board),
+            "passed": phase2_wrap_handoff_board.exists(),
+            "evidence": str(phase2_wrap_handoff_board),
         },
         {
-            "check_id": "day60_quality_floor",
+            "check_id": "phase2_wrap_handoff_quality_floor",
             "weight": 15,
-            "passed": day60_strict and day60_score >= 95,
+            "passed": phase2_wrap_handoff_strict and phase2_wrap_handoff_score >= 95,
             "evidence": {
-                "day60_score": day60_score,
-                "strict_pass": day60_strict,
-                "day60_checks": day60_check_count,
+                "phase2_wrap_handoff_score": phase2_wrap_handoff_score,
+                "strict_pass": phase2_wrap_handoff_strict,
+                "phase2_wrap_handoff_checks": phase2_wrap_handoff_check_count,
             },
         },
         {
-            "check_id": "day60_board_integrity",
+            "check_id": "phase2_wrap_handoff_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day60,
-            "evidence": {"board_items": board_count, "contains_day60": board_has_day60},
+            "passed": board_count >= 5 and board_has_phase2_wrap_handoff_day60,
+            "evidence": {"board_items": board_count, "contains_phase2_wrap_handoff_day60": board_has_phase2_wrap_handoff_day60},
         },
         {
             "check_id": "page_header",
@@ -257,24 +257,24 @@ def build_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day60_summary.exists() or not day60_board.exists():
-        critical_failures.append("day60_handoff_inputs")
-    if not day60_strict:
-        critical_failures.append("day60_strict_baseline")
+    if not phase2_wrap_handoff_summary.exists() or not phase2_wrap_handoff_board.exists():
+        critical_failures.append("phase2_wrap_handoff_handoff_inputs")
+    if not phase2_wrap_handoff_strict:
+        critical_failures.append("phase2_wrap_handoff_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day60_strict:
-        wins.append(f"Day 60 continuity is strict-pass with activation score={day60_score}.")
+    if phase2_wrap_handoff_strict:
+        wins.append(f"Phase2-wrap-handoff continuity is strict-pass with activation score={phase2_wrap_handoff_score}.")
     else:
         misses.append("Day 60 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 60 Phase-2 wrap + handoff closeout command and restore strict baseline before Day 61 lock."
         )
 
-    if board_count >= 5 and board_has_day60:
+    if board_count >= 5 and board_has_phase2_wrap_handoff_day60:
         wins.append(
             f"Day 60 delivery board integrity validated with {board_count} checklist items."
         )
@@ -307,18 +307,18 @@ def build_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day60_summary": str(day60_summary.relative_to(root))
-            if day60_summary.exists()
-            else str(day60_summary),
-            "day60_delivery_board": str(day60_board.relative_to(root))
-            if day60_board.exists()
-            else str(day60_board),
+            "phase2_wrap_handoff_summary": str(phase2_wrap_handoff_summary.relative_to(root))
+            if phase2_wrap_handoff_summary.exists()
+            else str(phase2_wrap_handoff_summary),
+            "phase2_wrap_handoff_delivery_board": str(phase2_wrap_handoff_board.relative_to(root))
+            if phase2_wrap_handoff_board.exists()
+            else str(phase2_wrap_handoff_board),
         },
         "checks": checks,
         "rollup": {
-            "day60_activation_score": day60_score,
-            "day60_checks": day60_check_count,
-            "day60_delivery_board_items": board_count,
+            "phase2_wrap_handoff_activation_score": phase2_wrap_handoff_score,
+            "phase2_wrap_handoff_checks": phase2_wrap_handoff_check_count,
+            "phase2_wrap_handoff_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,

--- a/src/sdetkit/stabilization_closeout_56.py
+++ b/src/sdetkit/stabilization_closeout_56.py
@@ -109,7 +109,7 @@ Day 56 weighted score (0-100):
 
 - Contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
-- Day 55 continuity and strict baseline carryover: 35 points.
+- Contributor-activation continuity and strict baseline carryover: 35 points.
 - Stabilization contract lock + delivery board readiness: 15 points.
 """
 
@@ -128,7 +128,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day55(path: Path) -> tuple[int, bool, int]:
+def _load_contributor_activation_summary(path: Path) -> tuple[int, bool, int]:
     payload_obj = _load_json(path)
     if not isinstance(payload_obj, dict):
         return 0, False, 0
@@ -170,10 +170,10 @@ def build_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day55_summary = root / _DAY55_SUMMARY_PATH
-    day55_board = root / _DAY55_BOARD_PATH
-    day55_score, day55_strict, day55_check_count = _load_day55(day55_summary)
-    board_count, board_has_day55 = _board_stats(day55_board)
+    contributor_activation_summary = root / _DAY55_SUMMARY_PATH
+    contributor_activation_board = root / _DAY55_BOARD_PATH
+    contributor_activation_score, contributor_activation_strict, contributor_activation_check_count = _load_contributor_activation_summary(contributor_activation_summary)
+    board_count, board_has_contributor_activation_day55 = _board_stats(contributor_activation_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -222,32 +222,32 @@ def build_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 56 + Day 57 strategy chain",
         },
         {
-            "check_id": "day55_summary_present",
+            "check_id": "contributor_activation_summary_present",
             "weight": 10,
-            "passed": day55_summary.exists(),
-            "evidence": str(day55_summary),
+            "passed": contributor_activation_summary.exists(),
+            "evidence": str(contributor_activation_summary),
         },
         {
-            "check_id": "day55_delivery_board_present",
+            "check_id": "contributor_activation_delivery_board_present",
             "weight": 8,
-            "passed": day55_board.exists(),
-            "evidence": str(day55_board),
+            "passed": contributor_activation_board.exists(),
+            "evidence": str(contributor_activation_board),
         },
         {
-            "check_id": "day55_quality_floor",
+            "check_id": "contributor_activation_quality_floor",
             "weight": 10,
-            "passed": day55_strict and day55_score >= 95,
+            "passed": contributor_activation_strict and contributor_activation_score >= 95,
             "evidence": {
-                "day55_score": day55_score,
-                "strict_pass": day55_strict,
-                "day55_checks": day55_check_count,
+                "contributor_activation_score": contributor_activation_score,
+                "strict_pass": contributor_activation_strict,
+                "contributor_activation_checks": contributor_activation_check_count,
             },
         },
         {
-            "check_id": "day55_board_integrity",
+            "check_id": "contributor_activation_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day55,
-            "evidence": {"board_items": board_count, "contains_day55": board_has_day55},
+            "passed": board_count >= 5 and board_has_contributor_activation_day55,
+            "evidence": {"board_items": board_count, "contains_contributor_activation_day55": board_has_contributor_activation_day55},
         },
         {
             "check_id": "stabilization_contract_locked",
@@ -271,24 +271,24 @@ def build_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
 
     failed = [c for c in checks if not c["passed"]]
     critical_failures: list[str] = []
-    if not day55_summary.exists() or not day55_board.exists():
-        critical_failures.append("day55_handoff_inputs")
-    if not day55_strict:
-        critical_failures.append("day55_strict_baseline")
+    if not contributor_activation_summary.exists() or not contributor_activation_board.exists():
+        critical_failures.append("contributor_activation_handoff_inputs")
+    if not contributor_activation_strict:
+        critical_failures.append("contributor_activation_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day55_strict:
-        wins.append(f"Day 55 continuity is strict-pass with activation score={day55_score}.")
+    if contributor_activation_strict:
+        wins.append(f"Contributor-activation continuity is strict-pass with activation score={contributor_activation_score}.")
     else:
         misses.append("Day 55 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 55 contributor activation closeout command and restore strict baseline before Day 56 lock."
         )
 
-    if board_count >= 5 and board_has_day55:
+    if board_count >= 5 and board_has_contributor_activation_day55:
         wins.append(
             f"Day 55 delivery board integrity validated with {board_count} checklist items."
         )
@@ -321,18 +321,18 @@ def build_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": "docs/index.md",
             "docs_page": _PAGE_PATH,
             "top10": _TOP10_PATH,
-            "day55_summary": str(day55_summary.relative_to(root))
-            if day55_summary.exists()
-            else str(day55_summary),
-            "day55_delivery_board": str(day55_board.relative_to(root))
-            if day55_board.exists()
-            else str(day55_board),
+            "contributor_activation_summary": str(contributor_activation_summary.relative_to(root))
+            if contributor_activation_summary.exists()
+            else str(contributor_activation_summary),
+            "contributor_activation_delivery_board": str(contributor_activation_board.relative_to(root))
+            if contributor_activation_board.exists()
+            else str(contributor_activation_board),
         },
         "checks": checks,
         "rollup": {
-            "day55_activation_score": day55_score,
-            "day55_checks": day55_check_count,
-            "day55_delivery_board_items": board_count,
+            "contributor_activation_activation_score": contributor_activation_score,
+            "contributor_activation_checks": contributor_activation_check_count,
+            "contributor_activation_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,


### PR DESCRIPTION
### Motivation
- Remove remaining active/public dayNN predecessor key residue from runtime outputs and checked-in artifact packs to make canonical predecessor naming primary across active closeout lanes.
- Perform a repo-wide inventory first and then clean all eligible active/public lanes in the same pass rather than fixing a single lane at a time.
- Preserve backward compatibility for intentionally narrow shims (CLI legacy aliases and reliability day15/16/17 flags) and avoid reworking lanes already proven clean.

### Description
- Replaced day-based predecessor keys/check IDs in five active closeout lanes: `demo-asset` (day32 -> `release_cadence_*`), `docs-loop-closeout` (day52 -> `narrative_closeout_*`), `contributor-activation-closeout` (day53 -> `docs_loop_closeout_*`), `stabilization-closeout` (day55 -> `contributor_activation_*`), and `phase3-kickoff-closeout` (day60 -> `phase2_wrap_handoff_*`).
- Updated the corresponding runtime code under `src/sdetkit/` (modules listed above) and regenerated the checked-in emitted artifact packs under `docs/artifacts/*-pack/` so the summaries/markdown now expose canonical predecessor keys and rollup names (examples: `release_cadence_activation_score`, `narrative_closeout_activation_score`, `docs_loop_closeout_activation_score`, `contributor_activation_activation_score`, `phase2_wrap_handoff_activation_score`).
- Kept intentionally narrow compatibility shims untouched, including known CLI legacy aliases for reliability/day50 and the suppressed reliability flags (`--day15-summary`, `--day16-summary`, `--day17-summary`).
- Changes are limited to public/active surfaces (selected `src/sdetkit/*` modules and their emitted artifact packs) and do not speculative-rename unrelated areas.

### Testing
- Ran targeted pytest for the modified lanes with `pytest -q tests/test_demo_asset.py tests/test_docs_loop_closeout.py tests/test_contributor_activation_closeout.py tests/test_stabilization_closeout.py tests/test_phase3_kickoff_closeout.py` and all tests passed (`21 passed`).
- Executed the non-strict CLI paths for the five lanes via `python -m sdetkit <lane> --format json` and each produced JSON output aligning with the new canonical predecessor keys.
- Attempted strict-mode checks via `--strict`; strict-mode runs failed due to pre-existing content/strict-baseline gaps in this repo snapshot that are unrelated to the naming-only refactor.
- Verified emitted checked-in artifact summaries now carry the canonical predecessor keys (examples found in `docs/artifacts/demo-asset-pack/demo-asset-summary.json`, `docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json`, `docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json`, and `docs/artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d2677c7d9483209b81716ccf227671)