### PR TITLE
Canonicalize weekly-review-closeout-2 README evidence string

### DIFF
--- a/docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json
+++ b/docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json
@@ -14,7 +14,7 @@
       "check_id": "readme_command_lane",
       "weight": 7,
       "passed": false,
-      "evidence": "README day65 command lane"
+      "evidence": "README weekly-review-closeout-2 command lane"
     },
     {
       "check_id": "docs_index_links",

--- a/docs/artifacts/weekly-review-closeout-pack-65/weekly-review-closeout-summary-65.json
+++ b/docs/artifacts/weekly-review-closeout-pack-65/weekly-review-closeout-summary-65.json
@@ -14,7 +14,7 @@
       "check_id": "readme_command_lane",
       "weight": 7,
       "passed": true,
-      "evidence": "README day65 command lane"
+      "evidence": "README weekly-review-closeout-2 command lane"
     },
     {
       "check_id": "docs_index_links",

--- a/src/sdetkit/weekly_review_closeout_65.py
+++ b/src/sdetkit/weekly_review_closeout_65.py
@@ -175,7 +175,7 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
             "check_id": "readme_command_lane",
             "weight": 7,
             "passed": ("weekly-review-closeout-2" in readme_text),
-            "evidence": "README day65 command lane",
+            "evidence": "README weekly-review-closeout-2 command lane",
         },
         {
             "check_id": "docs_index_links",


### PR DESCRIPTION
### Motivation
- Remove a remaining active/public day-based phrasing by making the weekly review closeout lane emit the canonical playbook name instead of a `day65` phrasing.
- Inventory-driven change: a repo-wide scan for `day([0-9]{1,2})` hits was performed first and residues were classified to avoid touching already-productized or compatibility-only lanes.

### Description
- Replaced the legacy evidence string `README day65 command lane` with the canonical `README weekly-review-closeout-2 command lane` in `src/sdetkit/weekly_review_closeout_65.py`.
- Updated checked-in emitted artifact summaries to match the canonical wording in `docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json` and `docs/artifacts/weekly-review-closeout-pack-65/weekly-review-closeout-summary-65.json`.
- Left other day-based residues alone after classification: compatibility aliases (CLI aliases and hidden `--day15/16/17` args), historical `docs/artifacts/**/evidence/**` logs, and test fixtures were explicitly retained as historical or narrow compatibility shims.

### Testing
- Ran `pytest -q tests/test_weekly_review_closeout_2.py` and all tests passed (`4 passed`).
- Ran `python -m sdetkit weekly-review-closeout-2 --format json` to confirm the emitted `readme` evidence string now reads `README weekly-review-closeout-2 command lane` (succeeds and shows canonical string).
- Ran the lane contract checker `python scripts/check_weekly_review_closeout_contract_65.py --skip-evidence`, which failed due to existing baseline contract conditions unrelated to the wording change (failure expected and not caused by this rename).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d26b76f3cc83209c141b13453b437c)