### PR TITLE
Promote Cycle 2 canonical naming and narrow Day92 compatibility alias

### DIFF
--- a/src/sdetkit/continuous_upgrade_closeout_2.py
+++ b/src/sdetkit/continuous_upgrade_closeout_2.py
@@ -70,7 +70,7 @@ _REQUIRED_DATA_KEYS = [
     "cadence_days",
 ]
 
-_DAY92_DEFAULT_PAGE = """# Cycle 2 \u2014 Continuous upgrade closeout lane
+_CYCLE2_DEFAULT_PAGE = """# Cycle 2 \u2014 Continuous upgrade closeout lane
 
 Cycle 2 closes with a major upgrade that converts Cycle 1 governance scale outcomes into a deterministic phase-3 wrap and publication operating lane.
 
@@ -122,6 +122,9 @@ python scripts/check_continuous_upgrade_contract_2.py
 
 Cycle 2 weights continuity + execution contract + governance artifact readiness for a 100-point activation score.
 """
+
+# Backward-compatible alias retained for transition-era imports.
+_DAY92_DEFAULT_PAGE = _CYCLE2_DEFAULT_PAGE
 
 
 def _read_text(path: Path) -> str:
@@ -554,7 +557,7 @@ def main(argv: list[str] | None = None) -> int:
 
     root = Path(ns.root).resolve()
     if ns.write_default_doc:
-        _write(root / _PAGE_PATH, _DAY92_DEFAULT_PAGE)
+        _write(root / _PAGE_PATH, _CYCLE2_DEFAULT_PAGE)
 
     payload = build_continuous_upgrade_cycle2_closeout_summary(root)
 

--- a/tests/test_continuous_upgrade_closeout_2.py
+++ b/tests/test_continuous_upgrade_closeout_2.py
@@ -29,7 +29,7 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/integrations-continuous-upgrade-closeout-2.md").write_text(
-        c2._DAY92_DEFAULT_PAGE, encoding="utf-8"
+        c2._CYCLE2_DEFAULT_PAGE, encoding="utf-8"
     )
     (root / "docs/continuous-upgrade-big-upgrade-report-2.md").write_text(
         "# Cycle 2 report\n", encoding="utf-8"

--- a/tests/test_continuous_upgrade_closeout_3.py
+++ b/tests/test_continuous_upgrade_closeout_3.py
@@ -29,7 +29,7 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/integrations-continuous-upgrade-closeout-3.md").write_text(
-        (getattr(c3, "_CYCLE3_DEFAULT_PAGE", None) or c3._DAY93_DEFAULT_PAGE), encoding="utf-8"
+        c3._CYCLE3_DEFAULT_PAGE, encoding="utf-8"
     )
     (root / "docs/continuous-upgrade-cycle3-report.md").write_text(
         "# Cycle 3 report\n", encoding="utf-8"
@@ -194,7 +194,7 @@ def test_cycle3_execute_strict_fails_on_command_error(tmp_path: Path, monkeypatc
     assert execution_data["strict_pass"] is False
 
 
-def test_cycle3_strict_fails_without_day92(tmp_path: Path) -> None:
+def test_cycle3_strict_fails_without_cycle2_inputs(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (
         tmp_path


### PR DESCRIPTION
### Motivation
- Inventorying `dayNN` residues across `src/`, `tests/`, `docs/`, and `scripts/` showed an active/public residue where Cycle 2 continuous-upgrade doc constant used a legacy `day92` primary symbol instead of a canonical `cycle` name.
- The intent is to make canonical cycle naming primary on active surfaces while preserving minimal compatibility shims where needed, not to do a blind global rename.

### Description
- Promoted the canonical constant `_CYCLE2_DEFAULT_PAGE` as the primary default-page symbol in `src/sdetkit/continuous_upgrade_closeout_2.py` and made `_DAY92_DEFAULT_PAGE` a backward-compatible alias only. 
- Updated the `--write-default-doc` path in `continuous_upgrade_closeout_2` to write from `_CYCLE2_DEFAULT_PAGE` on active surfaces. 
- Updated tests to prefer canonical cycle constants: `tests/test_continuous_upgrade_closeout_2.py` now references `c2._CYCLE2_DEFAULT_PAGE`, and `tests/test_continuous_upgrade_closeout_3.py` writes the canonical `c3._CYCLE3_DEFAULT_PAGE` and renamed one test to `test_cycle3_strict_fails_without_cycle2_inputs` to reflect the cycle-focused contract. 
- Limited scope: left already-clean lanes, intentional CLI aliases, and other compatibility shims untouched (e.g., reliability day aliases and onboarding shims) and did not alter historical/artifact evidence files.

### Testing
- Ran targeted unit tests with `pytest -q tests/test_continuous_upgrade_closeout_2.py tests/test_continuous_upgrade_closeout_3.py` which passed (`10 passed`).
- Ran contract checkers `python scripts/check_continuous_upgrade_contract_2.py` and `python scripts/check_continuous_upgrade_contract_3.py`, which failed due to pre-existing checker import/module-name expectations (these failures are caused by the checkers expecting modules named `sdetkit.continuous_upgrade_cycle2_closeout`/`...cycle3_closeout`, not by the changes to canonical constants).
- Performed repo scan to build the `dayNN` inventory and verified only the Cycle 2 continuous-upgrade lane required active/public cleanup in this pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d26e28690483209a9622e9d69d0c15)