### PR TITLE
Canonicalize dependency/check IDs for closeout lanes 42–46 (remove dayNN residue)

### DIFF
--- a/src/sdetkit/acceleration_closeout_43.py
+++ b/src/sdetkit/acceleration_closeout_43.py
@@ -130,7 +130,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day42(path: Path) -> tuple[float, bool, int]:
+def _load_optimization_closeout(path: Path) -> tuple[float, bool, int]:
     data = _load_json(path)
     if data is None:
         return 0.0, False, 0
@@ -180,10 +180,10 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day42_summary = _resolve_existing_path(root, _DAY42_SUMMARY_PATH, _DAY42_LEGACY_SUMMARY_PATH)
-    day42_board = _resolve_existing_path(root, _DAY42_BOARD_PATH, _DAY42_LEGACY_BOARD_PATH)
-    day42_score, day42_strict, day42_check_count = _load_day42(day42_summary)
-    board_count, board_has_day42, board_has_day43 = _board_stats(day42_board)
+    optimization_closeout_summary = _resolve_existing_path(root, _DAY42_SUMMARY_PATH, _DAY42_LEGACY_SUMMARY_PATH)
+    optimization_closeout_board = _resolve_existing_path(root, _DAY42_BOARD_PATH, _DAY42_LEGACY_BOARD_PATH)
+    optimization_closeout_score, optimization_closeout_strict, optimization_closeout_check_count = _load_optimization_closeout(optimization_closeout_summary)
+    board_count, board_has_optimization_closeout, board_has_acceleration_closeout = _board_stats(optimization_closeout_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -234,33 +234,33 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "optimization_closeout_summary_present",
             "weight": 10,
-            "passed": day42_summary.exists(),
-            "evidence": str(day42_summary),
+            "passed": optimization_closeout_summary.exists(),
+            "evidence": str(optimization_closeout_summary),
         },
         {
             "check_id": "optimization_closeout_delivery_board_present",
             "weight": 8,
-            "passed": day42_board.exists(),
-            "evidence": str(day42_board),
+            "passed": optimization_closeout_board.exists(),
+            "evidence": str(optimization_closeout_board),
         },
         {
             "check_id": "optimization_closeout_quality_floor",
             "weight": 10,
-            "passed": day42_strict and day42_score >= 95,
+            "passed": optimization_closeout_strict and optimization_closeout_score >= 95,
             "evidence": {
-                "day42_score": day42_score,
-                "strict_pass": day42_strict,
-                "optimization_closeout_checks": day42_check_count,
+                "optimization_closeout_score": optimization_closeout_score,
+                "strict_pass": optimization_closeout_strict,
+                "optimization_closeout_checks": optimization_closeout_check_count,
             },
         },
         {
             "check_id": "optimization_closeout_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day42 and board_has_day43,
+            "passed": board_count >= 5 and board_has_optimization_closeout and board_has_acceleration_closeout,
             "evidence": {
                 "board_items": board_count,
-                "contains_day42": board_has_day42,
-                "contains_day43": board_has_day43,
+                "contains_optimization_closeout": board_has_optimization_closeout,
+                "contains_acceleration_closeout": board_has_acceleration_closeout,
             },
         },
         {
@@ -286,24 +286,24 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
     failed = [c for c in checks if not c["passed"]]
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     critical_failures: list[str] = []
-    if not day42_summary.exists() or not day42_board.exists():
+    if not optimization_closeout_summary.exists() or not optimization_closeout_board.exists():
         critical_failures.append("optimization_closeout_handoff_inputs")
-    if not day42_strict:
+    if not optimization_closeout_strict:
         critical_failures.append("optimization_closeout_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day42_strict:
-        wins.append(f"Day 42 continuity is strict-pass with activation score={day42_score}.")
+    if optimization_closeout_strict:
+        wins.append(f"Day 42 continuity is strict-pass with activation score={optimization_closeout_score}.")
     else:
         misses.append("Day 42 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 42 optimization closeout command and restore strict pass baseline before Day 43 lock."
         )
 
-    if board_count >= 5 and board_has_day42 and board_has_day43:
+    if board_count >= 5 and board_has_optimization_closeout and board_has_acceleration_closeout:
         wins.append(
             f"Day 42 delivery board integrity validated with {board_count} checklist items."
         )
@@ -339,17 +339,17 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": docs_index_path,
             "docs_page": docs_page_path,
             "top10": top10_path,
-            "optimization_closeout_summary": str(day42_summary.relative_to(root))
-            if day42_summary.exists()
-            else str(day42_summary),
-            "optimization_closeout_delivery_board": str(day42_board.relative_to(root))
-            if day42_board.exists()
-            else str(day42_board),
+            "optimization_closeout_summary": str(optimization_closeout_summary.relative_to(root))
+            if optimization_closeout_summary.exists()
+            else str(optimization_closeout_summary),
+            "optimization_closeout_delivery_board": str(optimization_closeout_board.relative_to(root))
+            if optimization_closeout_board.exists()
+            else str(optimization_closeout_board),
         },
         "checks": checks,
         "rollup": {
-            "optimization_closeout_activation_score": day42_score,
-            "optimization_closeout_checks": day42_check_count,
+            "optimization_closeout_activation_score": optimization_closeout_score,
+            "optimization_closeout_checks": optimization_closeout_check_count,
             "optimization_closeout_delivery_board_items": board_count,
         },
         "summary": {

--- a/src/sdetkit/expansion_closeout_45.py
+++ b/src/sdetkit/expansion_closeout_45.py
@@ -126,7 +126,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day44(path: Path) -> tuple[float, bool, int]:
+def _load_scale_closeout(path: Path) -> tuple[float, bool, int]:
     data = _load_json(path)
     if data is None:
         return 0.0, False, 0
@@ -169,10 +169,10 @@ def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day44_summary = root / _DAY44_SUMMARY_PATH
-    day44_board = root / _DAY44_BOARD_PATH
-    day44_score, day44_strict, day44_check_count = _load_day44(day44_summary)
-    board_count, board_has_day44, board_has_day45 = _board_stats(day44_board)
+    scale_closeout_summary = root / _DAY44_SUMMARY_PATH
+    scale_closeout_board = root / _DAY44_BOARD_PATH
+    scale_closeout_score, scale_closeout_strict, scale_closeout_check_count = _load_scale_closeout(scale_closeout_summary)
+    board_count, board_has_scale_closeout, board_has_expansion_closeout = _board_stats(scale_closeout_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -221,35 +221,35 @@ def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 45 + Day 46 strategy chain",
         },
         {
-            "check_id": "day44_summary_present",
+            "check_id": "scale_closeout_summary_present",
             "weight": 10,
-            "passed": day44_summary.exists(),
-            "evidence": str(day44_summary),
+            "passed": scale_closeout_summary.exists(),
+            "evidence": str(scale_closeout_summary),
         },
         {
-            "check_id": "day44_delivery_board_present",
+            "check_id": "scale_closeout_delivery_board_present",
             "weight": 8,
-            "passed": day44_board.exists(),
-            "evidence": str(day44_board),
+            "passed": scale_closeout_board.exists(),
+            "evidence": str(scale_closeout_board),
         },
         {
-            "check_id": "day44_quality_floor",
+            "check_id": "scale_closeout_quality_floor",
             "weight": 10,
-            "passed": day44_strict and day44_score >= 95,
+            "passed": scale_closeout_strict and scale_closeout_score >= 95,
             "evidence": {
-                "day44_score": day44_score,
-                "strict_pass": day44_strict,
-                "day44_checks": day44_check_count,
+                "scale_closeout_score": scale_closeout_score,
+                "strict_pass": scale_closeout_strict,
+                "scale_closeout_checks": scale_closeout_check_count,
             },
         },
         {
-            "check_id": "day44_board_integrity",
+            "check_id": "scale_closeout_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day44 and board_has_day45,
+            "passed": board_count >= 5 and board_has_scale_closeout and board_has_expansion_closeout,
             "evidence": {
                 "board_items": board_count,
-                "contains_day44": board_has_day44,
-                "contains_day45": board_has_day45,
+                "contains_scale_closeout": board_has_scale_closeout,
+                "contains_expansion_closeout": board_has_expansion_closeout,
             },
         },
         {
@@ -275,24 +275,24 @@ def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     failed = [c for c in checks if not c["passed"]]
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     critical_failures: list[str] = []
-    if not day44_summary.exists() or not day44_board.exists():
-        critical_failures.append("day44_handoff_inputs")
-    if not day44_strict:
-        critical_failures.append("day44_strict_baseline")
+    if not scale_closeout_summary.exists() or not scale_closeout_board.exists():
+        critical_failures.append("scale_closeout_handoff_inputs")
+    if not scale_closeout_strict:
+        critical_failures.append("scale_closeout_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day44_strict:
-        wins.append(f"Day 44 continuity is strict-pass with activation score={day44_score}.")
+    if scale_closeout_strict:
+        wins.append(f"Day 44 continuity is strict-pass with activation score={scale_closeout_score}.")
     else:
         misses.append("Day 44 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 44 scale closeout command and restore strict pass baseline before Day 45 lock."
         )
 
-    if board_count >= 5 and board_has_day44 and board_has_day45:
+    if board_count >= 5 and board_has_scale_closeout and board_has_expansion_closeout:
         wins.append(
             f"Day 44 delivery board integrity validated with {board_count} checklist items."
         )
@@ -328,18 +328,18 @@ def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": docs_index_path,
             "docs_page": docs_page_path,
             "top10": top10_path,
-            "day44_summary": str(day44_summary.relative_to(root))
-            if day44_summary.exists()
-            else str(day44_summary),
-            "day44_delivery_board": str(day44_board.relative_to(root))
-            if day44_board.exists()
-            else str(day44_board),
+            "scale_closeout_summary": str(scale_closeout_summary.relative_to(root))
+            if scale_closeout_summary.exists()
+            else str(scale_closeout_summary),
+            "scale_closeout_delivery_board": str(scale_closeout_board.relative_to(root))
+            if scale_closeout_board.exists()
+            else str(scale_closeout_board),
         },
         "checks": checks,
         "rollup": {
-            "day44_activation_score": day44_score,
-            "day44_checks": day44_check_count,
-            "day44_delivery_board_items": board_count,
+            "scale_closeout_activation_score": scale_closeout_score,
+            "scale_closeout_checks": scale_closeout_check_count,
+            "scale_closeout_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,
@@ -361,9 +361,9 @@ def _render_text(payload: dict[str, Any]) -> str:
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
         f"- Critical failures: {payload['summary']['critical_failures']}",
-        f"- Day 44 activation score: `{payload['rollup']['day44_activation_score']}`",
-        f"- Day 44 checks evaluated: `{payload['rollup']['day44_checks']}`",
-        f"- Day 44 delivery board checklist items: `{payload['rollup']['day44_delivery_board_items']}`",
+        f"- Day 44 activation score: `{payload['rollup']['scale_closeout_activation_score']}`",
+        f"- Day 44 checks evaluated: `{payload['rollup']['scale_closeout_checks']}`",
+        f"- Day 44 delivery board checklist items: `{payload['rollup']['scale_closeout_delivery_board_items']}`",
     ]
     if payload["wins"]:
         lines.append("- Wins:")

--- a/src/sdetkit/optimization_closeout_42.py
+++ b/src/sdetkit/optimization_closeout_42.py
@@ -132,7 +132,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day41(path: Path) -> tuple[float, bool, int]:
+def _load_expansion_automation(path: Path) -> tuple[float, bool, int]:
     data = _load_json(path)
     if data is None:
         return 0.0, False, 0
@@ -182,10 +182,10 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day41_summary = _resolve_existing_path(root, _DAY41_SUMMARY_PATH, _DAY41_LEGACY_SUMMARY_PATH)
-    day41_board = _resolve_existing_path(root, _DAY41_BOARD_PATH, _DAY41_LEGACY_BOARD_PATH)
-    day41_score, day41_strict, day41_check_count = _load_day41(day41_summary)
-    board_count, board_has_day41, board_has_day42 = _board_stats(day41_board)
+    expansion_automation_summary = _resolve_existing_path(root, _DAY41_SUMMARY_PATH, _DAY41_LEGACY_SUMMARY_PATH)
+    expansion_automation_board = _resolve_existing_path(root, _DAY41_BOARD_PATH, _DAY41_LEGACY_BOARD_PATH)
+    expansion_automation_score, expansion_automation_strict, expansion_automation_check_count = _load_expansion_automation(expansion_automation_summary)
+    board_count, board_has_expansion_automation, board_has_optimization_closeout_foundation = _board_stats(expansion_automation_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -236,33 +236,33 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "expansion_automation_summary_present",
             "weight": 10,
-            "passed": day41_summary.exists(),
-            "evidence": str(day41_summary),
+            "passed": expansion_automation_summary.exists(),
+            "evidence": str(expansion_automation_summary),
         },
         {
             "check_id": "expansion_automation_delivery_board_present",
             "weight": 8,
-            "passed": day41_board.exists(),
-            "evidence": str(day41_board),
+            "passed": expansion_automation_board.exists(),
+            "evidence": str(expansion_automation_board),
         },
         {
             "check_id": "expansion_automation_quality_floor",
             "weight": 10,
-            "passed": day41_strict and day41_score >= 95,
+            "passed": expansion_automation_strict and expansion_automation_score >= 95,
             "evidence": {
-                "day41_score": day41_score,
-                "strict_pass": day41_strict,
-                "expansion_automation_checks": day41_check_count,
+                "expansion_automation_score": expansion_automation_score,
+                "strict_pass": expansion_automation_strict,
+                "expansion_automation_checks": expansion_automation_check_count,
             },
         },
         {
             "check_id": "expansion_automation_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day41 and board_has_day42,
+            "passed": board_count >= 5 and board_has_expansion_automation and board_has_optimization_closeout_foundation,
             "evidence": {
                 "board_items": board_count,
-                "contains_day41": board_has_day41,
-                "contains_day42": board_has_day42,
+                "contains_expansion_automation": board_has_expansion_automation,
+                "contains_optimization_closeout_foundation": board_has_optimization_closeout_foundation,
             },
         },
         {
@@ -288,24 +288,24 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     failed = [c for c in checks if not c["passed"]]
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     critical_failures: list[str] = []
-    if not day41_summary.exists() or not day41_board.exists():
+    if not expansion_automation_summary.exists() or not expansion_automation_board.exists():
         critical_failures.append("expansion_automation_handoff_inputs")
-    if not day41_strict:
+    if not expansion_automation_strict:
         critical_failures.append("expansion_automation_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day41_strict:
-        wins.append(f"Day 41 continuity is strict-pass with activation score={day41_score}.")
+    if expansion_automation_strict:
+        wins.append(f"Day 41 continuity is strict-pass with activation score={expansion_automation_score}.")
     else:
         misses.append("Day 41 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 41 expansion automation command and restore strict pass baseline before Optimization Closeout Foundation lock."
         )
 
-    if board_count >= 5 and board_has_day41 and board_has_day42:
+    if board_count >= 5 and board_has_expansion_automation and board_has_optimization_closeout_foundation:
         wins.append(
             f"Day 41 delivery board integrity validated with {board_count} checklist items."
         )
@@ -341,17 +341,17 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": docs_index_path,
             "docs_page": docs_page_path,
             "top10": top10_path,
-            "expansion_automation_summary": str(day41_summary.relative_to(root))
-            if day41_summary.exists()
-            else str(day41_summary),
-            "expansion_automation_delivery_board": str(day41_board.relative_to(root))
-            if day41_board.exists()
-            else str(day41_board),
+            "expansion_automation_summary": str(expansion_automation_summary.relative_to(root))
+            if expansion_automation_summary.exists()
+            else str(expansion_automation_summary),
+            "expansion_automation_delivery_board": str(expansion_automation_board.relative_to(root))
+            if expansion_automation_board.exists()
+            else str(expansion_automation_board),
         },
         "checks": checks,
         "rollup": {
-            "expansion_automation_activation_score": day41_score,
-            "expansion_automation_checks": day41_check_count,
+            "expansion_automation_activation_score": expansion_automation_score,
+            "expansion_automation_checks": expansion_automation_check_count,
             "expansion_automation_delivery_board_items": board_count,
         },
         "summary": {

--- a/src/sdetkit/optimization_closeout_46.py
+++ b/src/sdetkit/optimization_closeout_46.py
@@ -126,7 +126,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day45(path: Path) -> tuple[float, bool, int]:
+def _load_expansion_closeout(path: Path) -> tuple[float, bool, int]:
     data = _load_json(path)
     if data is None:
         return 0.0, False, 0
@@ -168,10 +168,10 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day45_summary = root / _DAY45_SUMMARY_PATH
-    day45_board = root / _DAY45_BOARD_PATH
-    day45_score, day45_strict, day45_check_count = _load_day45(day45_summary)
-    board_count, board_has_day45, board_has_day46 = _board_stats(day45_board)
+    expansion_closeout_summary = root / _DAY45_SUMMARY_PATH
+    expansion_closeout_board = root / _DAY45_BOARD_PATH
+    expansion_closeout_score, expansion_closeout_strict, expansion_closeout_check_count = _load_expansion_closeout(expansion_closeout_summary)
+    board_count, board_has_expansion_closeout, board_has_optimization_closeout = _board_stats(expansion_closeout_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -220,35 +220,35 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
             "evidence": "Day 46 + Day 47 strategy chain",
         },
         {
-            "check_id": "day45_summary_present",
+            "check_id": "expansion_closeout_summary_present",
             "weight": 10,
-            "passed": day45_summary.exists(),
-            "evidence": str(day45_summary),
+            "passed": expansion_closeout_summary.exists(),
+            "evidence": str(expansion_closeout_summary),
         },
         {
-            "check_id": "day45_delivery_board_present",
+            "check_id": "expansion_closeout_delivery_board_present",
             "weight": 8,
-            "passed": day45_board.exists(),
-            "evidence": str(day45_board),
+            "passed": expansion_closeout_board.exists(),
+            "evidence": str(expansion_closeout_board),
         },
         {
-            "check_id": "day45_quality_floor",
+            "check_id": "expansion_closeout_quality_floor",
             "weight": 10,
-            "passed": day45_strict and day45_score >= 95,
+            "passed": expansion_closeout_strict and expansion_closeout_score >= 95,
             "evidence": {
-                "day45_score": day45_score,
-                "strict_pass": day45_strict,
-                "day45_checks": day45_check_count,
+                "expansion_closeout_score": expansion_closeout_score,
+                "strict_pass": expansion_closeout_strict,
+                "expansion_closeout_checks": expansion_closeout_check_count,
             },
         },
         {
-            "check_id": "day45_board_integrity",
+            "check_id": "expansion_closeout_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day45 and board_has_day46,
+            "passed": board_count >= 5 and board_has_expansion_closeout and board_has_optimization_closeout,
             "evidence": {
                 "board_items": board_count,
-                "contains_day45": board_has_day45,
-                "contains_day46": board_has_day46,
+                "contains_expansion_closeout": board_has_expansion_closeout,
+                "contains_optimization_closeout": board_has_optimization_closeout,
             },
         },
         {
@@ -274,24 +274,24 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
     failed = [c for c in checks if not c["passed"]]
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     critical_failures: list[str] = []
-    if not day45_summary.exists() or not day45_board.exists():
-        critical_failures.append("day45_handoff_inputs")
-    if not day45_strict:
-        critical_failures.append("day45_strict_baseline")
+    if not expansion_closeout_summary.exists() or not expansion_closeout_board.exists():
+        critical_failures.append("expansion_closeout_handoff_inputs")
+    if not expansion_closeout_strict:
+        critical_failures.append("expansion_closeout_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day45_strict:
-        wins.append(f"Day 45 continuity is strict-pass with activation score={day45_score}.")
+    if expansion_closeout_strict:
+        wins.append(f"Day 45 continuity is strict-pass with activation score={expansion_closeout_score}.")
     else:
         misses.append("Day 45 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 45 expansion closeout command and restore strict pass baseline before Day 46 lock."
         )
 
-    if board_count >= 5 and board_has_day45 and board_has_day46:
+    if board_count >= 5 and board_has_expansion_closeout and board_has_optimization_closeout:
         wins.append(
             f"Day 45 delivery board integrity validated with {board_count} checklist items."
         )
@@ -327,18 +327,18 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": docs_index_path,
             "docs_page": docs_page_path,
             "top10": top10_path,
-            "day45_summary": str(day45_summary.relative_to(root))
-            if day45_summary.exists()
-            else str(day45_summary),
-            "day45_delivery_board": str(day45_board.relative_to(root))
-            if day45_board.exists()
-            else str(day45_board),
+            "expansion_closeout_summary": str(expansion_closeout_summary.relative_to(root))
+            if expansion_closeout_summary.exists()
+            else str(expansion_closeout_summary),
+            "expansion_closeout_delivery_board": str(expansion_closeout_board.relative_to(root))
+            if expansion_closeout_board.exists()
+            else str(expansion_closeout_board),
         },
         "checks": checks,
         "rollup": {
-            "day45_activation_score": day45_score,
-            "day45_checks": day45_check_count,
-            "day45_delivery_board_items": board_count,
+            "expansion_closeout_activation_score": expansion_closeout_score,
+            "expansion_closeout_checks": expansion_closeout_check_count,
+            "expansion_closeout_delivery_board_items": board_count,
         },
         "summary": {
             "activation_score": score,
@@ -360,9 +360,9 @@ def _render_text(payload: dict[str, Any]) -> str:
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
         f"- Critical failures: {payload['summary']['critical_failures']}",
-        f"- Day 45 activation score: `{payload['rollup']['day45_activation_score']}`",
-        f"- Day 45 checks evaluated: `{payload['rollup']['day45_checks']}`",
-        f"- Day 45 delivery board checklist items: `{payload['rollup']['day45_delivery_board_items']}`",
+        f"- Day 45 activation score: `{payload['rollup']['expansion_closeout_activation_score']}`",
+        f"- Day 45 checks evaluated: `{payload['rollup']['expansion_closeout_checks']}`",
+        f"- Day 45 delivery board checklist items: `{payload['rollup']['expansion_closeout_delivery_board_items']}`",
     ]
     if payload["wins"]:
         lines.append("- Wins:")

--- a/src/sdetkit/scale_closeout_44.py
+++ b/src/sdetkit/scale_closeout_44.py
@@ -139,7 +139,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _load_day43(path: Path) -> tuple[float, bool, int]:
+def _load_acceleration_closeout(path: Path) -> tuple[float, bool, int]:
     data = _load_json(path)
     if data is None:
         return 0.0, False, 0
@@ -182,10 +182,10 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
     missing_quality_lines = _contains_all_lines(page_text, _REQUIRED_QUALITY_LINES)
     missing_board_items = _contains_all_lines(page_text, _REQUIRED_DELIVERY_BOARD_LINES)
 
-    day43_summary = _resolve_existing_path(root, _DAY43_SUMMARY_PATH, _DAY43_LEGACY_SUMMARY_PATH)
-    day43_board = _resolve_existing_path(root, _DAY43_BOARD_PATH, _DAY43_LEGACY_BOARD_PATH)
-    day43_score, day43_strict, day43_check_count = _load_day43(day43_summary)
-    board_count, board_has_day43, board_has_day44 = _board_stats(day43_board)
+    acceleration_closeout_summary = _resolve_existing_path(root, _DAY43_SUMMARY_PATH, _DAY43_LEGACY_SUMMARY_PATH)
+    acceleration_closeout_board = _resolve_existing_path(root, _DAY43_BOARD_PATH, _DAY43_LEGACY_BOARD_PATH)
+    acceleration_closeout_score, acceleration_closeout_strict, acceleration_closeout_check_count = _load_acceleration_closeout(acceleration_closeout_summary)
+    board_count, board_has_acceleration_closeout, board_has_scale_closeout = _board_stats(acceleration_closeout_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -236,33 +236,33 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "acceleration_closeout_summary_present",
             "weight": 10,
-            "passed": day43_summary.exists(),
-            "evidence": str(day43_summary),
+            "passed": acceleration_closeout_summary.exists(),
+            "evidence": str(acceleration_closeout_summary),
         },
         {
             "check_id": "acceleration_closeout_delivery_board_present",
             "weight": 8,
-            "passed": day43_board.exists(),
-            "evidence": str(day43_board),
+            "passed": acceleration_closeout_board.exists(),
+            "evidence": str(acceleration_closeout_board),
         },
         {
             "check_id": "acceleration_closeout_quality_floor",
             "weight": 10,
-            "passed": day43_strict and day43_score >= 95,
+            "passed": acceleration_closeout_strict and acceleration_closeout_score >= 95,
             "evidence": {
-                "day43_score": day43_score,
-                "strict_pass": day43_strict,
-                "acceleration_closeout_checks": day43_check_count,
+                "acceleration_closeout_score": acceleration_closeout_score,
+                "strict_pass": acceleration_closeout_strict,
+                "acceleration_closeout_checks": acceleration_closeout_check_count,
             },
         },
         {
             "check_id": "acceleration_closeout_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5 and board_has_day43 and board_has_day44,
+            "passed": board_count >= 5 and board_has_acceleration_closeout and board_has_scale_closeout,
             "evidence": {
                 "board_items": board_count,
-                "contains_day43": board_has_day43,
-                "contains_day44": board_has_day44,
+                "contains_acceleration_closeout": board_has_acceleration_closeout,
+                "contains_scale_closeout": board_has_scale_closeout,
             },
         },
         {
@@ -288,24 +288,24 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
     failed = [c for c in checks if not c["passed"]]
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
     critical_failures: list[str] = []
-    if not day43_summary.exists() or not day43_board.exists():
+    if not acceleration_closeout_summary.exists() or not acceleration_closeout_board.exists():
         critical_failures.append("acceleration_closeout_handoff_inputs")
-    if not day43_strict:
+    if not acceleration_closeout_strict:
         critical_failures.append("acceleration_closeout_strict_baseline")
 
     wins: list[str] = []
     misses: list[str] = []
     handoff_actions: list[str] = []
 
-    if day43_strict:
-        wins.append(f"Day 43 continuity is strict-pass with activation score={day43_score}.")
+    if acceleration_closeout_strict:
+        wins.append(f"Day 43 continuity is strict-pass with activation score={acceleration_closeout_score}.")
     else:
         misses.append("Day 43 strict continuity signal is missing.")
         handoff_actions.append(
             "Re-run Day 43 acceleration closeout command and restore strict pass baseline before Day 44 lock."
         )
 
-    if board_count >= 5 and board_has_day43 and board_has_day44:
+    if board_count >= 5 and board_has_acceleration_closeout and board_has_scale_closeout:
         wins.append(
             f"Day 43 delivery board integrity validated with {board_count} checklist items."
         )
@@ -337,17 +337,17 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
             "docs_index": docs_index_path,
             "docs_page": docs_page_path,
             "top10": top10_path,
-            "acceleration_closeout_summary": str(day43_summary.relative_to(root))
-            if day43_summary.exists()
-            else str(day43_summary),
-            "acceleration_closeout_delivery_board": str(day43_board.relative_to(root))
-            if day43_board.exists()
-            else str(day43_board),
+            "acceleration_closeout_summary": str(acceleration_closeout_summary.relative_to(root))
+            if acceleration_closeout_summary.exists()
+            else str(acceleration_closeout_summary),
+            "acceleration_closeout_delivery_board": str(acceleration_closeout_board.relative_to(root))
+            if acceleration_closeout_board.exists()
+            else str(acceleration_closeout_board),
         },
         "checks": checks,
         "rollup": {
-            "acceleration_closeout_activation_score": day43_score,
-            "acceleration_closeout_checks": day43_check_count,
+            "acceleration_closeout_activation_score": acceleration_closeout_score,
+            "acceleration_closeout_checks": acceleration_closeout_check_count,
             "acceleration_closeout_delivery_board_items": board_count,
         },
         "summary": {


### PR DESCRIPTION
### Motivation
- A repo-wide scan for `day([0-9]{1,2})` showed remaining active/public `dayNN` residue concentrated in the closeout chain around days 41–46, so this change focuses on removing day-based emitted keys from that active chain while leaving proven compatibility aliases and historical evidence untouched.
- The intent is to make canonical lane dependency names primary in public outputs (checks/rollups/inputs) without altering runtime semantics or broadening compatibility shims.

### Description
- Replaced day-prefixed emitted keys/identifiers and local loader names across the 42→46 closeout chain in `src/sdetkit`: `optimization_closeout_42.py`, `acceleration_closeout_43.py`, `scale_closeout_44.py`, `expansion_closeout_45.py`, and `optimization_closeout_46.py`. 
- Converted loader/variable names and public `check_id` / evidence / rollup/input keys from `dayNN` to canonical lane names such as `expansion_automation_*`, `optimization_closeout_*`, `acceleration_closeout_*`, `scale_closeout_*`, and `expansion_closeout_*`, and updated corresponding board-integrity and critical-failure IDs. 
- Kept backwards-compatibility at CLI entrypoints and tests where explicitly retained (e.g. `day47-reliability-closeout` and `day50-execution-prioritization-closeout`) and left historical checked-in evidence logs under `docs/artifacts/**` unchanged. 
- Files changed: `src/sdetkit/optimization_closeout_42.py`, `src/sdetkit/acceleration_closeout_43.py`, `src/sdetkit/scale_closeout_44.py`, `src/sdetkit/expansion_closeout_45.py`, and `src/sdetkit/optimization_closeout_46.py`.

### Testing
- Ran the targeted unit tests with `pytest -q tests/test_optimization_closeout_foundation.py tests/test_acceleration_closeout.py tests/test_scale_closeout.py tests/test_expansion_closeout.py tests/test_optimization_closeout.py`, and all tests passed (`20 passed`).
- Verified the modified modules no longer emit `dayNN` keys by scanning the updated files with `rg -n --pcre2 'day([0-9]{1,2})'` which returned no matches in those files. 
- Executed the contract check scripts `python scripts/check_optimization_closeout_contract.py`, `python scripts/check_acceleration_closeout_contract.py`, `python scripts/check_scale_closeout_contract.py`, and `python scripts/check_expansion_closeout_contract.py`; these tools report failures driven by pre-existing missing docs/contract content in the repository baseline (not caused by the renaming), which is expected and left for documentation fixes. 
- Performed a repo-wide `dayNN` inventory scan to scope the change and confirmed this batch addressed the eligible active/public lane family (42–46) while leaving archive/evidence and explicit compatibility aliases intact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d2793aa3408320a283afe75067399b)