### PR TITLE
Add `--show-hidden` flag, route `playbooks` to playbooks CLI, and tests for hidden commands

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -196,18 +196,6 @@ def _hide_help_subcommands(sub) -> None:
     sub._choices_actions = filtered
 
 
-def _print_playbooks(sub) -> None:
-    mp = getattr(sub, "_name_parser_map", {})
-    if not isinstance(mp, dict):
-        return
-    names = sorted([k for k in mp.keys() if isinstance(k, str) and _is_hidden_cmd(k)])
-    print("Playbooks (hidden from main --help):")
-    for n in names:
-        print(f"  {n}")
-    print("")
-    print("Tip: these commands still run directly, e.g. sdetkit <name> --help")
-
-
 def _resolve_non_day_playbook_alias(cmd: str) -> str:
     """Resolve product/legacy playbook names to a parser-backed command."""
     try:
@@ -243,7 +231,9 @@ def _add_passthrough_subcommand(
     return parser
 
 
-def _build_root_parser() -> tuple[argparse.ArgumentParser, object]:
+def _build_root_parser(
+    *, show_hidden_commands: bool = False
+) -> tuple[argparse.ArgumentParser, object]:
     help_description = """\
 DevS69 SDETKit is an operator-grade SDET platform with four umbrella kits:
 release confidence, test intelligence, integration assurance, and failure forensics.
@@ -267,6 +257,11 @@ Start here:
         epilog=help_epilog,
     )
     p.add_argument("--version", action="version", version=_tool_version())
+    p.add_argument(
+        "--show-hidden",
+        action="store_true",
+        help="Include hidden/legacy playbook commands in `sdetkit --help` output.",
+    )
     sub = p.add_subparsers(
         dest="cmd",
         required=True,
@@ -275,9 +270,10 @@ Start here:
         description="Run `sdetkit <command> --help` for command-specific guidance.",
     )
     _add_passthrough_subcommand(sub, "baseline")
-    sub.add_parser(
+    _add_passthrough_subcommand(
+        sub,
         "playbooks",
-        help="Discover and run adoption/rollout playbooks",
+        help_text="Discover and run adoption/rollout playbooks",
     )
     _add_passthrough_subcommand(
         sub, "kits", help_text="[Stable/Core] Umbrella kit catalog and kit details"
@@ -745,7 +741,8 @@ Start here:
 
     tsa = sub.add_parser("trust-assets", help="Trust assets playbook")
     tsa.add_argument("args", nargs=argparse.REMAINDER)
-    _filter_hidden_subcommands(p)
+    if not show_hidden_commands:
+        _filter_hidden_subcommands(p)
     return p, sub
 
 
@@ -762,11 +759,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             "day50-execution-prioritization-closeout": "execution-prioritization-closeout",
         }
         argv[0] = legacy_aliases.get(str(argv[0]), str(argv[0]))
-
-    if argv and argv[0] == "playbooks":
-        from .playbooks_cli import main as _playbooks_main
-
-        return _playbooks_main(list(argv[1:]))
 
     if argv and argv[0] == "cassette-get":
         from .__main__ import _cassette_get
@@ -1149,9 +1141,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "trust-assets":
         return trust_assets.main(list(argv[1:]))
 
-    p, sub = _build_root_parser()
+    show_hidden_commands = "--show-hidden" in argv
+    p, sub = _build_root_parser(show_hidden_commands=show_hidden_commands)
 
-    _hide_help_subcommands(sub)
+    if not show_hidden_commands:
+        _hide_help_subcommands(sub)
 
     ns = p.parse_args(argv)
 
@@ -1217,9 +1211,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0 if ok else 2
 
     if ns.cmd == "playbooks":
-        _print_playbooks(sub)
+        from .playbooks_cli import main as _playbooks_main
 
-        return 0
+        return _playbooks_main(list(ns.args))
 
     if ns.cmd == "kits":
         return kits.main(ns.args)

--- a/tests/test_cli_hidden_surface.py
+++ b/tests/test_cli_hidden_surface.py
@@ -1,0 +1,28 @@
+from sdetkit import cli
+
+
+def test_root_help_hides_closeout_commands_by_default() -> None:
+    help_text = cli._build_root_parser()[0].format_help()
+    assert "docs-qa" not in help_text
+    assert "proof" not in help_text
+
+
+def test_root_help_can_show_hidden_commands() -> None:
+    help_text = cli._build_root_parser(show_hidden_commands=True)[0].format_help()
+    assert "docs-qa" in help_text
+    assert "proof" in help_text
+    assert "--show-hidden" in help_text
+
+
+def test_root_playbooks_command_dispatches_to_playbooks_surface(capsys) -> None:
+    rc = cli.main(["playbooks", "list", "--recommended", "--format", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"recommended"' in out
+
+
+def test_root_playbooks_no_args_lists_catalog(capsys) -> None:
+    rc = cli.main(["playbooks"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Recommended playbooks:" in out


### PR DESCRIPTION
### Motivation

- Allow administrators to opt-in to seeing legacy/hidden playbook commands from the top-level help output while keeping them hidden by default.
- Ensure the `playbooks` top-level command actually dispatches to the dedicated playbooks surface instead of printing a static list.

### Description

- Added an optional `--show-hidden` flag to the root parser and a `show_hidden_commands` parameter to `_build_root_parser` to control whether hidden/legacy playbook commands are included in `sdetkit --help` output.
- Wire `show_hidden_commands` through `main` by detecting `--show-hidden` in `argv` and skip `_filter_hidden_subcommands`/`_hide_help_subcommands` when enabled.
- Replace the old in-place `_print_playbooks` behavior with proper delegation to the playbooks surface by calling `playbooks_cli.main` when `ns.cmd == "playbooks"`.
- Remove the unused `_print_playbooks` usage and add/adjust parser construction to keep hidden commands out of help by default.

### Testing

- Added `tests/test_cli_hidden_surface.py` with tests that assert hidden commands are excluded by default, included when `show_hidden_commands=True`, that `playbooks` dispatches to the playbooks surface, and that `playbooks` with no args lists the catalog; these were run with `pytest` and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d2b7959e8c83208de31b2a0cf0930b)