### PR TITLE
Add `sdetkit kits discover` for repo-wide capability discovery and alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,21 @@ artifacts/     # generated evidence packs
 
 ```bash
 python -m sdetkit kits list
+python -m sdetkit kits discover --goal "align all repo capabilities"
 python -m sdetkit release gate release
 python -m sdetkit intelligence failure-fingerprint --failures examples/kits/intelligence/failures.json
 python -m sdetkit integration check --profile examples/kits/integration/profile.json
 python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json --fail-on error
 bash quality.sh verify
 bash premium-gate.sh --mode full
+```
+
+## Discover hidden/advanced surfaces
+
+```bash
+python -m sdetkit --help
+python -m sdetkit --help --show-hidden
+python -m sdetkit kits discover --query "release integration forensics"
 ```
 
 ## Documentation

--- a/docs/command-taxonomy.md
+++ b/docs/command-taxonomy.md
@@ -9,11 +9,12 @@ SDETKit is a unified SDET platform with four flagship kits:
 - **Integration assurance** (`sdetkit integration ...`)
 - **Failure forensics** (`sdetkit forensics ...`)
 
-Start with `sdetkit kits list`.
+Start with `sdetkit kits discover --goal "align all repo capabilities"` (or `sdetkit kits list` if you want a compact catalog view).
 
 ## Layer 1: Umbrella kits (primary)
 
 - `sdetkit kits list`
+- `sdetkit kits discover --goal "<goal>" --query "<query>"`
 - `sdetkit kits describe <kit>`
 - `sdetkit release ...`
 - `sdetkit intelligence ...`
@@ -43,3 +44,5 @@ These remain supported for existing automation, but are no longer first-run disc
 - Transition-era compatibility lanes: `dayNN-*`, `*-closeout`, `continuous-upgrade-cycleX-closeout`
 
 Use these intentionally; they are not the flagship product surface.
+
+For a full command inventory (including hidden/legacy lanes), run `sdetkit --help --show-hidden`.

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -2248,6 +2248,53 @@ def blueprint_payload(
     }
 
 
+def discover_payload(
+    *,
+    root: Path,
+    goal: str | None,
+    query: str | None,
+    selected_kits: list[str],
+    limit: int = 4,
+) -> dict[str, object]:
+    chosen = selected_kits or [kit["slug"] for kit in _KITS[:4]]
+    normalized_goal = goal or "align and operate all repo capabilities"
+    normalized_query = query or "release integration forensics intelligence"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "goal": normalized_goal,
+        "query": normalized_query,
+        "catalog": list_payload(),
+        "recommended_kits": search_payload(normalized_query, limit=limit),
+        "alignment_plan": optimize_payload(
+            root=root, goal=normalized_goal, selected_kits=chosen, limit=limit
+        ),
+        "expansion_plan": expand_payload(
+            root=root, goal=normalized_goal, selected_kits=chosen, limit=limit
+        ),
+        "dependency_radar": radar_payload(
+            root=root,
+            query=normalized_query,
+            repo_usage_tier=None,
+            impact_area=None,
+            limit=limit,
+        ),
+        "quickstart": [
+            "sdetkit kits list",
+            f"sdetkit kits search '{normalized_query}'",
+            f"sdetkit kits optimize --goal '{normalized_goal}'",
+            f"sdetkit kits expand --goal '{normalized_goal}'",
+        ],
+        "surface_visibility": {
+            "public_help": "sdetkit --help",
+            "full_help": "sdetkit --help --show-hidden",
+            "why": (
+                "Use --show-hidden when you need to inventory legacy/closeout commands "
+                "while keeping the default help focused."
+            ),
+        },
+    }
+
+
 def _print_kit_detail(kit: Payload) -> None:
     print(f"{kit['id']} [{kit['stability']}]")
     print(f"route: sdetkit {kit['slug']} ...")
@@ -2289,6 +2336,7 @@ def main(argv: list[str] | None = None) -> int:
             "describe",
             "search",
             "blueprint",
+            "discover",
             "optimize",
             "expand",
             "route-map",
@@ -2398,6 +2446,53 @@ def main(argv: list[str] | None = None) -> int:
         print("upgrade backlog:")
         for item in _payload_list(blueprint_result.get("upgrade_backlog")):
             print(f"- {item['title']}: {item['summary']}")
+        return 0
+
+    if ns.action == "discover":
+        discover_goal = str(ns.goal or ns.target or "").strip() or None
+        discover_query = str(ns.query or "").strip() or None
+        discover_result = discover_payload(
+            root=Path(str(ns.repo_root)).resolve(),
+            goal=discover_goal,
+            query=discover_query,
+            selected_kits=[str(item) for item in ns.selected_kits],
+            limit=ns.limit,
+        )
+        if ns.format == "json":
+            sys.stdout.write(canonical_json_dumps(discover_result))
+            return 0
+        print("Repo capability discovery + alignment")
+        print(f"goal: {discover_result['goal']}")
+        print(f"query: {discover_result['query']}")
+        print("quickstart:")
+        for cmd in _string_list(discover_result.get("quickstart")):
+            print(f"- {cmd}")
+        print("recommended kits:")
+        matches = _payload_list(_payload_dict(discover_result["recommended_kits"]).get("matches"))
+        for item in matches:
+            kit = _payload_dict(item.get("kit"))
+            capabilities = _string_list(kit.get("capabilities"))
+            print(f"- {kit.get('id', 'unknown')}: {capabilities[0] if capabilities else 'n/a'}")
+            print(f"  start with: {item['recommended_start']}")
+        surface = _payload_dict(discover_result.get("surface_visibility"))
+        print("surface visibility:")
+        print(f"- public help: {surface['public_help']}")
+        print(f"- full help: {surface['full_help']}")
+        print(f"- why: {surface['why']}")
+        alignment = _payload_dict(discover_result.get("alignment_plan"))
+        score = _payload_dict(alignment.get("alignment_score"))
+        print(f"alignment score: {score.get('score', 0)}% ({score.get('status', 'unknown')})")
+        print("expansion candidates:")
+        expansion = _payload_dict(discover_result.get("expansion_plan"))
+        for item in _payload_list(expansion.get("feature_candidates"))[:3]:
+            print(f"- {item['title']}: {item['summary']}")
+        print("radar headline:")
+        radar = _payload_dict(discover_result.get("dependency_radar"))
+        headline = _payload_dict(radar.get("headline_metrics"))
+        print(
+            f"- packages={headline.get('packages_audited', 0)} "
+            f"filtered={headline.get('filtered_matches', 0)}"
+        )
         return 0
 
     if ns.action == "optimize":

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -221,3 +221,58 @@ def test_radar_payload_exposes_dashboard_cards_and_watchlists(tmp_path: Path) ->
     assert payload["hotspots"][0]["package"] == "httpx"
     assert payload["watchlists"]["runtime_core"]
     assert payload["maintenance_lanes"][0]["id"] == "route-hotspots"
+
+
+def test_discover_payload_aligns_catalog_optimize_expand_and_radar(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        "name='x'\n"
+        "version='0.1.0'\n"
+        "dependencies=['httpx>=0.28.1,<1']\n",
+        encoding="utf-8",
+    )
+    src_dir = tmp_path / "src" / "demo"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    (src_dir / "api.py").write_text("import httpx\n", encoding="utf-8")
+    (tmp_path / "quality.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / "premium-gate.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / ".sdetkit").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".sdetkit" / "gate.fast.snapshot.json").write_text("{}", encoding="utf-8")
+
+    payload = kits.discover_payload(
+        root=tmp_path,
+        goal="align all repo capabilities",
+        query="release integration",
+        selected_kits=["release", "integration"],
+        limit=3,
+    )
+
+    assert payload["catalog"]["schema_version"] == kits.SCHEMA_VERSION
+    assert payload["recommended_kits"]["matches"]
+    assert payload["alignment_plan"]["alignment_score"]["score"] >= 0
+    assert payload["expansion_plan"]["feature_candidates"]
+    assert payload["dependency_radar"]["headline_metrics"]["packages_audited"] >= 1
+    assert payload["surface_visibility"]["full_help"] == "sdetkit --help --show-hidden"
+
+
+def test_discover_main_text_output_summarizes_alignment(tmp_path: Path, capsys) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname='x'\nversion='0.1.0'\ndependencies=['httpx>=0.28.1,<1']\n",
+        encoding="utf-8",
+    )
+    rc = kits.main(
+        [
+            "discover",
+            "--repo-root",
+            str(tmp_path),
+            "--goal",
+            "align all repo capabilities",
+            "--query",
+            "release integration",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Repo capability discovery + alignment" in out
+    assert "surface visibility:" in out
+    assert "sdetkit --help --show-hidden" in out


### PR DESCRIPTION
### Motivation

- Provide a single command to inventory and align the repo’s umbrella capabilities by combining catalog, search, optimization, expansion and dependency radar outputs. 

### Description

- Add a new `discover_payload` function that aggregates `list_payload`, `search_payload`, `optimize_payload`, `expand_payload`, and `radar_payload` into a single alignment payload in `src/sdetkit/kits.py`. 
- Wire a new `discover` action into the `sdetkit kits` CLI with both JSON and human-readable text rendering that surfaces quickstart steps and `--show-hidden` guidance. 
- Add unit tests for the new payload and CLI text output in `tests/test_kits_blueprint.py`. 
- Update user-facing docs in `README.md` and `docs/command-taxonomy.md` to advertise the new discovery flow and the `--show-hidden` help option.

### Testing

- Ran `python -m pytest -q tests/test_kits_blueprint.py`, which passed (`7 passed`).
- Exercised the new CLI output via `python -m sdetkit kits discover --goal "align all repo capabilities" --query "release integration" --format json`, which produced a valid JSON payload including `schema_version` and `surface_visibility["full_help"]` as expected. 
- Ran broader smoke tests `python -m pytest -q tests/test_cli_smoke_coverage.py` and observed an unrelated existing failure in `test_cli_apiget_exercises_http_stack` (AttributeError in a patched test client), which is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d2bbf43f508320bfab3da94b728d65)