### PR TITLE
Add strict boolean coercion util and replace ad-hoc truthiness checks across codebase

### DIFF
--- a/src/sdetkit/agent/dashboard.py
+++ b/src/sdetkit/agent/dashboard.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from sdetkit.atomicio import atomic_write_text
 
+from ..bools import coerce_bool
+
 
 def _sort_key(item: dict[str, Any]) -> tuple[str, str]:
     return (str(item.get("captured_at", "")), str(item.get("hash", "")))
@@ -86,11 +88,11 @@ def summarize_history(history_dir: Path) -> dict[str, Any]:
             if isinstance(action, dict):
                 action_counter[str(action.get("action", "unknown"))] += 1
                 worker_counter[str(action.get("worker_id", "unknown"))] += 1
-                if bool(action.get("denied")):
+                if coerce_bool(action.get("denied"), default=False):
                     approvals["denied"] += 1
-                elif bool(action.get("approved")):
+                elif coerce_bool(action.get("approved"), default=False):
                     approvals["approved"] += 1
-                    if not bool(action.get("ok")):
+                    if not coerce_bool(action.get("ok"), default=False):
                         approvals["failed_after_approval"] += 1
         if str(run.get("status", "")) != "ok":
             failure_tasks.append(

--- a/src/sdetkit/agent/templates.py
+++ b/src/sdetkit/agent/templates.py
@@ -434,7 +434,7 @@ def run_template(
             cmd = str(params.get("cmd", ""))
             shell_res = _run_shell(cmd, cwd=root)
             payload = shell_res
-            ok = bool(shell_res.get("ok"))
+            ok = _as_bool(shell_res.get("ok"))
             if isinstance(params.get("save_stdout"), str):
                 stdout_path = Path(str(params["save_stdout"]))
                 atomic_write_text(stdout_path, str(shell_res.get("stdout", "")))

--- a/src/sdetkit/author_problem.py
+++ b/src/sdetkit/author_problem.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from . import _toml
 from .atomicio import atomic_write_text, canonical_json_dumps
+from .bools import coerce_bool
 
 _BASE_IMAGE = "public.ecr.aws/x8v8d7g8/mars-base:latest"
 _DEFAULT_WORKFLOW_PATH = Path(".sdetkit/workflows/platform_problem.yaml")
@@ -1652,7 +1653,7 @@ def _write_demo_fixture_artifacts(
             "        state.update(\n"
             "            {\n"
             '                "history": history,\n'
-            '                "rotated": bool(snapshot.get("rotated", False)),\n'
+            '                "rotated": coerce_bool(snapshot.get("rotated", False), default=False),\n'
             '                "source": snapshot.get("source", "direct"),\n'
             '                "checkpoint": f"seq:{snapshot[\'sequence\']}",\n'
             "            }\n"
@@ -1767,7 +1768,7 @@ def run_container_authoring(
         repo_root, workdir, contract=contract, verify_triad=bool(successful_attempt)
     )
     summary = {
-        "ok": bool(successful_attempt) and verification.get("ok", False),
+        "ok": bool(successful_attempt) and coerce_bool(verification.get("ok", False), default=False),
         "repo_root": repo_root.as_posix(),
         "workdir": workdir.as_posix(),
         "workflow_contract": contract.path.as_posix(),

--- a/src/sdetkit/bools.py
+++ b/src/sdetkit/bools.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any
+
+_TRUE_VALUES = frozenset(
+    {
+        "1",
+        "t",
+        "true",
+        "y",
+        "yes",
+        "on",
+        "ok",
+        "pass",
+        "passed",
+        "enabled",
+        "enable",
+        "active",
+    }
+)
+_FALSE_VALUES = frozenset(
+    {
+        "0",
+        "f",
+        "false",
+        "n",
+        "no",
+        "off",
+        "fail",
+        "failed",
+        "error",
+        "disabled",
+        "disable",
+        "inactive",
+        "none",
+        "null",
+        "",
+    }
+)
+
+
+def coerce_bool(value: Any, *, default: bool = False) -> bool:
+    """Convert mixed scalar values into a deterministic boolean.
+
+    This is intentionally stricter than ``bool(value)`` for strings so values
+    like ``"false"`` or ``"inactive"`` are interpreted correctly.
+    """
+
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _TRUE_VALUES:
+            return True
+        if normalized in _FALSE_VALUES:
+            return False
+        try:
+            return float(normalized) != 0.0
+        except ValueError:
+            pass
+        return default
+    return bool(value)

--- a/src/sdetkit/case_snippet_closeout_51.py
+++ b/src/sdetkit/case_snippet_closeout_51.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-case-snippet-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY50_SUMMARY_PATH = "docs/artifacts/execution-prioritization-closeout-pack/execution-prioritization-closeout-summary.json"
@@ -139,7 +141,7 @@ def _load_day50(path: Path) -> tuple[float, bool, int]:
     checks_obj = data_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     score = float(summary.get("activation_score", 0.0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     check_count = len(checks)
     return score, strict, check_count
 

--- a/src/sdetkit/case_study_launch_closeout_73.py
+++ b/src/sdetkit/case_study_launch_closeout_73.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-case-study-launch-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY72_SUMMARY_PATH = (
@@ -142,7 +144,7 @@ def _load_prior_closeout(summary_path: Path) -> tuple[int, bool, int]:
     checks = payload.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/case_study_prep1_closeout_69.py
+++ b/src/sdetkit/case_study_prep1_closeout_69.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-case-study-prep1-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY68_SUMMARY_PATH = "docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.json"
@@ -140,7 +142,7 @@ def _load_prior_closeout(summary_path: Path) -> tuple[int, bool, int]:
     checks = payload.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/case_study_prep2_closeout_70.py
+++ b/src/sdetkit/case_study_prep2_closeout_70.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-case-study-prep2-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY69_SUMMARY_PATH = (
@@ -142,7 +144,7 @@ def _load_prior_closeout(summary_path: Path) -> tuple[int, bool, int]:
     checks = payload.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/case_study_prep3_closeout_71.py
+++ b/src/sdetkit/case_study_prep3_closeout_71.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-case-study-prep3-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY70_SUMMARY_PATH = (
@@ -142,7 +144,7 @@ def _load_prior_closeout(summary_path: Path) -> tuple[int, bool, int]:
     checks = payload.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/case_study_prep4_closeout_72.py
+++ b/src/sdetkit/case_study_prep4_closeout_72.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-case-study-prep4-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY71_SUMMARY_PATH = (
@@ -142,7 +144,7 @@ def _load_prior_closeout(summary_path: Path) -> tuple[int, bool, int]:
     checks = payload.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/checks/artifacts.py
+++ b/src/sdetkit/checks/artifacts.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+from ..bools import coerce_bool
 from .base import CheckProfileName
 from .results import CheckRecord, FinalVerdict, build_final_verdict
 from .runner import CheckRunReport
@@ -226,14 +227,14 @@ def build_verdict_payload(
         "recommendation": verdict.recommendation,
         "targeting": {
             "modes": check_summary["target_modes"],
-            "used_targeted_execution": bool(check_summary["target_modes"].get("targeted", 0)),
-            "used_smoke_execution": bool(check_summary["target_modes"].get("smoke", 0)),
-            "used_full_execution": bool(check_summary["target_modes"].get("full", 0)),
+            "used_targeted_execution": coerce_bool(check_summary["target_modes"].get("targeted", 0), default=False),
+            "used_smoke_execution": coerce_bool(check_summary["target_modes"].get("smoke", 0), default=False),
+            "used_full_execution": coerce_bool(check_summary["target_modes"].get("full", 0), default=False),
         },
         "cache": {
-            "enabled": bool(metadata.get("cache_enabled", False)),
+            "enabled": coerce_bool(metadata.get("cache_enabled", False), default=False),
             "summary": check_summary["cache_status"],
-            "used_cache_hits": bool(check_summary["cache_status"].get("hit", 0)),
+            "used_cache_hits": coerce_bool(check_summary["cache_status"].get("hit", 0), default=False),
         },
         "execution": {
             "mode": execution.get("mode", "sequential")

--- a/src/sdetkit/checks/main.py
+++ b/src/sdetkit/checks/main.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from typing import cast
 
+from ..bools import coerce_bool
 from .artifacts import (
     ArtifactPaths,
     artifact_paths_for,
@@ -152,7 +153,7 @@ def _load_records_from_ledger(path: Path) -> tuple[CheckRecord, ...]:
                 id=str(item["id"]),
                 title=str(item["title"]),
                 status=status,
-                blocking=bool(item.get("blocking", True)),
+                blocking=coerce_bool(item.get("blocking", True), default=True),
                 reason=str(item.get("reason", "")),
                 command=str(item.get("command") or item.get("cmd") or ""),
                 advisory=tuple(str(entry) for entry in item.get("advisory", []) if str(entry)),

--- a/src/sdetkit/ci.py
+++ b/src/sdetkit/ci.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _TEMPLATE_SPECS: dict[str, dict[str, Any]] = {
     "gitlab": {
         "path": "templates/ci/gitlab/gitlab-advanced-reference.yml",
@@ -106,7 +108,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.cmd == "validate-templates":
         root = Path(ns.root).resolve()
         data = _validate_templates(root)
-        ok = bool(data.get("ok"))
+        ok = coerce_bool(data.get("ok"), default=False)
 
         if ns.format == "json":
             output = json.dumps(data, sort_keys=True) + "\n"

--- a/src/sdetkit/community_program_closeout_62.py
+++ b/src/sdetkit/community_program_closeout_62.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-community-program-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY61_SUMMARY_PATH = (
@@ -135,7 +137,7 @@ def _load_day61(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/src/sdetkit/community_touchpoint_closeout_77.py
+++ b/src/sdetkit/community_touchpoint_closeout_77.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-community-touchpoint-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY76_SUMMARY_PATH = "docs/artifacts/contributor-recognition-closeout-pack/contributor-recognition-closeout-summary.json"
@@ -137,7 +139,7 @@ def _load_contributor_recognition(summary_path: Path) -> tuple[int, bool, int]:
     checks = data.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/continuous_upgrade_closeout_10.py
+++ b/src/sdetkit/continuous_upgrade_closeout_10.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-10.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _PREV_CYCLE_SUMMARY_PATH = (
@@ -211,7 +213,7 @@ def build_continuous_upgrade_cycle10_closeout_summary(root: Path) -> dict[str, A
         cycle9_data.get("summary", {}) if isinstance(cycle9_data.get("summary"), dict) else {}
     )
     cycle9_score = int(cycle9_summary_data.get("activation_score", 0) or 0)
-    cycle9_strict = bool(cycle9_summary_data.get("strict_pass", False))
+    cycle9_strict = coerce_bool(cycle9_summary_data.get("strict_pass", False), default=False)
     cycle9_check_count = (
         len(cycle9_data.get("checks", [])) if isinstance(cycle9_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/continuous_upgrade_closeout_11.py
+++ b/src/sdetkit/continuous_upgrade_closeout_11.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-11.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _PREV_CYCLE_SUMMARY_PATH = (
@@ -211,7 +213,7 @@ def build_continuous_upgrade_cycle11_closeout_summary(root: Path) -> dict[str, A
         cycle10_data.get("summary", {}) if isinstance(cycle10_data.get("summary"), dict) else {}
     )
     cycle10_score = int(cycle10_summary_data.get("activation_score", 0) or 0)
-    cycle10_strict = bool(cycle10_summary_data.get("strict_pass", False))
+    cycle10_strict = coerce_bool(cycle10_summary_data.get("strict_pass", False), default=False)
     cycle10_check_count = (
         len(cycle10_data.get("checks", [])) if isinstance(cycle10_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/continuous_upgrade_closeout_2.py
+++ b/src/sdetkit/continuous_upgrade_closeout_2.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-2.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _CYCLE1_SUMMARY_PATH = (
@@ -230,7 +232,7 @@ def build_continuous_upgrade_cycle2_closeout_summary(root: Path) -> dict[str, An
         cycle1_data.get("summary", {}) if isinstance(cycle1_data.get("summary"), dict) else {}
     )
     cycle1_score = int(cycle1_summary_data.get("activation_score", 0) or 0)
-    cycle1_strict = bool(cycle1_summary_data.get("strict_pass", False))
+    cycle1_strict = coerce_bool(cycle1_summary_data.get("strict_pass", False), default=False)
     cycle1_check_count = (
         len(cycle1_data.get("checks", [])) if isinstance(cycle1_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/continuous_upgrade_closeout_3.py
+++ b/src/sdetkit/continuous_upgrade_closeout_3.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-3.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _CYCLE2_SUMMARY_PATH = (
@@ -211,7 +213,7 @@ def build_continuous_upgrade_cycle3_closeout_summary(root: Path) -> dict[str, An
         cycle2_data.get("summary", {}) if isinstance(cycle2_data.get("summary"), dict) else {}
     )
     cycle2_score = int(cycle2_summary_data.get("activation_score", 0) or 0)
-    cycle2_strict = bool(cycle2_summary_data.get("strict_pass", False))
+    cycle2_strict = coerce_bool(cycle2_summary_data.get("strict_pass", False), default=False)
     cycle2_check_count = (
         len(cycle2_data.get("checks", [])) if isinstance(cycle2_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/continuous_upgrade_closeout_4.py
+++ b/src/sdetkit/continuous_upgrade_closeout_4.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-4.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _CYCLE3_SUMMARY_PATH = (
@@ -211,7 +213,7 @@ def build_continuous_upgrade_cycle4_closeout_summary(root: Path) -> dict[str, An
         cycle3_data.get("summary", {}) if isinstance(cycle3_data.get("summary"), dict) else {}
     )
     cycle3_score = int(cycle3_summary_data.get("activation_score", 0) or 0)
-    cycle3_strict = bool(cycle3_summary_data.get("strict_pass", False))
+    cycle3_strict = coerce_bool(cycle3_summary_data.get("strict_pass", False), default=False)
     cycle3_check_count = (
         len(cycle3_data.get("checks", [])) if isinstance(cycle3_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/continuous_upgrade_closeout_5.py
+++ b/src/sdetkit/continuous_upgrade_closeout_5.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-5.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _CYCLE4_SUMMARY_PATH = (
@@ -211,7 +213,7 @@ def build_continuous_upgrade_cycle5_closeout_summary(root: Path) -> dict[str, An
         cycle4_data.get("summary", {}) if isinstance(cycle4_data.get("summary"), dict) else {}
     )
     cycle4_score = int(cycle4_summary_data.get("activation_score", 0) or 0)
-    cycle4_strict = bool(cycle4_summary_data.get("strict_pass", False))
+    cycle4_strict = coerce_bool(cycle4_summary_data.get("strict_pass", False), default=False)
     cycle4_check_count = (
         len(cycle4_data.get("checks", [])) if isinstance(cycle4_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/continuous_upgrade_closeout_6.py
+++ b/src/sdetkit/continuous_upgrade_closeout_6.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-6.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _CYCLE5_SUMMARY_PATH = (
@@ -211,7 +213,7 @@ def build_continuous_upgrade_cycle6_closeout_summary(root: Path) -> dict[str, An
         cycle5_data.get("summary", {}) if isinstance(cycle5_data.get("summary"), dict) else {}
     )
     cycle5_score = int(cycle5_summary_data.get("activation_score", 0) or 0)
-    cycle5_strict = bool(cycle5_summary_data.get("strict_pass", False))
+    cycle5_strict = coerce_bool(cycle5_summary_data.get("strict_pass", False), default=False)
     cycle5_check_count = (
         len(cycle5_data.get("checks", [])) if isinstance(cycle5_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/continuous_upgrade_closeout_7.py
+++ b/src/sdetkit/continuous_upgrade_closeout_7.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-7.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _CYCLE6_SUMMARY_PATH = (
@@ -211,7 +213,7 @@ def build_continuous_upgrade_cycle7_closeout_summary(root: Path) -> dict[str, An
         cycle6_data.get("summary", {}) if isinstance(cycle6_data.get("summary"), dict) else {}
     )
     cycle6_score = int(cycle6_summary_data.get("activation_score", 0) or 0)
-    cycle6_strict = bool(cycle6_summary_data.get("strict_pass", False))
+    cycle6_strict = coerce_bool(cycle6_summary_data.get("strict_pass", False), default=False)
     cycle6_check_count = (
         len(cycle6_data.get("checks", [])) if isinstance(cycle6_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/continuous_upgrade_closeout_8.py
+++ b/src/sdetkit/continuous_upgrade_closeout_8.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-8.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _PREV_CYCLE_SUMMARY_PATH = (
@@ -211,7 +213,7 @@ def build_continuous_upgrade_cycle8_closeout_summary(root: Path) -> dict[str, An
         cycle7_data.get("summary", {}) if isinstance(cycle7_data.get("summary"), dict) else {}
     )
     cycle7_score = int(cycle7_summary_data.get("activation_score", 0) or 0)
-    cycle7_strict = bool(cycle7_summary_data.get("strict_pass", False))
+    cycle7_strict = coerce_bool(cycle7_summary_data.get("strict_pass", False), default=False)
     cycle7_check_count = (
         len(cycle7_data.get("checks", [])) if isinstance(cycle7_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/continuous_upgrade_closeout_9.py
+++ b/src/sdetkit/continuous_upgrade_closeout_9.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-continuous-upgrade-closeout-9.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _PREV_CYCLE_SUMMARY_PATH = (
@@ -211,7 +213,7 @@ def build_continuous_upgrade_cycle9_closeout_summary(root: Path) -> dict[str, An
         cycle8_data.get("summary", {}) if isinstance(cycle8_data.get("summary"), dict) else {}
     )
     cycle8_score = int(cycle8_summary_data.get("activation_score", 0) or 0)
-    cycle8_strict = bool(cycle8_summary_data.get("strict_pass", False))
+    cycle8_strict = coerce_bool(cycle8_summary_data.get("strict_pass", False), default=False)
     cycle8_check_count = (
         len(cycle8_data.get("checks", [])) if isinstance(cycle8_data.get("checks"), list) else 0
     )

--- a/src/sdetkit/contributor_activation_closeout_55.py
+++ b/src/sdetkit/contributor_activation_closeout_55.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-contributor-activation-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY53_SUMMARY_PATH = "docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json"
@@ -135,7 +137,7 @@ def _load_docs_loop_closeout_summary(path: Path) -> tuple[float, bool, int]:
     if not isinstance(summary, dict) or not isinstance(checks, list):
         return 0.0, False, 0
     score = float(summary.get("activation_score", 0.0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     return score, strict, len(checks)
 
 

--- a/src/sdetkit/contributor_recognition_closeout_76.py
+++ b/src/sdetkit/contributor_recognition_closeout_76.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-contributor-recognition-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY75_SUMMARY_PATH = (
@@ -139,7 +141,7 @@ def _load_trust_assets_refresh(summary_path: Path) -> tuple[int, bool, int]:
     checks = data.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/distribution_scaling_closeout_74.py
+++ b/src/sdetkit/distribution_scaling_closeout_74.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-distribution-scaling-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY73_SUMMARY_PATH = (
@@ -142,7 +144,7 @@ def _load_prior_closeout(summary_path: Path) -> tuple[int, bool, int]:
     checks = payload.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/docs_loop_closeout_53.py
+++ b/src/sdetkit/docs_loop_closeout_53.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-docs-loop-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY52_SUMMARY_PATH = "docs/artifacts/narrative-closeout-pack/narrative-closeout-summary.json"
@@ -135,7 +137,7 @@ def _load_narrative_closeout_summary(path: Path) -> tuple[float, bool, int]:
     checks_obj = data_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     score = float(summary.get("activation_score", 0.0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     check_count = len(checks)
     return score, strict, check_count
 

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from . import _toml, upgrade_audit
+from .bools import coerce_bool
 from .import_hazards import find_stdlib_shadowing
 from .security import SecurityError, safe_path
 
@@ -640,7 +641,7 @@ def _apply_plan(plan: dict[str, Any], root: Path) -> tuple[list[dict[str, Any]],
                 "stderr": stderr_text,
             }
         )
-    ok = all(bool(s.get("ok")) for s in steps)
+    ok = all(coerce_bool(s.get("ok"), default=False) for s in steps)
     return steps, ok
 
 
@@ -1896,7 +1897,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if ns.treat or getattr(ns, "treat_only", False):
         treat_steps = _treatments(root)
-        data_treat_ok = all(bool(s.get("ok")) for s in treat_steps)
+        data_treat_ok = all(coerce_bool(s.get("ok"), default=False) for s in treat_steps)
         if getattr(ns, "treat_only", False):
             payload = {
                 "ok": data_treat_ok,
@@ -2266,7 +2267,7 @@ def main(argv: list[str] | None = None) -> int:
     if failed_checks:
         data["failed_checks"] = failed_checks
     if isinstance(getattr(ns, "apply_plan", None), str) and ns.apply_plan:
-        data["post_plan_ok"] = bool(data.get("ok")) and bool(data.get("plan_ok"))
+        data["post_plan_ok"] = coerce_bool(data.get("ok"), default=False) and coerce_bool(data.get("plan_ok"), default=False)
 
     if ns.format == "json" or ns.json:
         output = json.dumps(data, sort_keys=True) + "\n"

--- a/src/sdetkit/ecosystem_priorities_closeout_78.py
+++ b/src/sdetkit/ecosystem_priorities_closeout_78.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-ecosystem-priorities-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY77_SUMMARY_PATH = (
@@ -139,7 +141,7 @@ def _load_community_touchpoint(summary_path: Path) -> tuple[int, bool, int]:
     checks = data.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/evidence_narrative_closeout_84.py
+++ b/src/sdetkit/evidence_narrative_closeout_84.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-evidence-narrative-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY83_SUMMARY_PATH = (
@@ -157,7 +159,7 @@ def build_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
     trust_faq_expansion_score = int(
         trust_faq_expansion_summary_data.get("activation_score", 0) or 0
     )
-    trust_faq_expansion_strict = bool(trust_faq_expansion_summary_data.get("strict_pass", False))
+    trust_faq_expansion_strict = coerce_bool(trust_faq_expansion_summary_data.get("strict_pass", False), default=False)
     trust_faq_expansion_check_count = (
         len(trust_faq_expansion_data.get("checks", []))
         if isinstance(trust_faq_expansion_data.get("checks"), list)

--- a/src/sdetkit/execution_prioritization_closeout_50.py
+++ b/src/sdetkit/execution_prioritization_closeout_50.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-execution-prioritization-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY49_SUMMARY_PATH = (
@@ -138,7 +140,7 @@ def _load_day49(path: Path) -> tuple[float, bool, int]:
     if not isinstance(summary, dict):
         return 0.0, False, 0
     score = float(summary.get("activation_score", 0.0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     check_count = len(checks) if isinstance(checks, list) else 0
     return score, strict, check_count
 

--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -10,6 +10,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 AVAILABLE_STEPS = [
     "ruff_fix",
     "ruff_format_apply",
@@ -107,7 +109,7 @@ def _parse_step_filter(raw: str | None) -> set[str]:
 
 
 def _format_text(payload: dict[str, Any]) -> str:
-    ok = bool(payload.get("ok"))
+    ok = coerce_bool(payload.get("ok"), default=False)
     lines: list[str] = []
     lines.append(f"gate fast: {'OK' if ok else 'FAIL'}")
     for step in payload.get("steps", []):
@@ -123,7 +125,7 @@ def _format_text(payload: dict[str, Any]) -> str:
 
 
 def _format_md(payload: dict[str, Any]) -> str:
-    ok = bool(payload.get("ok"))
+    ok = coerce_bool(payload.get("ok"), default=False)
     lines: list[str] = []
     lines.append("### SDET Gate Fast")
     lines.append("")

--- a/src/sdetkit/governance_handoff_closeout_87.py
+++ b/src/sdetkit/governance_handoff_closeout_87.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-governance-handoff-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY86_SUMMARY_PATH = (
@@ -155,7 +157,7 @@ def build_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
         else {}
     )
     launch_readiness_score = int(launch_readiness_summary_data.get("activation_score", 0) or 0)
-    launch_readiness_strict = bool(launch_readiness_summary_data.get("strict_pass", False))
+    launch_readiness_strict = coerce_bool(launch_readiness_summary_data.get("strict_pass", False), default=False)
     launch_readiness_check_count = (
         len(launch_readiness_data.get("checks", []))
         if isinstance(launch_readiness_data.get("checks"), list)

--- a/src/sdetkit/governance_priorities_closeout_88.py
+++ b/src/sdetkit/governance_priorities_closeout_88.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-governance-priorities-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY87_SUMMARY_PATH = (
@@ -155,7 +157,7 @@ def build_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
         else {}
     )
     governance_handoff_score = int(governance_handoff_summary_data.get("activation_score", 0) or 0)
-    governance_handoff_strict = bool(governance_handoff_summary_data.get("strict_pass", False))
+    governance_handoff_strict = coerce_bool(governance_handoff_summary_data.get("strict_pass", False), default=False)
     governance_handoff_check_count = (
         len(governance_handoff_data.get("checks", []))
         if isinstance(governance_handoff_data.get("checks"), list)

--- a/src/sdetkit/integration.py
+++ b/src/sdetkit/integration.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from .atomicio import canonical_json_dumps
+from .bools import coerce_bool
 from .cassette import Cassette
 from .security import SecurityError, safe_path
 
@@ -141,7 +142,7 @@ def _evaluate(profile: dict[str, Any]) -> dict[str, Any]:
     checks: list[dict[str, Any]] = []
 
     for env_name in sorted(str(x) for x in profile.get("required_env", [])):
-        present = bool(os.environ.get(env_name, ""))
+        present = coerce_bool(os.environ.get(env_name, ""), default=False)
         checks.append({"kind": "env", "name": env_name, "passed": present})
 
     for rel_file in sorted(str(x) for x in profile.get("required_files", [])):
@@ -175,7 +176,7 @@ def _evaluate(profile: dict[str, Any]) -> dict[str, Any]:
             )
 
     checks.sort(key=lambda x: (str(x.get("kind", "")), str(x.get("name", ""))))
-    failed = [item for item in checks if not bool(item.get("passed"))]
+    failed = [item for item in checks if not coerce_bool(item.get("passed"), default=False)]
     return {
         "schema_version": "sdetkit.integration.profile-check.v1",
         "profile_name": str(profile.get("name", "default")),
@@ -429,7 +430,7 @@ def _evaluate_topology(profile: dict[str, Any]) -> dict[str, Any]:
         name = str(svc.get("name", svc.get("role", "data-service")))
         role = _normalize(svc.get("role"))
         backup_strategy = _normalize(svc.get("backup_strategy"))
-        multi_az = bool(svc.get("multi_az"))
+        multi_az = coerce_bool(svc.get("multi_az"), default=False)
         checks.append(
             {
                 "kind": "data-resilience",
@@ -505,7 +506,7 @@ def _evaluate_topology(profile: dict[str, Any]) -> dict[str, Any]:
         )
 
     checks.sort(key=lambda item: (str(item.get("kind", "")), str(item.get("name", ""))))
-    failed = [item for item in checks if not bool(item.get("passed"))]
+    failed = [item for item in checks if not coerce_bool(item.get("passed"), default=False)]
     total = len(checks)
     passed_count = total - len(failed)
     return {

--- a/src/sdetkit/integration_expansion2_closeout_66.py
+++ b/src/sdetkit/integration_expansion2_closeout_66.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-integration-expansion2-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _WEEKLY_REVIEW_SUMMARY_PATH = (
@@ -147,7 +149,7 @@ def _load_weekly_review(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/src/sdetkit/integration_expansion3_closeout_67.py
+++ b/src/sdetkit/integration_expansion3_closeout_67.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-integration-expansion3-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _INTEGRATION_EXPANSION2_SUMMARY_PATH = "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json"
@@ -145,7 +147,7 @@ def _load_integration_expansion2(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/src/sdetkit/integration_expansion4_closeout_68.py
+++ b/src/sdetkit/integration_expansion4_closeout_68.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-integration-expansion4-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _INTEGRATION_EXPANSION3_SUMMARY_PATH = "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json"
@@ -145,7 +147,7 @@ def _load_integration_expansion3(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/src/sdetkit/integration_expansion_closeout_64.py
+++ b/src/sdetkit/integration_expansion_closeout_64.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-integration-expansion-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY63_SUMMARY_PATH = (
@@ -145,7 +147,7 @@ def _load_cycle63(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/src/sdetkit/integration_feedback_closeout_82.py
+++ b/src/sdetkit/integration_feedback_closeout_82.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-integration-feedback-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY81_SUMMARY_PATH = (
@@ -161,7 +163,7 @@ def build_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
         else {}
     )
     growth_campaign_score = int(growth_campaign_summary_data.get("activation_score", 0) or 0)
-    growth_campaign_strict = bool(growth_campaign_summary_data.get("strict_pass", False))
+    growth_campaign_strict = coerce_bool(growth_campaign_summary_data.get("strict_pass", False), default=False)
     growth_campaign_check_count = (
         len(growth_campaign_data.get("checks", []))
         if isinstance(growth_campaign_data.get("checks"), list)

--- a/src/sdetkit/kpi_deep_audit_closeout_57.py
+++ b/src/sdetkit/kpi_deep_audit_closeout_57.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-kpi-deep-audit-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY56_SUMMARY_PATH = (
@@ -137,7 +139,7 @@ def _load_day56(path: Path) -> tuple[int, bool, int]:
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     score = int(summary.get("activation_score", 0) or 0)
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     return score, strict, len(checks)
 
 

--- a/src/sdetkit/kvcli.py
+++ b/src/sdetkit/kvcli.py
@@ -3,6 +3,7 @@ import sys
 from collections.abc import Callable
 from typing import NoReturn
 
+from .bools import coerce_bool
 from .textutil import parse_kv_line
 
 
@@ -120,7 +121,7 @@ def _parse_fast(argv: list[str]) -> dict[str, object]:
 def _run_with_options(options: dict[str, object]) -> int:
     text = options.get("text")
     path = options.get("path")
-    strict = bool(options.get("strict", False))
+    strict = coerce_bool(options.get("strict", False), default=False)
     duplicates = str(options.get("duplicates", "last"))
 
     if text is not None and path is not None:

--- a/src/sdetkit/maintenance/checks/doctor_check.py
+++ b/src/sdetkit/maintenance/checks/doctor_check.py
@@ -6,6 +6,7 @@ from contextlib import redirect_stdout
 
 from sdetkit import doctor
 
+from ...bools import coerce_bool
 from ..types import CheckAction, CheckResult, MaintenanceContext
 
 CHECK_NAME = "doctor_check"
@@ -83,7 +84,7 @@ def run(ctx: MaintenanceContext) -> CheckResult:
                 )
 
     return CheckResult(
-        ok=bool(parsed.get("ok", False)),
+        ok=coerce_bool(parsed.get("ok", False), default=False),
         summary=summary,
         details={
             "doctor": parsed,

--- a/src/sdetkit/maintenance/cli.py
+++ b/src/sdetkit/maintenance/cli.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from sdetkit.security import safe_path
 
+from ..bools import coerce_bool
 from .registry import checks_for_mode
 from .types import CheckResult, MaintenanceContext
 
@@ -222,7 +223,7 @@ def _build_recommendations(checks: dict[str, dict[str, Any]]) -> list[str]:
             if not isinstance(action, dict):
                 continue
             title = str(action.get("title", "")).strip()
-            applied = bool(action.get("applied", False))
+            applied = coerce_bool(action.get("applied", False), default=False)
             if title and not applied:
                 suggested_actions.append(title)
     if suggested_actions:

--- a/src/sdetkit/narrative_closeout_52.py
+++ b/src/sdetkit/narrative_closeout_52.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-narrative-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY51_SUMMARY_PATH = "docs/artifacts/case-snippet-closeout-pack/case-snippet-closeout-summary.json"
@@ -135,7 +137,7 @@ def _load_cycle51(path: Path) -> tuple[float, bool, int]:
     checks_obj = data_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     score = float(summary.get("activation_score", 0.0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     check_count = len(checks)
     return score, strict, check_count
 

--- a/src/sdetkit/onboarding_activation_closeout_63.py
+++ b/src/sdetkit/onboarding_activation_closeout_63.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-onboarding-activation-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY62_SUMMARY_PATH = (
@@ -137,7 +139,7 @@ def _load_day62(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/src/sdetkit/ops.py
+++ b/src/sdetkit/ops.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from . import _toml
 from .atomicio import atomic_write_text
+from .bools import coerce_bool
 from .doctor import _scan_non_ascii
 from .repo import run_repo_audit
 from .report import build_run_record
@@ -318,10 +319,12 @@ def _load_workflow_resolved(resolved_path: Path) -> WorkflowDef:
         )
     policy_obj = w.get("policy", {})
     policy = Policy(
-        allow_shell=bool(policy_obj.get("allow_shell", False))
+        allow_shell=coerce_bool(policy_obj.get("allow_shell", False), default=False)
         if isinstance(policy_obj, dict)
         else False,
-        allow_artifact_escape=bool(policy_obj.get("allow_artifact_escape", False))
+        allow_artifact_escape=coerce_bool(
+            policy_obj.get("allow_artifact_escape", False), default=False
+        )
         if isinstance(policy_obj, dict)
         else False,
     )
@@ -446,7 +449,7 @@ def _step_execute(
         cmd = resolved_inputs.get("cmd", [])
         if not isinstance(cmd, list):
             raise ValueError("command.cmd must be list")
-        shell = bool(resolved_inputs.get("shell", False))
+        shell = coerce_bool(resolved_inputs.get("shell", False), default=False)
         if shell and not policy.allow_shell:
             raise ValueError("policy blocks shell=true")
         if shell:

--- a/src/sdetkit/partner_outreach_closeout_80.py
+++ b/src/sdetkit/partner_outreach_closeout_80.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-partner-outreach-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY79_SUMMARY_PATH = (
@@ -151,7 +153,7 @@ def build_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
     scale_upgrade_score = int(
         scale_upgrade_payload.get("summary", {}).get("activation_score", 0) or 0
     )
-    scale_upgrade_strict = bool(scale_upgrade_payload.get("summary", {}).get("strict_pass", False))
+    scale_upgrade_strict = coerce_bool(scale_upgrade_payload.get("summary", {}).get("strict_pass", False), default=False)
     scale_upgrade_check_count = (
         len(scale_upgrade_payload.get("checks", []))
         if isinstance(scale_upgrade_payload.get("checks", []), list)

--- a/src/sdetkit/patch.py
+++ b/src/sdetkit/patch.py
@@ -14,6 +14,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from .atomicio import atomic_write_text
+from .bools import coerce_bool
 from .security import SecurityError, safe_path
 
 INDENT_TOKEN = "<<INDENT>>"
@@ -217,7 +218,7 @@ def _op_replace_block(text: str, op: dict[str, Any]) -> str:
     if not m1:
         raise PatchSpecError("replace_block.end: no match after start")
 
-    include_end = bool(op.get("include_end", False))
+    include_end = coerce_bool(op.get("include_end", False), default=False)
     cut_end = m0.end() + (m1.end() if include_end else m1.start())
 
     new_block = _apply_indent(op["text"], indent)
@@ -238,7 +239,7 @@ def _op_replace_or_insert_block(text: str, op: dict[str, Any]) -> str:
         tail = text[m0.end() :]
         m1 = rx_end.search(tail)
         if m1:
-            include_end = bool(op.get("include_end", False))
+            include_end = coerce_bool(op.get("include_end", False), default=False)
             indent = _indent_from_match(m0)
             cut_end = m0.end() + (m1.end() if include_end else m1.start())
             new_block = _apply_indent(op["text"], indent)

--- a/src/sdetkit/phase2_hardening_closeout_58.py
+++ b/src/sdetkit/phase2_hardening_closeout_58.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-phase2-hardening-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY57_SUMMARY_PATH = (
@@ -138,7 +140,7 @@ def _load_kpi_deep_audit(path: Path) -> tuple[int, bool, int]:
     checks = checks_obj if isinstance(checks_obj, list) else []
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/phase2_wrap_handoff_closeout_60.py
+++ b/src/sdetkit/phase2_wrap_handoff_closeout_60.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-phase2-wrap-handoff-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY58_SUMMARY_PATH = (
@@ -135,7 +137,7 @@ def _load_phase3_preplan(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/src/sdetkit/phase3_kickoff_closeout_61.py
+++ b/src/sdetkit/phase3_kickoff_closeout_61.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-phase3-kickoff-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY60_SUMMARY_PATH = (
@@ -137,7 +139,7 @@ def _load_phase2_wrap_handoff_summary(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/src/sdetkit/phase3_preplan_closeout_59.py
+++ b/src/sdetkit/phase3_preplan_closeout_59.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-phase3-preplan-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY58_SUMMARY_PATH = (
@@ -137,7 +139,7 @@ def _load_phase2_hardening(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/src/sdetkit/phase3_wrap_publication_closeout_90.py
+++ b/src/sdetkit/phase3_wrap_publication_closeout_90.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-phase3-wrap-publication-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _GOVERNANCE_SCALE_SUMMARY_PATH = (
@@ -159,7 +161,7 @@ def build_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]
         else {}
     )
     governance_scale_score = int(governance_scale_summary_data.get("activation_score", 0) or 0)
-    governance_scale_strict = bool(governance_scale_summary_data.get("strict_pass", False))
+    governance_scale_strict = coerce_bool(governance_scale_summary_data.get("strict_pass", False), default=False)
     governance_scale_check_count = (
         len(governance_scale_data.get("checks", []))
         if isinstance(governance_scale_data.get("checks"), list)

--- a/src/sdetkit/premium_gate_engine.py
+++ b/src/sdetkit/premium_gate_engine.py
@@ -15,6 +15,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 SEVERITY_WEIGHT = {
     "critical": 20,
     "high": 12,
@@ -595,7 +597,7 @@ def _failed_step_ids(payload: dict[str, Any]) -> set[str]:
     if not isinstance(steps, list):
         return failed
     for item in steps:
-        if not isinstance(item, dict) or bool(item.get("ok", True)):
+        if not isinstance(item, dict) or coerce_bool(item.get("ok", True), default=True):
             continue
         name = _safe_text(item.get("name"))
         if name:
@@ -678,7 +680,7 @@ def _catalog_candidates(
             _safe_text(item) for item in entry.get("trigger_steps", []) if _safe_text(item)
         }
         matched_steps = sorted(step for step in failed_steps if step in trigger_steps)
-        trigger_on_autofix = bool(entry.get("trigger_on_autofix", False))
+        trigger_on_autofix = coerce_bool(entry.get("trigger_on_autofix", False), default=False)
 
         if (
             not matched_sources
@@ -1301,7 +1303,7 @@ class _InsightsHandler(http.server.BaseHTTPRequestHandler):
                 _safe_text(body.get("title")),
                 _safe_text(body.get("body")),
                 body.get("tags", []) if isinstance(body.get("tags"), list) else [],
-                active=bool(body.get("active", True)),
+                active=coerce_bool(body.get("active", True), default=True),
             )
             self._json(200 if ok else 404, {"ok": ok})
             return

--- a/src/sdetkit/release_prioritization_closeout_85.py
+++ b/src/sdetkit/release_prioritization_closeout_85.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-release-prioritization-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY84_SUMMARY_PATH = (
@@ -155,7 +157,7 @@ def build_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
         else {}
     )
     evidence_narrative_score = int(evidence_narrative_summary_data.get("activation_score", 0) or 0)
-    evidence_narrative_strict = bool(evidence_narrative_summary_data.get("strict_pass", False))
+    evidence_narrative_strict = coerce_bool(evidence_narrative_summary_data.get("strict_pass", False), default=False)
     evidence_narrative_check_count = (
         len(evidence_narrative_data.get("checks", []))
         if isinstance(evidence_narrative_data.get("checks"), list)

--- a/src/sdetkit/reliability_evidence_pack.py
+++ b/src/sdetkit/reliability_evidence_pack.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/reliability-evidence-pack.md"
 
 _SECTION_HEADER = "# Reliability evidence pack"
@@ -150,7 +152,7 @@ def build_reliability_pack(
     strict_all_green = (
         bool(github_actions["strict"])
         and bool(gitlab_ci["strict"])
-        and not bool(contribution_quality_summary.get("strict_failures"))
+        and not coerce_bool(contribution_quality_summary.get("strict_failures"), default=False)
     )
     recommendations: list[str] = []
     if not strict_all_green:

--- a/src/sdetkit/repo.py
+++ b/src/sdetkit/repo.py
@@ -25,6 +25,7 @@ from typing import Any, cast
 
 from . import _toml as _tomllib
 from .atomicio import atomic_write_text
+from .bools import coerce_bool
 from .ops_control import init_layout_at
 from .plugins import (
     Finding as PluginFinding,
@@ -1253,7 +1254,7 @@ def _to_sarif(payload: dict[str, Any]) -> dict[str, Any]:
                 "message": {"text": item["message"]},
                 "properties": {
                     "pack": item.get("pack", "core"),
-                    "fixable": bool(item.get("fixable", False)),
+                    "fixable": coerce_bool(item.get("fixable", False), default=False),
                     "suppression_status": item.get("suppression_status"),
                     "suppression_reason": item.get("suppression_reason"),
                 },
@@ -1600,7 +1601,7 @@ def _plan_repo_fix_audit(
                 line=int(item.get("line", 1)),
                 details={
                     "pack": item.get("pack", "core"),
-                    "fixable": bool(item.get("fixable", False)),
+                    "fixable": coerce_bool(item.get("fixable", False), default=False),
                     "fingerprint": item.get("fingerprint", ""),
                 },
                 fingerprint=str(item.get("fingerprint", "")),
@@ -3244,7 +3245,7 @@ def _to_ide_diagnostics(findings: list[dict[str, Any]]) -> dict[str, Any]:
             "severity": str(item.get("severity", "error")),
             "code": _repo_rule_id(item),
             "message": str(item.get("message", "")),
-            "fixable": bool(item.get("fixable", False)),
+            "fixable": coerce_bool(item.get("fixable", False), default=False),
         }
         col = item.get("column")
         if isinstance(col, int) and col > 0:
@@ -4235,7 +4236,7 @@ def main(argv: list[str] | None = None) -> int:
             fail_on=policy.fail_on,
             repo_root=str(root),
             config_used=ns.config,
-            incremental_used=bool(audit_summary.get("incremental", {}).get("used", False)),
+            incremental_used=coerce_bool(audit_summary.get("incremental", {}).get("used", False), default=False),
             changed_file_count=int(audit_summary.get("incremental", {}).get("changed_files", 0)),
             cache_summary=audit_summary.get("cache")
             if isinstance(audit_summary.get("cache"), dict)

--- a/src/sdetkit/report.py
+++ b/src/sdetkit/report.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, TypedDict
 
 from .atomicio import atomic_write_text, canonical_json_bytes, canonical_json_dumps
+from .bools import coerce_bool
 from .security import SecurityError, safe_path
 
 _UTC = getattr(dt, "UTC", dt.timezone.utc)  # noqa: UP017
@@ -146,7 +147,7 @@ def build_run_record(
                 "line": int(item.get("line", 1)) if item.get("line") is not None else None,
                 "tags": sorted(set(str(x) for x in (item.get("tags") or []))),
                 "pack": str(item.get("pack", "core")),
-                "fixable": bool(item.get("fixable", False)),
+                "fixable": coerce_bool(item.get("fixable", False), default=False),
                 "suppressed": fp in suppressed_map,
                 "suppression_reason": suppressed_map.get(fp),
             }

--- a/src/sdetkit/stabilization_closeout_56.py
+++ b/src/sdetkit/stabilization_closeout_56.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-stabilization-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY55_SUMMARY_PATH = "docs/artifacts/contributor-activation-closeout-pack/contributor-activation-closeout-summary.json"
@@ -138,7 +140,7 @@ def _load_contributor_activation_summary(path: Path) -> tuple[int, bool, int]:
     checks = checks_obj if isinstance(checks_obj, list) else []
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/trust_assets_refresh_closeout_75.py
+++ b/src/sdetkit/trust_assets_refresh_closeout_75.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-trust-assets-refresh-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY74_SUMMARY_PATH = (
@@ -139,7 +141,7 @@ def _load_distribution_scaling(summary_path: Path) -> tuple[int, bool, int]:
     checks = data.get("checks", [])
     return (
         int(summary.get("activation_score", 0)),
-        bool(summary.get("strict_pass", False)),
+        coerce_bool(summary.get("strict_pass", False), default=False),
         len(checks),
     )
 

--- a/src/sdetkit/trust_faq_expansion_closeout_83.py
+++ b/src/sdetkit/trust_faq_expansion_closeout_83.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-trust-faq-expansion-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY82_SUMMARY_PATH = (
@@ -165,7 +167,7 @@ def build_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     integration_feedback_score = int(
         integration_feedback_summary_data.get("activation_score", 0) or 0
     )
-    integration_feedback_strict = bool(integration_feedback_summary_data.get("strict_pass", False))
+    integration_feedback_strict = coerce_bool(integration_feedback_summary_data.get("strict_pass", False), default=False)
     integration_feedback_check_count = (
         len(integration_feedback_data.get("checks", []))
         if isinstance(integration_feedback_data.get("checks"), list)

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -14,6 +14,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+from .bools import coerce_bool
+
 REQ_NAME_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)")
 PINNED_VERSION_RE = re.compile(r"==\s*([A-Za-z0-9_.!+-]+)")
 CONSTRAINT_RE = re.compile(r"(==|~=|>=|<=|>|<)\s*([A-Za-z0-9_.!+-]+)")
@@ -639,7 +641,7 @@ def _release_is_python_compatible(
 
     compatibility_observed = False
     for release_file in release_files:
-        if not isinstance(release_file, dict) or bool(release_file.get("yanked")):
+        if not isinstance(release_file, dict) or coerce_bool(release_file.get("yanked"), default=False):
             continue
         requires_python = release_file.get("requires_python")
         if requires_python is not None and not isinstance(requires_python, str):

--- a/src/sdetkit/weekly_review_closeout_65.py
+++ b/src/sdetkit/weekly_review_closeout_65.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .bools import coerce_bool
+
 _PAGE_PATH = "docs/integrations-weekly-review-closeout-2.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _INTEGRATION_EXPANSION_SUMMARY_PATH = (
@@ -139,7 +141,7 @@ def _load_integration_expansion(path: Path) -> tuple[int, bool, int]:
     summary_obj = payload_obj.get("summary")
     summary = summary_obj if isinstance(summary_obj, dict) else {}
     score = int(summary.get("activation_score", 0))
-    strict = bool(summary.get("strict_pass", False))
+    strict = coerce_bool(summary.get("strict_pass", False), default=False)
     checks_obj = payload_obj.get("checks")
     checks = checks_obj if isinstance(checks_obj, list) else []
     return score, strict, len(checks)

--- a/tests/test_bool_coercion.py
+++ b/tests/test_bool_coercion.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.bools import coerce_bool
+from sdetkit.gate import _format_text as format_gate_text
+from sdetkit.integration import _evaluate
+from sdetkit.ops import run_workflow
+from sdetkit.premium_gate_engine import AutoFixResult, _build_script_candidates
+
+
+@pytest.mark.parametrize(
+    ("value", "default", "expected"),
+    [
+        ("true", False, True),
+        ("t", False, True),
+        ("y", False, True),
+        ("ok", False, True),
+        ("passed", False, True),
+        ("2", False, True),
+        ("2.5", False, True),
+        ("active", False, True),
+        ("false", True, False),
+        ("f", True, False),
+        ("n", True, False),
+        ("failed", True, False),
+        ("error", True, False),
+        ("null", True, False),
+        ("0.0", True, False),
+        ("inactive", True, False),
+        ("", True, False),
+        ("not-a-bool", False, False),
+        ("not-a-bool", True, True),
+    ],
+)
+def test_coerce_bool_handles_string_flags(value: object, default: bool, expected: bool) -> None:
+    assert coerce_bool(value, default=default) is expected
+
+
+def test_ops_policy_string_false_does_not_enable_shell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    wf = Path("workflow.json")
+    wf.write_text(
+        json.dumps(
+            {
+                "workflow": {
+                    "name": "bool-policy",
+                    "version": "1",
+                    "policy": {"allow_shell": "false"},
+                    "steps": [
+                        {
+                            "id": "cmd",
+                            "type": "command",
+                            "inputs": {"cmd": ["echo", "ok"], "shell": True},
+                        }
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="policy blocks shell=true"):
+        run_workflow(
+            wf,
+            inputs={},
+            artifacts_dir=tmp_path / "artifacts",
+            history_dir=tmp_path / "history",
+            workers=1,
+            dry_run=False,
+            fail_fast=False,
+        )
+
+
+def test_script_catalog_false_autofix_flag_is_respected(tmp_path: Path) -> None:
+    catalog = tmp_path / "script-catalog.json"
+    catalog.write_text(
+        json.dumps(
+            [
+                {
+                    "script_id": "noop",
+                    "reason": "autofix only",
+                    "command": ["echo", "ok"],
+                    "trigger_on_autofix": "false",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    candidates = _build_script_candidates(
+        payload={"warnings": [], "checks": []},
+        out_dir=tmp_path,
+        fix_root=tmp_path,
+        auto_fix_results=[AutoFixResult("SEC_1", "a.py", "fixed", "done")],
+        script_catalog_path=catalog,
+    )
+
+    assert all(item.script_id != "noop" for item in candidates)
+
+
+def test_integration_required_env_string_false_is_not_treated_as_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FEATURE_READY", "false")
+    payload = _evaluate({"required_env": ["FEATURE_READY"], "required_files": [], "services": []})
+    assert payload["summary"]["passed"] is False
+    assert payload["checks"][0]["passed"] is False
+
+
+def test_gate_format_respects_string_false() -> None:
+    output = format_gate_text({"ok": "false", "steps": [], "failed_steps": []})
+    assert "gate fast: FAIL" in output


### PR DESCRIPTION
### Motivation
- Introduce a deterministic boolean coercion helper to avoid misinterpreting string values like "false", "0", or "inactive" as truthy in many places across the codebase.
- Replace scattered uses of `bool(...)` or raw truthiness checks with a single `coerce_bool` to standardize behavior and reduce bugs caused by ambiguous flag representations.

### Description
- Add `sdetkit/bools.py` implementing `coerce_bool(value, *, default=False)` that normalizes strings, numbers, and common truthy/falsey tokens.
- Update numerous modules to import and use `coerce_bool` instead of `bool(...)` or raw truthiness for configuration, payload parsing, and policy flags (examples include `ops`, `repo`, `report`, `doctor`, `gate`, `integration`, `premium_gate_engine`, checks/closeout modules, and many closeout scripts).
- Adjust code paths where boolean semantics matter (policy `allow_shell`, workflow/policy flags, summary `strict_pass` fields, `fixable` markers, step/plan `ok`/`applied` flags, cache/target execution flags, etc.).
- Add `tests/test_bool_coercion.py` with unit tests covering string flag parsing, `run_workflow` policy handling, script-catalog autofix triggers, integration profile environment checks, and gate formatting behavior.

### Testing
- Ran the new unit tests with `pytest tests/test_bool_coercion.py` and the tests passed. 
- Ran the test suite with `pytest -q` (including the new test) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3079ebf0c8320973a2638c3e57163)