### PR TITLE
Add closeout alignment inventory + dev `bootstrap`/`max` Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 # --- dev targets (bootstrap) ---
 
-.PHONY: venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci
+.PHONY: bootstrap max venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci
+
+bootstrap: venv
+	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
+
+max: bootstrap
+	@bash -lc '. .venv/bin/activate && bash quality.sh boost'
 
 venv:
 	@test -x .venv/bin/python || python3 -m venv .venv

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ bash quality.sh ci
 python -m sdetkit kits list
 ```
 
+Need the deepest whole-repo improvement lane? Run:
+
+```bash
+make max
+```
+
 ## What this repo contains
 
 ```text

--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -1,3 +1,882 @@
 {
+  "closeout_alignment": {
+    "count": 60,
+    "entries": [
+      {
+        "contract_script_paths": [
+          "scripts/check_acceleration_closeout_contract_43.py"
+        ],
+        "contract_scripts": 1,
+        "id": 43,
+        "lane": "acceleration",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.acceleration_closeout_43",
+        "module_path": "src/sdetkit/acceleration_closeout_43.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_snippet_closeout_contract_51.py"
+        ],
+        "contract_scripts": 1,
+        "id": 51,
+        "lane": "case_snippet",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.case_snippet_closeout_51",
+        "module_path": "src/sdetkit/case_snippet_closeout_51.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_study_launch_closeout_contract_73.py"
+        ],
+        "contract_scripts": 1,
+        "id": 73,
+        "lane": "case_study_launch",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.case_study_launch_closeout_73",
+        "module_path": "src/sdetkit/case_study_launch_closeout_73.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_study_prep1_closeout_contract_69.py"
+        ],
+        "contract_scripts": 1,
+        "id": 69,
+        "lane": "case_study_prep1",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.case_study_prep1_closeout_69",
+        "module_path": "src/sdetkit/case_study_prep1_closeout_69.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_study_prep2_closeout_contract_70.py"
+        ],
+        "contract_scripts": 1,
+        "id": 70,
+        "lane": "case_study_prep2",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.case_study_prep2_closeout_70",
+        "module_path": "src/sdetkit/case_study_prep2_closeout_70.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [],
+        "contract_scripts": 0,
+        "id": 71,
+        "lane": "case_study_prep3",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.case_study_prep3_closeout_71",
+        "module_path": "src/sdetkit/case_study_prep3_closeout_71.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_study_prep4_closeout_contract_72.py"
+        ],
+        "contract_scripts": 1,
+        "id": 72,
+        "lane": "case_study_prep4",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.case_study_prep4_closeout_72",
+        "module_path": "src/sdetkit/case_study_prep4_closeout_72.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_community_program_closeout_contract_62.py"
+        ],
+        "contract_scripts": 1,
+        "id": 62,
+        "lane": "community_program",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.community_program_closeout_62",
+        "module_path": "src/sdetkit/community_program_closeout_62.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [],
+        "contract_scripts": 0,
+        "id": 77,
+        "lane": "community_touchpoint",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.community_touchpoint_closeout_77",
+        "module_path": "src/sdetkit/community_touchpoint_closeout_77.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_snippet_closeout_contract_51.py",
+          "scripts/check_case_study_prep1_closeout_contract.py",
+          "scripts/check_case_study_prep1_closeout_contract_69.py",
+          "scripts/check_continuous_upgrade_contract_1.py",
+          "scripts/check_continuous_upgrade_contract_10.py",
+          "scripts/check_continuous_upgrade_contract_11.py",
+          "scripts/check_docs_navigation_contract_11.py",
+          "scripts/check_expansion_automation_contract_41.py",
+          "scripts/check_first_contribution_contract_10.py",
+          "scripts/check_growth_campaign_closeout_contract_81.py",
+          "scripts/check_phase1_hardening_contract.py",
+          "scripts/check_phase1_hardening_contract_29.py",
+          "scripts/check_phase1_wrap_contract.py",
+          "scripts/check_phase1_wrap_contract_30.py",
+          "scripts/check_phase2_kickoff_contract_31.py",
+          "scripts/check_phase3_kickoff_closeout_contract_61.py",
+          "scripts/check_quality_contribution_delta_contract_17.py",
+          "scripts/check_weekly_review_contract_14.py",
+          "scripts/check_weekly_review_contract_21.py"
+        ],
+        "contract_scripts": 19,
+        "id": 1,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_1",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_1.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_continuous_upgrade_contract_10.py",
+          "scripts/check_first_contribution_contract_10.py"
+        ],
+        "contract_scripts": 2,
+        "id": 10,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_10",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_10.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_continuous_upgrade_contract_11.py",
+          "scripts/check_docs_navigation_contract_11.py"
+        ],
+        "contract_scripts": 2,
+        "id": 11,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_11",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_11.py",
+        "tests_referencing_module": 0
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_study_prep2_closeout_contract.py",
+          "scripts/check_case_study_prep2_closeout_contract_70.py",
+          "scripts/check_case_study_prep4_closeout_contract_72.py",
+          "scripts/check_community_activation_contract_25.py",
+          "scripts/check_community_program_closeout_contract_62.py",
+          "scripts/check_continuous_upgrade_contract_2.py",
+          "scripts/check_demo_asset2_contract.py",
+          "scripts/check_demo_asset2_contract_34.py",
+          "scripts/check_integration_expansion2_closeout_contract.py",
+          "scripts/check_integration_expansion2_closeout_contract_66.py",
+          "scripts/check_integration_feedback_closeout_contract_82.py",
+          "scripts/check_kpi_audit_contract_27.py",
+          "scripts/check_narrative_closeout_contract_52.py",
+          "scripts/check_optimization_closeout_contract_42.py",
+          "scripts/check_phase1_hardening_contract_29.py",
+          "scripts/check_phase2_hardening_closeout_contract.py",
+          "scripts/check_phase2_hardening_closeout_contract_58.py",
+          "scripts/check_phase2_kickoff_contract.py",
+          "scripts/check_phase2_kickoff_contract_31.py",
+          "scripts/check_phase2_wrap_handoff_closeout_contract.py",
+          "scripts/check_phase2_wrap_handoff_closeout_contract_60.py",
+          "scripts/check_release_cadence_contract_32.py",
+          "scripts/check_weekly_review_closeout_contract_2.py",
+          "scripts/check_weekly_review_contract_21.py",
+          "scripts/check_weekly_review_contract_28.py"
+        ],
+        "contract_scripts": 25,
+        "id": 2,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_2",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_2.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_acceleration_closeout_contract_43.py",
+          "scripts/check_case_study_launch_closeout_contract_73.py",
+          "scripts/check_case_study_prep3_closeout_contract.py",
+          "scripts/check_continuous_upgrade_contract_3.py",
+          "scripts/check_demo_asset2_contract_34.py",
+          "scripts/check_demo_asset_contract_33.py",
+          "scripts/check_distribution_batch_contract_38.py",
+          "scripts/check_distribution_closeout_contract_36.py",
+          "scripts/check_docs_loop_closeout_contract_53.py",
+          "scripts/check_experiment_lane_contract_37.py",
+          "scripts/check_integration_expansion3_closeout_contract.py",
+          "scripts/check_integration_expansion3_closeout_contract_67.py",
+          "scripts/check_kpi_instrumentation_contract_35.py",
+          "scripts/check_onboarding_activation_closeout_contract_63.py",
+          "scripts/check_phase1_wrap_contract_30.py",
+          "scripts/check_phase2_kickoff_contract_31.py",
+          "scripts/check_phase3_kickoff_closeout_contract.py",
+          "scripts/check_phase3_kickoff_closeout_contract_61.py",
+          "scripts/check_phase3_preplan_closeout_contract.py",
+          "scripts/check_phase3_preplan_closeout_contract_59.py",
+          "scripts/check_phase3_wrap_publication_closeout_contract.py",
+          "scripts/check_phase3_wrap_publication_closeout_contract_90.py",
+          "scripts/check_proof_contract_3.py",
+          "scripts/check_release_cadence_contract_32.py",
+          "scripts/check_trust_faq_expansion_closeout_contract_83.py"
+        ],
+        "contract_scripts": 25,
+        "id": 3,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_3",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_3.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_acceleration_closeout_contract_43.py",
+          "scripts/check_case_study_prep4_closeout_contract.py",
+          "scripts/check_case_study_prep4_closeout_contract_72.py",
+          "scripts/check_continuous_upgrade_contract_4.py",
+          "scripts/check_demo_asset2_contract_34.py",
+          "scripts/check_distribution_scaling_closeout_contract_74.py",
+          "scripts/check_evidence_narrative_closeout_contract_84.py",
+          "scripts/check_expansion_automation_contract_41.py",
+          "scripts/check_expansion_closeout_contract_45.py",
+          "scripts/check_integration_expansion4_closeout_contract.py",
+          "scripts/check_integration_expansion4_closeout_contract_68.py",
+          "scripts/check_integration_expansion_closeout_contract_64.py",
+          "scripts/check_objection_closeout_contract_48.py",
+          "scripts/check_optimization_closeout_contract_42.py",
+          "scripts/check_optimization_closeout_contract_46.py",
+          "scripts/check_reliability_closeout_contract_47.py",
+          "scripts/check_scale_closeout_contract_44.py",
+          "scripts/check_scale_lane_contract_40.py",
+          "scripts/check_skills_contract_4.py",
+          "scripts/check_weekly_review_closeout_contract_49.py",
+          "scripts/check_weekly_review_contract_14.py"
+        ],
+        "contract_scripts": 21,
+        "id": 4,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_4",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_4.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_snippet_closeout_contract_51.py",
+          "scripts/check_community_activation_contract_25.py",
+          "scripts/check_continuous_upgrade_contract_5.py",
+          "scripts/check_contributor_activation_closeout_contract_55.py",
+          "scripts/check_docs_loop_closeout_contract_53.py",
+          "scripts/check_execution_prioritization_closeout_contract_50.py",
+          "scripts/check_expansion_closeout_contract_45.py",
+          "scripts/check_kpi_deep_audit_closeout_contract_57.py",
+          "scripts/check_kpi_instrumentation_contract_35.py",
+          "scripts/check_narrative_closeout_contract_52.py",
+          "scripts/check_phase2_hardening_closeout_contract_58.py",
+          "scripts/check_phase3_preplan_closeout_contract_59.py",
+          "scripts/check_platform_contract_5.py",
+          "scripts/check_release_prioritization_closeout_contract_85.py",
+          "scripts/check_stabilization_closeout_contract_56.py",
+          "scripts/check_trust_assets_refresh_closeout_contract_75.py",
+          "scripts/check_weekly_review_closeout_contract_65.py"
+        ],
+        "contract_scripts": 17,
+        "id": 5,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_5",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_5.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_study_prep1_closeout_contract_69.py",
+          "scripts/check_community_program_closeout_contract_62.py",
+          "scripts/check_continuous_upgrade_contract_6.py",
+          "scripts/check_contributor_recognition_closeout_contract_76.py",
+          "scripts/check_conversion_contract_6.py",
+          "scripts/check_distribution_closeout_contract_36.py",
+          "scripts/check_integration_expansion2_closeout_contract_66.py",
+          "scripts/check_integration_expansion3_closeout_contract_67.py",
+          "scripts/check_integration_expansion4_closeout_contract_68.py",
+          "scripts/check_integration_expansion_closeout_contract_64.py",
+          "scripts/check_launch_readiness_closeout_contract_86.py",
+          "scripts/check_onboarding_activation_closeout_contract_63.py",
+          "scripts/check_optimization_closeout_contract_46.py",
+          "scripts/check_phase2_wrap_handoff_closeout_contract_60.py",
+          "scripts/check_phase3_kickoff_closeout_contract_61.py",
+          "scripts/check_stabilization_closeout_contract_56.py",
+          "scripts/check_weekly_review_closeout_contract_65.py"
+        ],
+        "contract_scripts": 17,
+        "id": 6,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_6",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_6.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_study_launch_closeout_contract_73.py",
+          "scripts/check_case_study_prep2_closeout_contract_70.py",
+          "scripts/check_case_study_prep4_closeout_contract_72.py",
+          "scripts/check_continuous_upgrade_contract_7.py",
+          "scripts/check_contributor_recognition_closeout_contract_76.py",
+          "scripts/check_distribution_scaling_closeout_contract_74.py",
+          "scripts/check_experiment_lane_contract_37.py",
+          "scripts/check_governance_handoff_closeout_contract_87.py",
+          "scripts/check_integration_expansion3_closeout_contract_67.py",
+          "scripts/check_kpi_audit_contract_27.py",
+          "scripts/check_kpi_deep_audit_closeout_contract_57.py",
+          "scripts/check_quality_contribution_delta_contract_17.py",
+          "scripts/check_reliability_closeout_contract_47.py",
+          "scripts/check_scale_upgrade_closeout_contract_79.py",
+          "scripts/check_trust_assets_refresh_closeout_contract_75.py",
+          "scripts/check_weekly_review_contract_7.py"
+        ],
+        "contract_scripts": 16,
+        "id": 7,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_7",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_7.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_continuous_upgrade_contract_8.py",
+          "scripts/check_contributor_funnel_contract_8.py",
+          "scripts/check_distribution_batch_contract_38.py",
+          "scripts/check_evidence_narrative_closeout_contract_84.py",
+          "scripts/check_governance_handoff_closeout_contract_87.py",
+          "scripts/check_governance_priorities_closeout_contract_88.py",
+          "scripts/check_governance_scale_closeout_contract_89.py",
+          "scripts/check_growth_campaign_closeout_contract_81.py",
+          "scripts/check_integration_expansion4_closeout_contract_68.py",
+          "scripts/check_integration_feedback_closeout_contract_82.py",
+          "scripts/check_launch_readiness_closeout_contract_86.py",
+          "scripts/check_objection_closeout_contract_48.py",
+          "scripts/check_partner_outreach_closeout_contract_80.py",
+          "scripts/check_phase2_hardening_closeout_contract_58.py",
+          "scripts/check_release_prioritization_closeout_contract_85.py",
+          "scripts/check_trust_faq_expansion_closeout_contract_83.py",
+          "scripts/check_weekly_review_contract_28.py"
+        ],
+        "contract_scripts": 17,
+        "id": 8,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_8",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_8.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_case_study_prep1_closeout_contract_69.py",
+          "scripts/check_continuous_upgrade_contract_9.py",
+          "scripts/check_contribution_templates_contract_9.py",
+          "scripts/check_governance_scale_closeout_contract_89.py",
+          "scripts/check_phase1_hardening_contract_29.py",
+          "scripts/check_phase3_preplan_closeout_contract_59.py",
+          "scripts/check_phase3_wrap_publication_closeout_contract_90.py",
+          "scripts/check_scale_upgrade_closeout_contract_79.py",
+          "scripts/check_weekly_review_closeout_contract_49.py"
+        ],
+        "contract_scripts": 9,
+        "id": 9,
+        "lane": "continuous_upgrade",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.continuous_upgrade_closeout_9",
+        "module_path": "src/sdetkit/continuous_upgrade_closeout_9.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_contributor_activation_closeout_contract_55.py"
+        ],
+        "contract_scripts": 1,
+        "id": 55,
+        "lane": "contributor_activation",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.contributor_activation_closeout_55",
+        "module_path": "src/sdetkit/contributor_activation_closeout_55.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_contributor_recognition_closeout_contract_76.py"
+        ],
+        "contract_scripts": 1,
+        "id": 76,
+        "lane": "contributor_recognition",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.contributor_recognition_closeout_76",
+        "module_path": "src/sdetkit/contributor_recognition_closeout_76.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_distribution_closeout_contract_36.py"
+        ],
+        "contract_scripts": 1,
+        "id": 36,
+        "lane": "distribution",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.distribution_closeout_36",
+        "module_path": "src/sdetkit/distribution_closeout_36.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_distribution_scaling_closeout_contract_74.py"
+        ],
+        "contract_scripts": 1,
+        "id": 74,
+        "lane": "distribution_scaling",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.distribution_scaling_closeout_74",
+        "module_path": "src/sdetkit/distribution_scaling_closeout_74.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_docs_loop_closeout_contract_53.py"
+        ],
+        "contract_scripts": 1,
+        "id": 53,
+        "lane": "docs_loop",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.docs_loop_closeout_53",
+        "module_path": "src/sdetkit/docs_loop_closeout_53.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [],
+        "contract_scripts": 0,
+        "id": 78,
+        "lane": "ecosystem_priorities",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.ecosystem_priorities_closeout_78",
+        "module_path": "src/sdetkit/ecosystem_priorities_closeout_78.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_evidence_narrative_closeout_contract_84.py"
+        ],
+        "contract_scripts": 1,
+        "id": 84,
+        "lane": "evidence_narrative",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.evidence_narrative_closeout_84",
+        "module_path": "src/sdetkit/evidence_narrative_closeout_84.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_execution_prioritization_closeout_contract_50.py"
+        ],
+        "contract_scripts": 1,
+        "id": 50,
+        "lane": "execution_prioritization",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.execution_prioritization_closeout_50",
+        "module_path": "src/sdetkit/execution_prioritization_closeout_50.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_expansion_closeout_contract_45.py"
+        ],
+        "contract_scripts": 1,
+        "id": 45,
+        "lane": "expansion",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.expansion_closeout_45",
+        "module_path": "src/sdetkit/expansion_closeout_45.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_governance_handoff_closeout_contract_87.py"
+        ],
+        "contract_scripts": 1,
+        "id": 87,
+        "lane": "governance_handoff",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.governance_handoff_closeout_87",
+        "module_path": "src/sdetkit/governance_handoff_closeout_87.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_governance_priorities_closeout_contract_88.py"
+        ],
+        "contract_scripts": 1,
+        "id": 88,
+        "lane": "governance_priorities",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.governance_priorities_closeout_88",
+        "module_path": "src/sdetkit/governance_priorities_closeout_88.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_governance_scale_closeout_contract_89.py"
+        ],
+        "contract_scripts": 1,
+        "id": 89,
+        "lane": "governance_scale",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.governance_scale_closeout_89",
+        "module_path": "src/sdetkit/governance_scale_closeout_89.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_growth_campaign_closeout_contract_81.py"
+        ],
+        "contract_scripts": 1,
+        "id": 81,
+        "lane": "growth_campaign",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.growth_campaign_closeout_81",
+        "module_path": "src/sdetkit/growth_campaign_closeout_81.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_integration_expansion2_closeout_contract_66.py"
+        ],
+        "contract_scripts": 1,
+        "id": 66,
+        "lane": "integration_expansion2",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.integration_expansion2_closeout_66",
+        "module_path": "src/sdetkit/integration_expansion2_closeout_66.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_integration_expansion3_closeout_contract_67.py"
+        ],
+        "contract_scripts": 1,
+        "id": 67,
+        "lane": "integration_expansion3",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.integration_expansion3_closeout_67",
+        "module_path": "src/sdetkit/integration_expansion3_closeout_67.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_integration_expansion4_closeout_contract_68.py"
+        ],
+        "contract_scripts": 1,
+        "id": 68,
+        "lane": "integration_expansion4",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.integration_expansion4_closeout_68",
+        "module_path": "src/sdetkit/integration_expansion4_closeout_68.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_integration_expansion_closeout_contract_64.py"
+        ],
+        "contract_scripts": 1,
+        "id": 64,
+        "lane": "integration_expansion",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.integration_expansion_closeout_64",
+        "module_path": "src/sdetkit/integration_expansion_closeout_64.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_integration_feedback_closeout_contract_82.py"
+        ],
+        "contract_scripts": 1,
+        "id": 82,
+        "lane": "integration_feedback",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.integration_feedback_closeout_82",
+        "module_path": "src/sdetkit/integration_feedback_closeout_82.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_kpi_deep_audit_closeout_contract_57.py"
+        ],
+        "contract_scripts": 1,
+        "id": 57,
+        "lane": "kpi_deep_audit",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.kpi_deep_audit_closeout_57",
+        "module_path": "src/sdetkit/kpi_deep_audit_closeout_57.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_launch_readiness_closeout_contract_86.py"
+        ],
+        "contract_scripts": 1,
+        "id": 86,
+        "lane": "launch_readiness",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.launch_readiness_closeout_86",
+        "module_path": "src/sdetkit/launch_readiness_closeout_86.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_narrative_closeout_contract_52.py"
+        ],
+        "contract_scripts": 1,
+        "id": 52,
+        "lane": "narrative",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.narrative_closeout_52",
+        "module_path": "src/sdetkit/narrative_closeout_52.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_objection_closeout_contract_48.py"
+        ],
+        "contract_scripts": 1,
+        "id": 48,
+        "lane": "objection",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.objection_closeout_48",
+        "module_path": "src/sdetkit/objection_closeout_48.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_onboarding_activation_closeout_contract_63.py"
+        ],
+        "contract_scripts": 1,
+        "id": 63,
+        "lane": "onboarding_activation",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.onboarding_activation_closeout_63",
+        "module_path": "src/sdetkit/onboarding_activation_closeout_63.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_optimization_closeout_contract_42.py"
+        ],
+        "contract_scripts": 1,
+        "id": 42,
+        "lane": "optimization",
+        "legacy_day_refs_in_module": 0,
+        "module": "sdetkit.optimization_closeout_42",
+        "module_path": "src/sdetkit/optimization_closeout_42.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_optimization_closeout_contract_46.py"
+        ],
+        "contract_scripts": 1,
+        "id": 46,
+        "lane": "optimization",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.optimization_closeout_46",
+        "module_path": "src/sdetkit/optimization_closeout_46.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_partner_outreach_closeout_contract_80.py"
+        ],
+        "contract_scripts": 1,
+        "id": 80,
+        "lane": "partner_outreach",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.partner_outreach_closeout_80",
+        "module_path": "src/sdetkit/partner_outreach_closeout_80.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_phase2_hardening_closeout_contract_58.py"
+        ],
+        "contract_scripts": 1,
+        "id": 58,
+        "lane": "phase2_hardening",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.phase2_hardening_closeout_58",
+        "module_path": "src/sdetkit/phase2_hardening_closeout_58.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_phase2_wrap_handoff_closeout_contract_60.py"
+        ],
+        "contract_scripts": 1,
+        "id": 60,
+        "lane": "phase2_wrap_handoff",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.phase2_wrap_handoff_closeout_60",
+        "module_path": "src/sdetkit/phase2_wrap_handoff_closeout_60.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_phase3_kickoff_closeout_contract_61.py"
+        ],
+        "contract_scripts": 1,
+        "id": 61,
+        "lane": "phase3_kickoff",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.phase3_kickoff_closeout_61",
+        "module_path": "src/sdetkit/phase3_kickoff_closeout_61.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_phase3_preplan_closeout_contract_59.py"
+        ],
+        "contract_scripts": 1,
+        "id": 59,
+        "lane": "phase3_preplan",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.phase3_preplan_closeout_59",
+        "module_path": "src/sdetkit/phase3_preplan_closeout_59.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_phase3_wrap_publication_closeout_contract_90.py"
+        ],
+        "contract_scripts": 1,
+        "id": 90,
+        "lane": "phase3_wrap_publication",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.phase3_wrap_publication_closeout_90",
+        "module_path": "src/sdetkit/phase3_wrap_publication_closeout_90.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_release_prioritization_closeout_contract_85.py"
+        ],
+        "contract_scripts": 1,
+        "id": 85,
+        "lane": "release_prioritization",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.release_prioritization_closeout_85",
+        "module_path": "src/sdetkit/release_prioritization_closeout_85.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_reliability_closeout_contract_47.py"
+        ],
+        "contract_scripts": 1,
+        "id": 47,
+        "lane": "reliability",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.reliability_closeout_47",
+        "module_path": "src/sdetkit/reliability_closeout_47.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_scale_closeout_contract_44.py"
+        ],
+        "contract_scripts": 1,
+        "id": 44,
+        "lane": "scale",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.scale_closeout_44",
+        "module_path": "src/sdetkit/scale_closeout_44.py",
+        "tests_referencing_module": 2
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_scale_upgrade_closeout_contract_79.py"
+        ],
+        "contract_scripts": 1,
+        "id": 79,
+        "lane": "scale_upgrade",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.scale_upgrade_closeout_79",
+        "module_path": "src/sdetkit/scale_upgrade_closeout_79.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_stabilization_closeout_contract_56.py"
+        ],
+        "contract_scripts": 1,
+        "id": 56,
+        "lane": "stabilization",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.stabilization_closeout_56",
+        "module_path": "src/sdetkit/stabilization_closeout_56.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_trust_assets_refresh_closeout_contract_75.py"
+        ],
+        "contract_scripts": 1,
+        "id": 75,
+        "lane": "trust_assets_refresh",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.trust_assets_refresh_closeout_75",
+        "module_path": "src/sdetkit/trust_assets_refresh_closeout_75.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_trust_faq_expansion_closeout_contract_83.py"
+        ],
+        "contract_scripts": 1,
+        "id": 83,
+        "lane": "trust_faq_expansion",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.trust_faq_expansion_closeout_83",
+        "module_path": "src/sdetkit/trust_faq_expansion_closeout_83.py",
+        "tests_referencing_module": 1
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_weekly_review_closeout_contract_49.py"
+        ],
+        "contract_scripts": 1,
+        "id": 49,
+        "lane": "weekly_review",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.weekly_review_closeout_49",
+        "module_path": "src/sdetkit/weekly_review_closeout_49.py",
+        "tests_referencing_module": 3
+      },
+      {
+        "contract_script_paths": [
+          "scripts/check_weekly_review_closeout_contract_65.py"
+        ],
+        "contract_scripts": 1,
+        "id": 65,
+        "lane": "weekly_review",
+        "legacy_day_refs_in_module": 1,
+        "module": "sdetkit.weekly_review_closeout_65",
+        "module_path": "src/sdetkit/weekly_review_closeout_65.py",
+        "tests_referencing_module": 1
+      }
+    ],
+    "fully_aligned_count": 56
+  },
   "phases": []
 }

--- a/src/sdetkit/roadmap_manifest.py
+++ b/src/sdetkit/roadmap_manifest.py
@@ -8,6 +8,7 @@ from typing import Any
 
 _REPORT_RE = re.compile(r"^impact-(\d+)-.*-report\.md$")
 _PLAN_RE = re.compile(r"^(?:impact|day)(\d+)(?:-.*)?\.json$")
+_CLOSEOUT_RE = re.compile(r"^(?P<lane>[a-z0-9_]+)_closeout_(?P<id>\d+)\.py$")
 
 
 def _repo_root(start: Path | None = None) -> Path:
@@ -30,6 +31,110 @@ def _first_heading(md: str) -> str | None:
 
 def _load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _closeout_inventory(root: Path) -> dict[str, Any]:
+    src_dir = root / "src" / "sdetkit"
+    tests_dir = root / "tests"
+    scripts_dir = root / "scripts"
+    entries: list[dict[str, Any]] = []
+    for path in sorted(src_dir.glob("*_closeout_*.py")):
+        m = _CLOSEOUT_RE.match(path.name)
+        if not m:
+            continue
+        closeout_id = int(m.group("id"))
+        lane = m.group("lane")
+        module_stem = path.stem
+
+        tests_refs = 0
+        for test_file in sorted(tests_dir.glob("test_*.py")):
+            text = test_file.read_text(encoding="utf-8", errors="replace")
+            if module_stem in text:
+                tests_refs += 1
+
+        contract_scripts = sorted(scripts_dir.glob(f"check_*{closeout_id}*.py"))
+        contract_refs = len(contract_scripts)
+
+        day_refs = 0
+        day_hint = f"day{closeout_id}"
+        for repo_file in [path]:
+            text = repo_file.read_text(encoding="utf-8", errors="replace")
+            lowered = text.lower()
+            if day_hint in lowered or f"day {closeout_id}" in lowered:
+                day_refs += 1
+
+        entries.append(
+            {
+                "id": closeout_id,
+                "lane": lane,
+                "module": f"sdetkit.{module_stem}",
+                "module_path": path.relative_to(root).as_posix(),
+                "tests_referencing_module": tests_refs,
+                "contract_scripts": contract_refs,
+                "contract_script_paths": [
+                    script_path.relative_to(root).as_posix() for script_path in contract_scripts
+                ],
+                "legacy_day_refs_in_module": day_refs,
+            }
+        )
+
+    covered = [
+        item
+        for item in entries
+        if item["tests_referencing_module"] > 0 and item["contract_scripts"] > 0
+    ]
+    return {
+        "count": len(entries),
+        "fully_aligned_count": len(covered),
+        "entries": entries,
+    }
+
+
+def _next_closeout_calls(repo_root: Path | None = None, *, limit: int = 10) -> list[dict[str, Any]]:
+    root = repo_root or _repo_root()
+    inventory = _closeout_inventory(root).get("entries", [])
+    if not isinstance(inventory, list):
+        return []
+
+    backlog: list[dict[str, Any]] = []
+    for item in inventory:
+        if not isinstance(item, dict):
+            continue
+        tests_refs = int(item.get("tests_referencing_module", 0))
+        contract_refs = int(item.get("contract_scripts", 0))
+        day_refs = int(item.get("legacy_day_refs_in_module", 0))
+        if tests_refs > 0 and contract_refs > 0 and day_refs == 0:
+            continue
+
+        lane = str(item.get("lane", "unknown"))
+        closeout_id = int(item.get("id", 0))
+        module = str(item.get("module", "sdetkit.unknown"))
+        script_paths = item.get("contract_script_paths", [])
+        next_call = f"pytest -q -k {module.split('.')[-1]}"
+        if isinstance(script_paths, list) and script_paths:
+            next_call = f"python {script_paths[0]}"
+
+        backlog.append(
+            {
+                "id": closeout_id,
+                "lane": lane,
+                "module": module,
+                "tests_referencing_module": tests_refs,
+                "contract_scripts": contract_refs,
+                "legacy_day_refs_in_module": day_refs,
+                "next_call": next_call,
+            }
+        )
+
+    backlog.sort(
+        key=lambda x: (
+            int(x["contract_scripts"] > 0),
+            int(x["tests_referencing_module"] > 0),
+            -x["legacy_day_refs_in_module"],
+            x["id"],
+        )
+    )
+    return backlog[: max(1, limit)]
 
 
 def build_manifest(repo_root: Path | None = None) -> dict[str, Any]:
@@ -79,7 +184,7 @@ def build_manifest(repo_root: Path | None = None) -> dict[str, Any]:
                 e["plan_title"] = plan_title
 
     phase_entries = [items[k] for k in sorted(items)]
-    return {"phases": phase_entries}
+    return {"phases": phase_entries, "closeout_alignment": _closeout_inventory(root)}
 
 
 def render_manifest_json(repo_root: Path | None = None) -> str:
@@ -113,7 +218,7 @@ def check_manifest(repo_root: Path | None = None) -> bool:
 def main(argv: list[str] | None = None) -> int:
     args = list(argv if argv is not None else sys.argv[1:])
     if not args or args[0] in {"-h", "--help"}:
-        print("usage: python -m sdetkit.roadmap_manifest {print|write|check}")
+        print("usage: python -m sdetkit.roadmap_manifest {print|write|check|closeout-next [limit]}")
         return 0
 
     cmd = args[0]
@@ -133,6 +238,18 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
+    if cmd == "closeout-next":
+        limit = 10
+        if len(args) > 1:
+            try:
+                limit = max(1, int(args[1]))
+            except ValueError:
+                print(f"invalid limit: {args[1]}", file=sys.stderr)
+                return 2
+        rows = _next_closeout_calls(limit=limit)
+        payload = {"next_calls": rows, "count": len(rows)}
+        sys.stdout.write(json.dumps(payload, sort_keys=True, indent=2, ensure_ascii=True) + "\n")
+        return 0
 
     print("unknown command", file=sys.stderr)
     return 2

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_makefile_has_bootstrap_and_max_targets() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "Makefile").read_text(encoding="utf-8")
+    assert "bootstrap: venv" in text
+    assert "max: bootstrap" in text
+    assert "bash scripts/bootstrap.sh" in text
+    assert "bash quality.sh boost" in text

--- a/tests/test_roadmap_manifest_tooling.py
+++ b/tests/test_roadmap_manifest_tooling.py
@@ -2,10 +2,28 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sdetkit.roadmap_manifest import check_manifest
+from sdetkit.roadmap_manifest import _next_closeout_calls, build_manifest, check_manifest
 
 
 def test_roadmap_manifest_is_fresh() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     ok = check_manifest(repo_root=repo_root)
     assert ok, "docs/roadmap/manifest.json is stale; run: python -m sdetkit.roadmap_manifest write"
+
+
+def test_roadmap_manifest_includes_closeout_alignment_inventory() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    manifest = build_manifest(repo_root=repo_root)
+    alignment = manifest.get("closeout_alignment")
+    assert isinstance(alignment, dict)
+    assert int(alignment.get("count", 0)) >= 1
+    assert isinstance(alignment.get("entries"), list)
+
+
+def test_next_closeout_calls_are_emitted_with_actionable_command() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    rows = _next_closeout_calls(repo_root=repo_root, limit=5)
+    assert rows
+    first = rows[0]
+    assert isinstance(first.get("next_call"), str)
+    assert first["next_call"]


### PR DESCRIPTION
### Motivation

- Surface an inventory of "closeout" modules and their test/contract coverage so maintainers can see alignment and next actions. 
- Provide convenient repo bootstrap and a deep-quality lane to speed contributor setup and whole-repo quality runs. 

### Description

- Added `bootstrap` and `max` Makefile targets and updated `.PHONY` to include them, with `bootstrap` invoking `scripts/bootstrap.sh` and `max` running `quality.sh boost` after bootstrapping. 
- Documented the `make max` lane in `README.md`. 
- Implemented closeout inventory and prioritized next-action tooling in `src/sdetkit/roadmap_manifest.py` by adding the `_CLOSEOUT_RE` pattern, `_closeout_inventory` and `_next_closeout_calls` helpers, wiring inventory output into `build_manifest`, and adding a CLI command `closeout-next` to emit actionable commands. 
- Updated `docs/roadmap/manifest.json` to include the generated `closeout_alignment` payload. 
- Added tests: `tests/test_makefile_targets.py` to verify the new Makefile targets and `tests/test_roadmap_manifest_tooling.py` to validate manifest freshness, the presence of the closeout inventory, and that `_next_closeout_calls` emits an actionable `next_call`. 

### Testing

- Ran the test suite with `pytest -q` including the new tests `tests/test_makefile_targets.py` and `tests/test_roadmap_manifest_tooling.py`. 
- All automated tests completed successfully. 
- The `build_manifest` and `check_manifest` logic were exercised by the tests and produce the updated `closeout_alignment` structure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d30ac8c3f083208ace9f3fc82b59c0)