### PR TITLE
Match closeout contract scripts by lane and add readiness percent to manifest

### DIFF
--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -63,8 +63,10 @@
         "tests_referencing_module": 1
       },
       {
-        "contract_script_paths": [],
-        "contract_scripts": 0,
+        "contract_script_paths": [
+          "scripts/check_case_study_prep3_closeout_contract.py"
+        ],
+        "contract_scripts": 1,
         "id": 71,
         "lane": "case_study_prep3",
         "legacy_day_refs_in_module": 1,
@@ -97,14 +99,16 @@
         "tests_referencing_module": 1
       },
       {
-        "contract_script_paths": [],
-        "contract_scripts": 0,
+        "contract_script_paths": [
+          "scripts/check_community_touchpoint_closeout_contract.py"
+        ],
+        "contract_scripts": 1,
         "id": 77,
         "lane": "community_touchpoint",
         "legacy_day_refs_in_module": 1,
         "module": "sdetkit.community_touchpoint_closeout_77",
         "module_path": "src/sdetkit/community_touchpoint_closeout_77.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 3
       },
       {
         "contract_script_paths": [
@@ -458,8 +462,10 @@
         "tests_referencing_module": 1
       },
       {
-        "contract_script_paths": [],
-        "contract_scripts": 0,
+        "contract_script_paths": [
+          "scripts/check_ecosystem_priorities_closeout_contract.py"
+        ],
+        "contract_scripts": 1,
         "id": 78,
         "lane": "ecosystem_priorities",
         "legacy_day_refs_in_module": 1,
@@ -876,7 +882,8 @@
         "tests_referencing_module": 1
       }
     ],
-    "fully_aligned_count": 56
+    "fully_aligned_count": 59,
+    "readiness_percent": 98.33
   },
   "phases": []
 }

--- a/src/sdetkit/roadmap_manifest.py
+++ b/src/sdetkit/roadmap_manifest.py
@@ -11,6 +11,14 @@ _PLAN_RE = re.compile(r"^(?:impact|day)(\d+)(?:-.*)?\.json$")
 _CLOSEOUT_RE = re.compile(r"^(?P<lane>[a-z0-9_]+)_closeout_(?P<id>\d+)\.py$")
 
 
+def _script_matches_closeout_lane(script: Path, lane: str) -> bool:
+    lane_tokens = [tok for tok in lane.lower().split("_") if tok]
+    if not lane_tokens:
+        return False
+    script_tokens = [tok for tok in script.stem.lower().split("_") if tok]
+    return all(token in script_tokens for token in lane_tokens)
+
+
 def _repo_root(start: Path | None = None) -> Path:
     here = (start or Path(__file__)).resolve()
     for p in [here] + list(here.parents):
@@ -38,6 +46,11 @@ def _closeout_inventory(root: Path) -> dict[str, Any]:
     tests_dir = root / "tests"
     scripts_dir = root / "scripts"
     entries: list[dict[str, Any]] = []
+    test_files = sorted(tests_dir.glob("test_*.py"))
+    test_contents = {
+        test_file: test_file.read_text(encoding="utf-8", errors="replace") for test_file in test_files
+    }
+    contract_candidates = sorted(scripts_dir.glob("check_*closeout_contract*.py"))
     for path in sorted(src_dir.glob("*_closeout_*.py")):
         m = _CLOSEOUT_RE.match(path.name)
         if not m:
@@ -47,12 +60,16 @@ def _closeout_inventory(root: Path) -> dict[str, Any]:
         module_stem = path.stem
 
         tests_refs = 0
-        for test_file in sorted(tests_dir.glob("test_*.py")):
-            text = test_file.read_text(encoding="utf-8", errors="replace")
+        for test_file, text in test_contents.items():
             if module_stem in text:
                 tests_refs += 1
 
         contract_scripts = sorted(scripts_dir.glob(f"check_*{closeout_id}*.py"))
+        if not contract_scripts:
+            for candidate in contract_candidates:
+                if _script_matches_closeout_lane(candidate, lane):
+                    contract_scripts.append(candidate)
+            contract_scripts = sorted({script.resolve(): script for script in contract_scripts}.values())
         contract_refs = len(contract_scripts)
 
         day_refs = 0
@@ -86,6 +103,7 @@ def _closeout_inventory(root: Path) -> dict[str, Any]:
     return {
         "count": len(entries),
         "fully_aligned_count": len(covered),
+        "readiness_percent": round((len(covered) / len(entries) * 100), 2) if entries else 0.0,
         "entries": entries,
     }
 

--- a/tests/test_roadmap_manifest_extra.py
+++ b/tests/test_roadmap_manifest_extra.py
@@ -19,6 +19,15 @@ def test_first_heading_and_repo_root_fallback(tmp_path: Path, monkeypatch) -> No
     assert rm._repo_root(Path("/tmp/missing/file.py")) == nested
 
 
+def test_script_matches_closeout_lane() -> None:
+    assert rm._script_matches_closeout_lane(
+        Path("scripts/check_community_touchpoint_closeout_contract.py"), "community_touchpoint"
+    )
+    assert not rm._script_matches_closeout_lane(
+        Path("scripts/check_community_program_closeout_contract.py"), "community_touchpoint"
+    )
+
+
 def test_build_manifest_merges_reports_and_plans(tmp_path: Path) -> None:
     reports = tmp_path / "docs" / "roadmap" / "reports"
     plans = tmp_path / "docs" / "roadmap" / "phase3" / "plans"
@@ -31,24 +40,54 @@ def test_build_manifest_merges_reports_and_plans(tmp_path: Path) -> None:
     (plans / "day4-plan.json").write_text('{"title": " Plan 4 "}', encoding="utf-8")
 
     manifest = rm.build_manifest(repo_root=tmp_path)
-    assert manifest == {
-        "phases": [
-            {
-                "impact": 3,
-                "report_path": "docs/roadmap/reports/impact-3-alpha-report.md",
-                "report_title": "Day 3 report",
-                "plan_path": "docs/roadmap/phase3/plans/day3-plan.json",
-                "plan_title": "Plan 3",
-            },
-            {
-                "impact": 4,
-                "report_path": "docs/roadmap/reports/impact-4-beta-report.md",
-                "report_title": "impact-4-beta-report.md",
-                "plan_path": "docs/roadmap/phase3/plans/day4-plan.json",
-                "plan_title": "Plan 4",
-            },
-        ]
-    }
+    assert manifest["phases"] == [
+        {
+            "impact": 3,
+            "report_path": "docs/roadmap/reports/impact-3-alpha-report.md",
+            "report_title": "Day 3 report",
+            "plan_path": "docs/roadmap/phase3/plans/day3-plan.json",
+            "plan_title": "Plan 3",
+        },
+        {
+            "impact": 4,
+            "report_path": "docs/roadmap/reports/impact-4-beta-report.md",
+            "report_title": "impact-4-beta-report.md",
+            "plan_path": "docs/roadmap/phase3/plans/day4-plan.json",
+            "plan_title": "Plan 4",
+        },
+    ]
+    assert manifest["closeout_alignment"]["count"] == 0
+    assert manifest["closeout_alignment"]["fully_aligned_count"] == 0
+    assert manifest["closeout_alignment"]["readiness_percent"] == 0.0
+    assert manifest["closeout_alignment"]["entries"] == []
+
+
+def test_closeout_inventory_matches_contract_by_lane_when_id_missing(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "sdetkit"
+    tests = tmp_path / "tests"
+    scripts = tmp_path / "scripts"
+    src.mkdir(parents=True)
+    tests.mkdir(parents=True)
+    scripts.mkdir(parents=True)
+
+    (src / "community_touchpoint_closeout_77.py").write_text(
+        "def main():\n    return 'day77'\n", encoding="utf-8"
+    )
+    (tests / "test_community_touchpoint_closeout.py").write_text(
+        "from sdetkit import community_touchpoint_closeout_77\n", encoding="utf-8"
+    )
+    (scripts / "check_community_touchpoint_closeout_contract.py").write_text(
+        "print('ok')\n", encoding="utf-8"
+    )
+
+    inventory = rm._closeout_inventory(tmp_path)
+    assert inventory["count"] == 1
+    assert inventory["fully_aligned_count"] == 1
+    assert inventory["readiness_percent"] == 100.0
+    assert inventory["entries"][0]["contract_scripts"] == 1
+    assert inventory["entries"][0]["contract_script_paths"] == [
+        "scripts/check_community_touchpoint_closeout_contract.py"
+    ]
 
 
 def test_build_manifest_duplicate_report_and_plan_errors(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Improve detection of contract scripts for closeout modules when the script filename does not include the numeric closeout id.
- Provide an overall readiness metric for closeout alignment in the generated roadmap manifest.

### Description
- Add `_script_matches_closeout_lane` to match script filenames against closeout lane tokens and use it as a fallback when id-specific contract scripts are not found.
- Cache test file contents and collect `contract_candidates` from `scripts/check_*closeout_contract*.py`, then perform lane-based matching and deduplicate matches when building the closeout inventory.
- Include a `readiness_percent` value in the `_closeout_inventory` return payload, calculated from fully aligned closeouts, and update output formatting accordingly.
- Update `tests/test_roadmap_manifest_extra.py` and `docs/roadmap/manifest.json` to reflect lane-based matching behavior and the new readiness metric.

### Testing
- Ran the test suite with `pytest -q` and all tests passed.
- Added `test_script_matches_closeout_lane` which passed.
- Added `test_closeout_inventory_matches_contract_by_lane_when_id_missing` and updated `test_build_manifest_merges_reports_and_plans`, and both updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d30d8b2f5083208cca132ff9c6b702)