### PR TITLE
Add feature registry with CLI, docs, validation scripts, and CI integration

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           python -m pre_commit run -a
 
+      - name: Feature registry maintenance lane
+        run: |
+          bash quality.sh registry
+
       - name: Tests
         env:
           COV_FAIL_UNDER: "95"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,16 @@ Reference: [docs/premium-quality-gate.md](docs/premium-quality-gate.md)
 - [ ] `mkdocs build` passes for docs changes.
 - [ ] `CHANGELOG.md` updated if behavior changed.
 
+### Feature registry governance checklist
+
+If your PR changes top-level commands, tier/stability, command examples, or command docs/test links, update the feature registry in one pass:
+
+- [ ] Update `src/sdetkit/data/feature_registry.json`.
+- [ ] Sync docs table: `python scripts/sync_feature_registry_docs.py`.
+- [ ] Verify contract: `python scripts/check_feature_registry_contract.py`.
+- [ ] Run maintenance lane: `bash quality.sh registry`.
+- [ ] Confirm CLI inspector output remains stable: `python -m sdetkit feature-registry --only-core --format table`.
+
 ## Commit guidance
 
 - Keep commits focused and easy to review.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # --- dev targets (bootstrap) ---
 
-.PHONY: bootstrap max venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci
+.PHONY: bootstrap max venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -28,6 +28,9 @@ fmt: install
 
 type: install
 	@bash -lc '. .venv/bin/activate && bash quality.sh type'
+
+registry: install
+	@bash -lc '. .venv/bin/activate && bash quality.sh registry'
 
 docs-serve: install
 	@bash -lc '. .venv/bin/activate && mkdocs serve'

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,3 +21,16 @@ python -m pre_commit run -a
 bash quality.sh cov
 mkdocs build
 ```
+
+## Feature registry governance (for command-surface changes)
+
+If your PR changes top-level commands, tier/stability metadata, examples, or docs/test links, keep registry updates in the same PR.
+
+See: [Feature registry](feature-registry.md).
+
+```bash
+python scripts/sync_feature_registry_docs.py
+python scripts/check_feature_registry_contract.py
+bash quality.sh registry
+python -m sdetkit feature-registry --only-core --format table
+```

--- a/docs/feature-registry.md
+++ b/docs/feature-registry.md
@@ -1,0 +1,70 @@
+# Feature registry
+
+The feature registry keeps SDETKit broad **and** useful by making each command explicitly accountable to user value.
+
+## Why this exists
+
+As the command surface grows, users need a deterministic way to know which commands are core, advanced, and experimental.
+
+The registry adds a lightweight contract per command:
+
+- Tier (`A`, `B`, `C`)
+- Stability status (`stable`, `advanced`, `experimental`)
+- Problem solved
+- Copy-paste example
+- Expected output summary
+- Linked test file
+- Linked docs page
+
+## Tier model
+
+- **Tier A**: core/default commands that should be trusted first by most users.
+- **Tier B**: advanced commands that are valuable but situational.
+- **Tier C**: experimental/lab commands where iteration speed matters more than API stability.
+
+## Registry table (auto-generated)
+
+The table below is generated from `src/sdetkit/data/feature_registry.json`.
+Run `python scripts/sync_feature_registry_docs.py` after registry updates.
+
+<!-- feature-registry:table:start -->
+| Command | Tier | Status | Problem solved | Example | Test | Docs |
+| --- | --- | --- | --- | --- | --- | --- |
+| `doctor` | A | stable | Provides deterministic repo diagnostics and readiness scoring. | `python -m sdetkit doctor --format md` | [tests/test_cli_doctor.py](../tests/test_cli_doctor.py) | [docs/doctor.md](doctor.md) |
+| `forensics` | A | stable | Compares runs and pinpoints failure deltas for root-cause analysis. | `python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json` | [tests/test_cli_sdetkit.py](../tests/test_cli_sdetkit.py) | [docs/cli.md](cli.md) |
+| `gate` | A | stable | Runs fast and strict confidence checks for release control. | `python -m sdetkit gate fast` | [tests/test_gate_fast.py](../tests/test_gate_fast.py) | [docs/cli.md](cli.md) |
+| `integration` | A | stable | Validates integration topologies and runtime compatibility. | `python -m sdetkit integration check --profile examples/kits/integration/profile.json` | [tests/test_integration_feedback_closeout.py](../tests/test_integration_feedback_closeout.py) | [docs/cli.md](cli.md) |
+| `intelligence` | A | stable | Analyzes failure trends and flaky behavior for triage. | `python -m sdetkit intelligence --help` | [tests/test_cli_sdetkit.py](../tests/test_cli_sdetkit.py) | [docs/cli.md](cli.md) |
+| `kits` | A | stable | Discovers the curated umbrella surfaces for fast adoption. | `python -m sdetkit kits list` | [tests/test_cli_sdetkit.py](../tests/test_cli_sdetkit.py) | [docs/cli.md](cli.md) |
+| `release` | A | stable | Runs release-confidence checks and gate workflows. | `python -m sdetkit release gate fast` | [tests/test_release_readiness.py](../tests/test_release_readiness.py) | [docs/release-readiness.md](release-readiness.md) |
+| `repo` | A | stable | Performs repo policy and automation audits. | `python -m sdetkit repo --help` | [tests/test_repo_check_cli.py](../tests/test_repo_check_cli.py) | [docs/repo-audit.md](repo-audit.md) |
+<!-- feature-registry:table:end -->
+
+## Source of truth
+
+Registry data file: `src/sdetkit/data/feature_registry.json`
+
+Loader module: `src/sdetkit/feature_registry.py`
+
+Validation test: `tests/test_feature_registry.py`
+
+CI contract command: `python scripts/check_feature_registry_contract.py`
+
+Docs sync command: `python scripts/sync_feature_registry_docs.py --check`
+
+CLI inspection command: `python -m sdetkit feature-registry --only-core --format table`
+
+Markdown export command: `python -m sdetkit feature-registry --format markdown`
+
+Maintenance lane command: `bash quality.sh registry`
+
+Summary command: `python -m sdetkit feature-registry --format summary-json`
+
+Assertion command (CI-safe): `python -m sdetkit feature-registry --only-core --expect-command kits --expect-command release --expect-total 8 --expect-tier-count A=8 --expect-status-count stable=8 --fail-on-empty --format summary-json`
+
+## Expected operating flow
+
+1. Add or update command in the registry.
+2. Link a test and docs page.
+3. Keep tier and stability current as command maturity changes.
+4. Use the registry as input for future CLI grouping and docs generation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Use this page as the primary navigation for repository documentation.
 - [Repository cleanup plan](repo-cleanup-plan.md)
 - [Repo audit guide](repo-audit.md)
 - [Policy and baselines](policy-and-baselines.md)
+- [Feature registry](feature-registry.md)
 
 ## Adoption and rollout
 

--- a/docs/recommended-ci-flow.md
+++ b/docs/recommended-ci-flow.md
@@ -64,6 +64,7 @@ jobs:
           COV_FAIL_UNDER: "95"
         run: |
           python -m pre_commit run -a
+          bash quality.sh registry
           bash quality.sh cov
           NO_MKDOCS_2_WARNING=1 python -m mkdocs build
 
@@ -120,6 +121,7 @@ Why: fast and deterministic contributor signal, with triage-ready JSON artifacts
 Keep PR commands, then add:
 
 - `python -m pre_commit run -a`
+- `bash quality.sh registry`
 - `bash quality.sh cov`
 - `NO_MKDOCS_2_WARNING=1 python -m mkdocs build`
 

--- a/quality.sh
+++ b/quality.sh
@@ -39,11 +39,11 @@ need_cmd() {
   exit 127
 }
 
-valid_modes=(all ci verify fmt lint type doctor test full-test cov mut muthtml boost help)
+valid_modes=(all ci verify fmt lint type doctor test full-test cov mut muthtml boost registry help)
 
 usage() {
   cat <<'USAGE' >&2
-Usage: bash quality.sh {all|ci|verify|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost}
+Usage: bash quality.sh {all|ci|verify|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost|registry}
 
 Profiles:
   quick     Fast local confidence / smoke profile.
@@ -65,6 +65,7 @@ Modes:
   mut        Run mutation testing.
   muthtml    Build mutation HTML output.
   boost      Chain doctor, fast gate, premium fast gate, and optimization summary.
+  registry   Validate and smoke-test feature-registry docs/contracts surface.
 USAGE
 }
 
@@ -157,6 +158,22 @@ run_cov() {
 }
 run_mut() { need_cmd mutmut; mutmut run; }
 run_muthtml() { need_cmd mutmut; mutmut html; }
+run_registry_contract() {
+  python scripts/sync_feature_registry_docs.py --check
+  python scripts/check_feature_registry_contract.py
+  python -m sdetkit feature-registry \
+    --only-core \
+    --expect-command kits \
+    --expect-command release \
+    --expect-command intelligence \
+    --expect-command integration \
+    --expect-command forensics \
+    --expect-total 8 \
+    --expect-tier-count A=8 \
+    --expect-status-count stable=8 \
+    --fail-on-empty \
+    --format summary-json >/dev/null
+}
 
 SDETKIT_OUT_DIR="${SDETKIT_OUT_DIR:-.sdetkit/out}"
 mkdir -p "$SDETKIT_OUT_DIR"
@@ -349,6 +366,11 @@ case "$mode" in
     profile_used="adaptive"
     profile_notes="Planner-oriented boost lane that chains multiple platform surfaces."
     run_required "boost" "Boost orchestration" 0 "run_boost"
+    ;;
+  registry)
+    profile_used="standard"
+    profile_notes="Feature registry maintenance lane for docs/contract/CLI consistency."
+    run_required "feature_registry_contract" "Feature registry maintenance lane" 1 "run_registry_contract"
     ;;
   ci)
     profile_used="quick"

--- a/scripts/check_feature_registry_contract.py
+++ b/scripts/check_feature_registry_contract.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _bootstrap_import_path(repo_root: Path) -> None:
+    src_dir = repo_root / "src"
+    src_path = str(src_dir)
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check_feature_registry_contract.py",
+        description="Validate feature registry entries and linked repo assets.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root used to validate linked docs/tests paths.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    _bootstrap_import_path(repo_root)
+
+    from sdetkit.feature_registry import validate_feature_registry_contract
+
+    errors = validate_feature_registry_contract(repo_root)
+    if errors:
+        for item in errors:
+            print(f"feature-registry-contract: {item}", file=sys.stderr)
+        return 1
+
+    print("feature-registry-contract check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_feature_registry_docs.py
+++ b/scripts/sync_feature_registry_docs.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _bootstrap_import_path(repo_root: Path) -> None:
+    src_dir = repo_root / "src"
+    src_path = str(src_dir)
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="sync_feature_registry_docs.py",
+        description="Sync docs/feature-registry.md table from src/sdetkit/data/feature_registry.json.",
+    )
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check-only mode. Exit non-zero if docs table is stale.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    _bootstrap_import_path(repo_root)
+
+    from sdetkit.feature_registry import (
+        _DOC_TABLE_END,
+        _DOC_TABLE_START,
+        load_feature_registry,
+        render_feature_registry_docs_block,
+    )
+
+    docs_path = repo_root / "docs" / "feature-registry.md"
+    if not docs_path.exists():
+        print("missing docs/feature-registry.md", file=sys.stderr)
+        return 1
+
+    text = docs_path.read_text(encoding="utf-8")
+    start = text.find(_DOC_TABLE_START)
+    end = text.find(_DOC_TABLE_END)
+    if start == -1 or end == -1 or end < start:
+        print("docs markers missing; add feature-registry table markers", file=sys.stderr)
+        return 1
+
+    end += len(_DOC_TABLE_END)
+    replacement = render_feature_registry_docs_block(load_feature_registry())
+    updated = text[:start] + replacement + text[end:]
+
+    if args.check:
+        if updated != text:
+            print("feature-registry docs table is stale", file=sys.stderr)
+            return 1
+        print("feature-registry docs table is up to date")
+        return 0
+
+    docs_path.write_text(updated, encoding="utf-8")
+    print(f"updated {docs_path.relative_to(repo_root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/checks/builtin.py
+++ b/src/sdetkit/checks/builtin.py
@@ -194,6 +194,12 @@ def _tests_full_command(ctx: CheckContext) -> tuple[str, ...]:
     return (ctx.python_executable, "-m", "pytest", "-q", "-o", "addopts=")
 
 
+
+
+def _feature_registry_contract_command(ctx: CheckContext) -> tuple[str, ...]:
+    return (ctx.python_executable, "scripts/check_feature_registry_contract.py")
+
+
 def _doctor_core_command(ctx: CheckContext) -> tuple[str, ...]:
     return (
         ctx.python_executable,
@@ -253,6 +259,20 @@ BUILTIN_CHECKS: tuple[CheckDefinition, ...] = (
             notes="Protects baseline repo structure before deeper checks run.",
         ),
         _make_command_runner(_repo_layout_command),
+    ),
+    _bind(
+        CheckDefinition(
+            id="feature_registry_contract",
+            title="Feature registry contract",
+            category="repo",
+            cost="cheap",
+            truth_level="smoke",
+            required_tools=("python",),
+            required_paths=("scripts/check_feature_registry_contract.py", "src/sdetkit/data/feature_registry.json"),
+            command=("python", "scripts/check_feature_registry_contract.py"),
+            notes="Ensures Tier-mapped commands keep valid docs/tests linkage and contract fields.",
+        ),
+        _make_command_runner(_feature_registry_contract_command),
     ),
     _bind(
         CheckDefinition(

--- a/src/sdetkit/checks/registry.py
+++ b/src/sdetkit/checks/registry.py
@@ -13,7 +13,7 @@ DEFAULT_PROFILES: tuple[CheckProfile, ...] = (
         description="Fast local confidence / smoke profile.",
         default_truth_level="smoke",
         merge_truth=False,
-        check_ids=("repo_layout", "format_check", "lint", "typing", "tests_smoke"),
+        check_ids=("repo_layout", "feature_registry_contract", "format_check", "lint", "typing", "tests_smoke"),
         notes="Honest smoke lane for developers; passing does not imply merge readiness.",
     ),
     CheckProfile(
@@ -23,6 +23,7 @@ DEFAULT_PROFILES: tuple[CheckProfile, ...] = (
         merge_truth=False,
         check_ids=(
             "repo_layout",
+            "feature_registry_contract",
             "doctor_core",
             "format_check",
             "lint",
@@ -39,6 +40,7 @@ DEFAULT_PROFILES: tuple[CheckProfile, ...] = (
         merge_truth=True,
         check_ids=(
             "repo_layout",
+            "feature_registry_contract",
             "doctor_core",
             "format_check",
             "lint",
@@ -55,6 +57,7 @@ DEFAULT_PROFILES: tuple[CheckProfile, ...] = (
         merge_truth=False,
         check_ids=(
             "repo_layout",
+            "feature_registry_contract",
             "doctor_core",
             "format_check",
             "lint",

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -51,6 +51,7 @@ from . import (
     expansion_closeout_45,
     experiment_lane_37,
     external_contribution,
+    feature_registry_cli,
     first_contribution,
     forensics,
     github_actions_quickstart,
@@ -344,6 +345,10 @@ Start here:
     )
 
     _add_passthrough_subcommand(sub, "dev", help_text="Shortcut to `repo dev` workflows")
+
+    _add_passthrough_subcommand(
+        sub, "feature-registry", help_text="Inspect feature-registry entries and filters"
+    )
 
     rpt = sub.add_parser("report", help="Reporting workflows and output packs")
     rpt.add_argument("args", nargs=argparse.REMAINDER)
@@ -1141,6 +1146,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "trust-assets":
         return trust_assets.main(list(argv[1:]))
 
+    if argv and argv[0] == "feature-registry":
+        return feature_registry_cli.main(list(argv[1:]))
+
     show_hidden_commands = "--show-hidden" in argv
     p, sub = _build_root_parser(show_hidden_commands=show_hidden_commands)
 
@@ -1286,6 +1294,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "dev":
         return repo.main(["dev", *ns.args])
+
+    if ns.cmd == "feature-registry":
+        return feature_registry_cli.main(ns.args)
 
     if ns.cmd == "report":
         return report.main(ns.args)

--- a/src/sdetkit/data/feature_registry.json
+++ b/src/sdetkit/data/feature_registry.json
@@ -1,0 +1,82 @@
+[
+  {
+    "command": "kits",
+    "tier": "A",
+    "status": "stable",
+    "problem_solved": "Discovers the curated umbrella surfaces for fast adoption.",
+    "example": "python -m sdetkit kits list",
+    "expected_output": "Lists available kits with short purpose descriptions.",
+    "test_file": "tests/test_cli_sdetkit.py",
+    "docs_page": "docs/cli.md"
+  },
+  {
+    "command": "release",
+    "tier": "A",
+    "status": "stable",
+    "problem_solved": "Runs release-confidence checks and gate workflows.",
+    "example": "python -m sdetkit release gate fast",
+    "expected_output": "Returns a gate verdict with actionable recommendations.",
+    "test_file": "tests/test_release_readiness.py",
+    "docs_page": "docs/release-readiness.md"
+  },
+  {
+    "command": "intelligence",
+    "tier": "A",
+    "status": "stable",
+    "problem_solved": "Analyzes failure trends and flaky behavior for triage.",
+    "example": "python -m sdetkit intelligence --help",
+    "expected_output": "Shows intelligence subcommands and usage help.",
+    "test_file": "tests/test_cli_sdetkit.py",
+    "docs_page": "docs/cli.md"
+  },
+  {
+    "command": "integration",
+    "tier": "A",
+    "status": "stable",
+    "problem_solved": "Validates integration topologies and runtime compatibility.",
+    "example": "python -m sdetkit integration check --profile examples/kits/integration/profile.json",
+    "expected_output": "Prints an integration validation summary.",
+    "test_file": "tests/test_integration_feedback_closeout.py",
+    "docs_page": "docs/cli.md"
+  },
+  {
+    "command": "forensics",
+    "tier": "A",
+    "status": "stable",
+    "problem_solved": "Compares runs and pinpoints failure deltas for root-cause analysis.",
+    "example": "python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json",
+    "expected_output": "Produces a structured delta report.",
+    "test_file": "tests/test_cli_sdetkit.py",
+    "docs_page": "docs/cli.md"
+  },
+  {
+    "command": "doctor",
+    "tier": "A",
+    "status": "stable",
+    "problem_solved": "Provides deterministic repo diagnostics and readiness scoring.",
+    "example": "python -m sdetkit doctor --format md",
+    "expected_output": "Outputs a diagnosis summary with remediation actions.",
+    "test_file": "tests/test_cli_doctor.py",
+    "docs_page": "docs/doctor.md"
+  },
+  {
+    "command": "gate",
+    "tier": "A",
+    "status": "stable",
+    "problem_solved": "Runs fast and strict confidence checks for release control.",
+    "example": "python -m sdetkit gate fast",
+    "expected_output": "Returns pass/warn/fail style gate output.",
+    "test_file": "tests/test_gate_fast.py",
+    "docs_page": "docs/cli.md"
+  },
+  {
+    "command": "repo",
+    "tier": "A",
+    "status": "stable",
+    "problem_solved": "Performs repo policy and automation audits.",
+    "example": "python -m sdetkit repo --help",
+    "expected_output": "Shows repository automation command surface.",
+    "test_file": "tests/test_repo_check_cli.py",
+    "docs_page": "docs/repo-audit.md"
+  }
+]

--- a/src/sdetkit/feature_registry.py
+++ b/src/sdetkit/feature_registry.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from .public_surface_contract import PUBLIC_SURFACE_CONTRACT
+
+_REQUIRED_FIELDS = {
+    "command",
+    "tier",
+    "status",
+    "problem_solved",
+    "example",
+    "expected_output",
+    "test_file",
+    "docs_page",
+}
+_ALLOWED_TIERS = {"A", "B", "C"}
+_ALLOWED_STATUSES = {"stable", "advanced", "experimental"}
+_DOC_TABLE_START = "<!-- feature-registry:table:start -->"
+_DOC_TABLE_END = "<!-- feature-registry:table:end -->"
+
+
+@dataclass(frozen=True)
+class FeatureEntry:
+    command: str
+    tier: str
+    status: str
+    problem_solved: str
+    example: str
+    expected_output: str
+    test_file: str
+    docs_page: str
+
+
+def _registry_path() -> Path:
+    return Path(__file__).resolve().parent / "data" / "feature_registry.json"
+
+
+def _known_top_level_commands() -> set[str]:
+    commands: set[str] = set()
+    for family in PUBLIC_SURFACE_CONTRACT:
+        commands.update(family.top_level_commands)
+    return commands
+
+
+def load_feature_registry() -> list[FeatureEntry]:
+    payload = json.loads(_registry_path().read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("feature registry must be a list")
+
+    rows: list[FeatureEntry] = []
+    seen: set[str] = set()
+    for i, item in enumerate(payload, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"feature registry item #{i} must be an object")
+        missing = sorted(_REQUIRED_FIELDS - set(item))
+        if missing:
+            raise ValueError(f"feature registry item #{i} missing fields: {', '.join(missing)}")
+
+        entry = FeatureEntry(
+            command=str(item["command"]).strip(),
+            tier=str(item["tier"]).strip(),
+            status=str(item["status"]).strip(),
+            problem_solved=str(item["problem_solved"]).strip(),
+            example=str(item["example"]).strip(),
+            expected_output=str(item["expected_output"]).strip(),
+            test_file=str(item["test_file"]).strip(),
+            docs_page=str(item["docs_page"]).strip(),
+        )
+        if not entry.command:
+            raise ValueError(f"feature registry item #{i} has empty command")
+        if entry.command in seen:
+            raise ValueError(f"feature registry duplicate command: {entry.command}")
+        seen.add(entry.command)
+        rows.append(entry)
+
+    return rows
+
+
+def _table_line(item: FeatureEntry) -> str:
+    return (
+        f"| `{item.command}` | {item.tier} | {item.status} | {item.problem_solved} | "
+        f"`{item.example}` | [{item.test_file}]({item.test_file}) | [{item.docs_page}]({item.docs_page}) |"
+    )
+
+
+def render_feature_registry_table(rows: list[FeatureEntry]) -> str:
+    lines = [
+        "| Command | Tier | Status | Problem solved | Example | Test | Docs |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    lines.extend(_table_line(item) for item in sorted(rows, key=lambda x: (x.tier, x.command)))
+    return "\n".join(lines)
+
+
+def render_feature_registry_docs_block(rows: list[FeatureEntry]) -> str:
+    lines = [
+        "| Command | Tier | Status | Problem solved | Example | Test | Docs |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for item in sorted(rows, key=lambda x: (x.tier, x.command)):
+        test_link = f"../{item.test_file}"
+        docs_link = item.docs_page.removeprefix("docs/")
+        lines.append(
+            f"| `{item.command}` | {item.tier} | {item.status} | {item.problem_solved} | "
+            f"`{item.example}` | [{item.test_file}]({test_link}) | [{item.docs_page}]({docs_link}) |"
+        )
+    table = "\n".join(lines)
+    return f"{_DOC_TABLE_START}\n{table}\n{_DOC_TABLE_END}"
+
+
+def summarize_feature_registry(rows: list[FeatureEntry]) -> dict[str, object]:
+    by_tier: dict[str, int] = {}
+    by_status: dict[str, int] = {}
+    commands: list[str] = []
+    for item in sorted(rows, key=lambda x: x.command):
+        by_tier[item.tier] = by_tier.get(item.tier, 0) + 1
+        by_status[item.status] = by_status.get(item.status, 0) + 1
+        commands.append(item.command)
+    return {
+        "total": len(rows),
+        "by_tier": by_tier,
+        "by_status": by_status,
+        "commands": commands,
+    }
+
+
+def ensure_feature_registry_docs_synced(repo_root: Path) -> list[str]:
+    docs_path = repo_root / "docs" / "feature-registry.md"
+    if not docs_path.exists():
+        return ["feature-registry docs page is missing"]
+
+    text = docs_path.read_text(encoding="utf-8")
+    start = text.find(_DOC_TABLE_START)
+    end = text.find(_DOC_TABLE_END)
+    if start == -1 or end == -1 or end < start:
+        return ["feature-registry docs markers are missing or malformed"]
+
+    end += len(_DOC_TABLE_END)
+    current = text[start:end].strip()
+    expected = render_feature_registry_docs_block(load_feature_registry()).strip()
+    if current != expected:
+        return ["feature-registry docs table is stale; run scripts/sync_feature_registry_docs.py"]
+    return []
+
+
+def validate_feature_registry_contract(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    known_commands = _known_top_level_commands()
+
+    for item in load_feature_registry():
+        if item.tier not in _ALLOWED_TIERS:
+            errors.append(f"{item.command}: tier must be one of {_ALLOWED_TIERS}")
+        if item.status not in _ALLOWED_STATUSES:
+            errors.append(f"{item.command}: status must be one of {_ALLOWED_STATUSES}")
+        if not item.example.startswith("python -m sdetkit"):
+            errors.append(f"{item.command}: example must start with 'python -m sdetkit'")
+        if item.command not in known_commands:
+            errors.append(f"{item.command}: command is not in the public surface contract")
+        if item.tier == "A" and item.status != "stable":
+            errors.append(f"{item.command}: tier A commands must use stable status")
+
+        test_path = repo_root / item.test_file
+        if not test_path.exists():
+            errors.append(f"{item.command}: missing test file: {item.test_file}")
+
+        docs_path = repo_root / item.docs_page
+        if not docs_path.exists():
+            errors.append(f"{item.command}: missing docs page: {item.docs_page}")
+
+    errors.extend(ensure_feature_registry_docs_synced(repo_root))
+    return errors

--- a/src/sdetkit/feature_registry_cli.py
+++ b/src/sdetkit/feature_registry_cli.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+
+from .feature_registry import (
+    load_feature_registry,
+    render_feature_registry_docs_block,
+    render_feature_registry_table,
+    summarize_feature_registry,
+)
+
+
+def _parse_count_expectations(items: list[str], *, label: str) -> tuple[dict[str, int], str | None]:
+    out: dict[str, int] = {}
+    for raw in items:
+        token = str(raw).strip()
+        if not token:
+            continue
+        if "=" not in token:
+            return {}, f"feature-registry: invalid {label} expectation `{token}` (use KEY=INT)"
+        key, value = token.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            return {}, f"feature-registry: invalid {label} expectation `{token}` (missing key)"
+        try:
+            parsed = int(value)
+        except ValueError:
+            return {}, f"feature-registry: invalid {label} expectation `{token}` (count must be int)"
+        if parsed < 0:
+            return {}, f"feature-registry: invalid {label} expectation `{token}` (count must be >= 0)"
+        out[key] = parsed
+    return out, None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sdetkit feature-registry",
+        description="Inspect feature registry entries and filter by tier/status.",
+    )
+    p.add_argument("--tier", choices=["A", "B", "C"], default=None)
+    p.add_argument(
+        "--only-core",
+        action="store_true",
+        help="Convenience alias for --tier A.",
+    )
+    p.add_argument("--status", choices=["stable", "advanced", "experimental"], default=None)
+    p.add_argument(
+        "--expect-command",
+        action="append",
+        default=[],
+        help="Require one or more command names to exist in the filtered result set.",
+    )
+    p.add_argument(
+        "--fail-on-empty",
+        action="store_true",
+        help="Exit non-zero when filters return zero rows.",
+    )
+    p.add_argument(
+        "--expect-tier-count",
+        action="append",
+        default=[],
+        help="Assert tier counts using KEY=INT (repeatable), e.g. --expect-tier-count A=8.",
+    )
+    p.add_argument(
+        "--expect-status-count",
+        action="append",
+        default=[],
+        help="Assert status counts using KEY=INT (repeatable), e.g. --expect-status-count stable=8.",
+    )
+    p.add_argument(
+        "--expect-total",
+        type=int,
+        default=None,
+        help="Assert total row count after filtering.",
+    )
+    p.add_argument("--format", choices=["table", "json", "markdown", "summary-json"], default="table")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_parser().parse_args(argv)
+    rows = load_feature_registry()
+
+    if ns.only_core:
+        if ns.tier not in (None, "A"):
+            raise SystemExit("--only-core cannot be combined with --tier B/C")
+        ns.tier = "A"
+
+    if ns.tier is not None:
+        rows = [item for item in rows if item.tier == ns.tier]
+    if ns.status is not None:
+        rows = [item for item in rows if item.status == ns.status]
+    commands = {item.command for item in rows}
+
+    missing_commands = sorted({str(name).strip() for name in ns.expect_command if str(name).strip()} - commands)
+    if missing_commands:
+        print(
+            "feature-registry: missing expected command(s): " + ", ".join(missing_commands),
+            file=sys.stderr,
+        )
+        return 2
+
+    if ns.fail_on_empty and not rows:
+        print("feature-registry: filtered result set is empty", file=sys.stderr)
+        return 1
+    summary = summarize_feature_registry(rows)
+
+    tier_expectations, tier_error = _parse_count_expectations(
+        list(ns.expect_tier_count), label="tier-count"
+    )
+    if tier_error is not None:
+        print(tier_error, file=sys.stderr)
+        return 2
+    for tier, expected in tier_expectations.items():
+        actual = int((summary.get("by_tier", {}) or {}).get(tier, 0))
+        if actual != expected:
+            print(
+                f"feature-registry: tier count mismatch for `{tier}` (expected {expected}, got {actual})",
+                file=sys.stderr,
+            )
+            return 2
+
+    status_expectations, status_error = _parse_count_expectations(
+        list(ns.expect_status_count), label="status-count"
+    )
+    if status_error is not None:
+        print(status_error, file=sys.stderr)
+        return 2
+    for status, expected in status_expectations.items():
+        actual = int((summary.get("by_status", {}) or {}).get(status, 0))
+        if actual != expected:
+            print(
+                f"feature-registry: status count mismatch for `{status}` (expected {expected}, got {actual})",
+                file=sys.stderr,
+            )
+            return 2
+
+    if ns.expect_total is not None:
+        if ns.expect_total < 0:
+            print("feature-registry: --expect-total must be >= 0", file=sys.stderr)
+            return 2
+        actual_total = int(summary.get("total", 0))
+        if actual_total != ns.expect_total:
+            print(
+                f"feature-registry: total count mismatch (expected {ns.expect_total}, got {actual_total})",
+                file=sys.stderr,
+            )
+            return 2
+
+    if ns.format == "json":
+        print(json.dumps([asdict(item) for item in rows], indent=2, sort_keys=True))
+        return 0
+
+    if ns.format == "summary-json":
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+
+    if ns.format == "markdown":
+        print(render_feature_registry_docs_block(rows))
+        return 0
+
+    print(render_feature_registry_table(rows))
+    return 0

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -50,6 +50,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
             "ops",
             "notify",
             "agent",
+            "feature-registry",
         ),
     ),
     CommandFamilyContract(

--- a/tests/test_checks_registry.py
+++ b/tests/test_checks_registry.py
@@ -14,6 +14,7 @@ def test_registry_exposes_initial_real_checks_and_profiles() -> None:
 
     assert registry.profile_names() == ("quick", "standard", "strict", "adaptive")
     assert {
+        "feature_registry_contract",
         "format_check",
         "lint",
         "typing",
@@ -24,6 +25,7 @@ def test_registry_exposes_initial_real_checks_and_profiles() -> None:
     }.issubset(set(registry.check_ids()))
     assert registry.profile_check_ids("quick") == (
         "repo_layout",
+        "feature_registry_contract",
         "format_check",
         "lint",
         "typing",
@@ -47,6 +49,7 @@ def test_planner_selects_expected_checks_by_profile() -> None:
 
     assert quick.selected_ids == (
         "repo_layout",
+        "feature_registry_contract",
         "format_check",
         "lint",
         "typing",
@@ -54,6 +57,7 @@ def test_planner_selects_expected_checks_by_profile() -> None:
     )
     assert standard.selected_ids == (
         "repo_layout",
+        "feature_registry_contract",
         "doctor_core",
         "format_check",
         "lint",
@@ -63,6 +67,7 @@ def test_planner_selects_expected_checks_by_profile() -> None:
     )
     assert strict.selected_ids == (
         "repo_layout",
+        "feature_registry_contract",
         "doctor_core",
         "format_check",
         "lint",

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -53,6 +53,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "release-communications" in out
     assert "release-narrative" not in out
     assert "trust-assets" in out
+    assert "feature-registry" in out
     assert "trust-signal-upgrade" not in out
     assert "objection-handling" in out
     assert "faq-objections" not in out

--- a/tests/test_feature_registry.py
+++ b/tests/test_feature_registry.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sdetkit.feature_registry import (
+    ensure_feature_registry_docs_synced,
+    load_feature_registry,
+    render_feature_registry_docs_block,
+    validate_feature_registry_contract,
+)
+from sdetkit.public_surface_contract import PUBLIC_SURFACE_CONTRACT
+
+
+def test_feature_registry_entries_are_loadable() -> None:
+    rows = load_feature_registry()
+
+    assert rows
+    assert all(row.tier in {"A", "B", "C"} for row in rows)
+    assert all(row.status in {"stable", "advanced", "experimental"} for row in rows)
+    assert all(row.example.startswith("python -m sdetkit") for row in rows)
+
+
+def test_feature_registry_contract_links_existing_assets() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    errors = validate_feature_registry_contract(repo_root)
+
+    assert errors == []
+
+
+def test_feature_registry_docs_table_is_synced() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    errors = ensure_feature_registry_docs_synced(repo_root)
+
+    assert errors == []
+
+
+def test_feature_registry_commands_are_in_public_surface_contract() -> None:
+    known: set[str] = set()
+    for family in PUBLIC_SURFACE_CONTRACT:
+        known.update(family.top_level_commands)
+
+    rows = load_feature_registry()
+    assert all(row.command in known for row in rows)
+
+
+def test_feature_registry_docs_block_uses_docs_relative_links() -> None:
+    rows = load_feature_registry()
+    block = render_feature_registry_docs_block(rows)
+    row_lines = [line for line in block.splitlines() if line.startswith("| `")]
+
+    assert "(../tests/" in block
+    assert "(docs/" not in block
+    assert "(doctor.md)" in block or "(cli.md)" in block
+    assert len(row_lines) == len(rows)
+
+
+def test_contract_script_runs_without_external_pythonpath() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+
+    proc = subprocess.run(
+        [sys.executable, "scripts/check_feature_registry_contract.py", "--repo-root", str(repo_root)],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "feature-registry-contract check passed" in proc.stdout
+
+
+def test_sync_script_check_mode_runs_without_external_pythonpath() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+
+    proc = subprocess.run(
+        [sys.executable, "scripts/sync_feature_registry_docs.py", "--repo-root", str(repo_root), "--check"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "feature-registry docs table is up to date" in proc.stdout

--- a/tests/test_feature_registry_cli.py
+++ b/tests/test_feature_registry_cli.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from sdetkit import feature_registry_cli
+
+
+def test_feature_registry_cli_json_filter_tier_a(capsys) -> None:
+    rc = feature_registry_cli.main(["--tier", "A", "--format", "json"])
+    assert rc == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload
+    assert all(item["tier"] == "A" for item in payload)
+
+
+def test_feature_registry_cli_table_contains_header(capsys) -> None:
+    rc = feature_registry_cli.main(["--format", "table"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "| Command | Tier | Status |" in out
+
+
+def test_feature_registry_cli_only_core_sets_tier_a(capsys) -> None:
+    rc = feature_registry_cli.main(["--only-core", "--format", "json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload
+    assert all(item["tier"] == "A" for item in payload)
+
+
+def test_feature_registry_cli_markdown_format_has_markers(capsys) -> None:
+    rc = feature_registry_cli.main(["--format", "markdown"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "<!-- feature-registry:table:start -->" in out
+    assert "<!-- feature-registry:table:end -->" in out
+
+
+def test_feature_registry_cli_summary_json_has_expected_shape(capsys) -> None:
+    rc = feature_registry_cli.main(["--format", "summary-json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total"] >= 1
+    assert "A" in payload["by_tier"]
+    assert "stable" in payload["by_status"]
+    assert isinstance(payload["commands"], list)
+    assert "kits" in payload["commands"]
+
+
+def test_feature_registry_cli_rejects_conflicting_only_core_and_tier() -> None:
+    with pytest.raises(SystemExit):
+        feature_registry_cli.main(["--only-core", "--tier", "B"])
+
+
+def test_feature_registry_cli_expect_command_passes_when_present(capsys) -> None:
+    rc = feature_registry_cli.main(["--expect-command", "kits", "--format", "summary-json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "kits" in payload["commands"]
+
+
+def test_feature_registry_cli_expect_command_fails_when_missing(capsys) -> None:
+    rc = feature_registry_cli.main(["--expect-command", "nope-nope-nope", "--format", "summary-json"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "missing expected command" in err
+
+
+def test_feature_registry_cli_fail_on_empty_returns_nonzero(capsys) -> None:
+    rc = feature_registry_cli.main(
+        ["--tier", "A", "--status", "experimental", "--fail-on-empty", "--format", "summary-json"]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "filtered result set is empty" in err
+
+
+def test_feature_registry_cli_expect_tier_and_status_count_pass(capsys) -> None:
+    rc = feature_registry_cli.main(
+        [
+            "--expect-total",
+            "8",
+            "--expect-tier-count",
+            "A=8",
+            "--expect-status-count",
+            "stable=8",
+            "--format",
+            "summary-json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["by_tier"]["A"] == 8
+    assert payload["by_status"]["stable"] == 8
+
+
+def test_feature_registry_cli_expect_total_mismatch_fails(capsys) -> None:
+    rc = feature_registry_cli.main(["--expect-total", "999", "--format", "summary-json"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "total count mismatch" in err
+
+
+def test_feature_registry_cli_expect_total_negative_fails(capsys) -> None:
+    rc = feature_registry_cli.main(["--expect-total", "-1", "--format", "summary-json"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "--expect-total must be >= 0" in err
+
+
+def test_feature_registry_cli_expect_tier_count_mismatch_fails(capsys) -> None:
+    rc = feature_registry_cli.main(["--expect-tier-count", "A=999", "--format", "summary-json"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "tier count mismatch" in err
+
+
+def test_feature_registry_cli_invalid_expectation_format_fails(capsys) -> None:
+    rc = feature_registry_cli.main(["--expect-tier-count", "bad-format", "--format", "summary-json"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "invalid tier-count expectation" in err
+
+
+def test_python_m_sdetkit_feature_registry_json() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "feature-registry", "--format", "json"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert isinstance(payload, list)
+    assert payload

--- a/tests/test_quality_script.py
+++ b/tests/test_quality_script.py
@@ -20,7 +20,7 @@ def test_quality_script_unknown_mode_suggests_closest_match() -> None:
 def test_quality_script_help_documents_fast_and_full_lanes() -> None:
     text = Path("quality.sh").read_text(encoding="utf-8")
     assert (
-        "Usage: bash quality.sh {all|ci|verify|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost}"
+        "Usage: bash quality.sh {all|ci|verify|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost|registry}"
         in text
     )
     assert "quick     Fast local confidence / smoke profile." in text
@@ -35,6 +35,7 @@ def test_quality_script_help_documents_fast_and_full_lanes() -> None:
         "Full verification lane before merge (doctor, format, lint, typing, full tests, security scan)."
         in text
     )
+    assert "registry   Validate and smoke-test feature-registry docs/contracts surface." in text
 
 
 def test_quality_script_verify_delegates_to_planner_runner() -> None:
@@ -68,3 +69,17 @@ def test_quality_script_writes_final_verdict_contract() -> None:
     assert "profile used" in text
     assert "checks skipped" in text
     assert "merge/release recommendation" in text
+
+
+def test_quality_script_registry_mode_runs_contract_chain() -> None:
+    text = Path("quality.sh").read_text(encoding="utf-8")
+    match = re.search(r"  registry\)\n(?P<body>.*?    ;;)", text, re.DOTALL)
+    assert match is not None
+    body = match.group("body")
+    assert "run_required \"feature_registry_contract\"" in body
+    assert "run_registry_contract" in body
+    assert "--expect-command kits" in text
+    assert "--expect-total 8" in text
+    assert "--expect-tier-count A=8" in text
+    assert "--expect-status-count stable=8" in text
+    assert "--fail-on-empty" in text


### PR DESCRIPTION
### Motivation

- Introduce a feature registry to make the CLI surface explicit, document command tiers/status, and enforce linkages between commands, tests, and docs.

### Description

- Add feature registry data and loader: `src/sdetkit/data/feature_registry.json` and `src/sdetkit/feature_registry.py` with rendering, summarization, and contract validation helpers.
- Add CLI and scripts: `src/sdetkit/feature_registry_cli.py`, `scripts/sync_feature_registry_docs.py`, and `scripts/check_feature_registry_contract.py` to inspect, sync, and validate the registry and docs table.
- Wire registry checks into the quality system: `quality.sh` gains a `registry` mode and `run_registry_contract`, `src/sdetkit/checks/builtin.py` and `src/sdetkit/checks/registry.py` include a `feature_registry_contract` check and profiles updated, and `Makefile` gains a `registry` target.
- Add docs and governance: `docs/feature-registry.md`, updates to `docs/*` and `CONTRIBUTING.md` with checklist entries, and include `feature-registry` in the public surface contract and root CLI wiring in `src/sdetkit/cli.py`.
- Add tests covering loader, CLI, scripts, and checks: `tests/test_feature_registry*.py` and update existing tests to expect the new check/CLI registration.

### Testing

- Ran the unit test suite with `pytest -q`, which includes the new `tests/test_feature_registry*.py` and related CLI tests, and the tests passed.
- Executed the registry smoke and sync checks via `bash quality.sh registry` and `python scripts/sync_feature_registry_docs.py --check` plus `scripts/check_feature_registry_contract.py`, which completed successfully in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d312891aa883209d95c95e280b368b)