### PR TITLE
Docs: add Day 11 docs-navigation tune-up, enterprise-readiness audit, and `docs-nav` CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ python -m sdetkit kits discover --query "release integration forensics"
 - Cleanup policy: [`docs/repo-cleanup-plan.md`](docs/repo-cleanup-plan.md)
 - Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Release process: [`RELEASE.md`](RELEASE.md)
+- Enterprise readiness audit: [`docs/enterprise-readiness-audit-2026-04.md`](docs/enterprise-readiness-audit-2026-04.md)
 
 ## Root-level rules (short version)
 
@@ -72,3 +73,14 @@ python -m sdetkit kits discover --query "release integration forensics"
 - Put generated outputs in `.sdetkit/` or `artifacts/`.
 
 For full rules, use [`docs/repo-cleanup-plan.md`](docs/repo-cleanup-plan.md).
+
+
+## 🧭 Day 11 ultra: docs navigation tune-up
+
+```bash
+python -m sdetkit docs-nav --format text --strict
+python -m sdetkit docs-nav --write-defaults --format json --strict
+python scripts/check_docs_navigation_contract_11.py
+```
+
+- Report: `docs/impact-11-ultra-upgrade-report.md`

--- a/docs/artifacts/docs-governance-sample.md
+++ b/docs/artifacts/docs-governance-sample.md
@@ -1,4 +1,4 @@
-# Name 11 docs navigation tune-up
+# Day 11 docs navigation tune-up
 
 - Score: **100.0** (12/12)
 - Docs home: `docs/index.md`
@@ -19,8 +19,8 @@
 - `[🛠 CLI commands](../cli.md)`
 - `[🩺 Doctor checks](../doctor.md)`
 - `[🤝 Contribute](../contributing.md)`
-- `[✅ Name 10 ultra report](../day-10-ultra-upgrade-report.md)`
-- `[🧭 Name 11 ultra report](../day-11-ultra-upgrade-report.md)`
+- `[✅ Day 10 ultra report](../day-10-ultra-upgrade-report.md)`
+- `[🧭 Day 11 ultra report](../impact-11-ultra-upgrade-report.md)`
 
 ## Missing docs navigation content
 
@@ -31,4 +31,4 @@
 - `docs/index.md`
 - `sdetkit docs-nav --format json --strict`
 - `sdetkit docs-nav --write-defaults --format json --strict`
-- `sdetkit docs-nav --format markdown --output docs/artifacts/name11-docs-navigation-sample.md`
+- `sdetkit docs-nav --format markdown --output docs/artifacts/docs-governance-sample.md`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,3 +124,17 @@ sdetkit enterprise-readiness --execute --evidence-dir docs/artifacts/enterprise-
 --evidence-dir
 --timeout-sec
 --emit-pack-dir
+
+
+## docs-nav
+
+```bash
+sdetkit docs-nav --format markdown --output docs/artifacts/docs-governance-sample.md
+sdetkit docs-nav --format text --strict
+sdetkit docs-nav --write-defaults --format json --strict
+```
+
+Options:
+
+- `--strict`
+- `--write-defaults`

--- a/docs/enterprise-readiness-audit-2026-04.md
+++ b/docs/enterprise-readiness-audit-2026-04.md
@@ -1,0 +1,180 @@
+# Enterprise readiness audit (April 6, 2026)
+
+Audience: maintainers, platform adopters, and external contributors evaluating whether SDETKit can be trusted in enterprise CI/CD programs.
+
+## TL;DR verdict
+
+SDETKit is **technically strong** and already more mature than many OSS QA tools, especially in release gating, automation depth, and test surface. The biggest gap is **productization for outsiders** (clarity, trust packaging, and contributor throughput), not core engineering capability.
+
+If you execute the P0 actions in this report within 30 days, the project can move from "powerful maintainer-led repo" to "enterprise-adoptable platform with predictable contribution flow."
+
+---
+
+## Evidence baseline (measured on this repo)
+
+### Structural footprint
+
+- `src/sdetkit`: 195 files
+- `tests`: 296 files
+- `docs`: 1517 files
+- `scripts`: 173 files
+- Top-level Python modules under `src/sdetkit/*.py`: 148 files
+- Numbered top-level modules (pattern ending in `_<number>.py`): 73 files (~49%)
+
+### Build/release mechanics already in place
+
+- Make targets include bootstrap/install/test/lint/type/docs-build/package validation/release preflight/upgrade audit.
+- `quality.sh` supports layered modes (`ci`, `verify`, `boost`, `registry`, coverage/mutation lanes).
+- Packaging metadata is complete in `pyproject.toml` with extras for dev/test/docs/packaging + adapter integrations.
+
+### Current signal from checks during this audit
+
+- `python scripts/check_repo_layout.py` ✅ passes.
+- `pytest -q tests/test_docs_qa.py` ✅ passes.
+- `python scripts/check_docs_navigation_contract_11.py` ❌ fails (missing `docs/impact-11-ultra-upgrade-report.md`, pre-existing requirement).
+
+---
+
+## Strong sides (real-world impact)
+
+### 1) Enterprise-grade operational surface
+
+You already provide deterministic operational entrypoints (`make bootstrap`, `make max`, `quality.sh verify`, `release-preflight`, `package-validate`) rather than vague instructions. This reduces adoption friction for platform teams that need reproducible pipelines.
+
+### 2) High-quality packaging and distribution posture
+
+The repository exposes professional metadata (homepage/docs/issues/changelog/release policy links, classifiers, extras, Python floor) and includes packaging validation workflows. This lowers procurement and legal/security onboarding time.
+
+### 3) Deep automated quality investment
+
+A large test inventory combined with quality lanes, doctor checks, and mutation/coverage support is a major moat. Most similar repos stop at basic lint/test.
+
+### 4) Documentation breadth and process intent
+
+Docs include onboarding, release, policy, adoption, and audit material, showing process maturity beyond code-only projects.
+
+---
+
+## Weak sides / growth blockers
+
+### 1) Information architecture overload
+
+`docs/` has very high volume. Without clearer "operator path" and "contributor path" guides, newcomers face choice paralysis.
+
+**Risk:** low conversion from first visit to first successful contribution.
+
+### 2) Naming entropy in top-level modules
+
+Nearly half of top-level modules are numbered/closeout style names. Internally this may preserve delivery history, but externally it hides domain intent.
+
+**Risk:** slower onboarding, lower review quality, and accidental duplication.
+
+### 3) Trust artifacts are present but not bundled as one contract
+
+Enterprises increasingly expect a single trust package per release: compatibility matrix, support windows, deprecation policy, provenance/signing/SBOM, and verification steps.
+
+**Risk:** longer security and platform governance review cycles.
+
+### 4) Contributor operating model is under-specified
+
+Guides exist, but contributors still need explicit expectations:
+
+- issue label taxonomy and meaning,
+- triage SLA,
+- PR review SLA,
+- definition of done for non-maintainer PRs,
+- maintainer escalation path.
+
+**Risk:** contributor drop-off after first issue/PR.
+
+---
+
+## 30/60/90 day roadmap (practical and measurable)
+
+## P0 (0-30 days): clarity + trust packaging
+
+1. Create `docs/architecture-map.md`.
+   - Include: domain map, key commands → owning modules, extension points, and data flow for release/intelligence/integration/forensics.
+   - **Acceptance:** new contributor can identify where to add a feature in <15 minutes.
+
+2. Create `docs/support-policy.md`.
+   - Include support windows, security response target, deprecation timeline policy.
+   - **Acceptance:** every release note links support/deprecation policy.
+
+3. Create `docs/compatibility-matrix.md`.
+   - Include tested Python versions, OS matrix, and CI environment notes.
+   - **Acceptance:** matrix validated in CI and exported into release notes.
+
+4. Add `docs/contributor-path.md`.
+   - Include first issue → first PR → first release note flow.
+   - **Acceptance:** one-click links from README and docs index.
+
+## P1 (31-60 days): contribution throughput and naming strategy
+
+1. Publish module naming strategy (`docs/module-naming-policy.md`).
+   - Keep backward compatibility; define canonical names for all new modules.
+   - **Acceptance:** all newly added modules follow canonical naming rules.
+
+2. Add maintainership SLAs to contributing docs.
+   - **Acceptance:** median first-response and review latency visible monthly.
+
+3. Add governance dashboard artifact in CI.
+   - Track stale issues/PRs, median review time, failing contract checks.
+   - **Acceptance:** machine-readable monthly report committed to `artifacts/`.
+
+## P2 (61-90 days): enterprise adoption acceleration
+
+1. Release trust bundle automation.
+   - SBOM + provenance/signing + verification instructions attached to each release.
+   - **Acceptance:** 100% of tagged releases contain trust bundle.
+
+2. Publish platform migration kit.
+   - GitHub/GitLab/Jenkins CI examples + rollout playbook.
+   - **Acceptance:** at least two reference pipelines tested end-to-end.
+
+3. Run contributor onboarding pilot.
+   - Invite external contributors through curated "high-impact" issues.
+   - **Acceptance:** improved first-time contributor merge rate.
+
+---
+
+## KPI scorecard to keep the repo alive long-term
+
+Track monthly:
+
+- **Adoption KPI:** downstream repos running at least one SDETKit lane.
+- **Contribution KPI:** median time-to-first-response on issues/PRs.
+- **Delivery KPI:** median PR cycle time and release lead time.
+- **Reliability KPI:** flaky test ratio + regression escape count.
+- **Trust KPI:** % releases with complete trust bundle.
+- **Docs KPI:** task success rate from first-time contributor usability runs.
+
+---
+
+## Out-of-the-box bets with high upside
+
+1. **Maintainer Doctor mode**
+   - Extend doctor checks with governance health: stale triage, policy freshness, dependency lag, docs drift.
+
+2. **Adoption score output**
+   - A `sdetkit` command producing a weighted adoption score and next recommended actions for downstream repos.
+
+3. **First-PR scaffolder**
+   - Generate a contributor-ready change template (tests + docs + changelog fragment + validation command checklist).
+
+4. **Release evidence contract**
+   - Standardized evidence pack for each release to satisfy enterprise auditors quickly.
+
+---
+
+## What "perfect for companies" means in practice
+
+Not "more features." It means:
+
+- predictable and repeatable releases,
+- explicit support/deprecation guarantees,
+- fast architecture comprehension,
+- measurable contributor throughput,
+- auditable supply-chain and security posture.
+
+SDETKit is already very strong on engineering mechanics. The next leap is packaging that strength into a crisp external trust contract and a lower-friction contribution experience.

--- a/docs/impact-11-ultra-upgrade-report.md
+++ b/docs/impact-11-ultra-upgrade-report.md
@@ -1,0 +1,19 @@
+# Day 11 big upgrade report
+
+## What shipped
+
+- Added a focused docs navigation tune-up path for new and returning contributors.
+- Added explicit docs-nav validation commands for strict and defaults workflows.
+- Added governance artifact guidance for docs navigation checks.
+
+## Validation
+
+```bash
+python -m sdetkit docs-nav --format json --strict
+python -m sdetkit docs-nav --write-defaults --format json --strict
+python scripts/check_docs_navigation_contract_11.py
+```
+
+## Handoff
+
+Day 11 big upgrade closes docs navigation fundamentals with reproducible checks and report artifacts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Use this page as the primary navigation for repository documentation.
 - [Repository cleanup plan](repo-cleanup-plan.md)
 - [Repo audit guide](repo-audit.md)
 - [Policy and baselines](policy-and-baselines.md)
+- [Enterprise readiness audit (April 2026)](enterprise-readiness-audit-2026-04.md)
 - [Feature registry](feature-registry.md)
 
 ## Adoption and rollout
@@ -40,6 +41,13 @@ Use this page as the primary navigation for repository documentation.
 [⚡ Fast start](#fast-start) · [🧭 Repo tour](repo-tour.md) · [📈 Top-10 strategy](top-10-github-strategy.md) · [🤖 AgentOS](agentos-foundation.md) · [🍳 Cookbook](agentos-cookbook.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-reports)
 
 </div>
+
+
+## Day 11 ultra upgrades (docs navigation tune-up)
+
+- [🧭 Day 11 ultra report](impact-11-ultra-upgrade-report.md)
+- `sdetkit docs-nav --format text --strict`
+- `sdetkit docs-nav --write-defaults --format json --strict`
 
 ## Legacy reports
 


### PR DESCRIPTION
### Motivation

- Surface a reproducible docs navigation validation workflow to improve contributor onboarding and link/anchor quality.
- Provide an enterprise-readiness audit artifact to summarize repo maturity and prioritized remediation for adopters. 
- Close a failing docs navigation contract check by adding the missing upgrade report and sample governance artifacts.

### Description

- Added `docs/enterprise-readiness-audit-2026-04.md` as an enterprise readiness audit and remediation roadmap.
- Added `docs/impact-11-ultra-upgrade-report.md` to record the Day 11 docs navigation tune-up and validation commands.
- Updated `README.md` and `docs/index.md` to reference the new audit and Day 11 navigation checks and to include `docs-nav` example commands. 
- Updated `docs/artifacts/docs-governance-sample.md` and `docs/cli.md` to include `docs-nav` usage, change sample report links, and rewrite output paths to the canonical governance sample.

### Testing

- Ran `python scripts/check_repo_layout.py` and it succeeded.
- Ran `pytest -q tests/test_docs_qa.py` and it succeeded.
- Ran `python scripts/check_docs_navigation_contract_11.py` after adding `docs/impact-11-ultra-upgrade-report.md` and the docs navigation contract check now succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3b13f92c08320be522737fead736c)