### PR TITLE
Fix CI/publish failures: lint, typing, docs sync, and mkdocs issues

### DIFF
--- a/docs/artifacts/trust-assets-pack/trust-assets-action-plan.md
+++ b/docs/artifacts/trust-assets-pack/trust-assets-action-plan.md
@@ -1,4 +1,5 @@
 # Trust assets action plan
 
+- Restore missing trust badges in README so reliability status is visible at a glance.
 - Ensure policy documents exist and are linked from README governance references.
 - Keep CI/security/pages workflows and docs index trust references present for reviewers.

--- a/docs/artifacts/trust-assets-pack/trust-assets-scorecard.md
+++ b/docs/artifacts/trust-assets-pack/trust-assets-scorecard.md
@@ -2,19 +2,19 @@
 
 ## Trust posture
 
-- Trust score: **68.0**
+- Trust score: **18.0**
 - Trust label: **review**
-- Weighted points: **68/100**
-- Failed checks: **4**
+- Weighted points: **18/100**
+- Failed checks: **9**
 - Critical failures: **security_doc_exists**
 
 ## Check matrix
 
-- **badges::ci_badge** (10 pts): pass
-- **badges::quality_badge** (10 pts): pass
-- **badges::mutation_badge** (10 pts): pass
-- **badges::security_badge** (10 pts): pass
-- **badges::pages_badge** (10 pts): pass
+- **badges::ci_badge** (10 pts): missing
+- **badges::quality_badge** (10 pts): missing
+- **badges::mutation_badge** (10 pts): missing
+- **badges::security_badge** (10 pts): missing
+- **badges::pages_badge** (10 pts): missing
 - **policy::security_doc_exists** (10 pts): missing
 - **policy::security_guide_exists** (10 pts): missing
 - **policy::policy_baseline_exists** (10 pts): missing
@@ -25,5 +25,6 @@
 
 ## Recommendations
 
+- Restore missing trust badges in README so reliability status is visible at a glance.
 - Ensure policy documents exist and are linked from README governance references.
 - Keep CI/security/pages workflows and docs index trust references present for reviewers.

--- a/docs/artifacts/trust-assets-pack/trust-assets-summary.json
+++ b/docs/artifacts/trust-assets-pack/trust-assets-summary.json
@@ -1,45 +1,45 @@
 {
   "badge_checks": {
-    "ci_badge": true,
-    "mutation_badge": true,
-    "pages_badge": true,
-    "quality_badge": true,
-    "security_badge": true
+    "ci_badge": false,
+    "mutation_badge": false,
+    "pages_badge": false,
+    "quality_badge": false,
+    "security_badge": false
   },
   "checks": [
     {
       "category": "badges",
       "evidence": "actions/workflows/ci.yml/badge.svg",
       "key": "ci_badge",
-      "passed": true,
+      "passed": false,
       "weight": 10
     },
     {
       "category": "badges",
       "evidence": "actions/workflows/quality.yml/badge.svg",
       "key": "quality_badge",
-      "passed": true,
+      "passed": false,
       "weight": 10
     },
     {
       "category": "badges",
       "evidence": "actions/workflows/mutation-tests.yml/badge.svg",
       "key": "mutation_badge",
-      "passed": true,
+      "passed": false,
       "weight": 10
     },
     {
       "category": "badges",
       "evidence": "actions/workflows/security.yml/badge.svg",
       "key": "security_badge",
-      "passed": true,
+      "passed": false,
       "weight": 10
     },
     {
       "category": "badges",
       "evidence": "actions/workflows/pages.yml/badge.svg",
       "key": "pages_badge",
-      "passed": true,
+      "passed": false,
       "weight": 10
     },
     {
@@ -121,6 +121,7 @@
     "security_guide_exists": false
   },
   "recommendations": [
+    "Restore missing trust badges in README so reliability status is visible at a glance.",
     "Ensure policy documents exist and are linked from README governance references.",
     "Keep CI/security/pages workflows and docs index trust references present for reviewers."
   ],
@@ -129,7 +130,7 @@
   "summary": {
     "category_coverage": {
       "badges": {
-        "passed": 5,
+        "passed": 0,
         "total": 5
       },
       "governance": {
@@ -144,11 +145,11 @@
     "critical_failures": [
       "security_doc_exists"
     ],
-    "failed_checks": 4,
+    "failed_checks": 9,
     "trust_label": "review",
-    "trust_score": 68.0,
+    "trust_score": 18.0,
     "weighted_points": {
-      "earned": 68,
+      "earned": 18,
       "total": 100
     }
   }

--- a/docs/feature-registry.md
+++ b/docs/feature-registry.md
@@ -30,14 +30,14 @@ Run `python scripts/sync_feature_registry_docs.py` after registry updates.
 <!-- feature-registry:table:start -->
 | Command | Tier | Status | Problem solved | Example | Test | Docs |
 | --- | --- | --- | --- | --- | --- | --- |
-| `doctor` | A | stable | Provides deterministic repo diagnostics and readiness scoring. | `python -m sdetkit doctor --format md` | [tests/test_cli_doctor.py](../tests/test_cli_doctor.py) | [docs/doctor.md](doctor.md) |
-| `forensics` | A | stable | Compares runs and pinpoints failure deltas for root-cause analysis. | `python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json` | [tests/test_cli_sdetkit.py](../tests/test_cli_sdetkit.py) | [docs/cli.md](cli.md) |
-| `gate` | A | stable | Runs fast and strict confidence checks for release control. | `python -m sdetkit gate fast` | [tests/test_gate_fast.py](../tests/test_gate_fast.py) | [docs/cli.md](cli.md) |
-| `integration` | A | stable | Validates integration topologies and runtime compatibility. | `python -m sdetkit integration check --profile examples/kits/integration/profile.json` | [tests/test_integration_feedback_closeout.py](../tests/test_integration_feedback_closeout.py) | [docs/cli.md](cli.md) |
-| `intelligence` | A | stable | Analyzes failure trends and flaky behavior for triage. | `python -m sdetkit intelligence --help` | [tests/test_cli_sdetkit.py](../tests/test_cli_sdetkit.py) | [docs/cli.md](cli.md) |
-| `kits` | A | stable | Discovers the curated umbrella surfaces for fast adoption. | `python -m sdetkit kits list` | [tests/test_cli_sdetkit.py](../tests/test_cli_sdetkit.py) | [docs/cli.md](cli.md) |
-| `release` | A | stable | Runs release-confidence checks and gate workflows. | `python -m sdetkit release gate fast` | [tests/test_release_readiness.py](../tests/test_release_readiness.py) | [docs/release-readiness.md](release-readiness.md) |
-| `repo` | A | stable | Performs repo policy and automation audits. | `python -m sdetkit repo --help` | [tests/test_repo_check_cli.py](../tests/test_repo_check_cli.py) | [docs/repo-audit.md](repo-audit.md) |
+| `doctor` | A | stable | Provides deterministic repo diagnostics and readiness scoring. | `python -m sdetkit doctor --format md` | `tests/test_cli_doctor.py` | [docs/doctor.md](doctor.md) |
+| `forensics` | A | stable | Compares runs and pinpoints failure deltas for root-cause analysis. | `python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json` | `tests/test_cli_sdetkit.py` | [docs/cli.md](cli.md) |
+| `gate` | A | stable | Runs fast and strict confidence checks for release control. | `python -m sdetkit gate fast` | `tests/test_gate_fast.py` | [docs/cli.md](cli.md) |
+| `integration` | A | stable | Validates integration topologies and runtime compatibility. | `python -m sdetkit integration check --profile examples/kits/integration/profile.json` | `tests/test_integration_feedback_closeout.py` | [docs/cli.md](cli.md) |
+| `intelligence` | A | stable | Analyzes failure trends and flaky behavior for triage. | `python -m sdetkit intelligence --help` | `tests/test_cli_sdetkit.py` | [docs/cli.md](cli.md) |
+| `kits` | A | stable | Discovers the curated umbrella surfaces for fast adoption. | `python -m sdetkit kits list` | `tests/test_cli_sdetkit.py` | [docs/cli.md](cli.md) |
+| `release` | A | stable | Runs release-confidence checks and gate workflows. | `python -m sdetkit release gate fast` | `tests/test_release_readiness.py` | [docs/release-readiness.md](release-readiness.md) |
+| `repo` | A | stable | Performs repo policy and automation audits. | `python -m sdetkit repo --help` | `tests/test_repo_check_cli.py` | [docs/repo-audit.md](repo-audit.md) |
 <!-- feature-registry:table:end -->
 
 ## Source of truth

--- a/docs/global-production-transformation-playbook.md
+++ b/docs/global-production-transformation-playbook.md
@@ -1,0 +1,6 @@
+# Global production transformation playbook
+
+This page is the global index for production transformation workflows.
+
+- Readiness: [Production readiness](production-readiness.md)
+- Program framing: [World class quality program](world-class-quality-program.md)

--- a/docs/governance-and-org-packs.md
+++ b/docs/governance-and-org-packs.md
@@ -1,0 +1,6 @@
+# Governance and org packs
+
+Governance packs bundle policy, ownership, and operating rhythm artifacts.
+
+- Governance baseline: [Policy and baselines](policy-and-baselines.md)
+- Enterprise framing: [Enterprise productization blueprint](enterprise-productization-blueprint.md)

--- a/docs/platform-problem-authoring.md
+++ b/docs/platform-problem-authoring.md
@@ -1,0 +1,6 @@
+# Platform problem authoring
+
+This page has moved into the platform problem template and automation docs.
+
+- Start here: [Automation templates engine](automation-templates-engine.md)
+- Related: [Policy and baselines](policy-and-baselines.md)

--- a/scripts/check_contribution_templates_contract_9.py
+++ b/scripts/check_contribution_templates_contract_9.py
@@ -11,14 +11,14 @@ LANE_ARTIFACT = Path("docs/artifacts/triage-templates-sample-9.md")
 ISSUE_CONFIG = Path(".github/ISSUE_TEMPLATE/config.yml")
 
 README_EXPECTED = [
-    '## 🧩  ultra: contribution templates',
+    "## 🧩  ultra: contribution templates",
     "python -m sdetkit triage-templates --format text --strict",
     "python -m sdetkit triage-templates --write-defaults --format json --strict",
     "docs/impact-9-ultra-upgrade-report.md",
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '##  ultra upgrades (contribution templates)',
+    "##  ultra upgrades (contribution templates)",
     "sdetkit triage-templates --format text --strict",
     "sdetkit triage-templates --write-defaults --format json --strict",
     "artifacts/triage-templates-sample-9.md",
@@ -32,7 +32,7 @@ DOCS_CLI_EXPECTED = [
 ]
 
 REPORT_EXPECTED = [
-    ' big upgrade',
+    " big upgrade",
     "python -m sdetkit triage-templates --format json --strict",
     "python -m sdetkit triage-templates --write-defaults --format json --strict",
     "scripts/check_contribution_templates_contract_9.py",

--- a/scripts/check_contributor_funnel_contract_8.py
+++ b/scripts/check_contributor_funnel_contract_8.py
@@ -12,20 +12,20 @@ ISSUE_PACK = Path("docs/artifacts/contributor-issue-pack")
 LANE_MODULE = Path("src/sdetkit/contributor_funnel.py")
 
 REQUIRED_README_SNIPPETS = [
-    '## 🧲  ultra: contributor funnel backlog',
+    "## 🧲  ultra: contributor funnel backlog",
     "python -m sdetkit contributor-funnel --format text --strict",
     "python -m sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/contributor-issue-pack",
     "docs/impact-8-ultra-upgrade-report.md",
 ]
 
 REQUIRED_INDEX_SNIPPETS = [
-    ' ultra upgrade report',
+    " ultra upgrade report",
     "sdetkit contributor-funnel --format text --strict",
     "sdetkit contributor-funnel --area docs --issue-pack-dir docs/artifacts/contributor-issue-pack",
 ]
 
 REQUIRED_REPORT_SNIPPETS = [
-    ' big upgrade',
+    " big upgrade",
     "src/sdetkit/contributor_funnel.py",
     "tests/test_contributor_funnel.py",
     "python scripts/check_contributor_funnel_contract_8.py",

--- a/scripts/check_conversion_contract_6.py
+++ b/scripts/check_conversion_contract_6.py
@@ -11,19 +11,19 @@ LANE_ARTIFACT = Path("docs/artifacts/conversion-qa-sample-6.md")
 DOCS_QA_MODULE = Path("src/sdetkit/docs_qa.py")
 
 REQUIRED_README_SNIPPETS = [
-    '## 🔗  ultra: conversion QA hardening',
+    "## 🔗  ultra: conversion QA hardening",
     "python -m sdetkit docs-qa --format text",
     "python -m sdetkit docs-qa --format markdown --output docs/artifacts/conversion-qa-sample-6.md",
     "docs/impact-6-ultra-upgrade-report.md",
 ]
 
 REQUIRED_INDEX_SNIPPETS = [
-    ' ultra upgrade report',
+    " ultra upgrade report",
     "sdetkit docs-qa --format text",
 ]
 
 REQUIRED_REPORT_SNIPPETS = [
-    ' big upgrade',
+    " big upgrade",
     "src/sdetkit/docs_qa.py",
     "tests/test_docs_qa.py",
     "python scripts/check_conversion_contract_6.py",

--- a/scripts/check_docs_navigation_contract_11.py
+++ b/scripts/check_docs_navigation_contract_11.py
@@ -10,7 +10,7 @@ LANE_REPORT = Path("docs/impact-11-ultra-upgrade-report.md")
 DOCS_NAV_ARTIFACT = Path("docs/artifacts/docs-governance-sample.md")
 
 README_EXPECTED = [
-    '## 🧭  ultra: docs navigation tune-up',
+    "## 🧭  ultra: docs navigation tune-up",
     "python -m sdetkit docs-nav --format text --strict",
     "python -m sdetkit docs-nav --write-defaults --format json --strict",
     "python scripts/check_docs_navigation_contract_11.py",
@@ -18,8 +18,8 @@ README_EXPECTED = [
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '[🧭  ultra report](impact-11-ultra-upgrade-report.md)',
-    '##  ultra upgrades (docs navigation tune-up)',
+    "[🧭  ultra report](impact-11-ultra-upgrade-report.md)",
+    "##  ultra upgrades (docs navigation tune-up)",
     "sdetkit docs-nav --format text --strict",
     "sdetkit docs-nav --write-defaults --format json --strict",
     "Run first command in under 60 seconds",
@@ -35,14 +35,14 @@ DOCS_CLI_EXPECTED = [
 ]
 
 REPORT_EXPECTED = [
-    ' big upgrade',
+    " big upgrade",
     "python -m sdetkit docs-nav --format json --strict",
     "python -m sdetkit docs-nav --write-defaults --format json --strict",
     "scripts/check_docs_navigation_contract_11.py",
 ]
 
 ARTIFACT_EXPECTED = [
-    '#  docs navigation tune-up',
+    "#  docs navigation tune-up",
     "- Score: **100.0** (12/12)",
 ]
 

--- a/scripts/check_first_contribution_contract_10.py
+++ b/scripts/check_first_contribution_contract_10.py
@@ -12,7 +12,7 @@ LANE_REPORT = Path("docs/impact-10-ultra-upgrade-report.md")
 FIRST_CONTRIBUTION_ARTIFACT = Path("docs/artifacts/first-contribution-checklist-sample.md")
 
 README_EXPECTED = [
-    '## ✅  ultra: first-contribution checklist',
+    "## ✅  ultra: first-contribution checklist",
     "python -m sdetkit first-contribution --format text --strict",
     "python -m sdetkit first-contribution --write-defaults --format json --strict",
     "python scripts/check_first_contribution_contract_10.py",
@@ -20,14 +20,14 @@ README_EXPECTED = [
 ]
 
 CONTRIBUTING_EXPECTED = [
-    '## 0)  first-contribution checklist',
+    "## 0)  first-contribution checklist",
     "Fork the repository and clone your fork locally.",
     "Create a branch named `feat/<topic>` or `fix/<topic>`.",
     "Run full quality gates (`pre-commit`, `quality.sh`, docs build) before opening a PR.",
 ]
 
 DOCS_INDEX_EXPECTED = [
-    '##  ultra upgrades (first-contribution checklist)',
+    "##  ultra upgrades (first-contribution checklist)",
     "sdetkit first-contribution --format text --strict",
     "sdetkit first-contribution --write-defaults --format json --strict",
     "artifacts/first-contribution-checklist-sample.md",
@@ -41,20 +41,20 @@ DOCS_CLI_EXPECTED = [
 ]
 
 DOCS_CONTRIBUTING_EXPECTED = [
-    '##  first-contribution checklist',
+    "##  first-contribution checklist",
     "sdetkit first-contribution --format text --strict",
     "sdetkit first-contribution --write-defaults --format json --strict",
 ]
 
 REPORT_EXPECTED = [
-    ' big upgrade',
+    " big upgrade",
     "python -m sdetkit first-contribution --format json --strict",
     "python -m sdetkit first-contribution --write-defaults --format json --strict",
     "scripts/check_first_contribution_contract_10.py",
 ]
 
 ARTIFACT_EXPECTED = [
-    '#  first-contribution checklist',
+    "#  first-contribution checklist",
     "- Score: **100.0** (14/14)",
 ]
 

--- a/scripts/check_platform_contract_5.py
+++ b/scripts/check_platform_contract_5.py
@@ -10,7 +10,7 @@ LANE_REPORT = Path("docs/impact-5-ultra-upgrade-report.md")
 LANE_ARTIFACT = Path("docs/artifacts/platform-onboarding-sample-5.md")
 
 REQUIRED_README_SNIPPETS = [
-    '## 🖥️  ultra: platform onboarding boost',
+    "## 🖥️  ultra: platform onboarding boost",
     "python -m sdetkit onboarding --format text --platform all",
     "python -m sdetkit onboarding --format markdown --platform all --output docs/artifacts/platform-onboarding-sample-5.md",
     "docs/impact-5-ultra-upgrade-report.md",
@@ -22,7 +22,7 @@ REQUIRED_PLATFORM_SECTION_LINKS = [
 ]
 
 REQUIRED_REPORT_SNIPPETS = [
-    ' big boost',
+    " big boost",
     "src/sdetkit/onboarding.py",
     "tests/test_onboarding_cli.py",
     "python -m sdetkit onboarding --format markdown --platform all --output docs/artifacts/platform-onboarding-sample-5.md",
@@ -30,7 +30,7 @@ REQUIRED_REPORT_SNIPPETS = [
 
 
 def _platform_section(text: str) -> str:
-    start = text.find('## 🖥️  ultra: platform onboarding boost')
+    start = text.find("## 🖥️  ultra: platform onboarding boost")
     if start == -1:
         return ""
     remainder = text[start:]
@@ -55,7 +55,7 @@ def main() -> int:
             errors.append(f"missing README snippet: {snippet}")
 
     if not platform_section:
-        errors.append('missing  ultra section in README')
+        errors.append("missing  ultra section in README")
 
     for link in REQUIRED_PLATFORM_SECTION_LINKS:
         if link not in platform_section:

--- a/scripts/check_weekly_review_contract_7.py
+++ b/scripts/check_weekly_review_contract_7.py
@@ -11,19 +11,19 @@ LANE_ARTIFACT = Path("docs/artifacts/weekly-review-sample-7.md")
 WEEKLY_MODULE = Path("src/sdetkit/weekly_review.py")
 
 REQUIRED_README_SNIPPETS = [
-    '## 📊  ultra: weekly review #1',
+    "## 📊  ultra: weekly review #1",
     "python -m sdetkit weekly-review --format text",
     "python -m sdetkit weekly-review --format markdown --output docs/artifacts/weekly-review-sample-7.md",
     "docs/impact-7-ultra-upgrade-report.md",
 ]
 
 REQUIRED_INDEX_SNIPPETS = [
-    ' ultra upgrade report',
+    " ultra upgrade report",
     "sdetkit weekly-review --format text",
 ]
 
 REQUIRED_REPORT_SNIPPETS = [
-    ' big upgrade',
+    " big upgrade",
     "src/sdetkit/weekly_review.py",
     "tests/test_weekly_review.py",
     "python scripts/check_weekly_review_contract_7.py",

--- a/scripts/cleanup_day_legacy_naming.py
+++ b/scripts/cleanup_day_legacy_naming.py
@@ -7,7 +7,9 @@ from collections import defaultdict
 from pathlib import Path
 
 ANCHOR_PATTERN = re.compile(r"anchor([0-9]{1,2})")
-TEST_NAME_PATTERN = re.compile(r"(def test_[^(]*?)_without_anchor\d{1,2}(\(tmp_path: Path\) -> None:)")
+TEST_NAME_PATTERN = re.compile(
+    r"(def test_[^(]*?)_without_anchor\d{1,2}(\(tmp_path: Path\) -> None:)"
+)
 PLAN_ID_PATTERN = re.compile(r'("plan_id"\s*:\s*")anchor[0-9]{1,2}-([^"\\n]+")')
 
 
@@ -61,9 +63,13 @@ def rewrite_tests(root: Path) -> tuple[int, int]:
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Inventory and optional cleanup for anchorNN legacy naming")
+    ap = argparse.ArgumentParser(
+        description="Inventory and optional cleanup for anchorNN legacy naming"
+    )
     ap.add_argument("--root", default=".", help="repo root")
-    ap.add_argument("--fix-tests", action="store_true", help="rewrite test names and test fixture plan_ids")
+    ap.add_argument(
+        "--fix-tests", action="store_true", help="rewrite test names and test fixture plan_ids"
+    )
     ns = ap.parse_args()
 
     root = Path(ns.root).resolve()
@@ -76,7 +82,9 @@ def main() -> int:
 
     if ns.fix_tests:
         renamed_tests, rewritten_plan_ids = rewrite_tests(root)
-        print(f"\nApplied fixes: renamed_tests={renamed_tests}, rewritten_plan_ids={rewritten_plan_ids}")
+        print(
+            f"\nApplied fixes: renamed_tests={renamed_tests}, rewritten_plan_ids={rewritten_plan_ids}"
+        )
 
     return 0
 

--- a/src/sdetkit/acceleration_closeout_43.py
+++ b/src/sdetkit/acceleration_closeout_43.py
@@ -16,7 +16,7 @@ _DAY42_SUMMARY_PATH = (
 _DAY42_BOARD_PATH = "docs/artifacts/optimization-closeout-pack-42/delivery-board-42.md"
 _DAY42_LEGACY_SUMMARY_PATH = "docs/artifacts/optimization-closeout-foundation-pack/optimization-closeout-foundation-summary.json"
 _DAY42_LEGACY_BOARD_PATH = "docs/artifacts/optimization-closeout-foundation-pack/delivery-board.md"
-_SECTION_HEADER = '#  — Acceleration closeout lane'
+_SECTION_HEADER = "#  — Acceleration closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why this lane matters",
     "## Required inputs (optimization closeout foundation)",
@@ -38,10 +38,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_acceleration_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  acceleration lane execution and KPI follow-up.',
-    'The  acceleration lane references  optimization winners and misses with deterministic growth loops.',
-    'Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.',
-    ' closeout records acceleration learnings and  scale priorities.',
+    "Single owner + backup reviewer are assigned for  acceleration lane execution and KPI follow-up.",
+    "The  acceleration lane references  optimization winners and misses with deterministic growth loops.",
+    "Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.",
+    " closeout records acceleration learnings and  scale priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes acceleration summary, growth matrix, and rollback strategy",
@@ -51,14 +51,14 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes acceleration plan, growth matrix, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  acceleration plan draft committed',
-    '- [ ]  review notes captured with owner + backup',
-    '- [ ]  growth matrix exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  scale priorities drafted from  learnings',
+    "- [ ]  acceleration plan draft committed",
+    "- [ ]  review notes captured with owner + backup",
+    "- [ ]  growth matrix exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  scale priorities drafted from  learnings",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Acceleration closeout lane\n\nThis lane closes with a major acceleration upgrade that converts optimization evidence into deterministic improvement loops.\n\n## Why this lane matters\n\n- Converts  optimization proof into growth-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from acceleration outcomes into  scale priorities.\n\n## Required inputs (optimization closeout foundation)\n\n- `docs/artifacts/optimization-closeout-pack-42/optimization-closeout-summary-42.json`\n- `docs/artifacts/optimization-closeout-pack-42/delivery-board-42.md`\n\n## Command lane\n\n```bash\npython -m sdetkit acceleration-closeout --format json --strict\npython -m sdetkit acceleration-closeout --emit-pack-dir docs/artifacts/acceleration-closeout-pack --format json --strict\npython -m sdetkit acceleration-closeout --execute --evidence-dir docs/artifacts/acceleration-closeout-pack/evidence --format json --strict\npython scripts/check_acceleration_closeout_contract.py\n```\n\n## Acceleration closeout contract\n\n- Single owner + backup reviewer are assigned for  acceleration lane execution and KPI follow-up.\n- The  acceleration lane references  optimization winners and misses with deterministic growth loops.\n- Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n-  closeout records acceleration learnings and  scale priorities.\n\n## Acceleration quality checklist\n\n- [ ] Includes acceleration summary, growth matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes acceleration plan, growth matrix, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  acceleration plan draft committed\n- [ ]  review notes captured with owner + backup\n- [ ]  growth matrix exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  scale priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Acceleration contract lock + delivery board readiness: 15 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Acceleration closeout lane\n\nThis lane closes with a major acceleration upgrade that converts optimization evidence into deterministic improvement loops.\n\n## Why this lane matters\n\n- Converts  optimization proof into growth-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from acceleration outcomes into  scale priorities.\n\n## Required inputs (optimization closeout foundation)\n\n- `docs/artifacts/optimization-closeout-pack-42/optimization-closeout-summary-42.json`\n- `docs/artifacts/optimization-closeout-pack-42/delivery-board-42.md`\n\n## Command lane\n\n```bash\npython -m sdetkit acceleration-closeout --format json --strict\npython -m sdetkit acceleration-closeout --emit-pack-dir docs/artifacts/acceleration-closeout-pack --format json --strict\npython -m sdetkit acceleration-closeout --execute --evidence-dir docs/artifacts/acceleration-closeout-pack/evidence --format json --strict\npython scripts/check_acceleration_closeout_contract.py\n```\n\n## Acceleration closeout contract\n\n- Single owner + backup reviewer are assigned for  acceleration lane execution and KPI follow-up.\n- The  acceleration lane references  optimization winners and misses with deterministic growth loops.\n- Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n-  closeout records acceleration learnings and  scale priorities.\n\n## Acceleration quality checklist\n\n- [ ] Includes acceleration summary, growth matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes acceleration plan, growth matrix, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  acceleration plan draft committed\n- [ ]  review notes captured with owner + backup\n- [ ]  growth matrix exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  scale priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Acceleration contract lock + delivery board readiness: 15 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -91,7 +91,7 @@ def _load_optimization_closeout(path: Path) -> tuple[float, bool, int]:
 def _board_stats(path: Path) -> tuple[int, bool, bool]:
     text = _read(path)
     items = [line for line in text.splitlines() if line.strip().startswith("- [")]
-    return len(items), '' in text, '' in text
+    return len(items), "" in text, "" in text
 
 
 def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
@@ -181,8 +181,8 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_acceleration_closeout_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "optimization_closeout_summary_present",
@@ -255,22 +255,16 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
             f"42 continuity is strict-pass with activation score={optimization_closeout_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
+        misses.append(" strict continuity signal is missing.")
         handoff_actions.append(
-            'Re-run  optimization closeout command and restore strict pass baseline before  lock.'
+            "Re-run  optimization closeout command and restore strict pass baseline before  lock."
         )
 
     if board_count >= 5 and board_has_optimization_closeout and board_has_acceleration_closeout:
-        wins.append(
-            f"42 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"42 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and /43 anchors).'
-        )
-        handoff_actions.append(
-            'Repair  delivery board entries to include  and  anchors.'
-        )
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and /43 anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  and  anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
         wins.append(
@@ -281,13 +275,11 @@ def build_acceleration_closeout_summary(root: Path) -> dict[str, Any]:
             "Acceleration contract, quality checklist, or delivery board entries are missing."
         )
         handoff_actions.append(
-            'Complete all  acceleration contract lines, quality checklist entries, and delivery board tasks in docs.'
+            "Complete all  acceleration contract lines, quality checklist entries, and delivery board tasks in docs."
         )
 
     if not failed and not critical_failures:
-        wins.append(
-            ' acceleration closeout lane is fully complete and ready for  scale lane.'
-        )
+        wins.append(" acceleration closeout lane is fully complete and ready for  scale lane.")
 
     return {
         "name": "acceleration-closeout",
@@ -356,7 +348,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(target / "acceleration-closeout-summary.md", _render_text(payload) + "\n")
     _write(
         target / "acceleration-plan.md",
-        '# Acceleration plan\n\n- Objective: close  with measurable quality and throughput gains.\n',
+        "# Acceleration plan\n\n- Objective: close  with measurable quality and throughput gains.\n",
     )
     _write(
         target / "growth-matrix.csv",
@@ -383,7 +375,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     )
     _write(
         target / "execution-log.md",
-        '# Acceleration execution log\n\n- [ ] 2026-03-12: Record misses, wins, and  scale priorities.\n',
+        "# Acceleration execution log\n\n- [ ] 2026-03-12: Record misses, wins, and  scale priorities.\n",
     )
     _write(
         target / "delivery-board.md",
@@ -433,7 +425,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def build_acceleration_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_acceleration_closeout_summary(root)
 
 

--- a/src/sdetkit/agent/actions.py
+++ b/src/sdetkit/agent/actions.py
@@ -174,7 +174,7 @@ class ActionRegistry:
         return ActionResult("report.build", True, {"output": output, "format": fmt})
 
     def _kits_blueprint(self, params: dict[str, Any]) -> ActionResult:
-        goal = str(params.get("goal", "")).strip() or None
+        goal = str(params.get("goal", "")).strip()
         output = str(params.get("output", ".sdetkit/agent/workdir/umbrella-blueprint.json"))
         limit = int(params.get("limit", 3) or 3)
         selected = params.get("kits") or []
@@ -211,7 +211,7 @@ class ActionRegistry:
         )
 
     def _kits_optimize(self, params: dict[str, Any]) -> ActionResult:
-        goal = str(params.get("goal", "")).strip() or None
+        goal = str(params.get("goal", "")).strip()
         output = str(params.get("output", ".sdetkit/agent/workdir/umbrella-optimize.json"))
         limit = int(params.get("limit", 3) or 3)
         selected = params.get("kits") or []
@@ -256,7 +256,7 @@ class ActionRegistry:
         )
 
     def _kits_expand(self, params: dict[str, Any]) -> ActionResult:
-        goal = str(params.get("goal", "")).strip() or None
+        goal = str(params.get("goal", "")).strip()
         output = str(params.get("output", ".sdetkit/agent/workdir/umbrella-expand.json"))
         limit = int(params.get("limit", 3) or 3)
         selected = params.get("kits") or []

--- a/src/sdetkit/agent/templates.py
+++ b/src/sdetkit/agent/templates.py
@@ -370,7 +370,7 @@ def run_template(
                 _write_json(target, repo._to_sarif(audit))
                 artifacts.append(target.as_posix())
         elif step.action == "kits.optimize":
-            goal = str(params.get("goal", "")).strip() or None
+            goal = str(params.get("goal", "")).strip()
             limit = int(params.get("limit", 3) or 3)
             selected = params.get("kits") or []
             selected_kits = [str(item) for item in selected] if isinstance(selected, list) else []
@@ -391,7 +391,7 @@ def run_template(
                 artifacts.append(target.as_posix())
             payload = result
         elif step.action == "kits.expand":
-            goal = str(params.get("goal", "")).strip() or None
+            goal = str(params.get("goal", "")).strip()
             limit = int(params.get("limit", 3) or 3)
             selected = params.get("kits") or []
             selected_kits = [str(item) for item in selected] if isinstance(selected, list) else []

--- a/src/sdetkit/case_study_launch_closeout_73.py
+++ b/src/sdetkit/case_study_launch_closeout_73.py
@@ -19,14 +19,14 @@ _DAY72_BOARD_PATH = (
     "docs/artifacts/case-study-prep4-closeout-pack/case-study-prep4-delivery-board.md"
 )
 _CASE_STUDY_DATA_PATH = "docs/roadmap/plans/published-case-study.json"
-_SECTION_HEADER = '#  — Case-study launch closeout lane'
+_SECTION_HEADER = "#  — Case-study launch closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Case-study launch contract",
     "## Case-study quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_case_study_launch_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  published case-study launch execution and signoff.',
-    'The  lane references  prep outputs, governance decisions, and KPI continuity signals.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records publication outcomes, evidence confidence notes, and  scaling priorities.',
+    "Single owner + backup reviewer are assigned for  published case-study launch execution and signoff.",
+    "The  lane references  prep outputs, governance decisions, and KPI continuity signals.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records publication outcomes, evidence confidence notes, and  scaling priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline window, treatment window, and outlier handling notes",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  published case-study narrative committed',
-    '- [ ]  controls and assumptions log exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  distribution scaling priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  published case-study narrative committed",
+    "- [ ]  controls and assumptions log exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  distribution scaling priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"case_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Case-study launch closeout lane\n\n closes with a major upgrade that turns  publication-quality prep into a published case-study launch pack with rollout safeguards.\n\n## Why  matters\n\n- Converts  prep outputs into published case-study assets tied to measurable incident-response outcomes.\n- Protects publication quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  publication launch execution into  distribution scaling.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.json`\n- `docs/artifacts/case-study-prep4-closeout-pack/case-study-prep4-delivery-board.md`\n- `docs/roadmap/plans/published-case-study.json`\n\n##  command lane\n\n```bash\npython -m sdetkit case-study-launch-closeout --format json --strict\npython -m sdetkit case-study-launch-closeout --emit-pack-dir docs/artifacts/case-study-launch-closeout-pack --format json --strict\npython -m sdetkit case-study-launch-closeout --execute --evidence-dir docs/artifacts/case-study-launch-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_launch_closeout_contract.py\n```\n\n## Case-study launch contract\n\n- Single owner + backup reviewer are assigned for  published case-study launch execution and signoff.\n- The  lane references  prep outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records publication outcomes, evidence confidence notes, and  scaling priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  published case-study narrative committed\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  distribution scaling priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Publication-quality evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Case-study launch closeout lane\n\n closes with a major upgrade that turns  publication-quality prep into a published case-study launch pack with rollout safeguards.\n\n## Why  matters\n\n- Converts  prep outputs into published case-study assets tied to measurable incident-response outcomes.\n- Protects publication quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  publication launch execution into  distribution scaling.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-prep4-closeout-pack/case-study-prep4-closeout-summary.json`\n- `docs/artifacts/case-study-prep4-closeout-pack/case-study-prep4-delivery-board.md`\n- `docs/roadmap/plans/published-case-study.json`\n\n##  command lane\n\n```bash\npython -m sdetkit case-study-launch-closeout --format json --strict\npython -m sdetkit case-study-launch-closeout --emit-pack-dir docs/artifacts/case-study-launch-closeout-pack --format json --strict\npython -m sdetkit case-study-launch-closeout --execute --evidence-dir docs/artifacts/case-study-launch-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_launch_closeout_contract.py\n```\n\n## Case-study launch contract\n\n- Single owner + backup reviewer are assigned for  published case-study launch execution and signoff.\n- The  lane references  prep outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records publication outcomes, evidence confidence notes, and  scaling priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  published case-study narrative committed\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  distribution scaling priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Publication-quality evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -112,7 +112,7 @@ def build_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]:
     prior_closeout_score, prior_closeout_strict, prior_closeout_check_count = _load_prior_closeout(
         prior_closeout_summary
     )
-    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, '')
+    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -143,8 +143,8 @@ def build_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "prior_closeout_summary_present",
@@ -233,36 +233,28 @@ def build_case_study_launch_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if prior_closeout_strict:
-        wins.append(
-            f"72 continuity is strict-pass with activation score={prior_closeout_score}."
-        )
+        wins.append(f"72 continuity is strict-pass with activation score={prior_closeout_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_prior_closeout:
-        wins.append(
-            f"72 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"72 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_case_data_keys:
-        wins.append(' published case-study dataset is available for launch execution.')
+        wins.append(" published case-study dataset is available for launch execution.")
     else:
-        misses.append(' published case-study dataset is missing required keys.')
+        misses.append(" published case-study dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/published-case-study.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' case-study launch closeout lane is fully complete and ready for  distribution scaling.'
+            " case-study launch closeout lane is fully complete and ready for  distribution scaling."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -323,8 +315,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "case-study-launch-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "case-study-launch-integration-brief.md", '#  integration brief\n')
-    _write(target / "case-study-launch-case-study-narrative.md", '#  case-study narrative\n')
+    _write(target / "case-study-launch-integration-brief.md", "#  integration brief\n")
+    _write(target / "case-study-launch-case-study-narrative.md", "#  case-study narrative\n")
     _write(
         target / "case-study-launch-controls-log.json",
         json.dumps({"controls": []}, indent=2) + "\n",
@@ -332,14 +324,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     _write(
         target / "case-study-launch-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n"
     )
-    _write(target / "case-study-launch-execution-log.md", '#  execution log\n')
+    _write(target / "case-study-launch-execution-log.md", "#  execution log\n")
     _write(
         target / "case-study-launch-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "case-study-launch-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -367,7 +359,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_case_study_launch_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_case_study_launch_closeout_summary(root)
 
 

--- a/src/sdetkit/case_study_prep1_closeout_69.py
+++ b/src/sdetkit/case_study_prep1_closeout_69.py
@@ -17,10 +17,10 @@ _DAY68_BOARD_PATH = (
     "docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-delivery-board.md"
 )
 _CASE_STUDY_DATA_PATH = "docs/roadmap/plans/reliability-case-study.json"
-_SECTION_HEADER = '#  — Case-study prep #1 closeout lane'
+_SECTION_HEADER = "#  — Case-study prep #1 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Case Study Prep1 Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Case Study Prep1 Closeout command lane",
     "## Case-study prep contract",
     "## Case-study quality checklist",
@@ -39,10 +39,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_case_study_prep1_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  reliability case-study prep and signoff.',
-    'The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records before/after reliability deltas, evidence confidence notes, and  prep priorities.',
+    "Single owner + backup reviewer are assigned for  reliability case-study prep and signoff.",
+    "The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records before/after reliability deltas, evidence confidence notes, and  prep priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline window, treatment window, and outlier handling notes",
@@ -52,11 +52,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  reliability case-study narrative published',
-    '- [ ]  controls and assumptions log exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  case-study prep priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  reliability case-study narrative published",
+    "- [ ]  controls and assumptions log exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  case-study prep priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"case_id"',
@@ -67,7 +67,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Case-study prep #1 closeout lane\n\n closes with a major upgrade that turns  integration outputs into a measurable reliability case-study prep pack.\n\n## Why Case Study Prep1 Closeout matters\n\n- Converts  implementation signals into before/after reliability evidence.\n- Protects case-study quality with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  case-study prep #1 to  case-study prep #2.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.json`\n- `docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-delivery-board.md`\n- `docs/roadmap/plans/reliability-case-study.json`\n\n## Case Study Prep1 Closeout command lane\n\n```bash\npython -m sdetkit case-study-prep1-closeout --format json --strict\npython -m sdetkit case-study-prep1-closeout --emit-pack-dir docs/artifacts/case-study-prep1-closeout-pack --format json --strict\npython -m sdetkit case-study-prep1-closeout --execute --evidence-dir docs/artifacts/case-study-prep1-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_prep1_closeout_contract.py\n```\n\n## Case-study prep contract\n\n- Single owner + backup reviewer are assigned for  reliability case-study prep and signoff.\n- The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records before/after reliability deltas, evidence confidence notes, and  prep priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n## Case Study Prep1 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  reliability case-study narrative published\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  case-study prep priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Reliability evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Case-study prep #1 closeout lane\n\n closes with a major upgrade that turns  integration outputs into a measurable reliability case-study prep pack.\n\n## Why Case Study Prep1 Closeout matters\n\n- Converts  implementation signals into before/after reliability evidence.\n- Protects case-study quality with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  case-study prep #1 to  case-study prep #2.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-closeout-summary.json`\n- `docs/artifacts/integration-expansion4-closeout-pack/integration-expansion4-delivery-board.md`\n- `docs/roadmap/plans/reliability-case-study.json`\n\n## Case Study Prep1 Closeout command lane\n\n```bash\npython -m sdetkit case-study-prep1-closeout --format json --strict\npython -m sdetkit case-study-prep1-closeout --emit-pack-dir docs/artifacts/case-study-prep1-closeout-pack --format json --strict\npython -m sdetkit case-study-prep1-closeout --execute --evidence-dir docs/artifacts/case-study-prep1-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_prep1_closeout_contract.py\n```\n\n## Case-study prep contract\n\n- Single owner + backup reviewer are assigned for  reliability case-study prep and signoff.\n- The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records before/after reliability deltas, evidence confidence notes, and  prep priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n## Case Study Prep1 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  reliability case-study narrative published\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  case-study prep priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Reliability evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -110,7 +110,7 @@ def build_case_study_prep1_closeout_summary(root: Path) -> dict[str, Any]:
     prior_closeout_score, prior_closeout_strict, prior_closeout_check_count = _load_prior_closeout(
         prior_closeout_summary
     )
-    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, '')
+    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -138,8 +138,8 @@ def build_case_study_prep1_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "prior_closeout_summary_present",
@@ -228,38 +228,28 @@ def build_case_study_prep1_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if prior_closeout_strict:
-        wins.append(
-            f"68 continuity is strict-pass with activation score={prior_closeout_score}."
-        )
+        wins.append(f"68 continuity is strict-pass with activation score={prior_closeout_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_prior_closeout:
-        wins.append(
-            f"68 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"68 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_case_data_keys:
-        wins.append(
-            ' reliability case-study dataset is available for case-study prep execution.'
-        )
+        wins.append(" reliability case-study dataset is available for case-study prep execution.")
     else:
-        misses.append(' reliability case-study dataset is missing required keys.')
+        misses.append(" reliability case-study dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/reliability-case-study.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' case-study prep #1 closeout lane is fully complete and ready for  case-study prep #2.'
+            " case-study prep #1 closeout lane is fully complete and ready for  case-study prep #2."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -320,22 +310,22 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "case-study-prep1-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "case-study-prep1-integration-brief.md", '#  integration brief\n')
-    _write(target / "case-study-prep1-case-study-narrative.md", '#  case-study narrative\n')
+    _write(target / "case-study-prep1-integration-brief.md", "#  integration brief\n")
+    _write(target / "case-study-prep1-case-study-narrative.md", "#  case-study narrative\n")
     _write(
         target / "case-study-prep1-controls-log.json", json.dumps({"controls": []}, indent=2) + "\n"
     )
     _write(
         target / "case-study-prep1-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n"
     )
-    _write(target / "case-study-prep1-execution-log.md", '#  execution log\n')
+    _write(target / "case-study-prep1-execution-log.md", "#  execution log\n")
     _write(
         target / "case-study-prep1-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "case-study-prep1-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -363,12 +353,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_case_study_prep1_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_case_study_prep1_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' case-study prep #1 closeout checks')
+    parser = argparse.ArgumentParser(description=" case-study prep #1 closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/case_study_prep2_closeout_70.py
+++ b/src/sdetkit/case_study_prep2_closeout_70.py
@@ -19,10 +19,10 @@ _DAY69_BOARD_PATH = (
     "docs/artifacts/case-study-prep1-closeout-pack/case-study-prep1-delivery-board.md"
 )
 _CASE_STUDY_DATA_PATH = "docs/roadmap/plans/triage-speed-case-study.json"
-_SECTION_HEADER = '#  — Case-study prep #2 closeout lane'
+_SECTION_HEADER = "#  — Case-study prep #2 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Case Study Prep 2 Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Case Study Prep 2 Closeout command lane",
     "## Case-study prep contract",
     "## Case-study quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_case_study_prep2_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  triage-speed case-study prep and signoff.',
-    'The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records before/after triage-speed deltas, evidence confidence notes, and  prep priorities.',
+    "Single owner + backup reviewer are assigned for  triage-speed case-study prep and signoff.",
+    "The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records before/after triage-speed deltas, evidence confidence notes, and  prep priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline window, treatment window, and outlier handling notes",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  triage-speed case-study narrative published',
-    '- [ ]  controls and assumptions log exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  case-study prep priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  triage-speed case-study narrative published",
+    "- [ ]  controls and assumptions log exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  case-study prep priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"case_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Case-study prep #2 closeout lane\n\n closes with a major upgrade that turns  integration outputs into a measurable triage-speed case-study prep pack.\n\n## Why Case Study Prep 2 Closeout matters\n\n- Converts  implementation signals into before/after triage-speed evidence.\n- Protects case-study quality with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  case-study prep #2 to  case-study prep #3.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-prep1-closeout-pack/case-study-prep1-closeout-summary.json`\n- `docs/artifacts/case-study-prep1-closeout-pack/case-study-prep1-delivery-board.md`\n- `docs/roadmap/plans/triage-speed-case-study.json`\n\n## Case Study Prep 2 Closeout command lane\n\n```bash\npython -m sdetkit case-study-prep2-closeout --format json --strict\npython -m sdetkit case-study-prep2-closeout --emit-pack-dir docs/artifacts/case-study-prep2-closeout-pack --format json --strict\npython -m sdetkit case-study-prep2-closeout --execute --evidence-dir docs/artifacts/case-study-prep2-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_prep2_closeout_contract.py\n```\n\n## Case-study prep contract\n\n- Single owner + backup reviewer are assigned for  triage-speed case-study prep and signoff.\n- The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records before/after triage-speed deltas, evidence confidence notes, and  prep priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n## Case Study Prep 2 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  triage-speed case-study narrative published\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  case-study prep priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Triage-speed evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Case-study prep #2 closeout lane\n\n closes with a major upgrade that turns  integration outputs into a measurable triage-speed case-study prep pack.\n\n## Why Case Study Prep 2 Closeout matters\n\n- Converts  implementation signals into before/after triage-speed evidence.\n- Protects case-study quality with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  case-study prep #2 to  case-study prep #3.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-prep1-closeout-pack/case-study-prep1-closeout-summary.json`\n- `docs/artifacts/case-study-prep1-closeout-pack/case-study-prep1-delivery-board.md`\n- `docs/roadmap/plans/triage-speed-case-study.json`\n\n## Case Study Prep 2 Closeout command lane\n\n```bash\npython -m sdetkit case-study-prep2-closeout --format json --strict\npython -m sdetkit case-study-prep2-closeout --emit-pack-dir docs/artifacts/case-study-prep2-closeout-pack --format json --strict\npython -m sdetkit case-study-prep2-closeout --execute --evidence-dir docs/artifacts/case-study-prep2-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_prep2_closeout_contract.py\n```\n\n## Case-study prep contract\n\n- Single owner + backup reviewer are assigned for  triage-speed case-study prep and signoff.\n- The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records before/after triage-speed deltas, evidence confidence notes, and  prep priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n## Case Study Prep 2 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  triage-speed case-study narrative published\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  case-study prep priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Triage-speed evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -112,7 +112,7 @@ def build_case_study_prep2_closeout_summary(root: Path) -> dict[str, Any]:
     prior_closeout_score, prior_closeout_strict, prior_closeout_check_count = _load_prior_closeout(
         prior_closeout_summary
     )
-    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, '')
+    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -140,8 +140,8 @@ def build_case_study_prep2_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "prior_closeout_summary_present",
@@ -230,38 +230,28 @@ def build_case_study_prep2_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if prior_closeout_strict:
-        wins.append(
-            f"69 continuity is strict-pass with activation score={prior_closeout_score}."
-        )
+        wins.append(f"69 continuity is strict-pass with activation score={prior_closeout_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_prior_closeout:
-        wins.append(
-            f"69 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"69 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_case_data_keys:
-        wins.append(
-            ' triage-speed case-study dataset is available for case-study prep execution.'
-        )
+        wins.append(" triage-speed case-study dataset is available for case-study prep execution.")
     else:
-        misses.append(' triage-speed case-study dataset is missing required keys.')
+        misses.append(" triage-speed case-study dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/triage-speed-case-study.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' case-study prep #2 closeout lane is fully complete and ready for  case-study prep #3.'
+            " case-study prep #2 closeout lane is fully complete and ready for  case-study prep #3."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -322,22 +312,22 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "case-study-prep2-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "case-study-prep2-integration-brief.md", '#  integration brief\n')
-    _write(target / "case-study-prep2-case-study-narrative.md", '#  case-study narrative\n')
+    _write(target / "case-study-prep2-integration-brief.md", "#  integration brief\n")
+    _write(target / "case-study-prep2-case-study-narrative.md", "#  case-study narrative\n")
     _write(
         target / "case-study-prep2-controls-log.json", json.dumps({"controls": []}, indent=2) + "\n"
     )
     _write(
         target / "case-study-prep2-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n"
     )
-    _write(target / "case-study-prep2-execution-log.md", '#  execution log\n')
+    _write(target / "case-study-prep2-execution-log.md", "#  execution log\n")
     _write(
         target / "case-study-prep2-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "case-study-prep2-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -365,12 +355,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_case_study_prep2_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_case_study_prep2_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' case-study prep #2 closeout checks')
+    parser = argparse.ArgumentParser(description=" case-study prep #2 closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/case_study_prep3_closeout_71.py
+++ b/src/sdetkit/case_study_prep3_closeout_71.py
@@ -19,14 +19,14 @@ _DAY70_BOARD_PATH = (
     "docs/artifacts/case-study-prep2-closeout-pack/case-study-prep2-delivery-board.md"
 )
 _CASE_STUDY_DATA_PATH = "docs/roadmap/plans/escalation-quality-case-study.json"
-_SECTION_HEADER = '#  — Case-study prep #3 closeout lane'
+_SECTION_HEADER = "#  — Case-study prep #3 closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Case-study prep contract",
     "## Case-study quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_case_study_prep3_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  escalation-quality case-study prep and signoff.',
-    'The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records before/after escalation-quality deltas, evidence confidence notes, and  prep priorities.',
+    "Single owner + backup reviewer are assigned for  escalation-quality case-study prep and signoff.",
+    "The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records before/after escalation-quality deltas, evidence confidence notes, and  prep priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline window, treatment window, and outlier handling notes",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  escalation-quality case-study narrative published',
-    '- [ ]  controls and assumptions log exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  case-study prep priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  escalation-quality case-study narrative published",
+    "- [ ]  controls and assumptions log exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  case-study prep priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"case_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Case-study prep #3 closeout lane\n\n closes with a major upgrade that turns  integration outputs into a measurable escalation-quality case-study prep pack.\n\n## Why  matters\n\n- Converts  implementation signals into before/after escalation-quality evidence.\n- Protects case-study quality with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  case-study prep #3 to  case-study prep #4.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-prep2-closeout-pack/case-study-prep2-closeout-summary.json`\n- `docs/artifacts/case-study-prep2-closeout-pack/case-study-prep2-delivery-board.md`\n- `docs/roadmap/plans/escalation-quality-case-study.json`\n\n##  command lane\n\n```bash\npython -m sdetkit case-study-prep3-closeout --format json --strict\npython -m sdetkit case-study-prep3-closeout --emit-pack-dir docs/artifacts/case-study-prep3-closeout-pack --format json --strict\npython -m sdetkit case-study-prep3-closeout --execute --evidence-dir docs/artifacts/case-study-prep3-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_prep3_closeout_contract.py\n```\n\n## Case-study prep contract\n\n- Single owner + backup reviewer are assigned for  escalation-quality case-study prep and signoff.\n- The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records before/after escalation-quality deltas, evidence confidence notes, and  prep priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  escalation-quality case-study narrative published\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  case-study prep priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Escalation-quality evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Case-study prep #3 closeout lane\n\n closes with a major upgrade that turns  integration outputs into a measurable escalation-quality case-study prep pack.\n\n## Why  matters\n\n- Converts  implementation signals into before/after escalation-quality evidence.\n- Protects case-study quality with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  case-study prep #3 to  case-study prep #4.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-prep2-closeout-pack/case-study-prep2-closeout-summary.json`\n- `docs/artifacts/case-study-prep2-closeout-pack/case-study-prep2-delivery-board.md`\n- `docs/roadmap/plans/escalation-quality-case-study.json`\n\n##  command lane\n\n```bash\npython -m sdetkit case-study-prep3-closeout --format json --strict\npython -m sdetkit case-study-prep3-closeout --emit-pack-dir docs/artifacts/case-study-prep3-closeout-pack --format json --strict\npython -m sdetkit case-study-prep3-closeout --execute --evidence-dir docs/artifacts/case-study-prep3-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_prep3_closeout_contract.py\n```\n\n## Case-study prep contract\n\n- Single owner + backup reviewer are assigned for  escalation-quality case-study prep and signoff.\n- The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records before/after escalation-quality deltas, evidence confidence notes, and  prep priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  escalation-quality case-study narrative published\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  case-study prep priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Escalation-quality evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -112,7 +112,7 @@ def build_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
     prior_closeout_score, prior_closeout_strict, prior_closeout_check_count = _load_prior_closeout(
         prior_closeout_summary
     )
-    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, '')
+    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -132,15 +132,15 @@ def build_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
             "check_id": "docs_index_case_study_prep3_links",
             "weight": 8,
             "passed": (
-                '-71-big-upgrade-report.md' in docs_index_text
+                "-71-big-upgrade-report.md" in docs_index_text
                 and "integrations-case-study-prep3-closeout.md" in docs_index_text
             ),
-            "evidence": '-71-big-upgrade-report.md + integrations-case-study-prep3-closeout.md',
+            "evidence": "-71-big-upgrade-report.md + integrations-case-study-prep3-closeout.md",
         },
         {
             "check_id": "top10_case_study_prep3_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
+            "passed": ("" in top10_text and "" in top10_text),
             "evidence": "Case-study prep #3 + prep #4 strategy chain",
         },
         {
@@ -178,7 +178,7 @@ def build_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
             "check_id": "page_header",
             "weight": 7,
             "passed": (
-                page_text.splitlines()[0].strip() == '#  — Case-study prep #3 closeout lane'
+                page_text.splitlines()[0].strip() == "#  — Case-study prep #3 closeout lane"
                 if page_text.strip()
                 else False
             ),
@@ -234,38 +234,30 @@ def build_case_study_prep3_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if prior_closeout_strict:
-        wins.append(
-            f"70 continuity is strict-pass with activation score={prior_closeout_score}."
-        )
+        wins.append(f"70 continuity is strict-pass with activation score={prior_closeout_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_prior_closeout:
-        wins.append(
-            f"70 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"70 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_case_data_keys:
         wins.append(
-            ' escalation-quality case-study dataset is available for case-study prep execution.'
+            " escalation-quality case-study dataset is available for case-study prep execution."
         )
     else:
-        misses.append(' escalation-quality case-study dataset is missing required keys.')
+        misses.append(" escalation-quality case-study dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/escalation-quality-case-study.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' case-study prep #3 closeout lane is fully complete and ready for  case-study prep #4.'
+            " case-study prep #3 closeout lane is fully complete and ready for  case-study prep #4."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -326,22 +318,22 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "case-study-prep3-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "case-study-prep3-integration-brief.md", '#  integration brief\n')
-    _write(target / "case-study-prep3-case-study-narrative.md", '#  case-study narrative\n')
+    _write(target / "case-study-prep3-integration-brief.md", "#  integration brief\n")
+    _write(target / "case-study-prep3-case-study-narrative.md", "#  case-study narrative\n")
     _write(
         target / "case-study-prep3-controls-log.json", json.dumps({"controls": []}, indent=2) + "\n"
     )
     _write(
         target / "case-study-prep3-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n"
     )
-    _write(target / "case-study-prep3-execution-log.md", '#  execution log\n')
+    _write(target / "case-study-prep3-execution-log.md", "#  execution log\n")
     _write(
         target / "case-study-prep3-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "case-study-prep3-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -369,7 +361,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_case_study_prep3_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_case_study_prep3_closeout_summary(root)
 
 

--- a/src/sdetkit/case_study_prep4_closeout_72.py
+++ b/src/sdetkit/case_study_prep4_closeout_72.py
@@ -21,12 +21,12 @@ _DAY71_BOARD_PATH = (
 _CASE_STUDY_DATA_PATH = "docs/roadmap/plans/publication-quality-case-study.json"
 _SECTION_HEADER = "# Case-study prep #4 closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Case-study prep contract",
     "## Case-study quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_case_study_prep4_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  publication-quality case-study prep and signoff.',
-    'The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records before/after publication-quality deltas, evidence confidence notes, and  prep priorities.',
+    "Single owner + backup reviewer are assigned for  publication-quality case-study prep and signoff.",
+    "The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records before/after publication-quality deltas, evidence confidence notes, and  prep priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline window, treatment window, and outlier handling notes",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  publication-quality case-study narrative published',
-    '- [ ]  controls and assumptions log exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  publication launch priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  publication-quality case-study narrative published",
+    "- [ ]  controls and assumptions log exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  publication launch priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"case_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Case-study prep #4 closeout lane\n\n closes with a major upgrade that turns  escalation-quality outputs into a measurable publication-quality case-study launch pack.\n\n## Why  matters\n\n- Converts  implementation signals into before/after publication-quality evidence.\n- Protects case-study quality with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  case-study prep #4 into  publication launch execution.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-prep3-closeout-pack/case-study-prep3-closeout-summary.json`\n- `docs/artifacts/case-study-prep3-closeout-pack/case-study-prep3-delivery-board.md`\n- `docs/roadmap/plans/publication-quality-case-study.json`\n\n##  command lane\n\n```bash\npython -m sdetkit case-study-prep4-closeout --format json --strict\npython -m sdetkit case-study-prep4-closeout --emit-pack-dir docs/artifacts/case-study-prep4-closeout-pack --format json --strict\npython -m sdetkit case-study-prep4-closeout --execute --evidence-dir docs/artifacts/case-study-prep4-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_prep4_closeout_contract.py\n```\n\n## Case-study prep contract\n\n- Single owner + backup reviewer are assigned for  publication-quality case-study prep and signoff.\n- The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records before/after publication-quality deltas, evidence confidence notes, and  prep priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  publication-quality case-study narrative published\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  publication launch priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Publication-quality evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Case-study prep #4 closeout lane\n\n closes with a major upgrade that turns  escalation-quality outputs into a measurable publication-quality case-study launch pack.\n\n## Why  matters\n\n- Converts  implementation signals into before/after publication-quality evidence.\n- Protects case-study quality with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  case-study prep #4 into  publication launch execution.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-prep3-closeout-pack/case-study-prep3-closeout-summary.json`\n- `docs/artifacts/case-study-prep3-closeout-pack/case-study-prep3-delivery-board.md`\n- `docs/roadmap/plans/publication-quality-case-study.json`\n\n##  command lane\n\n```bash\npython -m sdetkit case-study-prep4-closeout --format json --strict\npython -m sdetkit case-study-prep4-closeout --emit-pack-dir docs/artifacts/case-study-prep4-closeout-pack --format json --strict\npython -m sdetkit case-study-prep4-closeout --execute --evidence-dir docs/artifacts/case-study-prep4-closeout-pack/evidence --format json --strict\npython scripts/check_case_study_prep4_closeout_contract.py\n```\n\n## Case-study prep contract\n\n- Single owner + backup reviewer are assigned for  publication-quality case-study prep and signoff.\n- The  lane references  case-study prep outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records before/after publication-quality deltas, evidence confidence notes, and  prep priorities.\n\n## Case-study quality checklist\n\n- [ ] Includes baseline window, treatment window, and outlier handling notes\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures failure-rate delta, MTTR delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, case-study narrative, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  publication-quality case-study narrative published\n- [ ]  controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  publication launch priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Publication-quality evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -112,7 +112,7 @@ def build_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
     prior_closeout_score, prior_closeout_strict, prior_closeout_check_count = _load_prior_closeout(
         prior_closeout_summary
     )
-    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, '')
+    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -135,22 +135,18 @@ def build_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
             "check_id": "docs_index_case_study_prep4_links",
             "weight": 8,
             "passed": (
-                '-72-big-upgrade-report.md' in docs_index_text
+                "-72-big-upgrade-report.md" in docs_index_text
                 and "integrations-case-study-prep4-closeout.md" in docs_index_text
             ),
-            "evidence": '-72-big-upgrade-report.md + integrations-case-study-prep4-closeout.md',
+            "evidence": "-72-big-upgrade-report.md + integrations-case-study-prep4-closeout.md",
         },
         {
             "check_id": "top10_case_study_prep4_alignment",
             "weight": 5,
             "passed": (
                 ("case-study-prep4-closeout" in top10_text and "publication launch" in top10_text)
-                or (
-                    '' in top10_text
-                    and '' in top10_text
-                    and "Publication launch" in top10_text
-                )
-                or ' +  strategy chain' in top10_text
+                or ("" in top10_text and "" in top10_text and "Publication launch" in top10_text)
+                or " +  strategy chain" in top10_text
             ),
             "evidence": "Case-study prep #4 + publication launch strategy chain",
         },
@@ -192,7 +188,7 @@ def build_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
                 page_text.splitlines()[0].strip()
                 in {
                     "# Case-study prep #4 closeout lane",
-                    '#  — Case-study prep #4 closeout lane',
+                    "#  — Case-study prep #4 closeout lane",
                 }
                 if page_text.strip()
                 else False
@@ -249,38 +245,30 @@ def build_case_study_prep4_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if prior_closeout_strict:
-        wins.append(
-            f"71 continuity is strict-pass with activation score={prior_closeout_score}."
-        )
+        wins.append(f"71 continuity is strict-pass with activation score={prior_closeout_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_prior_closeout:
-        wins.append(
-            f"71 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"71 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_case_data_keys:
         wins.append(
-            ' publication-quality case-study dataset is available for case-study prep execution.'
+            " publication-quality case-study dataset is available for case-study prep execution."
         )
     else:
-        misses.append(' publication-quality case-study dataset is missing required keys.')
+        misses.append(" publication-quality case-study dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/publication-quality-case-study.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' case-study prep #4 closeout lane is fully complete and ready for  publication launch execution.'
+            " case-study prep #4 closeout lane is fully complete and ready for  publication launch execution."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -341,22 +329,22 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "case-study-prep4-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "case-study-prep4-integration-brief.md", '#  integration brief\n')
-    _write(target / "case-study-prep4-case-study-narrative.md", '#  case-study narrative\n')
+    _write(target / "case-study-prep4-integration-brief.md", "#  integration brief\n")
+    _write(target / "case-study-prep4-case-study-narrative.md", "#  case-study narrative\n")
     _write(
         target / "case-study-prep4-controls-log.json", json.dumps({"controls": []}, indent=2) + "\n"
     )
     _write(
         target / "case-study-prep4-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n"
     )
-    _write(target / "case-study-prep4-execution-log.md", '#  execution log\n')
+    _write(target / "case-study-prep4-execution-log.md", "#  execution log\n")
     _write(
         target / "case-study-prep4-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "case-study-prep4-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -384,7 +372,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_case_study_prep4_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_case_study_prep4_closeout_summary(root)
 
 

--- a/src/sdetkit/checks/artifacts.py
+++ b/src/sdetkit/checks/artifacts.py
@@ -227,14 +227,22 @@ def build_verdict_payload(
         "recommendation": verdict.recommendation,
         "targeting": {
             "modes": check_summary["target_modes"],
-            "used_targeted_execution": coerce_bool(check_summary["target_modes"].get("targeted", 0), default=False),
-            "used_smoke_execution": coerce_bool(check_summary["target_modes"].get("smoke", 0), default=False),
-            "used_full_execution": coerce_bool(check_summary["target_modes"].get("full", 0), default=False),
+            "used_targeted_execution": coerce_bool(
+                check_summary["target_modes"].get("targeted", 0), default=False
+            ),
+            "used_smoke_execution": coerce_bool(
+                check_summary["target_modes"].get("smoke", 0), default=False
+            ),
+            "used_full_execution": coerce_bool(
+                check_summary["target_modes"].get("full", 0), default=False
+            ),
         },
         "cache": {
             "enabled": coerce_bool(metadata.get("cache_enabled", False), default=False),
             "summary": check_summary["cache_status"],
-            "used_cache_hits": coerce_bool(check_summary["cache_status"].get("hit", 0), default=False),
+            "used_cache_hits": coerce_bool(
+                check_summary["cache_status"].get("hit", 0), default=False
+            ),
         },
         "execution": {
             "mode": execution.get("mode", "sequential")

--- a/src/sdetkit/checks/builtin.py
+++ b/src/sdetkit/checks/builtin.py
@@ -194,8 +194,6 @@ def _tests_full_command(ctx: CheckContext) -> tuple[str, ...]:
     return (ctx.python_executable, "-m", "pytest", "-q", "-o", "addopts=")
 
 
-
-
 def _feature_registry_contract_command(ctx: CheckContext) -> tuple[str, ...]:
     return (ctx.python_executable, "scripts/check_feature_registry_contract.py")
 
@@ -268,7 +266,10 @@ BUILTIN_CHECKS: tuple[CheckDefinition, ...] = (
             cost="cheap",
             truth_level="smoke",
             required_tools=("python",),
-            required_paths=("scripts/check_feature_registry_contract.py", "src/sdetkit/data/feature_registry.json"),
+            required_paths=(
+                "scripts/check_feature_registry_contract.py",
+                "src/sdetkit/data/feature_registry.json",
+            ),
             command=("python", "scripts/check_feature_registry_contract.py"),
             notes="Ensures Tier-mapped commands keep valid docs/tests linkage and contract fields.",
         ),

--- a/src/sdetkit/checks/registry.py
+++ b/src/sdetkit/checks/registry.py
@@ -13,7 +13,14 @@ DEFAULT_PROFILES: tuple[CheckProfile, ...] = (
         description="Fast local confidence / smoke profile.",
         default_truth_level="smoke",
         merge_truth=False,
-        check_ids=("repo_layout", "feature_registry_contract", "format_check", "lint", "typing", "tests_smoke"),
+        check_ids=(
+            "repo_layout",
+            "feature_registry_contract",
+            "format_check",
+            "lint",
+            "typing",
+            "tests_smoke",
+        ),
         notes="Honest smoke lane for developers; passing does not imply merge readiness.",
     ),
     CheckProfile(

--- a/src/sdetkit/community_activation.py
+++ b/src/sdetkit/community_activation.py
@@ -10,9 +10,9 @@ from typing import Any
 
 _PAGE_PATH = "docs/integrations-community-activation.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
-_SECTION_HEADER = '# Community activation ()'
+_SECTION_HEADER = "# Community activation ()"
 _REQUIRED_SECTIONS = [
-    '## Who should run ',
+    "## Who should run ",
     "## Roadmap-voting discussion contract",
     "## Launch checklist",
     "## Feedback triage SLA",
@@ -30,7 +30,7 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_community_activation_contract.py --skip-evidence",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '# Community activation ()\n\n converts passive roadmap readers into active contributors through a deterministic roadmap-voting and feedback loop.\n\n## Who should run \n\n- Maintainers preparing priorities for the next sprint or release train.\n- DevRel/community managers collecting qualitative and quantitative roadmap feedback.\n- Engineering leads that need transparent prioritization signals for backlog decisions.\n\n## Roadmap-voting discussion contract\n\n is complete when a public roadmap-voting thread is opened, tagged, and linked from docs so contributors can vote and comment on priority items.\n\n## Launch checklist\n\n```bash\npython -m sdetkit community-activation --format json --strict\npython -m sdetkit community-activation --emit-pack-dir docs/artifacts/community-activation-pack --format json --strict\npython -m sdetkit community-activation --execute --evidence-dir docs/artifacts/community-activation-pack/evidence --format json --strict\npython scripts/check_community_activation_contract.py\n```\n\n## Feedback triage SLA\n\n- Triage new roadmap votes/comments within 48 hours.\n- Label each item as `accepted`, `needs-info`, or `not-now`.\n- Publish weekly summary of wins, blockers, and next actions.\n\n## Activation scoring model\n\n computes weighted readiness score (0-100):\n\n- Docs contract + command lane completeness: 45 points.\n- Discoverability links in README/docs index: 25 points.\n- Top-10 roadmap alignment marker coverage: 20 points.\n- Evidence-lane readiness for strict validation: 10 points.\n\n## Execution evidence mode\n\n`--execute` runs deterministic  checks and writes logs to `--evidence-dir` for release review.\n'
+_DEFAULT_PAGE_TEMPLATE = "# Community activation ()\n\n converts passive roadmap readers into active contributors through a deterministic roadmap-voting and feedback loop.\n\n## Who should run \n\n- Maintainers preparing priorities for the next sprint or release train.\n- DevRel/community managers collecting qualitative and quantitative roadmap feedback.\n- Engineering leads that need transparent prioritization signals for backlog decisions.\n\n## Roadmap-voting discussion contract\n\n is complete when a public roadmap-voting thread is opened, tagged, and linked from docs so contributors can vote and comment on priority items.\n\n## Launch checklist\n\n```bash\npython -m sdetkit community-activation --format json --strict\npython -m sdetkit community-activation --emit-pack-dir docs/artifacts/community-activation-pack --format json --strict\npython -m sdetkit community-activation --execute --evidence-dir docs/artifacts/community-activation-pack/evidence --format json --strict\npython scripts/check_community_activation_contract.py\n```\n\n## Feedback triage SLA\n\n- Triage new roadmap votes/comments within 48 hours.\n- Label each item as `accepted`, `needs-info`, or `not-now`.\n- Publish weekly summary of wins, blockers, and next actions.\n\n## Activation scoring model\n\n computes weighted readiness score (0-100):\n\n- Docs contract + command lane completeness: 45 points.\n- Discoverability links in README/docs index: 25 points.\n- Top-10 roadmap alignment marker coverage: 20 points.\n- Evidence-lane readiness for strict validation: 10 points.\n\n## Execution evidence mode\n\n`--execute` runs deterministic  checks and writes logs to `--evidence-dir` for release review.\n"
 
 _SIGNALS = [
     {
@@ -76,7 +76,7 @@ _SIGNALS = [
         "check_id": "top10_strategy_alignment",
         "category": "strategy",
         "weight": 20,
-        "marker": ' — Community activation',
+        "marker": " — Community activation",
         "source": "top10",
     },
     {
@@ -187,19 +187,19 @@ def build_community_activation_summary(
     recommendations: list[str] = []
     if any(item["category"] == "contract" for item in failed):
         recommendations.append(
-            'Restore  docs contract sections and required command lane before launch.'
+            "Restore  docs contract sections and required command lane before launch."
         )
     if any(item["category"] == "discoverability" for item in failed):
         recommendations.append(
-            'Add  links and command snippets to README/docs index for contributor visibility.'
+            "Add  links and command snippets to README/docs index for contributor visibility."
         )
     if any(item["category"] == "strategy" for item in failed):
         recommendations.append(
-            'Align  outputs with top-10 roadmap activation objective and roadmap-voting messaging.'
+            "Align  outputs with top-10 roadmap activation objective and roadmap-voting messaging."
         )
     if not recommendations:
         recommendations.append(
-            ' community activation lane is healthy; keep weekly voting summaries flowing.'
+            " community activation lane is healthy; keep weekly voting summaries flowing."
         )
 
     return {
@@ -223,7 +223,7 @@ def build_community_activation_summary(
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' community activation summary',
+        " community activation summary",
         f"score={payload['summary']['activation_score']}",
         f"failed={','.join(payload['summary']['failed_checks']) or 'none'}",
         f"critical={','.join(payload['summary']['critical_failures']) or 'none'}",
@@ -250,7 +250,7 @@ def emit_pack(root: Path, out_dir: Path, payload: dict[str, Any]) -> list[str]:
     discussion.write_text(
         "\n".join(
             [
-                '#  roadmap-voting discussion template',
+                "#  roadmap-voting discussion template",
                 "",
                 "## Title",
                 "Roadmap voting: help prioritize the next sdetkit upgrades",
@@ -277,7 +277,7 @@ def emit_pack(root: Path, out_dir: Path, payload: dict[str, Any]) -> list[str]:
     triage.write_text(
         "\n".join(
             [
-                '#  feedback triage board',
+                "#  feedback triage board",
                 "",
                 "| Feedback item | Votes | Owner | Status | Decision date |",
                 "| --- | ---: | --- | --- | --- |",
@@ -290,8 +290,7 @@ def emit_pack(root: Path, out_dir: Path, payload: dict[str, Any]) -> list[str]:
         encoding="utf-8",
     )
     validation.write_text(
-        "\n".join(['#  validation commands', "", "```bash", *_REQUIRED_COMMANDS, "```"])
-        + "\n",
+        "\n".join(["#  validation commands", "", "```bash", *_REQUIRED_COMMANDS, "```"]) + "\n",
         encoding="utf-8",
     )
 
@@ -330,7 +329,7 @@ def execute_commands(root: Path, evidence_dir: Path, timeout_sec: int) -> dict[s
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="sdetkit community-activation",
-        description=' community activation and roadmap-voting closeout lane.',
+        description=" community activation and roadmap-voting closeout lane.",
     )
     parser.add_argument("--root", default=".", help="Repository root path.")
     parser.add_argument(
@@ -341,13 +340,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--top10", default=_TOP10_PATH, help="Top-10 roadmap strategy path.")
     parser.add_argument(
-        "--write-defaults", action="store_true", help='Create default  integration page.'
+        "--write-defaults", action="store_true", help="Create default  integration page."
     )
     parser.add_argument(
-        "--emit-pack-dir", default="", help='Optional output directory for generated  files.'
+        "--emit-pack-dir", default="", help="Optional output directory for generated  files."
     )
     parser.add_argument(
-        "--execute", action="store_true", help='Run  command chain and emit evidence logs.'
+        "--execute", action="store_true", help="Run  command chain and emit evidence logs."
     )
     parser.add_argument(
         "--evidence-dir",

--- a/src/sdetkit/community_touchpoint_closeout_77.py
+++ b/src/sdetkit/community_touchpoint_closeout_77.py
@@ -19,8 +19,8 @@ _DAY76_BOARD_PATH = (
 _PLAN_PATH = "docs/roadmap/plans/community-touchpoint-plan.json"
 _SECTION_HEADER = "# Community touchpoint closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
+    "## Why  matters",
+    "## Required inputs ()",
     "## Community touchpoint command lane",
     "## Community touchpoint contract",
     "## Touchpoint quality checklist",
@@ -39,10 +39,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_community_touchpoint_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  community touchpoint execution and signoff.',
-    'The  lane references  outcomes, controls, and KPI continuity signals.',
-    'Every  section includes community CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records touchpoint outcomes, confidence notes, and  ecosystem priorities.',
+    "Single owner + backup reviewer are assigned for  community touchpoint execution and signoff.",
+    "The  lane references  outcomes, controls, and KPI continuity signals.",
+    "Every  section includes community CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records touchpoint outcomes, confidence notes, and  ecosystem priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes community baseline, touchpoint cadence, and stakeholder assumptions",
@@ -52,11 +52,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, touchpoint plan, session ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  community touchpoint plan committed',
-    '- [ ]  touchpoint session ledger exported',
-    '- [ ]  touchpoint KPI scorecard snapshot exported',
-    '- [ ]  ecosystem priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  community touchpoint plan committed",
+    "- [ ]  touchpoint session ledger exported",
+    "- [ ]  touchpoint KPI scorecard snapshot exported",
+    "- [ ]  ecosystem priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -67,7 +67,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '# Community touchpoint closeout lane\n\n closes with a major upgrade that converts  contributor-recognition outcomes into a community-touchpoint execution pack.\n\n## Why  matters\n\n- Turns  contributor-recognition outcomes into community-facing touchpoint proof across docs, governance, and release channels.\n- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  community touchpoint into  ecosystem priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/contributor-recognition-closeout-pack/contributor-recognition-closeout-summary.json`\n- `docs/artifacts/contributor-recognition-closeout-pack/contributor-recognition-delivery-board.md`\n- `docs/roadmap/plans/community-touchpoint-plan.json`\n\n## Community touchpoint command lane\n\n```bash\npython -m sdetkit community-touchpoint-closeout --format json --strict\npython -m sdetkit community-touchpoint-closeout --emit-pack-dir docs/artifacts/community-touchpoint-closeout-pack --format json --strict\npython -m sdetkit community-touchpoint-closeout --execute --evidence-dir docs/artifacts/community-touchpoint-closeout-pack/evidence --format json --strict\npython scripts/check_community_touchpoint_closeout_contract.py\n```\n\n## Community touchpoint contract\n\n- Single owner + backup reviewer are assigned for  community touchpoint execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes community CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records touchpoint outcomes, confidence notes, and  ecosystem priorities.\n\n## Touchpoint quality checklist\n\n- [ ] Includes community baseline, touchpoint cadence, and stakeholder assumptions\n- [ ] Every touchpoint lane row has owner, session window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures touchpoint score delta, trust carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, touchpoint plan, session ledger, KPI scorecard, and execution log\n\n## Community touchpoint delivery board\n\n- [ ]  integration brief committed\n- [ ]  community touchpoint plan committed\n- [ ]  touchpoint session ledger exported\n- [ ]  touchpoint KPI scorecard snapshot exported\n- [ ]  ecosystem priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Touchpoint evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "# Community touchpoint closeout lane\n\n closes with a major upgrade that converts  contributor-recognition outcomes into a community-touchpoint execution pack.\n\n## Why  matters\n\n- Turns  contributor-recognition outcomes into community-facing touchpoint proof across docs, governance, and release channels.\n- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  community touchpoint into  ecosystem priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/contributor-recognition-closeout-pack/contributor-recognition-closeout-summary.json`\n- `docs/artifacts/contributor-recognition-closeout-pack/contributor-recognition-delivery-board.md`\n- `docs/roadmap/plans/community-touchpoint-plan.json`\n\n## Community touchpoint command lane\n\n```bash\npython -m sdetkit community-touchpoint-closeout --format json --strict\npython -m sdetkit community-touchpoint-closeout --emit-pack-dir docs/artifacts/community-touchpoint-closeout-pack --format json --strict\npython -m sdetkit community-touchpoint-closeout --execute --evidence-dir docs/artifacts/community-touchpoint-closeout-pack/evidence --format json --strict\npython scripts/check_community_touchpoint_closeout_contract.py\n```\n\n## Community touchpoint contract\n\n- Single owner + backup reviewer are assigned for  community touchpoint execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes community CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records touchpoint outcomes, confidence notes, and  ecosystem priorities.\n\n## Touchpoint quality checklist\n\n- [ ] Includes community baseline, touchpoint cadence, and stakeholder assumptions\n- [ ] Every touchpoint lane row has owner, session window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures touchpoint score delta, trust carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, touchpoint plan, session ledger, KPI scorecard, and execution log\n\n## Community touchpoint delivery board\n\n- [ ]  integration brief committed\n- [ ]  community touchpoint plan committed\n- [ ]  touchpoint session ledger exported\n- [ ]  touchpoint KPI scorecard snapshot exported\n- [ ]  ecosystem priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Touchpoint evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -110,7 +110,7 @@ def build_community_touchpoint_closeout_summary(root: Path) -> dict[str, Any]:
         contributor_recognition_check_count,
     ) = _load_contributor_recognition(contributor_recognition_summary)
     board_count, board_has_contributor_recognition = _count_board_items(
-        contributor_recognition_board, ''
+        contributor_recognition_board, ""
     )
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
@@ -235,32 +235,26 @@ def build_community_touchpoint_closeout_summary(root: Path) -> dict[str, Any]:
             f"76 continuity is strict-pass with activation score={contributor_recognition_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_contributor_recognition:
-        wins.append(
-            f"76 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"76 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' community touchpoint dataset is available for launch execution.')
+        wins.append(" community touchpoint dataset is available for launch execution.")
     else:
-        misses.append(' community touchpoint dataset is missing required keys.')
+        misses.append(" community touchpoint dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/community-touchpoint-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' community touchpoint closeout lane is fully complete and ready for  ecosystem priorities.'
+            " community touchpoint closeout lane is fully complete and ready for  ecosystem priorities."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -378,7 +372,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_community_touchpoint_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_community_touchpoint_closeout_summary(root)
 
 

--- a/src/sdetkit/contributor_activation_closeout_55.py
+++ b/src/sdetkit/contributor_activation_closeout_55.py
@@ -302,13 +302,9 @@ def build_contributor_activation_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     if board_count >= 5 and board_has_required:
-        wins.append(
-            f"delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            "delivery board integrity is incomplete (needs >=5 items and anchors)."
-        )
+        misses.append("delivery board integrity is incomplete (needs >=5 items and anchors).")
         handoff_actions.append("Repair delivery board entries to include anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:

--- a/src/sdetkit/contributor_recognition_closeout_76.py
+++ b/src/sdetkit/contributor_recognition_closeout_76.py
@@ -19,14 +19,14 @@ _DAY75_BOARD_PATH = (
     "docs/artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/contributor-recognition-plan.json"
-_SECTION_HEADER = '#  — Contributor recognition closeout lane'
+_SECTION_HEADER = "#  — Contributor recognition closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Contributor recognition contract",
     "## Recognition quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_contributor_recognition_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  contributor recognition execution and signoff.',
-    'The  lane references  outcomes, controls, and KPI continuity signals.',
-    'Every  section includes contributor CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records recognition outcomes, confidence notes, and  scale priorities.',
+    "Single owner + backup reviewer are assigned for  contributor recognition execution and signoff.",
+    "The  lane references  outcomes, controls, and KPI continuity signals.",
+    "Every  section includes contributor CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records recognition outcomes, confidence notes, and  scale priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes contributor baseline, recognition cadence, and stakeholder assumptions",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, recognition plan, credits ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  contributor recognition plan committed',
-    '- [ ]  recognition credits ledger exported',
-    '- [ ]  recognition KPI scorecard snapshot exported',
-    '- [ ]  scale priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  contributor recognition plan committed",
+    "- [ ]  recognition credits ledger exported",
+    "- [ ]  recognition KPI scorecard snapshot exported",
+    "- [ ]  scale priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Contributor recognition closeout lane\n\n closes with a major upgrade that converts  trust refresh outcomes into a contributor-recognition execution pack.\n\n## Why  matters\n\n- Turns  trust outcomes into contributor-facing recognition proof across docs, governance, and release channels.\n- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  contributor recognition into  scale priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.json`\n- `docs/artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-delivery-board.md`\n- `docs/roadmap/plans/contributor-recognition-plan.json`\n\n##  command lane\n\n```bash\npython -m sdetkit contributor-recognition-closeout --format json --strict\npython -m sdetkit contributor-recognition-closeout --emit-pack-dir docs/artifacts/contributor-recognition-closeout-pack --format json --strict\npython -m sdetkit contributor-recognition-closeout --execute --evidence-dir docs/artifacts/contributor-recognition-closeout-pack/evidence --format json --strict\npython scripts/check_contributor_recognition_closeout_contract.py\n```\n\n## Contributor recognition contract\n\n- Single owner + backup reviewer are assigned for  contributor recognition execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes contributor CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records recognition outcomes, confidence notes, and  scale priorities.\n\n## Recognition quality checklist\n\n- [ ] Includes contributor baseline, recognition cadence, and stakeholder assumptions\n- [ ] Every recognition lane row has owner, publish window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures recognition score delta, trust carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, recognition plan, credits ledger, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  contributor recognition plan committed\n- [ ]  recognition credits ledger exported\n- [ ]  recognition KPI scorecard snapshot exported\n- [ ]  scale priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Recognition evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Contributor recognition closeout lane\n\n closes with a major upgrade that converts  trust refresh outcomes into a contributor-recognition execution pack.\n\n## Why  matters\n\n- Turns  trust outcomes into contributor-facing recognition proof across docs, governance, and release channels.\n- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  contributor recognition into  scale priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-closeout-summary.json`\n- `docs/artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-delivery-board.md`\n- `docs/roadmap/plans/contributor-recognition-plan.json`\n\n##  command lane\n\n```bash\npython -m sdetkit contributor-recognition-closeout --format json --strict\npython -m sdetkit contributor-recognition-closeout --emit-pack-dir docs/artifacts/contributor-recognition-closeout-pack --format json --strict\npython -m sdetkit contributor-recognition-closeout --execute --evidence-dir docs/artifacts/contributor-recognition-closeout-pack/evidence --format json --strict\npython scripts/check_contributor_recognition_closeout_contract.py\n```\n\n## Contributor recognition contract\n\n- Single owner + backup reviewer are assigned for  contributor recognition execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes contributor CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records recognition outcomes, confidence notes, and  scale priorities.\n\n## Recognition quality checklist\n\n- [ ] Includes contributor baseline, recognition cadence, and stakeholder assumptions\n- [ ] Every recognition lane row has owner, publish window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures recognition score delta, trust carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, recognition plan, credits ledger, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  contributor recognition plan committed\n- [ ]  recognition credits ledger exported\n- [ ]  recognition KPI scorecard snapshot exported\n- [ ]  scale priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Recognition evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -109,9 +109,7 @@ def build_contributor_recognition_closeout_summary(root: Path) -> dict[str, Any]
     trust_assets_refresh_score, trust_assets_refresh_strict, trust_assets_refresh_check_count = (
         _load_trust_assets_refresh(trust_assets_refresh_summary)
     )
-    board_count, board_has_trust_assets_refresh = _count_board_items(
-        trust_assets_refresh_board, ''
-    )
+    board_count, board_has_trust_assets_refresh = _count_board_items(trust_assets_refresh_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -142,8 +140,8 @@ def build_contributor_recognition_closeout_summary(root: Path) -> dict[str, Any]
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "trust_assets_refresh_summary_present",
@@ -236,32 +234,26 @@ def build_contributor_recognition_closeout_summary(root: Path) -> dict[str, Any]
             f"75 continuity is strict-pass with activation score={trust_assets_refresh_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_trust_assets_refresh:
-        wins.append(
-            f"75 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"75 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' contributor recognition dataset is available for launch execution.')
+        wins.append(" contributor recognition dataset is available for launch execution.")
     else:
-        misses.append(' contributor recognition dataset is missing required keys.')
+        misses.append(" contributor recognition dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/contributor-recognition-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' contributor recognition closeout lane is fully complete and ready for  scale priorities.'
+            " contributor recognition closeout lane is fully complete and ready for  scale priorities."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -322,8 +314,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "contributor-recognition-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "contributor-recognition-integration-brief.md", '#  integration brief\n')
-    _write(target / "contributor-recognition-plan.md", '#  contributor recognition plan\n')
+    _write(target / "contributor-recognition-integration-brief.md", "#  integration brief\n")
+    _write(target / "contributor-recognition-plan.md", "#  contributor recognition plan\n")
     _write(
         target / "contributor-recognition-credits-ledger.json",
         json.dumps({"credits": []}, indent=2) + "\n",
@@ -332,14 +324,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "contributor-recognition-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "contributor-recognition-execution-log.md", '#  execution log\n')
+    _write(target / "contributor-recognition-execution-log.md", "#  execution log\n")
     _write(
         target / "contributor-recognition-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "contributor-recognition-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -367,7 +359,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_contributor_recognition_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_contributor_recognition_closeout_summary(root)
 
 

--- a/src/sdetkit/distribution_scaling_closeout_74.py
+++ b/src/sdetkit/distribution_scaling_closeout_74.py
@@ -19,14 +19,14 @@ _DAY73_BOARD_PATH = (
     "docs/artifacts/case-study-launch-closeout-pack/case-study-launch-delivery-board.md"
 )
 _SCALING_PLAN_PATH = "docs/roadmap/plans/distribution-scaling-plan.json"
-_SECTION_HEADER = '#  — Distribution scaling closeout lane'
+_SECTION_HEADER = "#  — Distribution scaling closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Distribution scaling contract",
     "## Distribution quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_distribution_scaling_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  distribution scaling execution and signoff.',
-    'The  lane references  publication outcomes, controls, and KPI continuity signals.',
-    'Every  section includes channel CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records distribution outcomes, confidence notes, and  trust refresh priorities.',
+    "Single owner + backup reviewer are assigned for  distribution scaling execution and signoff.",
+    "The  lane references  publication outcomes, controls, and KPI continuity signals.",
+    "Every  section includes channel CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records distribution outcomes, confidence notes, and  trust refresh priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes channel mix baseline, treatment cadence, and audience-segment assumptions",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, scaling plan, controls log, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  distribution scaling plan committed',
-    '- [ ]  channel controls and assumptions log exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  trust refresh priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  distribution scaling plan committed",
+    "- [ ]  channel controls and assumptions log exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  trust refresh priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Distribution scaling closeout lane\n\n closes with a major upgrade that turns  published case-study outcomes into a scalable distribution execution pack with governance safeguards.\n\n## Why  matters\n\n- Converts  publication proof into repeatable multi-channel distribution operations.\n- Protects scaling quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  distribution scaling execution into  trust-asset refresh.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.json`\n- `docs/artifacts/case-study-launch-closeout-pack/case-study-launch-delivery-board.md`\n- `docs/roadmap/plans/distribution-scaling-plan.json`\n\n##  command lane\n\n```bash\npython -m sdetkit distribution-scaling-closeout --format json --strict\npython -m sdetkit distribution-scaling-closeout --emit-pack-dir docs/artifacts/distribution-scaling-closeout-pack --format json --strict\npython -m sdetkit distribution-scaling-closeout --execute --evidence-dir docs/artifacts/distribution-scaling-closeout-pack/evidence --format json --strict\npython scripts/check_distribution_scaling_closeout_contract.py\n```\n\n## Distribution scaling contract\n\n- Single owner + backup reviewer are assigned for  distribution scaling execution and signoff.\n- The  lane references  publication outcomes, controls, and KPI continuity signals.\n- Every  section includes channel CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records distribution outcomes, confidence notes, and  trust refresh priorities.\n\n## Distribution quality checklist\n\n- [ ] Includes channel mix baseline, treatment cadence, and audience-segment assumptions\n- [ ] Every channel plan row has owner, launch window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures CTR delta, qualified lead delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, scaling plan, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  distribution scaling plan committed\n- [ ]  channel controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  trust refresh priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Distribution evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Distribution scaling closeout lane\n\n closes with a major upgrade that turns  published case-study outcomes into a scalable distribution execution pack with governance safeguards.\n\n## Why  matters\n\n- Converts  publication proof into repeatable multi-channel distribution operations.\n- Protects scaling quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  distribution scaling execution into  trust-asset refresh.\n\n## Required inputs ()\n\n- `docs/artifacts/case-study-launch-closeout-pack/case-study-launch-closeout-summary.json`\n- `docs/artifacts/case-study-launch-closeout-pack/case-study-launch-delivery-board.md`\n- `docs/roadmap/plans/distribution-scaling-plan.json`\n\n##  command lane\n\n```bash\npython -m sdetkit distribution-scaling-closeout --format json --strict\npython -m sdetkit distribution-scaling-closeout --emit-pack-dir docs/artifacts/distribution-scaling-closeout-pack --format json --strict\npython -m sdetkit distribution-scaling-closeout --execute --evidence-dir docs/artifacts/distribution-scaling-closeout-pack/evidence --format json --strict\npython scripts/check_distribution_scaling_closeout_contract.py\n```\n\n## Distribution scaling contract\n\n- Single owner + backup reviewer are assigned for  distribution scaling execution and signoff.\n- The  lane references  publication outcomes, controls, and KPI continuity signals.\n- Every  section includes channel CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records distribution outcomes, confidence notes, and  trust refresh priorities.\n\n## Distribution quality checklist\n\n- [ ] Includes channel mix baseline, treatment cadence, and audience-segment assumptions\n- [ ] Every channel plan row has owner, launch window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures CTR delta, qualified lead delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, scaling plan, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  distribution scaling plan committed\n- [ ]  channel controls and assumptions log exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  trust refresh priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Distribution evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -112,7 +112,7 @@ def build_distribution_scaling_closeout_summary(root: Path) -> dict[str, Any]:
     prior_closeout_score, prior_closeout_strict, prior_closeout_check_count = _load_prior_closeout(
         prior_closeout_summary
     )
-    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, '')
+    board_count, board_has_prior_closeout = _count_board_items(prior_closeout_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -143,8 +143,8 @@ def build_distribution_scaling_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "prior_closeout_summary_present",
@@ -233,36 +233,28 @@ def build_distribution_scaling_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if prior_closeout_strict:
-        wins.append(
-            f"73 continuity is strict-pass with activation score={prior_closeout_score}."
-        )
+        wins.append(f"73 continuity is strict-pass with activation score={prior_closeout_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_prior_closeout:
-        wins.append(
-            f"73 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"73 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_scaling_plan_keys:
-        wins.append(' distribution scaling dataset is available for launch execution.')
+        wins.append(" distribution scaling dataset is available for launch execution.")
     else:
-        misses.append(' distribution scaling dataset is missing required keys.')
+        misses.append(" distribution scaling dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/distribution-scaling-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' distribution scaling closeout lane is fully complete and ready for  trust refresh.'
+            " distribution scaling closeout lane is fully complete and ready for  trust refresh."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -323,8 +315,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "distribution-scaling-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "distribution-scaling-integration-brief.md", '#  integration brief\n')
-    _write(target / "distribution-scaling-plan.md", '#  distribution scaling plan\n')
+    _write(target / "distribution-scaling-integration-brief.md", "#  integration brief\n")
+    _write(target / "distribution-scaling-plan.md", "#  distribution scaling plan\n")
     _write(
         target / "distribution-scaling-channel-controls-log.json",
         json.dumps({"controls": []}, indent=2) + "\n",
@@ -333,14 +325,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "distribution-scaling-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "distribution-scaling-execution-log.md", '#  execution log\n')
+    _write(target / "distribution-scaling-execution-log.md", "#  execution log\n")
     _write(
         target / "distribution-scaling-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "distribution-scaling-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -368,7 +360,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_distribution_scaling_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_distribution_scaling_closeout_summary(root)
 
 

--- a/src/sdetkit/docs_loop_closeout_53.py
+++ b/src/sdetkit/docs_loop_closeout_53.py
@@ -181,9 +181,7 @@ def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
     narrative_closeout_score, narrative_closeout_strict, narrative_closeout_check_count = (
         _load_narrative_closeout_summary(narrative_closeout_summary)
     )
-    board_count, board_has_previous, board_has_required = _board_stats(
-        narrative_closeout_board
-    )
+    board_count, board_has_previous, board_has_required = _board_stats(narrative_closeout_board)
 
     checks: list[dict[str, Any]] = [
         {
@@ -262,9 +260,7 @@ def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "narrative_closeout_board_integrity",
             "weight": 7,
-            "passed": board_count >= 5
-            and board_has_previous
-            and board_has_required,
+            "passed": board_count >= 5 and board_has_previous and board_has_required,
             "evidence": {
                 "board_items": board_count,
                 "contains_previous": board_has_previous,
@@ -314,16 +310,10 @@ def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     if board_count >= 5 and board_has_previous and board_has_required:
-        wins.append(
-            f"delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            "delivery board integrity is incomplete (needs >=5 items and /53 anchors)."
-        )
-        handoff_actions.append(
-            "Repair delivery board entries to include and anchors."
-        )
+        misses.append("delivery board integrity is incomplete (needs >=5 items and /53 anchors).")
+        handoff_actions.append("Repair delivery board entries to include and anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
         wins.append("Docs-loop contract + quality checklist is fully locked for execution.")
@@ -336,9 +326,7 @@ def build_docs_loop_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     if not failed and not critical_failures:
-        wins.append(
-            "docs-loop closeout lane is fully complete and ready for execution lane."
-        )
+        wins.append("docs-loop closeout lane is fully complete and ready for execution lane.")
 
     return {
         "name": "docs-loop-closeout",

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -2267,7 +2267,9 @@ def main(argv: list[str] | None = None) -> int:
     if failed_checks:
         data["failed_checks"] = failed_checks
     if isinstance(getattr(ns, "apply_plan", None), str) and ns.apply_plan:
-        data["post_plan_ok"] = coerce_bool(data.get("ok"), default=False) and coerce_bool(data.get("plan_ok"), default=False)
+        data["post_plan_ok"] = coerce_bool(data.get("ok"), default=False) and coerce_bool(
+            data.get("plan_ok"), default=False
+        )
 
     if ns.format == "json" or ns.json:
         output = json.dumps(data, sort_keys=True) + "\n"

--- a/src/sdetkit/ecosystem_priorities_closeout_78.py
+++ b/src/sdetkit/ecosystem_priorities_closeout_78.py
@@ -21,8 +21,8 @@ _DAY77_BOARD_PATH = (
 _PLAN_PATH = "docs/roadmap/plans/ecosystem-priorities-plan.json"
 _SECTION_HEADER = "# Ecosystem priorities closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
+    "## Why  matters",
+    "## Required inputs ()",
     "## Ecosystem priorities command lane",
     "## Ecosystem priorities contract",
     "## Ecosystem priorities quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_ecosystem_priorities_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  ecosystem priorities execution and signoff.',
-    'The  lane references  outcomes, controls, and KPI continuity signals.',
-    'Every  section includes ecosystem CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records ecosystem outcomes, confidence notes, and  scale priorities.',
+    "Single owner + backup reviewer are assigned for  ecosystem priorities execution and signoff.",
+    "The  lane references  outcomes, controls, and KPI continuity signals.",
+    "Every  section includes ecosystem CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records ecosystem outcomes, confidence notes, and  scale priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes ecosystem baseline, priority cadence, and stakeholder assumptions",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, ecosystem priorities plan, workstream ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  ecosystem priorities plan committed',
-    '- [ ]  ecosystem workstream ledger exported',
-    '- [ ]  ecosystem KPI scorecard snapshot exported',
-    '- [ ]  scale priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  ecosystem priorities plan committed",
+    "- [ ]  ecosystem workstream ledger exported",
+    "- [ ]  ecosystem KPI scorecard snapshot exported",
+    "- [ ]  scale priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '# Ecosystem priorities closeout lane\n\n closes with a major upgrade that converts  community-touchpoint outcomes into an ecosystem-priorities execution pack.\n\n## Why  matters\n\n- Turns  community-touchpoint outcomes into ecosystem-facing expansion proof across docs, governance, and release channels.\n- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  ecosystem priorities into  scale priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/community-touchpoint-closeout-pack/community-touchpoint-closeout-summary.json`\n- `docs/artifacts/community-touchpoint-closeout-pack/community-touchpoint-delivery-board.md`\n- `docs/roadmap/plans/ecosystem-priorities-plan.json`\n\n## Ecosystem priorities command lane\n\n```bash\npython -m sdetkit ecosystem-priorities-closeout --format json --strict\npython -m sdetkit ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/ecosystem-priorities-closeout-pack --format json --strict\npython -m sdetkit ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/ecosystem-priorities-closeout-pack/evidence --format json --strict\npython scripts/check_ecosystem_priorities_closeout_contract.py\n```\n\n## Ecosystem priorities contract\n\n- Single owner + backup reviewer are assigned for  ecosystem priorities execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes ecosystem CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records ecosystem outcomes, confidence notes, and  scale priorities.\n\n## Ecosystem priorities quality checklist\n\n- [ ] Includes ecosystem baseline, priority cadence, and stakeholder assumptions\n- [ ] Every ecosystem lane row has owner, workstream window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures ecosystem score delta, touchpoint carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, ecosystem priorities plan, workstream ledger, KPI scorecard, and execution log\n\n## Ecosystem priorities delivery board\n\n- [ ]  integration brief committed\n- [ ]  ecosystem priorities plan committed\n- [ ]  ecosystem workstream ledger exported\n- [ ]  ecosystem KPI scorecard snapshot exported\n- [ ]  scale priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Ecosystem evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "# Ecosystem priorities closeout lane\n\n closes with a major upgrade that converts  community-touchpoint outcomes into an ecosystem-priorities execution pack.\n\n## Why  matters\n\n- Turns  community-touchpoint outcomes into ecosystem-facing expansion proof across docs, governance, and release channels.\n- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  ecosystem priorities into  scale priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/community-touchpoint-closeout-pack/community-touchpoint-closeout-summary.json`\n- `docs/artifacts/community-touchpoint-closeout-pack/community-touchpoint-delivery-board.md`\n- `docs/roadmap/plans/ecosystem-priorities-plan.json`\n\n## Ecosystem priorities command lane\n\n```bash\npython -m sdetkit ecosystem-priorities-closeout --format json --strict\npython -m sdetkit ecosystem-priorities-closeout --emit-pack-dir docs/artifacts/ecosystem-priorities-closeout-pack --format json --strict\npython -m sdetkit ecosystem-priorities-closeout --execute --evidence-dir docs/artifacts/ecosystem-priorities-closeout-pack/evidence --format json --strict\npython scripts/check_ecosystem_priorities_closeout_contract.py\n```\n\n## Ecosystem priorities contract\n\n- Single owner + backup reviewer are assigned for  ecosystem priorities execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes ecosystem CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records ecosystem outcomes, confidence notes, and  scale priorities.\n\n## Ecosystem priorities quality checklist\n\n- [ ] Includes ecosystem baseline, priority cadence, and stakeholder assumptions\n- [ ] Every ecosystem lane row has owner, workstream window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures ecosystem score delta, touchpoint carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, ecosystem priorities plan, workstream ledger, KPI scorecard, and execution log\n\n## Ecosystem priorities delivery board\n\n- [ ]  integration brief committed\n- [ ]  ecosystem priorities plan committed\n- [ ]  ecosystem workstream ledger exported\n- [ ]  ecosystem KPI scorecard snapshot exported\n- [ ]  scale priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Ecosystem evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -109,9 +109,7 @@ def build_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, Any]:
     community_touchpoint_score, community_touchpoint_strict, community_touchpoint_check_count = (
         _load_community_touchpoint(community_touchpoint_summary)
     )
-    board_count, board_has_community_touchpoint = _count_board_items(
-        community_touchpoint_board, ''
-    )
+    board_count, board_has_community_touchpoint = _count_board_items(community_touchpoint_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -233,7 +231,7 @@ def build_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, Any]:
     else:
         misses.append("Community touchpoint continuity baseline is below the floor (<85).")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 before  lock."
         )
 
     if board_count >= 5 and board_has_community_touchpoint:
@@ -241,15 +239,13 @@ def build_ecosystem_priorities_closeout_summary(root: Path) -> dict[str, Any]:
             f"Community touchpoint delivery board integrity validated with {board_count} checklist items."
         )
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
         wins.append("Ecosystem priorities dataset is available for launch execution.")
     else:
-        misses.append(' ecosystem priorities dataset is missing required keys.')
+        misses.append(" ecosystem priorities dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/ecosystem-priorities-plan.json to restore required keys."
         )
@@ -370,7 +366,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_ecosystem_priorities_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_ecosystem_priorities_closeout_summary(root)
 
 

--- a/src/sdetkit/evidence_narrative_closeout_84.py
+++ b/src/sdetkit/evidence_narrative_closeout_84.py
@@ -19,10 +19,10 @@ _DAY83_BOARD_PATH = (
     "docs/artifacts/trust-faq-expansion-closeout-pack/trust-faq-expansion-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/evidence-narrative-plan.json"
-_SECTION_HEADER = '#  — Evidence narrative closeout lane'
+_SECTION_HEADER = "#  — Evidence narrative closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Evidence Narrative Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Evidence narrative contract",
     "## Evidence narrative quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_evidence_narrative_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  evidence narrative execution and signoff.',
-    'The  lane references  outcomes, controls, and trust continuity signals.',
-    'Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records evidence narrative pack upgrades, storyline outcomes, and  release priorities.',
+    "Single owner + backup reviewer are assigned for  evidence narrative execution and signoff.",
+    "The  lane references  outcomes, controls, and trust continuity signals.",
+    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records evidence narrative pack upgrades, storyline outcomes, and  release priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  evidence brief committed',
-    '- [ ]  evidence narrative plan committed',
-    '- [ ]  narrative template upgrade ledger exported',
-    '- [ ]  storyline outcomes ledger exported',
-    '- [ ]  release priorities drafted from  outcomes',
+    "- [ ]  evidence brief committed",
+    "- [ ]  evidence narrative plan committed",
+    "- [ ]  narrative template upgrade ledger exported",
+    "- [ ]  storyline outcomes ledger exported",
+    "- [ ]  release priorities drafted from  outcomes",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Evidence narrative closeout lane\n\n closes with a major upgrade that converts  trust FAQ outcomes into a deterministic evidence narrative operating lane.\n\n## Why Evidence Narrative Closeout matters\n\n- Converts  trust FAQ outcomes into reusable evidence narratives across docs, release notes, and escalation playbooks.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  release priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/trust-faq-expansion-closeout-pack/trust-faq-expansion-closeout-summary.json`\n- `docs/artifacts/trust-faq-expansion-closeout-pack/trust-faq-expansion-delivery-board.md`\n- `docs/roadmap/plans/evidence-narrative-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit evidence-narrative-closeout --format json --strict\npython -m sdetkit evidence-narrative-closeout --emit-pack-dir docs/artifacts/evidence-narrative-closeout-pack --format json --strict\npython -m sdetkit evidence-narrative-closeout --execute --evidence-dir docs/artifacts/evidence-narrative-closeout-pack/evidence --format json --strict\npython scripts/check_evidence_narrative_closeout_contract.py\n```\n\n## Evidence narrative contract\n\n- Single owner + backup reviewer are assigned for  evidence narrative execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records evidence narrative pack upgrades, storyline outcomes, and  release priorities.\n\n## Evidence narrative quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures evidence narrative adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  evidence narrative plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  release priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + artifact readiness for a 100-point activation score.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Evidence narrative closeout lane\n\n closes with a major upgrade that converts  trust FAQ outcomes into a deterministic evidence narrative operating lane.\n\n## Why Evidence Narrative Closeout matters\n\n- Converts  trust FAQ outcomes into reusable evidence narratives across docs, release notes, and escalation playbooks.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  release priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/trust-faq-expansion-closeout-pack/trust-faq-expansion-closeout-summary.json`\n- `docs/artifacts/trust-faq-expansion-closeout-pack/trust-faq-expansion-delivery-board.md`\n- `docs/roadmap/plans/evidence-narrative-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit evidence-narrative-closeout --format json --strict\npython -m sdetkit evidence-narrative-closeout --emit-pack-dir docs/artifacts/evidence-narrative-closeout-pack --format json --strict\npython -m sdetkit evidence-narrative-closeout --execute --evidence-dir docs/artifacts/evidence-narrative-closeout-pack/evidence --format json --strict\npython scripts/check_evidence_narrative_closeout_contract.py\n```\n\n## Evidence narrative contract\n\n- Single owner + backup reviewer are assigned for  evidence narrative execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records evidence narrative pack upgrades, storyline outcomes, and  release priorities.\n\n## Evidence narrative quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures evidence narrative adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  evidence narrative plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  release priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + artifact readiness for a 100-point activation score.\n"
 
 
 def _read_text(path: Path) -> str:
@@ -108,7 +108,9 @@ def build_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
     trust_faq_expansion_score = int(
         trust_faq_expansion_summary_data.get("activation_score", 0) or 0
     )
-    trust_faq_expansion_strict = coerce_bool(trust_faq_expansion_summary_data.get("strict_pass", False), default=False)
+    trust_faq_expansion_strict = coerce_bool(
+        trust_faq_expansion_summary_data.get("strict_pass", False), default=False
+    )
     trust_faq_expansion_check_count = (
         len(trust_faq_expansion_data.get("checks", []))
         if isinstance(trust_faq_expansion_data.get("checks"), list)
@@ -117,9 +119,7 @@ def build_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(trust_faq_expansion_board)
     board_count = _checklist_count(board_text)
-    board_has_trust_faq_expansion = (
-        "trust faq expansion" in board_text.lower() or '' in board_text
-    )
+    board_has_trust_faq_expansion = "trust faq expansion" in board_text.lower() or "" in board_text
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
@@ -149,8 +149,8 @@ def build_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "trust_faq_expansion_summary_present",
@@ -241,32 +241,28 @@ def build_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
             f"Trust Faq Expansion continuity baseline is stable with activation score={trust_faq_expansion_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85) or not strict-pass.')
+        misses.append(" continuity baseline is below the floor (<85) or not strict-pass.")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock."
         )
 
     if board_count >= 5 and board_has_trust_faq_expansion:
-        wins.append(
-            f"83 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"83 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' evidence narrative dataset is available for launch execution.')
+        wins.append(" evidence narrative dataset is available for launch execution.")
     else:
-        misses.append(' evidence narrative dataset is missing required keys.')
+        misses.append(" evidence narrative dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/evidence-narrative-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' evidence narrative closeout lane is fully complete and ready for  release prioritization.'
+            " evidence narrative closeout lane is fully complete and ready for  release prioritization."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -306,7 +302,7 @@ def build_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' evidence narrative closeout summary',
+        " evidence narrative closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -327,8 +323,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "evidence-narrative-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "evidence-narrative-evidence-brief.md", '#  evidence narrative brief\n')
-    _write(target / "evidence-narrative-plan.md", '#  evidence narrative plan\n')
+    _write(target / "evidence-narrative-evidence-brief.md", "#  evidence narrative brief\n")
+    _write(target / "evidence-narrative-plan.md", "#  evidence narrative plan\n")
     _write(
         target / "evidence-narrative-narrative-template-upgrade-ledger.json",
         json.dumps({"upgrades": []}, indent=2) + "\n",
@@ -341,14 +337,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "evidence-narrative-narrative-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "evidence-narrative-execution-log.md", '#  execution log\n')
+    _write(target / "evidence-narrative-execution-log.md", "#  execution log\n")
     _write(
         target / "evidence-narrative-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "evidence-narrative-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -376,12 +372,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_evidence_narrative_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_evidence_narrative_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' evidence narrative closeout checks')
+    parser = argparse.ArgumentParser(description=" evidence narrative closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/expansion_closeout_45.py
+++ b/src/sdetkit/expansion_closeout_45.py
@@ -12,14 +12,14 @@ _PAGE_PATH = "docs/integrations-expansion-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY44_SUMMARY_PATH = "docs/artifacts/scale-closeout-pack/scale-closeout-summary.json"
 _DAY44_BOARD_PATH = "docs/artifacts/scale-closeout-pack/scale-delivery-board.md"
-_SECTION_HEADER = '#  — Expansion closeout lane'
+_SECTION_HEADER = "#  — Expansion closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Expansion closeout contract",
     "## Expansion quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -34,10 +34,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_expansion_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  expansion lane execution and KPI follow-up.',
-    'The  expansion lane references  scale winners and misses with deterministic growth loops.',
-    'Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.',
-    ' closeout records expansion learnings and  optimization priorities.',
+    "Single owner + backup reviewer are assigned for  expansion lane execution and KPI follow-up.",
+    "The  expansion lane references  scale winners and misses with deterministic growth loops.",
+    "Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.",
+    " closeout records expansion learnings and  optimization priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes expansion summary, growth matrix, and rollback strategy",
@@ -47,14 +47,14 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes expansion plan, growth matrix, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  expansion plan draft committed',
-    '- [ ]  review notes captured with owner + backup',
-    '- [ ]  growth matrix exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  optimization priorities drafted from  learnings',
+    "- [ ]  expansion plan draft committed",
+    "- [ ]  review notes captured with owner + backup",
+    "- [ ]  growth matrix exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  optimization priorities drafted from  learnings",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Expansion closeout lane\n\n closes with a major expansion upgrade that converts  scale evidence into deterministic improvement loops.\n\n## Why  matters\n\n- Converts  scale proof into growth-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from expansion outcomes into  optimization priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/scale-closeout-pack/scale-closeout-summary.json`\n- `docs/artifacts/scale-closeout-pack/scale-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit expansion-closeout --format json --strict\npython -m sdetkit expansion-closeout --emit-pack-dir docs/artifacts/expansion-closeout-pack --format json --strict\npython -m sdetkit expansion-closeout --execute --evidence-dir docs/artifacts/expansion-closeout-pack/evidence --format json --strict\npython scripts/check_expansion_closeout_contract.py\n```\n\n## Expansion closeout contract\n\n- Single owner + backup reviewer are assigned for  expansion lane execution and KPI follow-up.\n- The  expansion lane references  scale winners and misses with deterministic growth loops.\n- Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n-  closeout records expansion learnings and  optimization priorities.\n\n## Expansion quality checklist\n\n- [ ] Includes expansion summary, growth matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes expansion plan, growth matrix, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  expansion plan draft committed\n- [ ]  review notes captured with owner + backup\n- [ ]  growth matrix exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  optimization priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Expansion contract lock + delivery board readiness: 15 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Expansion closeout lane\n\n closes with a major expansion upgrade that converts  scale evidence into deterministic improvement loops.\n\n## Why  matters\n\n- Converts  scale proof into growth-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from expansion outcomes into  optimization priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/scale-closeout-pack/scale-closeout-summary.json`\n- `docs/artifacts/scale-closeout-pack/scale-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit expansion-closeout --format json --strict\npython -m sdetkit expansion-closeout --emit-pack-dir docs/artifacts/expansion-closeout-pack --format json --strict\npython -m sdetkit expansion-closeout --execute --evidence-dir docs/artifacts/expansion-closeout-pack/evidence --format json --strict\npython scripts/check_expansion_closeout_contract.py\n```\n\n## Expansion closeout contract\n\n- Single owner + backup reviewer are assigned for  expansion lane execution and KPI follow-up.\n- The  expansion lane references  scale winners and misses with deterministic growth loops.\n- Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n-  closeout records expansion learnings and  optimization priorities.\n\n## Expansion quality checklist\n\n- [ ] Includes expansion summary, growth matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes expansion plan, growth matrix, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  expansion plan draft committed\n- [ ]  review notes captured with owner + backup\n- [ ]  growth matrix exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  optimization priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Expansion contract lock + delivery board readiness: 15 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -87,7 +87,7 @@ def _load_scale_closeout(path: Path) -> tuple[float, bool, int]:
 def _board_stats(path: Path) -> tuple[int, bool, bool]:
     text = _read(path)
     items = [line for line in text.splitlines() if line.strip().startswith("- [")]
-    return len(items), '' in text, '' in text
+    return len(items), "" in text, "" in text
 
 
 def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
@@ -166,8 +166,8 @@ def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "scale_closeout_summary_present",
@@ -236,26 +236,18 @@ def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if scale_closeout_strict:
-        wins.append(
-            f"44 continuity is strict-pass with activation score={scale_closeout_score}."
-        )
+        wins.append(f"44 continuity is strict-pass with activation score={scale_closeout_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
+        misses.append(" strict continuity signal is missing.")
         handoff_actions.append(
-            'Re-run  scale closeout command and restore strict pass baseline before  lock.'
+            "Re-run  scale closeout command and restore strict pass baseline before  lock."
         )
 
     if board_count >= 5 and board_has_scale_closeout and board_has_expansion_closeout:
-        wins.append(
-            f"44 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"44 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and /45 anchors).'
-        )
-        handoff_actions.append(
-            'Repair  delivery board entries to include  and  anchors.'
-        )
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and /45 anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  and  anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
         wins.append(
@@ -266,13 +258,11 @@ def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
             "Expansion contract, quality checklist, or delivery board entries are missing."
         )
         handoff_actions.append(
-            'Complete all  expansion contract lines, quality checklist entries, and delivery board tasks in docs.'
+            "Complete all  expansion contract lines, quality checklist entries, and delivery board tasks in docs."
         )
 
     if not failed and not critical_failures:
-        wins.append(
-            ' expansion closeout lane is fully complete and ready for  optimization lane.'
-        )
+        wins.append(" expansion closeout lane is fully complete and ready for  optimization lane.")
 
     return {
         "name": "expansion-closeout",
@@ -309,7 +299,7 @@ def build_expansion_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' expansion closeout summary',
+        " expansion closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -339,7 +329,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(target / "expansion-closeout-summary.md", _render_text(payload) + "\n")
     _write(
         target / "expansion-plan.md",
-        '#  Expansion Plan\n\n- Objective: close  with measurable quality and throughput gains.\n',
+        "#  Expansion Plan\n\n- Objective: close  with measurable quality and throughput gains.\n",
     )
     _write(
         target / "expansion-growth-matrix.csv",
@@ -366,15 +356,15 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     )
     _write(
         target / "expansion-execution-log.md",
-        '#  Execution Log\n\n- [ ] 2026-03-12: Record misses, wins, and  optimization priorities.\n',
+        "#  Execution Log\n\n- [ ] 2026-03-12: Record misses, wins, and  optimization priorities.\n",
     )
     _write(
         target / "expansion-delivery-board.md",
-        '#  Delivery Board\n\n' + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
+        "#  Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
         target / "expansion-validation-commands.md",
-        '#  Validation Commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  Validation Commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -402,7 +392,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=' expansion closeout checks')
+    parser = argparse.ArgumentParser(description=" expansion closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")
@@ -414,7 +404,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def build_expansion_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_expansion_closeout_summary(root)
 
 

--- a/src/sdetkit/feature_registry.py
+++ b/src/sdetkit/feature_registry.py
@@ -101,11 +101,10 @@ def render_feature_registry_docs_block(rows: list[FeatureEntry]) -> str:
         "| --- | --- | --- | --- | --- | --- | --- |",
     ]
     for item in sorted(rows, key=lambda x: (x.tier, x.command)):
-        test_link = f"../{item.test_file}"
         docs_link = item.docs_page.removeprefix("docs/")
         lines.append(
             f"| `{item.command}` | {item.tier} | {item.status} | {item.problem_solved} | "
-            f"`{item.example}` | [{item.test_file}]({test_link}) | [{item.docs_page}]({docs_link}) |"
+            f"`{item.example}` | `{item.test_file}` | [{item.docs_page}]({docs_link}) |"
         )
     table = "\n".join(lines)
     return f"{_DOC_TABLE_START}\n{table}\n{_DOC_TABLE_END}"

--- a/src/sdetkit/feature_registry_cli.py
+++ b/src/sdetkit/feature_registry_cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import sys
 from dataclasses import asdict
+from typing import Any
 
 from .feature_registry import (
     load_feature_registry,
@@ -29,9 +30,15 @@ def _parse_count_expectations(items: list[str], *, label: str) -> tuple[dict[str
         try:
             parsed = int(value)
         except ValueError:
-            return {}, f"feature-registry: invalid {label} expectation `{token}` (count must be int)"
+            return (
+                {},
+                f"feature-registry: invalid {label} expectation `{token}` (count must be int)",
+            )
         if parsed < 0:
-            return {}, f"feature-registry: invalid {label} expectation `{token}` (count must be >= 0)"
+            return (
+                {},
+                f"feature-registry: invalid {label} expectation `{token}` (count must be >= 0)",
+            )
         out[key] = parsed
     return out, None
 
@@ -77,7 +84,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Assert total row count after filtering.",
     )
-    p.add_argument("--format", choices=["table", "json", "markdown", "summary-json"], default="table")
+    p.add_argument(
+        "--format", choices=["table", "json", "markdown", "summary-json"], default="table"
+    )
     return p
 
 
@@ -96,7 +105,9 @@ def main(argv: list[str] | None = None) -> int:
         rows = [item for item in rows if item.status == ns.status]
     commands = {item.command for item in rows}
 
-    missing_commands = sorted({str(name).strip() for name in ns.expect_command if str(name).strip()} - commands)
+    missing_commands = sorted(
+        {str(name).strip() for name in ns.expect_command if str(name).strip()} - commands
+    )
     if missing_commands:
         print(
             "feature-registry: missing expected command(s): " + ", ".join(missing_commands),
@@ -107,7 +118,7 @@ def main(argv: list[str] | None = None) -> int:
     if ns.fail_on_empty and not rows:
         print("feature-registry: filtered result set is empty", file=sys.stderr)
         return 1
-    summary = summarize_feature_registry(rows)
+    summary: dict[str, Any] = summarize_feature_registry(rows)
 
     tier_expectations, tier_error = _parse_count_expectations(
         list(ns.expect_tier_count), label="tier-count"
@@ -116,7 +127,9 @@ def main(argv: list[str] | None = None) -> int:
         print(tier_error, file=sys.stderr)
         return 2
     for tier, expected in tier_expectations.items():
-        actual = int((summary.get("by_tier", {}) or {}).get(tier, 0))
+        by_tier = summary.get("by_tier")
+        tier_counts = by_tier if isinstance(by_tier, dict) else {}
+        actual = int(tier_counts.get(tier, 0))
         if actual != expected:
             print(
                 f"feature-registry: tier count mismatch for `{tier}` (expected {expected}, got {actual})",
@@ -131,7 +144,9 @@ def main(argv: list[str] | None = None) -> int:
         print(status_error, file=sys.stderr)
         return 2
     for status, expected in status_expectations.items():
-        actual = int((summary.get("by_status", {}) or {}).get(status, 0))
+        by_status = summary.get("by_status")
+        status_counts = by_status if isinstance(by_status, dict) else {}
+        actual = int(status_counts.get(status, 0))
         if actual != expected:
             print(
                 f"feature-registry: status count mismatch for `{status}` (expected {expected}, got {actual})",

--- a/src/sdetkit/governance_handoff_closeout_87.py
+++ b/src/sdetkit/governance_handoff_closeout_87.py
@@ -19,10 +19,10 @@ _DAY86_BOARD_PATH = (
     "docs/artifacts/launch-readiness-closeout-pack/launch-readiness-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/governance-handoff-plan.json"
-_SECTION_HEADER = '#  — Governance handoff closeout lane'
+_SECTION_HEADER = "#  — Governance handoff closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Governance Handoff Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Governance handoff contract",
     "## Governance handoff quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_governance_handoff_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  governance handoff execution and signoff.',
-    'The  lane references  outcomes, controls, and trust continuity signals.',
-    'Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records governance handoff pack upgrades, storyline outcomes, and  governance priorities.',
+    "Single owner + backup reviewer are assigned for  governance handoff execution and signoff.",
+    "The  lane references  outcomes, controls, and trust continuity signals.",
+    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records governance handoff pack upgrades, storyline outcomes, and  governance priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  evidence brief committed',
-    '- [ ]  governance handoff plan committed',
-    '- [ ]  narrative template upgrade ledger exported',
-    '- [ ]  storyline outcomes ledger exported',
-    '- [ ]  governance priorities drafted from  outcomes',
+    "- [ ]  evidence brief committed",
+    "- [ ]  governance handoff plan committed",
+    "- [ ]  narrative template upgrade ledger exported",
+    "- [ ]  storyline outcomes ledger exported",
+    "- [ ]  governance priorities drafted from  outcomes",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Governance handoff closeout lane\n\n closes with a major upgrade that converts  launch readiness outcomes into a deterministic governance handoff operating lane.\n\n## Why Governance Handoff Closeout matters\n\n- Converts  launch readiness outcomes into reusable governance handoff decisions across governance rituals, roadmap reviews, and maintainer escalation paths.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  governance priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/launch-readiness-closeout-pack/launch-readiness-closeout-summary.json`\n- `docs/artifacts/launch-readiness-closeout-pack/launch-readiness-delivery-board.md`\n- `docs/roadmap/plans/governance-handoff-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit governance-handoff-closeout --format json --strict\npython -m sdetkit governance-handoff-closeout --emit-pack-dir docs/artifacts/governance-handoff-closeout-pack --format json --strict\npython -m sdetkit governance-handoff-closeout --execute --evidence-dir docs/artifacts/governance-handoff-closeout-pack/evidence --format json --strict\npython scripts/check_governance_handoff_closeout_contract.py\n```\n\n## Governance handoff contract\n\n- Single owner + backup reviewer are assigned for  governance handoff execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records governance handoff pack upgrades, storyline outcomes, and  governance priorities.\n\n## Governance handoff quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures governance handoff adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  governance handoff plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  governance priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + governance artifact readiness for a 100-point activation score.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Governance handoff closeout lane\n\n closes with a major upgrade that converts  launch readiness outcomes into a deterministic governance handoff operating lane.\n\n## Why Governance Handoff Closeout matters\n\n- Converts  launch readiness outcomes into reusable governance handoff decisions across governance rituals, roadmap reviews, and maintainer escalation paths.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  governance priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/launch-readiness-closeout-pack/launch-readiness-closeout-summary.json`\n- `docs/artifacts/launch-readiness-closeout-pack/launch-readiness-delivery-board.md`\n- `docs/roadmap/plans/governance-handoff-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit governance-handoff-closeout --format json --strict\npython -m sdetkit governance-handoff-closeout --emit-pack-dir docs/artifacts/governance-handoff-closeout-pack --format json --strict\npython -m sdetkit governance-handoff-closeout --execute --evidence-dir docs/artifacts/governance-handoff-closeout-pack/evidence --format json --strict\npython scripts/check_governance_handoff_closeout_contract.py\n```\n\n## Governance handoff contract\n\n- Single owner + backup reviewer are assigned for  governance handoff execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records governance handoff pack upgrades, storyline outcomes, and  governance priorities.\n\n## Governance handoff quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures governance handoff adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  governance handoff plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  governance priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + governance artifact readiness for a 100-point activation score.\n"
 
 
 def _read_text(path: Path) -> str:
@@ -106,7 +106,9 @@ def build_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
         else {}
     )
     launch_readiness_score = int(launch_readiness_summary_data.get("activation_score", 0) or 0)
-    launch_readiness_strict = coerce_bool(launch_readiness_summary_data.get("strict_pass", False), default=False)
+    launch_readiness_strict = coerce_bool(
+        launch_readiness_summary_data.get("strict_pass", False), default=False
+    )
     launch_readiness_check_count = (
         len(launch_readiness_data.get("checks", []))
         if isinstance(launch_readiness_data.get("checks"), list)
@@ -115,7 +117,7 @@ def build_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(launch_readiness_board)
     board_count = _checklist_count(board_text)
-    board_has_launch_readiness = '' in board_text
+    board_has_launch_readiness = "" in board_text
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
@@ -145,8 +147,8 @@ def build_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "launch_readiness_summary_present",
@@ -237,32 +239,28 @@ def build_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
             f"Launch readiness continuity baseline is stable with activation score={launch_readiness_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85) or not strict-pass.')
+        misses.append(" continuity baseline is below the floor (<85) or not strict-pass.")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock."
         )
 
     if board_count >= 5 and board_has_launch_readiness:
-        wins.append(
-            f"86 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"86 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' governance handoff dataset is available for governance execution.')
+        wins.append(" governance handoff dataset is available for governance execution.")
     else:
-        misses.append(' governance handoff dataset is missing required keys.')
+        misses.append(" governance handoff dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/governance-handoff-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' governance handoff closeout lane is fully complete and ready for  governance planning.'
+            " governance handoff closeout lane is fully complete and ready for  governance planning."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -302,7 +300,7 @@ def build_governance_handoff_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' governance handoff closeout summary',
+        " governance handoff closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -323,8 +321,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "governance-handoff-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "governance-handoff-evidence-brief.md", '#  governance handoff brief\n')
-    _write(target / "governance-handoff-plan.md", '#  governance handoff plan\n')
+    _write(target / "governance-handoff-evidence-brief.md", "#  governance handoff brief\n")
+    _write(target / "governance-handoff-plan.md", "#  governance handoff plan\n")
     _write(
         target / "governance-handoff-narrative-template-upgrade-ledger.json",
         json.dumps({"upgrades": []}, indent=2) + "\n",
@@ -337,14 +335,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "governance-handoff-narrative-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "governance-handoff-execution-log.md", '#  execution log\n')
+    _write(target / "governance-handoff-execution-log.md", "#  execution log\n")
     _write(
         target / "governance-handoff-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "governance-handoff-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -372,12 +370,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_governance_handoff_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_governance_handoff_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' governance handoff closeout checks')
+    parser = argparse.ArgumentParser(description=" governance handoff closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/governance_priorities_closeout_88.py
+++ b/src/sdetkit/governance_priorities_closeout_88.py
@@ -19,10 +19,10 @@ _DAY87_BOARD_PATH = (
     "docs/artifacts/governance-handoff-closeout-pack/governance-handoff-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/governance-priorities-plan.json"
-_SECTION_HEADER = '#  — Governance priorities closeout lane'
+_SECTION_HEADER = "#  — Governance priorities closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Governance Priorities Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Governance priorities contract",
     "## Governance priorities quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_governance_priorities_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  governance priorities execution and signoff.',
-    'The  lane references  outcomes, controls, and trust continuity signals.',
-    'Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records governance priorities pack upgrades, storyline outcomes, and  governance priorities.',
+    "Single owner + backup reviewer are assigned for  governance priorities execution and signoff.",
+    "The  lane references  outcomes, controls, and trust continuity signals.",
+    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records governance priorities pack upgrades, storyline outcomes, and  governance priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  evidence brief committed',
-    '- [ ]  governance priorities plan committed',
-    '- [ ]  narrative template upgrade ledger exported',
-    '- [ ]  storyline outcomes ledger exported',
-    '- [ ]  governance priorities drafted from  outcomes',
+    "- [ ]  evidence brief committed",
+    "- [ ]  governance priorities plan committed",
+    "- [ ]  narrative template upgrade ledger exported",
+    "- [ ]  storyline outcomes ledger exported",
+    "- [ ]  governance priorities drafted from  outcomes",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Governance priorities closeout lane\n\n closes with a major upgrade that converts  governance handoff outcomes into a deterministic governance priorities operating lane.\n\n## Why Governance Priorities Closeout matters\n\n- Converts  governance handoff outcomes into reusable governance priorities decisions across governance rituals, roadmap reviews, and maintainer escalation paths.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  governance priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/governance-handoff-closeout-pack/governance-handoff-closeout-summary.json`\n- `docs/artifacts/governance-handoff-closeout-pack/governance-handoff-delivery-board.md`\n- `docs/roadmap/plans/governance-priorities-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit governance-priorities-closeout --format json --strict\npython -m sdetkit governance-priorities-closeout --emit-pack-dir docs/artifacts/governance-priorities-closeout-pack --format json --strict\npython -m sdetkit governance-priorities-closeout --execute --evidence-dir docs/artifacts/governance-priorities-closeout-pack/evidence --format json --strict\npython scripts/check_governance_priorities_closeout_contract.py\n```\n\n## Governance priorities contract\n\n- Single owner + backup reviewer are assigned for  governance priorities execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records governance priorities pack upgrades, storyline outcomes, and  governance priorities.\n\n## Governance priorities quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures governance priorities adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  governance priorities plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  governance priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + governance artifact readiness for a 100-point activation score.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Governance priorities closeout lane\n\n closes with a major upgrade that converts  governance handoff outcomes into a deterministic governance priorities operating lane.\n\n## Why Governance Priorities Closeout matters\n\n- Converts  governance handoff outcomes into reusable governance priorities decisions across governance rituals, roadmap reviews, and maintainer escalation paths.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  governance priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/governance-handoff-closeout-pack/governance-handoff-closeout-summary.json`\n- `docs/artifacts/governance-handoff-closeout-pack/governance-handoff-delivery-board.md`\n- `docs/roadmap/plans/governance-priorities-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit governance-priorities-closeout --format json --strict\npython -m sdetkit governance-priorities-closeout --emit-pack-dir docs/artifacts/governance-priorities-closeout-pack --format json --strict\npython -m sdetkit governance-priorities-closeout --execute --evidence-dir docs/artifacts/governance-priorities-closeout-pack/evidence --format json --strict\npython scripts/check_governance_priorities_closeout_contract.py\n```\n\n## Governance priorities contract\n\n- Single owner + backup reviewer are assigned for  governance priorities execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records governance priorities pack upgrades, storyline outcomes, and  governance priorities.\n\n## Governance priorities quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures governance priorities adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  governance priorities plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  governance priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + governance artifact readiness for a 100-point activation score.\n"
 
 
 def _read_text(path: Path) -> str:
@@ -106,7 +106,9 @@ def build_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
         else {}
     )
     governance_handoff_score = int(governance_handoff_summary_data.get("activation_score", 0) or 0)
-    governance_handoff_strict = coerce_bool(governance_handoff_summary_data.get("strict_pass", False), default=False)
+    governance_handoff_strict = coerce_bool(
+        governance_handoff_summary_data.get("strict_pass", False), default=False
+    )
     governance_handoff_check_count = (
         len(governance_handoff_data.get("checks", []))
         if isinstance(governance_handoff_data.get("checks"), list)
@@ -115,7 +117,7 @@ def build_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(governance_handoff_board)
     board_count = _checklist_count(board_text)
-    board_has_governance_handoff = '' in board_text
+    board_has_governance_handoff = "" in board_text
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
@@ -145,8 +147,8 @@ def build_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "governance_handoff_summary_present",
@@ -237,32 +239,28 @@ def build_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
             f"Governance handoff continuity baseline is stable with activation score={governance_handoff_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85) or not strict-pass.')
+        misses.append(" continuity baseline is below the floor (<85) or not strict-pass.")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock."
         )
 
     if board_count >= 5 and board_has_governance_handoff:
-        wins.append(
-            f"87 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"87 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' governance priorities dataset is available for governance execution.')
+        wins.append(" governance priorities dataset is available for governance execution.")
     else:
-        misses.append(' governance priorities dataset is missing required keys.')
+        misses.append(" governance priorities dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/governance-priorities-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' governance priorities closeout lane is fully complete and ready for  governance planning.'
+            " governance priorities closeout lane is fully complete and ready for  governance planning."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -302,7 +300,7 @@ def build_governance_priorities_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' governance priorities closeout summary',
+        " governance priorities closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -323,10 +321,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "governance-priorities-closeout-summary.md", _render_text(payload) + "\n")
-    _write(
-        target / "governance-priorities-evidence-brief.md", '#  governance priorities brief\n'
-    )
-    _write(target / "governance-priorities-plan.md", '#  governance priorities plan\n')
+    _write(target / "governance-priorities-evidence-brief.md", "#  governance priorities brief\n")
+    _write(target / "governance-priorities-plan.md", "#  governance priorities plan\n")
     _write(
         target / "governance-priorities-narrative-template-upgrade-ledger.json",
         json.dumps({"upgrades": []}, indent=2) + "\n",
@@ -339,14 +335,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "governance-priorities-narrative-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "governance-priorities-execution-log.md", '#  execution log\n')
+    _write(target / "governance-priorities-execution-log.md", "#  execution log\n")
     _write(
         target / "governance-priorities-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "governance-priorities-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -374,12 +370,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_governance_priorities_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_governance_priorities_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' governance priorities closeout checks')
+    parser = argparse.ArgumentParser(description=" governance priorities closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/governance_scale_closeout_89.py
+++ b/src/sdetkit/governance_scale_closeout_89.py
@@ -17,10 +17,10 @@ _DAY88_BOARD_PATH = (
     "docs/artifacts/governance-priorities-closeout-pack/governance-priorities-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/governance-scale-plan.json"
-_SECTION_HEADER = '#  — Governance scale closeout lane'
+_SECTION_HEADER = "#  — Governance scale closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Governance Scale Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Governance scale contract",
     "## Governance scale quality checklist",
@@ -39,10 +39,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_governance_scale_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  governance scale execution and signoff.',
-    'The  lane references  outcomes, controls, and trust continuity signals.',
-    'Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records governance scale pack upgrades, storyline outcomes, and  governance planning inputs.',
+    "Single owner + backup reviewer are assigned for  governance scale execution and signoff.",
+    "The  lane references  outcomes, controls, and trust continuity signals.",
+    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records governance scale pack upgrades, storyline outcomes, and  governance planning inputs.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
@@ -52,11 +52,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  evidence brief committed',
-    '- [ ]  governance scale plan committed',
-    '- [ ]  narrative template upgrade ledger exported',
-    '- [ ]  storyline outcomes ledger exported',
-    '- [ ]  governance planning drafted from  outcomes',
+    "- [ ]  evidence brief committed",
+    "- [ ]  governance scale plan committed",
+    "- [ ]  narrative template upgrade ledger exported",
+    "- [ ]  storyline outcomes ledger exported",
+    "- [ ]  governance planning drafted from  outcomes",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -67,7 +67,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Governance scale closeout lane\n\n closes with a major upgrade that converts  governance handoff outcomes into a deterministic governance scale operating lane.\n\n## Why Governance Scale Closeout matters\n\n- Converts  governance handoff outcomes into reusable governance scale decisions across governance rituals, roadmap reviews, and maintainer escalation paths.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  governance planning.\n\n## Required inputs ()\n\n- `docs/artifacts/governance-priorities-closeout-pack/governance-priorities-closeout-summary.json`\n- `docs/artifacts/governance-priorities-closeout-pack/governance-priorities-delivery-board.md`\n- `docs/roadmap/plans/governance-scale-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit governance-scale-closeout --format json --strict\npython -m sdetkit governance-scale-closeout --emit-pack-dir docs/artifacts/governance-scale-closeout-pack --format json --strict\npython -m sdetkit governance-scale-closeout --execute --evidence-dir docs/artifacts/governance-scale-closeout-pack/evidence --format json --strict\npython scripts/check_governance_scale_closeout_contract.py\n```\n\n## Governance scale contract\n\n- Single owner + backup reviewer are assigned for  governance scale execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records governance scale pack upgrades, storyline outcomes, and  governance planning inputs.\n\n## Governance scale quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures governance scale adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  governance scale plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  governance planning drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + governance artifact readiness for a 100-point activation score.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Governance scale closeout lane\n\n closes with a major upgrade that converts  governance handoff outcomes into a deterministic governance scale operating lane.\n\n## Why Governance Scale Closeout matters\n\n- Converts  governance handoff outcomes into reusable governance scale decisions across governance rituals, roadmap reviews, and maintainer escalation paths.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  governance planning.\n\n## Required inputs ()\n\n- `docs/artifacts/governance-priorities-closeout-pack/governance-priorities-closeout-summary.json`\n- `docs/artifacts/governance-priorities-closeout-pack/governance-priorities-delivery-board.md`\n- `docs/roadmap/plans/governance-scale-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit governance-scale-closeout --format json --strict\npython -m sdetkit governance-scale-closeout --emit-pack-dir docs/artifacts/governance-scale-closeout-pack --format json --strict\npython -m sdetkit governance-scale-closeout --execute --evidence-dir docs/artifacts/governance-scale-closeout-pack/evidence --format json --strict\npython scripts/check_governance_scale_closeout_contract.py\n```\n\n## Governance scale contract\n\n- Single owner + backup reviewer are assigned for  governance scale execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records governance scale pack upgrades, storyline outcomes, and  governance planning inputs.\n\n## Governance scale quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures governance scale adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  governance scale plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  governance planning drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + governance artifact readiness for a 100-point activation score.\n"
 
 
 def _read_text(path: Path) -> str:
@@ -117,7 +117,7 @@ def build_governance_scale_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(governance_priorities_board)
     board_count = _checklist_count(board_text)
-    board_has_governance_priorities = '' in board_text
+    board_has_governance_priorities = "" in board_text
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
@@ -147,8 +147,8 @@ def build_governance_scale_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "governance_priorities_summary_present",
@@ -239,32 +239,28 @@ def build_governance_scale_closeout_summary(root: Path) -> dict[str, Any]:
             f"Governance priorities continuity baseline is stable with activation score={governance_priorities_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85) or not strict-pass.')
+        misses.append(" continuity baseline is below the floor (<85) or not strict-pass.")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock."
         )
 
     if board_count >= 5 and board_has_governance_priorities:
-        wins.append(
-            f"88 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"88 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' governance scale dataset is available for governance execution.')
+        wins.append(" governance scale dataset is available for governance execution.")
     else:
-        misses.append(' governance scale dataset is missing required keys.')
+        misses.append(" governance scale dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/governance-scale-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' governance scale closeout lane is fully complete and ready for  governance planning.'
+            " governance scale closeout lane is fully complete and ready for  governance planning."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -306,7 +302,7 @@ def build_governance_scale_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' governance scale closeout summary',
+        " governance scale closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -327,8 +323,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "governance-scale-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "governance-scale-evidence-brief.md", '#  governance scale brief\n')
-    _write(target / "governance-scale-plan.md", '#  governance scale plan\n')
+    _write(target / "governance-scale-evidence-brief.md", "#  governance scale brief\n")
+    _write(target / "governance-scale-plan.md", "#  governance scale plan\n")
     _write(
         target / "governance-scale-narrative-template-upgrade-ledger.json",
         json.dumps({"upgrades": []}, indent=2) + "\n",
@@ -341,14 +337,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "governance-scale-narrative-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "governance-scale-execution-log.md", '#  execution log\n')
+    _write(target / "governance-scale-execution-log.md", "#  execution log\n")
     _write(
         target / "governance-scale-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "governance-scale-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -376,12 +372,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_governance_scale_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_governance_scale_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' governance scale closeout checks')
+    parser = argparse.ArgumentParser(description=" governance scale closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/growth_campaign_closeout_81.py
+++ b/src/sdetkit/growth_campaign_closeout_81.py
@@ -17,10 +17,10 @@ _DAY80_BOARD_PATH = (
     "docs/artifacts/partner-outreach-closeout-pack/partner-outreach-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/growth-campaign-plan.json"
-_SECTION_HEADER = '#  — Growth campaign closeout lane'
+_SECTION_HEADER = "#  — Growth campaign closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Growth Campaign Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Growth campaign contract",
     "## Growth campaign quality checklist",
@@ -39,10 +39,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_growth_campaign_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  growth campaign execution and signoff.',
-    'The  lane references  outcomes, controls, and KPI continuity signals.',
-    'Every  section includes campaign CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records campaign outcomes, confidence notes, and  execution priorities.',
+    "Single owner + backup reviewer are assigned for  growth campaign execution and signoff.",
+    "The  lane references  outcomes, controls, and KPI continuity signals.",
+    "Every  section includes campaign CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records campaign outcomes, confidence notes, and  execution priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes campaign baseline, audience assumptions, and launch cadence",
@@ -52,11 +52,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, campaign plan, execution ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  growth campaign plan committed',
-    '- [ ]  campaign execution ledger exported',
-    '- [ ]  campaign KPI scorecard snapshot exported',
-    '- [ ]  execution priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  growth campaign plan committed",
+    "- [ ]  campaign execution ledger exported",
+    "- [ ]  campaign KPI scorecard snapshot exported",
+    "- [ ]  execution priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -67,7 +67,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Growth campaign closeout lane\n\n closes with a major upgrade that converts  partner outreach outcomes into a growth-campaign execution pack.\n\n## Why Growth Campaign Closeout matters\n\n- Turns  partner outreach outcomes into growth campaign execution proof across docs, rollout, and demand loops.\n- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  growth campaign closeout into  execution priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/partner-outreach-closeout-pack/partner-outreach-closeout-summary.json`\n- `docs/artifacts/partner-outreach-closeout-pack/partner-outreach-delivery-board.md`\n- `docs/roadmap/plans/growth-campaign-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit growth-campaign-closeout --format json --strict\npython -m sdetkit growth-campaign-closeout --emit-pack-dir docs/artifacts/growth-campaign-closeout-pack --format json --strict\npython -m sdetkit growth-campaign-closeout --execute --evidence-dir docs/artifacts/growth-campaign-closeout-pack/evidence --format json --strict\npython scripts/check_growth_campaign_closeout_contract.py\n```\n\n## Growth campaign contract\n\n- Single owner + backup reviewer are assigned for  growth campaign execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes campaign CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records campaign outcomes, confidence notes, and  execution priorities.\n\n## Growth campaign quality checklist\n\n- [ ] Includes campaign baseline, audience assumptions, and launch cadence\n- [ ] Every campaign lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures campaign score delta, partner carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, campaign plan, execution ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  integration brief committed\n- [ ]  growth campaign plan committed\n- [ ]  campaign execution ledger exported\n- [ ]  campaign KPI scorecard snapshot exported\n- [ ]  execution priorities drafted from  learnings\n\n## Scoring model\n\nGrowth Campaign Closeout weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Campaign evidence data + delivery board completeness (30)\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Growth campaign closeout lane\n\n closes with a major upgrade that converts  partner outreach outcomes into a growth-campaign execution pack.\n\n## Why Growth Campaign Closeout matters\n\n- Turns  partner outreach outcomes into growth campaign execution proof across docs, rollout, and demand loops.\n- Protects launch quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  growth campaign closeout into  execution priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/partner-outreach-closeout-pack/partner-outreach-closeout-summary.json`\n- `docs/artifacts/partner-outreach-closeout-pack/partner-outreach-delivery-board.md`\n- `docs/roadmap/plans/growth-campaign-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit growth-campaign-closeout --format json --strict\npython -m sdetkit growth-campaign-closeout --emit-pack-dir docs/artifacts/growth-campaign-closeout-pack --format json --strict\npython -m sdetkit growth-campaign-closeout --execute --evidence-dir docs/artifacts/growth-campaign-closeout-pack/evidence --format json --strict\npython scripts/check_growth_campaign_closeout_contract.py\n```\n\n## Growth campaign contract\n\n- Single owner + backup reviewer are assigned for  growth campaign execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes campaign CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records campaign outcomes, confidence notes, and  execution priorities.\n\n## Growth campaign quality checklist\n\n- [ ] Includes campaign baseline, audience assumptions, and launch cadence\n- [ ] Every campaign lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures campaign score delta, partner carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, campaign plan, execution ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  integration brief committed\n- [ ]  growth campaign plan committed\n- [ ]  campaign execution ledger exported\n- [ ]  campaign KPI scorecard snapshot exported\n- [ ]  execution priorities drafted from  learnings\n\n## Scoring model\n\nGrowth Campaign Closeout weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Campaign evidence data + delivery board completeness (30)\n"
 
 
 def _read_text(path: Path) -> str:
@@ -110,7 +110,7 @@ def build_growth_campaign_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(partner_outreach_board)
     board_count = _checklist_count(board_text)
-    board_has_partner_outreach = "partner outreach" in board_text.lower() or '' in board_text
+    board_has_partner_outreach = "partner outreach" in board_text.lower() or "" in board_text
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
@@ -140,8 +140,8 @@ def build_growth_campaign_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "partner_outreach_summary_present",
@@ -232,32 +232,28 @@ def build_growth_campaign_closeout_summary(root: Path) -> dict[str, Any]:
             f"Partner Outreach continuity baseline is stable with activation score={partner_outreach_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85).')
+        misses.append(" continuity baseline is below the floor (<85).")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 before  lock."
         )
 
     if board_count >= 5 and board_has_partner_outreach:
-        wins.append(
-            f"80 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"80 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' growth campaign dataset is available for launch execution.')
+        wins.append(" growth campaign dataset is available for launch execution.")
     else:
-        misses.append(' growth campaign dataset is missing required keys.')
+        misses.append(" growth campaign dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/growth-campaign-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' growth campaign closeout lane is fully complete and ready for  execution priorities.'
+            " growth campaign closeout lane is fully complete and ready for  execution priorities."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -297,7 +293,7 @@ def build_growth_campaign_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' growth campaign closeout summary',
+        " growth campaign closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -315,8 +311,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     target = pack_dir if pack_dir.is_absolute() else root / pack_dir
     _write(target / "growth-campaign-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
     _write(target / "growth-campaign-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "growth-campaign-integration-brief.md", '#  integration brief\n')
-    _write(target / "growth-campaign-plan.md", '#  growth campaign plan\n')
+    _write(target / "growth-campaign-integration-brief.md", "#  integration brief\n")
+    _write(target / "growth-campaign-plan.md", "#  growth campaign plan\n")
     _write(
         target / "growth-campaign-campaign-execution-ledger.json",
         json.dumps({"executions": []}, indent=2) + "\n",
@@ -325,14 +321,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "growth-campaign-campaign-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "growth-campaign-execution-log.md", '#  execution log\n')
+    _write(target / "growth-campaign-execution-log.md", "#  execution log\n")
     _write(
         target / "growth-campaign-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "growth-campaign-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -360,12 +356,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_growth_campaign_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_growth_campaign_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' growth campaign closeout checks')
+    parser = argparse.ArgumentParser(description=" growth campaign closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/integration_expansion2_closeout_66.py
+++ b/src/sdetkit/integration_expansion2_closeout_66.py
@@ -19,10 +19,10 @@ _WEEKLY_REVIEW_BOARD_PATH = (
     "docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-delivery-board-2.md"
 )
 _GITLAB_PATH = "templates/ci/gitlab/gitlab-advanced-reference.yml"
-_SECTION_HEADER = '#  — Integration expansion #2 closeout lane'
+_SECTION_HEADER = "#  — Integration expansion #2 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Expansion 2 Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Integration Expansion 2 Closeout command lane",
     "## Integration expansion contract",
     "## Integration quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_integration_expansion2_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  advanced GitLab CI rollout and signoff.',
-    'The  lane references  weekly review outputs, governance decisions, and KPI continuity signals.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records GitLab pipeline stages, parallel matrix controls, cache strategy, and  integration priorities.',
+    "Single owner + backup reviewer are assigned for  advanced GitLab CI rollout and signoff.",
+    "The  lane references  weekly review outputs, governance decisions, and KPI continuity signals.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records GitLab pipeline stages, parallel matrix controls, cache strategy, and  integration priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes GitLab stages + rules path, matrix or parallel fan-out, and rollback trigger",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, pipeline blueprint, matrix plan, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  advanced GitLab pipeline blueprint published',
-    '- [ ]  matrix and cache strategy exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  integration expansion priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  advanced GitLab pipeline blueprint published",
+    "- [ ]  matrix and cache strategy exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  integration expansion priorities drafted from  learnings",
 ]
 _REQUIRED_GITLAB_LINES = [
     "stages:",
@@ -69,7 +69,7 @@ _REQUIRED_GITLAB_LINES = [
     "cache:",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Integration expansion #2 closeout lane\n\n closes with a major integration upgrade that converts  weekly review outcomes into an advanced GitLab CI reference pipeline.\n\n## Why Integration Expansion 2 Closeout matters\n\n- Converts  governance outputs into reusable GitLab CI implementation patterns.\n- Protects integration outcomes with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  integration expansion to  integration expansion #3.\n\n## Required inputs ()\n\n- `docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json`\n- `docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-delivery-board-2.md`\n- `templates/ci/gitlab/gitlab-advanced-reference.yml`\n\n## Integration Expansion 2 Closeout command lane\n\n```bash\npython -m sdetkit integration-expansion2-closeout --format json --strict\npython -m sdetkit integration-expansion2-closeout --emit-pack-dir docs/artifacts/integration-expansion2-closeout-pack --format json --strict\npython -m sdetkit integration-expansion2-closeout --execute --evidence-dir docs/artifacts/integration-expansion2-closeout-pack/evidence --format json --strict\npython scripts/check_integration_expansion2_closeout_contract.py\n```\n\n## Integration expansion contract\n\n- Single owner + backup reviewer are assigned for  advanced GitLab CI rollout and signoff.\n- The  lane references  weekly review outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records GitLab pipeline stages, parallel matrix controls, cache strategy, and  integration priorities.\n\n## Integration quality checklist\n\n- [ ] Includes GitLab stages + rules path, matrix or parallel fan-out, and rollback trigger\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures pipeline pass-rate, median runtime, cache efficiency, confidence, and recovery owner\n- [ ] Artifact pack includes integration brief, pipeline blueprint, matrix plan, KPI scorecard, and execution log\n\n## Integration Expansion 2 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  advanced GitLab pipeline blueprint published\n- [ ]  matrix and cache strategy exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  integration expansion priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 25 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 30 points.\n- GitLab reference quality + guardrails: 25 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Integration expansion #2 closeout lane\n\n closes with a major integration upgrade that converts  weekly review outcomes into an advanced GitLab CI reference pipeline.\n\n## Why Integration Expansion 2 Closeout matters\n\n- Converts  governance outputs into reusable GitLab CI implementation patterns.\n- Protects integration outcomes with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  integration expansion to  integration expansion #3.\n\n## Required inputs ()\n\n- `docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json`\n- `docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-delivery-board-2.md`\n- `templates/ci/gitlab/gitlab-advanced-reference.yml`\n\n## Integration Expansion 2 Closeout command lane\n\n```bash\npython -m sdetkit integration-expansion2-closeout --format json --strict\npython -m sdetkit integration-expansion2-closeout --emit-pack-dir docs/artifacts/integration-expansion2-closeout-pack --format json --strict\npython -m sdetkit integration-expansion2-closeout --execute --evidence-dir docs/artifacts/integration-expansion2-closeout-pack/evidence --format json --strict\npython scripts/check_integration_expansion2_closeout_contract.py\n```\n\n## Integration expansion contract\n\n- Single owner + backup reviewer are assigned for  advanced GitLab CI rollout and signoff.\n- The  lane references  weekly review outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records GitLab pipeline stages, parallel matrix controls, cache strategy, and  integration priorities.\n\n## Integration quality checklist\n\n- [ ] Includes GitLab stages + rules path, matrix or parallel fan-out, and rollback trigger\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures pipeline pass-rate, median runtime, cache efficiency, confidence, and recovery owner\n- [ ] Artifact pack includes integration brief, pipeline blueprint, matrix plan, KPI scorecard, and execution log\n\n## Integration Expansion 2 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  advanced GitLab pipeline blueprint published\n- [ ]  matrix and cache strategy exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  integration expansion priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 25 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 30 points.\n- GitLab reference quality + guardrails: 25 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -119,7 +119,7 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
     weekly_review_score, weekly_review_strict, weekly_review_check_count = _load_weekly_review(
         weekly_review_summary
     )
-    board_count, board_has_weekly_review = _count_board_items(weekly_review_board, '')
+    board_count, board_has_weekly_review = _count_board_items(weekly_review_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -147,8 +147,8 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "weekly_review_summary_present",
@@ -237,38 +237,28 @@ def build_integration_expansion2_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if weekly_review_strict:
-        wins.append(
-            f"65 continuity is strict-pass with activation score={weekly_review_score}."
-        )
+        wins.append(f"65 continuity is strict-pass with activation score={weekly_review_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_weekly_review:
-        wins.append(
-            f"65 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"65 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_gitlab_lines:
-        wins.append(
-            ' GitLab reference pipeline is available for integration expansion execution.'
-        )
+        wins.append(" GitLab reference pipeline is available for integration expansion execution.")
     else:
-        misses.append(' GitLab reference pipeline is missing required controls.')
+        misses.append(" GitLab reference pipeline is missing required controls.")
         handoff_actions.append(
             "Update templates/ci/gitlab/gitlab-advanced-reference.yml to restore required controls."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' integration expansion #2 closeout lane is fully complete and ready for  integration expansion #3.'
+            " integration expansion #2 closeout lane is fully complete and ready for  integration expansion #3."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -331,8 +321,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "integration-expansion2-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "integration-expansion2-integration-brief.md", '#  integration brief\n')
-    _write(target / "integration-expansion2-pipeline-blueprint.md", '#  pipeline blueprint\n')
+    _write(target / "integration-expansion2-integration-brief.md", "#  integration brief\n")
+    _write(target / "integration-expansion2-pipeline-blueprint.md", "#  pipeline blueprint\n")
     _write(
         target / "integration-expansion2-matrix-plan.json",
         json.dumps({"matrix": []}, indent=2) + "\n",
@@ -341,14 +331,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "integration-expansion2-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "integration-expansion2-execution-log.md", '#  execution log\n')
+    _write(target / "integration-expansion2-execution-log.md", "#  execution log\n")
     _write(
         target / "integration-expansion2-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "integration-expansion2-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -376,12 +366,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_integration_expansion2_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_integration_expansion2_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' integration expansion #2 closeout checks')
+    parser = argparse.ArgumentParser(description=" integration expansion #2 closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/integration_expansion3_closeout_67.py
+++ b/src/sdetkit/integration_expansion3_closeout_67.py
@@ -17,10 +17,10 @@ _INTEGRATION_EXPANSION2_BOARD_PATH = (
     "docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md"
 )
 _JENKINS_PATH = "templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile"
-_SECTION_HEADER = '#  — Integration expansion #3 closeout lane'
+_SECTION_HEADER = "#  — Integration expansion #3 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Expansion3 Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Integration Expansion3 Closeout command lane",
     "## Integration expansion contract",
     "## Integration quality checklist",
@@ -39,10 +39,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_integration_expansion3_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  advanced Jenkins rollout and signoff.',
-    'The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records Jenkins pipeline stages, matrix controls, shared library strategy, and  integration priorities.',
+    "Single owner + backup reviewer are assigned for  advanced Jenkins rollout and signoff.",
+    "The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records Jenkins pipeline stages, matrix controls, shared library strategy, and  integration priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes Jenkins stages + post conditions, matrix or parallel fan-out, and rollback trigger",
@@ -52,11 +52,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, Jenkins blueprint, matrix plan, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  advanced Jenkins pipeline blueprint published',
-    '- [ ]  matrix and cache strategy exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  integration expansion priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  advanced Jenkins pipeline blueprint published",
+    "- [ ]  matrix and cache strategy exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  integration expansion priorities drafted from  learnings",
 ]
 _REQUIRED_JENKINS_LINES = [
     "pipeline {",
@@ -67,7 +67,7 @@ _REQUIRED_JENKINS_LINES = [
     "parallel",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Integration expansion #3 closeout lane\n\n closes with a major integration upgrade that converts  integration outputs into an advanced Jenkins reference pipeline.\n\n## Why Integration Expansion3 Closeout matters\n\n- Converts  governance outputs into reusable Jenkins implementation patterns.\n- Protects integration outcomes with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  integration expansion to  integration expansion #4.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json`\n- `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md`\n- `templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile`\n\n## Integration Expansion3 Closeout command lane\n\n```bash\npython -m sdetkit integration-expansion3-closeout --format json --strict\npython -m sdetkit integration-expansion3-closeout --emit-pack-dir docs/artifacts/integration-expansion3-closeout-pack --format json --strict\npython -m sdetkit integration-expansion3-closeout --execute --evidence-dir docs/artifacts/integration-expansion3-closeout-pack/evidence --format json --strict\npython scripts/check_integration_expansion3_closeout_contract.py\n```\n\n## Integration expansion contract\n\n- Single owner + backup reviewer are assigned for  advanced Jenkins rollout and signoff.\n- The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records Jenkins pipeline stages, matrix controls, shared library strategy, and  integration priorities.\n\n## Integration quality checklist\n\n- [ ] Includes Jenkins stages + post conditions, matrix or parallel fan-out, and rollback trigger\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures pipeline pass-rate, median runtime, cache efficiency, confidence, and recovery owner\n- [ ] Artifact pack includes integration brief, Jenkins blueprint, matrix plan, KPI scorecard, and execution log\n\n## Integration Expansion3 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  advanced Jenkins pipeline blueprint published\n- [ ]  matrix and cache strategy exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  integration expansion priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 25 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 30 points.\n- Jenkins reference quality + guardrails: 25 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Integration expansion #3 closeout lane\n\n closes with a major integration upgrade that converts  integration outputs into an advanced Jenkins reference pipeline.\n\n## Why Integration Expansion3 Closeout matters\n\n- Converts  governance outputs into reusable Jenkins implementation patterns.\n- Protects integration outcomes with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  integration expansion to  integration expansion #4.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-closeout-summary.json`\n- `docs/artifacts/integration-expansion2-closeout-pack/integration-expansion2-delivery-board.md`\n- `templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile`\n\n## Integration Expansion3 Closeout command lane\n\n```bash\npython -m sdetkit integration-expansion3-closeout --format json --strict\npython -m sdetkit integration-expansion3-closeout --emit-pack-dir docs/artifacts/integration-expansion3-closeout-pack --format json --strict\npython -m sdetkit integration-expansion3-closeout --execute --evidence-dir docs/artifacts/integration-expansion3-closeout-pack/evidence --format json --strict\npython scripts/check_integration_expansion3_closeout_contract.py\n```\n\n## Integration expansion contract\n\n- Single owner + backup reviewer are assigned for  advanced Jenkins rollout and signoff.\n- The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records Jenkins pipeline stages, matrix controls, shared library strategy, and  integration priorities.\n\n## Integration quality checklist\n\n- [ ] Includes Jenkins stages + post conditions, matrix or parallel fan-out, and rollback trigger\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures pipeline pass-rate, median runtime, cache efficiency, confidence, and recovery owner\n- [ ] Artifact pack includes integration brief, Jenkins blueprint, matrix plan, KPI scorecard, and execution log\n\n## Integration Expansion3 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  advanced Jenkins pipeline blueprint published\n- [ ]  matrix and cache strategy exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  integration expansion priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 25 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 30 points.\n- Jenkins reference quality + guardrails: 25 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -120,7 +120,7 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
         integration_expansion2_check_count,
     ) = _load_integration_expansion2(integration_expansion2_summary)
     board_count, board_has_integration_expansion2 = _count_board_items(
-        integration_expansion2_board, ''
+        integration_expansion2_board, ""
     )
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
@@ -149,8 +149,8 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "integration_expansion2_summary_present",
@@ -243,34 +243,26 @@ def build_integration_expansion3_closeout_summary(root: Path) -> dict[str, Any]:
             f"66 continuity is strict-pass with activation score={integration_expansion2_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_integration_expansion2:
-        wins.append(
-            f"66 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"66 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_jenkins_lines:
-        wins.append(
-            ' Jenkins reference pipeline is available for integration expansion execution.'
-        )
+        wins.append(" Jenkins reference pipeline is available for integration expansion execution.")
     else:
-        misses.append(' Jenkins reference pipeline is missing required controls.')
+        misses.append(" Jenkins reference pipeline is missing required controls.")
         handoff_actions.append(
             "Update templates/ci/jenkins/jenkins-advanced-reference.Jenkinsfile to restore required controls."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' integration expansion #3 closeout lane is fully complete and ready for  integration expansion #4.'
+            " integration expansion #3 closeout lane is fully complete and ready for  integration expansion #4."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -335,8 +327,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "integration-expansion3-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "integration-expansion3-integration-brief.md", '#  integration brief\n')
-    _write(target / "integration-expansion3-jenkins-blueprint.md", '#  Jenkins blueprint\n')
+    _write(target / "integration-expansion3-integration-brief.md", "#  integration brief\n")
+    _write(target / "integration-expansion3-jenkins-blueprint.md", "#  Jenkins blueprint\n")
     _write(
         target / "integration-expansion3-matrix-plan.json",
         json.dumps({"matrix": []}, indent=2) + "\n",
@@ -345,14 +337,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "integration-expansion3-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "integration-expansion3-execution-log.md", '#  execution log\n')
+    _write(target / "integration-expansion3-execution-log.md", "#  execution log\n")
     _write(
         target / "integration-expansion3-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "integration-expansion3-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -380,12 +372,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_integration_expansion3_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_integration_expansion3_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' integration expansion #3 closeout checks')
+    parser = argparse.ArgumentParser(description=" integration expansion #3 closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/integration_expansion4_closeout_68.py
+++ b/src/sdetkit/integration_expansion4_closeout_68.py
@@ -17,10 +17,10 @@ _INTEGRATION_EXPANSION3_BOARD_PATH = (
     "docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md"
 )
 _REFERENCE_PATH = "templates/ci/tekton/tekton-self-hosted-reference.yaml"
-_SECTION_HEADER = '#  — Integration expansion #4 closeout lane'
+_SECTION_HEADER = "#  — Integration expansion #4 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Expansion4 Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Integration Expansion4 Closeout command lane",
     "## Integration expansion contract",
     "## Integration quality checklist",
@@ -39,10 +39,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_integration_expansion4_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  self-hosted enterprise rollout and signoff.',
-    'The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records self-hosted pipeline stages, identity controls, runner policy strategy, and  case-study prep priorities.',
+    "Single owner + backup reviewer are assigned for  self-hosted enterprise rollout and signoff.",
+    "The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records self-hosted pipeline stages, identity controls, runner policy strategy, and  case-study prep priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes self-hosted stages + policy conditions, queue/parallel fan-out, and rollback trigger",
@@ -52,11 +52,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, self-hosted blueprint, policy plan, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  self-hosted enterprise pipeline blueprint published',
-    '- [ ]  identity and runner policy strategy exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  case-study prep priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  self-hosted enterprise pipeline blueprint published",
+    "- [ ]  identity and runner policy strategy exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  case-study prep priorities drafted from  learnings",
 ]
 _REQUIRED_REFERENCE_LINES = [
     "apiVersion: tekton.dev/v1",
@@ -67,7 +67,7 @@ _REQUIRED_REFERENCE_LINES = [
     "when:",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Integration expansion #4 closeout lane\n\n closes with a major integration upgrade that converts  outputs into a self-hosted enterprise Tekton reference.\n\n## Why Integration Expansion4 Closeout matters\n\n- Converts  governance outputs into reusable self-hosted implementation patterns.\n- Protects integration outcomes with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  integration expansion to  case-study prep #1.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json`\n- `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md`\n- `templates/ci/tekton/tekton-self-hosted-reference.yaml`\n\n## Integration Expansion4 Closeout command lane\n\n```bash\npython -m sdetkit integration-expansion4-closeout --format json --strict\npython -m sdetkit integration-expansion4-closeout --emit-pack-dir docs/artifacts/integration-expansion4-closeout-pack --format json --strict\npython -m sdetkit integration-expansion4-closeout --execute --evidence-dir docs/artifacts/integration-expansion4-closeout-pack/evidence --format json --strict\npython scripts/check_integration_expansion4_closeout_contract.py\n```\n\n## Integration expansion contract\n\n- Single owner + backup reviewer are assigned for  self-hosted enterprise rollout and signoff.\n- The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records self-hosted pipeline stages, identity controls, runner policy strategy, and  case-study prep priorities.\n\n## Integration quality checklist\n\n- [ ] Includes self-hosted stages + policy conditions, queue/parallel fan-out, and rollback trigger\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures pipeline pass-rate, median runtime, queue saturation, confidence, and recovery owner\n- [ ] Artifact pack includes integration brief, self-hosted blueprint, policy plan, KPI scorecard, and execution log\n\n## Integration Expansion4 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  self-hosted enterprise pipeline blueprint published\n- [ ]  identity and runner policy strategy exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  case-study prep priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 25 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 30 points.\n- Self-hosted reference quality + guardrails: 25 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Integration expansion #4 closeout lane\n\n closes with a major integration upgrade that converts  outputs into a self-hosted enterprise Tekton reference.\n\n## Why Integration Expansion4 Closeout matters\n\n- Converts  governance outputs into reusable self-hosted implementation patterns.\n- Protects integration outcomes with strict contract coverage, runnable commands, and rollback safety.\n- Creates a deterministic handoff from  integration expansion to  case-study prep #1.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-closeout-summary.json`\n- `docs/artifacts/integration-expansion3-closeout-pack/integration-expansion3-delivery-board.md`\n- `templates/ci/tekton/tekton-self-hosted-reference.yaml`\n\n## Integration Expansion4 Closeout command lane\n\n```bash\npython -m sdetkit integration-expansion4-closeout --format json --strict\npython -m sdetkit integration-expansion4-closeout --emit-pack-dir docs/artifacts/integration-expansion4-closeout-pack --format json --strict\npython -m sdetkit integration-expansion4-closeout --execute --evidence-dir docs/artifacts/integration-expansion4-closeout-pack/evidence --format json --strict\npython scripts/check_integration_expansion4_closeout_contract.py\n```\n\n## Integration expansion contract\n\n- Single owner + backup reviewer are assigned for  self-hosted enterprise rollout and signoff.\n- The  lane references  integration expansion outputs, governance decisions, and KPI continuity signals.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records self-hosted pipeline stages, identity controls, runner policy strategy, and  case-study prep priorities.\n\n## Integration quality checklist\n\n- [ ] Includes self-hosted stages + policy conditions, queue/parallel fan-out, and rollback trigger\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures pipeline pass-rate, median runtime, queue saturation, confidence, and recovery owner\n- [ ] Artifact pack includes integration brief, self-hosted blueprint, policy plan, KPI scorecard, and execution log\n\n## Integration Expansion4 Closeout delivery board\n\n- [ ]  integration brief committed\n- [ ]  self-hosted enterprise pipeline blueprint published\n- [ ]  identity and runner policy strategy exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  case-study prep priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 25 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 30 points.\n- Self-hosted reference quality + guardrails: 25 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -120,7 +120,7 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
         integration_expansion3_check_count,
     ) = _load_integration_expansion3(integration_expansion3_summary)
     board_count, board_has_integration_expansion3 = _count_board_items(
-        integration_expansion3_board, ''
+        integration_expansion3_board, ""
     )
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
@@ -149,8 +149,8 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "integration_expansion3_summary_present",
@@ -243,34 +243,28 @@ def build_integration_expansion4_closeout_summary(root: Path) -> dict[str, Any]:
             f"67 continuity is strict-pass with activation score={integration_expansion3_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_integration_expansion3:
-        wins.append(
-            f"67 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"67 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_reference_lines:
         wins.append(
-            ' self-hosted reference pipeline is available for integration expansion execution.'
+            " self-hosted reference pipeline is available for integration expansion execution."
         )
     else:
-        misses.append(' self-hosted reference pipeline is missing required controls.')
+        misses.append(" self-hosted reference pipeline is missing required controls.")
         handoff_actions.append(
             "Update templates/ci/tekton/tekton-self-hosted-reference.yaml to restore required controls."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' integration expansion #4 closeout lane is fully complete and ready for  case-study prep #1.'
+            " integration expansion #4 closeout lane is fully complete and ready for  case-study prep #1."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -335,10 +329,10 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "integration-expansion4-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "integration-expansion4-integration-brief.md", '#  integration brief\n')
+    _write(target / "integration-expansion4-integration-brief.md", "#  integration brief\n")
     _write(
         target / "integration-expansion4-self-hosted-blueprint.md",
-        '#  self-hosted blueprint\n',
+        "#  self-hosted blueprint\n",
     )
     _write(
         target / "integration-expansion4-policy-plan.json",
@@ -348,14 +342,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "integration-expansion4-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "integration-expansion4-execution-log.md", '#  execution log\n')
+    _write(target / "integration-expansion4-execution-log.md", "#  execution log\n")
     _write(
         target / "integration-expansion4-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "integration-expansion4-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -383,12 +377,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_integration_expansion4_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_integration_expansion4_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' integration expansion #4 closeout checks')
+    parser = argparse.ArgumentParser(description=" integration expansion #4 closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/integration_feedback_closeout_82.py
+++ b/src/sdetkit/integration_feedback_closeout_82.py
@@ -17,10 +17,10 @@ _DAY81_SUMMARY_PATH = (
 )
 _DAY81_BOARD_PATH = "docs/artifacts/growth-campaign-closeout-pack/growth-campaign-delivery-board.md"
 _PLAN_PATH = "docs/roadmap/plans/integration-feedback-plan.json"
-_SECTION_HEADER = '#  — Integration feedback loop closeout lane'
+_SECTION_HEADER = "#  — Integration feedback loop closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Integration Feedback Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Integration feedback contract",
     "## Integration feedback quality checklist",
@@ -39,10 +39,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_integration_feedback_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  integration feedback execution and signoff.',
-    'The  lane references  outcomes, controls, and campaign continuity signals.',
-    'Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records docs-template upgrades, community touchpoint outcomes, and  trust FAQ priorities.',
+    "Single owner + backup reviewer are assigned for  integration feedback execution and signoff.",
+    "The  lane references  outcomes, controls, and campaign continuity signals.",
+    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records docs-template upgrades, community touchpoint outcomes, and  trust FAQ priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline feedback volume, segmentation assumptions, and response SLA targets",
@@ -52,11 +52,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, feedback plan, template diffs, office-hours ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  integration feedback plan committed',
-    '- [ ]  template upgrade ledger exported',
-    '- [ ]  office-hours outcome ledger exported',
-    '- [ ]  trust FAQ priorities drafted from  feedback',
+    "- [ ]  integration brief committed",
+    "- [ ]  integration feedback plan committed",
+    "- [ ]  template upgrade ledger exported",
+    "- [ ]  office-hours outcome ledger exported",
+    "- [ ]  trust FAQ priorities drafted from  feedback",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -67,7 +67,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Integration feedback loop closeout lane\n\n closes with a major upgrade that folds  growth campaign outcomes into docs/template upgrades and community touchpoint execution.\n\n## Why Integration Feedback Closeout matters\n\n- Turns  growth campaign outcomes into deterministic integration feedback loops across docs, templates, and community operations.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  trust FAQ expansion priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/growth-campaign-closeout-pack/growth-campaign-closeout-summary.json`\n- `docs/artifacts/growth-campaign-closeout-pack/growth-campaign-delivery-board.md`\n- `docs/roadmap/plans/integration-feedback-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit integration-feedback-closeout --format json --strict\npython -m sdetkit integration-feedback-closeout --emit-pack-dir docs/artifacts/integration-feedback-closeout-pack --format json --strict\npython -m sdetkit integration-feedback-closeout --execute --evidence-dir docs/artifacts/integration-feedback-closeout-pack/evidence --format json --strict\npython scripts/check_integration_feedback_closeout_contract.py\n```\n\n## Integration feedback contract\n\n- Single owner + backup reviewer are assigned for  integration feedback execution and signoff.\n- The  lane references  outcomes, controls, and campaign continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records docs-template upgrades, community touchpoint outcomes, and  trust FAQ priorities.\n\n## Integration feedback quality checklist\n\n- [ ] Includes baseline feedback volume, segmentation assumptions, and response SLA targets\n- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to docs/templates + runnable command evidence\n- [ ] Scorecard captures docs adoption delta, community engagement delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, feedback plan, template diffs, office-hours ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  integration brief committed\n- [ ]  integration feedback plan committed\n- [ ]  template upgrade ledger exported\n- [ ]  office-hours outcome ledger exported\n- [ ]  trust FAQ priorities drafted from  feedback\n\n## Scoring model\n\nIntegration Feedback Closeout weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Feedback evidence data + delivery board completeness (30)\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Integration feedback loop closeout lane\n\n closes with a major upgrade that folds  growth campaign outcomes into docs/template upgrades and community touchpoint execution.\n\n## Why Integration Feedback Closeout matters\n\n- Turns  growth campaign outcomes into deterministic integration feedback loops across docs, templates, and community operations.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  trust FAQ expansion priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/growth-campaign-closeout-pack/growth-campaign-closeout-summary.json`\n- `docs/artifacts/growth-campaign-closeout-pack/growth-campaign-delivery-board.md`\n- `docs/roadmap/plans/integration-feedback-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit integration-feedback-closeout --format json --strict\npython -m sdetkit integration-feedback-closeout --emit-pack-dir docs/artifacts/integration-feedback-closeout-pack --format json --strict\npython -m sdetkit integration-feedback-closeout --execute --evidence-dir docs/artifacts/integration-feedback-closeout-pack/evidence --format json --strict\npython scripts/check_integration_feedback_closeout_contract.py\n```\n\n## Integration feedback contract\n\n- Single owner + backup reviewer are assigned for  integration feedback execution and signoff.\n- The  lane references  outcomes, controls, and campaign continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records docs-template upgrades, community touchpoint outcomes, and  trust FAQ priorities.\n\n## Integration feedback quality checklist\n\n- [ ] Includes baseline feedback volume, segmentation assumptions, and response SLA targets\n- [ ] Every upgrade lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to docs/templates + runnable command evidence\n- [ ] Scorecard captures docs adoption delta, community engagement delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, feedback plan, template diffs, office-hours ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  integration brief committed\n- [ ]  integration feedback plan committed\n- [ ]  template upgrade ledger exported\n- [ ]  office-hours outcome ledger exported\n- [ ]  trust FAQ priorities drafted from  feedback\n\n## Scoring model\n\nIntegration Feedback Closeout weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Feedback evidence data + delivery board completeness (30)\n"
 
 
 def _read_text(path: Path) -> str:
@@ -108,7 +108,9 @@ def build_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
         else {}
     )
     growth_campaign_score = int(growth_campaign_summary_data.get("activation_score", 0) or 0)
-    growth_campaign_strict = coerce_bool(growth_campaign_summary_data.get("strict_pass", False), default=False)
+    growth_campaign_strict = coerce_bool(
+        growth_campaign_summary_data.get("strict_pass", False), default=False
+    )
     growth_campaign_check_count = (
         len(growth_campaign_data.get("checks", []))
         if isinstance(growth_campaign_data.get("checks"), list)
@@ -117,7 +119,7 @@ def build_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(growth_campaign_board)
     board_count = _checklist_count(board_text)
-    board_has_growth_campaign = "growth campaign" in board_text.lower() or '' in board_text
+    board_has_growth_campaign = "growth campaign" in board_text.lower() or "" in board_text
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
@@ -147,8 +149,8 @@ def build_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "growth_campaign_summary_present",
@@ -239,32 +241,28 @@ def build_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
             f"Growth Campaign continuity baseline is stable with activation score={growth_campaign_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85) or not strict-pass.')
+        misses.append(" continuity baseline is below the floor (<85) or not strict-pass.")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock."
         )
 
     if board_count >= 5 and board_has_growth_campaign:
-        wins.append(
-            f"81 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"81 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' integration feedback dataset is available for launch execution.')
+        wins.append(" integration feedback dataset is available for launch execution.")
     else:
-        misses.append(' integration feedback dataset is missing required keys.')
+        misses.append(" integration feedback dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/integration-feedback-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' integration feedback closeout lane is fully complete and ready for  trust FAQ priorities.'
+            " integration feedback closeout lane is fully complete and ready for  trust FAQ priorities."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -304,7 +302,7 @@ def build_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' integration feedback closeout summary',
+        " integration feedback closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -325,8 +323,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "integration-feedback-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "integration-feedback-integration-brief.md", '#  integration brief\n')
-    _write(target / "integration-feedback-plan.md", '#  integration feedback plan\n')
+    _write(target / "integration-feedback-integration-brief.md", "#  integration brief\n")
+    _write(target / "integration-feedback-plan.md", "#  integration feedback plan\n")
     _write(
         target / "integration-feedback-template-upgrade-ledger.json",
         json.dumps({"upgrades": []}, indent=2) + "\n",
@@ -339,14 +337,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "integration-feedback-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "integration-feedback-execution-log.md", '#  execution log\n')
+    _write(target / "integration-feedback-execution-log.md", "#  execution log\n")
     _write(
         target / "integration-feedback-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "integration-feedback-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -374,12 +372,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_integration_feedback_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_integration_feedback_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' integration feedback closeout checks')
+    parser = argparse.ArgumentParser(description=" integration feedback closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -217,12 +217,6 @@ def route_map_payload(
         text = p.read_text(encoding="utf-8", errors="ignore")
         if any(t in text.lower() for t in tokens):
             usage.append(str(p.relative_to(root)))
-    dep_text = (
-        root.joinpath("pyproject.toml").read_text(encoding="utf-8")
-        if root.joinpath("pyproject.toml").exists()
-        else ""
-    )
-    packages_audited = dep_text.count(">=") + dep_text.count("==")
     return {
         "schema_version": SCHEMA_VERSION,
         "status": "ready",

--- a/src/sdetkit/launch_readiness_closeout_86.py
+++ b/src/sdetkit/launch_readiness_closeout_86.py
@@ -15,10 +15,10 @@ _DAY85_BOARD_PATH = (
     "docs/artifacts/release-prioritization-closeout-pack/release-prioritization-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/launch-readiness-plan.json"
-_SECTION_HEADER = '#  — Launch readiness closeout lane'
+_SECTION_HEADER = "#  — Launch readiness closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Launch Readiness Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Launch readiness contract",
     "## Launch readiness quality checklist",
@@ -37,10 +37,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_launch_readiness_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  launch readiness execution and signoff.',
-    'The  lane references  outcomes, controls, and trust continuity signals.',
-    'Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records launch readiness pack upgrades, storyline outcomes, and  launch priorities.',
+    "Single owner + backup reviewer are assigned for  launch readiness execution and signoff.",
+    "The  lane references  outcomes, controls, and trust continuity signals.",
+    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records launch readiness pack upgrades, storyline outcomes, and  launch priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
@@ -50,11 +50,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  evidence brief committed',
-    '- [ ]  launch readiness plan committed',
-    '- [ ]  narrative template upgrade ledger exported',
-    '- [ ]  storyline outcomes ledger exported',
-    '- [ ]  launch priorities drafted from  outcomes',
+    "- [ ]  evidence brief committed",
+    "- [ ]  launch readiness plan committed",
+    "- [ ]  narrative template upgrade ledger exported",
+    "- [ ]  storyline outcomes ledger exported",
+    "- [ ]  launch priorities drafted from  outcomes",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -65,7 +65,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Launch readiness closeout lane\n\n closes with a major upgrade that converts  release prioritization outcomes into a deterministic launch readiness operating lane.\n\n## Why Launch Readiness Closeout matters\n\n- Converts  release prioritization outcomes into reusable launch readiness decisions across launch briefs, release notes, and escalation playbooks.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  launch priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/release-prioritization-closeout-pack/release-prioritization-closeout-summary.json`\n- `docs/artifacts/release-prioritization-closeout-pack/release-prioritization-delivery-board.md`\n- `docs/roadmap/plans/launch-readiness-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit launch-readiness-closeout --format json --strict\npython -m sdetkit launch-readiness-closeout --emit-pack-dir docs/artifacts/launch-readiness-closeout-pack --format json --strict\npython -m sdetkit launch-readiness-closeout --execute --evidence-dir docs/artifacts/launch-readiness-closeout-pack/evidence --format json --strict\npython scripts/check_launch_readiness_closeout_contract.py\n```\n\n## Launch readiness contract\n\n- Single owner + backup reviewer are assigned for  launch readiness execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records launch readiness pack upgrades, storyline outcomes, and  launch priorities.\n\n## Launch readiness quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures launch readiness adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  launch readiness plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  launch priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + launch artifact readiness for a 100-point activation score.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Launch readiness closeout lane\n\n closes with a major upgrade that converts  release prioritization outcomes into a deterministic launch readiness operating lane.\n\n## Why Launch Readiness Closeout matters\n\n- Converts  release prioritization outcomes into reusable launch readiness decisions across launch briefs, release notes, and escalation playbooks.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  launch priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/release-prioritization-closeout-pack/release-prioritization-closeout-summary.json`\n- `docs/artifacts/release-prioritization-closeout-pack/release-prioritization-delivery-board.md`\n- `docs/roadmap/plans/launch-readiness-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit launch-readiness-closeout --format json --strict\npython -m sdetkit launch-readiness-closeout --emit-pack-dir docs/artifacts/launch-readiness-closeout-pack --format json --strict\npython -m sdetkit launch-readiness-closeout --execute --evidence-dir docs/artifacts/launch-readiness-closeout-pack/evidence --format json --strict\npython scripts/check_launch_readiness_closeout_contract.py\n```\n\n## Launch readiness contract\n\n- Single owner + backup reviewer are assigned for  launch readiness execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records launch readiness pack upgrades, storyline outcomes, and  launch priorities.\n\n## Launch readiness quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures launch readiness adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  launch readiness plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  launch priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + launch artifact readiness for a 100-point activation score.\n"
 
 
 def _read_text(path: Path) -> str:
@@ -115,7 +115,7 @@ def build_launch_readiness_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(release_prioritization_board)
     board_count = _checklist_count(board_text)
-    board_has_release_prioritization = '' in board_text
+    board_has_release_prioritization = "" in board_text
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
@@ -145,8 +145,8 @@ def build_launch_readiness_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "release_prioritization_summary_present",
@@ -237,32 +237,28 @@ def build_launch_readiness_closeout_summary(root: Path) -> dict[str, Any]:
             f"Release prioritization continuity baseline is stable with activation score={release_prioritization_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85) or not strict-pass.')
+        misses.append(" continuity baseline is below the floor (<85) or not strict-pass.")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock."
         )
 
     if board_count >= 5 and board_has_release_prioritization:
-        wins.append(
-            f"85 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"85 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' launch readiness dataset is available for launch execution.')
+        wins.append(" launch readiness dataset is available for launch execution.")
     else:
-        misses.append(' launch readiness dataset is missing required keys.')
+        misses.append(" launch readiness dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/launch-readiness-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' launch readiness closeout lane is fully complete and ready for  launch planning.'
+            " launch readiness closeout lane is fully complete and ready for  launch planning."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -304,7 +300,7 @@ def build_launch_readiness_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' launch readiness closeout summary',
+        " launch readiness closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -325,8 +321,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "launch-readiness-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "launch-readiness-evidence-brief.md", '#  launch readiness brief\n')
-    _write(target / "launch-readiness-plan.md", '#  launch readiness plan\n')
+    _write(target / "launch-readiness-evidence-brief.md", "#  launch readiness brief\n")
+    _write(target / "launch-readiness-plan.md", "#  launch readiness plan\n")
     _write(
         target / "launch-readiness-narrative-template-upgrade-ledger.json",
         json.dumps({"upgrades": []}, indent=2) + "\n",
@@ -339,14 +335,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "launch-readiness-narrative-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "launch-readiness-execution-log.md", '#  execution log\n')
+    _write(target / "launch-readiness-execution-log.md", "#  execution log\n")
     _write(
         target / "launch-readiness-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "launch-readiness-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -374,12 +370,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_launch_readiness_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_launch_readiness_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' launch readiness closeout checks')
+    parser = argparse.ArgumentParser(description=" launch readiness closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/optimization_closeout_42.py
+++ b/src/sdetkit/optimization_closeout_42.py
@@ -41,9 +41,9 @@ _EXECUTION_COMMANDS = [
 ]
 _REQUIRED_CONTRACT_LINES = [
     "Single owner + backup reviewer are assigned for Optimization Closeout Foundation optimization lane execution and KPI follow-up.",
-    'The Optimization Closeout Foundation optimization lane references  expansion winners and misses with deterministic remediation loops.',
+    "The Optimization Closeout Foundation optimization lane references  expansion winners and misses with deterministic remediation loops.",
     "Every Optimization Closeout Foundation section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.",
-    'Optimization Closeout Foundation closeout records optimization learnings and  acceleration priorities.',
+    "Optimization Closeout Foundation closeout records optimization learnings and  acceleration priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes optimization summary, remediation matrix, and rollback strategy",
@@ -57,10 +57,10 @@ _REQUIRED_DELIVERY_BOARD_LINES = [
     "- [ ] Optimization Closeout Foundation review notes captured with owner + backup",
     "- [ ] Optimization Closeout Foundation remediation matrix exported",
     "- [ ] Optimization Closeout Foundation KPI scorecard snapshot exported",
-    '- [ ]  acceleration priorities drafted from Optimization Closeout Foundation learnings',
+    "- [ ]  acceleration priorities drafted from Optimization Closeout Foundation learnings",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '# Optimization Closeout Foundation — Optimization closeout lane\n\nOptimization Closeout Foundation closes with a major optimization upgrade that converts  expansion evidence into deterministic improvement loops.\n\n## Why Optimization Closeout Foundation matters\n\n- Converts  expansion proof into remediation-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from optimization outcomes into  acceleration priorities.\n\n## Required inputs (expansion automation)\n\n- `docs/artifacts/expansion-automation-pack-41/expansion-automation-summary-41.json`\n- `docs/artifacts/expansion-automation-pack-41/delivery-board-41.md`\n\n## Optimization Closeout Foundation command lane\n\n```bash\npython -m sdetkit optimization-closeout-foundation --format json --strict\npython -m sdetkit optimization-closeout-foundation --emit-pack-dir docs/artifacts/optimization-closeout-foundation-pack --format json --strict\npython -m sdetkit optimization-closeout-foundation --execute --evidence-dir docs/artifacts/optimization-closeout-foundation-pack/evidence --format json --strict\npython scripts/check_optimization_closeout_contract.py\n```\n\n## Optimization closeout contract\n\n- Single owner + backup reviewer are assigned for Optimization Closeout Foundation optimization lane execution and KPI follow-up.\n- The Optimization Closeout Foundation optimization lane references  expansion winners and misses with deterministic remediation loops.\n- Every Optimization Closeout Foundation section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n- Optimization Closeout Foundation closeout records optimization learnings and  acceleration priorities.\n\n## Optimization quality checklist\n\n- [ ] Includes optimization summary, remediation matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes optimization plan, remediation matrix, KPI scorecard, and execution log\n\n## Optimization Closeout Foundation delivery board\n\n- [ ] Optimization Closeout Foundation optimization plan draft committed\n- [ ] Optimization Closeout Foundation review notes captured with owner + backup\n- [ ] Optimization Closeout Foundation remediation matrix exported\n- [ ] Optimization Closeout Foundation KPI scorecard snapshot exported\n- [ ]  acceleration priorities drafted from Optimization Closeout Foundation learnings\n\n## Scoring model\n\nOptimization Closeout Foundation weighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n- Expansion automation continuity and strict baseline carryover: 35 points.\n- Optimization contract lock + delivery board readiness: 15 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "# Optimization Closeout Foundation — Optimization closeout lane\n\nOptimization Closeout Foundation closes with a major optimization upgrade that converts  expansion evidence into deterministic improvement loops.\n\n## Why Optimization Closeout Foundation matters\n\n- Converts  expansion proof into remediation-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from optimization outcomes into  acceleration priorities.\n\n## Required inputs (expansion automation)\n\n- `docs/artifacts/expansion-automation-pack-41/expansion-automation-summary-41.json`\n- `docs/artifacts/expansion-automation-pack-41/delivery-board-41.md`\n\n## Optimization Closeout Foundation command lane\n\n```bash\npython -m sdetkit optimization-closeout-foundation --format json --strict\npython -m sdetkit optimization-closeout-foundation --emit-pack-dir docs/artifacts/optimization-closeout-foundation-pack --format json --strict\npython -m sdetkit optimization-closeout-foundation --execute --evidence-dir docs/artifacts/optimization-closeout-foundation-pack/evidence --format json --strict\npython scripts/check_optimization_closeout_contract.py\n```\n\n## Optimization closeout contract\n\n- Single owner + backup reviewer are assigned for Optimization Closeout Foundation optimization lane execution and KPI follow-up.\n- The Optimization Closeout Foundation optimization lane references  expansion winners and misses with deterministic remediation loops.\n- Every Optimization Closeout Foundation section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n- Optimization Closeout Foundation closeout records optimization learnings and  acceleration priorities.\n\n## Optimization quality checklist\n\n- [ ] Includes optimization summary, remediation matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes optimization plan, remediation matrix, KPI scorecard, and execution log\n\n## Optimization Closeout Foundation delivery board\n\n- [ ] Optimization Closeout Foundation optimization plan draft committed\n- [ ] Optimization Closeout Foundation review notes captured with owner + backup\n- [ ] Optimization Closeout Foundation remediation matrix exported\n- [ ] Optimization Closeout Foundation KPI scorecard snapshot exported\n- [ ]  acceleration priorities drafted from Optimization Closeout Foundation learnings\n\n## Scoring model\n\nOptimization Closeout Foundation weighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n- Expansion automation continuity and strict baseline carryover: 35 points.\n- Optimization contract lock + delivery board readiness: 15 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -93,7 +93,7 @@ def _load_expansion_automation(path: Path) -> tuple[float, bool, int]:
 def _board_stats(path: Path) -> tuple[int, bool, bool]:
     text = _read(path)
     items = [line for line in text.splitlines() if line.strip().startswith("- [")]
-    return len(items), '' in text, "Optimization Closeout Foundation" in text
+    return len(items), "" in text, "Optimization Closeout Foundation" in text
 
 
 def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
@@ -183,7 +183,7 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_optimization_closeout_foundation_alignment",
             "weight": 5,
-            "passed": ("Optimization Closeout Foundation" in top10_text and '' in top10_text),
+            "passed": ("Optimization Closeout Foundation" in top10_text and "" in top10_text),
             "evidence": "Optimization Closeout Foundation + acceleration strategy chain",
         },
         {
@@ -257,9 +257,9 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
             f"41 continuity is strict-pass with activation score={expansion_automation_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
+        misses.append(" strict continuity signal is missing.")
         handoff_actions.append(
-            'Re-run  expansion automation command and restore strict pass baseline before Optimization Closeout Foundation lock.'
+            "Re-run  expansion automation command and restore strict pass baseline before Optimization Closeout Foundation lock."
         )
 
     if (
@@ -267,15 +267,11 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
         and board_has_expansion_automation
         and board_has_optimization_closeout_foundation
     ):
-        wins.append(
-            f"41 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"41 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and /42 anchors).'
-        )
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and /42 anchors).")
         handoff_actions.append(
-            'Repair  delivery board entries to include  and Optimization Closeout Foundation anchors.'
+            "Repair  delivery board entries to include  and Optimization Closeout Foundation anchors."
         )
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
@@ -292,7 +288,7 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
 
     if not failed and not critical_failures:
         wins.append(
-            'Optimization Closeout Foundation optimization closeout lane is fully complete and ready for  acceleration lane.'
+            "Optimization Closeout Foundation optimization closeout lane is fully complete and ready for  acceleration lane."
         )
 
     return {
@@ -390,7 +386,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     )
     _write(
         target / "execution-log.md",
-        '# Optimization Closeout Foundation Execution Log\n\n- [ ] 2026-03-12: Record misses, wins, and  acceleration priorities.\n',
+        "# Optimization Closeout Foundation Execution Log\n\n- [ ] 2026-03-12: Record misses, wins, and  acceleration priorities.\n",
     )
     _write(
         target / "delivery-board.md",
@@ -444,7 +440,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def build_optimization_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_optimization_closeout_summary(root)
 
 

--- a/src/sdetkit/optimization_closeout_46.py
+++ b/src/sdetkit/optimization_closeout_46.py
@@ -12,14 +12,14 @@ _PAGE_PATH = "docs/integrations-optimization-closeout.md"
 _TOP10_PATH = "docs/top-10-github-strategy.md"
 _DAY45_SUMMARY_PATH = "docs/artifacts/expansion-closeout-pack/expansion-closeout-summary.json"
 _DAY45_BOARD_PATH = "docs/artifacts/expansion-closeout-pack/expansion-delivery-board.md"
-_SECTION_HEADER = '#  — Optimization closeout lane'
+_SECTION_HEADER = "#  — Optimization closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Optimization closeout contract",
     "## Optimization quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -34,10 +34,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_optimization_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  optimization lane execution and KPI follow-up.',
-    'The  optimization lane references  expansion winners and misses with deterministic optimization loops.',
-    'Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.',
-    ' closeout records optimization learnings and  reliability priorities.',
+    "Single owner + backup reviewer are assigned for  optimization lane execution and KPI follow-up.",
+    "The  optimization lane references  expansion winners and misses with deterministic optimization loops.",
+    "Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.",
+    " closeout records optimization learnings and  reliability priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes optimization summary, bottleneck map, and rollback strategy",
@@ -47,14 +47,14 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes optimization plan, bottleneck map, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  optimization plan draft committed',
-    '- [ ]  review notes captured with owner + backup',
-    '- [ ]  bottleneck map exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  reliability priorities drafted from  learnings',
+    "- [ ]  optimization plan draft committed",
+    "- [ ]  review notes captured with owner + backup",
+    "- [ ]  bottleneck map exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  reliability priorities drafted from  learnings",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Optimization closeout lane\n\n closes with a major optimization upgrade that converts  expansion evidence into deterministic improvement loops.\n\n## Why  matters\n\n- Converts  expansion proof into optimization-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from optimization outcomes into  reliability priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/expansion-closeout-pack/expansion-closeout-summary.json`\n- `docs/artifacts/expansion-closeout-pack/expansion-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit optimization-closeout --format json --strict\npython -m sdetkit optimization-closeout --emit-pack-dir docs/artifacts/optimization-closeout-pack --format json --strict\npython -m sdetkit optimization-closeout --execute --evidence-dir docs/artifacts/optimization-closeout-pack/evidence --format json --strict\npython scripts/check_optimization_closeout_contract.py\n```\n\n## Optimization closeout contract\n\n- Single owner + backup reviewer are assigned for  optimization lane execution and KPI follow-up.\n- The  optimization lane references  expansion winners and misses with deterministic optimization loops.\n- Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n-  closeout records optimization learnings and  reliability priorities.\n\n## Optimization quality checklist\n\n- [ ] Includes optimization summary, bottleneck map, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes optimization plan, bottleneck map, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  optimization plan draft committed\n- [ ]  review notes captured with owner + backup\n- [ ]  bottleneck map exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  reliability priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Optimization contract lock + delivery board readiness: 15 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Optimization closeout lane\n\n closes with a major optimization upgrade that converts  expansion evidence into deterministic improvement loops.\n\n## Why  matters\n\n- Converts  expansion proof into optimization-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from optimization outcomes into  reliability priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/expansion-closeout-pack/expansion-closeout-summary.json`\n- `docs/artifacts/expansion-closeout-pack/expansion-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit optimization-closeout --format json --strict\npython -m sdetkit optimization-closeout --emit-pack-dir docs/artifacts/optimization-closeout-pack --format json --strict\npython -m sdetkit optimization-closeout --execute --evidence-dir docs/artifacts/optimization-closeout-pack/evidence --format json --strict\npython scripts/check_optimization_closeout_contract.py\n```\n\n## Optimization closeout contract\n\n- Single owner + backup reviewer are assigned for  optimization lane execution and KPI follow-up.\n- The  optimization lane references  expansion winners and misses with deterministic optimization loops.\n- Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n-  closeout records optimization learnings and  reliability priorities.\n\n## Optimization quality checklist\n\n- [ ] Includes optimization summary, bottleneck map, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes optimization plan, bottleneck map, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  optimization plan draft committed\n- [ ]  review notes captured with owner + backup\n- [ ]  bottleneck map exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  reliability priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Optimization contract lock + delivery board readiness: 15 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -86,7 +86,7 @@ def _load_expansion_closeout(path: Path) -> tuple[float, bool, int]:
 def _board_stats(path: Path) -> tuple[int, bool, bool]:
     text = _read(path)
     items = [line for line in text.splitlines() if line.strip().startswith("- [")]
-    return len(items), '' in text, '' in text
+    return len(items), "" in text, "" in text
 
 
 def _contains_all_lines(text: str, lines: list[str]) -> list[str]:
@@ -165,8 +165,8 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "expansion_closeout_summary_present",
@@ -239,22 +239,16 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
             f"45 continuity is strict-pass with activation score={expansion_closeout_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
+        misses.append(" strict continuity signal is missing.")
         handoff_actions.append(
-            'Re-run  expansion closeout command and restore strict pass baseline before  lock.'
+            "Re-run  expansion closeout command and restore strict pass baseline before  lock."
         )
 
     if board_count >= 5 and board_has_expansion_closeout and board_has_optimization_closeout:
-        wins.append(
-            f"45 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"45 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and /46 anchors).'
-        )
-        handoff_actions.append(
-            'Repair  delivery board entries to include  and  anchors.'
-        )
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and /46 anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  and  anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
         wins.append(
@@ -265,12 +259,12 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
             "Optimization contract, quality checklist, or delivery board entries are missing."
         )
         handoff_actions.append(
-            'Complete all  optimization contract lines, quality checklist entries, and delivery board tasks in docs.'
+            "Complete all  optimization contract lines, quality checklist entries, and delivery board tasks in docs."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' optimization closeout lane is fully complete and ready for  reliability lane.'
+            " optimization closeout lane is fully complete and ready for  reliability lane."
         )
 
     return {
@@ -308,7 +302,7 @@ def build_optimization_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' optimization closeout summary',
+        " optimization closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -338,7 +332,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(target / "optimization-closeout-summary.md", _render_text(payload) + "\n")
     _write(
         target / "optimization-plan.md",
-        '#  Optimization Plan\n\n- Objective: close  with measurable efficiency and quality gains.\n',
+        "#  Optimization Plan\n\n- Objective: close  with measurable efficiency and quality gains.\n",
     )
     _write(
         target / "optimization-bottleneck-map.csv",
@@ -365,15 +359,15 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     )
     _write(
         target / "optimization-execution-log.md",
-        '#  Execution Log\n\n- [ ] 2026-03-13: Record misses, wins, and  reliability priorities.\n',
+        "#  Execution Log\n\n- [ ] 2026-03-13: Record misses, wins, and  reliability priorities.\n",
     )
     _write(
         target / "optimization-delivery-board.md",
-        '#  Delivery Board\n\n' + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
+        "#  Delivery Board\n\n" + "\n".join(_REQUIRED_DELIVERY_BOARD_LINES) + "\n",
     )
     _write(
         target / "optimization-validation-commands.md",
-        '#  Validation Commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  Validation Commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -401,7 +395,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=' optimization closeout checks')
+    parser = argparse.ArgumentParser(description=" optimization closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--strict", action="store_true")
@@ -413,7 +407,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def build_optimization_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_optimization_closeout_summary(root)
 
 

--- a/src/sdetkit/partner_outreach_closeout_80.py
+++ b/src/sdetkit/partner_outreach_closeout_80.py
@@ -153,7 +153,9 @@ def build_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
     scale_upgrade_score = int(
         scale_upgrade_payload.get("summary", {}).get("activation_score", 0) or 0
     )
-    scale_upgrade_strict = coerce_bool(scale_upgrade_payload.get("summary", {}).get("strict_pass", False), default=False)
+    scale_upgrade_strict = coerce_bool(
+        scale_upgrade_payload.get("summary", {}).get("strict_pass", False), default=False
+    )
     scale_upgrade_check_count = (
         len(scale_upgrade_payload.get("checks", []))
         if isinstance(scale_upgrade_payload.get("checks", []), list)
@@ -294,9 +296,7 @@ def build_partner_outreach_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     if board_count >= 5 and board_has_scale_upgrade:
-        wins.append(
-            f"Prior delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"Prior delivery board integrity validated with {board_count} checklist items.")
     else:
         misses.append(
             "Prior delivery board integrity is incomplete (needs >=5 items and prior anchors)."

--- a/src/sdetkit/phase2_hardening_closeout_58.py
+++ b/src/sdetkit/phase2_hardening_closeout_58.py
@@ -16,14 +16,14 @@ _DAY57_SUMMARY_PATH = (
     "docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json"
 )
 _DAY57_BOARD_PATH = "docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md"
-_SECTION_HEADER = '#  — Phase-2 hardening closeout lane'
+_SECTION_HEADER = "#  — Phase-2 hardening closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Phase-2 hardening contract",
     "## Phase-2 hardening quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -38,10 +38,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_phase2_hardening_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  Phase-2 hardening execution and signal triage.',
-    'The  lane references  KPI deep-audit outcomes and unresolved risks.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records hardening outcomes and  pre-plan priorities.',
+    "Single owner + backup reviewer are assigned for  Phase-2 hardening execution and signal triage.",
+    "The  lane references  KPI deep-audit outcomes and unresolved risks.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records hardening outcomes and  pre-plan priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes friction-map digest, page hardening actions, and rollback strategy",
@@ -51,14 +51,14 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes hardening brief, risk ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  Phase-2 hardening brief committed',
-    '- [ ]  hardening plan reviewed with owner + backup',
-    '- [ ]  risk ledger exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  pre-plan priorities drafted from  learnings',
+    "- [ ]  Phase-2 hardening brief committed",
+    "- [ ]  hardening plan reviewed with owner + backup",
+    "- [ ]  risk ledger exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  pre-plan priorities drafted from  learnings",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Phase-2 hardening closeout lane\n\n closes with a major Phase-2 hardening upgrade that turns  KPI deep-audit outcomes into deterministic execution hardening governance.\n\n## Why  matters\n\n- Converts  KPI deep-audit evidence into repeatable hardening execution loops.\n- Protects quality with ownership, command proof, and KPI rollback guardrails.\n- Produces a deterministic handoff from  closeout into  pre-plan execution planning.\n\n## Required inputs ()\n\n- `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json`\n- `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit phase2-hardening-closeout --format json --strict\npython -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/phase2-hardening-closeout-pack --format json --strict\npython -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/phase2-hardening-closeout-pack/evidence --format json --strict\npython scripts/check_phase2_hardening_closeout_contract.py\n```\n\n## Phase-2 hardening contract\n\n- Single owner + backup reviewer are assigned for  Phase-2 hardening execution and signal triage.\n- The  lane references  KPI deep-audit outcomes and unresolved risks.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records hardening outcomes and  pre-plan priorities.\n\n## Phase-2 hardening quality checklist\n\n- [ ] Includes friction-map digest, page hardening actions, and rollback strategy\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each KPI\n- [ ] Artifact pack includes hardening brief, risk ledger, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  Phase-2 hardening brief committed\n- [ ]  hardening plan reviewed with owner + backup\n- [ ]  risk ledger exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  pre-plan priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Phase-2 hardening contract lock + delivery board readiness: 15 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Phase-2 hardening closeout lane\n\n closes with a major Phase-2 hardening upgrade that turns  KPI deep-audit outcomes into deterministic execution hardening governance.\n\n## Why  matters\n\n- Converts  KPI deep-audit evidence into repeatable hardening execution loops.\n- Protects quality with ownership, command proof, and KPI rollback guardrails.\n- Produces a deterministic handoff from  closeout into  pre-plan execution planning.\n\n## Required inputs ()\n\n- `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json`\n- `docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit phase2-hardening-closeout --format json --strict\npython -m sdetkit phase2-hardening-closeout --emit-pack-dir docs/artifacts/phase2-hardening-closeout-pack --format json --strict\npython -m sdetkit phase2-hardening-closeout --execute --evidence-dir docs/artifacts/phase2-hardening-closeout-pack/evidence --format json --strict\npython scripts/check_phase2_hardening_closeout_contract.py\n```\n\n## Phase-2 hardening contract\n\n- Single owner + backup reviewer are assigned for  Phase-2 hardening execution and signal triage.\n- The  lane references  KPI deep-audit outcomes and unresolved risks.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records hardening outcomes and  pre-plan priorities.\n\n## Phase-2 hardening quality checklist\n\n- [ ] Includes friction-map digest, page hardening actions, and rollback strategy\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each KPI\n- [ ] Artifact pack includes hardening brief, risk ledger, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  Phase-2 hardening brief committed\n- [ ]  hardening plan reviewed with owner + backup\n- [ ]  risk ledger exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  pre-plan priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Phase-2 hardening contract lock + delivery board readiness: 15 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -94,7 +94,7 @@ def _load_board(path: Path) -> tuple[int, bool]:
     text = _read(path)
     lines = [line.strip() for line in text.splitlines()]
     items = [line for line in lines if line.startswith("- [")]
-    has_kpi_deep_audit = any('' in line for line in lines)
+    has_kpi_deep_audit = any("" in line for line in lines)
     return len(items), has_kpi_deep_audit
 
 
@@ -142,8 +142,8 @@ def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "kpi_deep_audit_summary_present",
@@ -226,24 +226,18 @@ def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if kpi_deep_audit_strict:
-        wins.append(
-            f"57 continuity is strict-pass with activation score={kpi_deep_audit_score}."
-        )
+        wins.append(f"57 continuity is strict-pass with activation score={kpi_deep_audit_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
+        misses.append(" strict continuity signal is missing.")
         handoff_actions.append(
-            'Re-run  KPI deep-audit closeout command and restore strict baseline before  lock.'
+            "Re-run  KPI deep-audit closeout command and restore strict baseline before  lock."
         )
 
     if board_count >= 5 and board_has_kpi_deep_audit:
-        wins.append(
-            f"57 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"57 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
         wins.append("Phase-2 hardening contract + quality checklist is fully locked for execution.")
@@ -252,12 +246,12 @@ def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
             "Phase-2 hardening contract, quality checklist, or delivery board entries are missing."
         )
         handoff_actions.append(
-            'Complete all  contract lines, quality checklist entries, and delivery board tasks in docs.'
+            "Complete all  contract lines, quality checklist entries, and delivery board tasks in docs."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' Phase-2 hardening closeout lane is fully complete and ready for  pre-plan lane.'
+            " Phase-2 hardening closeout lane is fully complete and ready for  pre-plan lane."
         )
 
     score = int(round(sum(c["weight"] for c in checks if bool(c["passed"]))))
@@ -296,7 +290,7 @@ def build_phase2_hardening_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        'Phase 2 Hardening Closeout summary (legacy: )',
+        "Phase 2 Hardening Closeout summary (legacy: )",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -317,17 +311,17 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "phase2-hardening-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "phase2-hardening-brief.md", '#  Phase-2 hardening brief\n')
+    _write(target / "phase2-hardening-brief.md", "#  Phase-2 hardening brief\n")
     _write(target / "phase2-hardening-risk-ledger.csv", "risk,owner,mitigation,status\n")
     _write(target / "phase2-hardening-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
-    _write(target / "phase2-hardening-execution-log.md", '#  execution log\n')
+    _write(target / "phase2-hardening-execution-log.md", "#  execution log\n")
     _write(
         target / "phase2-hardening-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "phase2-hardening-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -355,7 +349,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_phase2_hardening_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_phase2_hardening_closeout_summary(root)
 
 

--- a/src/sdetkit/phase2_wrap_handoff_closeout_60.py
+++ b/src/sdetkit/phase2_wrap_handoff_closeout_60.py
@@ -16,14 +16,14 @@ _DAY58_SUMMARY_PATH = (
     "docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json"
 )
 _DAY58_BOARD_PATH = "docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-delivery-board.md"
-_SECTION_HEADER = '#  — Phase-2 wrap + handoff closeout lane'
+_SECTION_HEADER = "#  — Phase-2 wrap + handoff closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Phase-2 wrap + handoff contract",
     "## Phase-2 wrap + handoff quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -38,10 +38,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_phase2_wrap_handoff_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  Phase-2 wrap + handoff execution and signal triage.',
-    'The  lane references  Phase-3 pre-plan outcomes and unresolved risks.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records Phase-2 wrap outcomes and  execution priorities.',
+    "Single owner + backup reviewer are assigned for  Phase-2 wrap + handoff execution and signal triage.",
+    "The  lane references  Phase-3 pre-plan outcomes and unresolved risks.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records Phase-2 wrap outcomes and  execution priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes priority digest, lane-level plan actions, and rollback strategy",
@@ -51,14 +51,14 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes wrap brief, risk ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  Phase-2 wrap + handoff brief committed',
-    '- [ ]  wrap reviewed with owner + backup',
-    '- [ ]  risk ledger exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  execution priorities drafted from  learnings',
+    "- [ ]  Phase-2 wrap + handoff brief committed",
+    "- [ ]  wrap reviewed with owner + backup",
+    "- [ ]  risk ledger exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  execution priorities drafted from  learnings",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Phase-2 wrap + handoff closeout lane\n\n closes with a major Phase-2 wrap + handoff upgrade that turns  pre-plan outcomes into deterministic  execution priorities.\n\n## Why  matters\n\n- Converts  pre-plan evidence into repeatable Phase-3 execution loops.\n- Protects quality with ownership, command proof, and KPI rollback guardrails.\n- Produces a deterministic handoff from  closeout into  execution planning.\n\n## Required inputs ()\n\n- `docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json`\n- `docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit phase2-wrap-handoff-closeout --format json --strict\npython -m sdetkit phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/phase2-wrap-handoff-closeout-pack --format json --strict\npython -m sdetkit phase2-wrap-handoff-closeout --execute --evidence-dir docs/artifacts/phase2-wrap-handoff-closeout-pack/evidence --format json --strict\npython scripts/check_phase2_wrap_handoff_closeout_contract.py\n```\n\n## Phase-2 wrap + handoff contract\n\n- Single owner + backup reviewer are assigned for  Phase-2 wrap + handoff execution and signal triage.\n- The  lane references  Phase-3 pre-plan outcomes and unresolved risks.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records Phase-2 wrap outcomes and  execution priorities.\n\n## Phase-2 wrap + handoff quality checklist\n\n- [ ] Includes priority digest, lane-level plan actions, and rollback strategy\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each KPI\n- [ ] Artifact pack includes wrap brief, risk ledger, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  Phase-2 wrap + handoff brief committed\n- [ ]  wrap reviewed with owner + backup\n- [ ]  risk ledger exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  execution priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Phase-2 wrap + handoff contract lock + delivery board readiness: 15 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Phase-2 wrap + handoff closeout lane\n\n closes with a major Phase-2 wrap + handoff upgrade that turns  pre-plan outcomes into deterministic  execution priorities.\n\n## Why  matters\n\n- Converts  pre-plan evidence into repeatable Phase-3 execution loops.\n- Protects quality with ownership, command proof, and KPI rollback guardrails.\n- Produces a deterministic handoff from  closeout into  execution planning.\n\n## Required inputs ()\n\n- `docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json`\n- `docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit phase2-wrap-handoff-closeout --format json --strict\npython -m sdetkit phase2-wrap-handoff-closeout --emit-pack-dir docs/artifacts/phase2-wrap-handoff-closeout-pack --format json --strict\npython -m sdetkit phase2-wrap-handoff-closeout --execute --evidence-dir docs/artifacts/phase2-wrap-handoff-closeout-pack/evidence --format json --strict\npython scripts/check_phase2_wrap_handoff_closeout_contract.py\n```\n\n## Phase-2 wrap + handoff contract\n\n- Single owner + backup reviewer are assigned for  Phase-2 wrap + handoff execution and signal triage.\n- The  lane references  Phase-3 pre-plan outcomes and unresolved risks.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records Phase-2 wrap outcomes and  execution priorities.\n\n## Phase-2 wrap + handoff quality checklist\n\n- [ ] Includes priority digest, lane-level plan actions, and rollback strategy\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each KPI\n- [ ] Artifact pack includes wrap brief, risk ledger, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  Phase-2 wrap + handoff brief committed\n- [ ]  wrap reviewed with owner + backup\n- [ ]  risk ledger exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  execution priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Phase-2 wrap + handoff contract lock + delivery board readiness: 15 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -106,7 +106,7 @@ def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
     phase3_preplan_score, phase3_preplan_strict, phase3_preplan_check_count = _load_phase3_preplan(
         phase3_preplan_summary
     )
-    board_count, board_has_phase3_preplan = _count_board_items(phase3_preplan_board, '')
+    board_count, board_has_phase3_preplan = _count_board_items(phase3_preplan_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -133,8 +133,8 @@ def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "phase3_preplan_summary_present",
@@ -217,24 +217,18 @@ def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if phase3_preplan_strict:
-        wins.append(
-            f"59 continuity is strict-pass with activation score={phase3_preplan_score}."
-        )
+        wins.append(f"59 continuity is strict-pass with activation score={phase3_preplan_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
+        misses.append(" strict continuity signal is missing.")
         handoff_actions.append(
-            'Re-run  Phase-3 pre-plan closeout command and restore strict baseline before  lock.'
+            "Re-run  Phase-3 pre-plan closeout command and restore strict baseline before  lock."
         )
 
     if board_count >= 5 and board_has_phase3_preplan:
-        wins.append(
-            f"59 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"59 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
         wins.append(
@@ -245,12 +239,12 @@ def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
             "Phase-2 wrap + handoff contract, quality checklist, or delivery board entries are missing."
         )
         handoff_actions.append(
-            'Complete all  contract lines, quality checklist entries, and delivery board tasks in docs.'
+            "Complete all  contract lines, quality checklist entries, and delivery board tasks in docs."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' Phase-2 wrap + handoff closeout lane is fully complete and ready for  execution lane.'
+            " Phase-2 wrap + handoff closeout lane is fully complete and ready for  execution lane."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -289,7 +283,7 @@ def build_phase2_wrap_handoff_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        'Phase 2 Wrap Handoff Closeout summary (legacy: )',
+        "Phase 2 Wrap Handoff Closeout summary (legacy: )",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -310,19 +304,19 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "phase2-wrap-handoff-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "phase2-wrap-handoff-brief.md", '#  Phase-2 wrap + handoff brief\n')
+    _write(target / "phase2-wrap-handoff-brief.md", "#  Phase-2 wrap + handoff brief\n")
     _write(target / "phase2-wrap-handoff-risk-ledger.csv", "risk,owner,mitigation,status\n")
     _write(
         target / "phase2-wrap-handoff-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n"
     )
-    _write(target / "phase2-wrap-handoff-execution-log.md", '#  execution log\n')
+    _write(target / "phase2-wrap-handoff-execution-log.md", "#  execution log\n")
     _write(
         target / "phase2-wrap-handoff-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "phase2-wrap-handoff-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -350,7 +344,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_phase2_wrap_handoff_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_phase2_wrap_handoff_closeout_summary(root)
 
 

--- a/src/sdetkit/phase3_kickoff_closeout_61.py
+++ b/src/sdetkit/phase3_kickoff_closeout_61.py
@@ -163,9 +163,7 @@ def build_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
     phase2_wrap_handoff_score, phase2_wrap_handoff_strict, phase2_wrap_handoff_check_count = (
         _load_phase2_wrap_handoff_summary(phase2_wrap_handoff_summary)
     )
-    board_count, board_has_required = _count_board_items(
-        phase2_wrap_handoff_board, ""
-    )
+    board_count, board_has_required = _count_board_items(phase2_wrap_handoff_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -286,13 +284,9 @@ def build_phase3_kickoff_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     if board_count >= 5 and board_has_required:
-        wins.append(
-            f"delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            "delivery board integrity is incomplete (needs >=5 items and anchors)."
-        )
+        misses.append("delivery board integrity is incomplete (needs >=5 items and anchors).")
         handoff_actions.append("Repair delivery board entries to include anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:

--- a/src/sdetkit/phase3_preplan_closeout_59.py
+++ b/src/sdetkit/phase3_preplan_closeout_59.py
@@ -18,14 +18,14 @@ _DAY58_SUMMARY_PATH = (
 _DAY58_BOARD_PATH = (
     "docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md"
 )
-_SECTION_HEADER = '#  — Phase-3 pre-plan closeout lane'
+_SECTION_HEADER = "#  — Phase-3 pre-plan closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Phase-3 pre-plan contract",
     "## Phase-3 pre-plan quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -40,10 +40,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_phase3_preplan_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  Phase-3 pre-plan execution and signal triage.',
-    'The  lane references  Phase-2 hardening outcomes and unresolved risks.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records pre-plan outcomes and  execution priorities.',
+    "Single owner + backup reviewer are assigned for  Phase-3 pre-plan execution and signal triage.",
+    "The  lane references  Phase-2 hardening outcomes and unresolved risks.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records pre-plan outcomes and  execution priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes priority digest, lane-level plan actions, and rollback strategy",
@@ -53,14 +53,14 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes pre-plan brief, risk ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  Phase-3 pre-plan brief committed',
-    '- [ ]  pre-plan reviewed with owner + backup',
-    '- [ ]  risk ledger exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  execution priorities drafted from  learnings',
+    "- [ ]  Phase-3 pre-plan brief committed",
+    "- [ ]  pre-plan reviewed with owner + backup",
+    "- [ ]  risk ledger exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  execution priorities drafted from  learnings",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Phase-3 pre-plan closeout lane\n\n closes with a major Phase-3 pre-plan upgrade that turns  hardening outcomes into deterministic  execution priorities.\n\n## Why  matters\n\n- Converts  hardening evidence into repeatable Phase-3 planning loops.\n- Protects quality with ownership, command proof, and KPI rollback guardrails.\n- Produces a deterministic handoff from  closeout into  execution planning.\n\n## Required inputs ()\n\n- `docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json`\n- `docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit phase3-preplan-closeout --format json --strict\npython -m sdetkit phase3-preplan-closeout --emit-pack-dir docs/artifacts/phase3-preplan-closeout-pack --format json --strict\npython -m sdetkit phase3-preplan-closeout --execute --evidence-dir docs/artifacts/phase3-preplan-closeout-pack/evidence --format json --strict\npython scripts/check_phase3_preplan_closeout_contract.py\n```\n\n## Phase-3 pre-plan contract\n\n- Single owner + backup reviewer are assigned for  Phase-3 pre-plan execution and signal triage.\n- The  lane references  Phase-2 hardening outcomes and unresolved risks.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records pre-plan outcomes and  execution priorities.\n\n## Phase-3 pre-plan quality checklist\n\n- [ ] Includes priority digest, lane-level plan actions, and rollback strategy\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each KPI\n- [ ] Artifact pack includes pre-plan brief, risk ledger, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  Phase-3 pre-plan brief committed\n- [ ]  pre-plan reviewed with owner + backup\n- [ ]  risk ledger exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  execution priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Phase-3 pre-plan contract lock + delivery board readiness: 15 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Phase-3 pre-plan closeout lane\n\n closes with a major Phase-3 pre-plan upgrade that turns  hardening outcomes into deterministic  execution priorities.\n\n## Why  matters\n\n- Converts  hardening evidence into repeatable Phase-3 planning loops.\n- Protects quality with ownership, command proof, and KPI rollback guardrails.\n- Produces a deterministic handoff from  closeout into  execution planning.\n\n## Required inputs ()\n\n- `docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-closeout-summary.json`\n- `docs/artifacts/phase2-hardening-closeout-pack/phase2-hardening-delivery-board.md`\n\n##  command lane\n\n```bash\npython -m sdetkit phase3-preplan-closeout --format json --strict\npython -m sdetkit phase3-preplan-closeout --emit-pack-dir docs/artifacts/phase3-preplan-closeout-pack --format json --strict\npython -m sdetkit phase3-preplan-closeout --execute --evidence-dir docs/artifacts/phase3-preplan-closeout-pack/evidence --format json --strict\npython scripts/check_phase3_preplan_closeout_contract.py\n```\n\n## Phase-3 pre-plan contract\n\n- Single owner + backup reviewer are assigned for  Phase-3 pre-plan execution and signal triage.\n- The  lane references  Phase-2 hardening outcomes and unresolved risks.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records pre-plan outcomes and  execution priorities.\n\n## Phase-3 pre-plan quality checklist\n\n- [ ] Includes priority digest, lane-level plan actions, and rollback strategy\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, confidence, and recovery owner for each KPI\n- [ ] Artifact pack includes pre-plan brief, risk ledger, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  Phase-3 pre-plan brief committed\n- [ ]  pre-plan reviewed with owner + backup\n- [ ]  risk ledger exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  execution priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Phase-3 pre-plan contract lock + delivery board readiness: 15 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -108,7 +108,7 @@ def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
     phase2_hardening_score, phase2_hardening_strict, phase2_hardening_check_count = (
         _load_phase2_hardening(phase2_hardening_summary)
     )
-    board_count, board_has_phase2_hardening = _count_board_items(phase2_hardening_board, '')
+    board_count, board_has_phase2_hardening = _count_board_items(phase2_hardening_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -135,8 +135,8 @@ def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "phase2_hardening_summary_present",
@@ -219,24 +219,18 @@ def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
     handoff_actions: list[str] = []
 
     if phase2_hardening_strict:
-        wins.append(
-            f"58 continuity is strict-pass with activation score={phase2_hardening_score}."
-        )
+        wins.append(f"58 continuity is strict-pass with activation score={phase2_hardening_score}.")
     else:
-        misses.append(' strict continuity signal is missing.')
+        misses.append(" strict continuity signal is missing.")
         handoff_actions.append(
-            'Re-run  Phase-2 hardening closeout command and restore strict baseline before  lock.'
+            "Re-run  Phase-2 hardening closeout command and restore strict baseline before  lock."
         )
 
     if board_count >= 5 and board_has_phase2_hardening:
-        wins.append(
-            f"58 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"58 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
         wins.append("Phase-3 pre-plan contract + quality checklist is fully locked for execution.")
@@ -245,12 +239,12 @@ def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
             "Phase-3 pre-plan contract, quality checklist, or delivery board entries are missing."
         )
         handoff_actions.append(
-            'Complete all  contract lines, quality checklist entries, and delivery board tasks in docs.'
+            "Complete all  contract lines, quality checklist entries, and delivery board tasks in docs."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' Phase-3 pre-plan closeout lane is fully complete and ready for  execution lane.'
+            " Phase-3 pre-plan closeout lane is fully complete and ready for  execution lane."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -289,7 +283,7 @@ def build_phase3_preplan_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        'Phase3 Preplan Closeout summary (legacy: )',
+        "Phase3 Preplan Closeout summary (legacy: )",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -307,17 +301,17 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     target = pack_dir if pack_dir.is_absolute() else root / pack_dir
     _write(target / "phase3-preplan-closeout-summary.json", json.dumps(payload, indent=2) + "\n")
     _write(target / "phase3-preplan-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "phase3-preplan-brief.md", '#  Phase-3 pre-plan brief\n')
+    _write(target / "phase3-preplan-brief.md", "#  Phase-3 pre-plan brief\n")
     _write(target / "phase3-preplan-risk-ledger.csv", "risk,owner,mitigation,status\n")
     _write(target / "phase3-preplan-kpi-scorecard.json", json.dumps({"kpis": []}, indent=2) + "\n")
-    _write(target / "phase3-preplan-execution-log.md", '#  execution log\n')
+    _write(target / "phase3-preplan-execution-log.md", "#  execution log\n")
     _write(
         target / "phase3-preplan-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "phase3-preplan-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -345,7 +339,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_phase3_preplan_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_phase3_preplan_closeout_summary(root)
 
 

--- a/src/sdetkit/phase3_wrap_publication_closeout_90.py
+++ b/src/sdetkit/phase3_wrap_publication_closeout_90.py
@@ -23,10 +23,10 @@ _CANONICAL_PACK_DIR = "docs/artifacts/phase3-wrap-publication-closeout-pack"
 _CANONICAL_SUMMARY_NAME = "phase3-wrap-publication-closeout-summary.json"
 _CANONICAL_BOARD_NAME = "phase3-wrap-publication-delivery-board.md"
 _CANONICAL_EVIDENCE_SUMMARY_NAME = "phase3-wrap-publication-execution-summary.json"
-_SECTION_HEADER = '#  — Phase-3 wrap publication closeout lane'
+_SECTION_HEADER = "#  — Phase-3 wrap publication closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Phase3 Wrap Publication Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Phase-3 wrap publication contract",
     "## Phase-3 wrap publication quality checklist",
@@ -45,10 +45,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_phase3_wrap_publication_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  phase-3 wrap publication execution and signoff.',
-    'The  lane references  outcomes, controls, and trust continuity signals.',
-    'Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records phase-3 wrap publication outputs, final report publication status, and next-impact roadmap inputs.',
+    "Single owner + backup reviewer are assigned for  phase-3 wrap publication execution and signoff.",
+    "The  lane references  outcomes, controls, and trust continuity signals.",
+    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records phase-3 wrap publication outputs, final report publication status, and next-impact roadmap inputs.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
@@ -58,11 +58,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  evidence brief committed',
-    '- [ ]  phase-3 wrap publication plan committed',
-    '- [ ]  narrative template upgrade ledger exported',
-    '- [ ]  storyline outcomes ledger exported',
-    '- [ ] Next-impact roadmap draft captured from  outcomes',
+    "- [ ]  evidence brief committed",
+    "- [ ]  phase-3 wrap publication plan committed",
+    "- [ ]  narrative template upgrade ledger exported",
+    "- [ ]  storyline outcomes ledger exported",
+    "- [ ] Next-impact roadmap draft captured from  outcomes",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -73,7 +73,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Phase-3 wrap publication closeout lane\n\n closes with a major upgrade that converts  governance scale outcomes into a deterministic phase-3 wrap and publication operating lane.\n\n## Why Phase3 Wrap Publication Closeout matters\n\n- Converts  governance scale outcomes into reusable publication decisions across release recap, roadmap governance, and maintainer escalation paths.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into the next-impact roadmap.\n\n## Required inputs ()\n\n- `docs/artifacts/governance-scale-closeout-pack/governance-scale-closeout-summary.json`\n- `docs/artifacts/governance-scale-closeout-pack/governance-scale-delivery-board.md`\n- `docs/roadmap/plans/phase3-wrap-publication-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit phase3-wrap-publication-closeout --format json --strict\npython -m sdetkit phase3-wrap-publication-closeout --emit-pack-dir docs/artifacts/phase3-wrap-publication-closeout-pack --format json --strict\npython -m sdetkit phase3-wrap-publication-closeout --execute --evidence-dir docs/artifacts/phase3-wrap-publication-closeout-pack/evidence --format json --strict\npython scripts/check_phase3_wrap_publication_closeout_contract.py\n```\n\n## Phase-3 wrap publication contract\n\n- Single owner + backup reviewer are assigned for  phase-3 wrap publication execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records phase-3 wrap publication outputs, final report publication status, and next-impact roadmap inputs.\n\n## Phase-3 wrap publication quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures phase-3 wrap publication adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  phase-3 wrap publication plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ] Next-impact roadmap draft captured from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + governance artifact readiness for a 100-point activation score.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Phase-3 wrap publication closeout lane\n\n closes with a major upgrade that converts  governance scale outcomes into a deterministic phase-3 wrap and publication operating lane.\n\n## Why Phase3 Wrap Publication Closeout matters\n\n- Converts  governance scale outcomes into reusable publication decisions across release recap, roadmap governance, and maintainer escalation paths.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into the next-impact roadmap.\n\n## Required inputs ()\n\n- `docs/artifacts/governance-scale-closeout-pack/governance-scale-closeout-summary.json`\n- `docs/artifacts/governance-scale-closeout-pack/governance-scale-delivery-board.md`\n- `docs/roadmap/plans/phase3-wrap-publication-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit phase3-wrap-publication-closeout --format json --strict\npython -m sdetkit phase3-wrap-publication-closeout --emit-pack-dir docs/artifacts/phase3-wrap-publication-closeout-pack --format json --strict\npython -m sdetkit phase3-wrap-publication-closeout --execute --evidence-dir docs/artifacts/phase3-wrap-publication-closeout-pack/evidence --format json --strict\npython scripts/check_phase3_wrap_publication_closeout_contract.py\n```\n\n## Phase-3 wrap publication contract\n\n- Single owner + backup reviewer are assigned for  phase-3 wrap publication execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records phase-3 wrap publication outputs, final report publication status, and next-impact roadmap inputs.\n\n## Phase-3 wrap publication quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures phase-3 wrap publication adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  phase-3 wrap publication plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ] Next-impact roadmap draft captured from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + governance artifact readiness for a 100-point activation score.\n"
 
 
 def _read_text(path: Path) -> str:
@@ -110,7 +110,9 @@ def build_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]
         else {}
     )
     governance_scale_score = int(governance_scale_summary_data.get("activation_score", 0) or 0)
-    governance_scale_strict = coerce_bool(governance_scale_summary_data.get("strict_pass", False), default=False)
+    governance_scale_strict = coerce_bool(
+        governance_scale_summary_data.get("strict_pass", False), default=False
+    )
     governance_scale_check_count = (
         len(governance_scale_data.get("checks", []))
         if isinstance(governance_scale_data.get("checks"), list)
@@ -149,8 +151,8 @@ def build_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "governance_scale_summary_present",
@@ -241,9 +243,9 @@ def build_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]
             f"89 continuity baseline is stable with activation score={governance_scale_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85) or not strict-pass.')
+        misses.append(" continuity baseline is below the floor (<85) or not strict-pass.")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock."
         )
 
     if board_count >= 5 and board_has_governance_scale:
@@ -251,24 +253,20 @@ def build_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]
             f"Governance scale delivery board integrity validated with {board_count} checklist items."
         )
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(
-            ' phase-3 wrap publication dataset is available for governance execution.'
-        )
+        wins.append(" phase-3 wrap publication dataset is available for governance execution.")
     else:
-        misses.append(' phase-3 wrap publication dataset is missing required keys.')
+        misses.append(" phase-3 wrap publication dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/phase3-wrap-publication-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' phase-3 wrap publication closeout lane is fully complete and ready for next-impact roadmap execution.'
+            " phase-3 wrap publication closeout lane is fully complete and ready for next-impact roadmap execution."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -308,7 +306,7 @@ def build_phase3_wrap_publication_closeout_summary(root: Path) -> dict[str, Any]
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' phase-3 wrap publication closeout summary',
+        " phase-3 wrap publication closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -331,9 +329,9 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     _write(target / "phase3-wrap-publication-closeout-summary.md", _render_text(payload) + "\n")
     _write(
         target / "phase3-wrap-publication-evidence-brief.md",
-        '#  phase-3 wrap publication brief\n',
+        "#  phase-3 wrap publication brief\n",
     )
-    _write(target / "phase3-wrap-publication-plan.md", '#  phase-3 wrap publication plan\n')
+    _write(target / "phase3-wrap-publication-plan.md", "#  phase-3 wrap publication plan\n")
     _write(
         target / "phase3-wrap-publication-narrative-template-upgrade-ledger.json",
         json.dumps({"upgrades": []}, indent=2) + "\n",
@@ -346,14 +344,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "phase3-wrap-publication-narrative-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "phase3-wrap-publication-execution-log.md", '#  execution log\n')
+    _write(target / "phase3-wrap-publication-execution-log.md", "#  execution log\n")
     _write(
         target / _CANONICAL_BOARD_NAME,
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "phase3-wrap-publication-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -381,12 +379,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_phase3_wrap_publication_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_phase3_wrap_publication_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' phase-3 wrap publication closeout checks')
+    parser = argparse.ArgumentParser(description=" phase-3 wrap publication closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/playbooks_cli.py
+++ b/src/sdetkit/playbooks_cli.py
@@ -62,7 +62,7 @@ RESERVED_NAMES: set[str] = (
     {"baseline", "playbooks"} | CORE_COMMANDS | DOC_AND_GOV_COMMANDS | set(RECOMMENDED_PLAYBOOKS)
 )
 
-_SERIES_PREFIX = re.compile('^(?:impact|)\\d+_')
+_SERIES_PREFIX = re.compile("^(?:impact|)\\d+_")
 _SERIES_CLOSEOUT = re.compile(r"^(.+_closeout)(?:_\d+)?$")
 
 # Stable product lanes promoted from legacy numeric-series naming.
@@ -107,7 +107,7 @@ _PLAYBOOK_ALIAS_TO_CANONICAL: dict[str, str] = {
 
 
 def _contains_day_token(name: str) -> bool:
-    return '' in re.split(r"[^a-z0-9]+", name.lower())
+    return "" in re.split(r"[^a-z0-9]+", name.lower())
 
 
 def _cmd_to_mod(cmd: str) -> str:
@@ -215,7 +215,7 @@ def _apply_search_list(xs: list[str], search: str | None) -> list[str]:
         return xs
     s = search.lower()
     if _contains_day_token(s):
-        s = " ".join(tok for tok in re.split(r"[^a-z0-9]+", s) if tok != '')
+        s = " ".join(tok for tok in re.split(r"[^a-z0-9]+", s) if tok != "")
         s = s.strip()
         if not s:
             return xs
@@ -228,7 +228,7 @@ def _apply_search_aliases(d: dict[str, str], search: str | None) -> dict[str, st
         return d
     s = search.lower()
     if _contains_day_token(s):
-        s = " ".join(tok for tok in re.split(r"[^a-z0-9]+", s) if tok != '')
+        s = " ".join(tok for tok in re.split(r"[^a-z0-9]+", s) if tok != "")
         s = s.strip()
         if not s:
             return d

--- a/src/sdetkit/quality_contribution_delta.py
+++ b/src/sdetkit/quality_contribution_delta.py
@@ -52,9 +52,7 @@ def _build_recommendations(
 ) -> list[str]:
     notes: list[str] = []
     if quality_deltas["completion_rate_percent"] < 0:
-        notes.append(
-            'Recover week-two completion rate by rerunning missing -13 closeout checks.'
-        )
+        notes.append("Recover week-two completion rate by rerunning missing -13 closeout checks.")
     if quality_deltas["artifact_coverage"] < 0:
         notes.append(
             "Regenerate missing artifacts and attach pack evidence before sprint closeout."
@@ -297,7 +295,7 @@ def _emit_pack(repo_root: Path, out_dir: str, payload: dict[str, Any]) -> list[s
     quality_md.write_text(
         "\n".join(
             [
-                '#  quality scorecard',
+                "#  quality scorecard",
                 "",
                 f"- Completion rate delta: {payload['quality']['deltas']['completion_rate_percent']:+d}",
                 f"- Artifact coverage delta: {payload['quality']['deltas']['artifact_coverage']:+d}",
@@ -313,7 +311,7 @@ def _emit_pack(repo_root: Path, out_dir: str, payload: dict[str, Any]) -> list[s
     action_plan.write_text(
         "\n".join(
             [
-                '#  contribution action plan',
+                "#  contribution action plan",
                 "",
                 "| Signal | Delta | Delta % | Action |",
                 "| --- | --- | --- | --- |",
@@ -331,7 +329,7 @@ def _emit_pack(repo_root: Path, out_dir: str, payload: dict[str, Any]) -> list[s
     checklist.write_text(
         "\n".join(
             [
-                '#  remediation checklist',
+                "#  remediation checklist",
                 "",
                 "- [ ] Review quality stability score and confirm no downward regression.",
                 "- [ ] Review contribution velocity score and assign owner for any negative signal.",

--- a/src/sdetkit/release_prioritization_closeout_85.py
+++ b/src/sdetkit/release_prioritization_closeout_85.py
@@ -19,10 +19,10 @@ _DAY84_BOARD_PATH = (
     "docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/release-prioritization-plan.json"
-_SECTION_HEADER = '#  — Release prioritization closeout lane'
+_SECTION_HEADER = "#  — Release prioritization closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Release Prioritization Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Release prioritization contract",
     "## Release prioritization quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_release_prioritization_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  release prioritization execution and signoff.',
-    'The  lane references  outcomes, controls, and trust continuity signals.',
-    'Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records release prioritization pack upgrades, storyline outcomes, and  launch priorities.',
+    "Single owner + backup reviewer are assigned for  release prioritization execution and signoff.",
+    "The  lane references  outcomes, controls, and trust continuity signals.",
+    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records release prioritization pack upgrades, storyline outcomes, and  launch priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  evidence brief committed',
-    '- [ ]  release prioritization plan committed',
-    '- [ ]  narrative template upgrade ledger exported',
-    '- [ ]  storyline outcomes ledger exported',
-    '- [ ]  launch priorities drafted from  outcomes',
+    "- [ ]  evidence brief committed",
+    "- [ ]  release prioritization plan committed",
+    "- [ ]  narrative template upgrade ledger exported",
+    "- [ ]  storyline outcomes ledger exported",
+    "- [ ]  launch priorities drafted from  outcomes",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Release prioritization closeout lane\n\n closes with a major upgrade that converts  evidence narrative outcomes into a deterministic release prioritization operating lane.\n\n## Why Release Prioritization Closeout matters\n\n- Converts  evidence narrative outcomes into reusable release prioritization decisions across docs, release notes, and escalation playbooks.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  launch priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-closeout-summary.json`\n- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md`\n- `docs/roadmap/plans/release-prioritization-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit release-prioritization-closeout --format json --strict\npython -m sdetkit release-prioritization-closeout --emit-pack-dir docs/artifacts/release-prioritization-closeout-pack --format json --strict\npython -m sdetkit release-prioritization-closeout --execute --evidence-dir docs/artifacts/release-prioritization-closeout-pack/evidence --format json --strict\npython scripts/check_release_prioritization_closeout_contract.py\n```\n\n## Release prioritization contract\n\n- Single owner + backup reviewer are assigned for  release prioritization execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records release prioritization pack upgrades, storyline outcomes, and  launch priorities.\n\n## Release prioritization quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures release prioritization adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  release prioritization plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  launch priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + release-priority artifact readiness for a 100-point activation score.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Release prioritization closeout lane\n\n closes with a major upgrade that converts  evidence narrative outcomes into a deterministic release prioritization operating lane.\n\n## Why Release Prioritization Closeout matters\n\n- Converts  evidence narrative outcomes into reusable release prioritization decisions across docs, release notes, and escalation playbooks.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  launch priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-closeout-summary.json`\n- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md`\n- `docs/roadmap/plans/release-prioritization-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit release-prioritization-closeout --format json --strict\npython -m sdetkit release-prioritization-closeout --emit-pack-dir docs/artifacts/release-prioritization-closeout-pack --format json --strict\npython -m sdetkit release-prioritization-closeout --execute --evidence-dir docs/artifacts/release-prioritization-closeout-pack/evidence --format json --strict\npython scripts/check_release_prioritization_closeout_contract.py\n```\n\n## Release prioritization contract\n\n- Single owner + backup reviewer are assigned for  release prioritization execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records release prioritization pack upgrades, storyline outcomes, and  launch priorities.\n\n## Release prioritization quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures release prioritization adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  release prioritization plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  launch priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + release-priority artifact readiness for a 100-point activation score.\n"
 
 
 def _read_text(path: Path) -> str:
@@ -106,7 +106,9 @@ def build_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
         else {}
     )
     evidence_narrative_score = int(evidence_narrative_summary_data.get("activation_score", 0) or 0)
-    evidence_narrative_strict = coerce_bool(evidence_narrative_summary_data.get("strict_pass", False), default=False)
+    evidence_narrative_strict = coerce_bool(
+        evidence_narrative_summary_data.get("strict_pass", False), default=False
+    )
     evidence_narrative_check_count = (
         len(evidence_narrative_data.get("checks", []))
         if isinstance(evidence_narrative_data.get("checks"), list)
@@ -115,9 +117,7 @@ def build_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(evidence_narrative_board)
     board_count = _checklist_count(board_text)
-    board_has_evidence_narrative = (
-        "evidence narrative" in board_text.lower() or '' in board_text
-    )
+    board_has_evidence_narrative = "evidence narrative" in board_text.lower() or "" in board_text
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]
@@ -147,8 +147,8 @@ def build_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "evidence_narrative_summary_present",
@@ -239,32 +239,28 @@ def build_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
             f"Evidence Narrative continuity baseline is stable with activation score={evidence_narrative_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85) or not strict-pass.')
+        misses.append(" continuity baseline is below the floor (<85) or not strict-pass.")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock."
         )
 
     if board_count >= 5 and board_has_evidence_narrative:
-        wins.append(
-            f"84 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"84 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' release prioritization dataset is available for launch execution.')
+        wins.append(" release prioritization dataset is available for launch execution.")
     else:
-        misses.append(' release prioritization dataset is missing required keys.')
+        misses.append(" release prioritization dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/release-prioritization-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' release prioritization closeout lane is fully complete and ready for  launch prioritization.'
+            " release prioritization closeout lane is fully complete and ready for  launch prioritization."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -304,7 +300,7 @@ def build_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' release prioritization closeout summary',
+        " release prioritization closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -327,9 +323,9 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     _write(target / "release-prioritization-closeout-summary.md", _render_text(payload) + "\n")
     _write(
         target / "release-prioritization-evidence-brief.md",
-        '#  release prioritization brief\n',
+        "#  release prioritization brief\n",
     )
-    _write(target / "release-prioritization-plan.md", '#  release prioritization plan\n')
+    _write(target / "release-prioritization-plan.md", "#  release prioritization plan\n")
     _write(
         target / "release-prioritization-narrative-template-upgrade-ledger.json",
         json.dumps({"upgrades": []}, indent=2) + "\n",
@@ -342,14 +338,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "release-prioritization-narrative-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "release-prioritization-execution-log.md", '#  execution log\n')
+    _write(target / "release-prioritization-execution-log.md", "#  execution log\n")
     _write(
         target / "release-prioritization-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "release-prioritization-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -377,12 +373,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_release_prioritization_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_release_prioritization_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' release prioritization closeout checks')
+    parser = argparse.ArgumentParser(description=" release prioritization closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/roadmap_manifest.py
+++ b/src/sdetkit/roadmap_manifest.py
@@ -61,7 +61,7 @@ def _closeout_inventory(root: Path) -> dict[str, Any]:
         module_stem = path.stem
 
         tests_refs = 0
-        for test_file, text in test_contents.items():
+        for _test_file, text in test_contents.items():
             if module_stem in text:
                 tests_refs += 1
 

--- a/src/sdetkit/scale_closeout_44.py
+++ b/src/sdetkit/scale_closeout_44.py
@@ -18,7 +18,7 @@ _DAY43_LEGACY_SUMMARY_PATH = (
     "docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
 )
 _DAY43_LEGACY_BOARD_PATH = "docs/artifacts/acceleration-closeout-pack/delivery-board.md"
-_SECTION_HEADER = '#  — Scale closeout lane'
+_SECTION_HEADER = "#  — Scale closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why this lane matters",
     "## Required inputs (acceleration closeout)",
@@ -40,10 +40,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_scale_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  scale lane execution and KPI follow-up.',
-    'The  scale lane references  acceleration winners and misses with deterministic growth loops.',
-    'Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.',
-    ' closeout records scale learnings and  expansion priorities.',
+    "Single owner + backup reviewer are assigned for  scale lane execution and KPI follow-up.",
+    "The  scale lane references  acceleration winners and misses with deterministic growth loops.",
+    "Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.",
+    " closeout records scale learnings and  expansion priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes scale summary, growth matrix, and rollback strategy",
@@ -53,14 +53,14 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes scale plan, growth matrix, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  scale plan draft committed',
-    '- [ ]  review notes captured with owner + backup',
-    '- [ ]  growth matrix exported',
-    '- [ ]  KPI scorecard snapshot exported',
-    '- [ ]  expansion priorities drafted from  learnings',
+    "- [ ]  scale plan draft committed",
+    "- [ ]  review notes captured with owner + backup",
+    "- [ ]  growth matrix exported",
+    "- [ ]  KPI scorecard snapshot exported",
+    "- [ ]  expansion priorities drafted from  learnings",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Scale closeout lane\n\nThis lane closes with a major scale upgrade that converts acceleration evidence into deterministic improvement loops.\n\n## Why this lane matters\n\n- Converts  acceleration proof into growth-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from scale outcomes into  expansion priorities.\n\n## Required inputs (acceleration closeout)\n\n- `docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json`\n- `docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md`\n\n## Command lane\n\n```bash\npython -m sdetkit scale-closeout --format json --strict\npython -m sdetkit scale-closeout --emit-pack-dir docs/artifacts/scale-closeout-pack --format json --strict\npython -m sdetkit scale-closeout --execute --evidence-dir docs/artifacts/scale-closeout-pack/evidence --format json --strict\npython scripts/check_scale_closeout_contract.py\n```\n\n## Scale closeout contract\n\n- Single owner + backup reviewer are assigned for  scale lane execution and KPI follow-up.\n- The  scale lane references  acceleration winners and misses with deterministic growth loops.\n- Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n-  closeout records scale learnings and  expansion priorities.\n\n## Scale quality checklist\n\n- [ ] Includes scale summary, growth matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes scale plan, growth matrix, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  scale plan draft committed\n- [ ]  review notes captured with owner + backup\n- [ ]  growth matrix exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  expansion priorities drafted from  learnings\n\n## Scoring model\n\nWeighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Scale contract lock + delivery board readiness: 15 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Scale closeout lane\n\nThis lane closes with a major scale upgrade that converts acceleration evidence into deterministic improvement loops.\n\n## Why this lane matters\n\n- Converts  acceleration proof into growth-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from scale outcomes into  expansion priorities.\n\n## Required inputs (acceleration closeout)\n\n- `docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json`\n- `docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md`\n\n## Command lane\n\n```bash\npython -m sdetkit scale-closeout --format json --strict\npython -m sdetkit scale-closeout --emit-pack-dir docs/artifacts/scale-closeout-pack --format json --strict\npython -m sdetkit scale-closeout --execute --evidence-dir docs/artifacts/scale-closeout-pack/evidence --format json --strict\npython scripts/check_scale_closeout_contract.py\n```\n\n## Scale closeout contract\n\n- Single owner + backup reviewer are assigned for  scale lane execution and KPI follow-up.\n- The  scale lane references  acceleration winners and misses with deterministic growth loops.\n- Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n-  closeout records scale learnings and  expansion priorities.\n\n## Scale quality checklist\n\n- [ ] Includes scale summary, growth matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes scale plan, growth matrix, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  scale plan draft committed\n- [ ]  review notes captured with owner + backup\n- [ ]  growth matrix exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  expansion priorities drafted from  learnings\n\n## Scoring model\n\nWeighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Scale contract lock + delivery board readiness: 15 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -100,7 +100,7 @@ def _load_acceleration_closeout(path: Path) -> tuple[float, bool, int]:
 def _board_stats(path: Path) -> tuple[int, bool, bool]:
     text = _read(path)
     items = [line for line in text.splitlines() if line.strip().startswith("- [")]
-    return len(items), '' in text, '' in text
+    return len(items), "" in text, "" in text
 
 
 def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
@@ -183,7 +183,7 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_scale_closeout_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
+            "passed": ("" in top10_text and "" in top10_text),
             "evidence": "Scale closeout + expansion closeout strategy chain",
         },
         {
@@ -257,35 +257,27 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
             f"43 continuity is strict-pass with activation score={acceleration_closeout_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
+        misses.append(" strict continuity signal is missing.")
         handoff_actions.append(
-            'Re-run  acceleration closeout command and restore strict pass baseline before  lock.'
+            "Re-run  acceleration closeout command and restore strict pass baseline before  lock."
         )
 
     if board_count >= 5 and board_has_acceleration_closeout and board_has_scale_closeout:
-        wins.append(
-            f"43 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"43 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and /44 anchors).'
-        )
-        handoff_actions.append(
-            'Repair  delivery board entries to include  and  anchors.'
-        )
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and /44 anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  and  anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
         wins.append("Scale execution contract + quality checklist is fully locked for execution.")
     else:
         misses.append("Scale contract, quality checklist, or delivery board entries are missing.")
         handoff_actions.append(
-            'Complete all  scale contract lines, quality checklist entries, and delivery board tasks in docs.'
+            "Complete all  scale contract lines, quality checklist entries, and delivery board tasks in docs."
         )
 
     if not failed and not critical_failures:
-        wins.append(
-            ' scale closeout lane is fully complete and ready for  expansion lane.'
-        )
+        wins.append(" scale closeout lane is fully complete and ready for  expansion lane.")
 
     return {
         "name": "scale-closeout",
@@ -354,7 +346,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     _write(target / "scale-closeout-summary.md", _render_text(payload) + "\n")
     _write(
         target / "scale-plan.md",
-        '# Scale plan\n\n- Objective: close  with measurable quality and throughput gains.\n',
+        "# Scale plan\n\n- Objective: close  with measurable quality and throughput gains.\n",
     )
     _write(
         target / "scale-growth-matrix.csv",
@@ -381,7 +373,7 @@ def _emit_pack(root: Path, payload: dict[str, Any], pack_dir: Path) -> None:
     )
     _write(
         target / "scale-execution-log.md",
-        '# Scale execution log\n\n- [ ] 2026-03-12: Record misses, wins, and  expansion priorities.\n',
+        "# Scale execution log\n\n- [ ] 2026-03-12: Record misses, wins, and  expansion priorities.\n",
     )
     _write(
         target / "scale-delivery-board.md",
@@ -429,7 +421,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def build_scale_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_scale_closeout_summary(root)
 
 

--- a/src/sdetkit/scale_upgrade_closeout_79.py
+++ b/src/sdetkit/scale_upgrade_closeout_79.py
@@ -20,7 +20,7 @@ _PLAN_PATH = "docs/roadmap/plans/scale-upgrade-plan.json"
 _SECTION_HEADER = "# Scale upgrade closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why scale upgrade matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Scale upgrade command lane",
     "## Scale upgrade contract",
     "## Scale upgrade quality checklist",
@@ -39,10 +39,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_scale_upgrade_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  scale upgrade execution and signoff.',
-    'The  lane references  outcomes, controls, and KPI continuity signals.',
-    'Every  section includes enterprise CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records enterprise onboarding outcomes, confidence notes, and  partner outreach priorities.',
+    "Single owner + backup reviewer are assigned for  scale upgrade execution and signoff.",
+    "The  lane references  outcomes, controls, and KPI continuity signals.",
+    "Every  section includes enterprise CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records enterprise onboarding outcomes, confidence notes, and  partner outreach priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes enterprise onboarding baseline, role coverage cadence, and stakeholder assumptions",
@@ -52,11 +52,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, scale upgrade plan, execution ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  scale upgrade plan committed',
-    '- [ ]  enterprise execution ledger exported',
-    '- [ ]  enterprise KPI scorecard snapshot exported',
-    '- [ ]  partner outreach priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  scale upgrade plan committed",
+    "- [ ]  enterprise execution ledger exported",
+    "- [ ]  enterprise KPI scorecard snapshot exported",
+    "- [ ]  partner outreach priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -67,7 +67,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '# Scale upgrade closeout lane\n\n closes with a major upgrade that converts  ecosystem priorities into an enterprise-scale onboarding execution pack.\n\n## Why scale upgrade matters\n\n- Turns  ecosystem priorities into enterprise onboarding readiness proof across docs, rollout, and adoption loops.\n- Protects scale quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  scale upgrades into  partner outreach priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/ecosystem-priorities-closeout-pack/ecosystem-priorities-closeout-summary.json`\n- `docs/artifacts/ecosystem-priorities-closeout-pack/ecosystem-priorities-delivery-board.md`\n- `docs/roadmap/plans/scale-upgrade-plan.json`\n\n## Scale upgrade command lane\n\n```bash\npython -m sdetkit scale-upgrade-closeout --format json --strict\npython -m sdetkit scale-upgrade-closeout --emit-pack-dir docs/artifacts/scale-upgrade-closeout-pack --format json --strict\npython -m sdetkit scale-upgrade-closeout --execute --evidence-dir docs/artifacts/scale-upgrade-closeout-pack/evidence --format json --strict\npython scripts/check_scale_upgrade_closeout_contract.py\n```\n\n## Scale upgrade contract\n\n- Single owner + backup reviewer are assigned for  scale upgrade execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes enterprise CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records enterprise onboarding outcomes, confidence notes, and  partner outreach priorities.\n\n## Scale upgrade quality checklist\n\n- [ ] Includes enterprise onboarding baseline, role coverage cadence, and stakeholder assumptions\n- [ ] Every scale lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures scale score delta, ecosystem carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, scale upgrade plan, execution ledger, KPI scorecard, and execution log\n\n## Scale upgrade delivery board\n\n- [ ]  integration brief committed\n- [ ]  scale upgrade plan committed\n- [ ]  enterprise execution ledger exported\n- [ ]  enterprise KPI scorecard snapshot exported\n- [ ]  partner outreach priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Scale evidence data + delivery board completeness (30)\n'
+_DEFAULT_PAGE_TEMPLATE = "# Scale upgrade closeout lane\n\n closes with a major upgrade that converts  ecosystem priorities into an enterprise-scale onboarding execution pack.\n\n## Why scale upgrade matters\n\n- Turns  ecosystem priorities into enterprise onboarding readiness proof across docs, rollout, and adoption loops.\n- Protects scale quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  scale upgrades into  partner outreach priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/ecosystem-priorities-closeout-pack/ecosystem-priorities-closeout-summary.json`\n- `docs/artifacts/ecosystem-priorities-closeout-pack/ecosystem-priorities-delivery-board.md`\n- `docs/roadmap/plans/scale-upgrade-plan.json`\n\n## Scale upgrade command lane\n\n```bash\npython -m sdetkit scale-upgrade-closeout --format json --strict\npython -m sdetkit scale-upgrade-closeout --emit-pack-dir docs/artifacts/scale-upgrade-closeout-pack --format json --strict\npython -m sdetkit scale-upgrade-closeout --execute --evidence-dir docs/artifacts/scale-upgrade-closeout-pack/evidence --format json --strict\npython scripts/check_scale_upgrade_closeout_contract.py\n```\n\n## Scale upgrade contract\n\n- Single owner + backup reviewer are assigned for  scale upgrade execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes enterprise CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records enterprise onboarding outcomes, confidence notes, and  partner outreach priorities.\n\n## Scale upgrade quality checklist\n\n- [ ] Includes enterprise onboarding baseline, role coverage cadence, and stakeholder assumptions\n- [ ] Every scale lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures scale score delta, ecosystem carryover delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, scale upgrade plan, execution ledger, KPI scorecard, and execution log\n\n## Scale upgrade delivery board\n\n- [ ]  integration brief committed\n- [ ]  scale upgrade plan committed\n- [ ]  enterprise execution ledger exported\n- [ ]  enterprise KPI scorecard snapshot exported\n- [ ]  partner outreach priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Scale evidence data + delivery board completeness (30)\n"
 
 
 def _read_text(path: Path) -> str:
@@ -108,7 +108,7 @@ def build_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
     board_text = _read_text(ecosystem_priorities_board)
     board_count = sum(1 for line in board_text.splitlines() if line.strip().startswith("- [ ]"))
     board_has_ecosystem_priorities = (
-        "ecosystem priorities" in board_text.lower() or '' in board_text
+        "ecosystem priorities" in board_text.lower() or "" in board_text
     )
 
     plan_text = _read_text(plan_path)
@@ -231,32 +231,28 @@ def build_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
             f"Ecosystem Priorities continuity baseline is stable with activation score={ecosystem_priorities_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85).')
+        misses.append(" continuity baseline is below the floor (<85).")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 before  lock."
         )
 
     if board_count >= 5 and board_has_ecosystem_priorities:
-        wins.append(
-            f"78 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"78 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' scale upgrade dataset is available for launch execution.')
+        wins.append(" scale upgrade dataset is available for launch execution.")
     else:
-        misses.append(' scale upgrade dataset is missing required keys.')
+        misses.append(" scale upgrade dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/scale-upgrade-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' scale upgrade closeout lane is fully complete and ready for  partner outreach priorities.'
+            " scale upgrade closeout lane is fully complete and ready for  partner outreach priorities."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -361,7 +357,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_scale_upgrade_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_scale_upgrade_closeout_summary(root)
 
 

--- a/src/sdetkit/stabilization_closeout_56.py
+++ b/src/sdetkit/stabilization_closeout_56.py
@@ -300,13 +300,9 @@ def build_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     if board_count >= 5 and board_has_required:
-        wins.append(
-            f"delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            "delivery board integrity is incomplete (needs >=5 items and anchors)."
-        )
+        misses.append("delivery board integrity is incomplete (needs >=5 items and anchors).")
         handoff_actions.append("Repair delivery board entries to include anchors.")
 
     if not missing_contract_lines and not missing_quality_lines and not missing_board_items:
@@ -320,9 +316,7 @@ def build_stabilization_closeout_summary(root: Path) -> dict[str, Any]:
         )
 
     if not failed and not critical_failures:
-        wins.append(
-            "stabilization closeout lane is fully complete and ready for deep audit lane."
-        )
+        wins.append("stabilization closeout lane is fully complete and ready for deep audit lane.")
 
     score = int(round(sum(c["weight"] for c in checks if bool(c["passed"]))))
     return {

--- a/src/sdetkit/trust_assets_refresh_closeout_75.py
+++ b/src/sdetkit/trust_assets_refresh_closeout_75.py
@@ -19,14 +19,14 @@ _DAY74_BOARD_PATH = (
     "docs/artifacts/distribution-scaling-closeout-pack/distribution-scaling-delivery-board.md"
 )
 _TRUST_PLAN_PATH = "docs/roadmap/plans/trust-assets-refresh-plan.json"
-_SECTION_HEADER = '#  — Trust assets refresh closeout lane'
+_SECTION_HEADER = "#  — Trust assets refresh closeout lane"
 _REQUIRED_SECTIONS = [
-    '## Why  matters',
-    '## Required inputs ()',
-    '##  command lane',
+    "## Why  matters",
+    "## Required inputs ()",
+    "##  command lane",
     "## Trust assets refresh contract",
     "## Trust refresh quality checklist",
-    '##  delivery board',
+    "##  delivery board",
     "## Scoring model",
 ]
 _REQUIRED_COMMANDS = [
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_trust_assets_refresh_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  trust assets refresh execution and signoff.',
-    'The  lane references  outcomes, controls, and KPI continuity signals.',
-    'Every  section includes trust-surface CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records trust outcomes, confidence notes, and  contributor-recognition priorities.',
+    "Single owner + backup reviewer are assigned for  trust assets refresh execution and signoff.",
+    "The  lane references  outcomes, controls, and KPI continuity signals.",
+    "Every  section includes trust-surface CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records trust outcomes, confidence notes, and  contributor-recognition priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes trust-surface baseline, proof-link cadence, and stakeholder assumptions",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes integration brief, trust refresh plan, controls log, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  integration brief committed',
-    '- [ ]  trust assets refresh plan committed',
-    '- [ ]  trust controls and assumptions log exported',
-    '- [ ]  trust KPI scorecard snapshot exported',
-    '- [ ]  contributor-recognition priorities drafted from  learnings',
+    "- [ ]  integration brief committed",
+    "- [ ]  trust assets refresh plan committed",
+    "- [ ]  trust controls and assumptions log exported",
+    "- [ ]  trust KPI scorecard snapshot exported",
+    "- [ ]  contributor-recognition priorities drafted from  learnings",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Trust assets refresh closeout lane\n\n closes with a major upgrade that turns  distribution outcomes into a governance-grade trust refresh execution pack.\n\n## Why  matters\n\n- Converts  scaling proof into trust-surface upgrades across security, governance, and reliability docs.\n- Protects trust quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  trust refresh execution into  contributor recognition.\n\n## Required inputs ()\n\n- `docs/artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.json`\n- `docs/artifacts/distribution-scaling-closeout-pack/distribution-scaling-delivery-board.md`\n- `docs/roadmap/plans/trust-assets-refresh-plan.json`\n\n##  command lane\n\n```bash\npython -m sdetkit trust-assets-refresh-closeout --format json --strict\npython -m sdetkit trust-assets-refresh-closeout --emit-pack-dir docs/artifacts/trust-assets-refresh-closeout-pack --format json --strict\npython -m sdetkit trust-assets-refresh-closeout --execute --evidence-dir docs/artifacts/trust-assets-refresh-closeout-pack/evidence --format json --strict\npython scripts/check_trust_assets_refresh_closeout_contract.py\n```\n\n## Trust assets refresh contract\n\n- Single owner + backup reviewer are assigned for  trust assets refresh execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes trust-surface CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records trust outcomes, confidence notes, and  contributor-recognition priorities.\n\n## Trust refresh quality checklist\n\n- [ ] Includes trust-surface baseline, proof-link cadence, and stakeholder assumptions\n- [ ] Every trust lane row has owner, refresh window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures trust score delta, governance proof coverage delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, trust refresh plan, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  trust assets refresh plan committed\n- [ ]  trust controls and assumptions log exported\n- [ ]  trust KPI scorecard snapshot exported\n- [ ]  contributor-recognition priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Trust evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Trust assets refresh closeout lane\n\n closes with a major upgrade that turns  distribution outcomes into a governance-grade trust refresh execution pack.\n\n## Why  matters\n\n- Converts  scaling proof into trust-surface upgrades across security, governance, and reliability docs.\n- Protects trust quality with strict contract coverage, runnable commands, rollout guardrails, and rollback safety.\n- Creates a deterministic handoff from  trust refresh execution into  contributor recognition.\n\n## Required inputs ()\n\n- `docs/artifacts/distribution-scaling-closeout-pack/distribution-scaling-closeout-summary.json`\n- `docs/artifacts/distribution-scaling-closeout-pack/distribution-scaling-delivery-board.md`\n- `docs/roadmap/plans/trust-assets-refresh-plan.json`\n\n##  command lane\n\n```bash\npython -m sdetkit trust-assets-refresh-closeout --format json --strict\npython -m sdetkit trust-assets-refresh-closeout --emit-pack-dir docs/artifacts/trust-assets-refresh-closeout-pack --format json --strict\npython -m sdetkit trust-assets-refresh-closeout --execute --evidence-dir docs/artifacts/trust-assets-refresh-closeout-pack/evidence --format json --strict\npython scripts/check_trust_assets_refresh_closeout_contract.py\n```\n\n## Trust assets refresh contract\n\n- Single owner + backup reviewer are assigned for  trust assets refresh execution and signoff.\n- The  lane references  outcomes, controls, and KPI continuity signals.\n- Every  section includes trust-surface CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records trust outcomes, confidence notes, and  contributor-recognition priorities.\n\n## Trust refresh quality checklist\n\n- [ ] Includes trust-surface baseline, proof-link cadence, and stakeholder assumptions\n- [ ] Every trust lane row has owner, refresh window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures trust score delta, governance proof coverage delta, confidence, and rollback owner\n- [ ] Artifact pack includes integration brief, trust refresh plan, controls log, KPI scorecard, and execution log\n\n##  delivery board\n\n- [ ]  integration brief committed\n- [ ]  trust assets refresh plan committed\n- [ ]  trust controls and assumptions log exported\n- [ ]  trust KPI scorecard snapshot exported\n- [ ]  contributor-recognition priorities drafted from  learnings\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Trust evidence data + delivery board completeness (30)\n\nStrict pass requires score >= 95 and zero critical failures.\n"
 
 
 def _read(path: Path) -> str:
@@ -109,9 +109,7 @@ def build_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, Any]:
     distribution_scaling_score, distribution_scaling_strict, distribution_scaling_check_count = (
         _load_distribution_scaling(distribution_scaling_summary)
     )
-    board_count, board_has_distribution_scaling = _count_board_items(
-        distribution_scaling_board, ''
-    )
+    board_count, board_has_distribution_scaling = _count_board_items(distribution_scaling_board, "")
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
     missing_commands = [x for x in _REQUIRED_COMMANDS if x not in page_text]
@@ -142,8 +140,8 @@ def build_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "distribution_scaling_summary_present",
@@ -236,32 +234,26 @@ def build_trust_assets_refresh_closeout_summary(root: Path) -> dict[str, Any]:
             f"74 continuity is strict-pass with activation score={distribution_scaling_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_distribution_scaling:
-        wins.append(
-            f"74 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"74 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' trust assets refresh dataset is available for launch execution.')
+        wins.append(" trust assets refresh dataset is available for launch execution.")
     else:
-        misses.append(' trust assets refresh dataset is missing required keys.')
+        misses.append(" trust assets refresh dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/trust-assets-refresh-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' trust assets refresh closeout lane is fully complete and ready for  contributor recognition.'
+            " trust assets refresh closeout lane is fully complete and ready for  contributor recognition."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -322,8 +314,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "trust-assets-refresh-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "trust-assets-refresh-integration-brief.md", '#  integration brief\n')
-    _write(target / "trust-assets-refresh-plan.md", '#  trust assets refresh plan\n')
+    _write(target / "trust-assets-refresh-integration-brief.md", "#  integration brief\n")
+    _write(target / "trust-assets-refresh-plan.md", "#  trust assets refresh plan\n")
     _write(
         target / "trust-assets-refresh-trust-controls-log.json",
         json.dumps({"controls": []}, indent=2) + "\n",
@@ -332,14 +324,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "trust-assets-refresh-trust-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "trust-assets-refresh-execution-log.md", '#  execution log\n')
+    _write(target / "trust-assets-refresh-execution-log.md", "#  execution log\n")
     _write(
         target / "trust-assets-refresh-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "trust-assets-refresh-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -367,7 +359,7 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_trust_assets_refresh_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_trust_assets_refresh_closeout_summary(root)
 
 

--- a/src/sdetkit/trust_faq_expansion_closeout_83.py
+++ b/src/sdetkit/trust_faq_expansion_closeout_83.py
@@ -19,10 +19,10 @@ _DAY82_BOARD_PATH = (
     "docs/artifacts/integration-feedback-closeout-pack/integration-feedback-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/trust-faq-expansion-plan.json"
-_SECTION_HEADER = '#  — Trust FAQ expansion loop closeout lane'
+_SECTION_HEADER = "#  — Trust FAQ expansion loop closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Trust FAQ Expansion Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Command lane",
     "## Trust FAQ expansion contract",
     "## Trust FAQ expansion quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_trust_faq_expansion_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  trust FAQ expansion execution and signoff.',
-    'The  lane references  outcomes, controls, and campaign continuity signals.',
-    'Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records trust FAQ content upgrades, escalation outcomes, and  evidence narrative priorities.',
+    "Single owner + backup reviewer are assigned for  trust FAQ expansion execution and signoff.",
+    "The  lane references  outcomes, controls, and campaign continuity signals.",
+    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records trust FAQ content upgrades, escalation outcomes, and  evidence narrative priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline trust FAQ coverage, objection segmentation assumptions, and response SLA targets",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes trust brief, FAQ expansion plan, template diffs, escalation ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  trust FAQ brief committed',
-    '- [ ]  trust FAQ expansion plan committed',
-    '- [ ]  trust template upgrade ledger exported',
-    '- [ ]  escalation outcomes ledger exported',
-    '- [ ]  evidence narrative priorities drafted from  outcomes',
+    "- [ ]  trust FAQ brief committed",
+    "- [ ]  trust FAQ expansion plan committed",
+    "- [ ]  trust template upgrade ledger exported",
+    "- [ ]  escalation outcomes ledger exported",
+    "- [ ]  evidence narrative priorities drafted from  outcomes",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Trust FAQ expansion loop closeout lane\n\n closes with a major upgrade that folds  integration feedback outcomes into trust FAQ coverage upgrades and escalation-readiness execution.\n\n## Why Trust FAQ Expansion Closeout matters\n\n- Turns  integration feedback outcomes into deterministic trust FAQ expansion loops across docs, templates, and support operations.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  evidence narrative priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-feedback-closeout-pack/integration-feedback-closeout-summary.json`\n- `docs/artifacts/integration-feedback-closeout-pack/integration-feedback-delivery-board.md`\n- `docs/roadmap/plans/trust-faq-expansion-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit trust-faq-expansion-closeout --format json --strict\npython -m sdetkit trust-faq-expansion-closeout --emit-pack-dir docs/artifacts/trust-faq-expansion-closeout-pack --format json --strict\npython -m sdetkit trust-faq-expansion-closeout --execute --evidence-dir docs/artifacts/trust-faq-expansion-closeout-pack/evidence --format json --strict\npython scripts/check_trust_faq_expansion_closeout_contract.py\n```\n\n## Trust FAQ expansion contract\n\n- Single owner + backup reviewer are assigned for  trust FAQ expansion execution and signoff.\n- The  lane references  outcomes, controls, and campaign continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records trust FAQ content upgrades, escalation outcomes, and  evidence narrative priorities.\n\n## Trust FAQ expansion quality checklist\n\n- [ ] Includes baseline trust FAQ coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every trust lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to trust docs/templates + runnable command evidence\n- [ ] Scorecard captures trust FAQ adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes trust brief, FAQ expansion plan, template diffs, escalation ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  trust FAQ brief committed\n- [ ]  trust FAQ expansion plan committed\n- [ ]  trust template upgrade ledger exported\n- [ ]  escalation outcomes ledger exported\n- [ ]  evidence narrative priorities drafted from  outcomes\n\n## Scoring model\n\nTrust FAQ Expansion Closeout weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Feedback evidence data + delivery board completeness (30)\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Trust FAQ expansion loop closeout lane\n\n closes with a major upgrade that folds  integration feedback outcomes into trust FAQ coverage upgrades and escalation-readiness execution.\n\n## Why Trust FAQ Expansion Closeout matters\n\n- Turns  integration feedback outcomes into deterministic trust FAQ expansion loops across docs, templates, and support operations.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  evidence narrative priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-feedback-closeout-pack/integration-feedback-closeout-summary.json`\n- `docs/artifacts/integration-feedback-closeout-pack/integration-feedback-delivery-board.md`\n- `docs/roadmap/plans/trust-faq-expansion-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit trust-faq-expansion-closeout --format json --strict\npython -m sdetkit trust-faq-expansion-closeout --emit-pack-dir docs/artifacts/trust-faq-expansion-closeout-pack --format json --strict\npython -m sdetkit trust-faq-expansion-closeout --execute --evidence-dir docs/artifacts/trust-faq-expansion-closeout-pack/evidence --format json --strict\npython scripts/check_trust_faq_expansion_closeout_contract.py\n```\n\n## Trust FAQ expansion contract\n\n- Single owner + backup reviewer are assigned for  trust FAQ expansion execution and signoff.\n- The  lane references  outcomes, controls, and campaign continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records trust FAQ content upgrades, escalation outcomes, and  evidence narrative priorities.\n\n## Trust FAQ expansion quality checklist\n\n- [ ] Includes baseline trust FAQ coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every trust lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to trust docs/templates + runnable command evidence\n- [ ] Scorecard captures trust FAQ adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes trust brief, FAQ expansion plan, template diffs, escalation ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  trust FAQ brief committed\n- [ ]  trust FAQ expansion plan committed\n- [ ]  trust template upgrade ledger exported\n- [ ]  escalation outcomes ledger exported\n- [ ]  evidence narrative priorities drafted from  outcomes\n\n## Scoring model\n\nTrust FAQ Expansion Closeout weighted score (0-100):\n\n- Contract + command lane integrity (35)\n-  continuity baseline quality (35)\n- Feedback evidence data + delivery board completeness (30)\n"
 
 
 def _read_text(path: Path) -> str:
@@ -112,7 +112,9 @@ def build_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     integration_feedback_score = int(
         integration_feedback_summary_data.get("activation_score", 0) or 0
     )
-    integration_feedback_strict = coerce_bool(integration_feedback_summary_data.get("strict_pass", False), default=False)
+    integration_feedback_strict = coerce_bool(
+        integration_feedback_summary_data.get("strict_pass", False), default=False
+    )
     integration_feedback_check_count = (
         len(integration_feedback_data.get("checks", []))
         if isinstance(integration_feedback_data.get("checks"), list)
@@ -122,7 +124,7 @@ def build_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
     board_text = _read_text(integration_feedback_board)
     board_count = _checklist_count(board_text)
     board_has_integration_feedback = (
-        "integration feedback" in board_text.lower() or '' in board_text
+        "integration feedback" in board_text.lower() or "" in board_text
     )
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
@@ -153,8 +155,8 @@ def build_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "integration_feedback_summary_present",
@@ -245,32 +247,28 @@ def build_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
             f"Integration Feedback continuity baseline is stable with activation score={integration_feedback_score}."
         )
     else:
-        misses.append(' continuity baseline is below the floor (<85) or not strict-pass.')
+        misses.append(" continuity baseline is below the floor (<85) or not strict-pass.")
         handoff_actions.append(
-            'Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock.'
+            "Re-run  closeout command and raise baseline quality above 85 with strict pass before  lock."
         )
 
     if board_count >= 5 and board_has_integration_feedback:
-        wins.append(
-            f"82 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"82 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
     if not missing_plan_keys:
-        wins.append(' trust FAQ expansion dataset is available for launch execution.')
+        wins.append(" trust FAQ expansion dataset is available for launch execution.")
     else:
-        misses.append(' trust FAQ expansion dataset is missing required keys.')
+        misses.append(" trust FAQ expansion dataset is missing required keys.")
         handoff_actions.append(
             "Update docs/roadmap/plans/trust-faq-expansion-plan.json to restore required keys."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' trust FAQ expansion closeout lane is fully complete and ready for  evidence narrative priorities.'
+            " trust FAQ expansion closeout lane is fully complete and ready for  evidence narrative priorities."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -310,7 +308,7 @@ def build_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
 
 def _render_text(payload: dict[str, Any]) -> str:
     lines = [
-        ' trust FAQ expansion closeout summary',
+        " trust FAQ expansion closeout summary",
         f"- Activation score: {payload['summary']['activation_score']}",
         f"- Passed checks: {payload['summary']['passed_checks']}",
         f"- Failed checks: {payload['summary']['failed_checks']}",
@@ -331,8 +329,8 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2) + "\n",
     )
     _write(target / "trust-faq-expansion-closeout-summary.md", _render_text(payload) + "\n")
-    _write(target / "trust-faq-expansion-trust-faq-brief.md", '#  trust FAQ brief\n')
-    _write(target / "trust-faq-expansion-plan.md", '#  trust FAQ expansion plan\n')
+    _write(target / "trust-faq-expansion-trust-faq-brief.md", "#  trust FAQ brief\n")
+    _write(target / "trust-faq-expansion-plan.md", "#  trust FAQ expansion plan\n")
     _write(
         target / "trust-faq-expansion-trust-template-upgrade-ledger.json",
         json.dumps({"upgrades": []}, indent=2) + "\n",
@@ -345,14 +343,14 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
         target / "trust-faq-expansion-trust-kpi-scorecard.json",
         json.dumps({"kpis": []}, indent=2) + "\n",
     )
-    _write(target / "trust-faq-expansion-execution-log.md", '#  execution log\n')
+    _write(target / "trust-faq-expansion-execution-log.md", "#  execution log\n")
     _write(
         target / "trust-faq-expansion-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "trust-faq-expansion-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -380,12 +378,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_trust_faq_expansion_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_trust_faq_expansion_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' trust FAQ expansion closeout checks')
+    parser = argparse.ArgumentParser(description=" trust FAQ expansion closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -641,7 +641,9 @@ def _release_is_python_compatible(
 
     compatibility_observed = False
     for release_file in release_files:
-        if not isinstance(release_file, dict) or coerce_bool(release_file.get("yanked"), default=False):
+        if not isinstance(release_file, dict) or coerce_bool(
+            release_file.get("yanked"), default=False
+        ):
             continue
         requires_python = release_file.get("requires_python")
         if requires_python is not None and not isinstance(requires_python, str):

--- a/src/sdetkit/weekly_review_closeout_65.py
+++ b/src/sdetkit/weekly_review_closeout_65.py
@@ -19,10 +19,10 @@ _INTEGRATION_EXPANSION_BOARD_PATH = (
     "docs/artifacts/integration-expansion-closeout-pack/integration-expansion-delivery-board.md"
 )
 _INTEGRATION_EXPANSION_WORKFLOW_PATH = ".github/workflows/advanced-github-actions-reference-64.yml"
-_SECTION_HEADER = '#  — Weekly review #9 closeout lane'
+_SECTION_HEADER = "#  — Weekly review #9 closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Weekly Review Closeout matters",
-    '## Required inputs ()',
+    "## Required inputs ()",
     "## Weekly Review Closeout command lane",
     "## Weekly review contract",
     "## Weekly review quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_weekly_review_closeout_contract_2.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    'Single owner + backup reviewer are assigned for  weekly review scoring, risk triage, and handoff signoff.',
-    'The  lane references  integration evidence, delivery board completion, and strict baseline continuity.',
-    'Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.',
-    ' closeout records weekly KPI deltas, governance decisions, and  integration expansion priorities.',
+    "Single owner + backup reviewer are assigned for  weekly review scoring, risk triage, and handoff signoff.",
+    "The  lane references  integration evidence, delivery board completion, and strict baseline continuity.",
+    "Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    " closeout records weekly KPI deltas, governance decisions, and  integration expansion priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes KPI baseline deltas, confidence band, and anomaly narrative",
@@ -54,14 +54,14 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes weekly brief, KPI dashboard, decision register, risk ledger, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    '- [ ]  weekly brief committed',
-    '- [ ]  KPI dashboard snapshot exported',
-    '- [ ]  governance decision register published',
-    '- [ ]  risk and recovery ledger exported',
-    '- [ ]  integration expansion priorities drafted from  review',
+    "- [ ]  weekly brief committed",
+    "- [ ]  KPI dashboard snapshot exported",
+    "- [ ]  governance decision register published",
+    "- [ ]  risk and recovery ledger exported",
+    "- [ ]  integration expansion priorities drafted from  review",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = '#  — Weekly review #9 closeout lane\n\n closes with a major weekly review upgrade that converts  integration execution evidence into strict KPI governance and a deterministic  handoff.\n\n## Why Weekly Review Closeout matters\n\n- Consolidates  integration expansion signals into a high-confidence weekly KPI baseline.\n- Protects momentum with strict review contract coverage, runnable commands, and rollback safeguards.\n- Creates a deterministic handoff from  weekly review into  integration expansion #2.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-expansion-closeout-pack/integration-expansion-closeout-summary.json`\n- `docs/artifacts/integration-expansion-closeout-pack/integration-expansion-delivery-board.md`\n- `.github/workflows/advanced-github-actions-reference-64.yml`\n\n## Weekly Review Closeout command lane\n\n```bash\npython -m sdetkit weekly-review-closeout --format json --strict\npython -m sdetkit weekly-review-closeout --emit-pack-dir docs/artifacts/weekly-review-closeout-2-pack --format json --strict\npython -m sdetkit weekly-review-closeout --execute --evidence-dir docs/artifacts/weekly-review-closeout-2-pack/evidence --format json --strict\npython scripts/check_weekly_review_closeout_contract_2.py\n```\n\n## Weekly review contract\n\n- Single owner + backup reviewer are assigned for  weekly review scoring, risk triage, and handoff signoff.\n- The  lane references  integration evidence, delivery board completion, and strict baseline continuity.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records weekly KPI deltas, governance decisions, and  integration expansion priorities.\n\n## Weekly review quality checklist\n\n- [ ] Includes KPI baseline deltas, confidence band, and anomaly narrative\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures pass-rate trend, reliability incidents, contributor signal quality, and recovery owner\n- [ ] Artifact pack includes weekly brief, KPI dashboard, decision register, risk ledger, and execution log\n\n## Weekly Review Closeout delivery board\n\n- [ ]  weekly brief committed\n- [ ]  KPI dashboard snapshot exported\n- [ ]  governance decision register published\n- [ ]  risk and recovery ledger exported\n- [ ]  integration expansion priorities drafted from  review\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 25 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 30 points.\n- Weekly review quality + governance handoff: 25 points.\n'
+_DEFAULT_PAGE_TEMPLATE = "#  — Weekly review #9 closeout lane\n\n closes with a major weekly review upgrade that converts  integration execution evidence into strict KPI governance and a deterministic  handoff.\n\n## Why Weekly Review Closeout matters\n\n- Consolidates  integration expansion signals into a high-confidence weekly KPI baseline.\n- Protects momentum with strict review contract coverage, runnable commands, and rollback safeguards.\n- Creates a deterministic handoff from  weekly review into  integration expansion #2.\n\n## Required inputs ()\n\n- `docs/artifacts/integration-expansion-closeout-pack/integration-expansion-closeout-summary.json`\n- `docs/artifacts/integration-expansion-closeout-pack/integration-expansion-delivery-board.md`\n- `.github/workflows/advanced-github-actions-reference-64.yml`\n\n## Weekly Review Closeout command lane\n\n```bash\npython -m sdetkit weekly-review-closeout --format json --strict\npython -m sdetkit weekly-review-closeout --emit-pack-dir docs/artifacts/weekly-review-closeout-2-pack --format json --strict\npython -m sdetkit weekly-review-closeout --execute --evidence-dir docs/artifacts/weekly-review-closeout-2-pack/evidence --format json --strict\npython scripts/check_weekly_review_closeout_contract_2.py\n```\n\n## Weekly review contract\n\n- Single owner + backup reviewer are assigned for  weekly review scoring, risk triage, and handoff signoff.\n- The  lane references  integration evidence, delivery board completion, and strict baseline continuity.\n- Every  section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records weekly KPI deltas, governance decisions, and  integration expansion priorities.\n\n## Weekly review quality checklist\n\n- [ ] Includes KPI baseline deltas, confidence band, and anomaly narrative\n- [ ] Every section has owner, review window, KPI threshold, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures pass-rate trend, reliability incidents, contributor signal quality, and recovery owner\n- [ ] Artifact pack includes weekly brief, KPI dashboard, decision register, risk ledger, and execution log\n\n## Weekly Review Closeout delivery board\n\n- [ ]  weekly brief committed\n- [ ]  KPI dashboard snapshot exported\n- [ ]  governance decision register published\n- [ ]  risk and recovery ledger exported\n- [ ]  integration expansion priorities drafted from  review\n\n## Scoring model\n\n weighted score (0-100):\n\n- Contract + command lane completeness: 25 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 30 points.\n- Weekly review quality + governance handoff: 25 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -111,7 +111,7 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
         _load_integration_expansion(integration_expansion_summary)
     )
     board_count, board_has_integration_expansion = _count_board_items(
-        integration_expansion_board, ''
+        integration_expansion_board, ""
     )
 
     missing_sections = [x for x in _REQUIRED_SECTIONS if x not in page_text]
@@ -139,8 +139,8 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_strategy_alignment",
             "weight": 5,
-            "passed": ('' in top10_text and '' in top10_text),
-            "evidence": ' +  strategy chain',
+            "passed": ("" in top10_text and "" in top10_text),
+            "evidence": " +  strategy chain",
         },
         {
             "check_id": "integration_expansion_summary_present",
@@ -212,8 +212,7 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "integration_expansion_workflow_reference_present",
             "weight": 10,
-            "passed": ' Advanced GitHub Actions Reference'
-            in integration_expansion_workflow_text,
+            "passed": " Advanced GitHub Actions Reference" in integration_expansion_workflow_text,
             "evidence": ".github/workflows/advanced-github-actions-reference-64.yml",
         },
     ]
@@ -234,32 +233,26 @@ def build_weekly_review_closeout_summary(root: Path) -> dict[str, Any]:
             f"64 continuity is strict-pass with activation score={integration_expansion_score}."
         )
     else:
-        misses.append(' strict continuity signal is missing.')
-        handoff_actions.append(
-            'Re-run  closeout command and restore strict baseline before  lock.'
-        )
+        misses.append(" strict continuity signal is missing.")
+        handoff_actions.append("Re-run  closeout command and restore strict baseline before  lock.")
 
     if board_count >= 5 and board_has_integration_expansion:
-        wins.append(
-            f"64 delivery board integrity validated with {board_count} checklist items."
-        )
+        wins.append(f"64 delivery board integrity validated with {board_count} checklist items.")
     else:
-        misses.append(
-            ' delivery board integrity is incomplete (needs >=5 items and  anchors).'
-        )
-        handoff_actions.append('Repair  delivery board entries to include  anchors.')
+        misses.append(" delivery board integrity is incomplete (needs >=5 items and  anchors).")
+        handoff_actions.append("Repair  delivery board entries to include  anchors.")
 
-    if ' Advanced GitHub Actions Reference' in integration_expansion_workflow_text:
-        wins.append(' workflow reference remains available for weekly KPI baseline review.')
+    if " Advanced GitHub Actions Reference" in integration_expansion_workflow_text:
+        wins.append(" workflow reference remains available for weekly KPI baseline review.")
     else:
-        misses.append(' workflow reference is missing for weekly review context.')
+        misses.append(" workflow reference is missing for weekly review context.")
         handoff_actions.append(
-            'Restore integration_expansion workflow reference before publishing  outcomes.'
+            "Restore integration_expansion workflow reference before publishing  outcomes."
         )
 
     if not failed and not critical_failures:
         wins.append(
-            ' weekly review closeout lane is fully complete and ready for  integration expansion #2.'
+            " weekly review closeout lane is fully complete and ready for  integration expansion #2."
         )
 
     score = int(round(sum(c["weight"] for c in checks if c["passed"])))
@@ -324,7 +317,7 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     _write(target / "weekly-review-closeout-2-summary.md", _render_text(payload) + "\n")
     _write(
         target / "weekly-review-closeout-2-weekly-brief.md",
-        '#  weekly brief\n',
+        "#  weekly brief\n",
     )
     _write(
         target / "weekly-review-closeout-2-kpi-dashboard.json",
@@ -332,20 +325,20 @@ def _emit_pack(root: Path, pack_dir: Path, payload: dict[str, Any]) -> None:
     )
     _write(
         target / "weekly-review-closeout-2-governance-decision-register.md",
-        '#  governance decision register\n',
+        "#  governance decision register\n",
     )
     _write(
         target / "weekly-review-closeout-2-risk-ledger.csv",
         "risk_id,severity,owner,mitigation,status\n",
     )
-    _write(target / "weekly-review-closeout-2-execution-log.md", '#  execution log\n')
+    _write(target / "weekly-review-closeout-2-execution-log.md", "#  execution log\n")
     _write(
         target / "weekly-review-closeout-2-delivery-board.md",
-        "\n".join(['#  delivery board', *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
+        "\n".join(["#  delivery board", *_REQUIRED_DELIVERY_BOARD_LINES]) + "\n",
     )
     _write(
         target / "weekly-review-closeout-2-validation-commands.md",
-        '#  validation commands\n\n```bash\n' + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
+        "#  validation commands\n\n```bash\n" + "\n".join(_EXECUTION_COMMANDS) + "\n```\n",
     )
 
 
@@ -373,12 +366,12 @@ def _execute_commands(root: Path, evidence_dir: Path) -> None:
 
 
 def build_weekly_review_closeout_summary_impl(root: Path) -> dict[str, Any]:
-    'Compatibility alias for legacy -based builder name.'
+    "Compatibility alias for legacy -based builder name."
     return build_weekly_review_closeout_summary(root)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=' weekly review closeout checks')
+    parser = argparse.ArgumentParser(description=" weekly review closeout checks")
     parser.add_argument("--root", default=".")
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--strict", action="store_true")

--- a/tests/test_acceleration_closeout.py
+++ b/tests/test_acceleration_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Acceleration closeout lane:** convert  evidence into deterministic growth loops.\n'
-        '- ** — Scale lane continuation:** convert  acceleration wins into scale plays.\n',
+        "- ** — Acceleration closeout lane:** convert  evidence into deterministic growth loops.\n"
+        "- ** — Scale lane continuation:** convert  acceleration wins into scale plays.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-acceleration-closeout.md").write_text(
         d42._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-43-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-43-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -60,12 +58,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  optimization plan draft committed',
-                '- [ ]  review notes captured with owner + backup',
-                '- [ ]  remediation matrix exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  acceleration priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  optimization plan draft committed",
+                "- [ ]  review notes captured with owner + backup",
+                "- [ ]  remediation matrix exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  acceleration priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_bool_coercion.py
+++ b/tests/test_bool_coercion.py
@@ -40,7 +40,9 @@ def test_coerce_bool_handles_string_flags(value: object, default: bool, expected
     assert coerce_bool(value, default=default) is expected
 
 
-def test_ops_policy_string_false_does_not_enable_shell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ops_policy_string_false_does_not_enable_shell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     wf = Path("workflow.json")
     wf.write_text(

--- a/tests/test_case_study_launch_closeout.py
+++ b/tests/test_case_study_launch_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Case-study launch:** lock publication-quality evidence and publication readiness handoff.\n'
-        '- ** — Distribution scaling:** convert  learnings into scaled distribution operations.\n',
+        "- ** — Case-study launch:** lock publication-quality evidence and publication readiness handoff.\n"
+        "- ** — Distribution scaling:** convert  learnings into scaled distribution operations.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-case-study-launch-closeout.md").write_text(
         d73._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-73-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-73-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -62,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  publication-quality case-study narrative published',
-                '- [ ]  controls and assumptions log exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  distribution scaling priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  publication-quality case-study narrative published",
+                "- [ ]  controls and assumptions log exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  distribution scaling priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_case_study_prep1_closeout.py
+++ b/tests/test_case_study_prep1_closeout.py
@@ -18,7 +18,7 @@ def _seed_repo(root: Path) -> None:
         "impact-69-big-upgrade-report.md\nintegrations-case-study-prep1-closeout.md\n",
         encoding="utf-8",
     )
-    (root / "docs/top-10-github-strategy.md").write_text('\n\n', encoding="utf-8")
+    (root / "docs/top-10-github-strategy.md").write_text("\n\n", encoding="utf-8")
     (root / "docs/integrations-case-study-prep1-closeout.md").write_text(
         d69._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
@@ -45,12 +45,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  item 1',
-                '- [ ]  item 2',
-                '- [ ]  item 3',
-                '- [ ]  item 4',
-                '- [ ]  item 5',
+                "#  delivery board",
+                "- [ ]  item 1",
+                "- [ ]  item 2",
+                "- [ ]  item 3",
+                "- [ ]  item 4",
+                "- [ ]  item 5",
             ]
         )
         + "\n",

--- a/tests/test_case_study_prep2_closeout.py
+++ b/tests/test_case_study_prep2_closeout.py
@@ -18,7 +18,7 @@ def _seed_repo(root: Path) -> None:
         "impact-70-big-upgrade-report.md\nintegrations-case-study-prep2-closeout.md\n",
         encoding="utf-8",
     )
-    (root / "docs/top-10-github-strategy.md").write_text('\n\n', encoding="utf-8")
+    (root / "docs/top-10-github-strategy.md").write_text("\n\n", encoding="utf-8")
     (root / "docs/integrations-case-study-prep2-closeout.md").write_text(
         d70._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
@@ -42,7 +42,7 @@ def _seed_repo(root: Path) -> None:
         root / "docs/artifacts/case-study-prep1-closeout-pack/case-study-prep1-delivery-board.md"
     )
     board.write_text(
-        "\n".join(['#  delivery board', *['- [ ]  item' for _ in range(5)]]) + "\n",
+        "\n".join(["#  delivery board", *["- [ ]  item" for _ in range(5)]]) + "\n",
         encoding="utf-8",
     )
     (root / "docs/roadmap/plans/triage-speed-case-study.json").write_text(

--- a/tests/test_case_study_prep3_closeout.py
+++ b/tests/test_case_study_prep3_closeout.py
@@ -26,18 +26,18 @@ def _seed_repo(root: Path) -> None:
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
     (root / "docs/index.md").write_text(
-        '-71-big-upgrade-report.md\nintegrations-case-study-prep3-closeout.md\n',
+        "-71-big-upgrade-report.md\nintegrations-case-study-prep3-closeout.md\n",
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Case-study prep #3:** lock escalation-quality evidence and publication readiness handoff.\n'
-        '- ** — Weekly review #10:** assess integration adoption and feedback quality.\n',
+        "- ** — Case-study prep #3:** lock escalation-quality evidence and publication readiness handoff.\n"
+        "- ** — Weekly review #10:** assess integration adoption and feedback quality.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-case-study-prep3-closeout.md").write_text(
         d71._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/big-upgrade-report-71.md").write_text('#  report\n', encoding="utf-8")
+    (root / "docs/big-upgrade-report-71.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -60,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  triage-speed case-study narrative published',
-                '- [ ]  controls and assumptions log exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  case-study prep priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  triage-speed case-study narrative published",
+                "- [ ]  controls and assumptions log exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  case-study prep priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_case_study_prep4_closeout.py
+++ b/tests/test_case_study_prep4_closeout.py
@@ -26,18 +26,18 @@ def _seed_repo(root: Path) -> None:
     )
     (root / "docs").mkdir(parents=True, exist_ok=True)
     (root / "docs/index.md").write_text(
-        '-72-big-upgrade-report.md\nintegrations-case-study-prep4-closeout.md\n',
+        "-72-big-upgrade-report.md\nintegrations-case-study-prep4-closeout.md\n",
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Case-study prep #4:** lock publication-quality evidence and publication readiness handoff.\n'
-        '- ** — Publication launch:** convert  outputs into externally shareable case study assets.\n',
+        "- ** — Case-study prep #4:** lock publication-quality evidence and publication readiness handoff.\n"
+        "- ** — Publication launch:** convert  outputs into externally shareable case study assets.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-case-study-prep4-closeout.md").write_text(
         d72._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/big-upgrade-report-72.md").write_text('#  report\n', encoding="utf-8")
+    (root / "docs/big-upgrade-report-72.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -60,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  triage-speed case-study narrative published',
-                '- [ ]  controls and assumptions log exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  publication launch priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  triage-speed case-study narrative published",
+                "- [ ]  controls and assumptions log exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  publication launch priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_cli_sdetkit.py
+++ b/tests/test_cli_sdetkit.py
@@ -162,7 +162,7 @@ def test_product_lane_alias_resolves_to_canonical(capsys):
         cli.main(["phase1-hardening", "--help"])
     assert excinfo.value.code == 0
     out = capsys.readouterr().out
-    assert ' phase-1 hardening scorer' in out
+    assert " phase-1 hardening scorer" in out
 
 
 def test_product_lane_canonical_help_is_available(capsys):

--- a/tests/test_community_activation.py
+++ b/tests/test_community_activation.py
@@ -14,7 +14,7 @@ def _seed(root: Path) -> None:
         "docs/integrations-community-activation.md\ncommunity-activation\n", encoding="utf-8"
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Community activation:** open roadmap-voting discussion and collect feedback.\n',
+        "- ** — Community activation:** open roadmap-voting discussion and collect feedback.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-community-activation.md").write_text(
@@ -73,7 +73,7 @@ def test_community_emit_pack_and_execute(tmp_path: Path) -> None:
 def test_community_strict_fails_when_sections_missing(tmp_path: Path) -> None:
     _seed(tmp_path)
     (tmp_path / "docs/integrations-community-activation.md").write_text(
-        '# Community activation ()\n', encoding="utf-8"
+        "# Community activation ()\n", encoding="utf-8"
     )
 
     rc = ca.main(["--root", str(tmp_path), "--strict", "--format", "json"])
@@ -87,4 +87,4 @@ def test_cli_dispatch(tmp_path: Path, capsys) -> None:
     rc = cli.main(["community-activation", "--root", str(tmp_path), "--format", "text"])
 
     assert rc == 0
-    assert ' community activation summary' in capsys.readouterr().out
+    assert " community activation summary" in capsys.readouterr().out

--- a/tests/test_community_program_closeout.py
+++ b/tests/test_community_program_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Community program setup:** publish office-hours cadence and participation rules.\n'
-        '- ** — Contributor onboarding activation:** launch orientation flow and ownership handoff loops.\n',
+        "- ** — Community program setup:** publish office-hours cadence and participation rules.\n"
+        "- ** — Contributor onboarding activation:** launch orientation flow and ownership handoff loops.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-community-program-closeout.md").write_text(
         d62._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-62-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-62-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root / "docs/artifacts/phase3-kickoff-closeout-pack/phase3-kickoff-closeout-summary.json"
@@ -59,12 +57,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  Phase-3 kickoff brief committed',
-                '- [ ]  kickoff reviewed with owner + backup',
-                '- [ ]  trust ledger exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  community program priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  Phase-3 kickoff brief committed",
+                "- [ ]  kickoff reviewed with owner + backup",
+                "- [ ]  trust ledger exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  community program priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_community_touchpoint_closeout.py
+++ b/tests/test_community_touchpoint_closeout.py
@@ -36,9 +36,7 @@ def _seed_repo(root: Path) -> None:
     (root / "docs/integrations-community-touchpoint-closeout.md").write_text(
         d77._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-77-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-77-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -62,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  contributor recognition plan committed',
-                '- [ ]  recognition credits ledger exported',
-                '- [ ]  recognition KPI scorecard snapshot exported',
-                '- [ ]  scale priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  contributor recognition plan committed",
+                "- [ ]  recognition credits ledger exported",
+                "- [ ]  recognition KPI scorecard snapshot exported",
+                "- [ ]  scale priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_contributor_activation_closeout.py
+++ b/tests/test_contributor_activation_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Contributor activation #2:** escalate repeat contributors into owner tracks.\n'
-        '- ** — Stabilization lane:** enforce deterministic follow-through and verification.\n',
+        "- ** — Contributor activation #2:** escalate repeat contributors into owner tracks.\n"
+        "- ** — Stabilization lane:** enforce deterministic follow-through and verification.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-contributor-activation-closeout.md").write_text(
         d55._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-55-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-55-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/docs-loop-closeout-pack/docs-loop-closeout-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  docs-loop brief committed',
-                '- [ ]  docs-loop plan reviewed with owner + backup',
-                '- [ ]  cross-link map exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  contributor activation priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  docs-loop brief committed",
+                "- [ ]  docs-loop plan reviewed with owner + backup",
+                "- [ ]  cross-link map exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  contributor activation priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_contributor_recognition_closeout.py
+++ b/tests/test_contributor_recognition_closeout.py
@@ -18,7 +18,7 @@ def _seed_repo(root: Path) -> None:
         "impact-76-big-upgrade-report.md\nintegrations-contributor-recognition-closeout.md\n",
         encoding="utf-8",
     )
-    (root / "docs/top-10-github-strategy.md").write_text('\n\n', encoding="utf-8")
+    (root / "docs/top-10-github-strategy.md").write_text("\n\n", encoding="utf-8")
     (root / "docs/integrations-contributor-recognition-closeout.md").write_text(
         d76._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
@@ -43,7 +43,7 @@ def _seed_repo(root: Path) -> None:
         / "docs/artifacts/trust-assets-refresh-closeout-pack/trust-assets-refresh-delivery-board.md"
     )
     board.write_text(
-        "\n".join(['#  delivery board', *['- [ ]  item' for _ in range(5)]]) + "\n",
+        "\n".join(["#  delivery board", *["- [ ]  item" for _ in range(5)]]) + "\n",
         encoding="utf-8",
     )
 

--- a/tests/test_demo_asset.py
+++ b/tests/test_demo_asset.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Demo asset #1:** produce/publish `doctor` workflow short video or GIF.\n'
-        '- ** — Demo asset #2:** produce/publish `repo audit` workflow short video or GIF.\n',
+        "- ** — Demo asset #1:** produce/publish `doctor` workflow short video or GIF.\n"
+        "- ** — Demo asset #2:** produce/publish `repo audit` workflow short video or GIF.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-demo-asset.md").write_text(
         d33._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-33-ultra-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-33-ultra-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/release-cadence-pack/release-cadence-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  cadence calendar committed',
-                '- [ ]  changelog template committed',
-                '- [ ]  demo asset #1 scope frozen',
-                '- [ ]  demo asset #2 scope frozen',
-                '- [ ]  weekly review KPI frame locked',
+                "#  delivery board",
+                "- [ ]  cadence calendar committed",
+                "- [ ]  changelog template committed",
+                "- [ ]  demo asset #1 scope frozen",
+                "- [ ]  demo asset #2 scope frozen",
+                "- [ ]  weekly review KPI frame locked",
             ]
         )
         + "\n",
@@ -115,7 +113,7 @@ def test_demo_asset_strict_fails_when_lane32_inputs_missing(tmp_path: Path) -> N
 def test_demo_asset_strict_fails_when_lane32_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/release-cadence-pack/release-delivery-board.md").write_text(
-        '- [ ]  demo asset #1 scope frozen\n', encoding="utf-8"
+        "- [ ]  demo asset #1 scope frozen\n", encoding="utf-8"
     )
     rc = d33.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -125,4 +123,4 @@ def test_demo_asset_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["demo-asset", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' demo asset summary' in capsys.readouterr().out
+    assert " demo asset summary" in capsys.readouterr().out

--- a/tests/test_demo_asset2.py
+++ b/tests/test_demo_asset2.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Demo asset #2:** produce/publish `repo audit` workflow short video or GIF.\n'
-        '- ** — KPI instrumentation:** tighten signal loops and close attribution gaps.\n',
+        "- ** — Demo asset #2:** produce/publish `repo audit` workflow short video or GIF.\n"
+        "- ** — KPI instrumentation:** tighten signal loops and close attribution gaps.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-demo-asset2.md").write_text(
         d34._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-34-ultra-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-34-ultra-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/demo-asset-pack/demo-asset-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  script draft committed',
-                '- [ ]  first cut rendered',
-                '- [ ]  final cut + caption copy approved',
-                '- [ ]  demo asset #2 backlog pre-scoped',
-                '- [ ]  KPI instrumentation plan updated',
+                "#  delivery board",
+                "- [ ]  script draft committed",
+                "- [ ]  first cut rendered",
+                "- [ ]  final cut + caption copy approved",
+                "- [ ]  demo asset #2 backlog pre-scoped",
+                "- [ ]  KPI instrumentation plan updated",
             ]
         )
         + "\n",
@@ -117,7 +115,7 @@ def test_lane34_strict_fails_when_lane33_inputs_missing(tmp_path: Path) -> None:
 def test_lane34_strict_fails_when_lane33_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/demo-asset-pack/demo-delivery-board.md").write_text(
-        '- [ ]  demo asset #2 backlog pre-scoped\n', encoding="utf-8"
+        "- [ ]  demo asset #2 backlog pre-scoped\n", encoding="utf-8"
     )
     rc = d34.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -127,4 +125,4 @@ def test_lane34_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["demo-asset2", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' demo asset #2 summary' in capsys.readouterr().out
+    assert " demo asset #2 summary" in capsys.readouterr().out

--- a/tests/test_distribution_batch.py
+++ b/tests/test_distribution_batch.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Distribution batch #1:** publish coordinated posts linking demo assets to docs.\n'
-        '- ** — Playbook post #1:** publish Repo Reliability Playbook article #1.\n',
+        "- ** — Distribution batch #1:** publish coordinated posts linking demo assets to docs.\n"
+        "- ** — Playbook post #1:** publish Repo Reliability Playbook article #1.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-distribution-batch.md").write_text(
         d38._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-38-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-38-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/experiment-lane-pack/experiment-lane-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  experiment matrix committed',
-                '- [ ]  hypothesis brief reviewed with owner + backup',
-                '- [ ]  scorecard snapshot exported',
-                '- [ ]  distribution batch actions selected from winners',
-                '- [ ]  fallback plan documented for losing variants',
+                "#  delivery board",
+                "- [ ]  experiment matrix committed",
+                "- [ ]  hypothesis brief reviewed with owner + backup",
+                "- [ ]  scorecard snapshot exported",
+                "- [ ]  distribution batch actions selected from winners",
+                "- [ ]  fallback plan documented for losing variants",
             ]
         )
         + "\n",
@@ -117,7 +115,7 @@ def test_distribution_batch_strict_fails_when_lane37_inputs_missing(tmp_path: Pa
 def test_distribution_batch_strict_fails_when_lane37_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/experiment-lane-pack/delivery-board.md").write_text(
-        '- [ ]  distribution batch actions selected from winners\n', encoding="utf-8"
+        "- [ ]  distribution batch actions selected from winners\n", encoding="utf-8"
     )
     rc = d38.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -127,4 +125,4 @@ def test_distribution_batch_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["distribution-batch", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' distribution batch summary' in capsys.readouterr().out
+    assert " distribution batch summary" in capsys.readouterr().out

--- a/tests/test_distribution_closeout.py
+++ b/tests/test_distribution_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Distribution closeout:** publish channel-ready  KPI narrative with owners and posting windows.\n'
-        '- ** — Experiment lane:** convert  misses into controlled growth experiments.\n',
+        "- ** — Distribution closeout:** publish channel-ready  KPI narrative with owners and posting windows.\n"
+        "- ** — Experiment lane:** convert  misses into controlled growth experiments.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-distribution-closeout.md").write_text(
         d36._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-36-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-36-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/kpi-instrumentation-pack/kpi-instrumentation-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  KPI dictionary committed',
-                '- [ ]  dashboard snapshot exported',
-                '- [ ]  alert policy reviewed with owner + backup',
-                '- [ ]  distribution message references KPI shifts',
-                '- [ ]  experiment backlog seeded from KPI misses',
+                "#  delivery board",
+                "- [ ]  KPI dictionary committed",
+                "- [ ]  dashboard snapshot exported",
+                "- [ ]  alert policy reviewed with owner + backup",
+                "- [ ]  distribution message references KPI shifts",
+                "- [ ]  experiment backlog seeded from KPI misses",
             ]
         )
         + "\n",
@@ -122,7 +120,7 @@ def test_lane36_strict_fails_when_lane35_inputs_missing(tmp_path: Path) -> None:
 def test_lane36_strict_fails_when_lane35_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/kpi-instrumentation-pack/delivery-board.md").write_text(
-        '- [ ]  distribution message references KPI shifts\n', encoding="utf-8"
+        "- [ ]  distribution message references KPI shifts\n", encoding="utf-8"
     )
     rc = d36.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -132,4 +130,4 @@ def test_lane36_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["distribution-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' community distribution summary' in capsys.readouterr().out
+    assert " community distribution summary" in capsys.readouterr().out

--- a/tests/test_distribution_scaling_closeout.py
+++ b/tests/test_distribution_scaling_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Distribution scaling:** convert  learnings into scaled channel operations.\n'
-        '- ** — Trust assets refresh:** turn  outcomes into governance-grade trust proof.\n',
+        "- ** — Distribution scaling:** convert  learnings into scaled channel operations.\n"
+        "- ** — Trust assets refresh:** turn  outcomes into governance-grade trust proof.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-distribution-scaling-closeout.md").write_text(
         d74._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-74-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-74-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -62,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  published case-study narrative committed',
-                '- [ ]  controls and assumptions log exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  distribution scaling priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  published case-study narrative committed",
+                "- [ ]  controls and assumptions log exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  distribution scaling priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_docs_loop_closeout.py
+++ b/tests/test_docs_loop_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Case snippet #2:** publish mini-case on reliability or quality gate value.\n'
-        '- ** — Docs loop optimization:** publish mini-case on security/ops workflow value.\n',
+        "- ** — Case snippet #2:** publish mini-case on reliability or quality gate value.\n"
+        "- ** — Docs loop optimization:** publish mini-case on security/ops workflow value.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-docs-loop-closeout.md").write_text(
         d53._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-53-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-53-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/narrative-closeout-pack/narrative-closeout-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  narrative brief committed',
-                '- [ ]  narrative reviewed with owner + backup',
-                '- [ ]  proof map exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  expansion priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  narrative brief committed",
+                "- [ ]  narrative reviewed with owner + backup",
+                "- [ ]  proof map exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  expansion priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_evidence_narrative_closeout.py
+++ b/tests/test_evidence_narrative_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Trust FAQ expansion loop:** convert field objections into deterministic trust upgrades.\n'
-        '- ** — Evidence narrative closeout lane:** convert trust outcomes into release-ready narrative proof packs.\n',
+        "- ** — Trust FAQ expansion loop:** convert field objections into deterministic trust upgrades.\n"
+        "- ** — Evidence narrative closeout lane:** convert trust outcomes into release-ready narrative proof packs.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-evidence-narrative-closeout.md").write_text(
         d84._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-84-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-84-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  trust FAQ brief committed',
-                '- [ ]  trust FAQ expansion plan committed',
-                '- [ ]  trust template upgrade ledger exported',
-                '- [ ]  escalation outcomes ledger exported',
-                '- [ ]  evidence narrative priorities drafted from  outcomes',
+                "#  delivery board",
+                "- [ ]  trust FAQ brief committed",
+                "- [ ]  trust FAQ expansion plan committed",
+                "- [ ]  trust template upgrade ledger exported",
+                "- [ ]  escalation outcomes ledger exported",
+                "- [ ]  evidence narrative priorities drafted from  outcomes",
             ]
         )
         + "\n",
@@ -168,4 +166,4 @@ def test_lane84_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["evidence-narrative-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' evidence narrative closeout summary' in capsys.readouterr().out
+    assert " evidence narrative closeout summary" in capsys.readouterr().out

--- a/tests/test_execution_prioritization_closeout.py
+++ b/tests/test_execution_prioritization_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Execution prioritization lock:** convert weekly-review wins into a deterministic execution board.\n'
-        '- ** — Case snippet #1:** publish mini-case on reliability or quality gate value.\n',
+        "- ** — Execution prioritization lock:** convert weekly-review wins into a deterministic execution board.\n"
+        "- ** — Case snippet #1:** publish mini-case on reliability or quality gate value.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-execution-prioritization-closeout.md").write_text(
         d50._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-50-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-50-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -60,12 +58,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  weekly review brief committed',
-                '- [ ]  priorities reviewed with owner + backup',
-                '- [ ]  risk register exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  execution priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  weekly review brief committed",
+                "- [ ]  priorities reviewed with owner + backup",
+                "- [ ]  risk register exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  execution priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -152,4 +150,4 @@ def test_lane50_cli_dispatch(tmp_path: Path, capsys) -> None:
         ["execution-prioritization-closeout", "--root", str(tmp_path), "--format", "text"]
     )
     assert rc == 0
-    assert ' execution prioritization closeout summary' in capsys.readouterr().out
+    assert " execution prioritization closeout summary" in capsys.readouterr().out

--- a/tests/test_expansion_automation.py
+++ b/tests/test_expansion_automation.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Expansion automation lane:** automate scale winners into repeatable workflows.\n'
-        '- ** — Optimization lane kickoff:** convert  execution into optimization loops.\n',
+        "- ** — Expansion automation lane:** automate scale winners into repeatable workflows.\n"
+        "- ** — Optimization lane kickoff:** convert  execution into optimization loops.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-expansion-automation.md").write_text(
         d41._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-41-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-41-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/scale-lane-pack/scale-lane-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  scale plan draft committed',
-                '- [ ]  review notes captured with owner + backup',
-                '- [ ]  rollout timeline exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  expansion priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  scale plan draft committed",
+                "- [ ]  review notes captured with owner + backup",
+                "- [ ]  rollout timeline exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  expansion priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_expansion_closeout.py
+++ b/tests/test_expansion_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Expansion closeout lane:** convert  scale proof into deterministic expansion loops.\n'
-        '- ** — Optimization lane continuation:** convert  expansion wins into optimization plays.\n',
+        "- ** — Expansion closeout lane:** convert  scale proof into deterministic expansion loops.\n"
+        "- ** — Optimization lane continuation:** convert  expansion wins into optimization plays.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-expansion-closeout.md").write_text(
         d45._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-45-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-45-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/scale-closeout-pack/scale-closeout-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  scale plan draft committed',
-                '- [ ]  review notes captured with owner + backup',
-                '- [ ]  growth matrix exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  expansion priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  scale plan draft committed",
+                "- [ ]  review notes captured with owner + backup",
+                "- [ ]  growth matrix exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  expansion priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -126,4 +124,4 @@ def test_lane45_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["expansion-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' expansion closeout summary' in capsys.readouterr().out
+    assert " expansion closeout summary" in capsys.readouterr().out

--- a/tests/test_experiment_lane.py
+++ b/tests/test_experiment_lane.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Experiment lane activation:** seed controlled experiments from  distribution misses and KPI deltas.\n'
-        '- ** — Distribution batch #1:** publish coordinated posts linking demo assets to docs.\n',
+        "- ** — Experiment lane activation:** seed controlled experiments from  distribution misses and KPI deltas.\n"
+        "- ** — Distribution batch #1:** publish coordinated posts linking demo assets to docs.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-experiment-lane.md").write_text(
         d37._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-37-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-37-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/distribution-closeout-pack/distribution-closeout-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  launch plan committed',
-                '- [ ]  message kit reviewed with owner + backup',
-                '- [ ]  posting windows locked',
-                '- [ ]  experiment backlog seeded from channel misses',
-                '- [ ]  summary owner confirmed',
+                "#  delivery board",
+                "- [ ]  launch plan committed",
+                "- [ ]  message kit reviewed with owner + backup",
+                "- [ ]  posting windows locked",
+                "- [ ]  experiment backlog seeded from channel misses",
+                "- [ ]  summary owner confirmed",
             ]
         )
         + "\n",
@@ -119,7 +117,7 @@ def test_lane37_strict_fails_when_lane36_inputs_missing(tmp_path: Path) -> None:
 def test_lane37_strict_fails_when_lane36_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/distribution-closeout-pack/delivery-board.md").write_text(
-        '- [ ]  experiment backlog seeded from channel misses\n', encoding="utf-8"
+        "- [ ]  experiment backlog seeded from channel misses\n", encoding="utf-8"
     )
     rc = d37.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -129,4 +127,4 @@ def test_lane37_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["experiment-lane", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' experiment lane summary' in capsys.readouterr().out
+    assert " experiment lane summary" in capsys.readouterr().out

--- a/tests/test_feature_registry.py
+++ b/tests/test_feature_registry.py
@@ -63,7 +63,12 @@ def test_contract_script_runs_without_external_pythonpath() -> None:
     env.pop("PYTHONPATH", None)
 
     proc = subprocess.run(
-        [sys.executable, "scripts/check_feature_registry_contract.py", "--repo-root", str(repo_root)],
+        [
+            sys.executable,
+            "scripts/check_feature_registry_contract.py",
+            "--repo-root",
+            str(repo_root),
+        ],
         cwd=repo_root,
         env=env,
         capture_output=True,
@@ -81,7 +86,13 @@ def test_sync_script_check_mode_runs_without_external_pythonpath() -> None:
     env.pop("PYTHONPATH", None)
 
     proc = subprocess.run(
-        [sys.executable, "scripts/sync_feature_registry_docs.py", "--repo-root", str(repo_root), "--check"],
+        [
+            sys.executable,
+            "scripts/sync_feature_registry_docs.py",
+            "--repo-root",
+            str(repo_root),
+            "--check",
+        ],
         cwd=repo_root,
         env=env,
         capture_output=True,

--- a/tests/test_feature_registry_cli.py
+++ b/tests/test_feature_registry_cli.py
@@ -65,7 +65,9 @@ def test_feature_registry_cli_expect_command_passes_when_present(capsys) -> None
 
 
 def test_feature_registry_cli_expect_command_fails_when_missing(capsys) -> None:
-    rc = feature_registry_cli.main(["--expect-command", "nope-nope-nope", "--format", "summary-json"])
+    rc = feature_registry_cli.main(
+        ["--expect-command", "nope-nope-nope", "--format", "summary-json"]
+    )
     assert rc == 2
     err = capsys.readouterr().err
     assert "missing expected command" in err
@@ -121,7 +123,9 @@ def test_feature_registry_cli_expect_tier_count_mismatch_fails(capsys) -> None:
 
 
 def test_feature_registry_cli_invalid_expectation_format_fails(capsys) -> None:
-    rc = feature_registry_cli.main(["--expect-tier-count", "bad-format", "--format", "summary-json"])
+    rc = feature_registry_cli.main(
+        ["--expect-tier-count", "bad-format", "--format", "summary-json"]
+    )
     assert rc == 2
     err = capsys.readouterr().err
     assert "invalid tier-count expectation" in err

--- a/tests/test_governance_handoff_closeout.py
+++ b/tests/test_governance_handoff_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Launch readiness closeout lane:** convert launch readiness outcomes into governance ownership scorecards.\n'
-        '- ** — Governance handoff closeout lane:** convert launch readiness outcomes into governance ownership scorecards.\n',
+        "- ** — Launch readiness closeout lane:** convert launch readiness outcomes into governance ownership scorecards.\n"
+        "- ** — Governance handoff closeout lane:** convert launch readiness outcomes into governance ownership scorecards.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-governance-handoff-closeout.md").write_text(
         d87._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-87-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-87-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -62,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  evidence brief committed',
-                '- [ ]  launch readiness plan committed',
-                '- [ ]  narrative template upgrade ledger exported',
-                '- [ ]  storyline outcomes ledger exported',
-                '- [ ]  governance priorities drafted from  outcomes',
+                "#  delivery board",
+                "- [ ]  evidence brief committed",
+                "- [ ]  launch readiness plan committed",
+                "- [ ]  narrative template upgrade ledger exported",
+                "- [ ]  storyline outcomes ledger exported",
+                "- [ ]  governance priorities drafted from  outcomes",
             ]
         )
         + "\n",
@@ -167,4 +165,4 @@ def test_lane87_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["governance-handoff-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' governance handoff closeout summary' in capsys.readouterr().out
+    assert " governance handoff closeout summary" in capsys.readouterr().out

--- a/tests/test_governance_priorities_closeout.py
+++ b/tests/test_governance_priorities_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Launch readiness closeout lane:** convert launch readiness outcomes into governance ownership scorecards.\n'
-        '- ** — Governance priorities closeout lane:** convert governance handoff outcomes into governed roadmap priorities.\n',
+        "- ** — Launch readiness closeout lane:** convert launch readiness outcomes into governance ownership scorecards.\n"
+        "- ** — Governance priorities closeout lane:** convert governance handoff outcomes into governed roadmap priorities.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-governance-priorities-closeout.md").write_text(
         d88._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-88-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-88-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  evidence brief committed',
-                '- [ ]  governance handoff plan committed',
-                '- [ ]  narrative template upgrade ledger exported',
-                '- [ ]  storyline outcomes ledger exported',
-                '- [ ]  governance priorities drafted from  outcomes',
+                "#  delivery board",
+                "- [ ]  evidence brief committed",
+                "- [ ]  governance handoff plan committed",
+                "- [ ]  narrative template upgrade ledger exported",
+                "- [ ]  storyline outcomes ledger exported",
+                "- [ ]  governance priorities drafted from  outcomes",
             ]
         )
         + "\n",
@@ -172,4 +170,4 @@ def test_lane88_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["governance-priorities-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' governance priorities closeout summary' in capsys.readouterr().out
+    assert " governance priorities closeout summary" in capsys.readouterr().out

--- a/tests/test_governance_scale_closeout.py
+++ b/tests/test_governance_scale_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Governance priorities closeout lane:** convert governance handoff outcomes into governance priorities.\n'
-        '- ** — Governance scale closeout lane:** scale governance priorities into deterministic execution lanes.\n',
+        "- ** — Governance priorities closeout lane:** convert governance handoff outcomes into governance priorities.\n"
+        "- ** — Governance scale closeout lane:** scale governance priorities into deterministic execution lanes.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-governance-scale-closeout.md").write_text(
         d89._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-89-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-89-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  evidence brief committed',
-                '- [ ]  governance priorities plan committed',
-                '- [ ]  narrative template upgrade ledger exported',
-                '- [ ]  storyline outcomes ledger exported',
-                '- [ ]  governance priorities drafted from  outcomes',
+                "#  delivery board",
+                "- [ ]  evidence brief committed",
+                "- [ ]  governance priorities plan committed",
+                "- [ ]  narrative template upgrade ledger exported",
+                "- [ ]  storyline outcomes ledger exported",
+                "- [ ]  governance priorities drafted from  outcomes",
             ]
         )
         + "\n",
@@ -164,4 +162,4 @@ def test_lane89_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["governance-scale-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' governance scale closeout summary' in capsys.readouterr().out
+    assert " governance scale closeout summary" in capsys.readouterr().out

--- a/tests/test_growth_campaign_closeout.py
+++ b/tests/test_growth_campaign_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Partner outreach closeout:** publish partner onboarding execution checklist.\n'
-        '- ** — Growth campaign closeout:** convert partner outcomes into deterministic campaign controls.\n',
+        "- ** — Partner outreach closeout:** publish partner onboarding execution checklist.\n"
+        "- ** — Growth campaign closeout:** convert partner outcomes into deterministic campaign controls.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-growth-campaign-closeout.md").write_text(
         d81._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-81-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-81-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -62,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  partner outreach plan committed',
-                '- [ ]  partner execution ledger exported',
-                '- [ ]  partner KPI scorecard snapshot exported',
-                '- [ ]  growth campaign priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  partner outreach plan committed",
+                "- [ ]  partner execution ledger exported",
+                "- [ ]  partner KPI scorecard snapshot exported",
+                "- [ ]  growth campaign priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -156,4 +154,4 @@ def test_lane81_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["growth-campaign-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' growth campaign closeout summary' in capsys.readouterr().out
+    assert " growth campaign closeout summary" in capsys.readouterr().out

--- a/tests/test_integration_expansion2_closeout.py
+++ b/tests/test_integration_expansion2_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Integration expansion #2:** publish advanced GitLab CI implementation path.\n'
-        '- ** — Integration expansion #3:** publish advanced Jenkins implementation path.\n',
+        "- ** — Integration expansion #2:** publish advanced GitLab CI implementation path.\n"
+        "- ** — Integration expansion #3:** publish advanced Jenkins implementation path.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-integration-expansion2-closeout.md").write_text(
         d66._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-66-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-66-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root / "docs/artifacts/weekly-review-closeout-pack-2/weekly-review-closeout-summary-2.json"
@@ -62,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  weekly brief committed',
-                '- [ ]  KPI dashboard snapshot exported',
-                '- [ ]  governance decision register published',
-                '- [ ]  risk and recovery ledger exported',
-                '- [ ]  integration expansion priorities drafted from  review',
+                "#  delivery board",
+                "- [ ]  weekly brief committed",
+                "- [ ]  KPI dashboard snapshot exported",
+                "- [ ]  governance decision register published",
+                "- [ ]  risk and recovery ledger exported",
+                "- [ ]  integration expansion priorities drafted from  review",
             ]
         )
         + "\n",

--- a/tests/test_integration_expansion3_closeout.py
+++ b/tests/test_integration_expansion3_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Integration expansion #3:** publish advanced Jenkins implementation path.\n'
-        '- ** — Integration expansion #4:** publish self-hosted enterprise implementation path.\n',
+        "- ** — Integration expansion #3:** publish advanced Jenkins implementation path.\n"
+        "- ** — Integration expansion #4:** publish self-hosted enterprise implementation path.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-integration-expansion3-closeout.md").write_text(
         d67._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-67-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-67-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  advanced GitLab pipeline blueprint published',
-                '- [ ]  matrix and cache strategy exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  integration expansion priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  advanced GitLab pipeline blueprint published",
+                "- [ ]  matrix and cache strategy exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  integration expansion priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_integration_expansion4_closeout.py
+++ b/tests/test_integration_expansion4_closeout.py
@@ -20,7 +20,7 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '-  integration expansion\n-  case study prep\n',
+        "-  integration expansion\n-  case study prep\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-integration-expansion4-closeout.md").write_text(
@@ -54,7 +54,7 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
+                "#  delivery board",
                 "- [ ] task 1",
                 "- [ ] task 2",
                 "- [ ] task 3",

--- a/tests/test_integration_feedback_closeout.py
+++ b/tests/test_integration_feedback_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Growth campaign closeout:** convert partner outcomes into deterministic campaign controls.\n'
-        '- ** — Integration feedback loop:** fold field feedback into docs/templates.\n',
+        "- ** — Growth campaign closeout:** convert partner outcomes into deterministic campaign controls.\n"
+        "- ** — Integration feedback loop:** fold field feedback into docs/templates.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-integration-feedback-closeout.md").write_text(
         d82._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-82-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-82-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root / "docs/artifacts/growth-campaign-closeout-pack/growth-campaign-closeout-summary.json"
@@ -59,12 +57,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  growth campaign plan committed',
-                '- [ ]  campaign execution ledger exported',
-                '- [ ]  campaign KPI scorecard snapshot exported',
-                '- [ ]  execution priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  growth campaign plan committed",
+                "- [ ]  campaign execution ledger exported",
+                "- [ ]  campaign KPI scorecard snapshot exported",
+                "- [ ]  execution priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -163,4 +161,4 @@ def test_lane82_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["integration-feedback-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' integration feedback closeout summary' in capsys.readouterr().out
+    assert " integration feedback closeout summary" in capsys.readouterr().out

--- a/tests/test_kits_blueprint.py
+++ b/tests/test_kits_blueprint.py
@@ -225,10 +225,7 @@ def test_radar_payload_exposes_dashboard_cards_and_watchlists(tmp_path: Path) ->
 
 def test_discover_payload_aligns_catalog_optimize_expand_and_radar(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text(
-        "[project]\n"
-        "name='x'\n"
-        "version='0.1.0'\n"
-        "dependencies=['httpx>=0.28.1,<1']\n",
+        "[project]\nname='x'\nversion='0.1.0'\ndependencies=['httpx>=0.28.1,<1']\n",
         encoding="utf-8",
     )
     src_dir = tmp_path / "src" / "demo"

--- a/tests/test_kpi_audit.py
+++ b/tests/test_kpi_audit.py
@@ -27,7 +27,7 @@ def _seed_repo(root: Path) -> None:
     (root / "docs").mkdir(parents=True, exist_ok=True)
     (root / "docs/index.md").write_text("impact-27-ultra-upgrade-report.md\n", encoding="utf-8")
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — KPI audit:** compare baseline vs current (stars/week, CTR, discussions, PRs).\n',
+        "- ** — KPI audit:** compare baseline vs current (stars/week, CTR, discussions, PRs).\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-kpi-audit.md").write_text(
@@ -81,9 +81,7 @@ def test_emit_pack_and_execute(tmp_path: Path) -> None:
 
 def test_strict_fails_when_sections_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
-    (tmp_path / "docs/integrations-kpi-audit.md").write_text(
-        '# KPI audit ()\n', encoding="utf-8"
-    )
+    (tmp_path / "docs/integrations-kpi-audit.md").write_text("# KPI audit ()\n", encoding="utf-8")
     rc = kpa.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
 
@@ -92,4 +90,4 @@ def test_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["kpi-audit", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' KPI audit summary' in capsys.readouterr().out
+    assert " KPI audit summary" in capsys.readouterr().out

--- a/tests/test_kpi_deep_audit_closeout.py
+++ b/tests/test_kpi_deep_audit_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — KPI deep audit:** validate strict trendlines and blockers.\n'
-        '- ** — Execution sprint:** convert audit outcomes into shipped changes.\n',
+        "- ** — KPI deep audit:** validate strict trendlines and blockers.\n"
+        "- ** — Execution sprint:** convert audit outcomes into shipped changes.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-kpi-deep-audit-closeout.md").write_text(
         d57._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-57-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-57-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root / "docs/artifacts/stabilization-closeout-pack/stabilization-closeout-summary.json"
@@ -59,12 +57,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  stabilization brief committed',
-                '- [ ]  stabilization plan reviewed with owner + backup',
-                '- [ ]  risk ledger exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  deep-audit priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  stabilization brief committed",
+                "- [ ]  stabilization plan reviewed with owner + backup",
+                "- [ ]  risk ledger exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  deep-audit priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_kpi_instrumentation.py
+++ b/tests/test_kpi_instrumentation.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — KPI instrumentation:** close attribution gaps and lock weekly review metrics.\n'
-        '- ** — Demo asset #3:** produce/publish `security gate` workflow short video or GIF.\n',
+        "- ** — KPI instrumentation:** close attribution gaps and lock weekly review metrics.\n"
+        "- ** — Demo asset #3:** produce/publish `security gate` workflow short video or GIF.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-kpi-instrumentation.md").write_text(
         d35._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-35-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-35-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/demo-asset2-pack/demo-asset2-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  script draft committed',
-                '- [ ]  first cut rendered',
-                '- [ ]  final cut + caption copy approved',
-                '- [ ]  KPI instrumentation backlog pre-scoped',
-                '- [ ]  community distribution plan updated',
+                "#  delivery board",
+                "- [ ]  script draft committed",
+                "- [ ]  first cut rendered",
+                "- [ ]  final cut + caption copy approved",
+                "- [ ]  KPI instrumentation backlog pre-scoped",
+                "- [ ]  community distribution plan updated",
             ]
         )
         + "\n",
@@ -122,7 +120,7 @@ def test_kpi_instrumentation_strict_fails_when_lane34_inputs_missing(tmp_path: P
 def test_kpi_instrumentation_strict_fails_when_lane34_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/demo-asset2-pack/demo-asset2-delivery-board.md").write_text(
-        '- [ ]  KPI instrumentation backlog pre-scoped\n', encoding="utf-8"
+        "- [ ]  KPI instrumentation backlog pre-scoped\n", encoding="utf-8"
     )
     rc = d35.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -132,4 +130,4 @@ def test_kpi_instrumentation_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["kpi-instrumentation", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' KPI instrumentation summary' in capsys.readouterr().out
+    assert " KPI instrumentation summary" in capsys.readouterr().out

--- a/tests/test_launch_readiness_closeout.py
+++ b/tests/test_launch_readiness_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Release prioritization closeout lane:** convert trust outcomes into release-ready narrative proof packs.\n'
-        '- ** — Launch readiness closeout lane:** convert release priorities into deterministic launch execution lanes.\n',
+        "- ** — Release prioritization closeout lane:** convert trust outcomes into release-ready narrative proof packs.\n"
+        "- ** — Launch readiness closeout lane:** convert release priorities into deterministic launch execution lanes.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-launch-readiness-closeout.md").write_text(
         d86._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-86-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-86-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  evidence brief committed',
-                '- [ ]  release prioritization plan committed',
-                '- [ ]  narrative template upgrade ledger exported',
-                '- [ ]  storyline outcomes ledger exported',
-                '- [ ]  launch priorities drafted from  outcomes',
+                "#  delivery board",
+                "- [ ]  evidence brief committed",
+                "- [ ]  release prioritization plan committed",
+                "- [ ]  narrative template upgrade ledger exported",
+                "- [ ]  storyline outcomes ledger exported",
+                "- [ ]  launch priorities drafted from  outcomes",
             ]
         )
         + "\n",
@@ -164,4 +162,4 @@ def test_lane86_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["launch-readiness-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' launch readiness closeout summary' in capsys.readouterr().out
+    assert " launch readiness closeout summary" in capsys.readouterr().out

--- a/tests/test_objection_closeout.py
+++ b/tests/test_objection_closeout.py
@@ -25,16 +25,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Objection closeout lock:** convert reliability wins into deterministic objection playbooks.\n'
-        '- ** — Weekly review closeout:** harden the evidence-to-priorities loop.\n',
+        "- ** — Objection closeout lock:** convert reliability wins into deterministic objection playbooks.\n"
+        "- ** — Weekly review closeout:** harden the evidence-to-priorities loop.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-objection-closeout.md").write_text(
         d48._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-48-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-48-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root / "docs/artifacts/reliability-closeout-pack-47/reliability-closeout-summary-47.json"
@@ -54,12 +52,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  reliability closeout brief committed',
-                '- [ ]  winners and misses reviewed with owner + backup',
-                '- [ ]  risk register exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  objection priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  reliability closeout brief committed",
+                "- [ ]  winners and misses reviewed with owner + backup",
+                "- [ ]  risk register exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  objection priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -120,4 +118,4 @@ def test_lane48_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["objection-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' objection closeout summary' in capsys.readouterr().out
+    assert " objection closeout summary" in capsys.readouterr().out

--- a/tests/test_optimization_closeout.py
+++ b/tests/test_optimization_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Optimization lane continuation:** convert  expansion wins into optimization plays.\n'
-        '- ** — Reliability lane continuation:** convert  optimization wins into reliability plays.\n',
+        "- ** — Optimization lane continuation:** convert  expansion wins into optimization plays.\n"
+        "- ** — Reliability lane continuation:** convert  optimization wins into reliability plays.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-optimization-closeout.md").write_text(
         d46._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-46-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-46-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/expansion-closeout-pack/expansion-closeout-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  expansion plan draft committed',
-                '- [ ]  review notes captured with owner + backup',
-                '- [ ]  growth matrix exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  optimization priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  expansion plan draft committed",
+                "- [ ]  review notes captured with owner + backup",
+                "- [ ]  growth matrix exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  optimization priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -135,4 +133,4 @@ def test_lane46_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["optimization-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' optimization closeout summary' in capsys.readouterr().out
+    assert " optimization closeout summary" in capsys.readouterr().out

--- a/tests/test_optimization_closeout_foundation.py
+++ b/tests/test_optimization_closeout_foundation.py
@@ -30,8 +30,8 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- **Optimization Closeout Foundation — Optimization closeout lane:** convert  evidence into deterministic remediation loops.\n'
-        '- ** — Acceleration lane kickoff:** scale Optimization Closeout Foundation optimizations into repeatable growth plays.\n',
+        "- **Optimization Closeout Foundation — Optimization closeout lane:** convert  evidence into deterministic remediation loops.\n"
+        "- ** — Acceleration lane kickoff:** scale Optimization Closeout Foundation optimizations into repeatable growth plays.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-optimization-closeout-foundation.md").write_text(
@@ -57,12 +57,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  expansion plan draft committed',
-                '- [ ]  review notes captured with owner + backup',
-                '- [ ]  automation matrix exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ] Optimization Closeout Foundation optimization priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  expansion plan draft committed",
+                "- [ ]  review notes captured with owner + backup",
+                "- [ ]  automation matrix exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ] Optimization Closeout Foundation optimization priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_phase1_hardening.py
+++ b/tests/test_phase1_hardening.py
@@ -30,18 +30,16 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Phase-1 hardening:** close stale docs gaps and polish top entry pages.\n',
+        "- ** — Phase-1 hardening:** close stale docs gaps and polish top entry pages.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-weekly-review.md").write_text(
-        '# Weekly review #4 ()\n', encoding="utf-8"
+        "# Weekly review #4 ()\n", encoding="utf-8"
     )
     (root / "docs/integrations-phase1-hardening.md").write_text(
         d29._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-29-ultra-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-29-ultra-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
 
 def test_phase1_hardening_hardening_json(tmp_path: Path, capsys) -> None:
@@ -85,7 +83,7 @@ def test_phase1_hardening_emit_pack_and_execute(tmp_path: Path) -> None:
 def test_phase1_hardening_strict_fails_when_sections_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/integrations-phase1-hardening.md").write_text(
-        '#  — Phase-1 hardening\n', encoding="utf-8"
+        "#  — Phase-1 hardening\n", encoding="utf-8"
     )
     rc = d29.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -95,4 +93,4 @@ def test_phase1_hardening_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase1-hardening", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' phase-1 hardening summary' in capsys.readouterr().out
+    assert " phase-1 hardening summary" in capsys.readouterr().out

--- a/tests/test_phase1_wrap.py
+++ b/tests/test_phase1_wrap.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Phase-1 wrap + handoff:** publish a full report and lock Phase-2 backlog.\n'
-        '- ** — Phase-2 kickoff:** set baseline metrics from end of Phase 1 and define weekly growth targets.\n',
+        "- ** — Phase-1 wrap + handoff:** publish a full report and lock Phase-2 backlog.\n"
+        "- ** — Phase-2 kickoff:** set baseline metrics from end of Phase 1 and define weekly growth targets.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-phase1-wrap.md").write_text(
         d30._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-30-ultra-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-30-ultra-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     for rel in [
         "docs/artifacts/kpi-audit-pack/kpi-audit-summary.json",
@@ -98,4 +96,4 @@ def test_phase1_wrap_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase1-wrap", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' phase-1 wrap summary' in capsys.readouterr().out
+    assert " phase-1 wrap summary" in capsys.readouterr().out

--- a/tests/test_phase2_hardening_closeout.py
+++ b/tests/test_phase2_hardening_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Phase-2 hardening:** polish highest-traffic pages and remove top friction points.\n'
-        '- ** — Phase-3 pre-plan:** convert Phase-2 learnings into Phase-3 priorities.\n',
+        "- ** — Phase-2 hardening:** polish highest-traffic pages and remove top friction points.\n"
+        "- ** — Phase-3 pre-plan:** convert Phase-2 learnings into Phase-3 priorities.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-phase2-hardening-closeout.md").write_text(
         d58._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-58-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-58-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root / "docs/artifacts/kpi-deep-audit-closeout-pack/kpi-deep-audit-closeout-summary.json"
@@ -59,12 +57,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  KPI deep audit brief committed',
-                '- [ ]  deep-audit plan reviewed with owner + backup',
-                '- [ ]  risk ledger exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  execution priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  KPI deep audit brief committed",
+                "- [ ]  deep-audit plan reviewed with owner + backup",
+                "- [ ]  risk ledger exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  execution priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_phase2_kickoff.py
+++ b/tests/test_phase2_kickoff.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Phase-2 kickoff:** set baseline metrics from end of Phase 1 and define weekly growth targets.\n'
-        '- ** — Release cadence setup:** lock weekly release rhythm and changelog publication checklist.\n',
+        "- ** — Phase-2 kickoff:** set baseline metrics from end of Phase 1 and define weekly growth targets.\n"
+        "- ** — Release cadence setup:** lock weekly release rhythm and changelog publication checklist.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-phase2-kickoff.md").write_text(
         d31._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-31-ultra-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-31-ultra-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/phase1-wrap-pack/phase1-wrap-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -58,14 +56,14 @@ def _seed_repo(root: Path) -> None:
         "\n".join(
             [
                 "# Locked Phase-2 backlog",
-                '- [ ]  baseline metrics + weekly targets',
-                '- [ ]  release cadence + changelog checklist',
-                '- [ ]  demo asset #1 (doctor)',
-                '- [ ]  demo asset #2 (repo audit)',
-                '- [ ]  weekly review #5',
-                '- [ ]  demo asset #3 (security gate)',
-                '- [ ]  demo asset #4 (cassette replay)',
-                '- [ ]  distribution batch #1',
+                "- [ ]  baseline metrics + weekly targets",
+                "- [ ]  release cadence + changelog checklist",
+                "- [ ]  demo asset #1 (doctor)",
+                "- [ ]  demo asset #2 (repo audit)",
+                "- [ ]  weekly review #5",
+                "- [ ]  demo asset #3 (security gate)",
+                "- [ ]  demo asset #4 (cassette replay)",
+                "- [ ]  distribution batch #1",
             ]
         )
         + "\n",
@@ -123,7 +121,7 @@ def test_lane31_strict_fails_when_lane30_inputs_missing(tmp_path: Path) -> None:
 def test_lane31_strict_fails_when_backlog_is_not_phase2_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/phase1-wrap-pack/phase1-wrap-phase2-backlog.md").write_text(
-        '- [ ]  baseline\n', encoding="utf-8"
+        "- [ ]  baseline\n", encoding="utf-8"
     )
     rc = d31.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -133,4 +131,4 @@ def test_lane31_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase2-kickoff", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' phase-2 kickoff summary' in capsys.readouterr().out
+    assert " phase-2 kickoff summary" in capsys.readouterr().out

--- a/tests/test_phase2_wrap_handoff_closeout.py
+++ b/tests/test_phase2_wrap_handoff_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Phase-2 wrap + handoff:** publish full Phase-2 report and lock Phase-3 execution board.\n'
-        '- ** — Phase-3 kickoff:** set Phase-3 baseline and define ecosystem/trust KPIs.\n',
+        "- ** — Phase-2 wrap + handoff:** publish full Phase-2 report and lock Phase-3 execution board.\n"
+        "- ** — Phase-3 kickoff:** set Phase-3 baseline and define ecosystem/trust KPIs.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-phase2-wrap-handoff-closeout.md").write_text(
         d60._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-60-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-60-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root / "docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json"
@@ -59,12 +57,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  Phase-3 pre-plan brief committed',
-                '- [ ]  pre-plan reviewed with owner + backup',
-                '- [ ]  risk ledger exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  execution priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  Phase-3 pre-plan brief committed",
+                "- [ ]  pre-plan reviewed with owner + backup",
+                "- [ ]  risk ledger exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  execution priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_phase3_kickoff_closeout.py
+++ b/tests/test_phase3_kickoff_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Phase-3 kickoff:** set Phase-3 baseline and define ecosystem/trust KPIs.\n'
-        '- ** — Community program setup:** publish office-hours cadence and participation rules.\n',
+        "- ** — Phase-3 kickoff:** set Phase-3 baseline and define ecosystem/trust KPIs.\n"
+        "- ** — Community program setup:** publish office-hours cadence and participation rules.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-phase3-kickoff-closeout.md").write_text(
         d61._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-61-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-61-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  Phase-2 wrap + handoff brief committed',
-                '- [ ]  wrap reviewed with owner + backup',
-                '- [ ]  risk ledger exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  execution priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  Phase-2 wrap + handoff brief committed",
+                "- [ ]  wrap reviewed with owner + backup",
+                "- [ ]  risk ledger exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  execution priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_phase3_preplan_closeout.py
+++ b/tests/test_phase3_preplan_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Phase-3 pre-plan:** convert Phase-2 learnings into Phase-3 priorities.\n'
-        '- ** — Phase-2 wrap + handoff:** publish full Phase-2 report and lock Phase-3 execution board.\n',
+        "- ** — Phase-3 pre-plan:** convert Phase-2 learnings into Phase-3 priorities.\n"
+        "- ** — Phase-2 wrap + handoff:** publish full Phase-2 report and lock Phase-3 execution board.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-phase3-preplan-closeout.md").write_text(
         d59._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-59-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-59-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -62,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  Phase-2 hardening brief committed',
-                '- [ ]  hardening plan reviewed with owner + backup',
-                '- [ ]  risk ledger exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  pre-plan priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  Phase-2 hardening brief committed",
+                "- [ ]  hardening plan reviewed with owner + backup",
+                "- [ ]  risk ledger exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  pre-plan priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_phase3_wrap_publication_closeout.py
+++ b/tests/test_phase3_wrap_publication_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Governance priorities closeout lane:** convert governance handoff outcomes into governance scale.\n'
-        '- ** — Phase-3 wrap publication closeout lane:** scale governance scale into deterministic execution lanes.\n',
+        "- ** — Governance priorities closeout lane:** convert governance handoff outcomes into governance scale.\n"
+        "- ** — Phase-3 wrap publication closeout lane:** scale governance scale into deterministic execution lanes.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-phase3-wrap-publication-closeout.md").write_text(
         d90._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-90-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-90-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -62,12 +60,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  evidence brief committed',
-                '- [ ]  governance scale plan committed',
-                '- [ ]  narrative template upgrade ledger exported',
-                '- [ ]  storyline outcomes ledger exported',
-                '- [ ]  governance scale drafted from  outcomes',
+                "#  delivery board",
+                "- [ ]  evidence brief committed",
+                "- [ ]  governance scale plan committed",
+                "- [ ]  narrative template upgrade ledger exported",
+                "- [ ]  storyline outcomes ledger exported",
+                "- [ ]  governance scale drafted from  outcomes",
             ]
         )
         + "\n",
@@ -174,4 +172,4 @@ def test_lane90_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["phase3-wrap-publication-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' phase-3 wrap publication closeout summary' in capsys.readouterr().out
+    assert " phase-3 wrap publication closeout summary" in capsys.readouterr().out

--- a/tests/test_playbook_post.py
+++ b/tests/test_playbook_post.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Playbook post #1:** publish the first reliability playbook post from  data.\n'
-        '- ** — Scale lane kickoff:** expand publication motion across additional channels.\n',
+        "- ** — Playbook post #1:** publish the first reliability playbook post from  data.\n"
+        "- ** — Scale lane kickoff:** expand publication motion across additional channels.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-playbook-post.md").write_text(
         d39._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-39-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-39-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/distribution-batch-pack/distribution-batch-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  channel plan committed',
-                '- [ ]  post copy reviewed with owner + backup',
-                '- [ ]  scheduling matrix exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  playbook post priorities drafted from  outcomes',
+                "#  delivery board",
+                "- [ ]  channel plan committed",
+                "- [ ]  post copy reviewed with owner + backup",
+                "- [ ]  scheduling matrix exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  playbook post priorities drafted from  outcomes",
             ]
         )
         + "\n",
@@ -118,4 +116,4 @@ def test_lane39_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["playbook-post", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' playbook post summary' in capsys.readouterr().out
+    assert " playbook post summary" in capsys.readouterr().out

--- a/tests/test_playbooks_cli_extra.py
+++ b/tests/test_playbooks_cli_extra.py
@@ -22,9 +22,9 @@ def test_alias_helpers_and_discovery(tmp_path: Path) -> None:
 
 
 def test_search_filters_day_tokens() -> None:
-    assert pc._apply_search_list(['-review', "weekly-review"], None) == ["weekly-review"]
-    assert pc._apply_search_list(["weekly-review", "release"], ' weekly') == ["weekly-review"]
-    assert pc._apply_search_aliases({'-alias': "weekly-review", "stable": "release"}, None) == {
+    assert pc._apply_search_list(["-review", "weekly-review"], None) == ["weekly-review"]
+    assert pc._apply_search_list(["weekly-review", "release"], " weekly") == ["weekly-review"]
+    assert pc._apply_search_aliases({"-alias": "weekly-review", "stable": "release"}, None) == {
         "stable": "release"
     }
 

--- a/tests/test_quality_script.py
+++ b/tests/test_quality_script.py
@@ -76,7 +76,7 @@ def test_quality_script_registry_mode_runs_contract_chain() -> None:
     match = re.search(r"  registry\)\n(?P<body>.*?    ;;)", text, re.DOTALL)
     assert match is not None
     body = match.group("body")
-    assert "run_required \"feature_registry_contract\"" in body
+    assert 'run_required "feature_registry_contract"' in body
     assert "run_registry_contract" in body
     assert "--expect-command kits" in text
     assert "--expect-total 8" in text

--- a/tests/test_release_cadence.py
+++ b/tests/test_release_cadence.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Release cadence setup:** lock weekly release rhythm and changelog publication checklist.\n'
-        '- ** — Demo asset #1:** produce/publish `doctor` workflow short video or GIF.\n',
+        "- ** — Release cadence setup:** lock weekly release rhythm and changelog publication checklist.\n"
+        "- ** — Demo asset #1:** produce/publish `doctor` workflow short video or GIF.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-release-cadence.md").write_text(
         d32._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-32-ultra-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-32-ultra-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/phase2-kickoff-pack/phase2-kickoff-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  baseline metrics snapshot emitted',
-                '- [ ]  release cadence checklist drafted',
-                '- [ ]  demo asset plan (doctor) assigned',
-                '- [ ]  demo asset plan (repo audit) assigned',
-                '- [ ]  weekly review preparation checklist ready',
+                "#  delivery board",
+                "- [ ]  baseline metrics snapshot emitted",
+                "- [ ]  release cadence checklist drafted",
+                "- [ ]  demo asset plan (doctor) assigned",
+                "- [ ]  demo asset plan (repo audit) assigned",
+                "- [ ]  weekly review preparation checklist ready",
             ]
         )
         + "\n",
@@ -117,7 +115,7 @@ def test_release_cadence_strict_fails_when_lane31_inputs_missing(tmp_path: Path)
 def test_release_cadence_strict_fails_when_lane31_board_is_not_ready(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/artifacts/phase2-kickoff-pack/phase2-kickoff-delivery-board.md").write_text(
-        '- [ ]  release cadence checklist drafted\n', encoding="utf-8"
+        "- [ ]  release cadence checklist drafted\n", encoding="utf-8"
     )
     rc = d32.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -127,4 +125,4 @@ def test_release_cadence_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["release-cadence", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' release cadence summary' in capsys.readouterr().out
+    assert " release cadence summary" in capsys.readouterr().out

--- a/tests/test_release_prioritization_closeout.py
+++ b/tests/test_release_prioritization_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Evidence narrative closeout lane:** convert field objections into deterministic trust upgrades.\n'
-        '- ** — Release prioritization closeout lane:** convert trust outcomes into release-ready narrative proof packs.\n',
+        "- ** — Evidence narrative closeout lane:** convert field objections into deterministic trust upgrades.\n"
+        "- ** — Release prioritization closeout lane:** convert trust outcomes into release-ready narrative proof packs.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-release-prioritization-closeout.md").write_text(
         d85._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-85-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-85-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  evidence brief committed',
-                '- [ ]  evidence narrative plan committed',
-                '- [ ]  narrative template upgrade ledger exported',
-                '- [ ]  storyline outcomes ledger exported',
-                '- [ ]  release priorities drafted from  outcomes',
+                "#  delivery board",
+                "- [ ]  evidence brief committed",
+                "- [ ]  evidence narrative plan committed",
+                "- [ ]  narrative template upgrade ledger exported",
+                "- [ ]  storyline outcomes ledger exported",
+                "- [ ]  release priorities drafted from  outcomes",
             ]
         )
         + "\n",
@@ -173,4 +171,4 @@ def test_lane85_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["release-prioritization-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' release prioritization closeout summary' in capsys.readouterr().out
+    assert " release prioritization closeout summary" in capsys.readouterr().out

--- a/tests/test_reliability_closeout.py
+++ b/tests/test_reliability_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Optimization lane continuation:** convert  expansion wins into optimization plays.\n'
-        '- ** — Reliability lane continuation:** convert  optimization wins into reliability plays.\n',
+        "- ** — Optimization lane continuation:** convert  expansion wins into optimization plays.\n"
+        "- ** — Reliability lane continuation:** convert  optimization wins into reliability plays.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-reliability-closeout.md").write_text(
         d47._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-47-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-47-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/optimization-closeout-pack/optimization-closeout-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  optimization plan draft committed',
-                '- [ ]  review notes captured with owner + backup',
-                '- [ ]  bottleneck map exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  reliability priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  optimization plan draft committed",
+                "- [ ]  review notes captured with owner + backup",
+                "- [ ]  bottleneck map exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  reliability priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -124,4 +122,4 @@ def test_lane47_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["reliability-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' reliability closeout summary' in capsys.readouterr().out
+    assert " reliability closeout summary" in capsys.readouterr().out

--- a/tests/test_reliability_evidence_pack.py
+++ b/tests/test_reliability_evidence_pack.py
@@ -167,7 +167,6 @@ def test_reliability_pack_help_prefers_canonical_summary_flags() -> None:
     assert "--cq_summary-summary" not in help_text
 
 
-
 def test_reliability_pack_load_json_requires_object(tmp_path: Path) -> None:
     p = tmp_path / "bad.json"
     p.write_text("[]\n", encoding="utf-8")

--- a/tests/test_roadmap_cli.py
+++ b/tests/test_roadmap_cli.py
@@ -22,7 +22,11 @@ def test_load_manifest_resolves_report_and_plan_paths(tmp_path: Path, monkeypatc
         json.dumps(
             {
                 "phases": [
-                    {"impact": 1, "report_file": "impact01-report.md", "plan_file": "impact01-plan.json"}
+                    {
+                        "impact": 1,
+                        "report_file": "impact01-report.md",
+                        "plan_file": "impact01-plan.json",
+                    }
                 ]
             }
         ),

--- a/tests/test_scale_closeout.py
+++ b/tests/test_scale_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Scale closeout lane:** convert  acceleration proof into deterministic scale loops.\n'
-        '- ** — Expansion lane continuation:** convert  scale wins into expansion plays.\n',
+        "- ** — Scale closeout lane:** convert  acceleration proof into deterministic scale loops.\n"
+        "- ** — Expansion lane continuation:** convert  scale wins into expansion plays.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-scale-closeout.md").write_text(
         d44._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-44-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-44-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  acceleration plan draft committed',
-                '- [ ]  review notes captured with owner + backup',
-                '- [ ]  remediation matrix exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  scale priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  acceleration plan draft committed",
+                "- [ ]  review notes captured with owner + backup",
+                "- [ ]  remediation matrix exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  scale priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_scale_lane.py
+++ b/tests/test_scale_lane.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Scale lane #1:** expand distribution and publication motion across channels.\n'
-        '- ** — Expansion lane kickoff:** convert  outcomes into repeatable automation.\n',
+        "- ** — Scale lane #1:** expand distribution and publication motion across channels.\n"
+        "- ** — Expansion lane kickoff:** convert  outcomes into repeatable automation.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-scale-lane.md").write_text(
         d40._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-40-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-40-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/playbook-post-pack/playbook-post-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -57,12 +55,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  playbook draft committed',
-                '- [ ]  review notes captured with owner + backup',
-                '- [ ]  rollout timeline exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  scale priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  playbook draft committed",
+                "- [ ]  review notes captured with owner + backup",
+                "- [ ]  rollout timeline exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  scale priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -118,4 +116,4 @@ def test_lane40_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["scale-lane", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' scale lane summary' in capsys.readouterr().out
+    assert " scale lane summary" in capsys.readouterr().out

--- a/tests/test_stabilization_closeout.py
+++ b/tests/test_stabilization_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Stabilization closeout:** enforce deterministic follow-through and recovery loops.\n'
-        '- ** — KPI deep audit:** validate strict trendlines and blockers.\n',
+        "- ** — Stabilization closeout:** enforce deterministic follow-through and recovery loops.\n"
+        "- ** — KPI deep audit:** validate strict trendlines and blockers.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-stabilization-closeout.md").write_text(
         d56._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-56-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-56-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  contributor brief committed',
-                '- [ ]  activation plan reviewed with owner + backup',
-                '- [ ]  contributor ladder exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  contributor brief committed",
+                "- [ ]  activation plan reviewed with owner + backup",
+                "- [ ]  contributor ladder exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_trust_assets_refresh_closeout.py
+++ b/tests/test_trust_assets_refresh_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Trust assets refresh:** turn  outcomes into governance-grade trust proof.\n'
-        '- ** — Contributor recognition board:** publish contributor spotlight and release credits model.\n',
+        "- ** — Trust assets refresh:** turn  outcomes into governance-grade trust proof.\n"
+        "- ** — Contributor recognition board:** publish contributor spotlight and release credits model.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-trust-assets-refresh-closeout.md").write_text(
         d75._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-75-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-75-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  distribution scaling plan committed',
-                '- [ ]  channel controls and assumptions log exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  trust refresh priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  distribution scaling plan committed",
+                "- [ ]  channel controls and assumptions log exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  trust refresh priorities drafted from  learnings",
             ]
         )
         + "\n",

--- a/tests/test_trust_faq_expansion_closeout.py
+++ b/tests/test_trust_faq_expansion_closeout.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Integration feedback loop:** fold field feedback into docs/templates.\n'
-        '- ** — Trust FAQ expansion loop:** convert field objections into deterministic trust upgrades.\n',
+        "- ** — Integration feedback loop:** fold field feedback into docs/templates.\n"
+        "- ** — Trust FAQ expansion loop:** convert field objections into deterministic trust upgrades.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-trust-faq-expansion-closeout.md").write_text(
         d83._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-83-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-83-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  integration feedback plan committed',
-                '- [ ]  template upgrade ledger exported',
-                '- [ ]  office-hours outcome ledger exported',
-                '- [ ]  trust FAQ priorities drafted from  feedback',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  integration feedback plan committed",
+                "- [ ]  template upgrade ledger exported",
+                "- [ ]  office-hours outcome ledger exported",
+                "- [ ]  trust FAQ priorities drafted from  feedback",
             ]
         )
         + "\n",
@@ -167,4 +165,4 @@ def test_lane83_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["trust-faq-expansion-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' trust FAQ expansion closeout summary' in capsys.readouterr().out
+    assert " trust FAQ expansion closeout summary" in capsys.readouterr().out

--- a/tests/test_weekly_review_closeout.py
+++ b/tests/test_weekly_review_closeout.py
@@ -27,16 +27,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Weekly review closeout:** convert objection wins into deterministic weekly review loops.\n'
-        '- ** — Execution prioritization:** lock ownership and priorities for release motion.\n',
+        "- ** — Weekly review closeout:** convert objection wins into deterministic weekly review loops.\n"
+        "- ** — Execution prioritization:** lock ownership and priorities for release motion.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-weekly-review-closeout.md").write_text(
         d49._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-49-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-49-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/objection-closeout-pack/objection-closeout-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -54,12 +52,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  objection plan draft committed',
-                '- [ ]  review notes captured with owner + backup',
-                '- [ ]  FAQ objection map exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  weekly-review priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  objection plan draft committed",
+                "- [ ]  review notes captured with owner + backup",
+                "- [ ]  FAQ objection map exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  weekly-review priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -125,7 +123,7 @@ def test_lane49_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["weekly-review-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' advanced weekly review control tower summary' in capsys.readouterr().out
+    assert " advanced weekly review control tower summary" in capsys.readouterr().out
 
 
 def test_lane49_advanced_alias_cli_rejected(tmp_path: Path, capsys) -> None:

--- a/tests/test_weekly_review_closeout_2.py
+++ b/tests/test_weekly_review_closeout_2.py
@@ -30,16 +30,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Weekly review #9:** report baseline movement and community signal quality.\n'
-        '- ** — Integration expansion #2:** publish advanced GitLab CI implementation path.\n',
+        "- ** — Weekly review #9:** report baseline movement and community signal quality.\n"
+        "- ** — Integration expansion #2:** publish advanced GitLab CI implementation path.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-weekly-review-closeout-2.md").write_text(
         d65._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-65-big-upgrade-report.md").write_text(
-        '#  report\n', encoding="utf-8"
-    )
+    (root / "docs/impact-65-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
 
     summary = (
         root
@@ -63,12 +61,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                '#  delivery board',
-                '- [ ]  integration brief committed',
-                '- [ ]  advanced workflow blueprint published',
-                '- [ ]  matrix and concurrency plan exported',
-                '- [ ]  KPI scorecard snapshot exported',
-                '- [ ]  weekly review priorities drafted from  learnings',
+                "#  delivery board",
+                "- [ ]  integration brief committed",
+                "- [ ]  advanced workflow blueprint published",
+                "- [ ]  matrix and concurrency plan exported",
+                "- [ ]  KPI scorecard snapshot exported",
+                "- [ ]  weekly review priorities drafted from  learnings",
             ]
         )
         + "\n",
@@ -77,7 +75,7 @@ def _seed_repo(root: Path) -> None:
 
     workflow = root / ".github/workflows/advanced-github-actions-reference-64.yml"
     workflow.parent.mkdir(parents=True, exist_ok=True)
-    workflow.write_text('name:  Advanced GitHub Actions Reference\n', encoding="utf-8")
+    workflow.write_text("name:  Advanced GitHub Actions Reference\n", encoding="utf-8")
 
 
 def test_lane65_json(tmp_path: Path, capsys) -> None:

--- a/tests/test_weekly_review_lane.py
+++ b/tests/test_weekly_review_lane.py
@@ -27,7 +27,7 @@ def _seed_repo(root: Path) -> None:
     (root / "docs").mkdir(parents=True, exist_ok=True)
     (root / "docs/index.md").write_text("impact-28-ultra-upgrade-report.md\n", encoding="utf-8")
     (root / "docs/top-10-github-strategy.md").write_text(
-        '- ** — Weekly review #4:** document wins, misses, and corrective actions.\n',
+        "- ** — Weekly review #4:** document wins, misses, and corrective actions.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-weekly-review.md").write_text(
@@ -89,7 +89,7 @@ def test_lane28_emit_pack_and_execute(tmp_path: Path) -> None:
 def test_lane28_strict_fails_when_sections_missing(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "docs/integrations-weekly-review.md").write_text(
-        '# Weekly review #4 ()\n', encoding="utf-8"
+        "# Weekly review #4 ()\n", encoding="utf-8"
     )
     rc = d28.main(["--root", str(tmp_path), "--strict", "--format", "json"])
     assert rc == 1
@@ -99,4 +99,4 @@ def test_lane28_cli_dispatch(tmp_path: Path, capsys) -> None:
     _seed_repo(tmp_path)
     rc = cli.main(["weekly-review-lane", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
-    assert ' weekly review summary' in capsys.readouterr().out
+    assert " weekly review summary" in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- The Fast CI lanes and Pages/Premium Gate were failing due to lint/type regressions and stale docs references that broke strict MkDocs and CI checks.
- Address unused/incorrect variables and typing mismatches that caused `ruff`, `ruff format --check` and `mypy` failures.
- Prevent MkDocs strict build warnings from stale feature-registry links and missing nav targets.
- Make agent template/action payloads type-safe so `mypy` no longer flags `str | None` mismatches.

### Description
- Fixed lint issues and removed unused assignments in `route_map_payload`/`kits.py` and renamed an unused loop variable in `roadmap_manifest.py` to `_test_file` to satisfy Ruff/Bandit rules. 
- Tightened typing and defensive parsing in `feature_registry_cli.py` so `summarize_feature_registry` usage is type-safe and missing counts are handled robustly. 
- Ensured `goal` is always passed as `str` (not `None`) into `optimize_payload`/`expand_payload`/`blueprint_payload` calls by changing `or None` patterns to `.strip()` results in `src/sdetkit/agent/templates.py` and `src/sdetkit/agent/actions.py`. 
- Updated docs generation: `src/sdetkit/feature_registry.py` now renders test file paths as inline code (not relative links) to avoid MkDocs strict-mode link errors and synced `docs/feature-registry.md` via the sync script. 
- Added missing docs pages referenced by `mkdocs.yml`: `platform-problem-authoring.md`, `global-production-transformation-playbook.md`, and `governance-and-org-packs.md`. 
- Ran repository-wide formatting with `ruff format` so `ruff format --check .` passes consistently and applied multiple small style/quote fixes across many modules to satisfy format and style rules. 
- Miscellaneous whitespace/quote/formatting and doc text cleanups across many closeout/check modules to align with project style and avoid false positives.

### Testing
- Ran `source .venv/bin/activate && ruff check . && ruff format --check . && mypy src` and all checks passed. (Success)
- Ran the fast CI gate via `bash ci.sh quick --skip-docs --artifact-dir build` and the gate completed with no blocking failures. (Success)
- Built docs with `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict` and the site built without strict-mode link errors after syncing docs. (Success)
- Executed the premium gate fast profile with `bash premium-gate.sh --mode fast` and it completed successfully. (Success)
- Verified the feature-registry docs sync and contract with `python scripts/sync_feature_registry_docs.py && python scripts/check_feature_registry_contract.py`, which updated and then passed the contract check. (Success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3f93acbf88320a1020aee0997f4e9)