### PR TITLE
Docs: canonicalize first-proof path, artifact-first review, and CI artifact names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 DevS69 SDETKit gives engineering teams deterministic release go/no-go decisions with machine-readable evidence, using one repeatable command path from local to CI.
 
-Use the same three commands everywhere (`gate fast`, `gate release`, `doctor`) so release decisions are consistent across developer machines and CI.
+## Canonical first proof lane (start here)
 
-## 60-second first run
+Run this exact command path first:
 
 ```bash
 python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
@@ -13,7 +13,7 @@ python -m sdetkit gate release --format json --stable-json --out build/release-p
 python -m sdetkit doctor
 ```
 
-## Expected artifacts and what to inspect first
+Expected first artifacts:
 
 ```text
 build/
@@ -21,10 +21,23 @@ build/
 └── release-preflight.json
 ```
 
-Check these keys first:
-- `ok` → pass/fail decision
-- `failed_steps` → first triage targets
-- `profile` → gate profile used
+Inspect order:
+1. `build/release-preflight.json` (`ok`, `failed_steps`, `profile`)
+2. If `failed_steps` includes `gate_fast`, open `build/gate-fast.json` (`ok`, `failed_steps`, `profile`)
+3. Use raw logs only after artifact triage
+
+What success means:
+- `release-preflight.json` has `ok: true`
+- `gate-fast.json` has `ok: true`
+
+What failure means:
+- `ok: false` and/or non-empty `failed_steps` gives the first deterministic remediation target.
+
+## Canonical local-to-CI journey
+
+- Canonical first proof: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
+- Canonical CI rollout path: [`docs/recommended-ci-flow.md`](docs/recommended-ci-flow.md)
+- Canonical artifact decoder: [`docs/ci-artifact-walkthrough.md`](docs/ci-artifact-walkthrough.md)
 
 ## Who this is for / not for
 
@@ -41,31 +54,14 @@ Check these keys first:
 
 - Install (canonical): [`docs/install.md`](docs/install.md)
 - Blank repo proof in 60 seconds: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
+- Guided run (same path): [`docs/ready-to-use.md`](docs/ready-to-use.md)
 - Release-confidence model (canonical): [`docs/release-confidence.md`](docs/release-confidence.md)
 - Before/after evidence behavior: [`docs/before-after-evidence-example.md`](docs/before-after-evidence-example.md)
 - Real evidence artifacts from this repo: [`docs/evidence-showcase.md`](docs/evidence-showcase.md)
 
-## Guided onboarding path (first 10 minutes)
-
-```bash
-python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
-python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
-python -m sdetkit doctor
-```
-
-Then continue with:
-- [Choose your path](docs/choose-your-path.md)
-- [Decision guide](docs/decision-guide.md)
-- [Recommended CI flow](docs/recommended-ci-flow.md)
-
 ## Secondary: broader surfaces and advanced lanes
 
-These remain available when you already have the core release-confidence lane working.
-
-### Additional command families (only after core lane is stable)
-
-- Release confidence is the primary lane.
-- Other command families remain available through the CLI reference and kits docs.
+These remain available after the core release-confidence lane is trusted.
 
 ### Extended repo lanes
 
@@ -104,11 +100,8 @@ artifacts/     # generated evidence packs
 - Release process: [`RELEASE.md`](RELEASE.md)
 - Enterprise readiness audit: [`docs/enterprise-readiness-audit-2026-04.md`](docs/enterprise-readiness-audit-2026-04.md)
 
-## Root-level rules (short version)
+### See also (secondary, after core lane is stable)
 
-- Keep root files project-wide only.
-- Put implementation in `src/sdetkit/` and coverage in `tests/`.
-- Put deep docs in `docs/`.
-- Put generated outputs in `.sdetkit/` or `artifacts/`.
-
-For full rules, use [`docs/repo-cleanup-plan.md`](docs/repo-cleanup-plan.md).
+- Compare against ad hoc workflows: [`docs/sdetkit-vs-ad-hoc.md`](docs/sdetkit-vs-ad-hoc.md)
+- Repo hygiene boundaries: [`docs/repo-cleanup-plan.md`](docs/repo-cleanup-plan.md)
+- Ongoing repo status view: [`docs/repo-health-dashboard.md`](docs/repo-health-dashboard.md)

--- a/docs/before-after-evidence-example.md
+++ b/docs/before-after-evidence-example.md
@@ -40,42 +40,55 @@ build/
 └── release-preflight.json
 ```
 
-Representative real shapes documented in this repository:
-
-- `gate-fast.json` includes `ok`, `profile`, `failed_steps`.
-- `security-enforce.json` includes `ok`, `counts`, `exceeded`.
-- `release-preflight.json` includes `ok`, `profile`, `failed_steps`.
-
-See exact examples in [Evidence showcase](evidence-showcase.md).
+Representative real shapes are documented in [Evidence showcase](evidence-showcase.md).
 
 ## What this changes in practice
 
 | Decision step | Before (log-only) | After (SDETKit evidence) |
 | --- | --- | --- |
-| First triage move | Read mixed console output | Open JSON artifact and check `ok` + first failed key |
-| Policy traceability | Often implicit in scripts | Explicit thresholds in `security enforce` output |
+| First triage move | Read mixed console output | Open JSON artifact and check `ok` + `failed_steps` |
+| Policy traceability | Often implicit in scripts | Explicit thresholds in `security enforce` (`counts`, `exceeded`) |
 | CI review speed | Depends on who wrote scripts | Consistent artifact structure across runs |
-| Release handoff | Human summary in chat | Attach `build/*.json` as decision evidence |
+| Release handoff | Human summary in chat | Attach artifact links + machine-readable fields |
 
 ## Minimal review playbook
 
 1. Open `build/release-preflight.json`.
 2. If it references `gate_fast`, open `build/gate-fast.json`.
-3. If policy is failing, open `build/security-enforce.json` and inspect `exceeded`.
+3. If policy is relevant, open `build/security-enforce.json` and inspect `counts` + `exceeded`.
 4. Only then deep-dive into raw logs.
 
-## How to reference artifacts in PRs or release discussions
+## Canonical PR comment template (copy/paste)
 
-Use artifact fields directly instead of long raw log excerpts:
+```md
+### Release-confidence evidence
+- Artifact: `build/release-preflight.json`
+  - `ok`: <value>
+  - `failed_steps`: <value>
+- Artifact: `build/gate-fast.json`
+  - `ok`: <value>
+  - `failed_steps`: <value>
+- Artifact: `build/security-enforce.json` (if used in this run)
+  - `ok`: <value>
+  - `counts`: <value>
+  - `exceeded`: <value>
 
-- Link to uploaded `build/release-preflight.json`.
-- Include `ok` and `failed_steps` values in the PR summary.
-- If security policy is relevant, include `counts`/`exceeded` from `build/security-enforce.json`.
+Decision: <go / no-go / conditional> based on the fields above.
+```
 
-This keeps decisions auditable without inventing claims or hiding failing context.
+## Canonical release discussion template (copy/paste)
+
+```md
+## Release evidence summary
+- `build/release-preflight.json` -> `ok`: <value>, `failed_steps`: <value>
+- `build/gate-fast.json` -> `ok`: <value>, `failed_steps`: <value>
+- `build/security-enforce.json` -> `ok`: <value>, `counts`: <value>, `exceeded`: <value>
+
+Release recommendation: <ready / not ready / ready with follow-up>.
+```
 
 ## Where to go next
 
 - Canonical release-confidence model: [Release confidence](release-confidence.md)
-- Artifact decode rules: [CI artifact walkthrough](ci-artifact-walkthrough.md)
+- Canonical artifact decode: [CI artifact walkthrough](ci-artifact-walkthrough.md)
 - Fit check: [Decision guide](decision-guide.md)

--- a/docs/blank-repo-to-value-60-seconds.md
+++ b/docs/blank-repo-to-value-60-seconds.md
@@ -1,10 +1,10 @@
-# Blank repo to value in 60 seconds (ultra-fast proof)
+# Blank repo to value in 60 seconds (canonical first proof)
 
-Use this page for the fastest honest proof-of-value in a fresh repository.
+Use this as the canonical first proof in a fresh repository.
 
-If you want a guided walkthrough and interpretation flow, use [First run quickstart](ready-to-use.md).
+If you want the same path with more guidance, use [First run quickstart](ready-to-use.md).
 
-## 60-second proof command flow
+## Canonical first-proof command path
 
 ```bash
 python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
@@ -13,12 +13,7 @@ python -m sdetkit gate release --format json --stable-json --out build/release-p
 python -m sdetkit doctor
 ```
 
-## Immediate outcomes
-
-1. Deterministic fast gate decision
-2. Deterministic release gate decision
-3. Environment/release diagnostics
-4. Machine-readable evidence in `build/`
+## Expected first artifacts
 
 ```text
 build/
@@ -26,12 +21,32 @@ build/
 └── release-preflight.json
 ```
 
-Inspect `ok`, `failed_steps`, and `profile` first.
+Key fields to inspect first:
+- `ok`
+- `failed_steps`
+- `profile`
+
+## Proof acceptance criteria
+
+A first proof is accepted when all of the following are true:
+1. `build/gate-fast.json` exists and is valid JSON.
+2. `build/release-preflight.json` exists and is valid JSON.
+3. Both files expose `ok`, `failed_steps`, and `profile`.
+4. `build/release-preflight.json` is reviewed first, then `build/gate-fast.json` if needed.
+
+## What to do if the first run fails
+
+1. Open `build/release-preflight.json` first.
+2. If `failed_steps` includes `gate_fast`, open `build/gate-fast.json`.
+3. Fix the first failed step category.
+4. Re-run the same command path.
+
+For canonical decode rules, use [CI artifact walkthrough](ci-artifact-walkthrough.md).
 
 ## Next step after proof
 
-- Guided first run: [First run quickstart](ready-to-use.md)
+- Guided first run (same path): [First run quickstart](ready-to-use.md)
 - Product model: [Release confidence](release-confidence.md)
 - Evidence behavior: [Before/after evidence example](before-after-evidence-example.md)
-- Representative artifacts: [Evidence showcase](evidence-showcase.md)
-- Team/CI rollout: [Adopt SDETKit](adoption.md), [Recommended CI flow](recommended-ci-flow.md)
+- Real artifact anchor: [Evidence showcase](evidence-showcase.md)
+- Team CI rollout: [Recommended CI flow](recommended-ci-flow.md)

--- a/docs/ci-artifact-walkthrough.md
+++ b/docs/ci-artifact-walkthrough.md
@@ -1,29 +1,38 @@
-# CI artifact walkthrough (core release-confidence path)
+# CI artifact walkthrough (canonical evidence decoder)
 
-Use this page when a CI run is finished and you need the fastest **artifact-first** review path.
+Use this page when a CI run is finished and you need the fastest artifact-first review.
 
-This is the **canonical page for evidence/artifact interpretation**.
+This is the canonical decoder for release-confidence evidence.
 
-Grounded in this repository's documented workflow/artifacts:
-
-- `ci-gate-diagnostics` upload bundle (`build/gate-fast.json`, `build/security-enforce.json`)
-- `release-diagnostics` upload bundle (`build/release-preflight.json`)
-
-For full troubleshooting depth, continue to [adoption-troubleshooting.md](adoption-troubleshooting.md).
+Grounded in current workflow artifact uploads:
+- CI fast lane diagnostics: `ci-gate-diagnostics-py3.11` / `ci-gate-diagnostics-py3.12`
+- Release diagnostics: `release-diagnostics`
 
 ## Artifact-to-action map
 
 | Artifact/file | What it represents | Look here first | If healthy, do this next | If failure/risk, do this next |
 | --- | --- | --- | --- | --- |
-| `build/gate-fast.json` | Fast PR-safe gate result (`gate fast`) and first failing step list | `ok`, then `failed_steps` (first item), then matching `steps[]` entry (`id`, `rc`) | Keep PR flow unchanged; move to `build/security-enforce.json` for threshold posture. | Fix the first failed step category (lint/type/tests/doctor/templates), rerun fast gate, then re-check artifact. |
-| `build/security-enforce.json` | Security budget enforcement result (`security enforce`) with current counts vs limits | `ok`, `counts`, `exceeded`, `limits` | Keep current thresholds; proceed with stricter `main`/release checks. | Remediate findings or temporarily tune budget with explicit follow-up to ratchet down. |
-| `build/release-preflight.json` | Release metadata preflight state used in tag/release workflows | `ok`, `version`, `tag`, `pyproject`, `changelog` (and summary fields when present) | Continue to package validation/publish flow for the same tag. | Fix tag/version/changelog mismatch first, rerun preflight, then continue release checks. |
+| `build/release-preflight.json` | Release preflight decision | `ok`, then `failed_steps`, then `profile` | Continue release/package validation flow. | If `gate_fast` appears in `failed_steps`, open `build/gate-fast.json` next. |
+| `build/gate-fast.json` | Fast gate decision and failing step IDs | `ok`, then first item in `failed_steps`, then `profile` | Continue normal PR flow. | Fix first failing step category, rerun, and re-check artifact. |
+| `build/security-enforce.json` | Security threshold posture | `ok`, `counts`, `exceeded` | Keep current threshold posture. | Remediate findings or adjust thresholds with explicit follow-up. |
 
-## Recommended review order
+## Canonical review order
 
-1. Download artifacts from the workflow run: `ci-gate-diagnostics` and (for tag builds) `release-diagnostics`.
-2. Open `build/gate-fast.json` first for fastest actionable failure.
-3. Open `build/security-enforce.json` second for policy/budget posture.
-4. On release/tag runs, open `build/release-preflight.json` before checking later packaging logs.
+1. Download CI artifacts (`ci-gate-diagnostics-py*`; for tags also `release-diagnostics`).
+2. Open `build/release-preflight.json` first.
+3. If needed, open `build/gate-fast.json` second.
+4. Open `build/security-enforce.json` for policy/budget context.
+5. Only then deep-dive into raw logs.
 
-This order keeps review focused on deterministic go/no-go evidence before log-deep-dives.
+## Copy-paste evidence snippet (PR or release discussion)
+
+```md
+### Evidence (artifact-first)
+- `build/release-preflight.json`: `ok=<value>`, `failed_steps=<value>`, `profile=<value>`
+- `build/gate-fast.json`: `ok=<value>`, `failed_steps=<value>`, `profile=<value>`
+- `build/security-enforce.json`: `ok=<value>`, `counts=<value>`, `exceeded=<value>`
+
+Decision: <go / no-go / conditional> based on artifact fields above.
+```
+
+For full troubleshooting depth, continue to [adoption-troubleshooting.md](adoption-troubleshooting.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -14,6 +14,11 @@ If this is your first external PR, start with [First contribution quickstart](fi
 3. Do not invent proof (no synthetic benchmarks, customer claims, or fake outputs).
 4. Prefer clarification, consolidation, and cross-linking over adding new surfaces.
 
+Secondary references for contributor context (do not replace canonical first-proof docs):
+- [SDETKit vs ad hoc](sdetkit-vs-ad-hoc.md)
+- [Repo cleanup plan](repo-cleanup-plan.md)
+- [Repo health dashboard](repo-health-dashboard.md)
+
 ## What not to change in this docs sprint
 
 - Do not add new product surfaces, kits, bots, workers, or integrations.

--- a/docs/decision-guide.md
+++ b/docs/decision-guide.md
@@ -67,3 +67,9 @@ After confirming fit, choose exactly one lane:
 - **Advanced/reference** (only when needed): [cli.md](cli.md), [api.md](api.md), [plugins.md](plugins.md), [tool-server.md](tool-server.md)
 
 Historical transition-era docs remain available under [Archive and history](archive/index.md).
+
+## Next if you need more context (secondary)
+
+- Compare value proposition vs scattered tooling: [sdetkit-vs-ad-hoc.md](sdetkit-vs-ad-hoc.md)
+- Keep repo layout/rules clean during adoption: [repo-cleanup-plan.md](repo-cleanup-plan.md)
+- Track longer-term repository posture: [repo-health-dashboard.md](repo-health-dashboard.md)

--- a/docs/evidence-showcase.md
+++ b/docs/evidence-showcase.md
@@ -1,19 +1,23 @@
-# Evidence showcase: representative artifacts from this repository
+# Evidence showcase: real-output proof anchor from this repository
 
-Use this page to see real output shapes from a representative SDETKit run in this repository.
+Use this page as the canonical real-output anchor for artifact shape and interpretation language.
 
-For first-time adoption, start with [Start here](index.md), [Install](install.md), and [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md).
+For first-time adoption, start with [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md). For decode order, use [CI artifact walkthrough](ci-artifact-walkthrough.md).
 
-Canonical artifact interpretation is in [CI artifact walkthrough](ci-artifact-walkthrough.md).
+## Source-of-truth context
 
-## Representative scenario
+- These excerpts come from actual generated outputs captured in this repository's documented workflow.
+- They are not customer data, synthetic benchmarks, or fabricated screenshots.
+- Values (counts, failing steps) are context-dependent and can differ by branch, time, and repo state.
+
+## Evidence scenario (context)
 
 Scenario used for this evidence set:
+- Run `gate fast`
+- Run strict `security enforce`
+- Run `gate release`
 
-- Operator runs a fast quality gate, strict security budget enforcement, then release preflight.
-- The run intentionally produces actionable failures to show triage behavior.
-
-Commands actually run:
+Commands used:
 
 ```bash
 mkdir -p build
@@ -22,8 +26,7 @@ python -m sdetkit security enforce --format json --out build/security-enforce.js
 python -m sdetkit gate release --format json --out build/release-preflight.json
 ```
 
-Observed exit codes in this run:
-
+Observed exit codes in this captured run:
 - `gate fast`: `2`
 - `security enforce`: `1`
 - `gate release`: `2`
@@ -37,16 +40,9 @@ build/
 └── release-preflight.json
 ```
 
-## What each artifact means
+## Artifact excerpts and reviewer decision sentence
 
 ### `build/gate-fast.json`
-
-Purpose:
-
-- Structured result of the fast confidence lane.
-- Shows which sub-steps passed/failed (`doctor`, `ci_templates`, `ruff`, `ruff_format`, `mypy`, targeted `pytest`).
-
-Real excerpt from this run:
 
 ```json
 {
@@ -59,18 +55,10 @@ Real excerpt from this run:
 }
 ```
 
-Operator value:
-
-- Deterministic failed step IDs without scanning long logs.
-- Direct handoff to remediation lanes.
+Reviewer decision sentence:
+- "Fast gate is not ready to merge: `ok=false`; first remediation target is `ruff`."
 
 ### `build/security-enforce.json`
-
-Purpose:
-
-- Security budget decision object with explicit counts, limits, and exceeded metrics.
-
-Real excerpt from this run:
 
 ```json
 {
@@ -91,18 +79,10 @@ Real excerpt from this run:
 }
 ```
 
-Operator value:
-
-- Gate reason is machine-readable (`info` budget exceeded), so policy decisions are auditable.
+Reviewer decision sentence:
+- "Security budget failed on `info` (`131 > 0`); release stays blocked until threshold or findings are addressed."
 
 ### `build/release-preflight.json`
-
-Purpose:
-
-- Release lane aggregation that records preflight step outcomes.
-- Shows whether `doctor --release`, playbook validation, and nested `gate fast` passed.
-
-Real excerpt from this run:
 
 ```json
 {
@@ -114,37 +94,33 @@ Real excerpt from this run:
 }
 ```
 
-Operator value:
+Reviewer decision sentence:
+- "Release preflight is not ready: `ok=false`; blocker is nested `gate_fast`."
 
-- Explains why release preflight failed without replaying the full workflow manually.
+## Canonical inspect order
 
-## What to inspect first when a gate fails
-
-1. Open `build/release-preflight.json` for the top-level release decision.
-2. If `gate_fast` failed, inspect `build/gate-fast.json` and read `failed_steps`.
-3. For policy/budget failures, inspect `build/security-enforce.json` (`counts`, `limits`, `exceeded`).
+1. Open `build/release-preflight.json` first.
+2. If `gate_fast` failed, open `build/gate-fast.json`.
+3. If policy is relevant, open `build/security-enforce.json` (`counts`, `exceeded`).
 4. Use raw logs only after artifact-level triage.
 
-## How teams can reference these artifacts in PRs/releases
+## How teams should reference these artifacts
 
 - Upload JSON files as CI artifacts.
-- In PR summaries, cite `ok`, `failed_steps`, and any exceeded security metric.
-- Keep the artifact links with release notes so decision inputs remain auditable.
+- In PR summaries and release discussions, cite fields (`ok`, `failed_steps`, `counts`, `exceeded`) rather than long log excerpts.
+- Keep artifact links in decision threads so go/no-go reasoning stays auditable.
 
-## Why this is better than raw terminal logs alone
+## Caution on context and time
 
-- JSON artifacts preserve structure (`ok`, `failed_steps`, `counts`, `limits`) for automation.
-- They are easier to diff between runs than free-form logs.
-- Reviewers confirm decision inputs quickly instead of parsing mixed stdout/stderr.
-
-## Limitations / representative-example note
-
-- This is a representative run from this repository state and branch, not a universal baseline for all repositories.
-- Counts and failing step IDs vary by project content, policy thresholds, and tooling state.
-- Snippets here come from actual generated outputs in this run (no fabricated artifacts).
+This is a repository-specific captured run. Treat the structure as canonical and the values as situational.
 
 ## Related pages
 
 - Behavior comparison: [Before/after evidence example](before-after-evidence-example.md)
 - Product model: [Release confidence](release-confidence.md)
-- Fit decision: [Decision guide](decision-guide.md)
+- Canonical decoder: [CI artifact walkthrough](ci-artifact-walkthrough.md)
+
+Secondary references (after core proof path):
+- [SDETKit vs ad hoc](sdetkit-vs-ad-hoc.md)
+- [Repo cleanup plan](repo-cleanup-plan.md)
+- [Repo health dashboard](repo-health-dashboard.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,3 +53,8 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 ## Secondary and advanced references
 
 Deep references, advanced integrations, and historical material remain available in navigation and are intentionally secondary to first-time adoption.
+
+If you need context after the canonical first-proof path is working:
+- [SDETKit vs ad hoc tooling](sdetkit-vs-ad-hoc.md)
+- [Repo cleanup plan](repo-cleanup-plan.md)
+- [Repo health dashboard](repo-health-dashboard.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -1,10 +1,10 @@
-# First run quickstart (canonical guided run)
+# First run quickstart (guided canonical path)
 
-Use this page if you already installed SDETKit and want a guided first run with interpretation steps.
+Use this page for a guided run of the same canonical first-proof lane.
 
-If you only want the fastest proof first, use [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md).
+If you only want the fastest proof with minimal text, use [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md).
 
-## Guided first run (5 minutes)
+## Guided run (5 minutes)
 
 1. (Optional) Verify CLI wiring:
 
@@ -31,18 +31,13 @@ python -m sdetkit gate release --format json --stable-json --out build/release-p
 python -m sdetkit doctor
 ```
 
-## How to read the first artifacts
+## Canonical artifact interpretation order
 
-Start with these files:
-- `build/release-preflight.json`
-- `build/gate-fast.json`
+1. Open `build/release-preflight.json` first (`ok`, `failed_steps`, `profile`).
+2. If `failed_steps` includes `gate_fast`, open `build/gate-fast.json` (`ok`, `failed_steps`, `profile`).
+3. Only then move to raw logs for deep debugging.
 
-Check these keys first:
-- `ok`
-- `failed_steps`
-- `profile`
-
-For deeper decode rules, use [CI artifact walkthrough (canonical)](ci-artifact-walkthrough.md).
+This order matches the canonical decoder: [CI artifact walkthrough](ci-artifact-walkthrough.md).
 
 ## Optional wrappers (this repository only)
 
@@ -59,5 +54,5 @@ External repositories should use direct `python -m sdetkit ...` commands.
 
 - Release-confidence model: [Release confidence](release-confidence.md)
 - Team rollout: [Adopt SDETKit in your repository](adoption.md)
-- CI policy stages: [Recommended CI flow](recommended-ci-flow.md)
+- Canonical CI flow: [Recommended CI flow](recommended-ci-flow.md)
 - Evidence behavior: [Before/after example](before-after-evidence-example.md), [Evidence showcase](evidence-showcase.md)

--- a/docs/recommended-ci-flow.md
+++ b/docs/recommended-ci-flow.md
@@ -1,30 +1,24 @@
-# Recommended CI flow for team adoption
+# Recommended CI flow for team adoption (canonical)
 
-This page is the **canonical CI rollout guide** for operationalizing SDETKit in GitHub Actions with minimal friction.
+This page defines one canonical baseline CI path for deterministic release confidence.
 
-**Not this page:** first-time local users should start with [First run quickstart](ready-to-use.md); team onboarding should start with [Adoption](adoption.md).
+First-time local users should start with [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md) and [First run quickstart](ready-to-use.md).
 
-For a compact reviewer/operator read path over CI artifacts, see [CI artifact walkthrough](ci-artifact-walkthrough.md).
+Canonical artifact decoding is in [CI artifact walkthrough](ci-artifact-walkthrough.md).
 
-It is intentionally small and derived from this repository's current CI/release patterns in:
-
-- `.github/workflows/ci.yml`
-- `.github/workflows/release.yml`
-- `docs/adoption.md`
-
-For tier and scope boundaries, use [integrations-and-extension-boundary.md](integrations-and-extension-boundary.md).
-
-## Recommended shape
+## Canonical baseline shape
 
 Use three stages:
 
-1. **Pull requests (fast feedback):** block on `gate fast`; always upload fast diagnostics.
-2. **`main` branch (stricter confidence):** keep fast gate, then run security thresholds + full quality/docs checks.
-3. **Release tags (release-oriented):** run release preflight + build validation + wheel smoke before publish.
+1. **Pull requests:** run fast gate; always upload diagnostics.
+2. **`main` branch:** keep fast gate + security diagnostics; add stricter quality/docs checks.
+3. **Release tags:** run release preflight + package validation + install smoke.
 
-This gives teams quick PR signal, stronger merge confidence, and explicit release controls without forcing strict release checks on every feature branch.
+This is derived from current workflows:
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
 
-## Minimal baseline workflow (GitHub Actions)
+## Canonical baseline workflow (GitHub Actions)
 
 ```yaml
 name: sdetkit-recommended-baseline
@@ -47,17 +41,14 @@ jobs:
       - name: Install project + CI extras
         run: python -m pip install -e .[dev,test,docs]
 
-      # Fast PR-safe gate (also emits JSON when artifact-dir is set)
       - name: Fast gate
         run: bash ci.sh quick --skip-docs --artifact-dir build
 
-      # Keep threshold evidence even when gate fails
       - name: Security diagnostics (non-blocking)
         if: always()
         continue-on-error: true
         run: python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
 
-      # Tighten only on main
       - name: Main branch stricter checks
         if: github.ref == 'refs/heads/main'
         env:
@@ -72,7 +63,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ci-gate-diagnostics
+          name: ci-gate-diagnostics-py3.12
           path: |
             build/gate-fast.json
             build/security-enforce.json
@@ -107,96 +98,24 @@ jobs:
           if-no-files-found: warn
 ```
 
-## Stage-by-stage command recommendations
-
-### Pull requests (fast feedback)
-
-- `bash ci.sh quick --skip-docs --artifact-dir build`
-- `python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json` (non-blocking diagnostics)
-
-Why: fast and deterministic contributor signal, with triage-ready JSON artifacts.
-
-### `main` branch (stricter checks)
-
-Keep PR commands, then add:
-
-- `python -m pre_commit run -a`
-- `bash quality.sh registry`
-- `bash quality.sh cov`
-- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build`
-
-Why: stronger confidence on integrated code without slowing every PR.
-
-### Release-oriented workflow (tags)
-
-- `python scripts/release_preflight.py --tag "${GITHUB_REF_NAME}" --format json --out build/release-preflight.json`
-- `python scripts/check_release_tag_version.py "${GITHUB_REF_NAME}"`
-- `python -m build`
-- `python -m twine check dist/*`
-- `python -m check_wheel_contents --ignore W009 dist/*.whl`
-- `python -m pip install --force-reinstall dist/*.whl && sdetkit --help`
-
-Why: explicit release metadata validation + package integrity + installability proof.
-
 ## Artifacts to preserve
 
-For CI failure triage and release reviews, keep:
+- `build/release-preflight.json`
+- `build/gate-fast.json`
+- `build/security-enforce.json`
 
-- `build/gate-fast.json` (fast lane failed step details)
-- `build/security-enforce.json` (threshold counts/exceeded budgets)
-- `build/release-preflight.json` (release metadata status)
-
-Recommended upload names:
-
-- `ci-gate-diagnostics`
+Current workflow upload names in this repo:
+- `ci-gate-diagnostics-py3.11`
+- `ci-gate-diagnostics-py3.12`
 - `release-diagnostics`
-
-## Progressive adoption path
-
-1. **Week 1:** PR-only `gate fast` with diagnostics upload.
-2. **Week 2:** Add security threshold diagnostics, then enforce stricter thresholds once noise is reduced.
-3. **Week 3+:** Apply stricter `main` checks (coverage/docs/pre-commit).
-4. **Release maturity:** Add tag-triggered release preflight + package validation.
-
-This sequencing avoids "all-at-once" CI pain while still moving toward deterministic release confidence.
 
 ## When checks fail
 
-- **Fast gate failed:** open `build/gate-fast.json`; fix the first failing step before broad refactors.
-- **Security threshold exceeded:** open `build/security-enforce.json`; either remediate findings or temporarily tune thresholds with an explicit follow-up issue.
-- **Release preflight failed:** open `build/release-preflight.json`; fix tag/version metadata mismatch first.
+- Fast gate failed: open `build/gate-fast.json`; fix first failed step.
+- Security threshold exceeded: open `build/security-enforce.json`; remediate or tune thresholds with follow-up.
+- Release preflight failed: open `build/release-preflight.json`; fix tag/version/changelog mismatch first.
 
-For remediation playbooks, use:
+## Secondary appendix: optional maintenance automation
 
-- `docs/adoption-troubleshooting.md`
-- `docs/remediation-cookbook.md`
-
-## Optional maintenance-bot layer
-
-If you want the hosted repo to keep surfacing upgrade and security work between manual reviews, add these companion automations from this repo as-is or adapt them to your org:
-
-- `.github/workflows/ghas-review-bot.yml` for a weekly GitHub Advanced Security digest issue.
-- `.github/workflows/ghas-campaign-bot.yml` for a weekly GHAS campaign planner with Copilot Autofix-aware alert grouping.
-- `.github/workflows/ghas-alert-sla-bot.yml` for a weekly GHAS SLA tracker covering 7/14/30- alert backlog slices.
-- `.github/workflows/ghas-metrics-export-bot.yml` for a weekly GHAS metrics artifact and snapshot issue.
-- `.github/workflows/security-configuration-audit-bot.yml` for a monthly GHAS configuration audit and coverage report.
-- `.github/workflows/secret-protection-review-bot.yml` for a weekly secret protection posture and backlog review.
-- `.github/workflows/dependency-review.yml` for a pull-request dependency guardrail before merge.
-- `.github/workflows/dependency-radar-bot.yml` for a weekly dependency radar and runtime fast-follow watchlist.
-- `.github/workflows/adapter-smoke-bot.yml` for a weekly adapter smoke pack over optional notification adapters and integration-adapter route-map coverage.
-- `.github/workflows/repo-optimization-bot.yml` for a weekly optimize/expand-driven feature and automation backlog.
-- `.github/workflows/docs-experience-bot.yml` for a weekly docs experience radar over nav coverage, search posture, and flagship entrypoints.
-- `.github/workflows/runtime-watchlist-bot.yml` for a weekly runtime fast-follow watchlist over hot-path runtime-core packages.
-- `.github/workflows/release-readiness-radar-bot.yml` for a weekly release readiness radar over doctor output, release assets, and publish workflows.
-- `.github/workflows/security-maintenance-bot.yml` for the broader weekly security checklist and weak-spot report.
-
-These do not replace the CI merge bar; they make the maintenance backlog visible so the team can act before the merge bar starts failing.
-
-## Keep it lighter for smaller repositories
-
-If your repo is small or early-stage, keep only:
-
-- PR: `python -m sdetkit gate fast`
-- Optional JSON artifact: `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`
-
-Delay coverage/doc/release packaging jobs until the fast lane is stable and trusted by the team.
+This repo also has optional maintenance workflows (GHAS, dependency radar, docs experience, runtime watchlist, etc.).
+These are secondary and should not replace the canonical CI merge/release evidence path above.

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -9,12 +9,34 @@ Release confidence means a repository can answer **"Is this ready to ship?"** wi
 ## Canonical command path (primary)
 
 ```bash
-python -m sdetkit gate fast
-python -m sdetkit gate release
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
 python -m sdetkit doctor
 ```
 
-These are the primary commands for first-time adoption and ongoing release checks.
+## Canonical proof contract (local and CI)
+
+Invariant path:
+- Local run uses the same gate path as CI evidence review: `gate fast` -> `gate release` -> `doctor`.
+- CI preserves the same JSON decision objects as artifacts.
+
+Invariant artifacts:
+
+```text
+build/
+├── gate-fast.json
+└── release-preflight.json
+```
+
+Invariant fields for first triage:
+- `ok`
+- `failed_steps`
+- `profile`
+
+Go/no-go support model:
+- `ok` gives deterministic pass/fail.
+- `failed_steps` gives first remediation targets.
+- `profile` confirms which lane produced the result.
 
 ## Primary vs optional
 
@@ -23,37 +45,20 @@ These are the primary commands for first-time adoption and ongoing release check
 - `gate release`
 - `doctor`
 - JSON artifacts in `build/` for review decisions
+- CI artifact decoder: [CI artifact walkthrough](ci-artifact-walkthrough.md)
 
-### Optional (use when needed)
-- Team rollout documents and CI policy layers
+### Optional (use later)
+- Team rollout documents and stricter CI layers
 - Broader command families (intelligence/integration/forensics)
 - Advanced references and integrations
 
-## Why artifacts matter
-
-Artifact files provide machine-readable decision objects that reviewers can inspect consistently.
-
-Typical first artifacts:
-
-```text
-build/
-├── gate-fast.json
-└── release-preflight.json
-```
-
-Inspect `ok`, `failed_steps`, and `profile` first.
-
-For concrete representative artifacts in this repo, use [Evidence showcase](evidence-showcase.md).
-
 ## Local and CI stay aligned
 
-The same command path is used locally and in CI, so teams avoid one-off script behavior drift:
-
 - Local developer run: execute canonical commands directly.
-- CI run: execute same commands, upload JSON outputs as artifacts.
-- Review: use artifact fields as source-of-truth for go/no-go decisions.
+- CI run: execute same core commands and upload JSON outputs.
+- Review: use artifact fields as source-of-truth before log deep-dives.
 
-For implementation details, continue with [Recommended CI flow](recommended-ci-flow.md).
+Canonical CI rollout details: [Recommended CI flow](recommended-ci-flow.md).
 
 ## What this does not try to be
 

--- a/docs/sample-outputs.md
+++ b/docs/sample-outputs.md
@@ -1,107 +1,51 @@
-# Sample outputs (representative first-run evidence)
+# Sample outputs (exploratory, non-canonical examples)
 
-Need a compact “what this artifact means and what to do next” map? See [CI artifact walkthrough](ci-artifact-walkthrough.md).
+This page is exploratory and non-canonical.
 
-Use this page to quickly see what a **realistic first run** can look like on the Stable/Core path.
+For canonical first-proof and CI evidence interpretation, use:
+- [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
+- [CI artifact walkthrough](ci-artifact-walkthrough.md)
+- [Evidence showcase](evidence-showcase.md)
 
-These snippets are **representative/illustrative** and based on documented outputs already used in this repository (not customer production screenshots).
+## Scope note
 
-## 1) Quick confidence run: `gate fast` succeeds
+- These examples are shape-oriented and explanatory.
+- Do not treat this page as the source of truth for go/no-go decisions.
+- Use real run artifacts (`build/*.json`) from your local run or CI upload for decision-making.
 
-**Command**
+## Example 1: `gate fast` shape
 
 ```bash
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
 ```
 
-**Illustrative output snippet (pass shape)**
+Look for:
+- `ok`
+- `failed_steps`
+- `profile`
 
-```json
-{
-  "failed_steps": [],
-  "ok": true,
-  "profile": "fast"
-}
-```
-
-**What to notice**
-
-- `ok: true` and empty `failed_steps` means the fast gate is green.
-- `profile: "fast"` confirms this is the quick-confidence lane artifact.
-
-**What to do next**
-
-- Keep `gate fast` on PRs.
-- Add strict security enforcement next on release branches:
+## Example 2: `security enforce` shape
 
 ```bash
 python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0 --out build/security-enforce.json
 ```
 
-## 2) First strict security run: budget fails
+Look for:
+- `ok`
+- `counts`
+- `exceeded`
 
-**Command**
-
-```bash
-python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 0
-```
-
-**Representative output snippet**
-
-```json
-{"counts":{"error":0,"info":131,"total":131,"warn":0},"ok":false,"exceeded":[{"metric":"info","count":131,"limit":0}]}
-```
-
-**What to notice**
-
-- `ok: false` with `exceeded` tells you exactly which budget blocked the gate.
-- In first adoption, this is common and expected when `--max-info 0` is too strict for current baseline.
-
-**What to do next**
-
-- Keep `--max-error 0 --max-warn 0` strict.
-- Set a temporary realistic `--max-info` baseline and ratchet down:
+## Example 3: `gate release` shape
 
 ```bash
-python -m sdetkit security enforce --format json --max-error 0 --max-warn 0 --max-info 200
+python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
 ```
 
-## 3) Release-confidence evidence artifact: release readiness summary
+Look for:
+- `ok`
+- `failed_steps`
+- `profile`
 
-**Command path**
+## Decision reminder
 
-```bash
-python -m sdetkit gate release --format json --out build/release-preflight.json
-```
-
-**Representative evidence snippet**
-
-```json
-{
-  "name": "release-readiness",
-  "summary": {
-    "gate_status": "pass",
-    "release_score": 96.56,
-    "strict_all_green": true
-  },
-  "strict_failures": []
-}
-```
-
-**What to notice**
-
-- A compact summary can be used as release-review evidence (`gate_status`, score, strict-failure list).
-- `strict_failures: []` indicates no strict blockers in this sample.
-
-**What to do next**
-
-- Upload release JSON artifacts in CI and link them in release decisions.
-- If release fails, triage in order: `failed_steps` -> `doctor --release` -> rerun `gate release`.
-
-## Related guides
-
-- [Ready-to-use setup](ready-to-use.md)
-- [Adopt SDETKit in your repository](adoption.md)
-- [Release confidence with SDETKit](release-confidence.md)
-- [First-failure triage](first-failure-triage.md)
-- [Evidence showcase](evidence-showcase.md)
+For PR and release decisions, cite fields from your real artifacts and link the uploaded files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ nav:
   - First-time release-confidence path:
       - Install (canonical): install.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
-      - First run quickstart (canonical guided run): ready-to-use.md
+      - First run quickstart (guided canonical path): ready-to-use.md
       - Release confidence (canonical explainer): release-confidence.md
       - Before/after evidence example: before-after-evidence-example.md
       - Evidence showcase: evidence-showcase.md
@@ -103,7 +103,7 @@ nav:
       - CI artifact walkthrough (canonical evidence decode): ci-artifact-walkthrough.md
       - CI contract (reference): ci-contract.md
       - Reporting and trends: reporting-and-trends.md
-      - Sample outputs (first-run evidence): sample-outputs.md
+      - Sample outputs (exploratory, non-canonical): sample-outputs.md
       - Remediation cookbook: remediation-cookbook.md
   - Contributing and maintenance:
       - Repo tour: repo-tour.md


### PR DESCRIPTION
### Motivation
- Make the onboarding and review experience deterministic by promoting a single canonical local-to-CI command path and decoder for evidence artifacts.
- Encourage an artifact-first triage workflow so reviewers use compact JSON fields (`ok`, `failed_steps`, `profile`, `counts`, `exceeded`) before inspecting raw logs.
- Align docs, examples, and CI upload names so teams have a consistent decoder and copy/paste templates for PRs and release discussions. 

### Description
- Reworked top-level and many docs (`README.md`, `docs/*`) to present a single canonical first-proof path (`gate fast` → `gate release` → `doctor`) with JSON artifact outputs (`build/gate-fast.json`, `build/release-preflight.json`).
- Added explicit artifact-first review order, copy/paste PR comment and release discussion templates, and a short failure/remediation playbook in multiple pages (`before-after-evidence-example.md`, `ci-artifact-walkthrough.md`, `evidence-showcase.md`, `ready-to-use.md`, `blank-repo-to-value-60-seconds.md`).
- Updated recommended CI flow docs to standardize artifact upload names (e.g. `ci-gate-diagnostics-py3.11` / `ci-gate-diagnostics-py3.12`) and to show the canonical baseline workflow and artifact preservation guidance (`recommended-ci-flow.md`).
- Clarified scope and tone for sample outputs by labeling `sample-outputs.md` as exploratory/non-canonical, and updated the site nav in `mkdocs.yml` to match rewritten page titles and ordering.

### Testing
- Built the documentation site with `mkdocs build` to validate rewritten pages and navigation, and the build completed successfully. 
- Ran pre-commit checks with `python -m pre_commit run -a` to validate formatting and lint rules, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d428e2d4248320b982c013f64eb7cd)