### PR TITLE
Add stability-levels guidance and link it from README and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ What failure means:
 - Blank repo proof in 60 seconds: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
 - Guided run (same path): [`docs/ready-to-use.md`](docs/ready-to-use.md)
 - Release-confidence model (canonical): [`docs/release-confidence.md`](docs/release-confidence.md)
+- Stability levels (policy boundary): [`docs/stability-levels.md`](docs/stability-levels.md) — understand what is stable vs advanced vs experimental
 - Before/after evidence behavior: [`docs/before-after-evidence-example.md`](docs/before-after-evidence-example.md)
 - Real evidence artifacts from this repo: [`docs/evidence-showcase.md`](docs/evidence-showcase.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Need team rollout: [Adopt in your repository](adoption.md)
 - Need CI rollout: [Recommended CI flow](recommended-ci-flow.md)
 - Need contributor workflow: [Contributing](contributing.md)
+- Need boundary guidance: [Stability levels](stability-levels.md) for adopters and contributors
 
 ## Secondary and advanced references
 

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -74,3 +74,4 @@ SDETKit focuses first on deterministic release-confidence decisions and evidence
 - Ultra-fast proof: [blank-repo-to-value-60-seconds.md](blank-repo-to-value-60-seconds.md)
 - Evidence and comparison: [before-after-evidence-example.md](before-after-evidence-example.md), [evidence-showcase.md](evidence-showcase.md)
 - Fit decision: [decision-guide.md](decision-guide.md)
+- Boundary policy: [stability-levels.md](stability-levels.md)

--- a/docs/stability-levels.md
+++ b/docs/stability-levels.md
@@ -1,55 +1,85 @@
-# Stability levels (current policy)
+# Stability levels (boundary declaration)
 
-SDETKit's flagship promise remains:
+## Why this page exists
 
-> **Release confidence / shipping readiness for software teams.**
+This page declares the current product boundary so adopters and contributors can make consistent decisions without guessing which surfaces are primary vs optional.
 
-This page defines the current stability labels used across docs and CLI help. It is intended to set clear expectations without changing existing commands or workflows.
+## Flagship promise
 
-## Stable/Core
+DevS69 SDETKit's flagship promise is:
 
-- **Intended audience:** teams making impact-to-impact go/no-go release decisions.
-- **Expected stability:** highest stability in this repository; this is the default starting path.
-- **Support expectations:** prioritized for maintenance, docs clarity, and regression prevention.
-- **Backward compatibility:** best-effort compatibility is expected for normal usage; changes should be deliberate and clearly documented.
-- **How to use in production:** safe as the primary production lane for release confidence checks.
+> **Deterministic release confidence / shipping readiness for software teams.**
 
-Typical examples include `gate`, `doctor`, `security`, `evidence`, and `scripts/ready_to_use.sh quick|release`.
+## This page is a declaration, not a refactor
 
-## Integrations
+This is a policy and guidance page. It does **not** rename commands, remove aliases, move modules, or change CLI behavior.
 
-- **Intended audience:** teams connecting SDETKit to CI platforms, notifications, plugins, or external automation.
-- **Expected stability:** stable for practical adoption, with occasional environment-specific adjustments.
-- **Support expectations:** maintained and documented, but behavior can depend on third-party systems.
-- **Backward compatibility:** best-effort compatibility with clear migration notes when interfaces evolve.
-- **How to use in production:** recommended when integration points are validated in your own environment.
+## Tier definitions
 
-## Playbooks
+### Public / stable
 
-- **Intended audience:** teams adopting guided rollout lanes (onboarding, contribution, reliability storytelling, governance execution).
-- **Expected stability:** generally usable and supported, but more iterative than core gate commands.
-- **Support expectations:** maintained as practical guidance with incremental improvements.
-- **Backward compatibility:** command availability is expected, while workflows and narrative output can evolve.
-- **How to use in production:** use for operational rollout and enablement, alongside stable/core release gates.
+Primary surfaces for release-confidence decisions. This is the default path for new adopters and the strongest compatibility commitment.
 
-## Experimental
+### Advanced but supported
 
-- **Intended audience:** advanced users and maintainers exploring incubator lanes or historical impact/closeout flows.
-- **Expected stability:** lower stability and faster iteration; not the first stop for new adopters.
-- **Support expectations:** best-effort maintenance; focus is learning, transition support, and preserving historical value.
-- **Backward compatibility:** may change more quickly, though breaking changes should still be communicated where practical.
-- **How to use in production:** treat as opt-in and validate locally/in CI before relying on it for critical release decisions.
+Supported surfaces for deeper rollout, integrations, operations, and guided adoption workflows. These are production-usable, with more iterative UX and documentation evolution than the public/stable tier.
 
-This includes many impact/impact/closeout lanes. They remain available as transition-era and advanced playbook material, not removed.
+### Experimental / incubator
 
-## Usage guidance
+Opt-in surfaces for incubator and transition-era workflows. Useful for advanced users, but expected to evolve faster.
 
-1. Start with **Stable/Core** for release confidence and shipping readiness decisions.
-2. Add **Integrations** to embed checks into your delivery systems.
-3. Use **Playbooks** for guided adoption and organizational rollout.
-4. Use **Experimental** lanes intentionally, with explicit validation.
+## Current classification of the product surface
 
-See also:
+### Public / stable (default)
+
+- Canonical release-confidence path: `gate fast` -> `gate release` -> `doctor`
+- Core decision support commands and evidence lane: `gate`, `doctor`, `security`, `evidence`
+- Canonical wrapper lane: `scripts/ready_to_use.sh quick|release`
+- First-proof and adoption-critical docs (README start-here path, docs index start-here path, release-confidence explainer)
+
+### Advanced but supported
+
+- Broader operational and governance families (for example: `repo`, `ci`, `policy`, `report`, `maintenance`, `ops`)
+- Integration and ecosystem connectors (for example: `agent`, notify/plugin/integration quickstarts)
+- Guided rollout and organizational playbook families
+- Secondary advanced/reference documentation used after the canonical first-proof path is trusted
+
+### Experimental / incubator
+
+- Impact/closeout and other transition-era command lanes
+- Hidden/legacy long-tail command families intended for explicit opt-in use
+- Archive/history-heavy material that remains available for context and continuity
+
+## Compatibility expectations by tier
+
+- **Public / stable:** highest compatibility expectation; changes should be deliberate, documented, and migration-aware.
+- **Advanced but supported:** supported for real use, but command ergonomics, docs flow, and supporting interfaces may iterate faster.
+- **Experimental / incubator:** best-effort continuity with faster evolution; validate in your repo/CI before treating as a hard dependency.
+
+When lower-level CLI/help labels are more granular, this page should be read as the higher-level product policy, not a command-contract rewrite.
+
+## What this page does NOT mean
+
+- Not a deprecation wave.
+- Not immediate command renames.
+- Not feature removal.
+- Not a breaking refactor.
+
+## How to use this page
+
+### For adopters
+
+1. Start in **Public / stable** to get deterministic shipping readiness signals.
+2. Add **Advanced but supported** surfaces as your rollout matures.
+3. Use **Experimental / incubator** only with explicit validation and local/CI proof.
+
+### For contributors
+
+1. Protect **Public / stable** behaviors and docs clarity first.
+2. Keep **Advanced but supported** improvements practical and backwards-aware.
+3. Keep **Experimental / incubator** changes clearly labeled and non-disruptive to default onboarding.
+
+## See also
 
 - [Productization map](productization-map.md)
 - [Versioning and support posture](versioning-and-support.md)


### PR DESCRIPTION
### Motivation
- Declare the product boundary and stability tiers so adopters and contributors can make consistent decisions about which surfaces are primary vs optional.
- Make the stability guidance discoverable from the repo start pages and the release-confidence explainer.

### Description
- Add `docs/stability-levels.md` which defines three tiers (Public / stable, Advanced but supported, Experimental / incubator) and explains usage and compatibility expectations.
- Link the new stability guidance from `README.md`, `docs/index.md`, and `docs/release-confidence.md` so the page is surfaced in the canonical start-here paths.
- Rework the stability page copy to be a policy/boundary declaration and organize tier definitions and compatibility expectations for adopters and contributors.

### Testing
- This is a docs-only change and does not alter runtime code behavior or APIs.
- Ran the repository linter with `ruff check .` to validate style and it completed successfully.
- Built the documentation site with `mkdocs build` to validate links and rendering and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d43d70d62483208b783ad59d3f1389)