### PR TITLE
Clarify CLI canonical path and stability-tier labels in docs and root help

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ What failure means:
 - Blank repo proof in 60 seconds: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
 - Guided run (same path): [`docs/ready-to-use.md`](docs/ready-to-use.md)
 - Release-confidence model (canonical): [`docs/release-confidence.md`](docs/release-confidence.md)
+- Root CLI grouping and canonical path view: `python -m sdetkit --help`
 - Stability levels (policy boundary): [`docs/stability-levels.md`](docs/stability-levels.md) — understand what is stable vs advanced vs experimental
 - Before/after evidence behavior: [`docs/before-after-evidence-example.md`](docs/before-after-evidence-example.md)
 - Real evidence artifacts from this repo: [`docs/evidence-showcase.md`](docs/evidence-showcase.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ SDETKit is a release-confidence command path for engineering teams that need cle
 3. [Release confidence explainer](release-confidence.md)
 
 If you want a guided run instead of the ultra-fast proof lane, use [First run quickstart](ready-to-use.md).
+For CLI-first orientation, run `python -m sdetkit --help` to see canonical path plus stability-tier grouping.
 
 ## What artifacts appear
 

--- a/docs/stability-levels.md
+++ b/docs/stability-levels.md
@@ -58,6 +58,8 @@ Opt-in surfaces for incubator and transition-era workflows. Useful for advanced 
 
 When lower-level CLI/help labels are more granular, this page should be read as the higher-level product policy, not a command-contract rewrite.
 
+Root CLI help maps to these tiers as display guidance: canonical `gate fast` -> `gate release` -> `doctor` is shown as **Public / stable**, broader kits/operations/playbooks as **Advanced but supported**, and transition-era lanes as **Experimental / incubator**.
+
 ## What this page does NOT mean
 
 - Not a deprecation wave.

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -240,13 +240,13 @@ def _build_root_parser(
 DevS69 SDETKit is an operator-grade SDET platform with four umbrella kits:
 release confidence, test intelligence, integration assurance, and failure forensics.
 
-Stability levels: Stable/Core, Stable/Compatibility, Stable/Supporting, Playbooks, Experimental.
+Policy tiers: Public / stable, Advanced but supported, Experimental / incubator.
 
-Start here:
-  1) [Stable/Core] Discover kits: sdetkit kits list
-  2) [Stable/Core] Release lane: sdetkit release gate fast
-  3) [Stable/Core] Test lane: sdetkit intelligence flake classify --history <history.json>
-  4) [Stable/Compatibility] Existing direct commands (gate/doctor/security/...) still work
+Start here (canonical release-confidence path):
+  1) [Public / stable] python -m sdetkit gate fast
+  2) [Public / stable] python -m sdetkit gate release
+  3) [Public / stable] python -m sdetkit doctor
+  4) Then explore umbrella kits: python -m sdetkit kits list
 """
 
     help_epilog = render_root_help_groups()

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -19,7 +19,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     CommandFamilyContract(
         name="umbrella-kits",
         role="Primary product surface for release confidence, test intelligence, integration assurance, and failure forensics.",
-        stability_tier="Stable/Core",
+        stability_tier="Advanced but supported",
         first_time_recommended=True,
         transition_legacy_oriented=False,
         top_level_commands=("kits", "release", "intelligence", "integration", "forensics"),
@@ -27,7 +27,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     CommandFamilyContract(
         name="compatibility-aliases",
         role="Backward-compatible direct lanes preserved for existing automation and muscle memory.",
-        stability_tier="Stable/Compatibility",
+        stability_tier="Public / stable",
         first_time_recommended=False,
         transition_legacy_oriented=False,
         top_level_commands=("gate", "doctor", "security", "repo", "evidence", "report", "policy"),
@@ -35,7 +35,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     CommandFamilyContract(
         name="supporting-utilities-and-automation",
         role="Supporting utilities and automation lanes; useful but intentionally secondary to flagship kits.",
-        stability_tier="Stable/Supporting",
+        stability_tier="Advanced but supported",
         first_time_recommended=False,
         transition_legacy_oriented=False,
         top_level_commands=(
@@ -56,7 +56,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     CommandFamilyContract(
         name="playbooks",
         role="Guided adoption and rollout lanes for operational outcomes.",
-        stability_tier="Playbooks",
+        stability_tier="Advanced but supported",
         first_time_recommended=False,
         transition_legacy_oriented=False,
         top_level_commands=(
@@ -70,7 +70,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     CommandFamilyContract(
         name="experimental-transition-lanes",
         role="Transition-era and legacy-oriented lanes retained for compatibility.",
-        stability_tier="Experimental",
+        stability_tier="Experimental / incubator",
         first_time_recommended=False,
         transition_legacy_oriented=True,
         top_level_commands=("legacy compatibility lanes", "archived transition commands"),
@@ -85,12 +85,12 @@ def render_root_help_groups() -> str:
         name = family.name.replace("-", " ")
         lines.append(
             f"  {name} [{family.stability_tier}]"
-            f" (first-time: {'yes' if family.first_time_recommended else 'no'};"
+            f" (use first: {'yes' if family.first_time_recommended else 'no'};"
             f" transition-era: {'yes' if family.transition_legacy_oriented else 'no'}):"
         )
         lines.append(f"    {family.role}")
         lines.append(f"    {', '.join(family.top_level_commands)}")
         lines.append("")
-    lines.append("Run: sdetkit kits list")
-    lines.append("  to discover umbrella kits first, then use compatibility aliases as needed.")
+    lines.append("Start with: python -m sdetkit gate fast -> gate release -> doctor")
+    lines.append("Then expand: python -m sdetkit kits list")
     return "\n".join(lines)


### PR DESCRIPTION
### Motivation
- Align documentation and root CLI help to present the canonical command path using the `python -m sdetkit` invocation and to make the recommended onboarding path more discoverable. 
- Standardize stability-tier naming across help text and the public surface contract to use the productized tiers (`Public / stable`, `Advanced but supported`, `Experimental / incubator`).
- Improve root help guidance so users see the recommended flow first and then expansion options.

### Description
- Updated `README.md` and `docs/index.md` to add a CLI-first hint and surface the canonical `python -m sdetkit --help` entry and show the canonical path in docs. 
- Modified `docs/stability-levels.md` to map the root CLI help groups to the new stability-tier phrasing and show the canonical release-confidence path. 
- Updated `src/sdetkit/cli.py` to refresh the root `help_description` to reference `python -m sdetkit` canonical commands and to align language with the policy tiers. 
- Updated `src/sdetkit/public_surface_contract.py` to normalize `stability_tier` string values and adjust `render_root_help_groups()` output to recommend `python -m sdetkit gate fast -> gate release -> doctor` and to tweak the phrasing for first-time recommended families.

### Testing
- Ran unit tests with `PYTHONPATH=src pytest -q`, which succeeded. 
- Ran static checks with `ruff check .`, which succeeded. 
- Performed a smoke check of the root help by running `python -m sdetkit --help` to verify no formatting errors in the rendered help text.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d4441f94d48320b961c03beab22e21)