### PR TITLE
test: lock CLI root-help discoverability and stability-tier vocabulary

### DIFF
--- a/tests/test_cli_help_discoverability_contract.py
+++ b/tests/test_cli_help_discoverability_contract.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from sdetkit.public_surface_contract import render_root_help_groups
+
+
+POLICY_TIERS = (
+    "Public / stable",
+    "Advanced but supported",
+    "Experimental / incubator",
+)
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "-m", "sdetkit", *args], text=True, capture_output=True)
+
+
+def _normalize(text: str) -> str:
+    """Normalize help/doc text for robust contains checks across wrapping changes."""
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def test_root_help_exposes_canonical_first_time_path() -> None:
+    proc = _run("--help")
+    assert proc.returncode == 0
+    normalized = _normalize(proc.stdout)
+
+    canonical_markers = (
+        "python -m sdetkit gate fast",
+        "python -m sdetkit gate release",
+        "python -m sdetkit doctor",
+    )
+    for marker in canonical_markers:
+        assert marker in normalized
+
+
+def test_root_help_includes_policy_tier_vocabulary() -> None:
+    proc = _run("--help")
+    assert proc.returncode == 0
+
+    for tier in POLICY_TIERS:
+        assert tier in proc.stdout
+
+
+def test_policy_tier_vocabulary_matches_public_contract_and_docs() -> None:
+    contract_help = render_root_help_groups()
+    docs_text = Path("docs/stability-levels.md").read_text(encoding="utf-8")
+
+    for tier in POLICY_TIERS:
+        assert tier in contract_help
+        assert tier in docs_text


### PR DESCRIPTION
### Motivation
- Add focused contract tests to lock the canonical first-time discoverability story and prevent wording drift between CLI help rendering and the published stability policy.

### Description
- Add `tests/test_cli_help_discoverability_contract.py` which asserts the root `--help` exposes the canonical path markers `python -m sdetkit gate fast`, `python -m sdetkit gate release`, and `python -m sdetkit doctor`.
- Assert the presence of policy-tier vocabulary (`Public / stable`, `Advanced but supported`, `Experimental / incubator`) in the root help output and verify the same terms appear in `render_root_help_groups()` and `docs/stability-levels.md` to keep surfaces consistent.
- Use a small, resilient normalization helper for the canonical-path checks so tests avoid brittle full-output snapshots and remain tolerant of harmless wrapping/spacing changes.

### Testing
- Ran `python -m sdetkit --help`, `python -m sdetkit gate --help`, and `python -m sdetkit release --help` and validated outputs returned successfully.
- Ran `pytest -q tests/test_cli_help_discoverability_contract.py tests/test_cli_umbrella_surface.py tests/test_cli_help_lists_subcommands.py` with `10 passed`.
- `git diff --stat` shows one file added (`tests/test_cli_help_discoverability_contract.py`, 55 insertions) and repository status is clean; changes are committed and the PR is merge-ready.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d448b2f2648320826756962043af42)