### PR TITLE
Add real-repo adoption example flow and expected artifact outputs to README and docs/index

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ What success means:
 What failure means:
 - `ok: false` and/or non-empty `failed_steps` gives the first deterministic remediation target.
 
+```text
+$ cd examples/adoption/real-repo
+$ python -m sdetkit gate fast
+exit 2  -> build/gate-fast.json: ok=false (fixture triage)
+$ python -m sdetkit gate release
+exit 2  -> build/release-preflight.json: ok=false (fixture triage)
+$ python -m sdetkit doctor
+exit 0  -> build/doctor.json: ok=true
+```
+
+Real fixture-oriented canonical flow; any failing gate result shown here is expected triage for the adoption fixture, not a product failure.
+
+Context: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
+
 ## Canonical local-to-CI journey
 
 - Canonical first proof: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,20 @@ SDETKit is a release-confidence command path for engineering teams that need cle
 - Outputs are machine-readable JSON artifacts, not only terminal logs.
 - Evidence examples in this repo use representative real output shapes (no fabricated customer claims or synthetic benchmarks).
 
+```text
+$ cd examples/adoption/real-repo
+$ python -m sdetkit gate fast
+exit 2  -> build/gate-fast.json: ok=false (fixture triage)
+$ python -m sdetkit gate release
+exit 2  -> build/release-preflight.json: ok=false (fixture triage)
+$ python -m sdetkit doctor
+exit 0  -> build/doctor.json: ok=true
+```
+
+Real fixture-oriented canonical flow; any failing gate result shown here is expected triage for the adoption fixture, not a product failure.
+
+Context: [real-repo adoption fixture + golden artifacts](real-repo-adoption.md)
+
 ## What to run first
 
 1. [Install (canonical)](install.md)


### PR DESCRIPTION
### Motivation
- Provide a concrete, fixture-oriented example of the canonical local-to-CI flow showing commands and expected artifact outcomes for the real-repo adoption fixture. 
- Clarify that failing `gate` results in the example are expected triage for the adoption fixture and not a product failure, and point readers to the detailed context document. 

### Description
- Inserted a short `text` example block in `README.md` showing `python -m sdetkit gate fast`, `python -m sdetkit gate release`, and `python -m sdetkit doctor` with expected exit codes and artifact locations. 
- Added the same example block and a contextual note to `docs/index.md` with a link to the real-repo adoption artifacts. 
- Added an explicit line noting that failing gate results in the example are expected for the adoption fixture and added the context pointer to `docs/real-repo-adoption.md`.

### Testing
- This is a documentation-only change so no automated tests were executed as part of this PR. 
- No code or test behavior was modified by these edits, so existing CI and test suites remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d44bf3d8e08320843c0e288f59e9c8)