### PR TITLE
docs: align first-contribution canonical command flow across contributor entry points

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,11 @@ python -m sdetkit gate release
 python -m sdetkit doctor
 ```
 
+Quick purpose guide (same order everywhere):
+- `python -m sdetkit gate fast` — fast local quality gate signal before deeper checks.
+- `python -m sdetkit gate release` — release-readiness preflight with machine-readable evidence.
+- `python -m sdetkit doctor` — environment and diagnostics snapshot for troubleshooting context.
+
 For a condensed version, see `docs/first-contribution-quickstart.md`.
 For concrete, repo-grounded starter categories, use `docs/starter-work-inventory.md`.
 For file-placement and root-directory guidance, see `docs/project-structure.md`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,9 +12,10 @@ Use this page as a concise handoff, then follow the detailed path in [`CONTRIBUT
 2. Keep scope to one issue and one clear outcome.
 3. Validate locally before opening your PR.
 4. Preserve canonical release-confidence command language in docs/examples:
-   - `python -m sdetkit gate fast`
-   - `python -m sdetkit gate release`
-   - `python -m sdetkit doctor`
+   - `python -m sdetkit gate fast` — fast local quality gate signal.
+   - `python -m sdetkit gate release` — release-readiness preflight evidence.
+   - `python -m sdetkit doctor` — environment diagnostics snapshot.
+   - Detailed rationale and surrounding guidance: [`CONTRIBUTING.md`](https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CONTRIBUTING.md#canonical-release-confidence-alignment-check).
 
 ## What not to change in this docs sprint
 

--- a/docs/first-contribution-quickstart.md
+++ b/docs/first-contribution-quickstart.md
@@ -36,6 +36,19 @@ Use `docs/starter-work-inventory.md` for concrete categories mapped to this repo
 
 ## 3) Validate locally before opening a PR
 
+Keep first-contribution docs/examples aligned with the canonical command path:
+
+```bash
+python -m sdetkit gate fast
+python -m sdetkit gate release
+python -m sdetkit doctor
+```
+
+Purpose in order:
+- `python -m sdetkit gate fast` — quick local quality gate signal.
+- `python -m sdetkit gate release` — release-readiness preflight evidence.
+- `python -m sdetkit doctor` — environment diagnostics snapshot.
+
 Run minimum checks:
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ SDETKit is a release-confidence command path for engineering teams that need cle
 
 ## Why trust it
 
-- The core flow is explicit and repeatable: `gate fast` → `gate release` → `doctor`.
+- The core flow is explicit and repeatable: `python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`.
 - Outputs are machine-readable JSON artifacts, not only terminal logs.
 - Evidence examples in this repo use representative real output shapes (no fabricated customer claims or synthetic benchmarks).
 


### PR DESCRIPTION
### Motivation
- New contributors saw inconsistent starter command lists across entry points; this aligns those lists so the first-contribution flow is clear and trustworthy. 
- Keep a single detailed source-of-truth for contributor guidance while making handoff pages concise and consistent. 
- Make only narrow docs edits without changing CLI behavior, command names, or aliases.

### Description
- Added a short, ordered purpose guide for the canonical starter commands to `CONTRIBUTING.md` so it remains the detailed authority. 
- Updated `docs/contributing.md` to list the canonical commands with concise purpose descriptions and to point explicitly to the `CONTRIBUTING.md` rationale. 
- Added the canonical command snippet and short purposes to `docs/first-contribution-quickstart.md` to ensure newcomers see the same starter flow. 
- Clarified `docs/index.md` trust statement to use the full canonical command forms for consistency with contributor docs.

### Testing
- Ran `python -m mkdocs build` and the docs site built successfully. 
- Ran `rg -n "gate fast|gate release|doctor"` across the specified files to verify the canonical commands appear consistently and the search returned the expected hits. 
- Ran `git diff --stat` and `git status --short` to confirm the change set consists of the intended docs edits (4 files changed) and the working tree is clean.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d46be171a88320a71adfb5ae4359d0)