### PR TITLE
Add tests to protect starter-contribution guidance in docs and templates

### DIFF
--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 import pytest
 
 from sdetkit import docs_qa
+
+
+def _starter_inventory_text() -> str:
+    return Path("docs/starter-work-inventory.md").read_text(encoding="utf-8")
 
 
 def test_docs_qa_passes_repo_docs() -> None:
@@ -76,3 +81,23 @@ def test_docs_qa_markdown_output_is_structured(tmp_path: Path, capsys) -> None:
     assert "## Summary" in out
     assert "- Status: pass" in out
     assert "## Issues" in out
+
+
+def test_starter_work_inventory_keeps_first_contribution_structure() -> None:
+    text = _starter_inventory_text()
+    headings = {
+        match.group(1).strip().lower()
+        for match in re.finditer(r"^##\s+(.+)$", text, flags=re.MULTILINE)
+    }
+
+    assert "how to use this inventory" in headings
+    assert "starter contribution categories" in headings
+    assert "if no starter issue is available" in headings
+
+
+def test_starter_work_inventory_keeps_contributor_path_references() -> None:
+    text = _starter_inventory_text()
+
+    assert "[First contribution quickstart](first-contribution-quickstart.md)" in text
+    assert ".github/ISSUE_TEMPLATE/feature_request.yml" in text
+    assert "docs/first-contribution-quickstart.md" in text

--- a/tests/test_triage_templates.py
+++ b/tests/test_triage_templates.py
@@ -101,3 +101,12 @@ def test_triage_templates_markdown_output_is_structured(tmp_path: Path, capsys):
     assert "## Missing checks" in out
     assert "## Triage SLA targets" in out
     assert "## Recovery actions" in out
+
+
+def test_feature_request_template_keeps_starter_scope_guidance() -> None:
+    text = Path(".github/ISSUE_TEMPLATE/feature_request.yml").read_text(encoding="utf-8")
+
+    assert "id: contributor-path" in text
+    assert "first contribution (small, reviewable in one PR)" in text
+    assert "id: starter-scope" in text
+    assert "label: Starter scope (for small contributions)" in text


### PR DESCRIPTION
### Motivation
- Ensure the starter contribution guidance and references remain intact in the repository documentation and issue templates to avoid regressions.
- Add coverage to detect accidental removals or structural changes to the starter-work inventory and feature request template.

### Description
- Add `_starter_inventory_text` helper and two tests to `tests/test_docs_qa.py` that assert specific headings and path references exist in `docs/starter-work-inventory.md`.
- Import `re` to support heading extraction in the new inventory tests.
- Add `test_feature_request_template_keeps_starter_scope_guidance` to `tests/test_triage_templates.py` that reads `.github/ISSUE_TEMPLATE/feature_request.yml` and asserts the presence of `id: contributor-path`, `id: starter-scope`, and the starter scope label text.
- These changes only add tests and do not modify runtime application logic.

### Testing
- Ran the unit test suite with `pytest`, including the added tests in `tests/test_docs_qa.py` and `tests/test_triage_templates.py`.
- All tests including the newly added inventory and template checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d46dd7bbb883208b61e2be4ec65e7e)