### PR TITLE
Align root CLI help and public surface contract to canonical release-confidence path

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -237,8 +237,8 @@ def _build_root_parser(
     *, show_hidden_commands: bool = False
 ) -> tuple[argparse.ArgumentParser, object]:
     help_description = """\
-DevS69 SDETKit is an operator-grade SDET platform with four umbrella kits:
-release confidence, test intelligence, integration assurance, and failure forensics.
+DevS69 SDETKit is an operator-grade SDET platform for deterministic release confidence
+and shipping readiness.
 
 Policy tiers: Public / stable, Advanced but supported, Experimental / incubator.
 
@@ -246,7 +246,7 @@ Start here (canonical release-confidence path):
   1) [Public / stable] python -m sdetkit gate fast
   2) [Public / stable] python -m sdetkit gate release
   3) [Public / stable] python -m sdetkit doctor
-  4) Then explore umbrella kits: python -m sdetkit kits list
+  4) Then expand into umbrella kits (advanced): python -m sdetkit kits list
 """
 
     help_epilog = render_root_help_groups()

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -17,10 +17,18 @@ class CommandFamilyContract:
 
 PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     CommandFamilyContract(
-        name="umbrella-kits",
-        role="Primary product surface for release confidence, test intelligence, integration assurance, and failure forensics.",
-        stability_tier="Advanced but supported",
+        name="release-confidence-canonical-path",
+        role="Primary first-time product surface for deterministic shipping readiness and release confidence.",
+        stability_tier="Public / stable",
         first_time_recommended=True,
+        transition_legacy_oriented=False,
+        top_level_commands=("gate", "doctor", "release"),
+    ),
+    CommandFamilyContract(
+        name="umbrella-kits",
+        role="Umbrella kits remain fully supported for expanded release, intelligence, integration, and forensics workflows.",
+        stability_tier="Advanced but supported",
+        first_time_recommended=False,
         transition_legacy_oriented=False,
         top_level_commands=("kits", "release", "intelligence", "integration", "forensics"),
     ),
@@ -92,5 +100,5 @@ def render_root_help_groups() -> str:
         lines.append(f"    {', '.join(family.top_level_commands)}")
         lines.append("")
     lines.append("Start with: python -m sdetkit gate fast -> gate release -> doctor")
-    lines.append("Then expand: python -m sdetkit kits list")
+    lines.append("Then expand (advanced): python -m sdetkit kits list")
     return "\n".join(lines)

--- a/tests/test_cli_help_discoverability_contract.py
+++ b/tests/test_cli_help_discoverability_contract.py
@@ -37,6 +37,9 @@ def test_root_help_exposes_canonical_first_time_path() -> None:
     for marker in canonical_markers:
         assert marker in normalized
 
+    assert "release confidence canonical path" in normalized
+    assert "umbrella kits [advanced but supported] (use first: no;" in normalized
+
 
 def test_root_help_includes_policy_tier_vocabulary() -> None:
     proc = _run("--help")

--- a/tests/test_cli_umbrella_surface.py
+++ b/tests/test_cli_umbrella_surface.py
@@ -9,13 +9,15 @@ def _run(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run([sys.executable, "-m", "sdetkit", *args], text=True, capture_output=True)
 
 
-def test_root_help_prioritizes_umbrella_then_compatibility() -> None:
+def test_root_help_prioritizes_canonical_path_then_umbrella_kits() -> None:
     proc = _run("--help")
     assert proc.returncode == 0
     out = proc.stdout
-    assert "umbrella kits" in out.lower()
-    assert "compatibility aliases" in out.lower()
-    assert out.index("umbrella kits") < out.index("compatibility aliases")
+    primary = "release confidence canonical path [Public / stable] (use first: yes;"
+    secondary = "umbrella kits [Advanced but supported] (use first: no;"
+    assert primary in out
+    assert secondary in out
+    assert out.index(primary) < out.index(secondary)
 
 
 def test_kits_list_and_describe_contract() -> None:


### PR DESCRIPTION
### Motivation
- The repository documentation and onboarding treat `gate fast` / `gate release` / `doctor` as the canonical first-time path, but root help and the public-surface contract still emphasized umbrella kits as primary.  
- The change should correct the first impression without altering any CLI behavior, command names, aliases, or availability.

### Description
- Updated the root help description in `src/sdetkit/cli.py` to lead with deterministic release confidence/shipping readiness and surface the canonical onboarding path (`gate fast`, `gate release`, `doctor`) near the top while marking umbrella kits as advanced.  
- Reordered and reworded `PUBLIC_SURFACE_CONTRACT` in `src/sdetkit/public_surface_contract.py` so the canonical release-confidence family is the first-time recommended product surface and umbrella kits remain fully supported and secondary.  
- Tightened targeted tests in `tests/test_cli_umbrella_surface.py` and `tests/test_cli_help_discoverability_contract.py` to assert the new help/contract ordering and phrasing without snapshot brittleness.  
- No parser, dispatch, alias, command renames, removals, or behavioral changes were made; only help/contract wording and focused tests were adjusted.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_cli_umbrella_surface.py tests/test_cli_help_discoverability_contract.py tests/test_cli_help_lists_subcommands.py` and the test suite passed: `10 passed`.  
- The modified tests specifically validate the help wording and ordering and succeeded, confirming the contract alignment without changing CLI behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d472b47f848320b392ff3891632220)