### PR TITLE
Align versioning/support doc with current stability tiers and add drift-prevention test

### DIFF
--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -4,87 +4,57 @@ SDETKit's flagship promise remains:
 
 > **Release confidence / shipping readiness for software teams.**
 
-This page documents the **current** trust-and-governance posture for versions,
-compatibility, support, and deprecation. It is intentionally compact and avoids
-promises that are not yet operationally guaranteed.
+This page is the operational policy for versioning, compatibility, support, and
+deprecation. It intentionally avoids guarantees we do not operationally enforce.
 
 ## Scope and intent
 
-- This is a **current policy** for users and maintainers.
-- It complements (not replaces) command docs, release workflow docs, and
-  stability-level guidance.
-- Where needed, this page uses terms like **intended direction** and
-  **best-effort** to stay honest about present-impact guarantees.
+- This is a **current policy** for maintainers and adopters.
+- It complements command docs and release workflow docs.
+- Tier definitions live in [stability-levels.md](stability-levels.md); this page
+  defines versioning/support behavior against those tiers.
 
 ## Versioning expectations
 
-- SDETKit uses a semantic version format (`MAJOR.MINOR.PATCH`) as the current
-  release convention.
-- Current intent:
+- SDETKit uses semantic version format (`MAJOR.MINOR.PATCH`).
+- Current maintainer intent:
   - `PATCH` for fixes/docs/internal non-breaking improvements.
   - `MINOR` for backward-compatible feature growth.
   - `MAJOR` for deliberate breaking changes.
-- Versioning is maintained with release process checks, but users should treat
-  this as a practical maintainer policy rather than a legal compatibility SLA.
+- Treat this as practical project policy, not a legal compatibility SLA.
 
-## Compatibility expectations
+## Compatibility and support posture by tier
 
-- **Stable/Core** commands and workflows are the primary compatibility target.
-- Integrations and playbooks are supported with best-effort compatibility,
-  recognizing third-party/environment variability.
-- Experimental and transition-era lanes may evolve faster and should be
-  validated before production reliance.
-- Compatibility expectations are intentionally tied to stability tiers rather
-  than assuming all surfaces have the same change velocity.
+- **Public / stable:** primary compatibility target and strongest change-control
+  expectation for release-confidence flows.
+- **Advanced but supported:** supported for production use, but docs/ergonomics
+  and integration-facing edges may iterate faster.
+- **Experimental / incubator:** opt-in and best-effort continuity; validate in
+  your own repo/CI before treating as a hard dependency.
 
-## Stability tiers and what they imply
-
-- **Stable/Core:** highest confidence for impact-to-impact release gating and shipping
-  readiness checks.
-- **Integrations:** suitable for production use after local/CI validation in
-  your environment.
-- **Playbooks:** supported and useful, but expected to iterate more than core
-  gates.
-- **Experimental:** opt-in, best-effort maintenance, and faster evolution.
-
-For tier definitions and rollout guidance, see
-[stability-levels.md](stability-levels.md).
+This posture does not mean every command has the same change velocity.
+Compatibility expectations are intentionally tier-aware.
 
 ## Deprecation approach (current)
 
-- No blanket hard timeline is promised for all deprecations.
+- No blanket deprecation SLA/timeline is promised across all surfaces.
 - Preferred approach:
-  1. Mark direction clearly in docs/CLI help/changelog where practical.
+  1. Mark direction in docs/CLI help/changelog where practical.
   2. Keep compatibility aliases/wrappers during transition windows when
      feasible.
   3. Remove or tighten behavior deliberately in a major version when impact is
      material.
-- Some historical and transition-era commands remain intentionally available for
-  auditability and migration support.
+- Some transition-era commands remain available for auditability and migration.
 
-## What users should treat as stable vs evolving
+## Maintainer release/changelog hygiene
 
-Treat as most stable for production rollout:
+When a change can affect compatibility expectations (behavior, outputs, install
+path, or integration-facing interfaces), release notes should:
 
-- Core release-confidence flow (`quick` then `release`).
-- Core gate/security/doctor/evidence command families.
-- Published installation and release-validation docs.
-
-Treat as evolving (validate before broad dependence):
-
-- Environment-specific integration edges.
-- Guided playbook narratives and transition-era/impact closeout lanes.
-- Newer or explicitly experimental command families.
-
-## Maintainer operational note (release/changelog hygiene)
-
-When a change can affect compatibility expectations (command behavior, output shape, install path, or integration-facing interfaces), maintainers should make the impact explicit in release materials:
-
-1. Call out the affected stability tier (**Stable/Core**, **Integrations**, **Playbooks**, or **Experimental**).
+1. Name the affected tier (**Public / stable**, **Advanced but supported**, or
+   **Experimental / incubator**).
 2. State whether the change is backward-compatible or transitionary.
-3. Keep `CHANGELOG.md` wording aligned with this page and [stability-levels.md](stability-levels.md).
-
-This keeps trust policy operational in everyreview and release decisions without adding heavy process overhead.
+3. Keep wording aligned with this page and [stability-levels.md](stability-levels.md).
 
 ## Related references
 

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -101,3 +101,23 @@ def test_starter_work_inventory_keeps_contributor_path_references() -> None:
     assert "[First contribution quickstart](first-contribution-quickstart.md)" in text
     assert ".github/ISSUE_TEMPLATE/feature_request.yml" in text
     assert "docs/first-contribution-quickstart.md" in text
+
+
+def test_versioning_and_stability_policy_terms_stay_aligned() -> None:
+    versioning = Path("docs/versioning-and-support.md").read_text(encoding="utf-8")
+    stability = Path("docs/stability-levels.md").read_text(encoding="utf-8")
+
+    required_tiers = (
+        "Public / stable",
+        "Advanced but supported",
+        "Experimental / incubator",
+    )
+    for tier in required_tiers:
+        assert tier in versioning
+        assert tier in stability
+
+    assert "Stable/Core" not in versioning
+    assert "Integrations" not in versioning
+    assert "Playbooks" not in versioning
+    assert "highest compatibility expectation" in stability
+    assert "primary compatibility target" in versioning


### PR DESCRIPTION
### Motivation

- Bring `docs/versioning-and-support.md` into alignment with the repo's canonical stability vocabulary so maintainers and adopters see a single, consistent policy framing. 
- Prevent future accidental reintroduction of legacy tier wording that would create mixed signals during release/review decisions. 
- Keep guidance practical and conservative (no SLAs, keep best-effort nuance) while adding a small automated guard to detect regressions.

### Description

- Rewrote `docs/versioning-and-support.md` to use the current tier vocabulary: `Public / stable`, `Advanced but supported`, and `Experimental / incubator`, and removed legacy labels from that page so wording is consistent with the stability contract. 
- Left `docs/stability-levels.md` unchanged because it was already aligned to the current vocabulary. 
- Added a focused drift-prevention test in `tests/test_docs_qa.py` named `test_versioning_and_stability_policy_terms_stay_aligned` that asserts the three canonical tier terms appear in both pages and asserts legacy labels (`Stable/Core`, `Integrations`, `Playbooks`) do not appear on the versioning/support page. 
- Changes are documentation and test-only and do not modify CLI behavior, commands, aliases, or product surfaces.

### Testing

- Built the docs with `python -m mkdocs build` and the site build completed successfully. 
- Ran the focused pytest command `PYTHONPATH=src pytest -q tests/test_docs_qa.py tests/test_first_contribution.py`; outcome: `1 failed, 15 passed` where the single failure is an existing repository docs QA anchor issue (missing local anchors in artifact docs) unrelated to this PR's edits. 
- Ran a quick grep validation (`rg -n "Public / stable|Advanced but supported|Experimental / incubator|Stable/Core|Integrations|Playbooks" docs/versioning-and-support.md docs/stability-levels.md`) to confirm the canonical tier markers exist in both pages and legacy labels were removed from the versioning/support page, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d47c8db13083209b8e2a6b68c21268)