### PR TITLE
Fix artifact docs fast-start anchor links

### DIFF
--- a/docs/artifacts/demo-sample-2.md
+++ b/docs/artifacts/demo-sample-2.md
@@ -26,4 +26,4 @@
 - Use --format markdown --output demo.md to save a shareable run artifact.
 - If a snippet check fails, rerun a single command manually and compare output with the expected markers.
 
-Related docs: [Docs fast start](../index.md#fast-start), [repo audit](../repo-audit.md).
+Related docs: [Docs fast start](../index.md#what-to-run-first), [repo audit](../repo-audit.md).

--- a/docs/artifacts/onboarding-sample-1.md
+++ b/docs/artifacts/onboarding-sample-1.md
@@ -34,4 +34,4 @@ python -m pip install -r requirements-test.txt -e .
 python -m sdetkit doctor --format text
 ```
 
-Quick start: [Docs fast start](../index.md#fast-start)
+Quick start: [Docs fast start](../index.md#what-to-run-first)


### PR DESCRIPTION
### Motivation
- Fix a pre-existing docs-QA anchor failure that caused `docs_qa` validation to fail because artifact pages pointed at a non-existent `#fast-start` anchor in `docs/index.md`, using the smallest honest docs change to restore validation.

### Description
- Update two artifact files (`docs/artifacts/demo-sample-2.md` and `docs/artifacts/onboarding-sample-1.md`) to replace `../index.md#fast-start` with the existing heading slug `../index.md#what-to-run-first` and make no other changes to CLI behavior or tests.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_docs_qa.py tests/test_first_contribution.py` which passed (`16 passed`), and ran `python -m mkdocs build` which completed successfully building the site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d47f1bd3888320b4ebead762644832)