### PR TITLE
Clarify canonical vs compatibility lane visibility in policy docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ Context: [real-repo adoption fixture + golden artifacts](real-repo-adoption.md)
 
 If you want a guided run instead of the ultra-fast proof lane, use [First run quickstart](ready-to-use.md).
 For CLI-first orientation, run `python -m sdetkit --help` to see canonical path plus stability-tier grouping.
+Need compatibility-lane expectations? See [Versioning and support posture](versioning-and-support.md#canonical-path-vs-compatibility-lanes-visibility-policy).
 
 ## What artifacts appear
 

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -35,6 +35,22 @@ deprecation. It intentionally avoids guarantees we do not operationally enforce.
 This posture does not mean every command has the same change velocity.
 Compatibility expectations are intentionally tier-aware.
 
+## Canonical path vs compatibility lanes (visibility policy)
+
+For first-time adoption and release-confidence proof, use the canonical path:
+
+1. `python -m sdetkit gate fast`
+2. `python -m sdetkit gate release`
+3. `python -m sdetkit doctor`
+
+Compatibility surfaces remain supported, including umbrella kits and
+backward-compatible aliases used by existing automation. Their continued
+availability preserves transition continuity and advanced workflows, but does
+**not** make them the primary first-time recommendation.
+
+This section is guidance visibility only. It is **not** a new deprecation wave,
+removal announcement, or command-behavior change.
+
 ## Deprecation approach (current)
 
 - No blanket deprecation SLA/timeline is promised across all surfaces.

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -121,3 +121,15 @@ def test_versioning_and_stability_policy_terms_stay_aligned() -> None:
     assert "Playbooks" not in versioning
     assert "highest compatibility expectation" in stability
     assert "primary compatibility target" in versioning
+
+
+def test_canonical_visibility_policy_keeps_compatibility_lanes_secondary() -> None:
+    versioning = Path("docs/versioning-and-support.md").read_text(encoding="utf-8")
+
+    assert "## Canonical path vs compatibility lanes (visibility policy)" in versioning
+    assert "`python -m sdetkit gate fast`" in versioning
+    assert "`python -m sdetkit gate release`" in versioning
+    assert "`python -m sdetkit doctor`" in versioning
+    assert "Compatibility surfaces remain supported" in versioning
+    assert "primary first-time recommendation" in versioning
+    assert "new deprecation wave" in versioning


### PR DESCRIPTION
### Motivation
- Make the repo's recommended onboarding and release-confidence path explicit in policy so first-time users and maintainers can clearly distinguish the canonical path from compatibility/legacy surfaces. 
- Provide visibility (not removal) guidance so compatibility lanes remain honestly described as supported but intentionally secondary, without changing CLI behavior or product surfaces.

### Description
- Added a compact visibility-policy section to `docs/versioning-and-support.md` that states the canonical first-time path (`python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor`) and explains compatibility lanes remain supported but are not the primary first-time recommendation. 
- Added a single-line pointer from `docs/index.md` to the new visibility-policy section for readers who need compatibility-lane expectations. 
- Added a focused anti-drift test in `tests/test_docs_qa.py` that checks the new heading and ensures canonical-path language and compatibility-lane framing remain present. 
- No CLI behavior, command names, aliases, or product surfaces were changed; this is documentation- and policy-only.

### Testing
- Built the docs with `python -m mkdocs build` and the site build completed successfully. 
- Ran the repository tests with `PYTHONPATH=src pytest -q tests/test_docs_qa.py tests/test_first_contribution.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d4804dc4048320aa39a5aa8dfa0adb)