### PR TITLE
Align docs to canonical tier vocabulary and add anti-drift test

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,8 +1,14 @@
 # CLI
 
-DevS69 SDETKit is organized around four umbrella kits. Use these first.
+DevS69 SDETKit first-time guidance is the canonical release-confidence path.
 
-## Primary product surface (umbrella kits)
+## Canonical first-time path (public / stable)
+
+1. `python -m sdetkit gate fast`
+2. `python -m sdetkit gate release`
+3. `python -m sdetkit doctor`
+
+## Advanced but supported surfaces (including umbrella kits)
 
 1. **Release Confidence Kit**: `sdetkit release ...`
 2. **Test Intelligence Kit**: `sdetkit intelligence ...`
@@ -10,11 +16,9 @@ DevS69 SDETKit is organized around four umbrella kits. Use these first.
 4. **Failure Forensics Kit**: `sdetkit forensics ...`
 5. **Kit discovery**: `sdetkit kits list` and `sdetkit kits describe <kit>`
 
-### First-run hero commands
+### Expanded hero commands after first proof
 
 - `sdetkit kits list`
-- `sdetkit release gate fast`
-- `sdetkit release gate release`
 - `sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json`
 - `sdetkit integration check --profile examples/kits/integration/profile.json`
 - `sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json`
@@ -30,7 +34,7 @@ Supporting utilities remain available, but are no longer the primary discovery s
 
 - `kv`, `apiget`, `cassette-get`, `patch`, `maintenance`, `ops`, `notify`, `agent`
 
-Playbook and transition-era lanes are preserved but intentionally secondary:
+Advanced playbook and experimental/incubator transition-era lanes are preserved but intentionally secondary:
 
 - `sdetkit playbooks`
 - legacy compatibility lanes and archived transition commands

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -1,6 +1,6 @@
 # Command surface inventory (stability-aware)
 
-SDETKit's public surface is unified around umbrella kits first, compatibility aliases second.
+SDETKit's public surface is unified around the canonical public/stable first-time path, with advanced and compatibility lanes secondary.
 
 ## Command-family contract snapshot
 
@@ -10,22 +10,20 @@ This table is sourced from `src/sdetkit/public_surface_contract.py`.
 
 | Command family | Purpose | Stability tier | First-time adopter default? | Transition-era / legacy-oriented? |
 |---|---|---|---|---|
-| `umbrella-kits` | Primary product surface for release confidence, test intelligence, integration assurance, and failure forensics. | Stable/Core | Yes | No |
-| `compatibility-aliases` | Backward-compatible direct lanes preserved for existing automation and muscle memory. | Stable/Compatibility | No | No |
-| `supporting-utilities-and-automation` | Supporting utilities and automation lanes; useful but intentionally secondary to flagship kits. | Stable/Supporting | No | No |
-| `playbooks` | Guided adoption and rollout lanes for operational outcomes. | Playbooks | No | No |
-| `experimental-transition-lanes` | Transition-era and legacy-oriented lanes retained for compatibility. | Experimental | No | Yes |
+| `release-confidence-canonical-path` | Primary first-time product surface for deterministic shipping readiness and release confidence. | Public / stable | Yes | No |
+| `umbrella-kits` | Umbrella kits remain fully supported for expanded release, intelligence, integration, and forensics workflows. | Advanced but supported | No | No |
+| `compatibility-aliases` | Backward-compatible direct lanes preserved for existing automation and muscle memory. | Public / stable | No | No |
+| `supporting-utilities-and-automation` | Supporting utilities and automation lanes; useful but intentionally secondary to the canonical public/stable first-time path. | Advanced but supported | No | No |
+| `playbooks` | Guided adoption and rollout lanes for operational outcomes. | Advanced but supported | No | No |
+| `experimental-transition-lanes` | Transition-era and legacy-oriented lanes retained for compatibility. | Experimental / incubator | No | Yes |
 
 <!-- END:PUBLIC_SURFACE_CONTRACT_TABLE -->
 
-## First-time path
+## First-time path (public / stable)
 
-1. `sdetkit kits list`
-2. `sdetkit release gate fast`
-3. `sdetkit release gate release`
-4. `sdetkit intelligence ...`
-5. `sdetkit integration ...`
-6. `sdetkit forensics ...`
+1. `python -m sdetkit gate fast`
+2. `python -m sdetkit gate release`
+3. `python -m sdetkit doctor`
 
 ## Compatibility path
 
@@ -33,7 +31,7 @@ Direct commands stay stable and supported:
 
 - `gate`, `doctor`, `security`, `repo`, `evidence`, `report`, `policy`
 
-Use these for existing scripts while migrating discovery/docs to umbrella-kit routes.
+Use these for existing scripts while keeping first-time discovery/docs on the canonical path.
 
 ## Supporting and experimental
 

--- a/docs/integrations-and-extension-boundary.md
+++ b/docs/integrations-and-extension-boundary.md
@@ -10,44 +10,39 @@ This page defines practical ecosystem boundaries so future growth stays useful w
 
 Use this mental model when deciding where commands, docs, and workflows should live:
 
-1. **Stable/Core** = default release-confidence path for most teams.
-2. **Integrations** = optional environment/platform wiring around core checks.
-3. **Playbooks** = guided rollout/adoption operating lanes.
-4. **Experimental / transition-era** = incubator or historical lanes kept available but secondary.
+1. **Public / stable** = default release-confidence path for most teams.
+2. **Advanced but supported** = optional environment/platform wiring and guided operating lanes around core checks.
+3. **Experimental / incubator** = transition-era or historical lanes kept available but secondary.
 
 For formal tier definitions, see [stability-levels.md](stability-levels.md) and [versioning-and-support.md](versioning-and-support.md).
 
-## What belongs in Stable/Core
+## What belongs in Public / stable
 
-Put something in **Stable/Core** when it is broadly applicable to everyshipping-readiness decisions:
+Put something in **Public / stable** when it is broadly applicable to shipping-readiness decisions:
 
 - Core gate/security/doctor/evidence workflows used across repository types.
 - Deterministic pass/fail or policy outputs relied on for go/no-go decisions.
 - Installation and first-run docs that all adopters need.
 
-Core should stay focused on the default path (`quick` then `release`) and should avoid platform- or vendor-specific assumptions.
+This tier should stay focused on the canonical first-time path (`gate fast` then `gate release` then `doctor`) and should avoid platform- or vendor-specific assumptions.
 
-## What belongs in Integrations
+## What belongs in Advanced but supported
 
-Put something in **Integrations** when it connects core signals into a specific delivery environment:
+Put something in **Advanced but supported** when it connects core signals into a specific delivery environment or guided rollout flow:
 
 - CI provider wiring, artifact upload conventions, and external notification paths.
 - Adopter-facing guidance for using SDETKit in another repository or platform.
 - Optional integrations that depend on third-party services or environment-specific credentials.
 
-Integrations should reuse Stable/Core command outputs rather than redefining core decision logic.
-
-## What belongs in Playbooks
-
-Put something in **Playbooks** when it guides how teams adopt or operate, instead of adding a new core decision primitive:
+These lanes should reuse Public/stable command outputs rather than redefining core decision logic.
 
 - Rollout sequencing and team operating patterns.
 - Onboarding and contribution guidance.
 - Scenario- or organization-specific execution narratives.
 
-Playbooks may iterate faster than core command docs as long as they stay aligned with the current stability and support posture.
+Guided adoption lanes may iterate faster than core command docs as long as they stay aligned with the current stability and support posture.
 
-## What remains Experimental / transition-era
+## What remains Experimental / incubator
 
 Keep material in **Experimental** (or explicitly transition-era) when it is:
 
@@ -63,7 +58,7 @@ SDETKit keeps optional dependencies as opt-in extras (`dev`, `test`, `docs`, `pa
 
 Practical policy:
 
-- Stable/Core usage should not require optional integrations.
+- Public/stable usage should not require optional integrations.
 - Optional extras should be documented with explicit "use when" context.
 - Integration-specific dependencies should stay isolated from default install paths.
 
@@ -73,7 +68,7 @@ See installation guidance in [install.md](install.md) and [ready-to-use.md](read
 
 When proposing a new integration or extension surface:
 
-1. Prove value using existing Stable/Core outputs first.
+1. Prove value using existing Public/stable outputs first.
 2. Keep the integration optional and environment-scoped.
 3. Document setup, failure modes, and rollback/disable path.
 4. Cross-link stability tier and versioning/support implications.
@@ -83,12 +78,12 @@ When proposing a new integration or extension surface:
 
 Maintainers should avoid:
 
-- Promoting niche/vendor-specific integrations into Stable/Core too early.
+- Promoting niche/vendor-specific integrations into Public/stable too early.
 - Treating experimental or transition-era lanes as stable compatibility promises.
 - Expanding optional surfaces without matching docs/policy updates.
 - Introducing new extension claims (for example, a formal plugin API promise) unless truly implemented and supported.
 
-If uncertain, keep new capability in Integrations or Experimental first, gather adoption evidence, then promote deliberately.
+If uncertain, keep new capability in Advanced but supported or Experimental / incubator first, gather adoption evidence, then promote deliberately.
 
 ## Related references
 

--- a/docs/migration-compatibility-note.md
+++ b/docs/migration-compatibility-note.md
@@ -2,7 +2,13 @@
 
 ## What changed
 
-SDETKit now treats umbrella kits as the primary public entry point:
+SDETKit now treats the canonical public/stable path as the first-time entry point:
+
+- `python -m sdetkit gate fast`
+- `python -m sdetkit gate release`
+- `python -m sdetkit doctor`
+
+Umbrella kits remain advanced but supported:
 
 - `sdetkit kits ...`
 - `sdetkit release ...`

--- a/docs/productization-map.md
+++ b/docs/productization-map.md
@@ -42,11 +42,11 @@ These appear closest to stable product surface:
 - Docs navigation includes strong flagship pages plus a very large historical/report corpus in the same visible namespace.
 - Command naming has overlap in places (`weekly-review`, `weekly-review-lane`, impact-specific closeouts), which can feel incubator-like to external adopters.
 
-## 2) Classification of current contents (core / integrations / playbooks / experimental)
+## 2) Classification of current contents (public/stable / advanced but supported / experimental/incubator)
 
 Classification is based on current repository contents and naming patterns.
 
-## Core
+## Public / stable
 
 **Definition:** mandatory, high-confidence paths directly tied to release confidence / shipping readiness.
 
@@ -57,7 +57,7 @@ Classification is based on current repository contents and naming patterns.
 - Primary docs:
   - `README.md`, `docs/index.md`, `docs/ready-to-use.md`, `docs/release-confidence.md`, `docs/decision-guide.md`, `docs/recommended-ci-flow.md`, `docs/adoption.md`, `docs/adoption-troubleshooting.md`.
 
-## Integrations
+## Advanced but supported
 
 **Definition:** ecosystem connectors and platform-specific interoperability that extend the core.
 
@@ -68,16 +68,7 @@ Classification is based on current repository contents and naming patterns.
 - Example integration assets:
   - `examples/ci/*`, template-related CI docs/pages.
 
-## Playbooks
-
-**Definition:** guided rollout/use-case workflows for adoption and organizational execution.
-
-- Named playbook modules:
-  - `onboarding`, `weekly_review`, `demo`, `evidence-assets`, `first_contribution`, `contributor_funnel`, `triage_templates`, `startup_readiness`, `enterprise_readiness`.
-- Rollout-oriented narrative modules:
-  - `release_communications`, `release_readiness`, `reliability_evidence_pack`, `quality_contribution_delta`, `objection_handling`, `community_activation`, `external_contribution`, `kpi_audit`.
-- Playbook discovery/routing:
-  - `playbooks_cli.py`, `sdetkit playbooks`.
+Guided playbook workflows are included in this tier for rollout/use-case execution, including `sdetkit playbooks` and associated onboarding/adoption modules.
 
 ## Experimental
 
@@ -88,17 +79,18 @@ Classification is based on current repository contents and naming patterns.
 - Large archive of impact-based docs and integration closeout pages in `docs/`.
 - Long-tail command aliases and hidden command behavior currently needed to keep main help usable.
 
-## 3) Public/stable vs unclear boundary statement
+## 3) Public/stable vs boundary clarity statement
 
 ## Treat as public/stable now
 
-- `sdetkit gate ...`
-- `sdetkit doctor ...`
+- `python -m sdetkit gate fast`
+- `python -m sdetkit gate release`
+- `python -m sdetkit doctor`
 - `sdetkit security ...`
 - `sdetkit evidence ...`
 - `sdetkit repo ...`
 - `sdetkit ci ...`
-- `scripts/ready_to_use.sh quick|release`
+- `scripts/ready_to_use.sh quick|release` (compatible wrapper lane)
 
 ## Treat as "advanced but supported"
 

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -42,7 +42,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     ),
     CommandFamilyContract(
         name="supporting-utilities-and-automation",
-        role="Supporting utilities and automation lanes; useful but intentionally secondary to flagship kits.",
+        role="Supporting utilities and automation lanes; useful but intentionally secondary to the canonical public/stable first-time path.",
         stability_tier="Advanced but supported",
         first_time_recommended=False,
         transition_legacy_oriented=False,

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -133,3 +133,27 @@ def test_canonical_visibility_policy_keeps_compatibility_lanes_secondary() -> No
     assert "Compatibility surfaces remain supported" in versioning
     assert "primary first-time recommendation" in versioning
     assert "new deprecation wave" in versioning
+
+
+def test_command_surface_policy_docs_avoid_legacy_primary_taxonomy() -> None:
+    command_surface = Path("docs/command-surface.md").read_text(encoding="utf-8")
+    boundary = Path("docs/integrations-and-extension-boundary.md").read_text(encoding="utf-8")
+
+    assert "Stable/Core" not in command_surface
+    assert "Integrations" not in command_surface
+    assert "| Playbooks |" not in command_surface
+    assert "Stable/Core" not in boundary
+    assert "## What belongs in Integrations" not in boundary
+    assert "## What belongs in Playbooks" not in boundary
+
+    for required in (
+        "Public / stable",
+        "Advanced but supported",
+        "Experimental / incubator",
+    ):
+        assert required in command_surface
+        assert required in boundary
+
+    assert "`python -m sdetkit gate fast`" in command_surface
+    assert "`python -m sdetkit gate release`" in command_surface
+    assert "`python -m sdetkit doctor`" in command_surface


### PR DESCRIPTION
### Motivation
- Reduce taxonomy drift across command-surface and policy-adjacent docs so the repo uses the canonical tiers and a single, clear first-time path. 
- Make the recommended onboarding path unambiguous while keeping umbrella kits and legacy/compatibility lanes clearly supported but secondary. 
- Add a narrow guard to prevent reintroduction of legacy primary taxonomy in the targeted docs.

### Description
- Replaced legacy labels and aligned wording to the canonical tiers (`Public / stable`, `Advanced but supported`, `Experimental / incubator`) and made the canonical first-time path explicit as `python -m sdetkit gate fast`, `python -m sdetkit gate release`, `python -m sdetkit doctor` across the targeted docs. 
- Files changed: `docs/cli.md`, `docs/command-surface.md`, `docs/integrations-and-extension-boundary.md`, `docs/migration-compatibility-note.md`, `docs/productization-map.md`, `src/sdetkit/public_surface_contract.py`, and `tests/test_docs_qa.py`. 
- Updated the public-surface contract wording in `src/sdetkit/public_surface_contract.py` and re-rendered the contract table into `docs/command-surface.md` so generated docs stay aligned. 
- Added one focused anti-drift test `test_command_surface_policy_docs_avoid_legacy_primary_taxonomy` in `tests/test_docs_qa.py` that enforces absence of legacy primary taxonomy and presence of the canonical tiers and first-time path in the targeted pages.

### Testing
- Ran `python -m mkdocs build` and the docs built successfully (site generated). 
- Ran `PYTHONPATH=src pytest -q tests/test_docs_qa.py tests/test_first_contribution.py` and all tests passed (`18 passed`). 
- Ran a repo grep to confirm expected strings and absence of legacy terms in the target files, and inspected the diff/changed files to confirm the scope is limited to terminology/policy alignment only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d4843b0218832083eab4b80d8770c0)