### PR TITLE
Add contract tests for canonical real-repo adoption fixture and goldens

### DIFF
--- a/tests/test_real_repo_adoption_contracts.py
+++ b/tests/test_real_repo_adoption_contracts.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = REPO_ROOT / "examples" / "adoption" / "real-repo"
+GOLDEN_ROOT = REPO_ROOT / "artifacts" / "adoption" / "real-repo-golden"
+
+
+def test_real_repo_fixture_has_canonical_structure() -> None:
+    required_fixture_paths = (
+        "pyproject.toml",
+        "src/app/__init__.py",
+        "src/app/main.py",
+        "tests/test_main.py",
+    )
+
+    missing = [rel_path for rel_path in required_fixture_paths if not (FIXTURE_ROOT / rel_path).is_file()]
+    assert not missing, f"missing canonical fixture files: {missing}"
+
+
+def test_real_repo_golden_artifacts_exist() -> None:
+    required_artifacts = ("gate-fast.json", "release-preflight.json", "doctor.json", "README.md")
+
+    missing = [name for name in required_artifacts if not (GOLDEN_ROOT / name).is_file()]
+    assert not missing, f"missing canonical golden artifacts: {missing}"
+
+
+def test_real_repo_gate_artifacts_preserve_contract_keys() -> None:
+    expected_profiles = {
+        "gate-fast.json": "fast",
+        "release-preflight.json": "release",
+    }
+
+    for artifact_name, expected_profile in expected_profiles.items():
+        payload = json.loads((GOLDEN_ROOT / artifact_name).read_text(encoding="utf-8"))
+        assert {"ok", "failed_steps", "profile", "steps"}.issubset(payload)
+        assert isinstance(payload["ok"], bool)
+        assert isinstance(payload["failed_steps"], list)
+        assert payload["profile"] == expected_profile
+        assert isinstance(payload["steps"], list)
+
+
+def test_real_repo_doctor_artifact_preserves_contract_keys() -> None:
+    payload = json.loads((GOLDEN_ROOT / "doctor.json").read_text(encoding="utf-8"))
+
+    assert {"ok", "quality", "recommendations"}.issubset(payload)
+    assert isinstance(payload["ok"], bool)
+    assert isinstance(payload["quality"], dict)
+    assert "failed_check_ids" in payload["quality"]
+    assert isinstance(payload["quality"]["failed_check_ids"], list)
+    assert isinstance(payload["recommendations"], list)


### PR DESCRIPTION
### Motivation
- Protect the canonical real-repo adoption proof path and its checked-in golden artifacts from silent structural drift while avoiding brittle full-file snapshots.

### Description
- Add a focused test module `tests/test_real_repo_adoption_contracts.py` that asserts the presence of the canonical fixture files under `examples/adoption/real-repo/`.
- Validate presence of the canonical golden artifacts in `artifacts/adoption/real-repo-golden/` and check contract-critical JSON markers and types for `gate-fast.json`, `release-preflight.json`, and `doctor.json` (keys such as `ok`, `failed_steps`, `profile`, `steps`, `quality.failed_check_ids`, and `recommendations`).
- No CLI behavior, command names, aliases, or broad docs were changed.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_real_repo_adoption_contracts.py` and observed `4 passed` (all new tests passed).
- Ran `python -m mkdocs build` and the docs build completed successfully (non-blocking MkDocs Material warning only).
- Local repository status shows the single new file `tests/test_real_repo_adoption_contracts.py` as the only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d485fbef7c832091f77db4478e6a4d)