### PR TITLE
Add canonical real-repo golden drift guard test

### DIFF
--- a/tests/test_real_repo_adoption_contracts.py
+++ b/tests/test_real_repo_adoption_contracts.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_ROOT = REPO_ROOT / "examples" / "adoption" / "real-repo"
@@ -51,3 +55,83 @@ def test_real_repo_doctor_artifact_preserves_contract_keys() -> None:
     assert "failed_check_ids" in payload["quality"]
     assert isinstance(payload["quality"]["failed_check_ids"], list)
     assert isinstance(payload["recommendations"], list)
+
+
+def _run_fixture_command(args: list[str], out_path: Path) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT / "src")
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "sdetkit", *args, "--format", "json", "--out", str(out_path)],
+        cwd=FIXTURE_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    assert out_path.is_file(), (
+        f"expected fixture command to emit {out_path.name} (rc={proc.returncode})\n"
+        f"stdout:\n{proc.stdout}\n"
+        f"stderr:\n{proc.stderr}"
+    )
+    return json.loads(out_path.read_text(encoding="utf-8"))
+
+
+def _normalize_cmd(parts: list[str]) -> list[str]:
+    normalized: list[str] = []
+    for part in parts:
+        if part in {str(FIXTURE_ROOT), str(REPO_ROOT)}:
+            normalized.append("<repo>")
+            continue
+        if part.endswith("/python") or part.endswith("\\python.exe"):
+            normalized.append("python")
+            continue
+        normalized.append(part.replace(str(FIXTURE_ROOT), "<repo>").replace(str(REPO_ROOT), "<repo>"))
+    return normalized
+
+
+def _project_gate_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "ok": payload["ok"],
+        "failed_steps": payload["failed_steps"],
+        "profile": payload["profile"],
+        "steps": [
+            {
+                "id": step["id"],
+                "ok": step["ok"],
+                "rc": step["rc"],
+                "cmd": _normalize_cmd(step["cmd"]),
+            }
+            for step in payload["steps"]
+        ],
+    }
+
+
+def _project_release_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    projected = _project_gate_contract(payload)
+    projected["dry_run"] = payload["dry_run"]
+    return projected
+
+
+def _project_doctor_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    quality = dict(payload["quality"])
+    quality["failed_check_ids"] = sorted(quality["failed_check_ids"])
+    return {
+        "ok": payload["ok"],
+        "quality": quality,
+        "recommendations": payload["recommendations"],
+    }
+
+
+def test_real_repo_fixture_output_matches_golden_contract_projection(tmp_path: Path) -> None:
+    actual_gate = _run_fixture_command(["gate", "fast", "--stable-json"], tmp_path / "gate-fast.json")
+    actual_release = _run_fixture_command(["gate", "release"], tmp_path / "release-preflight.json")
+    actual_doctor = _run_fixture_command(["doctor"], tmp_path / "doctor.json")
+
+    golden_gate = json.loads((GOLDEN_ROOT / "gate-fast.json").read_text(encoding="utf-8"))
+    golden_release = json.loads((GOLDEN_ROOT / "release-preflight.json").read_text(encoding="utf-8"))
+    golden_doctor = json.loads((GOLDEN_ROOT / "doctor.json").read_text(encoding="utf-8"))
+
+    assert _project_gate_contract(actual_gate) == _project_gate_contract(golden_gate)
+    assert _project_release_contract(actual_release) == _project_release_contract(golden_release)
+    assert _project_doctor_contract(actual_doctor) == _project_doctor_contract(golden_doctor)


### PR DESCRIPTION
### Motivation
- Provide a narrow, deterministic guard that detects when the canonical example fixture output (`examples/adoption/real-repo`) drifts from the checked-in golden artifacts (`artifacts/adoption/real-repo-golden`).
- Existing contract tests only verify structure and key fields but do not run the real commands and compare semantic outputs, so a replay + normalized comparison is needed. 
- Keep the change minimal and focused on artifact freshness without altering CLI behavior, commands, aliases, or product surfaces.

### Description
- Added a targeted projection-based drift test in `tests/test_real_repo_adoption_contracts.py` that re-runs the canonical fixture commands (`gate fast`, `gate release`, `doctor`) and loads the emitted JSON artifacts for comparison. 
- Implemented small helpers to run the fixture commands (`_run_fixture_command`), normalize noisy `cmd` tokens (`_normalize_cmd`), and project contract-critical fields for `gate`, `release`, and `doctor` artifacts (`_project_gate_contract`, `_project_release_contract`, `_project_doctor_contract`).
- The comparison asserts equality of the projected, normalized objects only, preserving strict checks on meaningful fields (e.g., `ok`, `failed_steps`, `profile`, per-step `id/ok/rc/cmd`, `dry_run`, `quality`, and `recommendations`) while normalizing only nondeterministic noise.
- File changed: `tests/test_real_repo_adoption_contracts.py`.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_real_repo_adoption_contracts.py` and the suite completed successfully (`5 passed`).
- Ran `python -m mkdocs build` and documentation built successfully (MkDocs emitted a non-fatal Material theme warning). 
- Verified repository status with `git diff --stat` and `git status --short` showing a single file change, and committed the test as `Add real-repo golden drift guard projection test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d48808328c8320b9f6c7a35a075ff7)