### PR TITLE
Add helper to regenerate real-repo adoption golden artifacts

### DIFF
--- a/docs/real-repo-adoption.md
+++ b/docs/real-repo-adoption.md
@@ -73,5 +73,11 @@ uploads artifacts with the same filenames, plus per-command return code files
 ## Regeneration note
 
 To refresh golden artifacts after intentional changes to fixture or gate
-behavior, rerun the local commands above and copy outputs from
+behavior, run:
+
+```bash
+python scripts/regenerate_real_repo_adoption_goldens.py
+```
+
+This helper runs the same canonical commands and copies outputs from
 `examples/adoption/real-repo/build/` to `artifacts/adoption/real-repo-golden/`.

--- a/scripts/regenerate_real_repo_adoption_goldens.py
+++ b/scripts/regenerate_real_repo_adoption_goldens.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = REPO_ROOT / "examples" / "adoption" / "real-repo"
+BUILD_DIR = FIXTURE_ROOT / "build"
+GOLDEN_DIR = REPO_ROOT / "artifacts" / "adoption" / "real-repo-golden"
+
+CANONICAL_COMMANDS = (
+    (
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "gate",
+            "fast",
+            "--format",
+            "json",
+            "--stable-json",
+            "--out",
+            "build/gate-fast.json",
+        ],
+        BUILD_DIR / "gate-fast.json",
+        GOLDEN_DIR / "gate-fast.json",
+    ),
+    (
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "gate",
+            "release",
+            "--format",
+            "json",
+            "--out",
+            "build/release-preflight.json",
+        ],
+        BUILD_DIR / "release-preflight.json",
+        GOLDEN_DIR / "release-preflight.json",
+    ),
+    (
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "doctor",
+            "--format",
+            "json",
+            "--out",
+            "build/doctor.json",
+        ],
+        BUILD_DIR / "doctor.json",
+        GOLDEN_DIR / "doctor.json",
+    ),
+)
+
+
+def _run_command(cmd: list[str], expected_output: Path) -> None:
+    proc = subprocess.run(cmd, cwd=FIXTURE_ROOT, text=True, capture_output=True, check=False)
+    if not expected_output.is_file():
+        raise RuntimeError(
+            "expected output was not produced: "
+            f"{expected_output}\n"
+            f"command: {' '.join(cmd)}\n"
+            f"returncode: {proc.returncode}\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+
+    if proc.returncode != 0:
+        print(
+            f"warning: command returned {proc.returncode} but produced {expected_output.name}",
+            file=sys.stderr,
+        )
+
+
+def main() -> int:
+    if not FIXTURE_ROOT.is_dir():
+        raise FileNotFoundError(f"fixture directory not found: {FIXTURE_ROOT}")
+    if not GOLDEN_DIR.is_dir():
+        raise FileNotFoundError(f"golden directory not found: {GOLDEN_DIR}")
+
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+
+    for cmd, build_artifact, golden_artifact in CANONICAL_COMMANDS:
+        _run_command(cmd, build_artifact)
+        shutil.copyfile(build_artifact, golden_artifact)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_real_repo_adoption_regen_helper.py
+++ b/tests/test_real_repo_adoption_regen_helper.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "regenerate_real_repo_adoption_goldens.py"
+
+
+def test_regen_helper_script_targets_canonical_paths_and_artifacts() -> None:
+    assert SCRIPT_PATH.is_file(), "missing real-repo golden regeneration helper"
+
+    script_text = SCRIPT_PATH.read_text(encoding="utf-8")
+
+    expected_tokens = (
+        "examples",
+        "adoption",
+        "real-repo",
+        "artifacts",
+        "real-repo-golden",
+        "build/gate-fast.json",
+        "build/release-preflight.json",
+        "build/doctor.json",
+        "gate-fast.json",
+        "release-preflight.json",
+        "doctor.json",
+        "--stable-json",
+    )
+
+    for token in expected_tokens:
+        assert token in script_text, f"regeneration helper drifted: missing `{token}`"


### PR DESCRIPTION
### Motivation
- Provide a small, low-friction maintainer helper that consistently regenerates the canonical real-repo adoption golden artifacts without changing CLI behavior or expanding product surface.

### Description
- Add `scripts/regenerate_real_repo_adoption_goldens.py`, a minimal Python helper that runs the three canonical commands in `examples/adoption/real-repo` and copies `build/gate-fast.json`, `build/release-preflight.json`, and `build/doctor.json` into `artifacts/adoption/real-repo-golden/`, while failing clearly if expected outputs are not produced.
- Add a focused contract test `tests/test_real_repo_adoption_regen_helper.py` that ensures the helper script exists and references the expected fixture/golden paths and artifact names (including `--stable-json`).
- Update the regeneration note in `docs/real-repo-adoption.md` to point maintainers to run `python scripts/regenerate_real_repo_adoption_goldens.py`.

### Testing
- Ran the helper once with `python scripts/regenerate_real_repo_adoption_goldens.py`, which completed and emitted warnings when gate commands returned non-zero but still produced artifacts (no silent fabrication). (succeeded)
- Ran `PYTHONPATH=src pytest -q tests/test_real_repo_adoption_contracts.py tests/test_example_goldens.py tests/test_real_repo_adoption_regen_helper.py`, which passed (`8 passed`).
- Ran `python -m mkdocs build` to validate docs build, which completed successfully (mkdocs informational warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d48c13038c8320af58c2f0f97efd4d)