### PR TITLE
Add --check mode to real-repo golden regeneration helper

### DIFF
--- a/docs/real-repo-adoption.md
+++ b/docs/real-repo-adoption.md
@@ -72,6 +72,12 @@ uploads artifacts with the same filenames, plus per-command return code files
 
 ## Regeneration note
 
+To verify whether checked-in goldens are fresh without rewriting files, run:
+
+```bash
+python scripts/regenerate_real_repo_adoption_goldens.py --check
+```
+
 To refresh golden artifacts after intentional changes to fixture or gate
 behavior, run:
 

--- a/scripts/regenerate_real_repo_adoption_goldens.py
+++ b/scripts/regenerate_real_repo_adoption_goldens.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import argparse
+import json
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_ROOT = REPO_ROOT / "examples" / "adoption" / "real-repo"
@@ -78,19 +81,116 @@ def _run_command(cmd: list[str], expected_output: Path) -> None:
         )
 
 
-def main() -> int:
+def _normalize_cmd(parts: list[str]) -> list[str]:
+    normalized: list[str] = []
+    for part in parts:
+        if part in {str(FIXTURE_ROOT), str(REPO_ROOT)}:
+            normalized.append("<repo>")
+            continue
+        if part.endswith("/python") or part.endswith("\\python.exe"):
+            normalized.append("python")
+            continue
+        normalized.append(part.replace(str(FIXTURE_ROOT), "<repo>").replace(str(REPO_ROOT), "<repo>"))
+    return normalized
+
+
+def _project_gate_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "ok": payload["ok"],
+        "failed_steps": payload["failed_steps"],
+        "profile": payload["profile"],
+        "steps": [
+            {
+                "id": step["id"],
+                "ok": step["ok"],
+                "rc": step["rc"],
+                "cmd": _normalize_cmd(step["cmd"]),
+            }
+            for step in payload["steps"]
+        ],
+    }
+
+
+def _project_release_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    projected = _project_gate_contract(payload)
+    projected["dry_run"] = payload["dry_run"]
+    return projected
+
+
+def _project_doctor_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    quality = dict(payload["quality"])
+    quality["failed_check_ids"] = sorted(quality["failed_check_ids"])
+    return {
+        "ok": payload["ok"],
+        "quality": quality,
+        "recommendations": payload["recommendations"],
+    }
+
+
+def _project_contract(artifact: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    if artifact.name == "gate-fast.json":
+        return _project_gate_contract(payload)
+    if artifact.name == "release-preflight.json":
+        return _project_release_contract(payload)
+    if artifact.name == "doctor.json":
+        return _project_doctor_contract(payload)
+    return payload
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _regenerate_goldens() -> int:
+    for cmd, build_artifact, golden_artifact in CANONICAL_COMMANDS:
+        _run_command(cmd, build_artifact)
+        shutil.copyfile(build_artifact, golden_artifact)
+    return 0
+
+
+def _check_goldens() -> int:
+    mismatches: list[str] = []
+    for cmd, build_artifact, golden_artifact in CANONICAL_COMMANDS:
+        _run_command(cmd, build_artifact)
+        generated = _project_contract(build_artifact, _load_json(build_artifact))
+        golden = _project_contract(golden_artifact, _load_json(golden_artifact))
+        if generated != golden:
+            mismatches.append(golden_artifact.name)
+
+    if mismatches:
+        print("real-repo adoption golden drift detected:", file=sys.stderr)
+        for artifact in mismatches:
+            print(f"  - mismatch: {artifact}", file=sys.stderr)
+        print(
+            "run `python scripts/regenerate_real_repo_adoption_goldens.py` to intentionally refresh checked-in goldens.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("real-repo adoption goldens are up to date.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Regenerate or verify canonical real-repo adoption golden artifacts.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify generated outputs match checked-in goldens without rewriting files.",
+    )
+    args = parser.parse_args(argv)
+
     if not FIXTURE_ROOT.is_dir():
         raise FileNotFoundError(f"fixture directory not found: {FIXTURE_ROOT}")
     if not GOLDEN_DIR.is_dir():
         raise FileNotFoundError(f"golden directory not found: {GOLDEN_DIR}")
 
     BUILD_DIR.mkdir(parents=True, exist_ok=True)
-
-    for cmd, build_artifact, golden_artifact in CANONICAL_COMMANDS:
-        _run_command(cmd, build_artifact)
-        shutil.copyfile(build_artifact, golden_artifact)
-
-    return 0
+    if args.check:
+        return _check_goldens()
+    return _regenerate_goldens()
 
 
 if __name__ == "__main__":

--- a/tests/test_real_repo_adoption_regen_helper.py
+++ b/tests/test_real_repo_adoption_regen_helper.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -24,7 +26,23 @@ def test_regen_helper_script_targets_canonical_paths_and_artifacts() -> None:
         "release-preflight.json",
         "doctor.json",
         "--stable-json",
+        "--check",
     )
 
     for token in expected_tokens:
         assert token in script_text, f"regeneration helper drifted: missing `{token}`"
+
+
+def test_regen_helper_check_mode_succeeds_when_goldens_match() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--check"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        "expected --check to succeed when canonical fixture output matches checked-in goldens\n"
+        f"stdout:\n{proc.stdout}\n"
+        f"stderr:\n{proc.stderr}"
+    )


### PR DESCRIPTION
### Motivation
- Provide maintainers a safe, single-command way to verify whether the canonical real-repo fixture output still matches the checked-in golden artifacts without overwriting them.
- Preserve the existing regeneration flow and filenames so the helper remains predictable and CI/workflow-compatible.

### Description
- Added a `--check` flag to `scripts/regenerate_real_repo_adoption_goldens.py` that runs the canonical commands, projects/generated outputs through contract-focused normalization, compares them to checked-in goldens, prints a clear mismatch summary, and exits non-zero on drift.
- Kept the default behavior unchanged by extracting regeneration into `_regenerate_goldens()` and check behavior into `_check_goldens()`, and wired both through a new `argparse`-driven `main()` entry.
- Reused/test-proven normalization/projection logic (command path normalization, gate/release/doctor contract projections, and stable ordering of `failed_check_ids`) so only instability-prone noise is normalized while contract-critical fields are preserved. 
- Files changed: `scripts/regenerate_real_repo_adoption_goldens.py` (added CLI flag, projection helpers, check/regenerate split), `tests/test_real_repo_adoption_regen_helper.py` (added `--check` token assertion and an execution test), and `docs/real-repo-adoption.md` (short note showing the `--check` command).

### Testing
- Ran `python scripts/regenerate_real_repo_adoption_goldens.py --check` which completed and exited `0` (goldens up to date). 
- Ran `python scripts/regenerate_real_repo_adoption_goldens.py` (regeneration) which completed and exited `0`.
- Ran `PYTHONPATH=src pytest -q tests/test_real_repo_adoption_contracts.py tests/test_real_repo_adoption_regen_helper.py` and all tests passed (`8 passed`).
- Built docs with `python -m mkdocs build` which completed successfully (tooling warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d48f11ded48320b0b5a562512dbcf1)