### PR TITLE
ci: enforce canonical adoption golden freshness

### DIFF
--- a/.github/workflows/adoption-real-repo-canonical.yml
+++ b/.github/workflows/adoption-real-repo-canonical.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install sdetkit from this repo
         run: python -m pip install -e .
 
+      - name: Verify canonical goldens are fresh
+        run: python scripts/regenerate_real_repo_adoption_goldens.py --check
+
       - name: Run canonical fixture path (capture rc, keep artifacts)
         working-directory: examples/adoption/real-repo
         shell: bash

--- a/docs/real-repo-adoption.md
+++ b/docs/real-repo-adoption.md
@@ -69,6 +69,8 @@ Workflow: `.github/workflows/adoption-real-repo-canonical.yml`
 The CI workflow runs the same three commands against the same fixture and
 uploads artifacts with the same filenames, plus per-command return code files
 (`*.rc`) to make pass/fail interpretation explicit during review.
+It also runs `python scripts/regenerate_real_repo_adoption_goldens.py --check`
+to fail fast when checked-in canonical goldens drift.
 
 ## Regeneration note
 

--- a/tests/test_real_repo_adoption_contracts.py
+++ b/tests/test_real_repo_adoption_contracts.py
@@ -148,6 +148,7 @@ def test_canonical_replay_workflow_contract_is_stable() -> None:
     run_scripts = "\n".join(step.get("run", "") for step in replay_steps if isinstance(step, dict))
 
     expected_commands = (
+        "python scripts/regenerate_real_repo_adoption_goldens.py --check",
         "python -m sdetkit gate fast",
         "python -m sdetkit gate release",
         "python -m sdetkit doctor",


### PR DESCRIPTION
### Motivation
- Prevent silent drift of the checked-in canonical real-repo golden artifacts by making the existing `--check` helper run in CI so PRs that touch the fixture/goldens/docs path fail fast on meaningful drift.

### Description
- Add a single CI step to `.github/workflows/adoption-real-repo-canonical.yml` that runs `python scripts/regenerate_real_repo_adoption_goldens.py --check` immediately after installing the package.
- Extend `tests/test_real_repo_adoption_contracts.py` so the workflow contract test asserts the presence of the new `--check` command in the replay job.
- Add a brief note to `docs/real-repo-adoption.md` documenting that CI runs the helper in `--check` mode.
- Files changed: `.github/workflows/adoption-real-repo-canonical.yml`, `tests/test_real_repo_adoption_contracts.py`, and `docs/real-repo-adoption.md`.

### Testing
- Ran `python scripts/regenerate_real_repo_adoption_goldens.py --check`, which completed and reported the goldens are up to date.
- Ran `PYTHONPATH=src pytest -q tests/test_real_repo_adoption_contracts.py tests/test_real_repo_adoption_regen_helper.py`, and the test suite passed (`8 passed`).
- Ran `python -m mkdocs build` to validate docs build, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d50f1736208320a72cfc0e6dd500d8)