### PR TITLE
Deduplicate canonical real-repo adoption contract projection logic

### DIFF
--- a/scripts/real_repo_adoption_projection.py
+++ b/scripts/real_repo_adoption_projection.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def normalize_cmd(parts: list[str], *, fixture_root: Path, repo_root: Path) -> list[str]:
+    normalized: list[str] = []
+    fixture_root_str = str(fixture_root)
+    repo_root_str = str(repo_root)
+
+    for part in parts:
+        if part in {fixture_root_str, repo_root_str}:
+            normalized.append("<repo>")
+            continue
+        if part.endswith("/python") or part.endswith("\\python.exe"):
+            normalized.append("python")
+            continue
+        normalized.append(part.replace(fixture_root_str, "<repo>").replace(repo_root_str, "<repo>"))
+    return normalized
+
+
+def project_gate_contract(payload: dict[str, Any], *, fixture_root: Path, repo_root: Path) -> dict[str, Any]:
+    return {
+        "ok": payload["ok"],
+        "failed_steps": payload["failed_steps"],
+        "profile": payload["profile"],
+        "steps": [
+            {
+                "id": step["id"],
+                "ok": step["ok"],
+                "rc": step["rc"],
+                "cmd": normalize_cmd(step["cmd"], fixture_root=fixture_root, repo_root=repo_root),
+            }
+            for step in payload["steps"]
+        ],
+    }
+
+
+def project_release_contract(payload: dict[str, Any], *, fixture_root: Path, repo_root: Path) -> dict[str, Any]:
+    projected = project_gate_contract(payload, fixture_root=fixture_root, repo_root=repo_root)
+    projected["dry_run"] = payload["dry_run"]
+    return projected
+
+
+def project_doctor_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    quality = dict(payload["quality"])
+    quality["failed_check_ids"] = sorted(quality["failed_check_ids"])
+    return {
+        "ok": payload["ok"],
+        "quality": quality,
+        "recommendations": payload["recommendations"],
+    }
+
+
+def project_contract_for_artifact(artifact_name: str, payload: dict[str, Any], *, fixture_root: Path, repo_root: Path) -> dict[str, Any]:
+    if artifact_name == "gate-fast.json":
+        return project_gate_contract(payload, fixture_root=fixture_root, repo_root=repo_root)
+    if artifact_name == "release-preflight.json":
+        return project_release_contract(payload, fixture_root=fixture_root, repo_root=repo_root)
+    if artifact_name == "doctor.json":
+        return project_doctor_contract(payload)
+    return payload

--- a/scripts/regenerate_real_repo_adoption_goldens.py
+++ b/scripts/regenerate_real_repo_adoption_goldens.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from real_repo_adoption_projection import project_contract_for_artifact
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_ROOT = REPO_ROOT / "examples" / "adoption" / "real-repo"
 BUILD_DIR = FIXTURE_ROOT / "build"
@@ -81,62 +83,6 @@ def _run_command(cmd: list[str], expected_output: Path) -> None:
         )
 
 
-def _normalize_cmd(parts: list[str]) -> list[str]:
-    normalized: list[str] = []
-    for part in parts:
-        if part in {str(FIXTURE_ROOT), str(REPO_ROOT)}:
-            normalized.append("<repo>")
-            continue
-        if part.endswith("/python") or part.endswith("\\python.exe"):
-            normalized.append("python")
-            continue
-        normalized.append(part.replace(str(FIXTURE_ROOT), "<repo>").replace(str(REPO_ROOT), "<repo>"))
-    return normalized
-
-
-def _project_gate_contract(payload: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "ok": payload["ok"],
-        "failed_steps": payload["failed_steps"],
-        "profile": payload["profile"],
-        "steps": [
-            {
-                "id": step["id"],
-                "ok": step["ok"],
-                "rc": step["rc"],
-                "cmd": _normalize_cmd(step["cmd"]),
-            }
-            for step in payload["steps"]
-        ],
-    }
-
-
-def _project_release_contract(payload: dict[str, Any]) -> dict[str, Any]:
-    projected = _project_gate_contract(payload)
-    projected["dry_run"] = payload["dry_run"]
-    return projected
-
-
-def _project_doctor_contract(payload: dict[str, Any]) -> dict[str, Any]:
-    quality = dict(payload["quality"])
-    quality["failed_check_ids"] = sorted(quality["failed_check_ids"])
-    return {
-        "ok": payload["ok"],
-        "quality": quality,
-        "recommendations": payload["recommendations"],
-    }
-
-
-def _project_contract(artifact: Path, payload: dict[str, Any]) -> dict[str, Any]:
-    if artifact.name == "gate-fast.json":
-        return _project_gate_contract(payload)
-    if artifact.name == "release-preflight.json":
-        return _project_release_contract(payload)
-    if artifact.name == "doctor.json":
-        return _project_doctor_contract(payload)
-    return payload
-
-
 def _load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -152,8 +98,8 @@ def _check_goldens() -> int:
     mismatches: list[str] = []
     for cmd, build_artifact, golden_artifact in CANONICAL_COMMANDS:
         _run_command(cmd, build_artifact)
-        generated = _project_contract(build_artifact, _load_json(build_artifact))
-        golden = _project_contract(golden_artifact, _load_json(golden_artifact))
+        generated = project_contract_for_artifact(build_artifact.name, _load_json(build_artifact), fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT)
+        golden = project_contract_for_artifact(golden_artifact.name, _load_json(golden_artifact), fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT)
         if generated != golden:
             mismatches.append(golden_artifact.name)
 

--- a/tests/test_real_repo_adoption_contracts.py
+++ b/tests/test_real_repo_adoption_contracts.py
@@ -11,6 +11,13 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_ROOT = REPO_ROOT / "examples" / "adoption" / "real-repo"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from real_repo_adoption_projection import (
+    project_doctor_contract,
+    project_gate_contract,
+    project_release_contract,
+)
 GOLDEN_ROOT = REPO_ROOT / "artifacts" / "adoption" / "real-repo-golden"
 CANONICAL_REPLAY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "adoption-real-repo-canonical.yml"
 
@@ -80,52 +87,6 @@ def _run_fixture_command(args: list[str], out_path: Path) -> dict[str, Any]:
     return json.loads(out_path.read_text(encoding="utf-8"))
 
 
-def _normalize_cmd(parts: list[str]) -> list[str]:
-    normalized: list[str] = []
-    for part in parts:
-        if part in {str(FIXTURE_ROOT), str(REPO_ROOT)}:
-            normalized.append("<repo>")
-            continue
-        if part.endswith("/python") or part.endswith("\\python.exe"):
-            normalized.append("python")
-            continue
-        normalized.append(part.replace(str(FIXTURE_ROOT), "<repo>").replace(str(REPO_ROOT), "<repo>"))
-    return normalized
-
-
-def _project_gate_contract(payload: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "ok": payload["ok"],
-        "failed_steps": payload["failed_steps"],
-        "profile": payload["profile"],
-        "steps": [
-            {
-                "id": step["id"],
-                "ok": step["ok"],
-                "rc": step["rc"],
-                "cmd": _normalize_cmd(step["cmd"]),
-            }
-            for step in payload["steps"]
-        ],
-    }
-
-
-def _project_release_contract(payload: dict[str, Any]) -> dict[str, Any]:
-    projected = _project_gate_contract(payload)
-    projected["dry_run"] = payload["dry_run"]
-    return projected
-
-
-def _project_doctor_contract(payload: dict[str, Any]) -> dict[str, Any]:
-    quality = dict(payload["quality"])
-    quality["failed_check_ids"] = sorted(quality["failed_check_ids"])
-    return {
-        "ok": payload["ok"],
-        "quality": quality,
-        "recommendations": payload["recommendations"],
-    }
-
-
 def test_real_repo_fixture_output_matches_golden_contract_projection(tmp_path: Path) -> None:
     actual_gate = _run_fixture_command(["gate", "fast", "--stable-json"], tmp_path / "gate-fast.json")
     actual_release = _run_fixture_command(["gate", "release"], tmp_path / "release-preflight.json")
@@ -135,9 +96,9 @@ def test_real_repo_fixture_output_matches_golden_contract_projection(tmp_path: P
     golden_release = json.loads((GOLDEN_ROOT / "release-preflight.json").read_text(encoding="utf-8"))
     golden_doctor = json.loads((GOLDEN_ROOT / "doctor.json").read_text(encoding="utf-8"))
 
-    assert _project_gate_contract(actual_gate) == _project_gate_contract(golden_gate)
-    assert _project_release_contract(actual_release) == _project_release_contract(golden_release)
-    assert _project_doctor_contract(actual_doctor) == _project_doctor_contract(golden_doctor)
+    assert project_gate_contract(actual_gate, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT) == project_gate_contract(golden_gate, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT)
+    assert project_release_contract(actual_release, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT) == project_release_contract(golden_release, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT)
+    assert project_doctor_contract(actual_doctor) == project_doctor_contract(golden_doctor)
 
 
 def test_canonical_replay_workflow_contract_is_stable() -> None:

--- a/tests/test_real_repo_adoption_regen_helper.py
+++ b/tests/test_real_repo_adoption_regen_helper.py
@@ -5,6 +5,13 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = REPO_ROOT / "examples" / "adoption" / "real-repo"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from real_repo_adoption_projection import (
+    normalize_cmd,
+    project_contract_for_artifact,
+)
 SCRIPT_PATH = REPO_ROOT / "scripts" / "regenerate_real_repo_adoption_goldens.py"
 
 
@@ -46,3 +53,40 @@ def test_regen_helper_check_mode_succeeds_when_goldens_match() -> None:
         f"stdout:\n{proc.stdout}\n"
         f"stderr:\n{proc.stderr}"
     )
+
+
+def test_projection_helper_normalizes_repo_paths_and_python_binary() -> None:
+    normalized = normalize_cmd(
+        [
+            str(FIXTURE_ROOT),
+            str(REPO_ROOT),
+            "/tmp/venv/bin/python",
+            f"{FIXTURE_ROOT}/subdir",
+            f"{REPO_ROOT}/scripts/run.py",
+        ],
+        fixture_root=FIXTURE_ROOT,
+        repo_root=REPO_ROOT,
+    )
+    assert normalized == ["<repo>", "<repo>", "python", "<repo>/subdir", "<repo>/scripts/run.py"]
+
+
+def test_projection_helper_projects_doctor_contract_with_sorted_failed_checks() -> None:
+    payload = {
+        "ok": False,
+        "quality": {"failed_check_ids": ["b", "a"], "score": 91},
+        "recommendations": [{"id": "fix-1"}],
+        "noise": "ignored",
+    }
+
+    projected = project_contract_for_artifact(
+        "doctor.json",
+        payload,
+        fixture_root=FIXTURE_ROOT,
+        repo_root=REPO_ROOT,
+    )
+
+    assert projected == {
+        "ok": False,
+        "quality": {"failed_check_ids": ["a", "b"], "score": 91},
+        "recommendations": [{"id": "fix-1"}],
+    }


### PR DESCRIPTION
### Motivation
- Prevent drift by centralizing the canonical projection/normalization logic that was duplicated between the regen helper and tests. 
- Keep the change narrowly scoped to real-repo adoption artifacts (gate/release/doctor) and preserve all external CLI behavior.

### Description
- Add a small internal helper `scripts/real_repo_adoption_projection.py` exposing `normalize_cmd`, per-artifact projection functions (`project_gate_contract`, `project_release_contract`, `project_doctor_contract`) and a dispatcher `project_contract_for_artifact`.
- Update `scripts/regenerate_real_repo_adoption_goldens.py` to use `project_contract_for_artifact(...)` for `--check` comparisons and remove the in-file projection duplication.
- Update `tests/test_real_repo_adoption_contracts.py` to import and use the shared projection helpers for golden comparisons.
- Add focused tests in `tests/test_real_repo_adoption_regen_helper.py` that assert command/path normalization and doctor `failed_check_ids` sorting.

### Testing
- Ran `python scripts/regenerate_real_repo_adoption_goldens.py --check`, which succeeded and reported goldens up to date while preserving prior warning behavior from fixture commands.
- Ran `PYTHONPATH=src pytest -q tests/test_real_repo_adoption_contracts.py tests/test_real_repo_adoption_regen_helper.py`, which passed (`10 passed`).
- Ran `python -m mkdocs build`, which completed successfully.
- Verified local diff/status to confirm the helper was added and only the expected scripts/tests were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d512cef0848320bec815c09ac16c26)