### PR TITLE
test: add focused policy-chain alignment contract

### DIFF
--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -157,3 +157,30 @@ def test_command_surface_policy_docs_avoid_legacy_primary_taxonomy() -> None:
     assert "`python -m sdetkit gate fast`" in command_surface
     assert "`python -m sdetkit gate release`" in command_surface
     assert "`python -m sdetkit doctor`" in command_surface
+
+
+def test_policy_chain_contract_keeps_canonical_first_time_primary() -> None:
+    stability = Path("docs/stability-levels.md").read_text(encoding="utf-8")
+    versioning = Path("docs/versioning-and-support.md").read_text(encoding="utf-8")
+    contract = Path("src/sdetkit/public_surface_contract.py").read_text(encoding="utf-8")
+
+    for text in (stability, versioning):
+        for tier in (
+            "Public / stable",
+            "Advanced but supported",
+            "Experimental / incubator",
+        ):
+            assert tier in text
+
+    assert "Primary first-time product surface" in contract
+    assert "first_time_recommended=True" in contract
+    assert "first_time_recommended=False" in contract
+    assert "Compatibility surfaces remain supported" in versioning
+    assert (
+        "does **not** make them the primary first-time recommendation"
+        in " ".join(versioning.split())
+    )
+
+    policy_chain = " ".join((stability, versioning, contract)).lower()
+    assert "legacy-primary" not in policy_chain
+    assert "primary recommendation for legacy" not in policy_chain


### PR DESCRIPTION
### Motivation
- Prevent silent drift between the policy docs and the public-surface contract by adding a narrow, automated contract test that protects canonical-first-time visibility and tier vocabulary alignment.

### Description
- Add `test_policy_chain_contract_keeps_canonical_first_time_primary` to `tests/test_docs_qa.py`, which asserts required tier labels appear in `docs/stability-levels.md` and `docs/versioning-and-support.md`, verifies the `public_surface_contract.py` contains primary/secondary `first_time_recommended` markers, asserts compatibility lanes are described as supported but non-primary, and checks for the absence of legacy-primary phrasing.
- Make the non-primary phrasing assertion whitespace-tolerant to avoid brittle line-wrap failures.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_docs_qa.py tests/test_first_contribution.py` and got `19 passed` (tests succeeded).
- Ran `python -m mkdocs build` which completed successfully, and inspected repository state with `git diff --stat` and `git status --short`; the only code change is `tests/test_docs_qa.py` (+27 lines) and the change is committed, so the PR is merge-ready.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d51546aff08320be76f1557a5e28d4)