### PR TITLE
Tighten CLI/reference surface around canonical stability-aware discovery

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,144 +1,68 @@
-# CLI
+# CLI reference
 
-DevS69 SDETKit first-time guidance is the canonical release-confidence path.
+This page is the **current CLI reference for command discovery**.
+
+It intentionally prioritizes:
+
+1. the canonical public/stable first-time path,
+2. stability-aware expansion into advanced surfaces,
+3. clear demotion of transition-era or legacy-oriented material.
 
 ## Canonical first-time path (public / stable)
+
+Use this exact sequence first:
 
 1. `python -m sdetkit gate fast`
 2. `python -m sdetkit gate release`
 3. `python -m sdetkit doctor`
 
-## Advanced but supported surfaces (including umbrella kits)
+This is the primary product path for first-time adoption and release-confidence proof.
 
-1. **Release Confidence Kit**: `sdetkit release ...`
-2. **Test Intelligence Kit**: `sdetkit intelligence ...`
-3. **Integration Assurance Kit**: `sdetkit integration ...`
-4. **Failure Forensics Kit**: `sdetkit forensics ...`
-5. **Kit discovery**: `sdetkit kits list` and `sdetkit kits describe <kit>`
+## Stability-aware command discovery
 
-### Expanded hero commands after first proof
+After the canonical path is working, expand deliberately:
 
-- `sdetkit kits list`
-- `sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json`
-- `sdetkit integration check --profile examples/kits/integration/profile.json`
-- `sdetkit integration topology-check --profile examples/kits/integration/heterogeneous-topology.json`
-- `sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json`
+### Advanced but supported
 
-## Compatibility and supporting surfaces
+- Umbrella kits: `sdetkit kits list`, `sdetkit kits describe <kit>`
+- Release Confidence Kit: `sdetkit release ...`
+- Test Intelligence Kit: `sdetkit intelligence ...`
+- Integration Assurance Kit: `sdetkit integration ...`
+- Failure Forensics Kit: `sdetkit forensics ...`
 
-Legacy direct commands remain fully supported for backward compatibility:
+### Public/stable compatibility aliases (secondary for discovery)
+
+These remain fully supported for existing automation and muscle memory:
 
 - `gate`, `doctor`, `security`, `repo`, `evidence`, `report`, `policy`
 
-Supporting utilities remain available, but are no longer the primary discovery surface:
+### Supporting utilities (secondary)
+
+Available utility lanes include:
 
 - `kv`, `apiget`, `cassette-get`, `patch`, `maintenance`, `ops`, `notify`, `agent`
 
-Advanced playbook and experimental/incubator transition-era lanes are preserved but intentionally secondary:
+## Transition-era and legacy-oriented material
+
+Transition-era and archived lanes remain available for compatibility, but they are **not** first-time entrypoints:
 
 - `sdetkit playbooks`
-- legacy compatibility lanes and archived transition commands
+- archived transition commands and legacy compatibility lanes
 - canonical rename map: [public-surface-rename-map](public-surface-rename-map.md)
+- historical material: [archive index](archive/index.md)
 
 ## Contract expectations
 
 Public kit commands are contract-oriented:
 
-- Machine-readable JSON with `schema_version`
-- Deterministic ordering and reproducible artifacts
-- Stable exit code lanes (`0` success, `1` policy/contract failure, `2` invalid input/usage)
+- machine-readable JSON with `schema_version`
+- deterministic ordering and reproducible artifacts
+- stable exit-code lanes (`0` success, `1` policy/contract failure, `2` invalid input/usage)
 
-## References
+## Related references
 
+- [Command surface inventory (stability-aware)](command-surface.md)
+- [Stability levels](stability-levels.md)
+- [Versioning and support posture](versioning-and-support.md)
 - [Command taxonomy](command-taxonomy.md)
-- [Command surface](command-surface.md)
 - [Umbrella architecture](architecture/umbrella-kits.md)
-- [Release kit](kits/release-confidence.md)
-- [Intelligence kit](kits/test-intelligence.md)
-- [Integration kit](kits/integration-assurance.md)
-- [Forensics kit](kits/failure-forensics.md)
-
-## reliability-evidence-pack
-
---github-actions-summary
---gitlab-ci-summary
---contribution-quality-summary
---min-reliability-score
---write-defaults
---execute
---evidence-dir
---timeout-sec
---emit-pack-dir
-
-## objection-handling
-
---docs-page
---min-faq-score
---execute
---evidence-dir
---timeout-sec
---emit-pack-dir
-
-## release-readiness
-
-```bash
-python -m sdetkit release-readiness --format json --strict
-
-Options:
-
---reliability-summary
---weekly-review-summary
---min-release-score
---write-defaults
---execute
---evidence-dir
---timeout-sec
---emit-pack-dir
-
-## startup-readiness
-
-sdetkit startup-readiness --format markdown --output docs/artifacts/startup-readiness-sample.md
-sdetkit startup-readiness --emit-pack-dir docs/artifacts/startup-readiness-pack --format json --strict
---write-defaults
-
-## enterprise-readiness
-
-sdetkit enterprise-readiness --format markdown --output docs/artifacts/enterprise-readiness-sample.md
-sdetkit enterprise-readiness --emit-pack-dir docs/artifacts/enterprise-readiness-pack --format json --strict
-sdetkit enterprise-readiness --execute --evidence-dir docs/artifacts/enterprise-readiness-pack/evidence --format json --strict
---write-defaults
---evidence-dir
-
-## release-communications
-
---release-summary
---changelog
---min-release-score
---execute
---evidence-dir
---timeout-sec
---emit-pack-dir
-
-## trust-assets
-
---readme
---docs-index
---min-trust-score
---execute
---evidence-dir
---timeout-sec
---emit-pack-dir
-
-
-## docs-nav
-
-```bash
-sdetkit docs-nav --format markdown --output docs/artifacts/docs-governance-sample.md
-sdetkit docs-nav --format text --strict
-sdetkit docs-nav --write-defaults --format json --strict
-```
-
-Options:
-
-- `--strict`
-- `--write-defaults`

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -1,6 +1,10 @@
 # Command surface inventory (stability-aware)
 
-SDETKit's public surface is unified around the canonical public/stable first-time path, with advanced and compatibility lanes secondary.
+SDETKit's public command surface is organized for coherent discovery:
+
+1. canonical public/stable first-time path,
+2. advanced but supported expansion lanes,
+3. compatibility and transition-era lanes kept available but secondary.
 
 ## Command-family contract snapshot
 
@@ -19,25 +23,22 @@ This table is sourced from `src/sdetkit/public_surface_contract.py`.
 
 <!-- END:PUBLIC_SURFACE_CONTRACT_TABLE -->
 
-## First-time path (public / stable)
+## Canonical first-time path (public / stable)
 
 1. `python -m sdetkit gate fast`
 2. `python -m sdetkit gate release`
 3. `python -m sdetkit doctor`
 
-## Compatibility path
+## Expansion and compatibility
 
-Direct commands stay stable and supported:
+- Advanced kits and discovery: `sdetkit kits list`, `sdetkit kits describe <kit>`, then `release`, `intelligence`, `integration`, `forensics`
+- Compatibility aliases: `gate`, `doctor`, `security`, `repo`, `evidence`, `report`, `policy`
+- Supporting utilities and automation: `kv`, `apiget`, `cassette-get`, `patch`, `maintenance`, `dev`, `ci`, `ops`, `notify`, `agent`
 
-- `gate`, `doctor`, `security`, `repo`, `evidence`, `report`, `policy`
+## Transition-era and historical lanes
 
-Use these for existing scripts while keeping first-time discovery/docs on the canonical path.
-
-## Supporting and experimental
-
-- Supporting utilities: `kv`, `apiget`, `cassette-get`, `patch`, `maintenance`, `dev`, `ci`, `ops`, `notify`, `agent`
 - Playbooks catalog: `sdetkit playbooks`
-- Transition-era lanes: legacy compatibility lanes and archived transition commands
+- Transition-era compatibility lanes and archived commands
 - Canonical rename map: [public-surface-rename-map](public-surface-rename-map.md)
 
 Maintainer sync:

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -246,7 +246,9 @@ Start here (canonical release-confidence path):
   1) [Public / stable] python -m sdetkit gate fast
   2) [Public / stable] python -m sdetkit gate release
   3) [Public / stable] python -m sdetkit doctor
-  4) Then expand into umbrella kits (advanced): python -m sdetkit kits list
+
+Then use stability-aware command discovery:
+  4) [Advanced but supported] python -m sdetkit kits list
 """
 
     help_epilog = render_root_help_groups()

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -88,7 +88,14 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
 
 def render_root_help_groups() -> str:
     """Render concise command-family guidance for root CLI help text."""
-    lines = ["Command groups:", ""]
+    lines = [
+        "Command discovery (stability-aware):",
+        "",
+        "  Canonical first-time path (public / stable):",
+        "    python -m sdetkit gate fast -> gate release -> doctor",
+        "",
+        "  Then expand deliberately:",
+    ]
     for family in PUBLIC_SURFACE_CONTRACT:
         name = family.name.replace("-", " ")
         lines.append(
@@ -99,6 +106,5 @@ def render_root_help_groups() -> str:
         lines.append(f"    {family.role}")
         lines.append(f"    {', '.join(family.top_level_commands)}")
         lines.append("")
-    lines.append("Start with: python -m sdetkit gate fast -> gate release -> doctor")
-    lines.append("Then expand (advanced): python -m sdetkit kits list")
+    lines.append("Next step (advanced but supported): python -m sdetkit kits list")
     return "\n".join(lines)

--- a/tests/test_cli_help_discoverability_contract.py
+++ b/tests/test_cli_help_discoverability_contract.py
@@ -38,6 +38,7 @@ def test_root_help_exposes_canonical_first_time_path() -> None:
         assert marker in normalized
 
     assert "release confidence canonical path" in normalized
+    assert "command discovery (stability-aware)" in normalized
     assert "umbrella kits [advanced but supported] (use first: no;" in normalized
 
 

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -184,3 +184,26 @@ def test_policy_chain_contract_keeps_canonical_first_time_primary() -> None:
     policy_chain = " ".join((stability, versioning, contract)).lower()
     assert "legacy-primary" not in policy_chain
     assert "primary recommendation for legacy" not in policy_chain
+
+
+def test_cli_reference_keeps_current_surface_and_demotes_transition_appendix() -> None:
+    cli_ref = Path("docs/cli.md").read_text(encoding="utf-8")
+
+    assert "## Canonical first-time path (public / stable)" in cli_ref
+    assert "`python -m sdetkit gate fast`" in cli_ref
+    assert "`python -m sdetkit gate release`" in cli_ref
+    assert "`python -m sdetkit doctor`" in cli_ref
+    assert "## Stability-aware command discovery" in cli_ref
+    assert "## Transition-era and legacy-oriented material" in cli_ref
+
+    for appendix_heading in (
+        "## reliability-evidence-pack",
+        "## objection-handling",
+        "## release-readiness",
+        "## startup-readiness",
+        "## enterprise-readiness",
+        "## release-communications",
+        "## trust-assets",
+        "## docs-nav",
+    ):
+        assert appendix_heading not in cli_ref


### PR DESCRIPTION
### Motivation

- The main CLI reference mixed current guidance with a large historical appendix, which diluted the canonical discovery story and caused wording drift between help text, docs, and the public surface contract.
- The intent is to present one clear, stability-aware source of truth for new adopters: canonical first-time path first, advanced/compatibility lanes second, and transition-era historical material clearly demoted.

### Description

- Rewrote `docs/cli.md` into a focused current-reference that prioritizes the canonical first-time path (`python -m sdetkit gate fast` → `gate release` → `doctor`), then stability-aware expansion, and demotes transition-era material to links out to archives.
- Aligned `docs/command-surface.md` with the same ordering and language so docs and contract match the discovered surface.
- Updated root help copy in `src/sdetkit/cli.py` and the epilog rendered by `src/sdetkit/public_surface_contract.py` to call out "command discovery (stability-aware)" after the canonical path.
- Tightened tests by adjusting `tests/test_cli_help_discoverability_contract.py` and adding `test_cli_reference_keeps_current_surface_and_demotes_transition_appendix` to `tests/test_docs_qa.py` to guard against regressions in help/docs wording and appendix reappearance.

### Testing

- Ran `pytest -q tests/test_cli_help_discoverability_contract.py tests/test_cli_umbrella_surface.py tests/test_docs_qa.py`, which passed: `22 passed`.
- Ran `python tools/render_public_surface_contract_table.py --check` to validate the contract table generation, which returned successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d5ca2c59008320bffd7ae7045282ac)