### PR TITLE
Align front-door product story across README/docs/CLI surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # DevS69 SDETKit
 
-DevS69 SDETKit gives engineering teams deterministic release go/no-go decisions with machine-readable evidence, using one repeatable command path from local to CI.
+DevS69 SDETKit is a release-confidence CLI: it gives engineering teams deterministic ship/no-ship decisions with machine-readable evidence, using one repeatable command path from local to CI.
+
+## Product promise (30-second view)
+
+SDETKit's primary user outcome is **shipping readiness confidence**: a team can decide go/no-go from explicit JSON evidence instead of ad hoc interpretation.
+
+The primary path is always:
+
+`python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`
+
+Everything else (umbrella kits, utilities, historical/transition-era lanes) stays available, but is intentionally secondary to first-time adoption.
 
 ## Canonical first proof lane (start here)
 
@@ -76,7 +86,7 @@ Context: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
 - Before/after evidence behavior: [`docs/before-after-evidence-example.md`](docs/before-after-evidence-example.md)
 - Real evidence artifacts from this repo: [`docs/evidence-showcase.md`](docs/evidence-showcase.md)
 
-## Secondary: broader surfaces and advanced lanes
+## Secondary surfaces (after canonical confidence path)
 
 These remain available after the core release-confidence lane is trusted.
 
@@ -117,8 +127,9 @@ artifacts/     # generated evidence packs
 - Release process: [`RELEASE.md`](RELEASE.md)
 - Enterprise readiness audit: [`docs/enterprise-readiness-audit-2026-04.md`](docs/enterprise-readiness-audit-2026-04.md)
 
-### See also (secondary, after core lane is stable)
+### Historical and transition-era references (secondary)
 
 - Compare against ad hoc workflows: [`docs/sdetkit-vs-ad-hoc.md`](docs/sdetkit-vs-ad-hoc.md)
 - Repo hygiene boundaries: [`docs/repo-cleanup-plan.md`](docs/repo-cleanup-plan.md)
 - Ongoing repo status view: [`docs/repo-health-dashboard.md`](docs/repo-health-dashboard.md)
+- Historical archive index: [`docs/archive/index.md`](docs/archive/index.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI reference
 
-This page is the **current CLI reference for command discovery**.
+This page is the **current CLI reference for command discovery** and mirrors the front-door product story.
 
 It intentionally prioritizes:
 
@@ -44,7 +44,7 @@ Available utility lanes include:
 
 ## Transition-era and legacy-oriented material
 
-Transition-era and archived lanes remain available for compatibility, but they are **not** first-time entrypoints:
+Transition-era and archived lanes remain available for compatibility, but they are **not** first-time entrypoints and should not dominate discovery:
 
 - `sdetkit playbooks`
 - archived transition commands and legacy compatibility lanes

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -1,6 +1,6 @@
 # Command surface inventory (stability-aware)
 
-SDETKit's public command surface is organized for coherent discovery:
+SDETKit's public command surface is organized for one coherent product story:
 
 1. canonical public/stable first-time path,
 2. advanced but supported expansion lanes,
@@ -14,12 +14,12 @@ This table is sourced from `src/sdetkit/public_surface_contract.py`.
 
 | Command family | Purpose | Stability tier | First-time adopter default? | Transition-era / legacy-oriented? |
 |---|---|---|---|---|
-| `release-confidence-canonical-path` | Primary first-time product surface for deterministic shipping readiness and release confidence. | Public / stable | Yes | No |
-| `umbrella-kits` | Umbrella kits remain fully supported for expanded release, intelligence, integration, and forensics workflows. | Advanced but supported | No | No |
+| `release-confidence-canonical-path` | Primary first-time product surface for deterministic shipping readiness via one canonical command path. | Public / stable | Yes | No |
+| `umbrella-kits` | Umbrella kits are fully supported expansion surfaces for release, intelligence, integration, and forensics workflows. | Advanced but supported | No | No |
 | `compatibility-aliases` | Backward-compatible direct lanes preserved for existing automation and muscle memory. | Public / stable | No | No |
 | `supporting-utilities-and-automation` | Supporting utilities and automation lanes; useful but intentionally secondary to the canonical public/stable first-time path. | Advanced but supported | No | No |
 | `playbooks` | Guided adoption and rollout lanes for operational outcomes. | Advanced but supported | No | No |
-| `experimental-transition-lanes` | Transition-era and legacy-oriented lanes retained for compatibility. | Experimental / incubator | No | Yes |
+| `experimental-transition-lanes` | Transition-era and legacy-oriented lanes retained for compatibility and historical continuity. | Experimental / incubator | No | Yes |
 
 <!-- END:PUBLIC_SURFACE_CONTRACT_TABLE -->
 
@@ -29,7 +29,7 @@ This table is sourced from `src/sdetkit/public_surface_contract.py`.
 2. `python -m sdetkit gate release`
 3. `python -m sdetkit doctor`
 
-## Expansion and compatibility
+## Expansion and compatibility (secondary to first proof)
 
 - Advanced kits and discovery: `sdetkit kits list`, `sdetkit kits describe <kit>`, then `release`, `intelligence`, `integration`, `forensics`
 - Compatibility aliases: `gate`, `doctor`, `security`, `repo`, `evidence`, `report`, `policy`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 # Start here: deterministic release confidence
 
-DevS69 SDETKit gives engineering teams deterministic release go/no-go decisions with machine-readable evidence, using one repeatable command path from local to CI.
+DevS69 SDETKit is a release-confidence CLI: it gives engineering teams deterministic ship/no-ship decisions with machine-readable evidence, using one repeatable command path from local to CI.
 
 ## What this is
 
-SDETKit is a release-confidence command path for engineering teams that need clear ship/no-ship decisions backed by structured artifacts.
+SDETKit is a productized release-confidence path for engineering teams that need clear ship/no-ship decisions backed by structured artifacts.
 
 ## Why trust it
 
@@ -69,10 +69,11 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 
 ## Secondary and advanced references
 
-Deep references, advanced integrations, and historical material remain available in navigation and are intentionally secondary to first-time adoption.
+This page is a product homepage/router, not a historical archive. Deep references, advanced integrations, and historical material remain available and are intentionally secondary to first-time adoption.
 
 If you need context after the canonical first-proof path is working:
 - New contributor? Start with the safe-first lane in [Contributing](contributing.md#first-trustworthy-contribution-safe-first-lane).
 - [SDETKit vs ad hoc tooling](sdetkit-vs-ad-hoc.md)
 - [Repo cleanup plan](repo-cleanup-plan.md)
 - [Repo health dashboard](repo-health-dashboard.md)
+- [Archive index](archive/index.md)

--- a/docs/stability-levels.md
+++ b/docs/stability-levels.md
@@ -2,7 +2,7 @@
 
 ## Why this page exists
 
-This page declares the current product boundary so adopters and contributors can make consistent decisions without guessing which surfaces are primary vs optional.
+This page declares the current product boundary so adopters and contributors can make consistent decisions about what is primary vs secondary without guesswork.
 
 ## Flagship promise
 

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -2,7 +2,7 @@
 
 SDETKit's flagship promise remains:
 
-> **Release confidence / shipping readiness for software teams.**
+> **Release confidence / shipping readiness for software teams through one canonical command path.**
 
 This page is the operational policy for versioning, compatibility, support, and
 deprecation. It intentionally avoids guarantees we do not operationally enforce.

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -18,7 +18,7 @@ class CommandFamilyContract:
 PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     CommandFamilyContract(
         name="release-confidence-canonical-path",
-        role="Primary first-time product surface for deterministic shipping readiness and release confidence.",
+        role="Primary first-time product surface for deterministic shipping readiness via one canonical command path.",
         stability_tier="Public / stable",
         first_time_recommended=True,
         transition_legacy_oriented=False,
@@ -26,7 +26,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     ),
     CommandFamilyContract(
         name="umbrella-kits",
-        role="Umbrella kits remain fully supported for expanded release, intelligence, integration, and forensics workflows.",
+        role="Umbrella kits are fully supported expansion surfaces for release, intelligence, integration, and forensics workflows.",
         stability_tier="Advanced but supported",
         first_time_recommended=False,
         transition_legacy_oriented=False,
@@ -77,7 +77,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     ),
     CommandFamilyContract(
         name="experimental-transition-lanes",
-        role="Transition-era and legacy-oriented lanes retained for compatibility.",
+        role="Transition-era and legacy-oriented lanes retained for compatibility and historical continuity.",
         stability_tier="Experimental / incubator",
         first_time_recommended=False,
         transition_legacy_oriented=True,

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -186,6 +186,34 @@ def test_policy_chain_contract_keeps_canonical_first_time_primary() -> None:
     assert "primary recommendation for legacy" not in policy_chain
 
 
+def test_front_door_story_alignment_across_readme_docs_and_cli_contract() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+    docs_home = Path("docs/index.md").read_text(encoding="utf-8")
+    command_surface = Path("docs/command-surface.md").read_text(encoding="utf-8")
+    cli_ref = Path("docs/cli.md").read_text(encoding="utf-8")
+    contract = Path("src/sdetkit/public_surface_contract.py").read_text(encoding="utf-8")
+
+    canonical_phrase = "deterministic ship/no-ship decisions with machine-readable evidence"
+    for text in (readme, docs_home):
+        assert canonical_phrase in text
+
+    canonical_commands = (
+        "`python -m sdetkit gate fast`",
+        "`python -m sdetkit gate release`",
+        "`python -m sdetkit doctor`",
+    )
+    for cmd in canonical_commands:
+        assert cmd in readme
+        assert cmd in docs_home
+        assert cmd in command_surface
+        assert cmd in cli_ref
+
+    assert "secondary" in readme.lower()
+    assert "product homepage/router" in docs_home
+    assert "archive index" in docs_home.lower()
+    assert "one canonical command path" in contract
+
+
 def test_cli_reference_keeps_current_surface_and_demotes_transition_appendix() -> None:
     cli_ref = Path("docs/cli.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
### Motivation
- Reduce conflicting product messaging so the repo front door presents one coherent identity: SDETKit as a release-confidence CLI with a single canonical first-time command path. 
- Make the primary user outcome, first commands, and primary vs secondary surfaces explicit so new visitors can understand the product in ~30 seconds. 
- Protect that story with a docs QA assertion to prevent wording drift between README, docs home, CLI reference, and the public-surface contract.

### Description
- Reframed the README front door and added a `Product promise (30-second view)` section that states the canonical path and demotes secondary/historical surfaces (`README.md`).
- Updated docs home wording and navigation to present the page as a product homepage/router and surface an archive index as secondary (`docs/index.md`).
- Aligned command-discovery and CLI reference text to prioritize the canonical path and mark expansion/transition lanes as secondary (`docs/command-surface.md`, `docs/cli.md`).
- Clarified policy wording in `docs/stability-levels.md` and `docs/versioning-and-support.md` to reference the single canonical command path.
- Adjusted `PUBLIC_SURFACE_CONTRACT` role text in `src/sdetkit/public_surface_contract.py` to match the docs narrative and regenerated the contract table in `docs/command-surface.md`.
- Added a new docs QA test `test_front_door_story_alignment_across_readme_docs_and_cli_contract` to `tests/test_docs_qa.py` to assert cross-surface alignment for the canonical phrase, first commands, and archive demotion, without changing any CLI behavior or commands.

### Testing
- Ran `pytest -q tests/test_docs_qa.py tests/test_feature_registry.py` and all tests passed (`21 passed`).
- Ran the public-surface contract sync/check with `python tools/render_public_surface_contract_table.py --check` and it reported the docs are in sync (exit 0).
- The updated suite includes the new docs QA assertion which passed as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d5ce3de17c8320a0bc3a79e09ea2f2)