### PR TITLE
Lock canonical first-run command path and artifact examples as test-enforced contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run this exact command path first:
 ```bash
 python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
-python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor
 ```
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -31,7 +31,7 @@ This is a signal-producing gate, not a guaranteed-green onboarding command.
 ## Stage 2 — baseline release confidence
 
 ```bash
-python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
 ```
 
 Add security budgets once the team has agreement on thresholds:

--- a/docs/blank-repo-to-value-60-seconds.md
+++ b/docs/blank-repo-to-value-60-seconds.md
@@ -9,7 +9,7 @@ If you want the same path with more guidance, use [First run quickstart](ready-t
 ```bash
 python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
-python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor
 ```
 

--- a/docs/choose-your-path.md
+++ b/docs/choose-your-path.md
@@ -7,7 +7,7 @@ Core promise: deterministic release-confidence checks and evidence-backed shippi
 | Who this is for | First page to open | First command or proof step | Expected outcome |
 | --- | --- | --- | --- |
 | Evaluating fit in a new repo | [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md) | `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json` | You get immediate machine-readable go/no-go evidence. |
-| New user wanting guided onboarding | [First run quickstart](ready-to-use.md) | `python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json` | You complete the canonical local command path with clear artifacts. |
+| New user wanting guided onboarding | [First run quickstart](ready-to-use.md) | `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json` then `python -m sdetkit gate release --format json --out build/release-preflight.json` | You complete the canonical local command path with clear artifacts. |
 | Team rolling out policy in CI | [Recommended CI flow](recommended-ci-flow.md) | Upload `build/*.json` artifacts from gate runs | Release checks become repeatable and reviewable in CI. |
 | Stakeholder asking “why this vs ad hoc?” | [Before/after evidence example](before-after-evidence-example.md) | Compare log-only triage vs JSON artifact triage | Decision quality and traceability become explicit. |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,14 @@ Context: [real-repo adoption fixture + golden artifacts](real-repo-adoption.md)
 
 ## What to run first
 
+Canonical first-proof commands (same as README and first-run guides):
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor
+```
+
 1. [Install (canonical)](install.md)
 2. [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
 3. [Release confidence explainer](release-confidence.md)

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -22,7 +22,7 @@ python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.js
 3. Run release gate:
 
 ```bash
-python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
 ```
 
 4. Run diagnostics:

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -10,7 +10,7 @@ Release confidence means a repository can answer **"Is this ready to ship?"** wi
 
 ```bash
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
-python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor
 ```
 

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -8,6 +8,24 @@ import pytest
 from sdetkit import docs_qa
 
 
+CANONICAL_FIRST_PROOF_DOCS = (
+    Path("README.md"),
+    Path("docs/index.md"),
+    Path("docs/blank-repo-to-value-60-seconds.md"),
+    Path("docs/ready-to-use.md"),
+    Path("docs/release-confidence.md"),
+    Path("docs/adoption.md"),
+    Path("docs/choose-your-path.md"),
+    Path("docs/real-repo-adoption.md"),
+)
+
+CANONICAL_FAST_COMMAND = "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
+CANONICAL_RELEASE_COMMAND = "python -m sdetkit gate release --format json --out build/release-preflight.json"
+NON_CANONICAL_RELEASE_STABLE_JSON = (
+    "python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json"
+)
+
+
 def _starter_inventory_text() -> str:
     return Path("docs/starter-work-inventory.md").read_text(encoding="utf-8")
 
@@ -235,3 +253,31 @@ def test_cli_reference_keeps_current_surface_and_demotes_transition_appendix() -
         "## docs-nav",
     ):
         assert appendix_heading not in cli_ref
+
+
+def test_canonical_public_docs_lock_first_proof_command_contract() -> None:
+    for path in CANONICAL_FIRST_PROOF_DOCS:
+        text = path.read_text(encoding="utf-8")
+        assert CANONICAL_FAST_COMMAND in text, f"missing canonical fast command in {path}"
+        assert (
+            CANONICAL_RELEASE_COMMAND in text
+        ), f"missing canonical release command in {path}"
+
+        assert (
+            NON_CANONICAL_RELEASE_STABLE_JSON not in text
+        ), f"non-supported release --stable-json drifted into {path}"
+
+
+def test_canonical_public_docs_lock_first_artifact_paths() -> None:
+    required_artifacts = ("build/gate-fast.json", "build/release-preflight.json")
+    for path in (
+        Path("README.md"),
+        Path("docs/index.md"),
+        Path("docs/blank-repo-to-value-60-seconds.md"),
+        Path("docs/ready-to-use.md"),
+        Path("docs/release-confidence.md"),
+        Path("docs/real-repo-adoption.md"),
+    ):
+        text = path.read_text(encoding="utf-8")
+        for artifact in required_artifacts:
+            assert artifact in text, f"missing canonical artifact path {artifact} in {path}"

--- a/tests/test_real_repo_adoption_contracts.py
+++ b/tests/test_real_repo_adoption_contracts.py
@@ -20,6 +20,11 @@ from real_repo_adoption_projection import (
 )
 GOLDEN_ROOT = REPO_ROOT / "artifacts" / "adoption" / "real-repo-golden"
 CANONICAL_REPLAY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "adoption-real-repo-canonical.yml"
+CANONICAL_FAST_COMMAND = "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
+CANONICAL_RELEASE_COMMAND = "python -m sdetkit gate release --format json --out build/release-preflight.json"
+NON_CANONICAL_RELEASE_STABLE_JSON = (
+    "python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json"
+)
 
 
 def test_real_repo_fixture_has_canonical_structure() -> None:
@@ -145,3 +150,17 @@ def test_canonical_replay_workflow_contract_is_stable() -> None:
         assert (
             f"examples/adoption/real-repo/{rel_path}" in upload_paths
         ), f"workflow drifted: missing uploaded artifact path for `{rel_path}`"
+
+
+def test_real_repo_proof_docs_and_goldens_match_canonical_command_contract() -> None:
+    real_repo_doc = (REPO_ROOT / "docs" / "real-repo-adoption.md").read_text(encoding="utf-8")
+    golden_readme = (GOLDEN_ROOT / "README.md").read_text(encoding="utf-8")
+
+    for text in (real_repo_doc, golden_readme):
+        assert CANONICAL_FAST_COMMAND in text
+        assert CANONICAL_RELEASE_COMMAND in text
+        assert NON_CANONICAL_RELEASE_STABLE_JSON not in text
+
+    assert "build/gate-fast.json" in real_repo_doc
+    assert "build/release-preflight.json" in real_repo_doc
+    assert "build/doctor.json" in real_repo_doc


### PR DESCRIPTION
### Motivation
- Prevent silent drift in the repo’s canonical public command examples by treating the first-run fast→release→doctor path and main artifact names as a product contract.
- Remove an unsupported/ambiguous flag usage (`--stable-json` on `gate release`) from primary public surfaces to avoid future accidental reintroduction.
- Ensure real-repo adoption proof surfaces and checked-in golden artifacts remain aligned with the canonical docs story.

### Description
- Normalized canonical examples so `gate release` examples no longer use `--stable-json` across `README.md`, `docs/blank-repo-to-value-60-seconds.md`, `docs/ready-to-use.md`, `docs/release-confidence.md`, and `docs/adoption.md`, and updated the README to match the supported CLI flags.  
- Added an explicit canonical first-proof command block to `docs/index.md` so the docs homepage and README share the same concrete first-run command sequence.  
- Updated `docs/choose-your-path.md` to reflect the canonical `gate fast` then `gate release` sequence for guided onboarding.  
- Added test-enforced contract checks: new assertions in `tests/test_docs_qa.py` lock the canonical command strings and required artifact paths (`build/gate-fast.json`, `build/release-preflight.json`) across the selected public docs and assert the unsupported `gate release --stable-json` does not appear; `tests/test_real_repo_adoption_contracts.py` was extended to assert `docs/real-repo-adoption.md` and `artifacts/adoption/real-repo-golden/README.md` match the canonical command/flag support and artifact paths.

### Testing
- Ran the focused test suites with `PYTHONPATH=src pytest -q tests/test_docs_qa.py tests/test_real_repo_adoption_contracts.py` and observed all tests pass (`23 passed`).
- Verified relevant CLI help outputs with `PYTHONPATH=src python -m sdetkit gate fast --help`, `PYTHONPATH=src python -m sdetkit gate release --help`, and `PYTHONPATH=src python -m sdetkit doctor --help` to confirm flag availability and help text matched expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d5d133213483209fa7afcb0a1bb41d)