### PR TITLE
Enforce public-surface alignment in Pages publishing flow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           enablement: true
 
+      - name: Verify public surface alignment contract
+        run: python scripts/check_public_surface_alignment.py
+
       - name: Build mkdocs site
         run: NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
 

--- a/scripts/check_public_surface_alignment.py
+++ b/scripts/check_public_surface_alignment.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+MKDOCS = Path("mkdocs.yml")
+PAGES_WORKFLOW = Path(".github/workflows/pages.yml")
+
+CANONICAL_PROMISE = "deterministic ship/no-ship decisions with machine-readable evidence"
+CANONICAL_FAST_COMMAND = "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
+CANONICAL_RELEASE_COMMAND = "python -m sdetkit gate release --format json --out build/release-preflight.json"
+
+
+def _missing_lines(path: Path, expected: tuple[str, ...]) -> list[str]:
+    text = path.read_text(encoding="utf-8") if path.is_file() else ""
+    return [line for line in expected if line not in text]
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    required_files = (README, DOCS_INDEX, MKDOCS, PAGES_WORKFLOW)
+    for file_path in required_files:
+        if not file_path.is_file():
+            errors.append(f"missing required file: {file_path}")
+
+    if errors:
+        print("public-surface-alignment check failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    readme_missing = _missing_lines(
+        README,
+        (
+            "release-confidence CLI",
+            CANONICAL_PROMISE,
+            CANONICAL_FAST_COMMAND,
+            CANONICAL_RELEASE_COMMAND,
+        ),
+    )
+    docs_home_missing = _missing_lines(
+        DOCS_INDEX,
+        (
+            "release-confidence CLI",
+            CANONICAL_PROMISE,
+            "product homepage/router",
+            CANONICAL_FAST_COMMAND,
+            CANONICAL_RELEASE_COMMAND,
+        ),
+    )
+    errors.extend(f"{README}: missing '{entry}'" for entry in readme_missing)
+    errors.extend(f"{DOCS_INDEX}: missing '{entry}'" for entry in docs_home_missing)
+
+    mkdocs_text = MKDOCS.read_text(encoding="utf-8")
+    if "nav:" not in mkdocs_text:
+        errors.append("mkdocs.yml: nav is missing")
+    elif "\n  - Start here: index.md" not in mkdocs_text:
+        errors.append("mkdocs.yml: first nav item must be 'Start here: index.md'")
+
+    workflow = yaml.safe_load(PAGES_WORKFLOW.read_text(encoding="utf-8"))
+    build_steps = workflow.get("jobs", {}).get("build", {}).get("steps", [])
+    run_commands = "\n".join(step.get("run", "") for step in build_steps if isinstance(step, dict))
+
+    if "python scripts/check_public_surface_alignment.py" not in run_commands:
+        errors.append("pages workflow: missing public-surface alignment contract check")
+    if "python -m mkdocs build --strict" not in run_commands:
+        errors.append("pages workflow: missing strict mkdocs build command")
+
+    if errors:
+        print("public-surface-alignment check failed:", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    print("public-surface-alignment check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_public_surface_alignment.py
+++ b/tests/test_public_surface_alignment.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PAGES_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pages.yml"
+
+
+def test_public_surface_alignment_script_passes() -> None:
+    proc = subprocess.run(
+        [sys.executable, "scripts/check_public_surface_alignment.py"],
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "public-surface-alignment check passed" in proc.stdout
+
+
+def test_pages_workflow_enforces_alignment_check_before_mkdocs_build() -> None:
+    workflow = yaml.safe_load(PAGES_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["build"]["steps"]
+    run_steps = [step.get("run", "") for step in steps if isinstance(step, dict)]
+    command_blob = "\n".join(run_steps)
+
+    assert "python scripts/check_public_surface_alignment.py" in command_blob
+    assert "python -m mkdocs build --strict" in command_blob
+    assert command_blob.index("python scripts/check_public_surface_alignment.py") < command_blob.index(
+        "python -m mkdocs build --strict"
+    )


### PR DESCRIPTION
### Motivation
- Ensure the repo's published front door (README + docs site) reliably reflects the product identity and canonical first path for release confidence.
- Prevent docs-site deploys from drifting by making the Pages publish step verify the public-surface contract before building the site.
- Provide a verifiable, repo-side guard that can be exercised in CI to maintain alignment over time.

### Description
- Add `scripts/check_public_surface_alignment.py` which validates `README.md`, `docs/index.md`, `mkdocs.yml`, and `.github/workflows/pages.yml` for the canonical promise and canonical command path and for the required `nav` start item.
- Update `.github/workflows/pages.yml` to run the alignment check before `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict` so publishing is gated on the contract.
- Add `tests/test_public_surface_alignment.py` that executes the new script and asserts the Pages workflow contains the alignment check and that it runs before the MkDocs build.
- Keep the change scoped to publication/config/tests only and do not alter product behavior or CLI surface.

### Testing
- Ran `python scripts/check_public_surface_alignment.py` which exited successfully and printed the pass message.
- Ran `PYTHONPATH=src pytest -q tests/test_public_surface_alignment.py tests/test_docs_qa.py::test_front_door_story_alignment_across_readme_docs_and_cli_contract` and the tests passed (`3 passed`).
- Built the docs with `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict` which completed successfully and produced the site.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d5d4e1894c832089c5c5cc7c3f6452)