### PR TITLE
Align front-door identity around release-confidence canonical path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 DevS69 SDETKit is a release-confidence CLI: it gives engineering teams deterministic ship/no-ship decisions with machine-readable evidence, using one repeatable command path from local to CI.
 
+**Primary outcome:** know if a change is ready to ship.
+
+**Canonical first path:** `python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`.
+
 ## Product promise (30-second view)
 
 SDETKit's primary user outcome is **shipping readiness confidence**: a team can decide go/no-go from explicit JSON evidence instead of ad hoc interpretation.
+
+In plain terms: one clear product identity, one outcome, one first path.
 
 The primary path is always:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI reference
 
-This page is the **current CLI reference for command discovery** and mirrors the front-door product story.
+This page is the **current CLI reference for command discovery** and mirrors the front-door product story: release confidence first, expansion second.
 
 It intentionally prioritizes:
 
@@ -16,7 +16,7 @@ Use this exact sequence first:
 2. `python -m sdetkit gate release`
 3. `python -m sdetkit doctor`
 
-This is the primary product path for first-time adoption and release-confidence proof.
+This is the primary product path for first-time adoption and release-confidence proof. If a new visitor remembers only one thing, it should be this exact path.
 
 ## Stability-aware command discovery
 

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -1,6 +1,6 @@
 # Command surface inventory (stability-aware)
 
-SDETKit's public command surface is organized for one coherent product story:
+SDETKit's public command surface is organized for one coherent product story: release-confidence shipping readiness via one canonical first path.
 
 1. canonical public/stable first-time path,
 2. advanced but supported expansion lanes,
@@ -29,7 +29,7 @@ This table is sourced from `src/sdetkit/public_surface_contract.py`.
 2. `python -m sdetkit gate release`
 3. `python -m sdetkit doctor`
 
-## Expansion and compatibility (secondary to first proof)
+## Expansion and compatibility (intentionally secondary to first proof)
 
 - Advanced kits and discovery: `sdetkit kits list`, `sdetkit kits describe <kit>`, then `release`, `intelligence`, `integration`, `forensics`
 - Compatibility aliases: `gate`, `doctor`, `security`, `repo`, `evidence`, `report`, `policy`

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,15 @@
 
 DevS69 SDETKit is a release-confidence CLI: it gives engineering teams deterministic ship/no-ship decisions with machine-readable evidence, using one repeatable command path from local to CI.
 
+**Primary outcome:** know if a change is ready to ship.
+
+**Canonical first path:** `python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`.
+
 ## What this is
 
 SDETKit is a productized release-confidence path for engineering teams that need clear ship/no-ship decisions backed by structured artifacts.
+
+Everything else is intentionally secondary until this first proof lane is trusted.
 
 ## Why trust it
 

--- a/docs/stability-levels.md
+++ b/docs/stability-levels.md
@@ -4,11 +4,14 @@
 
 This page declares the current product boundary so adopters and contributors can make consistent decisions about what is primary vs secondary without guesswork.
 
-## Flagship promise
+## Flagship promise (single primary identity)
 
 DevS69 SDETKit's flagship promise is:
 
 > **Deterministic release confidence / shipping readiness for software teams.**
+
+Primary outcome: decide if a change is ready to ship from explicit evidence.
+Primary first path: `gate fast` -> `gate release` -> `doctor`.
 
 ## This page is a declaration, not a refactor
 

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -4,6 +4,9 @@ SDETKit's flagship promise remains:
 
 > **Release confidence / shipping readiness for software teams through one canonical command path.**
 
+Primary outcome: know if a change is ready to ship.
+Canonical first path: `python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor`.
+
 This page is the operational policy for versioning, compatibility, support, and
 deprecation. It intentionally avoids guarantees we do not operationally enforce.
 

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -18,7 +18,7 @@ class CommandFamilyContract:
 PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     CommandFamilyContract(
         name="release-confidence-canonical-path",
-        role="Primary first-time product surface for deterministic shipping readiness via one canonical command path.",
+        role="Primary first-time product surface for deterministic shipping readiness; one clear outcome and one canonical command path.",
         stability_tier="Public / stable",
         first_time_recommended=True,
         transition_legacy_oriented=False,
@@ -26,7 +26,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     ),
     CommandFamilyContract(
         name="umbrella-kits",
-        role="Umbrella kits are fully supported expansion surfaces for release, intelligence, integration, and forensics workflows.",
+        role="Umbrella kits are fully supported expansion surfaces for release, intelligence, integration, and forensics workflows after the canonical first proof path.",
         stability_tier="Advanced but supported",
         first_time_recommended=False,
         transition_legacy_oriented=False,
@@ -34,7 +34,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     ),
     CommandFamilyContract(
         name="compatibility-aliases",
-        role="Backward-compatible direct lanes preserved for existing automation and muscle memory.",
+        role="Backward-compatible direct lanes preserved for existing automation and muscle memory; visible but secondary for first-time discovery.",
         stability_tier="Public / stable",
         first_time_recommended=False,
         transition_legacy_oriented=False,

--- a/tests/test_public_front_door_alignment.py
+++ b/tests/test_public_front_door_alignment.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+README = Path("README.md")
+DOCS_INDEX = Path("docs/index.md")
+DOCS_CLI = Path("docs/cli.md")
+DOCS_COMMAND_SURFACE = Path("docs/command-surface.md")
+DOCS_STABILITY = Path("docs/stability-levels.md")
+DOCS_VERSIONING = Path("docs/versioning-and-support.md")
+
+CANONICAL_PATH = (
+    "python -m sdetkit gate fast",
+    "python -m sdetkit gate release",
+    "python -m sdetkit doctor",
+)
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_readme_and_docs_home_share_primary_identity_language() -> None:
+    readme = _text(README)
+    docs_home = _text(DOCS_INDEX)
+
+    required = (
+        "release-confidence CLI",
+        "Primary outcome:",
+        "Canonical first path:",
+    )
+
+    for marker in required:
+        assert marker in readme
+        assert marker in docs_home
+
+
+
+def test_front_door_and_reference_docs_keep_canonical_path_obvious() -> None:
+    pages = (README, DOCS_INDEX, DOCS_CLI, DOCS_COMMAND_SURFACE, DOCS_VERSIONING)
+
+    for page in pages:
+        content = _text(page)
+        for command in CANONICAL_PATH:
+            assert command in content, f"missing canonical path command in {page}: {command}"
+
+
+
+def test_secondary_material_is_explicitly_demoted_from_front_door() -> None:
+    readme = _text(README)
+    docs_home = _text(DOCS_INDEX)
+    command_surface = _text(DOCS_COMMAND_SURFACE)
+    stability = _text(DOCS_STABILITY)
+
+    assert "Historical and transition-era references (secondary)" in readme
+    assert "intentionally secondary to first-time adoption" in docs_home
+    assert "intentionally secondary to first proof" in command_surface
+    assert "single primary identity" in stability


### PR DESCRIPTION
### Motivation
- The public entry surfaces were broad and noisy, so the repo front door needs a single clear product identity: SDETKit as a release-confidence / shipping-readiness CLI. 
- First-time visitors must see one obvious primary outcome and one canonical first path without losing secondary/legacy material. 
- Tests and the public-surface contract must protect cross-doc alignment so the front-door story remains stable.

### Description
- Reframed the README front door to add explicit `Primary outcome` and `Canonical first path` callouts and tightened the 30-second product promise so a visitor immediately understands what to run first. 
- Updated `docs/index.md`, `docs/cli.md`, `docs/command-surface.md`, `docs/stability-levels.md`, and `docs/versioning-and-support.md` to align language around a canonical-first release-confidence path while demoting secondary/historical material. 
- Adjusted wording in `src/sdetkit/public_surface_contract.py` so command-family roles explicitly reinforce the canonical-first narrative and demotion of expansion/compatibility lanes. 
- Added a new contract test `tests/test_public_front_door_alignment.py` that enforces shared primary-identity language across `README.md` and key docs and checks canonical commands are present in reference docs.

### Testing
- Ran `pytest -q tests/test_public_front_door_alignment.py tests/test_cli_help_discoverability_contract.py` and both tests passed. 
- Ran the public-surface alignment script `python scripts/check_public_surface_alignment.py` and it passed. 
- Verified the public-surface contract table check with `python tools/render_public_surface_contract_table.py --check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d5dcf89b0083209b5dcd56cc7113cd)