### PR TITLE
Sharpen front-door positioning around release-confidence CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DevS69 SDETKit is a release-confidence CLI: it gives engineering teams determini
 
 SDETKit's primary user outcome is **shipping readiness confidence**: a team can decide go/no-go from explicit JSON evidence instead of ad hoc interpretation.
 
-In plain terms: one clear product identity, one outcome, one first path.
+In plain terms: one clear product identity, one primary outcome, one canonical first path.
 
 The primary path is always:
 
@@ -81,12 +81,12 @@ Context: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
 - Very low-risk repos that do not need structured release evidence.
 - Teams that only want raw tool invocations with fully custom orchestration.
 
-## Start here
+## Start here (canonical first path)
 
 - Install (canonical): [`docs/install.md`](docs/install.md)
-- Blank repo proof in 60 seconds: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
-- Guided run (same path): [`docs/ready-to-use.md`](docs/ready-to-use.md)
-- Release-confidence model (canonical): [`docs/release-confidence.md`](docs/release-confidence.md)
+- Blank repo proof in 60 seconds (recommended first run): [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
+- Guided run (same canonical path): [`docs/ready-to-use.md`](docs/ready-to-use.md)
+- Release-confidence model (why this product exists): [`docs/release-confidence.md`](docs/release-confidence.md)
 - Root CLI grouping and canonical path view: `python -m sdetkit --help`
 - Stability levels (policy boundary): [`docs/stability-levels.md`](docs/stability-levels.md) — understand what is stable vs advanced vs experimental
 - Before/after evidence behavior: [`docs/before-after-evidence-example.md`](docs/before-after-evidence-example.md)
@@ -94,7 +94,7 @@ Context: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
 
 ## Secondary surfaces (after canonical confidence path)
 
-These remain available after the core release-confidence lane is trusted.
+These remain available and supported after the core release-confidence lane is trusted, but they are intentionally not the front-door recommendation.
 
 ### Extended repo lanes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,10 @@
 
 This page is the **current CLI reference for command discovery** and mirrors the front-door product story: release confidence first, expansion second.
 
+**Primary outcome:** know if a change is ready to ship.
+
+**Canonical first path:** `python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`.
+
 It intentionally prioritizes:
 
 1. the canonical public/stable first-time path,

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -2,6 +2,8 @@
 
 SDETKit's public command surface is organized for one coherent product story: release-confidence shipping readiness via one canonical first path.
 
+Primary outcome: know if a change is ready to ship.
+
 1. canonical public/stable first-time path,
 2. advanced but supported expansion lanes,
 3. compatibility and transition-era lanes kept available but secondary.
@@ -14,7 +16,7 @@ This table is sourced from `src/sdetkit/public_surface_contract.py`.
 
 | Command family | Purpose | Stability tier | First-time adopter default? | Transition-era / legacy-oriented? |
 |---|---|---|---|---|
-| `release-confidence-canonical-path` | Primary first-time product surface for deterministic shipping readiness via one canonical command path. | Public / stable | Yes | No |
+| `release-confidence-canonical-path` | Primary first-time product surface for deterministic shipping readiness; one primary outcome (know if a change is ready to ship) and one canonical command path. | Public / stable | Yes | No |
 | `umbrella-kits` | Umbrella kits are fully supported expansion surfaces for release, intelligence, integration, and forensics workflows. | Advanced but supported | No | No |
 | `compatibility-aliases` | Backward-compatible direct lanes preserved for existing automation and muscle memory. | Public / stable | No | No |
 | `supporting-utilities-and-automation` | Supporting utilities and automation lanes; useful but intentionally secondary to the canonical public/stable first-time path. | Advanced but supported | No | No |

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ DevS69 SDETKit is a release-confidence CLI: it gives engineering teams determini
 
 SDETKit is a productized release-confidence path for engineering teams that need clear ship/no-ship decisions backed by structured artifacts.
 
-Everything else is intentionally secondary until this first proof lane is trusted.
+Everything else is intentionally secondary until this canonical first-proof lane is trusted.
 
 ## Why trust it
 
@@ -47,7 +47,7 @@ python -m sdetkit doctor
 3. [Release confidence explainer](release-confidence.md)
 
 If you want a guided run instead of the ultra-fast proof lane, use [First run quickstart](ready-to-use.md).
-For CLI-first orientation, run `python -m sdetkit --help` to see canonical path plus stability-tier grouping.
+For CLI-first orientation, run `python -m sdetkit --help` to see the same canonical path plus stability-tier grouping.
 Need compatibility-lane expectations? See [Versioning and support posture](versioning-and-support.md#canonical-path-vs-compatibility-lanes-visibility-policy).
 
 ## What artifacts appear

--- a/docs/stability-levels.md
+++ b/docs/stability-levels.md
@@ -10,8 +10,8 @@ DevS69 SDETKit's flagship promise is:
 
 > **Deterministic release confidence / shipping readiness for software teams.**
 
-Primary outcome: decide if a change is ready to ship from explicit evidence.
-Primary first path: `gate fast` -> `gate release` -> `doctor`.
+Primary outcome: know if a change is ready to ship from explicit evidence.
+Canonical first path: `python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor`.
 
 ## This page is a declaration, not a refactor
 

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -4,7 +4,7 @@ SDETKit's flagship promise remains:
 
 > **Release confidence / shipping readiness for software teams through one canonical command path.**
 
-Primary outcome: know if a change is ready to ship.
+Primary outcome: know if a change is ready to ship from explicit evidence.
 Canonical first path: `python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor`.
 
 This page is the operational policy for versioning, compatibility, support, and

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -18,7 +18,7 @@ class CommandFamilyContract:
 PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     CommandFamilyContract(
         name="release-confidence-canonical-path",
-        role="Primary first-time product surface for deterministic shipping readiness; one clear outcome and one canonical command path.",
+        role="Primary first-time product surface for deterministic shipping readiness; one primary outcome (know if a change is ready to ship) and one canonical command path.",
         stability_tier="Public / stable",
         first_time_recommended=True,
         transition_legacy_oriented=False,

--- a/tests/test_public_front_door_alignment.py
+++ b/tests/test_public_front_door_alignment.py
@@ -36,6 +36,16 @@ def test_readme_and_docs_home_share_primary_identity_language() -> None:
         assert marker in docs_home
 
 
+def test_front_door_pages_share_same_primary_outcome_sentence() -> None:
+    expected_outcome = "know if a change is ready to ship"
+    pages = (README, DOCS_INDEX, DOCS_CLI, DOCS_COMMAND_SURFACE, DOCS_VERSIONING)
+
+    for page in pages:
+        content = _text(page)
+        assert "Primary outcome" in content, f"missing primary outcome label in {page}"
+        assert expected_outcome in content, f"missing shared primary outcome phrase in {page}"
+
+
 
 def test_front_door_and_reference_docs_keep_canonical_path_obvious() -> None:
     pages = (README, DOCS_INDEX, DOCS_CLI, DOCS_COMMAND_SURFACE, DOCS_VERSIONING)


### PR DESCRIPTION
### Motivation

- Make the repo front door present one clear product identity (SDETKit as a release-confidence / shipping-readiness CLI) so first-time visitors understand the primary outcome quickly.
- Ensure README and docs home tell the same canonical story and demote broader/legacy material to a clearly secondary position.

### Description

- Tightened front-door wording in `README.md` to explicitly state the primary outcome and canonical first path (`python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`).
- Aligned docs home and CLI/reference pages by editing `docs/index.md`, `docs/cli.md`, `docs/command-surface.md`, `docs/stability-levels.md`, and `docs/versioning-and-support.md` to use the same primary-outcome / canonical-path language and mark secondary lanes as intentionally non-front-door.
- Updated the public surface contract text in `src/sdetkit/public_surface_contract.py` and synchronized the rendered contract table row in `docs/command-surface.md` to reflect the primary-outcome framing.
- Added an alignment test in `tests/test_public_front_door_alignment.py` that asserts the shared primary-outcome phrasing appears across README, docs home, CLI, command-surface, and versioning docs.

### Testing

- Ran the public-front-door and docs QA tests with `pytest -q tests/test_public_front_door_alignment.py tests/test_docs_qa.py` and all tests passed (`20 passed`).
- Executed the public-surface contract render script with `python tools/render_public_surface_contract_table.py` to ensure the table is in sync.
- No functional CLI code or command behavior was changed; changes are wording and contract alignment only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d5debf71b48320879543ac300d9864)