### PR TITLE
docs: prioritize product-first docs navigation and demote archive

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -6,7 +6,7 @@ This section preserves **historical, transition-era, and closeout material** tha
 
 If you're new to SDETKit, start with:
 
-- [Start here (core path)](../ready-to-use.md)
+- [Start here (core path)](../index.md)
 - [Team adoption lane](../adoption.md)
 - [CI and automation lane](../recommended-ci-flow.md)
 - [Advanced and reference lane](../cli.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,16 +78,22 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Need lane routing: [Choose your path](choose-your-path.md)
 - Need team rollout: [Adopt in your repository](adoption.md)
 - Need CI rollout: [Recommended CI flow](recommended-ci-flow.md)
+- Need current references: [CLI reference](cli.md), [API](api.md), and [repo audit reference](repo-audit.md)
 - Need contributor workflow: [Contributing](contributing.md)
 - Need boundary guidance: [Stability levels](stability-levels.md) for adopters and contributors
 
-## Secondary and advanced references
+## Secondary references (current)
 
-This page is a product homepage/router, not a historical archive. Deep references, advanced integrations, and historical material remain available and are intentionally secondary to first-time adoption.
+This page is a product homepage/router, not a historical archive. Deep references and advanced material remain available and are intentionally secondary to first-time adoption.
 
 If you need context after the canonical first-proof path is working:
 - New contributor? Start with the safe-first lane in [Contributing](contributing.md#first-trustworthy-contribution-safe-first-lane).
 - [SDETKit vs ad hoc tooling](sdetkit-vs-ad-hoc.md)
 - [Repo cleanup plan](repo-cleanup-plan.md)
 - [Repo health dashboard](repo-health-dashboard.md)
+
+## Historical archive (non-primary)
+
+Historical and transition-era documentation is preserved for traceability, but intentionally demoted in primary navigation.
+
 - [Archive index](archive/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,7 @@ extra_javascript:
 
 nav:
   - Start here: index.md
-  - First-time release-confidence path:
+  - Canonical first-proof path (primary):
       - Install (canonical): install.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
       - First run quickstart (guided canonical path): ready-to-use.md
@@ -93,7 +93,7 @@ nav:
       - Decision guide (is SDETKit a fit?): decision-guide.md
       - Choose your path (30-second router): choose-your-path.md
       - Doctor checks: doctor.md
-  - Team adoption and CI rollout:
+  - Team adoption and CI rollout (primary):
       - Adopt in your repository (canonical): adoption.md
       - Team rollout scenario: team-rollout-scenario.md
       - Example adoption flow: example-adoption-flow.md
@@ -105,7 +105,20 @@ nav:
       - Reporting and trends: reporting-and-trends.md
       - Sample outputs (exploratory, non-canonical): sample-outputs.md
       - Remediation cookbook: remediation-cookbook.md
-  - Contributing and maintenance:
+  - Current reference and discoverability (secondary):
+      - CLI reference: cli.md
+      - API: api.md
+      - Repo Audit: repo-audit.md
+      - Security Gate: security-gate.md
+      - Security model: security-model.md
+      - Security hardening: security.md
+      - Policy-as-Code: policy.md
+      - Feature registry: feature-registry.md
+      - Release confidence architecture note: architecture/umbrella-kits.md
+      - Release verification records: release-verification.md
+      - Roadmap: roadmap.md
+      - Changelog: changelog.md
+  - Contributing and maintenance (secondary):
       - Repo tour: repo-tour.md
       - First contribution quickstart: first-contribution-quickstart.md
       - Contributing: contributing.md
@@ -116,7 +129,6 @@ nav:
       - Automation bots and maintenance control loop: automation-bots.md
       - n8n integration (PR webhook automation): n8n.md
   - Kits (secondary umbrella):
-      - Umbrella architecture note: architecture/umbrella-kits.md
       - Release Confidence Kit: kits/release-confidence.md
       - Test Intelligence Kit: kits/test-intelligence.md
       - Integration Assurance Kit: kits/integration-assurance.md
@@ -125,16 +137,9 @@ nav:
       - Validation route map: kits/validation-route-map.md
       - Expansion lab: kits/expansion-lab.md
   - Advanced and reference (secondary):
-      - CLI reference: cli.md
       - Platform problem authoring: platform-problem-authoring.md
       - Command surface inventory: command-surface.md
       - Capability map and command taxonomy: command-taxonomy.md
-      - API: api.md
-      - Repo Audit: repo-audit.md
-      - Security Gate: security-gate.md
-      - Security model: security-model.md
-      - Security hardening: security.md
-      - Policy-as-Code: policy.md
       - Determinism checklist: determinism-checklist.md
       - Determinism contract: determinism-contract.md
       - Evidence Pack: evidence.md
@@ -157,15 +162,13 @@ nav:
       - Releasing sdetkit: releasing.md
       - Packaging/install/release-readiness audit: packaging-readiness-audit.md
       - Public release verification records: release-verification.md
-      - Changelog: changelog.md
-      - Roadmap: roadmap.md
       - License: license.md
   - Advanced live views (secondary):
       - 🕹️ DevS69 Command HUD — Live Detail View: command-hud-live.md
       - 🔄 DevS69 Diff-to-Decision — Live Detail View: diff-flow-live.md
       - 🗺️ DevS69 Repo Map — Live Detail View: repo-map-live.md
       - DevS69 Visual HUD Showcase: hud-showcase.md
-  - Archive and history:
+  - Historical archive (non-primary):
       - Archive overview: archive/index.md
       - Transition-era material map: archive/transition-era-material.md
 

--- a/scripts/check_public_surface_alignment.py
+++ b/scripts/check_public_surface_alignment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -13,6 +14,13 @@ PAGES_WORKFLOW = Path(".github/workflows/pages.yml")
 CANONICAL_PROMISE = "deterministic ship/no-ship decisions with machine-readable evidence"
 CANONICAL_FAST_COMMAND = "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
 CANONICAL_RELEASE_COMMAND = "python -m sdetkit gate release --format json --out build/release-preflight.json"
+PRIMARY_NAV_SECTIONS = (
+    "Start here",
+    "Canonical first-proof path (primary)",
+    "Team adoption and CI rollout (primary)",
+)
+SECONDARY_NAV_SECTION = "Current reference and discoverability (secondary)"
+ARCHIVE_NAV_SECTION = "Historical archive (non-primary)"
 
 
 def _missing_lines(path: Path, expected: tuple[str, ...]) -> list[str]:
@@ -61,6 +69,21 @@ def main() -> int:
         errors.append("mkdocs.yml: nav is missing")
     elif "\n  - Start here: index.md" not in mkdocs_text:
         errors.append("mkdocs.yml: first nav item must be 'Start here: index.md'")
+    nav_block = mkdocs_text.split("\nnav:\n", 1)[1].split("\nexclude_docs:", 1)[0]
+    top_level_labels: list[str] = []
+    for line in nav_block.splitlines():
+        match = re.match(r"^  - ([^:]+):", line)
+        if match:
+            top_level_labels.append(match.group(1))
+    for section in PRIMARY_NAV_SECTIONS:
+        if section not in top_level_labels:
+            errors.append(f"mkdocs.yml: missing primary nav section '{section}'")
+    if SECONDARY_NAV_SECTION not in top_level_labels:
+        errors.append(f"mkdocs.yml: missing secondary nav section '{SECONDARY_NAV_SECTION}'")
+    if ARCHIVE_NAV_SECTION not in top_level_labels:
+        errors.append(f"mkdocs.yml: missing archive nav section '{ARCHIVE_NAV_SECTION}'")
+    if ARCHIVE_NAV_SECTION in top_level_labels and top_level_labels[-1] != ARCHIVE_NAV_SECTION:
+        errors.append("mkdocs.yml: historical archive section must be the final top-level nav section")
 
     workflow = yaml.safe_load(PAGES_WORKFLOW.read_text(encoding="utf-8"))
     build_steps = workflow.get("jobs", {}).get("build", {}).get("steps", [])

--- a/tests/test_public_surface_alignment.py
+++ b/tests/test_public_surface_alignment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -37,3 +38,19 @@ def test_pages_workflow_enforces_alignment_check_before_mkdocs_build() -> None:
     assert command_blob.index("python scripts/check_public_surface_alignment.py") < command_blob.index(
         "python -m mkdocs build --strict"
     )
+
+
+def test_mkdocs_nav_demotes_archive_to_last_section() -> None:
+    text = (REPO_ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    nav_block = text.split("\nnav:\n", 1)[1].split("\nexclude_docs:", 1)[0]
+    labels = [
+        match.group(1) for line in nav_block.splitlines() if (match := re.match(r"^  - ([^:]+):", line))
+    ]
+
+    assert labels[:3] == [
+        "Start here",
+        "Canonical first-proof path (primary)",
+        "Team adoption and CI rollout (primary)",
+    ]
+    assert "Current reference and discoverability (secondary)" in labels
+    assert labels[-1] == "Historical archive (non-primary)"


### PR DESCRIPTION
### Motivation

- Reduce docs-navigation clutter so the public docs read like a product site first and a historical archive second. 
- Make the canonical first-proof path and team/CI adoption lanes prominent while keeping historical and transition-era material reachable but demoted. 
- Enforce this intent with automated checks so historical content does not drift back into primary navigation. 

### Description

- Reworked top-level MkDocs navigation order and labels in `mkdocs.yml` to make primary product pages first and to add explicit sections: `Canonical first-proof path (primary)`, `Team adoption and CI rollout (primary)`, `Current reference and discoverability (secondary)`, and `Historical archive (non-primary)` (kept last). 
- Updated `docs/index.md` to reinforce a product-first router, add a short current-reference section, and add a dedicated `Historical archive (non-primary)` block. 
- Fixed archive routing in `docs/archive/index.md` so the archive points back to the main product front door (`docs/index.md`). 
- Strengthened the public-surface check in `scripts/check_public_surface_alignment.py` to parse the `nav` block and validate presence/order of primary/secondary/archive sections and require archive to be the final top-level nav section. 
- Added test coverage in `tests/test_public_surface_alignment.py` to lock nav ordering and archive-demotion expectations and adjusted parsing logic used in the tests. 

### Testing

- Ran `python scripts/check_public_surface_alignment.py`, which passed. 
- Ran `pytest -q tests/test_public_surface_alignment.py`, which passed (`3 passed`). 
- Ran `python scripts/check_docs_navigation_contract_11.py`, which failed due to unrelated expected documentation markers (README/cli/index expectations) that are outside this change's scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d5e0627494832080e49ebf38bf4166)