### PR TITLE
Strengthen external first-run trust contract for blank repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Everything else (umbrella kits, utilities, historical/transition-era lanes) stay
 
 ## Canonical first proof lane (start here)
 
-Run this exact command path first:
+Run this exact command path first in a brand-new repository (not this repo):
 
 ```bash
+mkdir my-repo && cd my-repo
+git init
 python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
 python -m sdetkit gate release --format json --out build/release-preflight.json
@@ -48,6 +50,15 @@ What success means:
 
 What failure means:
 - `ok: false` and/or non-empty `failed_steps` gives the first deterministic remediation target.
+- A non-zero exit code with JSON artifacts present is still a trustworthy first run: inspect `failed_steps` instead of treating it as a hidden crash.
+
+External first-run contract proof (automated):
+
+```bash
+python -m pytest -q tests/test_external_first_run_contract.py
+```
+
+This acceptance test creates a truly fresh temporary repo, installs SDETKit into a clean virtual environment, executes the canonical commands, and verifies artifact contracts.
 
 ```text
 $ cd examples/adoption/real-repo

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -16,8 +16,15 @@ Move from local confidence checks to repeatable team gates with machine-readable
 Use [Install](install.md), then verify:
 
 ```bash
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
 python -m sdetkit --help
 python -m sdetkit gate --help
+```
+
+For maintainers validating the external-install contract itself (from this repository):
+
+```bash
+python -m pytest -q tests/test_external_first_run_contract.py
 ```
 
 ## Stage 1 — local proof in the team repo

--- a/docs/blank-repo-to-value-60-seconds.md
+++ b/docs/blank-repo-to-value-60-seconds.md
@@ -7,6 +7,8 @@ If you want the same path with more guidance, use [First run quickstart](ready-t
 ## Canonical first-proof command path
 
 ```bash
+mkdir my-repo && cd my-repo
+git init
 python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
 python -m sdetkit gate release --format json --out build/release-preflight.json
@@ -34,6 +36,11 @@ A first proof is accepted when all of the following are true:
 3. Both files expose `ok`, `failed_steps`, and `profile`.
 4. `build/release-preflight.json` is reviewed first, then `build/gate-fast.json` if needed.
 
+First-run trust is about inspectable outcomes, not guaranteed green status:
+- It is valid for `gate fast`/`gate release` to return non-zero on an unprepared blank repo.
+- It is **not** valid for commands to fail without JSON artifacts.
+- A trustworthy first run always leaves machine-readable triage artifacts with `ok`, `failed_steps`, and `profile`.
+
 ## What to do if the first run fails
 
 1. Open `build/release-preflight.json` first.
@@ -42,6 +49,16 @@ A first proof is accepted when all of the following are true:
 4. Re-run the same command path.
 
 For canonical decode rules, use [CI artifact walkthrough](ci-artifact-walkthrough.md).
+
+## Automated proof that this external path stays real
+
+From this repository root, run:
+
+```bash
+python -m pytest -q tests/test_external_first_run_contract.py
+```
+
+This test creates a temporary blank external repo, installs SDETKit in a clean virtual environment, runs the canonical path, and verifies artifact contracts.
 
 ## Next step after proof
 

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -6,6 +6,12 @@ If you only want the fastest proof with minimal text, use [Blank repo to value i
 
 ## Guided run (5 minutes)
 
+0. Install in the target external repo (skip only if already installed):
+
+```bash
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+```
+
 1. (Optional) Verify CLI wiring:
 
 ```bash
@@ -49,6 +55,12 @@ bash scripts/ready_to_use.sh release
 ```
 
 External repositories should use direct `python -m sdetkit ...` commands.
+
+## Contract truth model for first-time external runs
+
+- `gate fast` and `gate release` can legitimately fail on first run while still generating trustworthy JSON triage artifacts.
+- Trust breaks only when artifacts are missing or malformed.
+- Inspect `build/release-preflight.json` and `build/gate-fast.json` before raw logs.
 
 ## Next step routing
 

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -9,6 +9,7 @@ Release confidence means a repository can answer **"Is this ready to ship?"** wi
 ## Canonical command path (primary)
 
 ```bash
+python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
 python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor
@@ -37,6 +38,16 @@ Go/no-go support model:
 - `ok` gives deterministic pass/fail.
 - `failed_steps` gives first remediation targets.
 - `profile` confirms which lane produced the result.
+
+External-first-run trust model:
+- First run is considered trustworthy when commands always emit inspectable JSON artifacts, even when gates fail.
+- Missing artifacts are contract failures; failing gates with artifacts are expected triage behavior in many fresh repos.
+
+Automated contract guard:
+
+```bash
+python -m pytest -q tests/test_external_first_run_contract.py
+```
 
 ## Primary vs optional
 

--- a/tests/test_external_first_run_contract.py
+++ b/tests/test_external_first_run_contract.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str], *, cwd: Path, env: dict[str, str], timeout: int = 240) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def test_canonical_first_path_runs_from_fresh_external_repo(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    external_repo = tmp_path / "external-repo"
+    external_repo.mkdir(parents=True)
+    (external_repo / "README.md").write_text("# external fixture\n", encoding="utf-8")
+
+    venv_dir = tmp_path / ".venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+    python_bin = venv_dir / "bin" / "python"
+
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    install = _run([str(python_bin), "-m", "pip", "install", str(repo_root)], cwd=external_repo, env=env)
+    assert install.returncode == 0, (
+        "package install failed in blank external repo fixture\n"
+        f"stdout:\n{install.stdout}\n"
+        f"stderr:\n{install.stderr}"
+    )
+
+    commands = (
+        (
+            [
+                str(python_bin),
+                "-m",
+                "sdetkit",
+                "gate",
+                "fast",
+                "--format",
+                "json",
+                "--stable-json",
+                "--out",
+                "build/gate-fast.json",
+            ],
+            external_repo / "build/gate-fast.json",
+            {"ok", "failed_steps", "profile", "steps"},
+        ),
+        (
+            [
+                str(python_bin),
+                "-m",
+                "sdetkit",
+                "gate",
+                "release",
+                "--format",
+                "json",
+                "--out",
+                "build/release-preflight.json",
+            ],
+            external_repo / "build/release-preflight.json",
+            {"ok", "failed_steps", "profile", "steps"},
+        ),
+        (
+            [
+                str(python_bin),
+                "-m",
+                "sdetkit",
+                "doctor",
+                "--format",
+                "json",
+                "--out",
+                "build/doctor.json",
+            ],
+            external_repo / "build/doctor.json",
+            {"ok", "quality", "recommendations"},
+        ),
+    )
+
+    outcomes: list[dict[str, object]] = []
+    for cmd, artifact_path, required_keys in commands:
+        proc = _run(cmd, cwd=external_repo, env=env)
+        assert artifact_path.is_file(), (
+            f"expected artifact {artifact_path} from `{cmd}`\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+        payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        assert required_keys.issubset(payload), f"artifact {artifact_path.name} missing keys"
+        outcomes.append(
+            {
+                "cmd": cmd,
+                "returncode": proc.returncode,
+                "artifact": str(artifact_path.relative_to(external_repo)),
+                "ok": payload.get("ok"),
+                "failed_steps": payload.get("failed_steps", []),
+            }
+        )
+
+    trust_summary = {
+        "fixture": "fresh-external-repo",
+        "install": "python -m pip install <repo-root>",
+        "outcomes": outcomes,
+    }
+    summary_path = external_repo / "build/external-first-run-proof-summary.json"
+    summary_path.write_text(json.dumps(trust_summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    assert summary_path.is_file()


### PR DESCRIPTION
### Motivation
- Make the canonical first-time user path verifiably trustworthy from a genuinely fresh external repository by removing hidden repo-context assumptions and codifying the product contract for first-run behavior.  
- Provide an automated, focused acceptance proof that the external-install + canonical path produces inspectable JSON artifacts even when gates truthfully fail.  
- Skills used: none (no `skill-creator`/`skill-installer` invoked because changes are repo-local docs and tests).  

### Description
- Add a new acceptance test `tests/test_external_first_run_contract.py` that provisions a clean virtualenv, creates a blank temporary repo, installs `sdetkit` (non-editable), runs the canonical path (`gate fast` → `gate release` → `doctor`), and asserts the expected artifact keys and generation.  
- Update `README.md`, `docs/blank-repo-to-value-60-seconds.md`, `docs/ready-to-use.md`, `docs/release-confidence.md`, and `docs/adoption.md` to explicitly document the external first-run workflow (e.g. `mkdir my-repo && git init` + `pip install "git+https://..."`), clarify that non-zero exit codes with JSON artifacts are valid triage outcomes, and surface the automated proof command.  
- Document the automated contract guard command (`python -m pytest -q tests/test_external_first_run_contract.py`) so maintainers can continuously verify the external-first-run contract.  

### Testing
- Ran linting: `python -m ruff check tests/test_external_first_run_contract.py README.md docs/...` and the checks passed.  
- Ran the new acceptance test: `python -m pytest -q tests/test_external_first_run_contract.py` and it passed (`1 passed`).  
- Ran targeted docs QA checks: `python -m pytest -q tests/test_docs_qa.py -k 'canonical_public_docs_lock_first_proof_command_contract or canonical_public_docs_lock_first_artifact_paths'` and the selected tests passed (`2 passed, 14 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d66a8be2fc8320b14f5e0ea86fec16)