### PR TITLE
docs: refresh repository analysis snapshot — 2026-04-10

### DIFF
--- a/docs/repo-analysis-2026-04-10.md
+++ b/docs/repo-analysis-2026-04-10.md
@@ -2,93 +2,67 @@
 
 ## Scope
 
-This report summarizes a quick health and structure analysis of the repository, focused on:
+This is a quick structural and quality snapshot of the DevS69 SDETKit repository as of **April 10, 2026**.
 
-- project layout and scale,
-- packaging/tooling posture,
-- current test/lint status,
-- immediate risks visible from failing checks.
+## What I inspected
 
-## What was inspected
+- Product and positioning entrypoint: `README.md`
+- Packaging and toolchain configuration: `pyproject.toml`
+- Architecture map: `docs/project-structure.md`
+- CLI discoverability surface: `python -m sdetkit --help`
+- Current lint baseline: `ruff check src tests`
 
-- `README.md`
-- `pyproject.toml`
-- `quality.sh`
-- `docs/index.md`
-- `src/sdetkit/cli.py`
+## High-level architecture read
 
-## High-level findings
+1. **Product intent is clear and opinionated.**  
+   The repository is centered around deterministic release-confidence decisions with a canonical first path: `gate fast -> gate release -> doctor`.
 
-1. **Clear product direction and first-run path.**
-   The README strongly centers the release-confidence flow and artifact-first troubleshooting path.
+2. **Codebase is broad and mature.**  
+   Current repository-level counts from local scan:
+   - **649** Python files
+   - **183** Python modules under `src/sdetkit/`
+   - **278** `test_*.py` files under `tests/`
+   - **685** Markdown docs under `docs/`
 
-2. **Large, mature surface area.**
-   The repository currently contains:
-   - ~3,596 Python files,
-   - 278 test files,
-   - 684 docs markdown files.
+3. **The CLI surface is very large.**  
+   Root help exposes a substantial command catalog (core gates + many advanced/supporting lanes), indicating this is both a product CLI and an automation platform.
 
-3. **Quality baseline is mostly healthy.**
-   - `ruff check src tests` passes.
-   - Full pytest run is high-pass but not green (4 failures / 1,569 passing, 3 deselected).
+## Operational findings
 
-4. **Current failures are mostly contract drift, not runtime crashes.**
-   The failing tests point to content/expectation mismatches:
-   - hidden-command/help text policy around the word `proof`,
-   - docs navigation strict contract expectations,
-   - quality script usage string mismatch.
+### 1) Strengths
 
-## Failing areas from test run
+- **Strong front-door narrative** in `README.md` with explicit expected artifacts and triage order.
+- **Well-defined packaging posture** in `pyproject.toml` (Python 3.11+, explicit optional dependency groups, configured ruff/mypy/pytest).
+- **Documented structure discipline** in `docs/project-structure.md` with concrete file-placement rules.
 
-### 1) CLI help surface contract drift
+### 2) Current quality signal
 
-Two tests fail because they expect `proof` to not appear in root help output, but `proof` appears in description text (e.g., “canonical first proof path”).
+- `ruff check src tests` currently fails with **4 import-order violations** in tests:
+  - `tests/test_cli_help_discoverability_contract.py`
+  - `tests/test_docs_qa.py`
+  - `tests/test_public_front_door_alignment.py`
+  - `tests/test_public_surface_alignment.py`
 
-Likely cause:
-- tests currently enforce a very strict string-level constraint,
-- help prose changed in a way that includes the token while command hiding still exists.
+These are low-risk style violations (auto-fixable), but they will block “lint green” CI if enforced as required status checks.
 
-### 2) Docs navigation strict mode mismatch
+## Suggested next steps
 
-`docs-navigation` strict test reports missing required sections/anchors in `docs/index.md`, including quick-jump wrapper and legacy reports links.
+1. **Clear lint debt first** with `ruff check --fix` (or manually reorder imports in the four tests).
+2. **Run a focused confidence lane** after lint repair:
+   - `pytest -q tests/test_cli_help_discoverability_contract.py`
+   - `pytest -q tests/test_docs_qa.py`
+   - `pytest -q tests/test_public_surface_alignment.py`
+3. **Consider command-surface consolidation** for discoverability:
+   - keep the canonical path prominent,
+   - group/retire overlapping advanced lanes over time,
+   - maintain strict help-contract tests for front-door stability.
 
-Likely cause:
-- docs governance checks were tightened or defaults changed,
-- `docs/index.md` structure did not get updated to satisfy the current strict contract.
+## Commands run for this snapshot
 
-### 3) `quality.sh` usage text mismatch
-
-A test expects a usage line without `brutal`, but script now documents `brutal` mode.
-
-Likely cause:
-- script behavior evolved,
-- test assertion string was not updated.
-
-## Suggested next actions
-
-1. **Resolve contract intent first (policy decision):**
-   Decide whether tests should enforce literal token exclusion (`proof`) in all help text, or only exclude it as a command listing.
-
-2. **Align docs governance contract:**
-   Either:
-   - restore expected quick-jump/legacy/top-journeys sections in `docs/index.md`, or
-   - intentionally update `docs_navigation` expected defaults/tests if governance rules changed.
-
-3. **Synchronize `quality.sh` and tests:**
-   Update test expectation to include `brutal` mode, or remove `brutal` from usage/help if it should not be public.
-
-4. **Add a “contract drift” CI lane (optional):**
-   A focused test subset around CLI help, docs-nav, and quality script contracts can fail fast before full-suite runtime.
-
-## Commands run
-
-- `python --version`
-- `pytest -q`
+- `find . -maxdepth 1 -type d`
+- `rg --files -g '*.py' | wc -l`
+- `rg --files tests -g 'test_*.py' | wc -l`
+- `rg --files docs -g '*.md' | wc -l`
+- `rg --files src/sdetkit -g '*.py' | wc -l`
+- `python -m sdetkit --help`
 - `ruff check src tests`
-- `python - <<'PY' ...` (counts for Python files, test files, docs markdown)
-
-## Current status snapshot
-
-- Lint: pass
-- Test suite: mostly pass, 4 targeted failures
-- Risk level: **low-to-moderate** (contract drift with high visibility, low core runtime risk based on this pass)


### PR DESCRIPTION
### Motivation
- Refresh the repository analysis to record current repository scale, CLI-surface observations, and actionable next steps based on a recent scan.

### Description
- Update `docs/repo-analysis-2026-04-10.md` to replace stale findings with an up-to-date snapshot including counts of Python files/modules/tests/docs, CLI help observations, lint findings, and suggested remediation steps.

### Testing
- Ran `python -m sdetkit --help` (succeeded) and `ruff check src tests`, which reported 4 auto-fixable import-order violations in existing test files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90685545c833299fc9cad2e43fd77)