### PR TITLE
CI/CLI: enforce public command contract, add premerge gate & KPI pack, lazy-load CLI, and CI summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,20 @@ jobs:
       - name: Install project + dev/test extras
         run: python -m pip install -c constraints-ci.txt -e .[dev,test]
 
+      - name: Ruff lint baseline
+        run: python -m ruff check src tests
+
+      - name: Public surface alignment contract
+        run: |
+          python scripts/check_public_surface_alignment.py
+          python -m pytest -q tests/test_cli_help_discoverability_contract.py tests/test_public_surface_alignment.py
+
+      - name: Pre-merge changed-files strict gate
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          QUALITY_DIFF_BASE: ${{ github.event.pull_request.base.sha }}
+        run: bash quality.sh premerge
+
       - name: Canonical fast gate (offline default)
         if: ${{ github.event.inputs.run_network_tests != 'true' }}
         run: bash ci.sh quick --skip-docs --artifact-dir build
@@ -102,6 +116,13 @@ jobs:
           python -m sdetkit intelligence flake classify --history examples/kits/intelligence/flake-history.json > build/intelligence-flake.json
           python -m sdetkit integration check --profile examples/kits/integration/profile.json > build/integration-check.json
           python -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json > build/forensics-compare.json
+          python -m sdetkit doctor --format json --out build/doctor.json || true
+
+      - name: Build unified CI summary artifact
+        if: always()
+        run: |
+          mkdir -p build
+          python scripts/build_ci_summary.py --artifact-dir build --out-json build/ci-summary.json --out-md build/ci-summary.md
 
       - name: Upload CI gate diagnostics
         if: always()
@@ -118,6 +139,9 @@ jobs:
             build/intelligence-flake.json
             build/integration-check.json
             build/forensics-compare.json
+            build/doctor.json
+            build/ci-summary.json
+            build/ci-summary.md
           retention-days: 14
           if-no-files-found: warn
 
@@ -172,11 +196,28 @@ jobs:
       - name: Wheel contents check
         run: python -m check_wheel_contents --ignore W009 dist/*.whl
 
+      - name: Emit package-validate summary
+        run: |
+          mkdir -p build
+          python - <<'PY'
+          import json
+          from datetime import UTC, datetime
+          payload = {
+            "ok": True,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "checks": ["build", "twine_check", "wheel_contents_check"],
+          }
+          with open("build/package-validate.json", "w", encoding="utf-8") as f:
+            f.write(json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")) + "\n")
+          PY
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: dist
-          path: dist/*
+          path: |
+            dist/*
+            build/package-validate.json
 
   smoke-install:
     name: Smoke install from built wheel (py${{ matrix.python-version }})

--- a/.github/workflows/kpi-weekly.yml
+++ b/.github/workflows/kpi-weekly.yml
@@ -1,0 +1,124 @@
+name: Weekly Release Confidence KPI Pack
+
+on:
+  schedule:
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  kpi-pack:
+    name: Build weekly KPI pack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install project + dev/test extras
+        run: python -m pip install -c constraints-ci.txt -e .[dev,test]
+
+      - name: Build KPI metric snapshot
+        run: |
+          set +e
+          mkdir -p build docs/artifacts/kpi-weekly
+          START_TS=$(date +%s)
+          python -m ruff check src tests --output-format json > build/ruff-report.json || true
+          python -m mypy src/sdetkit --hide-error-context --no-color-output --no-error-summary > build/mypy-report.txt || true
+
+          FIRST_SUCCESS_SEC=""
+          RELEASE_GATE_RC=1
+          for CMD in \
+            "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json" \
+            "python -m sdetkit gate release --format json --out build/release-preflight.json" \
+            "python -m sdetkit doctor --format json --out build/doctor.json"; do
+            bash -lc "$CMD"
+            RC=$?
+            if [[ "$CMD" == *"gate release"* ]]; then
+              RELEASE_GATE_RC=$RC
+            fi
+            if [ "$RC" -eq 0 ] && [ -z "$FIRST_SUCCESS_SEC" ]; then
+              FIRST_SUCCESS_SEC=$(( $(date +%s) - START_TS ))
+            fi
+          done
+
+          END_TS=$(date +%s)
+          export START_TS END_TS FIRST_SUCCESS_SEC RELEASE_GATE_RC
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          import os
+
+          start_ts = int(os.environ['START_TS'])
+          end_ts = int(os.environ['END_TS'])
+          first_success_sec = os.environ.get('FIRST_SUCCESS_SEC')
+          first_success_minutes = round((int(first_success_sec) / 60.0), 3) if first_success_sec else None
+
+          ruff_path = Path('build/ruff-report.json')
+          lint_debt_count = 0
+          if ruff_path.is_file():
+            try:
+              payload = json.loads(ruff_path.read_text(encoding='utf-8'))
+              if isinstance(payload, list):
+                lint_debt_count = len(payload)
+            except Exception:
+              lint_debt_count = 0
+
+          mypy_path = Path('build/mypy-report.txt')
+          type_debt_count = 0
+          if mypy_path.is_file():
+            type_debt_count = sum(1 for line in mypy_path.read_text(encoding='utf-8').splitlines() if ': error:' in line)
+
+          release = {}
+          release_path = Path('build/release-preflight.json')
+          if release_path.is_file():
+            try:
+              maybe = json.loads(release_path.read_text(encoding='utf-8'))
+              if isinstance(maybe, dict):
+                release = maybe
+            except Exception:
+              release = {}
+
+          snapshot = {
+            'time_to_first_success_minutes': first_success_minutes,
+            'lint_debt_count': lint_debt_count,
+            'type_debt_count': type_debt_count,
+            'ci_cycle_minutes': round((end_ts - start_ts) / 60.0, 3),
+            'release_gate_pass_rate': 1.0 if (release.get('ok') is True or os.environ.get('RELEASE_GATE_RC') == '0') else 0.0,
+          }
+          Path('build/kpi-metrics-current.json').write_text(json.dumps(snapshot, sort_keys=True), encoding='utf-8')
+          PY
+          set -e
+
+      - name: Build KPI pack artifacts
+        run: |
+          PREV=""
+          if [ -f docs/artifacts/kpi-weekly/latest-kpi-pack.json ]; then
+            PREV="--previous docs/artifacts/kpi-weekly/latest-kpi-pack.json"
+          fi
+          python -m sdetkit kpi-report \
+            --current build/kpi-metrics-current.json \
+            ${PREV} \
+            --week "$(date -u +%Y-%m-%d)" \
+            --out-json build/release-confidence-kpi-pack.json \
+            --out-md build/release-confidence-kpi-pack.md
+          cp build/release-confidence-kpi-pack.json docs/artifacts/kpi-weekly/latest-kpi-pack.json
+          cp build/release-confidence-kpi-pack.md docs/artifacts/kpi-weekly/latest-kpi-pack.md
+
+      - name: Upload weekly KPI pack artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: weekly-release-confidence-kpi-pack
+          path: |
+            build/kpi-metrics-current.json
+            build/release-confidence-kpi-pack.json
+            build/release-confidence-kpi-pack.md
+            docs/artifacts/kpi-weekly/latest-kpi-pack.json
+            docs/artifacts/kpi-weekly/latest-kpi-pack.md
+          retention-days: 28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- release-confidence operating loop polish: added machine-readable public command surface enforcement, pre-merge changed-files strict gate, unified CI summary artifact, weekly KPI pack workflow (`sdetkit kpi-report`), and lazy root CLI command routing with legacy namespace support.
 - dependency upgrades: raised `twilio` floor to `>=9.10.4,<10` and aligned `tomli` to `2.4.1` across requirements and lock manifests.
 - add GHAS alert SLA + metrics export bots, wire them into maintenance coverage checks, and refresh GHAS automation docs.
 - add Name 86 launch readiness closeout lane command, docs, checks, and tests (`name86-launch-readiness-closeout`).

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Context: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
 - Guided run (same canonical path): [`docs/ready-to-use.md`](docs/ready-to-use.md)
 - Release-confidence model (why this product exists): [`docs/release-confidence.md`](docs/release-confidence.md)
 - Root CLI grouping and canonical path view: `python -m sdetkit --help`
+- Machine-readable public command contract: [`src/sdetkit/public_command_surface.json`](src/sdetkit/public_command_surface.json)
 - Stability levels (policy boundary): [`docs/stability-levels.md`](docs/stability-levels.md) — understand what is stable vs advanced vs experimental
 - Before/after evidence behavior: [`docs/before-after-evidence-example.md`](docs/before-after-evidence-example.md)
 - Real evidence artifacts from this repo: [`docs/evidence-showcase.md`](docs/evidence-showcase.md)
@@ -113,6 +114,8 @@ These remain available and supported after the core release-confidence lane is t
 make bootstrap
 bash quality.sh ci
 python -m sdetkit kits list
+python -m sdetkit legacy list
+python -m sdetkit legacy <historical-command>
 python -m sdetkit --help --show-hidden
 ```
 

--- a/docs/docs-map.md
+++ b/docs/docs-map.md
@@ -1,0 +1,37 @@
+# Docs Map (compact)
+
+Use this map to avoid browsing dozens of pages when you only need the next right step.
+
+## Primary (start here)
+
+1. [Start here homepage](index.md)
+2. [Start Here in 5 Minutes](start-here-5-minutes.md)
+3. [Install (canonical)](install.md)
+4. [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
+5. [Recommended CI flow](recommended-ci-flow.md)
+6. [CI artifact walkthrough](ci-artifact-walkthrough.md)
+
+## Canonical troubleshooting
+
+- [First failure triage](first-failure-triage.md)
+- [Adoption troubleshooting](adoption-troubleshooting.md)
+- [Remediation cookbook](remediation-cookbook.md)
+
+## Secondary (use after primary is stable)
+
+- [CLI reference](cli.md)
+- [API](api.md)
+- [Repo audit reference](repo-audit.md)
+- [Feature registry](feature-registry.md)
+- [Project structure](project-structure.md)
+
+## Historical archive (non-primary)
+
+- [Archive overview](archive/index.md)
+- [Transition-era material map](archive/transition-era-material.md)
+
+## Overlap redirect hints
+
+- Need first-run speed? use **Start Here in 5 Minutes** instead of jumping into full adoption pages.
+- Need team rollout? go directly to **Recommended CI flow**.
+- Need a specific command option? use **CLI reference** (skip broad narrative docs).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,8 @@ DevS69 SDETKit is a release-confidence CLI: it gives engineering teams determini
 
 **Canonical first path:** `python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`.
 
+Need the fastest onboarding path? Start with [Start Here in 5 Minutes](start-here-5-minutes.md).
+
 ## What this is
 
 SDETKit is a productized release-confidence path for engineering teams that need clear ship/no-ship decisions backed by structured artifacts.
@@ -43,8 +45,9 @@ python -m sdetkit doctor
 ```
 
 1. [Install (canonical)](install.md)
-2. [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
-3. [Release confidence explainer](release-confidence.md)
+2. [Start Here in 5 Minutes](start-here-5-minutes.md)
+3. [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
+4. [Release confidence explainer](release-confidence.md)
 
 If you want a guided run instead of the ultra-fast proof lane, use [First run quickstart](ready-to-use.md).
 For CLI-first orientation, run `python -m sdetkit --help` to see the same canonical path plus stability-tier grouping.
@@ -78,6 +81,8 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Need lane routing: [Choose your path](choose-your-path.md)
 - Need team rollout: [Adopt in your repository](adoption.md)
 - Need CI rollout: [Recommended CI flow](recommended-ci-flow.md)
+- Need fast troubleshooting: [First failure triage](first-failure-triage.md), [Adoption troubleshooting](adoption-troubleshooting.md), [Remediation cookbook](remediation-cookbook.md)
+- Need compact navigation: [Docs map (compact)](docs-map.md)
 - Need current references: [CLI reference](cli.md), [API](api.md), and [repo audit reference](repo-audit.md)
 - Need contributor workflow: [Contributing](contributing.md)
 - Need boundary guidance: [Stability levels](stability-levels.md) for adopters and contributors

--- a/docs/release-confidence-kpi-pack.md
+++ b/docs/release-confidence-kpi-pack.md
@@ -1,0 +1,32 @@
+# Release Confidence KPI Pack
+
+Use this weekly KPI pack to turn release-confidence improvements into a measurable operating loop.
+
+## KPIs tracked
+
+- **Time to first success** (minutes)
+- **Lint debt trend** (issue count)
+- **Type debt trend** (issue count)
+- **CI cycle trend** (minutes)
+- **Release gate pass trend** (pass rate)
+
+## Command
+
+```bash
+python -m sdetkit kpi-report \
+  --current build/kpi-metrics-current.json \
+  --previous docs/artifacts/kpi-weekly/latest-kpi-pack.json \
+  --week "$(date -u +%Y-%m-%d)" \
+  --out-json build/release-confidence-kpi-pack.json \
+  --out-md build/release-confidence-kpi-pack.md
+```
+
+## Weekly CI artifact
+
+The `kpi-weekly.yml` workflow generates and uploads:
+
+- `build/kpi-metrics-current.json`
+- `build/release-confidence-kpi-pack.json`
+- `build/release-confidence-kpi-pack.md`
+
+Use these artifacts as the weekly baseline for continuous improvement decisions.

--- a/docs/start-here-5-minutes.md
+++ b/docs/start-here-5-minutes.md
@@ -1,0 +1,37 @@
+# Start Here in 5 Minutes (fast path)
+
+If you only have a few minutes, use this page and run the canonical commands exactly in this order.
+
+## Goal
+
+Get a deterministic ship/no-ship signal with machine-readable artifacts in one short loop.
+
+## 5-minute flow
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor
+```
+
+## What to check first
+
+1. `build/release-preflight.json`:
+   - `ok`
+   - `failed_steps`
+2. If `failed_steps` contains `gate_fast`, inspect `build/gate-fast.json`:
+   - `ok`
+   - `failed_steps`
+3. Use terminal logs only after artifact triage.
+
+## Troubleshooting (top links)
+
+- First failure triage: [first-failure-triage.md](first-failure-triage.md)
+- Adoption troubleshooting: [adoption-troubleshooting.md](adoption-troubleshooting.md)
+- Remediation cookbook: [remediation-cookbook.md](remediation-cookbook.md)
+
+## Next steps
+
+- Guided first run: [ready-to-use.md](ready-to-use.md)
+- Team rollout + CI: [recommended-ci-flow.md](recommended-ci-flow.md)
+- Compact docs map (primary vs secondary vs archive): [docs-map.md](docs-map.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ extra_javascript:
 nav:
   - Start here: index.md
   - Canonical first-proof path (primary):
+      - Start Here in 5 Minutes (fast path): start-here-5-minutes.md
       - Install (canonical): install.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
       - First run quickstart (guided canonical path): ready-to-use.md
@@ -103,9 +104,11 @@ nav:
       - CI artifact walkthrough (canonical evidence decode): ci-artifact-walkthrough.md
       - CI contract (reference): ci-contract.md
       - Reporting and trends: reporting-and-trends.md
+      - Release confidence KPI pack: release-confidence-kpi-pack.md
       - Sample outputs (exploratory, non-canonical): sample-outputs.md
       - Remediation cookbook: remediation-cookbook.md
   - Current reference and discoverability (secondary):
+      - Docs map (compact): docs-map.md
       - CLI reference: cli.md
       - API: api.md
       - Repo Audit: repo-audit.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,10 +113,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
   "sdetkit.__main__",
-  "sdetkit.apiclient",
   "sdetkit.apiget",
-  "sdetkit.cli",
-  "sdetkit.netclient",
   "sdetkit.patch",
 ]
 ignore_errors = true

--- a/quality.sh
+++ b/quality.sh
@@ -39,11 +39,11 @@ need_cmd() {
   exit 127
 }
 
-valid_modes=(all ci verify brutal fmt lint type doctor test full-test cov mut muthtml boost registry help)
+valid_modes=(all ci verify premerge brutal fmt lint type doctor test full-test cov mut muthtml boost registry help)
 
 usage() {
   cat <<'USAGE' >&2
-Usage: bash quality.sh {all|ci|verify|brutal|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost|registry}
+Usage: bash quality.sh {all|ci|verify|premerge|brutal|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost|registry}
 
 Profiles:
   quick     Fast local confidence / smoke profile.
@@ -54,6 +54,7 @@ Profiles:
 Modes:
   ci         Fast/smoke lane for local confidence; not merge truth.
   verify     Full verification lane before merge (doctor, format, lint, typing, full tests, security scan).
+  premerge   Strict changed-files gate (lint + typing + targeted tests).
   brutal     Maximum hardening lane (strict verify + mutation + premium full gate).
   all        Standard repo validation lane (auto-format, lint, typing, pytest, coverage).
   fmt        Apply Ruff formatting.
@@ -189,6 +190,56 @@ run_registry_contract() {
     --expect-status-count stable=8 \
     --fail-on-empty \
     --format summary-json >/dev/null
+}
+
+run_premerge_changed() {
+  local base_ref="${QUALITY_DIFF_BASE:-HEAD~1}"
+  local changed=""
+
+  if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+    changed="$(git diff --name-only --diff-filter=ACMRTUXB "$base_ref" HEAD || true)"
+  fi
+  if [[ -z "$changed" ]]; then
+    changed="$(git ls-files '*.py' pyproject.toml || true)"
+  fi
+
+  local -a lint_targets=()
+  local -a type_targets=()
+  local -a test_targets=()
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    if [[ "$f" == *.py || "$f" == "pyproject.toml" ]]; then
+      lint_targets+=("$f")
+    fi
+    if [[ "$f" == src/sdetkit/*.py ]]; then
+      type_targets+=("$f")
+      local stem
+      stem="$(basename "$f" .py)"
+      local mapped_test="tests/test_${stem}.py"
+      if [[ -f "$mapped_test" ]]; then
+        test_targets+=("$mapped_test")
+      fi
+    fi
+  done <<< "$changed"
+
+  if (( ${#lint_targets[@]} > 0 )); then
+    python -m ruff check "${lint_targets[@]}"
+  else
+    echo "[premerge] no lint targets detected"
+  fi
+
+  if (( ${#type_targets[@]} > 0 )); then
+    python -m mypy --config-file pyproject.toml "${type_targets[@]}"
+  else
+    echo "[premerge] no typed src targets detected"
+  fi
+
+  if (( ${#test_targets[@]} > 0 )); then
+    python -m pytest -q "${test_targets[@]}"
+  else
+    echo "[premerge] no mapped tests detected; running contract smoke"
+    python -m pytest -q tests/test_cli_help_discoverability_contract.py
+  fi
 }
 
 SDETKIT_OUT_DIR="${SDETKIT_OUT_DIR:-.sdetkit/out}"
@@ -401,6 +452,11 @@ case "$mode" in
     echo "[quality] Full verification lane before merge (doctor, format, lint, typing, full tests, security scan)."
     python -m sdetkit.checks run       --profile strict       --repo-root .       --out-dir "$SDETKIT_OUT_DIR"       --format text       --json-output "$QUALITY_VERDICT_JSON"       --markdown-output "$QUALITY_SUMMARY_MD"
     exit $?
+    ;;
+  premerge)
+    profile_used="strict"
+    profile_notes="Changed-files pre-merge strict gate: lint + typing + targeted tests."
+    run_required "premerge_changed" "Changed-files pre-merge strict gate" 1 "run_premerge_changed"
     ;;
   brutal)
     profile_used="strict"

--- a/scripts/build_ci_summary.py
+++ b/scripts/build_ci_summary.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _build_summary(artifact_dir: Path) -> dict[str, Any]:
+    gate = _read_json(artifact_dir / "gate-fast.json")
+    doctor = _read_json(artifact_dir / "doctor.json")
+    security = _read_json(artifact_dir / "security-enforce.json")
+    package_validate = _read_json(artifact_dir / "package-validate.json")
+
+    gate_ok = gate.get("ok") if gate else None
+    doctor_ok = doctor.get("ok") if doctor else None
+    security_ok = security.get("ok") if security else None
+    package_ok = package_validate.get("ok") if package_validate else None
+
+    checks = {
+        "gate_fast": {
+            "present": gate is not None,
+            "ok": gate_ok,
+            "failed_steps": gate.get("failed_steps", []) if gate else [],
+        },
+        "doctor": {
+            "present": doctor is not None,
+            "ok": doctor_ok,
+            "score": doctor.get("score") if doctor else None,
+        },
+        "security": {
+            "present": security is not None,
+            "ok": security_ok,
+            "max_error": security.get("max_error") if security else None,
+            "max_warn": security.get("max_warn") if security else None,
+        },
+        "package_validate": {
+            "present": package_validate is not None,
+            "ok": package_ok,
+            "note": "Produced by package-validate job when available.",
+        },
+    }
+
+    hard_fail = gate_ok is False or security_ok is False
+    status = "fail" if hard_fail else "pass"
+
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "status": status,
+        "checks": checks,
+    }
+
+
+def _render_markdown(summary: dict[str, Any]) -> str:
+    checks = summary["checks"]
+    lines = [
+        "# CI Operator Summary",
+        "",
+        f"- Generated at: `{summary['generated_at']}`",
+        f"- Overall status: **{summary['status'].upper()}**",
+        "",
+        "| Check | Present | OK | Notes |",
+        "| --- | --- | --- | --- |",
+    ]
+    lines.append(
+        f"| gate_fast | {checks['gate_fast']['present']} | {checks['gate_fast']['ok']} | failed_steps={checks['gate_fast']['failed_steps']} |"
+    )
+    lines.append(
+        f"| doctor | {checks['doctor']['present']} | {checks['doctor']['ok']} | score={checks['doctor']['score']} |"
+    )
+    lines.append(
+        f"| security | {checks['security']['present']} | {checks['security']['ok']} | max_error={checks['security']['max_error']}, max_warn={checks['security']['max_warn']} |"
+    )
+    lines.append(
+        f"| package_validate | {checks['package_validate']['present']} | {checks['package_validate']['ok']} | {checks['package_validate']['note']} |"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build unified CI summary artifacts.")
+    parser.add_argument("--artifact-dir", default="build")
+    parser.add_argument("--out-json", default="build/ci-summary.json")
+    parser.add_argument("--out-md", default="build/ci-summary.md")
+    ns = parser.parse_args(argv)
+
+    artifact_dir = Path(ns.artifact_dir)
+    summary = _build_summary(artifact_dir)
+
+    out_json = Path(ns.out_json)
+    out_md = Path(ns.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(
+        json.dumps(summary, ensure_ascii=True, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    out_md.write_text(_render_markdown(summary), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_public_surface_alignment.py
+++ b/scripts/check_public_surface_alignment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -8,8 +9,10 @@ import yaml
 
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
+DOCS_STABILITY = Path("docs/stability-levels.md")
 MKDOCS = Path("mkdocs.yml")
 PAGES_WORKFLOW = Path(".github/workflows/pages.yml")
+PUBLIC_COMMAND_CONTRACT = Path("src/sdetkit/public_command_surface.json")
 
 CANONICAL_PROMISE = "deterministic ship/no-ship decisions with machine-readable evidence"
 CANONICAL_FAST_COMMAND = "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
@@ -31,7 +34,14 @@ def _missing_lines(path: Path, expected: tuple[str, ...]) -> list[str]:
 def main() -> int:
     errors: list[str] = []
 
-    required_files = (README, DOCS_INDEX, MKDOCS, PAGES_WORKFLOW)
+    required_files = (
+        README,
+        DOCS_INDEX,
+        DOCS_STABILITY,
+        MKDOCS,
+        PAGES_WORKFLOW,
+        PUBLIC_COMMAND_CONTRACT,
+    )
     for file_path in required_files:
         if not file_path.is_file():
             errors.append(f"missing required file: {file_path}")
@@ -42,13 +52,15 @@ def main() -> int:
             print(f" - {error}", file=sys.stderr)
         return 1
 
+    contract = json.loads(PUBLIC_COMMAND_CONTRACT.read_text(encoding="utf-8"))
+    canonical_path = tuple(contract.get("canonical_first_path", []))
+    required_tiers = tuple(contract.get("required_policy_tiers", []))
     readme_missing = _missing_lines(
         README,
         (
             "release-confidence CLI",
             CANONICAL_PROMISE,
-            CANONICAL_FAST_COMMAND,
-            CANONICAL_RELEASE_COMMAND,
+            *canonical_path,
         ),
     )
     docs_home_missing = _missing_lines(
@@ -57,12 +69,17 @@ def main() -> int:
             "release-confidence CLI",
             CANONICAL_PROMISE,
             "product homepage/router",
-            CANONICAL_FAST_COMMAND,
-            CANONICAL_RELEASE_COMMAND,
+            *canonical_path,
         ),
     )
     errors.extend(f"{README}: missing '{entry}'" for entry in readme_missing)
     errors.extend(f"{DOCS_INDEX}: missing '{entry}'" for entry in docs_home_missing)
+    if contract.get("advanced_supported_next_step") != "python -m sdetkit kits list":
+        errors.append("public command contract: advanced_supported_next_step must be 'python -m sdetkit kits list'")
+    stability_text = DOCS_STABILITY.read_text(encoding="utf-8")
+    for tier in required_tiers:
+        if tier not in stability_text:
+            errors.append(f"{DOCS_STABILITY}: missing policy tier '{tier}' from machine-readable contract")
 
     mkdocs_text = MKDOCS.read_text(encoding="utf-8")
     if "nav:" not in mkdocs_text:

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -4,131 +4,27 @@ import argparse
 import os
 import sys
 from collections.abc import Sequence
-from importlib import metadata
+from importlib import import_module, metadata
+from typing import cast
 
-from . import (
-    acceleration_closeout_43,
-    apiget,
-    author_problem,
-    case_snippet_closeout_51,
-    case_study_launch_closeout_73,
-    case_study_prep1_closeout_69,
-    case_study_prep2_closeout_70,
-    case_study_prep3_closeout_71,
-    case_study_prep4_closeout_72,
-    community_activation,
-    community_program_closeout_62,
-    community_touchpoint_closeout_77,
-    continuous_upgrade_closeout_1,
-    continuous_upgrade_closeout_2,
-    continuous_upgrade_closeout_3,
-    continuous_upgrade_closeout_4,
-    continuous_upgrade_closeout_5,
-    continuous_upgrade_closeout_6,
-    continuous_upgrade_closeout_7,
-    continuous_upgrade_closeout_8,
-    continuous_upgrade_closeout_9,
-    continuous_upgrade_closeout_10,
-    continuous_upgrade_closeout_11,
-    contributor_activation_closeout_55,
-    contributor_funnel,
-    contributor_recognition_closeout_76,
-    demo,
-    demo_asset2_34,
-    demo_asset_33,
-    distribution_batch_38,
-    distribution_closeout_36,
-    distribution_scaling_closeout_74,
-    docs_loop_closeout_53,
-    docs_navigation,
-    docs_qa,
-    ecosystem_priorities_closeout_78,
-    enterprise_readiness,
-    evidence,
-    evidence_narrative_closeout_84,
-    execution_prioritization_closeout_50,
-    expansion_automation_41,
-    expansion_closeout_45,
-    experiment_lane_37,
-    external_contribution,
-    feature_registry_cli,
-    first_contribution,
-    forensics,
-    github_actions_quickstart,
-    gitlab_ci_quickstart,
-    governance_handoff_closeout_87,
-    governance_priorities_closeout_88,
-    governance_scale_closeout_89,
-    growth_campaign_closeout_81,
-    integration,
-    integration_expansion2_closeout_66,
-    integration_expansion3_closeout_67,
-    integration_expansion4_closeout_68,
-    integration_expansion_closeout_64,
-    integration_feedback_closeout_82,
-    intelligence,
-    kits,
-    kpi_audit,
-    kpi_deep_audit_closeout_57,
-    kpi_instrumentation_35,
-    kvcli,
-    launch_readiness_closeout_86,
-    narrative_closeout_52,
-    notify,
-    objection_closeout_48,
-    objection_handling,
-    onboarding,
-    onboarding_activation_closeout_63,
-    onboarding_optimization,
-    ops,
-    optimization_closeout_42,
-    optimization_closeout_46,
-    partner_outreach_closeout_80,
-    patch,
-    phase1_hardening_29,
-    phase1_wrap_30,
-    phase2_hardening_closeout_58,
-    phase2_kickoff_31,
-    phase2_wrap_handoff_closeout_60,
-    phase3_kickoff_closeout_61,
-    phase3_preplan_closeout_59,
-    phase3_wrap_publication_closeout_90,
-    phase_boost,
-    playbook_post_39,
-    policy,
-    production_readiness,
-    proof,
-    quality_contribution_delta,
-    release_cadence_32,
-    release_communications,
-    release_prioritization_closeout_85,
-    release_readiness,
-    reliability_closeout_47,
-    reliability_evidence_pack,
-    repo,
-    report,
-    roadmap,
-    scale_closeout_44,
-    scale_lane_40,
-    scale_upgrade_closeout_79,
-    sdet_package,
-    stabilization_closeout_56,
-    startup_readiness,
-    triage_templates,
-    trust_assets,
-    trust_assets_refresh_closeout_75,
-    trust_faq_expansion_closeout_83,
-    upgrade_hub,
-    weekly_review,
-    weekly_review_28,
-    weekly_review_closeout_49,
-    weekly_review_closeout_65,
-)
-from . import gate as gate_cmd
-from .agent.cli import main as agent_main
-from .maintenance import main as maintenance_main
 from .public_surface_contract import render_root_help_groups
-from .security_gate import main as security_main
+
+LEGACY_NAMESPACE_COMMANDS: tuple[str, ...] = (
+    "weekly-review-lane",
+    "phase1-hardening",
+    "phase1-wrap",
+    "phase2-kickoff",
+    "release-cadence",
+    "demo-asset",
+    "demo-asset2",
+    "kpi-instrumentation",
+    "experiment-lane",
+    "distribution-batch",
+    "playbook-post",
+    "scale-lane",
+    "expansion-automation",
+    "optimization-closeout-foundation",
+)
 
 
 def _tool_version() -> str:
@@ -139,7 +35,8 @@ def _tool_version() -> str:
 
 
 def _add_apiget_args(p: argparse.ArgumentParser) -> None:
-    apiget._add_apiget_args(p)
+    apiget_module = import_module("sdetkit.apiget")
+    apiget_module._add_apiget_args(p)
 
     p.add_argument("--cassette", default=None, help="Cassette file path (enables record/replay).")
     p.add_argument(
@@ -150,8 +47,15 @@ def _add_apiget_args(p: argparse.ArgumentParser) -> None:
     )
 
 
+def _run_module_main(module_name: str, args: Sequence[str]) -> int:
+    module = import_module(module_name)
+    return cast(int, module.main(list(args)))
+
+
 def _is_hidden_cmd(name: str) -> bool:
     if name == "playbooks":
+        return False
+    if name == "legacy":
         return False
     if name in {
         "docs-qa",
@@ -161,6 +65,8 @@ def _is_hidden_cmd(name: str) -> bool:
         "quality-contribution-delta",
         "proof",
     }:
+        return True
+    if name in LEGACY_NAMESPACE_COMMANDS:
         return True
     if name.startswith("impact") and len(name) > 3 and name[3].isdigit():
         return True
@@ -280,6 +186,11 @@ Then use stability-aware command discovery:
         help_text="Discover and run adoption/rollout playbooks",
     )
     _add_passthrough_subcommand(
+        sub,
+        "legacy",
+        help_text="[Advanced but supported] Access historical/closeout compatibility lanes",
+    )
+    _add_passthrough_subcommand(
         sub, "kits", help_text="[Advanced but supported] Umbrella kit catalog and kit details"
     )
 
@@ -397,6 +308,9 @@ Then use stability-aware command discovery:
 
     kpa = sub.add_parser("kpi-audit", help="KPI audit and tracking playbook")
     kpa.add_argument("args", nargs=argparse.REMAINDER)
+
+    kpr = sub.add_parser("kpi-report", help="Release confidence KPI weekly pack")
+    kpr.add_argument("args", nargs=argparse.REMAINDER)
 
     dwr = sub.add_parser("weekly-review-lane")
     dwr.set_defaults(cmd="weekly-review-lane")
@@ -765,11 +679,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         argv = list(argv)
         argv[0] = _resolve_non_day_playbook_alias(str(argv[0]))
 
+    if argv and argv[0] == "legacy":
+        if len(argv) == 1:
+            sys.stderr.write("legacy error: expected a legacy command name\n")
+            return 2
+        if argv[1] == "list":
+            sys.stdout.write("\n".join(LEGACY_NAMESPACE_COMMANDS) + "\n")
+            return 0
+        return main(list(argv[1:]))
+
     if argv and argv[0] == "cassette-get":
         from .__main__ import _cassette_get
 
         try:
-            return _cassette_get(argv[1:])
+            return _cassette_get(list(argv[1:]))
         except Exception as e:
             print(str(e), file=sys.stderr)
             return 2
@@ -777,7 +700,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv and argv[0] == "doctor":
         from .doctor import main as _doctor_main
 
-        return _doctor_main(argv[1:])
+        return _doctor_main(list(argv[1:]))
 
     if argv and argv[0] == "gate":
         from .gate import main as _gate_main
@@ -790,367 +713,369 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _ci_main(list(argv[1:]))
 
     if argv and argv[0] == "patch":
-        return patch.main(list(argv[1:]))
+        return _run_module_main("sdetkit.patch", list(argv[1:]))
 
     if argv and argv[0] == "repo":
-        return repo.main(list(argv[1:]))
+        return _run_module_main("sdetkit.repo", list(argv[1:]))
 
     if argv and argv[0] == "dev":
-        return repo.main(["dev", *list(argv[1:])])
+        return _run_module_main("sdetkit.repo", ["dev", *list(argv[1:])])
 
     if argv and argv[0] == "report":
-        return report.main(list(argv[1:]))
+        return _run_module_main("sdetkit.report", list(argv[1:]))
 
     if argv and argv[0] == "maintenance":
-        return maintenance_main(list(argv[1:]))
+        return _run_module_main("sdetkit.maintenance", list(argv[1:]))
 
     if argv and argv[0] == "agent":
-        return agent_main(list(argv[1:]))
+        return _run_module_main("sdetkit.agent.cli", list(argv[1:]))
 
     if argv and argv[0] == "security":
-        return security_main(list(argv[1:]))
+        return _run_module_main("sdetkit.security_gate", list(argv[1:]))
 
     if argv and argv[0] == "ops":
-        return ops.main(list(argv[1:]))
+        return _run_module_main("sdetkit.ops", list(argv[1:]))
 
     if argv and argv[0] == "notify":
-        return notify.main(list(argv[1:]))
+        return _run_module_main("sdetkit.notify", list(argv[1:]))
 
     if argv and argv[0] == "policy":
-        return policy.main(list(argv[1:]))
+        return _run_module_main("sdetkit.policy", list(argv[1:]))
 
     if argv and argv[0] == "evidence":
-        return evidence.main(list(argv[1:]))
+        return _run_module_main("sdetkit.evidence", list(argv[1:]))
 
     if argv and argv[0] == "onboarding":
-        return onboarding.main(list(argv[1:]))
+        return _run_module_main("sdetkit.onboarding", list(argv[1:]))
 
     if argv and argv[0] == "onboarding-optimization":
-        return onboarding_optimization.main(list(argv[1:]))
+        return _run_module_main("sdetkit.onboarding_optimization", list(argv[1:]))
 
     if argv and argv[0] == "phase-boost":
-        return phase_boost.main(list(argv[1:]))
+        return _run_module_main("sdetkit.phase_boost", list(argv[1:]))
 
     if argv and argv[0] == "production-readiness":
-        return production_readiness.main(list(argv[1:]))
+        return _run_module_main("sdetkit.production_readiness", list(argv[1:]))
 
     if argv and argv[0] == "community-activation":
-        return community_activation.main(list(argv[1:]))
+        return _run_module_main("sdetkit.community_activation", list(argv[1:]))
 
     if argv and argv[0] == "external-contribution":
-        return external_contribution.main(list(argv[1:]))
+        return _run_module_main("sdetkit.external_contribution", list(argv[1:]))
 
     if argv and argv[0] == "kpi-audit":
-        return kpi_audit.main(list(argv[1:]))
+        return _run_module_main("sdetkit.kpi_audit", list(argv[1:]))
+    if argv and argv[0] == "kpi-report":
+        return _run_module_main("sdetkit.kpi_report", list(argv[1:]))
 
     if argv and argv[0] in {"weekly-review-lane"}:
-        return weekly_review_28.main(list(argv[1:]))
+        return _run_module_main("sdetkit.weekly_review_28", list(argv[1:]))
 
     if argv and argv[0] == "phase1-hardening":
-        return phase1_hardening_29.main(list(argv[1:]))
+        return _run_module_main("sdetkit.phase1_hardening_29", list(argv[1:]))
 
     if argv and argv[0] == "phase1-wrap":
-        return phase1_wrap_30.main(list(argv[1:]))
+        return _run_module_main("sdetkit.phase1_wrap_30", list(argv[1:]))
 
     if argv and argv[0] == "phase2-kickoff":
-        return phase2_kickoff_31.main(list(argv[1:]))
+        return _run_module_main("sdetkit.phase2_kickoff_31", list(argv[1:]))
 
     if argv and argv[0] == "release-cadence":
-        return release_cadence_32.main(list(argv[1:]))
+        return _run_module_main("sdetkit.release_cadence_32", list(argv[1:]))
 
     if argv and argv[0] == "demo-asset":
-        return demo_asset_33.main(list(argv[1:]))
+        return _run_module_main("sdetkit.demo_asset_33", list(argv[1:]))
 
     if argv and argv[0] == "demo-asset2":
-        return demo_asset2_34.main(list(argv[1:]))
+        return _run_module_main("sdetkit.demo_asset2_34", list(argv[1:]))
 
     if argv and argv[0] == "kpi-instrumentation":
-        return kpi_instrumentation_35.main(list(argv[1:]))
+        return _run_module_main("sdetkit.kpi_instrumentation_35", list(argv[1:]))
 
     if argv and argv[0] in {"distribution-closeout"}:
-        return distribution_closeout_36.main(list(argv[1:]))
+        return _run_module_main("sdetkit.distribution_closeout_36", list(argv[1:]))
 
     if argv and argv[0] in {"experiment-lane"}:
-        return experiment_lane_37.main(list(argv[1:]))
+        return _run_module_main("sdetkit.experiment_lane_37", list(argv[1:]))
 
     if argv and argv[0] in {"distribution-batch"}:
-        return distribution_batch_38.main(list(argv[1:]))
+        return _run_module_main("sdetkit.distribution_batch_38", list(argv[1:]))
 
     if argv and argv[0] == "playbook-post":
-        return playbook_post_39.main(list(argv[1:]))
+        return _run_module_main("sdetkit.playbook_post_39", list(argv[1:]))
 
     if argv and argv[0] in {"scale-lane"}:
-        return scale_lane_40.main(list(argv[1:]))
+        return _run_module_main("sdetkit.scale_lane_40", list(argv[1:]))
 
     if argv and argv[0] == "expansion-automation":
-        return expansion_automation_41.main(list(argv[1:]))
+        return _run_module_main("sdetkit.expansion_automation_41", list(argv[1:]))
 
     if argv and argv[0] in {"optimization-closeout-foundation"}:
-        return optimization_closeout_42.main(list(argv[1:]))
+        return _run_module_main("sdetkit.optimization_closeout_42", list(argv[1:]))
 
     if argv and argv[0] == "acceleration-closeout":
-        return acceleration_closeout_43.main(list(argv[1:]))
+        return _run_module_main("sdetkit.acceleration_closeout_43", list(argv[1:]))
 
     if argv and argv[0] == "scale-closeout":
-        return scale_closeout_44.main(list(argv[1:]))
+        return _run_module_main("sdetkit.scale_closeout_44", list(argv[1:]))
 
     if argv and argv[0] == "expansion-closeout":
-        return expansion_closeout_45.main(list(argv[1:]))
+        return _run_module_main("sdetkit.expansion_closeout_45", list(argv[1:]))
 
     if argv and argv[0] in {"optimization-closeout"}:
-        return optimization_closeout_46.main(list(argv[1:]))
+        return _run_module_main("sdetkit.optimization_closeout_46", list(argv[1:]))
 
     if argv and argv[0] == "reliability-closeout":
-        return reliability_closeout_47.main(list(argv[1:]))
+        return _run_module_main("sdetkit.reliability_closeout_47", list(argv[1:]))
     if argv and argv[0] == "objection-closeout":
-        return objection_closeout_48.main(list(argv[1:]))
+        return _run_module_main("sdetkit.objection_closeout_48", list(argv[1:]))
     if argv and argv[0] in {
         "weekly-review-closeout",
     }:
-        return weekly_review_closeout_49.main(list(argv[1:]))
+        return _run_module_main("sdetkit.weekly_review_closeout_49", list(argv[1:]))
     if argv and argv[0] in {
         "execution-prioritization-closeout",
     }:
-        return execution_prioritization_closeout_50.main(list(argv[1:]))
+        return _run_module_main("sdetkit.execution_prioritization_closeout_50", list(argv[1:]))
     if argv and argv[0] in {"case-snippet-closeout"}:
-        return case_snippet_closeout_51.main(list(argv[1:]))
+        return _run_module_main("sdetkit.case_snippet_closeout_51", list(argv[1:]))
     if argv and argv[0] in {"narrative-closeout"}:
-        return narrative_closeout_52.main(list(argv[1:]))
+        return _run_module_main("sdetkit.narrative_closeout_52", list(argv[1:]))
     if argv and argv[0] in {"docs-loop-closeout"}:
-        return docs_loop_closeout_53.main(list(argv[1:]))
+        return _run_module_main("sdetkit.docs_loop_closeout_53", list(argv[1:]))
     if argv and argv[0] in {
         "contributor-activation-closeout",
     }:
-        return contributor_activation_closeout_55.main(list(argv[1:]))
+        return _run_module_main("sdetkit.contributor_activation_closeout_55", list(argv[1:]))
 
     if argv and argv[0] in {"stabilization-closeout"}:
-        return stabilization_closeout_56.main(list(argv[1:]))
+        return _run_module_main("sdetkit.stabilization_closeout_56", list(argv[1:]))
 
     if argv and argv[0] in {"kpi-deep-audit-closeout"}:
-        return kpi_deep_audit_closeout_57.main(list(argv[1:]))
+        return _run_module_main("sdetkit.kpi_deep_audit_closeout_57", list(argv[1:]))
 
     if argv and argv[0] in {"phase2-hardening-closeout"}:
-        return phase2_hardening_closeout_58.main(list(argv[1:]))
+        return _run_module_main("sdetkit.phase2_hardening_closeout_58", list(argv[1:]))
 
     if argv and argv[0] in {"phase3-preplan-closeout"}:
-        return phase3_preplan_closeout_59.main(list(argv[1:]))
+        return _run_module_main("sdetkit.phase3_preplan_closeout_59", list(argv[1:]))
 
     if argv and argv[0] in {"phase2-wrap-handoff-closeout"}:
-        return phase2_wrap_handoff_closeout_60.main(list(argv[1:]))
+        return _run_module_main("sdetkit.phase2_wrap_handoff_closeout_60", list(argv[1:]))
 
     if argv and argv[0] in {"phase3-kickoff-closeout"}:
-        return phase3_kickoff_closeout_61.main(list(argv[1:]))
+        return _run_module_main("sdetkit.phase3_kickoff_closeout_61", list(argv[1:]))
 
     if argv and argv[0] in {"community-program-closeout"}:
-        return community_program_closeout_62.main(list(argv[1:]))
+        return _run_module_main("sdetkit.community_program_closeout_62", list(argv[1:]))
 
     if argv and argv[0] in {
         "onboarding-activation-closeout",
     }:
-        return onboarding_activation_closeout_63.main(list(argv[1:]))
+        return _run_module_main("sdetkit.onboarding_activation_closeout_63", list(argv[1:]))
 
     if argv and argv[0] in {
         "integration-expansion-closeout",
     }:
-        return integration_expansion_closeout_64.main(list(argv[1:]))
+        return _run_module_main("sdetkit.integration_expansion_closeout_64", list(argv[1:]))
 
     if argv and argv[0] in {"weekly-review-closeout-2"}:
-        return weekly_review_closeout_65.main(list(argv[1:]))
+        return _run_module_main("sdetkit.weekly_review_closeout_65", list(argv[1:]))
 
     if argv and argv[0] in {
         "integration-expansion2-closeout",
     }:
-        return integration_expansion2_closeout_66.main(list(argv[1:]))
+        return _run_module_main("sdetkit.integration_expansion2_closeout_66", list(argv[1:]))
 
     if argv and argv[0] in {
         "integration-expansion3-closeout",
     }:
-        return integration_expansion3_closeout_67.main(list(argv[1:]))
+        return _run_module_main("sdetkit.integration_expansion3_closeout_67", list(argv[1:]))
 
     if argv and argv[0] in {
         "integration-expansion4-closeout",
     }:
-        return integration_expansion4_closeout_68.main(list(argv[1:]))
+        return _run_module_main("sdetkit.integration_expansion4_closeout_68", list(argv[1:]))
 
     if argv and argv[0] in {"case-study-prep1-closeout"}:
-        return case_study_prep1_closeout_69.main(list(argv[1:]))
+        return _run_module_main("sdetkit.case_study_prep1_closeout_69", list(argv[1:]))
 
     if argv and argv[0] in {"case-study-prep2-closeout"}:
-        return case_study_prep2_closeout_70.main(list(argv[1:]))
+        return _run_module_main("sdetkit.case_study_prep2_closeout_70", list(argv[1:]))
 
     if argv and argv[0] in {"case-study-prep3-closeout"}:
-        return case_study_prep3_closeout_71.main(list(argv[1:]))
+        return _run_module_main("sdetkit.case_study_prep3_closeout_71", list(argv[1:]))
 
     if argv and argv[0] in {"case-study-prep4-closeout"}:
-        return case_study_prep4_closeout_72.main(list(argv[1:]))
+        return _run_module_main("sdetkit.case_study_prep4_closeout_72", list(argv[1:]))
 
     if argv and argv[0] in {"case-study-launch-closeout"}:
-        return case_study_launch_closeout_73.main(list(argv[1:]))
+        return _run_module_main("sdetkit.case_study_launch_closeout_73", list(argv[1:]))
 
     if argv and argv[0] in {"distribution-scaling-closeout"}:
-        return distribution_scaling_closeout_74.main(list(argv[1:]))
+        return _run_module_main("sdetkit.distribution_scaling_closeout_74", list(argv[1:]))
 
     if argv and argv[0] in {"trust-assets-refresh-closeout"}:
-        return trust_assets_refresh_closeout_75.main(list(argv[1:]))
+        return _run_module_main("sdetkit.trust_assets_refresh_closeout_75", list(argv[1:]))
 
     if argv and argv[0] in {
         "contributor-recognition-closeout",
     }:
-        return contributor_recognition_closeout_76.main(list(argv[1:]))
+        return _run_module_main("sdetkit.contributor_recognition_closeout_76", list(argv[1:]))
 
     if argv and argv[0] in {"community-touchpoint-closeout"}:
-        return community_touchpoint_closeout_77.main(list(argv[1:]))
+        return _run_module_main("sdetkit.community_touchpoint_closeout_77", list(argv[1:]))
 
     if argv and argv[0] in {"ecosystem-priorities-closeout"}:
-        return ecosystem_priorities_closeout_78.main(list(argv[1:]))
+        return _run_module_main("sdetkit.ecosystem_priorities_closeout_78", list(argv[1:]))
 
     if argv and argv[0] in {"scale-upgrade-closeout"}:
-        return scale_upgrade_closeout_79.main(list(argv[1:]))
+        return _run_module_main("sdetkit.scale_upgrade_closeout_79", list(argv[1:]))
 
     if argv and argv[0] in {"partner-outreach-closeout"}:
-        return partner_outreach_closeout_80.main(list(argv[1:]))
+        return _run_module_main("sdetkit.partner_outreach_closeout_80", list(argv[1:]))
 
     if argv and argv[0] in {"growth-campaign-closeout"}:
-        return growth_campaign_closeout_81.main(list(argv[1:]))
+        return _run_module_main("sdetkit.growth_campaign_closeout_81", list(argv[1:]))
 
     if argv and argv[0] in {"integration-feedback-closeout"}:
-        return integration_feedback_closeout_82.main(list(argv[1:]))
+        return _run_module_main("sdetkit.integration_feedback_closeout_82", list(argv[1:]))
 
     if argv and argv[0] in {"trust-faq-expansion-closeout"}:
-        return trust_faq_expansion_closeout_83.main(list(argv[1:]))
+        return _run_module_main("sdetkit.trust_faq_expansion_closeout_83", list(argv[1:]))
 
     if argv and argv[0] in {"evidence-narrative-closeout"}:
-        return evidence_narrative_closeout_84.main(list(argv[1:]))
+        return _run_module_main("sdetkit.evidence_narrative_closeout_84", list(argv[1:]))
 
     if argv and argv[0] in {
         "release-prioritization-closeout",
     }:
-        return release_prioritization_closeout_85.main(list(argv[1:]))
+        return _run_module_main("sdetkit.release_prioritization_closeout_85", list(argv[1:]))
 
     if argv and argv[0] in {"launch-readiness-closeout"}:
-        return launch_readiness_closeout_86.main(list(argv[1:]))
+        return _run_module_main("sdetkit.launch_readiness_closeout_86", list(argv[1:]))
 
     if argv and argv[0] in {"governance-handoff-closeout"}:
-        return governance_handoff_closeout_87.main(list(argv[1:]))
+        return _run_module_main("sdetkit.governance_handoff_closeout_87", list(argv[1:]))
 
     if argv and argv[0] in {
         "governance-priorities-closeout",
     }:
-        return governance_priorities_closeout_88.main(list(argv[1:]))
+        return _run_module_main("sdetkit.governance_priorities_closeout_88", list(argv[1:]))
 
     if argv and argv[0] in {"governance-scale-closeout"}:
-        return governance_scale_closeout_89.main(list(argv[1:]))
+        return _run_module_main("sdetkit.governance_scale_closeout_89", list(argv[1:]))
 
     if argv and argv[0] in {
         "phase3-wrap-publication-closeout",
     }:
-        return phase3_wrap_publication_closeout_90.main(list(argv[1:]))
+        return _run_module_main("sdetkit.phase3_wrap_publication_closeout_90", list(argv[1:]))
 
     if argv and argv[0] == "continuous-upgrade-closeout-1":
-        return continuous_upgrade_closeout_1.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_1", list(argv[1:]))
 
     if argv and argv[0] in {
         "continuous-upgrade-closeout-2",
     }:
-        return continuous_upgrade_closeout_2.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_2", list(argv[1:]))
 
     if argv and argv[0] in {
         "continuous-upgrade-closeout-3",
     }:
-        return continuous_upgrade_closeout_3.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_3", list(argv[1:]))
 
     if argv and argv[0] in {
         "continuous-upgrade-closeout-4",
     }:
-        return continuous_upgrade_closeout_4.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_4", list(argv[1:]))
     if argv and argv[0] in {
         "continuous-upgrade-closeout-5",
     }:
-        return continuous_upgrade_closeout_5.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_5", list(argv[1:]))
     if argv and argv[0] in {
         "continuous-upgrade-closeout-6",
     }:
-        return continuous_upgrade_closeout_6.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_6", list(argv[1:]))
     if argv and argv[0] in {
         "continuous-upgrade-closeout-7",
     }:
-        return continuous_upgrade_closeout_7.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_7", list(argv[1:]))
     if argv and argv[0] == "continuous-upgrade-closeout-8":
-        return continuous_upgrade_closeout_8.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_8", list(argv[1:]))
 
     if argv and argv[0] == "continuous-upgrade-closeout-9":
-        return continuous_upgrade_closeout_9.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_9", list(argv[1:]))
 
     if argv and argv[0] == "continuous-upgrade-closeout-10":
-        return continuous_upgrade_closeout_10.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_10", list(argv[1:]))
 
     if argv and argv[0] == "continuous-upgrade-closeout-11":
-        return continuous_upgrade_closeout_11.main(list(argv[1:]))
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_11", list(argv[1:]))
 
     if argv and argv[0] == "objection-handling":
-        return objection_handling.main(list(argv[1:]))
+        return _run_module_main("sdetkit.objection_handling", list(argv[1:]))
 
     if argv and argv[0] == "first-contribution":
-        return first_contribution.main(list(argv[1:]))
+        return _run_module_main("sdetkit.first_contribution", list(argv[1:]))
 
     if argv and argv[0] == "demo":
-        return demo.main(list(argv[1:]))
+        return _run_module_main("sdetkit.demo", list(argv[1:]))
 
     if argv and argv[0] == "contributor-funnel":
-        return contributor_funnel.main(list(argv[1:]))
+        return _run_module_main("sdetkit.contributor_funnel", list(argv[1:]))
 
     if argv and argv[0] in {"evidence-assets", "proof"}:
-        return proof.main(list(argv[1:]))
+        return _run_module_main("sdetkit.proof", list(argv[1:]))
 
     if argv and argv[0] == "triage-templates":
-        return triage_templates.main(list(argv[1:]))
+        return _run_module_main("sdetkit.triage_templates", list(argv[1:]))
 
     if argv and argv[0] in {"docs-quality", "docs-qa"}:
-        return docs_qa.main(list(argv[1:]))
+        return _run_module_main("sdetkit.docs_qa", list(argv[1:]))
 
     if argv and argv[0] == "weekly-review":
-        return weekly_review.main(list(argv[1:]))
+        return _run_module_main("sdetkit.weekly_review", list(argv[1:]))
 
     if argv and argv[0] in {"docs-governance", "docs-nav"}:
-        return docs_navigation.main(list(argv[1:]))
+        return _run_module_main("sdetkit.docs_navigation", list(argv[1:]))
     if argv and argv[0] == "roadmap":
-        return roadmap.main(list(argv[1:]))
+        return _run_module_main("sdetkit.roadmap", list(argv[1:]))
 
     if argv and argv[0] == "startup-readiness":
-        return startup_readiness.main(list(argv[1:]))
+        return _run_module_main("sdetkit.startup_readiness", list(argv[1:]))
 
     if argv and argv[0] == "upgrade-hub":
-        return upgrade_hub.main(list(argv[1:]))
+        return _run_module_main("sdetkit.upgrade_hub", list(argv[1:]))
 
     if argv and argv[0] == "sdet-package":
-        return sdet_package.main(list(argv[1:]))
+        return _run_module_main("sdetkit.sdet_package", list(argv[1:]))
 
     if argv and argv[0] == "enterprise-readiness":
-        return enterprise_readiness.main(list(argv[1:]))
+        return _run_module_main("sdetkit.enterprise_readiness", list(argv[1:]))
 
     if argv and argv[0] in {"github-actions-onboarding", "github-actions-quickstart"}:
-        return github_actions_quickstart.main(list(argv[1:]))
+        return _run_module_main("sdetkit.github_actions_quickstart", list(argv[1:]))
 
     if argv and argv[0] in {"gitlab-ci-onboarding", "gitlab-ci-quickstart"}:
-        return gitlab_ci_quickstart.main(list(argv[1:]))
+        return _run_module_main("sdetkit.gitlab_ci_quickstart", list(argv[1:]))
 
     if argv and argv[0] in {"contribution-quality-report", "quality-contribution-delta"}:
-        return quality_contribution_delta.main(list(argv[1:]))
+        return _run_module_main("sdetkit.quality_contribution_delta", list(argv[1:]))
 
     if argv and argv[0] == "reliability-evidence-pack":
-        return reliability_evidence_pack.main(list(argv[1:]))
+        return _run_module_main("sdetkit.reliability_evidence_pack", list(argv[1:]))
 
     if argv and argv[0] == "release-readiness":
-        return release_readiness.main(list(argv[1:]))
+        return _run_module_main("sdetkit.release_readiness", list(argv[1:]))
 
     if argv and argv[0] == "release-communications":
-        return release_communications.main(list(argv[1:]))
+        return _run_module_main("sdetkit.release_communications", list(argv[1:]))
 
     if argv and argv[0] == "trust-assets":
-        return trust_assets.main(list(argv[1:]))
+        return _run_module_main("sdetkit.trust_assets", list(argv[1:]))
 
     if argv and argv[0] == "feature-registry":
-        return feature_registry_cli.main(list(argv[1:]))
+        return _run_module_main("sdetkit.feature_registry_cli", list(argv[1:]))
 
     show_hidden_commands = "--show-hidden" in argv
     p, sub = _build_root_parser(show_hidden_commands=show_hidden_commands)
@@ -1226,8 +1151,17 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         return _playbooks_main(list(ns.args))
 
+    if ns.cmd == "legacy":
+        if not ns.args:
+            sys.stderr.write("legacy error: expected a legacy command name\n")
+            return 2
+        if ns.args[0] == "list":
+            sys.stdout.write("\n".join(LEGACY_NAMESPACE_COMMANDS) + "\n")
+            return 0
+        return main(list(ns.args))
+
     if ns.cmd == "kits":
-        return kits.main(ns.args)
+        return _run_module_main("sdetkit.kits", ns.args)
 
     if ns.cmd == "release":
         if not ns.args:
@@ -1238,39 +1172,37 @@ def main(argv: Sequence[str] | None = None) -> int:
         subcmd = ns.args[0]
         rest = ns.args[1:]
         if subcmd == "gate":
-            return gate_cmd.main(rest)
+            return _run_module_main("sdetkit.gate", rest)
         if subcmd == "doctor":
-            from . import doctor as doctor_cmd
-
-            return doctor_cmd.main(rest)
+            return _run_module_main("sdetkit.doctor", rest)
         if subcmd == "security":
-            return security_main(rest)
+            return _run_module_main("sdetkit.security_gate", rest)
         if subcmd == "evidence":
-            return evidence.main(rest)
+            return _run_module_main("sdetkit.evidence", rest)
         if subcmd == "repo":
-            return repo.main(rest)
+            return _run_module_main("sdetkit.repo", rest)
         sys.stderr.write(
             "release error: supported subcommands are gate|doctor|security|evidence|repo\n"
         )
         return 2
 
     if ns.cmd == "intelligence":
-        return intelligence.main(ns.args)
+        return _run_module_main("sdetkit.intelligence", ns.args)
 
     if ns.cmd == "integration":
-        return integration.main(ns.args)
+        return _run_module_main("sdetkit.integration", ns.args)
 
     if ns.cmd == "author":
-        return author_problem.main(ns.args)
+        return _run_module_main("sdetkit.author_problem", ns.args)
 
     if ns.cmd == "forensics":
-        return forensics.main(ns.args)
+        return _run_module_main("sdetkit.forensics", ns.args)
 
     if ns.cmd == "kv":
-        return kvcli.main(ns.args)
+        return _run_module_main("sdetkit.kvcli", ns.args)
 
     if ns.cmd == "patch":
-        return patch.main(ns.args)
+        return _run_module_main("sdetkit.patch", ns.args)
 
     if ns.cmd == "init":
         forwarded = [
@@ -1290,304 +1222,306 @@ def main(argv: Sequence[str] | None = None) -> int:
             forwarded.append("--diff")
         if ns.write_config:
             forwarded.append("--write-config")
-        return repo.main(forwarded)
+        return _run_module_main("sdetkit.repo", forwarded)
 
     if ns.cmd == "repo":
-        return repo.main(ns.args)
+        return _run_module_main("sdetkit.repo", ns.args)
 
     if ns.cmd == "dev":
-        return repo.main(["dev", *ns.args])
+        return _run_module_main("sdetkit.repo", ["dev", *ns.args])
 
     if ns.cmd == "feature-registry":
-        return feature_registry_cli.main(ns.args)
+        return _run_module_main("sdetkit.feature_registry_cli", ns.args)
 
     if ns.cmd == "report":
-        return report.main(ns.args)
+        return _run_module_main("sdetkit.report", ns.args)
 
     if ns.cmd == "maintenance":
-        return maintenance_main(ns.args)
+        return _run_module_main("sdetkit.maintenance", ns.args)
 
     if ns.cmd == "agent":
-        return agent_main(ns.args)
+        return _run_module_main("sdetkit.agent.cli", ns.args)
 
     if ns.cmd == "security":
-        return security_main(ns.args)
+        return _run_module_main("sdetkit.security_gate", ns.args)
 
     if ns.cmd == "ops":
-        return ops.main(ns.args)
+        return _run_module_main("sdetkit.ops", ns.args)
 
     if ns.cmd == "notify":
-        return notify.main(ns.args)
+        return _run_module_main("sdetkit.notify", ns.args)
 
     if ns.cmd == "policy":
-        return policy.main(ns.args)
+        return _run_module_main("sdetkit.policy", ns.args)
 
     if ns.cmd == "evidence":
-        return evidence.main(ns.args)
+        return _run_module_main("sdetkit.evidence", ns.args)
 
     if ns.cmd == "onboarding":
-        return onboarding.main(ns.args)
+        return _run_module_main("sdetkit.onboarding", ns.args)
 
     if ns.cmd == "onboarding-optimization":
-        return onboarding_optimization.main(ns.args)
+        return _run_module_main("sdetkit.onboarding_optimization", ns.args)
 
     if ns.cmd == "community-activation":
-        return community_activation.main(ns.args)
+        return _run_module_main("sdetkit.community_activation", ns.args)
 
     if ns.cmd == "external-contribution":
-        return external_contribution.main(ns.args)
+        return _run_module_main("sdetkit.external_contribution", ns.args)
 
     if ns.cmd == "kpi-audit":
-        return kpi_audit.main(ns.args)
+        return _run_module_main("sdetkit.kpi_audit", ns.args)
+    if ns.cmd == "kpi-report":
+        return _run_module_main("sdetkit.kpi_report", ns.args)
 
     if ns.cmd in {"distribution-closeout"}:
-        return distribution_closeout_36.main(ns.args)
+        return _run_module_main("sdetkit.distribution_closeout_36", ns.args)
 
     if ns.cmd in {"experiment-lane"}:
-        return experiment_lane_37.main(ns.args)
+        return _run_module_main("sdetkit.experiment_lane_37", ns.args)
 
     if ns.cmd in {"distribution-batch"}:
-        return distribution_batch_38.main(ns.args)
+        return _run_module_main("sdetkit.distribution_batch_38", ns.args)
 
     if ns.cmd == "playbook-post":
-        return playbook_post_39.main(ns.args)
+        return _run_module_main("sdetkit.playbook_post_39", ns.args)
 
     if ns.cmd in {"scale-lane"}:
-        return scale_lane_40.main(ns.args)
+        return _run_module_main("sdetkit.scale_lane_40", ns.args)
 
     if ns.cmd in {"expansion-automation"}:
-        return expansion_automation_41.main(ns.args)
+        return _run_module_main("sdetkit.expansion_automation_41", ns.args)
 
     if ns.cmd in {"optimization-closeout-foundation"}:
-        return optimization_closeout_42.main(ns.args)
+        return _run_module_main("sdetkit.optimization_closeout_42", ns.args)
 
     if ns.cmd in {"acceleration-closeout"}:
-        return acceleration_closeout_43.main(ns.args)
+        return _run_module_main("sdetkit.acceleration_closeout_43", ns.args)
 
     if ns.cmd in {"scale-closeout"}:
-        return scale_closeout_44.main(ns.args)
+        return _run_module_main("sdetkit.scale_closeout_44", ns.args)
 
     if ns.cmd in {"expansion-closeout"}:
-        return expansion_closeout_45.main(ns.args)
+        return _run_module_main("sdetkit.expansion_closeout_45", ns.args)
 
     if ns.cmd in {"optimization-closeout"}:
-        return optimization_closeout_46.main(ns.args)
+        return _run_module_main("sdetkit.optimization_closeout_46", ns.args)
 
     if ns.cmd in {"reliability-closeout"}:
-        return reliability_closeout_47.main(ns.args)
+        return _run_module_main("sdetkit.reliability_closeout_47", ns.args)
     if ns.cmd in {"objection-closeout"}:
-        return objection_closeout_48.main(ns.args)
+        return _run_module_main("sdetkit.objection_closeout_48", ns.args)
     if ns.cmd in {
         "weekly-review-closeout",
     }:
-        return weekly_review_closeout_49.main(ns.args)
+        return _run_module_main("sdetkit.weekly_review_closeout_49", ns.args)
     if ns.cmd in {"execution-prioritization-closeout"}:
-        return execution_prioritization_closeout_50.main(ns.args)
+        return _run_module_main("sdetkit.execution_prioritization_closeout_50", ns.args)
     if ns.cmd in {"case-snippet-closeout"}:
-        return case_snippet_closeout_51.main(ns.args)
+        return _run_module_main("sdetkit.case_snippet_closeout_51", ns.args)
     if ns.cmd in {"narrative-closeout"}:
-        return narrative_closeout_52.main(ns.args)
+        return _run_module_main("sdetkit.narrative_closeout_52", ns.args)
     if ns.cmd in {"docs-loop-closeout"}:
-        return docs_loop_closeout_53.main(ns.args)
+        return _run_module_main("sdetkit.docs_loop_closeout_53", ns.args)
     if ns.cmd in {"contributor-activation-closeout"}:
-        return contributor_activation_closeout_55.main(ns.args)
+        return _run_module_main("sdetkit.contributor_activation_closeout_55", ns.args)
 
     if ns.cmd in {"stabilization-closeout"}:
-        return stabilization_closeout_56.main(ns.args)
+        return _run_module_main("sdetkit.stabilization_closeout_56", ns.args)
 
     if ns.cmd in {"kpi-deep-audit-closeout"}:
-        return kpi_deep_audit_closeout_57.main(ns.args)
+        return _run_module_main("sdetkit.kpi_deep_audit_closeout_57", ns.args)
 
     if ns.cmd in {"phase2-hardening-closeout"}:
-        return phase2_hardening_closeout_58.main(ns.args)
+        return _run_module_main("sdetkit.phase2_hardening_closeout_58", ns.args)
 
     if ns.cmd in {"phase3-preplan-closeout"}:
-        return phase3_preplan_closeout_59.main(ns.args)
+        return _run_module_main("sdetkit.phase3_preplan_closeout_59", ns.args)
 
     if ns.cmd in {"phase2-wrap-handoff-closeout"}:
-        return phase2_wrap_handoff_closeout_60.main(ns.args)
+        return _run_module_main("sdetkit.phase2_wrap_handoff_closeout_60", ns.args)
 
     if ns.cmd in {"phase3-kickoff-closeout"}:
-        return phase3_kickoff_closeout_61.main(ns.args)
+        return _run_module_main("sdetkit.phase3_kickoff_closeout_61", ns.args)
 
     if ns.cmd in {"community-program-closeout"}:
-        return community_program_closeout_62.main(ns.args)
+        return _run_module_main("sdetkit.community_program_closeout_62", ns.args)
 
     if ns.cmd in {"onboarding-activation-closeout"}:
-        return onboarding_activation_closeout_63.main(ns.args)
+        return _run_module_main("sdetkit.onboarding_activation_closeout_63", ns.args)
 
     if ns.cmd in {"integration-expansion-closeout"}:
-        return integration_expansion_closeout_64.main(ns.args)
+        return _run_module_main("sdetkit.integration_expansion_closeout_64", ns.args)
 
     if ns.cmd in {"weekly-review-closeout-2"}:
-        return weekly_review_closeout_65.main(ns.args)
+        return _run_module_main("sdetkit.weekly_review_closeout_65", ns.args)
 
     if ns.cmd in {"integration-expansion2-closeout"}:
-        return integration_expansion2_closeout_66.main(ns.args)
+        return _run_module_main("sdetkit.integration_expansion2_closeout_66", ns.args)
 
     if ns.cmd in {"integration-expansion3-closeout"}:
-        return integration_expansion3_closeout_67.main(ns.args)
+        return _run_module_main("sdetkit.integration_expansion3_closeout_67", ns.args)
 
     if ns.cmd in {"integration-expansion4-closeout"}:
-        return integration_expansion4_closeout_68.main(ns.args)
+        return _run_module_main("sdetkit.integration_expansion4_closeout_68", ns.args)
 
     if ns.cmd in {"case-study-prep1-closeout"}:
-        return case_study_prep1_closeout_69.main(ns.args)
+        return _run_module_main("sdetkit.case_study_prep1_closeout_69", ns.args)
 
     if ns.cmd in {"case-study-prep2-closeout"}:
-        return case_study_prep2_closeout_70.main(ns.args)
+        return _run_module_main("sdetkit.case_study_prep2_closeout_70", ns.args)
 
     if ns.cmd == "case-study-prep3-closeout":
-        return case_study_prep3_closeout_71.main(ns.args)
+        return _run_module_main("sdetkit.case_study_prep3_closeout_71", ns.args)
 
     if ns.cmd == "case-study-prep4-closeout":
-        return case_study_prep4_closeout_72.main(ns.args)
+        return _run_module_main("sdetkit.case_study_prep4_closeout_72", ns.args)
 
     if ns.cmd == "case-study-launch-closeout":
-        return case_study_launch_closeout_73.main(ns.args)
+        return _run_module_main("sdetkit.case_study_launch_closeout_73", ns.args)
 
     if ns.cmd == "distribution-scaling-closeout":
-        return distribution_scaling_closeout_74.main(ns.args)
+        return _run_module_main("sdetkit.distribution_scaling_closeout_74", ns.args)
 
     if ns.cmd == "trust-assets-refresh-closeout":
-        return trust_assets_refresh_closeout_75.main(ns.args)
+        return _run_module_main("sdetkit.trust_assets_refresh_closeout_75", ns.args)
 
     if ns.cmd == "contributor-recognition-closeout":
-        return contributor_recognition_closeout_76.main(ns.args)
+        return _run_module_main("sdetkit.contributor_recognition_closeout_76", ns.args)
 
     if ns.cmd == "community-touchpoint-closeout":
-        return community_touchpoint_closeout_77.main(ns.args)
+        return _run_module_main("sdetkit.community_touchpoint_closeout_77", ns.args)
 
     if ns.cmd == "ecosystem-priorities-closeout":
-        return ecosystem_priorities_closeout_78.main(ns.args)
+        return _run_module_main("sdetkit.ecosystem_priorities_closeout_78", ns.args)
 
     if ns.cmd == "scale-upgrade-closeout":
-        return scale_upgrade_closeout_79.main(ns.args)
+        return _run_module_main("sdetkit.scale_upgrade_closeout_79", ns.args)
 
     if ns.cmd == "partner-outreach-closeout":
-        return partner_outreach_closeout_80.main(ns.args)
+        return _run_module_main("sdetkit.partner_outreach_closeout_80", ns.args)
 
     if ns.cmd in {"growth-campaign-closeout"}:
-        return growth_campaign_closeout_81.main(ns.args)
+        return _run_module_main("sdetkit.growth_campaign_closeout_81", ns.args)
 
     if ns.cmd in {"integration-feedback-closeout"}:
-        return integration_feedback_closeout_82.main(ns.args)
+        return _run_module_main("sdetkit.integration_feedback_closeout_82", ns.args)
 
     if ns.cmd in {"trust-faq-expansion-closeout"}:
-        return trust_faq_expansion_closeout_83.main(ns.args)
+        return _run_module_main("sdetkit.trust_faq_expansion_closeout_83", ns.args)
 
     if ns.cmd in {"evidence-narrative-closeout"}:
-        return evidence_narrative_closeout_84.main(ns.args)
+        return _run_module_main("sdetkit.evidence_narrative_closeout_84", ns.args)
 
     if ns.cmd in {"release-prioritization-closeout"}:
-        return release_prioritization_closeout_85.main(ns.args)
+        return _run_module_main("sdetkit.release_prioritization_closeout_85", ns.args)
 
     if ns.cmd in {"launch-readiness-closeout"}:
-        return launch_readiness_closeout_86.main(ns.args)
+        return _run_module_main("sdetkit.launch_readiness_closeout_86", ns.args)
 
     if ns.cmd in {"governance-handoff-closeout"}:
-        return governance_handoff_closeout_87.main(ns.args)
+        return _run_module_main("sdetkit.governance_handoff_closeout_87", ns.args)
 
     if ns.cmd in {"governance-priorities-closeout"}:
-        return governance_priorities_closeout_88.main(ns.args)
+        return _run_module_main("sdetkit.governance_priorities_closeout_88", ns.args)
 
     if ns.cmd in {"governance-scale-closeout"}:
-        return governance_scale_closeout_89.main(ns.args)
+        return _run_module_main("sdetkit.governance_scale_closeout_89", ns.args)
 
     if ns.cmd in {"phase3-wrap-publication-closeout"}:
-        return phase3_wrap_publication_closeout_90.main(ns.args)
+        return _run_module_main("sdetkit.phase3_wrap_publication_closeout_90", ns.args)
 
     if ns.cmd == "continuous-upgrade-closeout-1":
-        return continuous_upgrade_closeout_1.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_1", ns.args)
 
     if ns.cmd == "continuous-upgrade-closeout-2":
-        return continuous_upgrade_closeout_2.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_2", ns.args)
 
     if ns.cmd == "continuous-upgrade-closeout-3":
-        return continuous_upgrade_closeout_3.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_3", ns.args)
 
     if ns.cmd == "continuous-upgrade-closeout-4":
-        return continuous_upgrade_closeout_4.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_4", ns.args)
     if ns.cmd == "continuous-upgrade-closeout-5":
-        return continuous_upgrade_closeout_5.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_5", ns.args)
     if ns.cmd == "continuous-upgrade-closeout-6":
-        return continuous_upgrade_closeout_6.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_6", ns.args)
     if ns.cmd == "continuous-upgrade-closeout-7":
-        return continuous_upgrade_closeout_7.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_7", ns.args)
 
     if ns.cmd == "continuous-upgrade-closeout-8":
-        return continuous_upgrade_closeout_8.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_8", ns.args)
 
     if ns.cmd == "continuous-upgrade-closeout-9":
-        return continuous_upgrade_closeout_9.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_9", ns.args)
 
     if ns.cmd == "continuous-upgrade-closeout-10":
-        return continuous_upgrade_closeout_10.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_10", ns.args)
 
     if ns.cmd == "continuous-upgrade-closeout-11":
-        return continuous_upgrade_closeout_11.main(ns.args)
+        return _run_module_main("sdetkit.continuous_upgrade_closeout_11", ns.args)
 
     if ns.cmd == "objection-handling":
-        return objection_handling.main(ns.args)
+        return _run_module_main("sdetkit.objection_handling", ns.args)
 
     if ns.cmd == "demo":
-        return demo.main(ns.args)
+        return _run_module_main("sdetkit.demo", ns.args)
 
     if ns.cmd == "first-contribution":
-        return first_contribution.main(ns.args)
+        return _run_module_main("sdetkit.first_contribution", ns.args)
 
     if ns.cmd == "contributor-funnel":
-        return contributor_funnel.main(ns.args)
+        return _run_module_main("sdetkit.contributor_funnel", ns.args)
 
     if ns.cmd == "evidence-assets":
-        return proof.main(ns.args)
+        return _run_module_main("sdetkit.proof", ns.args)
 
     if ns.cmd == "triage-templates":
-        return triage_templates.main(ns.args)
+        return _run_module_main("sdetkit.triage_templates", ns.args)
 
     if ns.cmd == "docs-quality":
-        return docs_qa.main(ns.args)
+        return _run_module_main("sdetkit.docs_qa", ns.args)
 
     if ns.cmd == "weekly-review":
-        return weekly_review.main(ns.args)
+        return _run_module_main("sdetkit.weekly_review", ns.args)
 
     if ns.cmd == "docs-governance":
-        return docs_navigation.main(ns.args)
+        return _run_module_main("sdetkit.docs_navigation", ns.args)
     if ns.cmd == "roadmap":
-        return roadmap.main(ns.args)
+        return _run_module_main("sdetkit.roadmap", ns.args)
 
     if ns.cmd == "startup-readiness":
-        return startup_readiness.main(ns.args)
+        return _run_module_main("sdetkit.startup_readiness", ns.args)
 
     if ns.cmd == "upgrade-hub":
-        return upgrade_hub.main(ns.args)
+        return _run_module_main("sdetkit.upgrade_hub", ns.args)
 
     if ns.cmd == "sdet-package":
-        return sdet_package.main(ns.args)
+        return _run_module_main("sdetkit.sdet_package", ns.args)
 
     if ns.cmd == "enterprise-readiness":
-        return enterprise_readiness.main(ns.args)
+        return _run_module_main("sdetkit.enterprise_readiness", ns.args)
 
     if ns.cmd == "github-actions-onboarding":
-        return github_actions_quickstart.main(ns.args)
+        return _run_module_main("sdetkit.github_actions_quickstart", ns.args)
 
     if ns.cmd == "gitlab-ci-onboarding":
-        return gitlab_ci_quickstart.main(ns.args)
+        return _run_module_main("sdetkit.gitlab_ci_quickstart", ns.args)
 
     if ns.cmd == "contribution-quality-report":
-        return quality_contribution_delta.main(ns.args)
+        return _run_module_main("sdetkit.quality_contribution_delta", ns.args)
 
     if ns.cmd == "reliability-evidence-pack":
-        return reliability_evidence_pack.main(ns.args)
+        return _run_module_main("sdetkit.reliability_evidence_pack", ns.args)
 
     if ns.cmd == "release-readiness":
-        return release_readiness.main(ns.args)
+        return _run_module_main("sdetkit.release_readiness", ns.args)
 
     if ns.cmd == "release-communications":
-        return release_communications.main(ns.args)
+        return _run_module_main("sdetkit.release_communications", ns.args)
 
     if ns.cmd == "trust-assets":
-        return trust_assets.main(ns.args)
+        return _run_module_main("sdetkit.trust_assets", ns.args)
 
     if ns.cmd == "apiget":
         raw_args = list(argv)
@@ -1610,13 +1544,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             clean.append(a)
         rest = clean
         if not cassette:
-            return apiget.main(rest)
+            return _run_module_main("sdetkit.apiget", rest)
         old_cassette = os.environ.get("SDETKIT_CASSETTE")
         old_mode = os.environ.get("SDETKIT_CASSETTE_MODE")
         try:
             os.environ["SDETKIT_CASSETTE"] = str(cassette)
             os.environ["SDETKIT_CASSETTE_MODE"] = str(cassette_mode)
-            return apiget.main(rest)
+            return _run_module_main("sdetkit.apiget", rest)
         finally:
             if old_cassette is None:
                 os.environ.pop("SDETKIT_CASSETTE", None)

--- a/src/sdetkit/kpi_report.py
+++ b/src/sdetkit/kpi_report.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _compute_delta(current: float | None, previous: float | None) -> float | None:
+    if current is None or previous is None:
+        return None
+    return round(current - previous, 3)
+
+
+def _build_report(
+    *,
+    current: dict[str, Any],
+    previous: dict[str, Any] | None,
+    week_label: str,
+) -> dict[str, Any]:
+    current_metrics = {
+        "time_to_first_success_minutes": _safe_float(current.get("time_to_first_success_minutes")),
+        "lint_debt_count": _safe_float(current.get("lint_debt_count")),
+        "type_debt_count": _safe_float(current.get("type_debt_count")),
+        "ci_cycle_minutes": _safe_float(current.get("ci_cycle_minutes")),
+        "release_gate_pass_rate": _safe_float(current.get("release_gate_pass_rate")),
+    }
+
+    previous_metrics: dict[str, float | None] = {}
+    if previous is not None:
+        prev_values = previous.get("metrics", {}) if isinstance(previous.get("metrics", {}), dict) else {}
+        previous_metrics = {
+            "time_to_first_success_minutes": _safe_float(prev_values.get("time_to_first_success_minutes")),
+            "lint_debt_count": _safe_float(prev_values.get("lint_debt_count")),
+            "type_debt_count": _safe_float(prev_values.get("type_debt_count")),
+            "ci_cycle_minutes": _safe_float(prev_values.get("ci_cycle_minutes")),
+            "release_gate_pass_rate": _safe_float(prev_values.get("release_gate_pass_rate")),
+        }
+
+    trends = {
+        key: {
+            "previous": previous_metrics.get(key),
+            "current": value,
+            "delta": _compute_delta(value, previous_metrics.get(key)),
+        }
+        for key, value in current_metrics.items()
+    }
+
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "week": week_label,
+        "metrics": current_metrics,
+        "trends": trends,
+        "source": {
+            "current_input": current.get("_source_path"),
+            "previous_input": previous.get("_source_path") if previous else None,
+        },
+    }
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Release Confidence KPI Pack",
+        "",
+        f"- Week: `{payload['week']}`",
+        f"- Generated at: `{payload['generated_at']}`",
+        "",
+        "| KPI | Previous | Current | Delta |",
+        "| --- | --- | --- | --- |",
+    ]
+
+    label_map = {
+        "time_to_first_success_minutes": "Time to first success (minutes)",
+        "lint_debt_count": "Lint debt count",
+        "type_debt_count": "Type debt count",
+        "ci_cycle_minutes": "CI cycle (minutes)",
+        "release_gate_pass_rate": "Release gate pass rate",
+    }
+    for key, label in label_map.items():
+        trend = payload["trends"][key]
+        lines.append(
+            f"| {label} | {trend['previous']} | {trend['current']} | {trend['delta']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build weekly release-confidence KPI pack artifacts.")
+    parser.add_argument("--current", required=True, help="Path to JSON with current KPI values.")
+    parser.add_argument("--previous", default=None, help="Optional previous KPI summary JSON for trend delta.")
+    parser.add_argument("--week", default=datetime.now(UTC).date().isoformat())
+    parser.add_argument("--out-json", default="build/release-confidence-kpi-pack.json")
+    parser.add_argument("--out-md", default="build/release-confidence-kpi-pack.md")
+    ns = parser.parse_args(argv)
+
+    current_path = Path(ns.current)
+    current = _read_json(current_path)
+    if current is None:
+        raise SystemExit(f"Invalid current KPI input: {current_path}")
+    current["_source_path"] = str(current_path)
+
+    previous: dict[str, Any] | None = None
+    if ns.previous:
+        previous_path = Path(ns.previous)
+        loaded = _read_json(previous_path)
+        if loaded is not None:
+            loaded["_source_path"] = str(previous_path)
+            previous = loaded
+
+    payload = _build_report(current=current, previous=previous, week_label=ns.week)
+
+    out_json = Path(ns.out_json)
+    out_md = Path(ns.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(
+        json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    out_md.write_text(_render_markdown(payload), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -120,6 +120,12 @@ def _retry_after_seconds(headers: Any) -> float | None:
         return None
 
 
+def _normalized_timeout(timeout: float | httpx.Timeout | None) -> float | httpx.Timeout | None:
+    if isinstance(timeout, httpx.Timeout):
+        return timeout
+    return default_http_timeout(timeout)
+
+
 def _link_next_url(r: httpx.Response) -> str | None:
     link = r.headers.get("Link")
     if not link:
@@ -250,7 +256,7 @@ class SdetHttpClient:
                 if json is not None:
                     kwargs["json"] = json
                 r = self._client.request(
-                    method, url, timeout=default_http_timeout(timeout), **kwargs
+                    method, url, timeout=_normalized_timeout(timeout), **kwargs
                 )
             except httpx.TimeoutException as e:
                 if b is not None:
@@ -589,9 +595,9 @@ class SdetHttpClient:
 
             try:
                 if hdrs is None:
-                    r = self._client.get(url, timeout=default_http_timeout(timeout))
+                    r = self._client.get(url, timeout=_normalized_timeout(timeout))
                 else:
-                    r = self._client.get(url, headers=hdrs, timeout=default_http_timeout(timeout))
+                    r = self._client.get(url, headers=hdrs, timeout=_normalized_timeout(timeout))
             except httpx.TimeoutException as e:
                 if b is not None:
                     b.record_failure(self._clock())
@@ -887,10 +893,10 @@ class SdetAsyncHttpClient:
 
             try:
                 if hdrs is None:
-                    r = await self._client.get(url, timeout=default_http_timeout(timeout))
+                    r = await self._client.get(url, timeout=_normalized_timeout(timeout))
                 else:
                     r = await self._client.get(
-                        url, headers=hdrs, timeout=default_http_timeout(timeout)
+                        url, headers=hdrs, timeout=_normalized_timeout(timeout)
                     )
             except httpx.TimeoutException as e:
                 if b is not None:

--- a/src/sdetkit/public_command_surface.json
+++ b/src/sdetkit/public_command_surface.json
@@ -1,0 +1,20 @@
+{
+  "contract_version": 1,
+  "primary_outcome": "know if a change is ready to ship",
+  "canonical_first_path": [
+    "python -m sdetkit gate fast",
+    "python -m sdetkit gate release",
+    "python -m sdetkit doctor"
+  ],
+  "public_stable_front_door_commands": [
+    "gate",
+    "doctor",
+    "release"
+  ],
+  "advanced_supported_next_step": "python -m sdetkit kits list",
+  "required_policy_tiers": [
+    "Public / stable",
+    "Advanced but supported",
+    "Experimental / incubator"
+  ]
+}

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
 
 
 @dataclass(frozen=True)
@@ -86,13 +89,36 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
 )
 
 
+def load_public_command_surface_contract() -> dict[str, object]:
+    contract_path = Path(__file__).with_name("public_command_surface.json")
+    loaded = json.loads(contract_path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        return {}
+    return cast(dict[str, object], loaded)
+
+
 def render_root_help_groups() -> str:
     """Render concise command-family guidance for root CLI help text."""
+    contract = load_public_command_surface_contract()
+    canonical_obj = contract.get(
+        "canonical_first_path",
+        [
+            "python -m sdetkit gate fast",
+            "python -m sdetkit gate release",
+            "python -m sdetkit doctor",
+        ],
+    )
+    canonical = canonical_obj if isinstance(canonical_obj, list) else []
+    next_step = contract.get("advanced_supported_next_step", "python -m sdetkit kits list")
+    canonical_summary = " -> ".join(
+        cmd.replace("python -m sdetkit ", "") if isinstance(cmd, str) else str(cmd)
+        for cmd in canonical
+    )
     lines = [
         "Command discovery (stability-aware):",
         "",
         "  Canonical first-time path (public / stable):",
-        "    python -m sdetkit gate fast -> gate release -> doctor",
+        f"    {canonical_summary}",
         "",
         "  Then expand deliberately:",
     ]
@@ -106,5 +132,5 @@ def render_root_help_groups() -> str:
         lines.append(f"    {family.role}")
         lines.append(f"    {', '.join(family.top_level_commands)}")
         lines.append("")
-    lines.append("Next step (advanced but supported): python -m sdetkit kits list")
+    lines.append(f"Next step (advanced but supported): {next_step}")
     return "\n".join(lines)

--- a/tests/test_build_ci_summary.py
+++ b/tests/test_build_ci_summary.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_build_ci_summary_writes_json_and_markdown(tmp_path: Path) -> None:
+    _write_json(tmp_path / "gate-fast.json", {"ok": True, "failed_steps": []})
+    _write_json(tmp_path / "doctor.json", {"ok": True, "score": 93})
+    _write_json(tmp_path / "security-enforce.json", {"ok": True, "max_error": 0, "max_warn": 0})
+    _write_json(tmp_path / "package-validate.json", {"ok": True})
+
+    out_json = tmp_path / "ci-summary.json"
+    out_md = tmp_path / "ci-summary.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/build_ci_summary.py",
+            "--artifact-dir",
+            str(tmp_path),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert out_json.is_file()
+    assert out_md.is_file()
+
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["status"] == "pass"
+    assert payload["checks"]["gate_fast"]["ok"] is True
+    assert payload["checks"]["doctor"]["score"] == 93
+    assert payload["checks"]["package_validate"]["present"] is True
+    assert payload["checks"]["package_validate"]["ok"] is True
+    markdown = out_md.read_text(encoding="utf-8")
+    assert "# CI Operator Summary" in markdown
+    assert "gate_fast" in markdown
+
+
+def test_build_ci_summary_marks_failure_when_gate_or_security_fails(tmp_path: Path) -> None:
+    _write_json(tmp_path / "gate-fast.json", {"ok": False, "failed_steps": ["lint"]})
+    _write_json(tmp_path / "security-enforce.json", {"ok": True, "max_error": 0, "max_warn": 0})
+    out_json = tmp_path / "ci-summary.json"
+    out_md = tmp_path / "ci-summary.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/build_ci_summary.py",
+            "--artifact-dir",
+            str(tmp_path),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    summary = json.loads(out_json.read_text(encoding="utf-8"))
+    assert summary["status"] == "fail"
+    assert summary["checks"]["gate_fast"]["failed_steps"] == ["lint"]

--- a/tests/test_ci_workflow_premerge_gate.py
+++ b/tests/test_ci_workflow_premerge_gate.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def test_fast_ci_workflow_runs_premerge_changed_files_gate_for_pull_requests() -> None:
+    workflow = yaml.safe_load(Path(".github/workflows/ci.yml").read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["fast-ci"]["steps"]
+    premerge_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Pre-merge changed-files strict gate"
+    ]
+    assert len(premerge_steps) == 1
+    step = premerge_steps[0]
+    assert step.get("if") == "${{ github.event_name == 'pull_request' }}"
+    assert step.get("run") == "bash quality.sh premerge"
+    assert step.get("env", {}).get("QUALITY_DIFF_BASE") == "${{ github.event.pull_request.base.sha }}"

--- a/tests/test_cli_help_discoverability_contract.py
+++ b/tests/test_cli_help_discoverability_contract.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from sdetkit.public_surface_contract import render_root_help_groups
 
-
 POLICY_TIERS = (
     "Public / stable",
     "Advanced but supported",
@@ -55,6 +54,29 @@ def test_root_help_avoids_legacy_tier_labels() -> None:
     assert proc.returncode == 0
     assert "Stable/Core" not in proc.stdout
     assert "Stable/Compatibility" not in proc.stdout
+
+
+def test_root_help_exposes_legacy_namespace_but_hides_legacy_lanes() -> None:
+    proc = _run("--help")
+    assert proc.returncode == 0
+    assert "legacy" in proc.stdout
+    assert "weekly-review-lane" not in proc.stdout
+    assert "phase1-hardening" not in proc.stdout
+
+
+def test_legacy_namespace_routes_to_legacy_commands() -> None:
+    proc = _run("legacy", "weekly-review-lane", "--help")
+    assert proc.returncode == 0
+    assert "usage:" in proc.stdout.lower()
+
+
+def test_legacy_namespace_lists_contained_legacy_commands() -> None:
+    proc = _run("legacy", "list")
+    assert proc.returncode == 0
+    listed = set(proc.stdout.splitlines())
+    assert "weekly-review-lane" in listed
+    assert "phase1-hardening" in listed
+    assert "optimization-closeout-foundation" in listed
 
 
 def test_policy_tier_vocabulary_matches_public_contract_and_docs() -> None:

--- a/tests/test_cli_lazy_loading.py
+++ b/tests/test_cli_lazy_loading.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from sdetkit import cli
+
+
+def test_importing_cli_does_not_eager_import_heavy_command_modules() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "PYTHONPATH": str(repo_root / "src")}
+    script = """
+import sys
+import sdetkit.cli  # noqa: F401
+assert "sdetkit.repo" not in sys.modules
+assert "sdetkit.report" not in sys.modules
+assert "sdetkit.patch" not in sys.modules
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_run_module_main_imports_target_module_on_demand(monkeypatch) -> None:
+    called: dict[str, list[str]] = {}
+
+    def _fake_main(args: list[str]) -> int:
+        called["args"] = args
+        return 0
+
+    def _fake_import(name: str) -> SimpleNamespace:
+        assert name == "sdetkit.fake_command"
+        return SimpleNamespace(main=_fake_main)
+
+    monkeypatch.setattr(cli, "import_module", _fake_import)
+
+    rc = cli._run_module_main("sdetkit.fake_command", ("--flag", "value"))
+    assert rc == 0
+    assert called["args"] == ["--flag", "value"]

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
 import re
+from pathlib import Path
 
 import pytest
 
 from sdetkit import docs_qa
-
 
 CANONICAL_FIRST_PROOF_DOCS = (
     Path("README.md"),

--- a/tests/test_kpi_report.py
+++ b/tests/test_kpi_report.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_kpi_report_builds_outputs_and_trends(tmp_path: Path) -> None:
+    current = tmp_path / "current.json"
+    previous = tmp_path / "previous.json"
+    out_json = tmp_path / "report.json"
+    out_md = tmp_path / "report.md"
+
+    _write(
+        current,
+        {
+            "time_to_first_success_minutes": 7.5,
+            "lint_debt_count": 9,
+            "type_debt_count": 2,
+            "ci_cycle_minutes": 14.0,
+            "release_gate_pass_rate": 1.0,
+        },
+    )
+    _write(
+        previous,
+        {
+            "metrics": {
+                "time_to_first_success_minutes": 10.0,
+                "lint_debt_count": 11,
+                "type_debt_count": 4,
+                "ci_cycle_minutes": 16.0,
+                "release_gate_pass_rate": 0.0,
+            }
+        },
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "kpi-report",
+            "--current",
+            str(current),
+            "--previous",
+            str(previous),
+            "--week",
+            "2026-04-10",
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["week"] == "2026-04-10"
+    assert payload["metrics"]["lint_debt_count"] == 9.0
+    assert payload["trends"]["lint_debt_count"]["delta"] == -2.0
+    assert payload["trends"]["release_gate_pass_rate"]["delta"] == 1.0
+    markdown = out_md.read_text(encoding="utf-8")
+    assert "# Release Confidence KPI Pack" in markdown
+    assert "Release gate pass rate" in markdown

--- a/tests/test_kpi_weekly_workflow.py
+++ b/tests/test_kpi_weekly_workflow.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "kpi-weekly.yml"
+
+
+def test_weekly_kpi_workflow_exists_and_publishes_artifact() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    on_block = workflow.get("on") if isinstance(workflow, dict) else None
+    if on_block is None and isinstance(workflow, dict):
+        on_block = workflow.get(True)  # YAML 1.1 can coerce "on" to bool
+    assert isinstance(on_block, dict)
+    assert "schedule" in on_block
+    assert any("cron" in item for item in on_block["schedule"])
+
+    job = workflow["jobs"]["kpi-pack"]
+    run_blob = "\n".join(step.get("run", "") for step in job["steps"] if isinstance(step, dict))
+    assert "python -m sdetkit kpi-report" in run_blob
+    assert "kpi-metrics-current.json" in run_blob
+
+    upload_steps = [s for s in job["steps"] if isinstance(s, dict) and "upload-artifact" in str(s.get("uses", ""))]
+    assert upload_steps, "expected artifact upload step"

--- a/tests/test_public_front_door_alignment.py
+++ b/tests/test_public_front_door_alignment.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 README = Path("README.md")
 DOCS_INDEX = Path("docs/index.md")
 DOCS_CLI = Path("docs/cli.md")

--- a/tests/test_public_surface_alignment.py
+++ b/tests/test_public_surface_alignment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -8,9 +9,14 @@ from pathlib import Path
 
 import yaml
 
+from sdetkit.public_surface_contract import (
+    load_public_command_surface_contract,
+    render_root_help_groups,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PAGES_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pages.yml"
+PUBLIC_COMMAND_CONTRACT = REPO_ROOT / "src" / "sdetkit" / "public_command_surface.json"
 
 
 def test_public_surface_alignment_script_passes() -> None:
@@ -25,6 +31,28 @@ def test_public_surface_alignment_script_passes() -> None:
 
     assert proc.returncode == 0, proc.stderr
     assert "public-surface-alignment check passed" in proc.stdout
+
+
+def test_public_command_surface_contract_is_machine_readable_and_stable() -> None:
+    contract = load_public_command_surface_contract()
+    assert contract == json.loads(PUBLIC_COMMAND_CONTRACT.read_text(encoding="utf-8"))
+    assert contract["contract_version"] == 1
+    assert contract["canonical_first_path"] == [
+        "python -m sdetkit gate fast",
+        "python -m sdetkit gate release",
+        "python -m sdetkit doctor",
+    ]
+    assert contract["public_stable_front_door_commands"] == ["gate", "doctor", "release"]
+    assert contract["advanced_supported_next_step"] == "python -m sdetkit kits list"
+
+
+def test_root_help_groups_include_machine_readable_contract_commands() -> None:
+    contract = load_public_command_surface_contract()
+    help_groups = render_root_help_groups()
+    for command in contract["public_stable_front_door_commands"]:
+        assert command in help_groups
+    assert "gate fast -> gate release -> doctor" in help_groups
+    assert contract["advanced_supported_next_step"] in help_groups
 
 
 def test_pages_workflow_enforces_alignment_check_before_mkdocs_build() -> None:

--- a/tests/test_quality_script.py
+++ b/tests/test_quality_script.py
@@ -20,7 +20,7 @@ def test_quality_script_unknown_mode_suggests_closest_match() -> None:
 def test_quality_script_help_documents_fast_and_full_lanes() -> None:
     text = Path("quality.sh").read_text(encoding="utf-8")
     assert (
-        "Usage: bash quality.sh {all|ci|verify|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost|registry}"
+        "Usage: bash quality.sh {all|ci|verify|premerge|brutal|fmt|lint|type|doctor|test|full-test|cov|mut|muthtml|boost|registry}"
         in text
     )
     assert "quick     Fast local confidence / smoke profile." in text
@@ -35,6 +35,7 @@ def test_quality_script_help_documents_fast_and_full_lanes() -> None:
         "Full verification lane before merge (doctor, format, lint, typing, full tests, security scan)."
         in text
     )
+    assert "premerge   Strict changed-files gate (lint + typing + targeted tests)." in text
     assert "registry   Validate and smoke-test feature-registry docs/contracts surface." in text
 
 
@@ -58,6 +59,16 @@ def test_quality_script_ci_delegates_to_planner_runner() -> None:
     assert 'profile_used="quick"' in body
     assert "python -m sdetkit.checks run" in body
     assert "--profile quick" in body
+
+
+def test_quality_script_premerge_mode_runs_changed_file_gate() -> None:
+    text = Path("quality.sh").read_text(encoding="utf-8")
+    match = re.search(r"  premerge\)\n(?P<body>.*?    ;;)", text, re.DOTALL)
+    assert match is not None
+    body = match.group("body")
+    assert 'profile_used="strict"' in body
+    assert "run_premerge_changed" in body
+    assert "Changed-files pre-merge strict gate" in body
 
 
 def test_quality_script_writes_final_verdict_contract() -> None:


### PR DESCRIPTION
### Motivation
- Enforce a machine-readable public command surface and surface-level discoverability checks in CI to keep docs, help text, and nav aligned with the product contract. 
- Add a strict changed-files pre-merge gate and produce a unified CI summary artifact to improve pre-merge feedback and operator visibility. 
- Provide a weekly KPI pack for release-confidence metrics and reduce CLI import overhead by lazily importing heavy command modules while preserving legacy compatibility.

### Description
- CI/workflows: updated `.github/workflows/ci.yml` to run `ruff` baseline, `scripts/check_public_surface_alignment.py`, a new pre-merge changed-files gate (`bash quality.sh premerge`), emit `doctor.json`, build a unified CI summary via `scripts/build_ci_summary.py`, and upload these artifacts; added a new `kpi-weekly.yml` workflow to generate and upload weekly KPI packs. 
- Scripts & reporting: added `scripts/build_ci_summary.py` to aggregate gate/doctor/security/package checks into JSON/MD summaries and added `scripts/check_public_surface_alignment.py` to validate docs/help/mkdocs against a machine-readable contract. 
- Public contract & docs: added `src/sdetkit/public_command_surface.json`, wired it into `src/sdetkit/public_surface_contract.py` (loader + render updates), and updated README/docs/mkdocs navigation and several new docs pages for the KPI pack and quick-start flow. 
- CLI & runtime: refactored `src/sdetkit/cli.py` to lazy-load submodules via `import_module` and `_run_module_main`, added a `legacy` namespace passthrough and `kpi-report` passthrough, and preserved help discoverability while reducing eager imports. 
- KPI tooling: added `src/sdetkit/kpi_report.py` to build weekly KPI pack JSON/MD artifacts. 
- Quality script & premerge logic: extended `quality.sh` with a `premerge` mode and `run_premerge_changed` implementation to lint, type-check, and run mapped tests only for changed files. 
- Networking robustness: normalized timeout handling in `src/sdetkit/netclient.py` to accept `httpx.Timeout` or float. 
- Tests: added multiple unit tests and workflow/tests to cover the new CI steps, scripts, CLI lazy-loading, KPI pack generation, and public-surface contract checks (files under `tests/`).

### Testing
- Ran the repository test suite via `pytest -q` (non-network tests) which executed the newly added tests including `tests/test_build_ci_summary.py`, `tests/test_kpi_report.py`, `tests/test_cli_lazy_loading.py`, `tests/test_public_surface_alignment.py`, `tests/test_kpi_weekly_workflow.py`, and workflow/config verification tests, and the suite completed successfully. 
- Executed the new scripts in isolation in unit tests: `scripts/build_ci_summary.py` and `scripts/check_public_surface_alignment.py` were exercised by tests and produced the expected JSON/MD outputs. 
- Validated `bash quality.sh premerge` behavior via added tests that assert the mode exists and the help/usage includes the new `premerge` profile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90843a7348332979bf9fddeb91cad)