### PR TITLE
Add git branch tracking docs and git-health helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ artifacts/     # generated evidence packs
 - Docs hub: [`docs/index.md`](docs/index.md)
 - Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Release process: [`RELEASE.md`](RELEASE.md)
+- Git workflow (branch tracking + ahead/behind): [`docs/git-workflow.md`](docs/git-workflow.md)
 - Enterprise readiness audit: [`docs/enterprise-readiness-audit-2026-04.md`](docs/enterprise-readiness-audit-2026-04.md)
 
 ### Historical and transition-era references (secondary)

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,103 @@
+# Git workflow: branch tracking health
+
+This quick reference keeps branch tracking deterministic so ahead/behind status is always visible.
+
+## 1) Set the remote (if missing)
+
+Check remotes:
+
+```bash
+git remote -v
+```
+
+If `origin` is missing, add it:
+
+```bash
+git remote add origin <git@github.com:ORG/REPO.git>
+# or
+git remote add origin <https://github.com/ORG/REPO.git>
+```
+
+Verify:
+
+```bash
+git remote -v
+```
+
+## 2) Set upstream for the current branch
+
+For the current branch (first push):
+
+```bash
+git push -u origin "$(git branch --show-current)"
+```
+
+If branch already exists remotely, set tracking without pushing:
+
+```bash
+git branch --set-upstream-to "origin/$(git branch --show-current)"
+```
+
+## 3) Verify tracking branch
+
+```bash
+git status -sb
+git rev-parse --abbrev-ref --symbolic-full-name @{u}
+```
+
+Expected:
+- `git status -sb` shows `## <branch>...origin/<branch>`.
+- `git rev-parse ... @{u}` prints the upstream ref (for example `origin/main`).
+
+## 4) Read ahead/behind output
+
+Use either built-in status or helper script:
+
+```bash
+git status -sb
+bash scripts/dev.sh git-health
+```
+
+Interpretation:
+- `ahead N`: local branch has `N` commits not on upstream.
+- `behind N`: upstream has `N` commits not in local.
+- both can be non-zero when branch histories diverge.
+
+## 5) Troubleshooting
+
+### `NO_UPSTREAM`
+
+Symptoms:
+- helper script prints `NO_UPSTREAM`
+- `git rev-parse --abbrev-ref --symbolic-full-name @{u}` fails
+
+Fix:
+
+```bash
+git push -u origin "$(git branch --show-current)"
+# or
+git branch --set-upstream-to "origin/$(git branch --show-current)"
+```
+
+### Detached `HEAD`
+
+Symptoms:
+- `git branch --show-current` is empty
+- helper script reports detached `HEAD`
+
+Fix:
+
+```bash
+git switch -c <new-branch-name>
+# then set upstream
+git push -u origin <new-branch-name>
+```
+
+## Daily check (copy/paste)
+
+```bash
+bash scripts/dev.sh git-health
+git status -sb
+```
+
+Safety: these commands are non-destructive and do not use force push.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -12,6 +12,7 @@ Commands:
   quality     Run quality gate (quality.sh all)
   security    Run security gate (security.sh)
   test        Run pytest (full suite unless --fast)
+  git-health  Print git branch/upstream and ahead/behind status
   all         Run quality + security + tests
 
 Flags:
@@ -69,11 +70,44 @@ run_test() {
   fi
 }
 
+run_git_health() {
+  if ! git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Not a git repository: $root" >&2
+    exit 1
+  fi
+
+  local branch
+  branch="$(git -C "$root" rev-parse --abbrev-ref HEAD)"
+  echo "Current branch: $branch"
+
+  if [[ "$branch" == "HEAD" ]]; then
+    echo "Upstream branch: NO_UPSTREAM (detached HEAD)"
+    echo "Ahead/behind: N/A"
+    return 0
+  fi
+
+  local upstream
+  if ! upstream="$(git -C "$root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
+    echo "Upstream branch: NO_UPSTREAM (set with: git branch --set-upstream-to origin/$branch)"
+    echo "Ahead/behind: N/A"
+    return 0
+  fi
+
+  echo "Upstream branch: $upstream"
+
+  local counts behind ahead
+  counts="$(git -C "$root" rev-list --left-right --count "$upstream...HEAD")"
+  behind="${counts%%[[:space:]]*}"
+  ahead="${counts##*[[:space:]]}"
+  echo "Ahead/behind: ahead $ahead, behind $behind"
+}
+
 case "$cmd" in
   bootstrap) bootstrap ;;
   quality) run_quality ;;
   security) run_security ;;
   test) run_test ;;
+  git-health) run_git_health ;;
   all)
     run_quality
     run_security


### PR DESCRIPTION
### Motivation
- Provide deterministic, copy/paste guidance so contributors can reliably see branch `ahead/behind` health. 
- Surface clear remediation for common failure modes (`NO_UPSTREAM`, detached `HEAD`).
- Offer a small, non-destructive helper to make daily checks fast and scriptable. 

### Description
- Add `docs/git-workflow.md` containing steps to set a remote, set upstream for the current branch, verify tracking, read `ahead/behind` output, and troubleshoot `NO_UPSTREAM` and detached `HEAD` scenarios. 
- Add a short `Git workflow` link to `README.md` under documentation references. 
- Extend `scripts/dev.sh` with a new `git-health` command that prints the current branch, prints the upstream or a clear `NO_UPSTREAM` message, and reports ahead/behind counts via `git rev-list --left-right --count` when an upstream exists; detached `HEAD` is handled gracefully. 
- Preserve safety and style constraints: no destructive git commands, no force pushes, no changes under `src/sdetkit/`, and the script remains POSIX/Bash-safe (`set -euo pipefail`). 

### Testing
- Ran `bash scripts/dev.sh git-health`, which completed successfully and reported the current branch and `NO_UPSTREAM` when appropriate. 
- Ran `git status -sb && (git rev-parse --abbrev-ref --symbolic-full-name '@{u}' || echo 'NO_UPSTREAM')`, which completed successfully and showed the repo state and `NO_UPSTREAM`. 
- Ran `mkdocs build`, which completed successfully (site built; existing non-blocking navigation warnings were emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9313acd4c8332b9b223f4f376ba5b)