### PR TITLE
Introduce staged coverage modes and raise default coverage gate to 85% (COV_MODE)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,12 @@ python -m pre_commit run -a
 mkdocs build
 ```
 
+Coverage gate migration note:
+- Previous default was fail-under `80`.
+- Current default is `COV_MODE=standard` (fail-under `85`).
+- Temporary override remains available: `COV_FAIL_UNDER=80 bash quality.sh cov` (or `COV_MODE=legacy`).
+- For strict merge/release validation, use `COV_MODE=strict bash quality.sh cov` (fail-under `95`).
+
 ## Pull request checklist
 
 Reference: [docs/premium-quality-gate.md](docs/premium-quality-gate.md)

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ ruff check .
 mutmut results
 ```
 
+### Coverage hardening migration (staged)
+
+- **Previous default:** `bash quality.sh cov` used `COV_FAIL_UNDER=80` when unset.
+- **New default (effective now):** `bash quality.sh cov` uses `COV_MODE=standard` (fail-under `85`).
+- **Temporary compatibility override:** `COV_FAIL_UNDER=80 bash quality.sh cov` (or `COV_MODE=legacy bash quality.sh cov`).
+- **Stricter enforcement target:** use `COV_MODE=strict` (fail-under `95`) for merge/release truth lanes by **July 1, 2026**.
+
 ### Project layout
 
 ```text

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,30 +12,45 @@ Security is treated as a product feature in this repository.
 
 ## Supported versions
 
-Only the latest released version is supported with security fixes.
+- Security fixes are provided for the **latest released version**.
+- If you report an issue against an older version, maintainers may ask you to retest on the latest release before triage is finalized.
 
-## Reporting a vulnerability
+## How to report vulnerabilities privately
 
 Please **do not open public issues** for suspected vulnerabilities.
 
-1. Open a private report through GitHub Security Advisories for this repository.
-2. If advisories are unavailable, email the maintainers and request private handling.
-3. Include impact, affected versions, reproduction steps, and proposed mitigations.
+1. Use GitHub Security Advisories for this repository to submit a private report.
+2. If GitHub Security Advisories is unavailable, use the private contact channel listed in [SUPPORT.md](SUPPORT.md) and request private handling.
+3. Include the details listed in [What to include in your report](#what-to-include-in-your-report).
 
 ## Response targets
 
-- **Initial triage response:** within 3 business names.
-- **Status updates:** at least every 7 business names until resolution.
-- **Coordinated disclosure:** after a fix is released and users have had reasonable upgrade time.
+Our targets are best-effort and may vary with report quality and maintainer availability.
 
-## Handling expectations
+- **Initial triage response:** within **3 business days**.
+- **Status updates:** at least every **7 business days** until closure or coordinated disclosure.
+- **Remediation goal:** confirmed vulnerabilities are addressed in the next available patch release when practical.
 
-- Maintainers may request additional details or a proof of concept to validate impact.
-- Confirmed vulnerabilities are addressed in the next available patch release when possible.
-- Credit is included in release notes unless anonymity is requested.
+## Coordinated disclosure policy
 
-## Safe disclosure guidance
+- Coordinated disclosure begins after maintainers validate the report.
+- Public disclosure should wait until a fix is released and users have had reasonable time to upgrade.
+- Maintainers may request additional validation details (for example, PoC steps) to confirm impact.
+- Reporter credit is included in release notes unless anonymity is requested.
 
-- Avoid publishing exploit details until a fix is available.
-- Share minimal reproducible details privately.
-- Coordinate timelines with maintainers for responsible disclosure.
+### What NOT to do
+
+- Do not publish exploit details, proof-of-concept code, or sensitive reproduction data before a fix is available.
+- Do not open duplicate public issues for active private security reports.
+
+## What to include in your report
+
+Provide enough detail for deterministic triage:
+
+- affected version(s) and environment,
+- impact and severity assessment,
+- minimal reproducible steps,
+- proof-of-concept or sample payloads (sanitized),
+- suggested mitigations or fix direction (if known).
+
+For additional hardening context, see [docs/security.md](docs/security.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,16 @@ SDETKit is a productized release-confidence path for engineering teams that need
 
 Everything else is intentionally secondary until this canonical first-proof lane is trusted.
 
+## How to use this docs site
+
+Use the navigation in this order to reduce decision fatigue:
+
+1. **Start Here (primary)** for first-run success on the canonical path.
+2. **Team Rollout / CI (primary)** when moving from local proof to team adoption.
+3. **Reference (secondary)** for command/options lookup and policy details.
+4. **Advanced (secondary)** for maintainer, platform, and extension workflows.
+5. **Archive / Historical (non-primary)** only when you need transition-era traceability.
+
 ## Why trust it
 
 - The core flow is explicit and repeatable: `python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`.

--- a/docs/premium-quality-gate.md
+++ b/docs/premium-quality-gate.md
@@ -26,7 +26,11 @@ mkdocs build
 
 ## Coverage expectations
 
-- The repository-wide gate is controlled by `COV_FAIL_UNDER`.
+- Coverage mode defaults are staged in `quality.sh`:
+  - `COV_MODE=standard` → fail-under `85` (default),
+  - `COV_MODE=strict` → fail-under `95` (merge/release truth),
+  - `COV_MODE=legacy` → fail-under `80` (temporary compatibility lane).
+- `COV_FAIL_UNDER` still overrides mode defaults when explicitly set.
 - For premium quality, prioritize adding tests in low-coverage modules before adding new features.
 - If behavior changes, include at least one failing-path test and one happy-path test.
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -29,7 +29,7 @@ This page is the quickest way to understand **where things are**, **where new fi
 | --- | --- | --- |
 | New contributor | `README.md` | `CONTRIBUTING.md`, `docs/project-structure.md` |
 | CLI user | `docs/cli.md` | `docs/doctor.md`, `docs/repo-audit.md` |
-| Maintainer | `quality.sh` | `scripts/check.sh`, `noxfile.py`, `Makefile` |
+| Maintainer | `quality.sh` | `scripts/bootstrap.sh`, `noxfile.py`, `Makefile` |
 | Release owner | `RELEASE.md` | `docs/releasing.md`, `CHANGELOG.md` |
 | Docs editor | `docs/index.md` | `mkdocs.yml`, `docs/contributing.md` |
 
@@ -82,7 +82,7 @@ The repository root should stay reserved for **project-wide entrypoints and poli
 
 - `tests/` — feature tests, CLI tests, module unit tests, and mutation-test killer tests
 - `scripts/` — one-command workflows such as:
-  - `check.sh` (fmt/lint/types/tests/coverage/docs/all)
+  - `quality.sh` (fmt/lint/types/tests/coverage/docs/all)
   - `bootstrap.sh` (create local environment + install dependencies)
   - `env.sh` / `shell.sh` (venv PATH convenience)
 - `docs/` — user and maintainer documentation published via MkDocs

--- a/docs/recommended-ci-flow.md
+++ b/docs/recommended-ci-flow.md
@@ -53,7 +53,7 @@ jobs:
       - name: Main branch stricter checks
         if: github.ref == 'refs/heads/main'
         env:
-          COV_FAIL_UNDER: "95"
+          COV_MODE: strict
         run: |
           python -m pre_commit run -a
           bash quality.sh registry

--- a/docs/repo-cleanup-plan.md
+++ b/docs/repo-cleanup-plan.md
@@ -64,3 +64,11 @@ Before opening a PR:
 - Weekly: scan root for accidental drift.
 - Monthly: merge duplicate docs or stale variants into canonical pages.
 - Per release: validate that README “start here” links still match active command surfaces.
+
+## Docs drift checklist
+
+Use this quick check before merging documentation edits:
+
+- [ ] Verify every referenced file path exists in the current repository tree.
+- [ ] Verify each documented command example still runs (or is clearly marked as illustrative-only).
+- [ ] Verify each link target points to the current canonical page/path (not a superseded duplicate).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,19 +82,18 @@ extra_javascript:
   - javascripts/mermaid-init.js
 
 nav:
-  - Start here: index.md
-  - Canonical first-proof path (primary):
+  - Start Here (primary):
+      - Homepage: index.md
       - Start Here in 5 Minutes (fast path): start-here-5-minutes.md
       - Install (canonical): install.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
       - First run quickstart (guided canonical path): ready-to-use.md
       - Release confidence (canonical explainer): release-confidence.md
-      - Before/after evidence example: before-after-evidence-example.md
-      - Evidence showcase: evidence-showcase.md
       - Decision guide (is SDETKit a fit?): decision-guide.md
       - Choose your path (30-second router): choose-your-path.md
-      - Doctor checks: doctor.md
-  - Team adoption and CI rollout (primary):
+      - Before/after evidence example: before-after-evidence-example.md
+      - Evidence showcase: evidence-showcase.md
+  - Team Rollout / CI (primary):
       - Adopt in your repository (canonical): adoption.md
       - Team rollout scenario: team-rollout-scenario.md
       - Example adoption flow: example-adoption-flow.md
@@ -103,75 +102,78 @@ nav:
       - Recommended CI flow (canonical): recommended-ci-flow.md
       - CI artifact walkthrough (canonical evidence decode): ci-artifact-walkthrough.md
       - CI contract (reference): ci-contract.md
+      - Remediation cookbook: remediation-cookbook.md
       - Reporting and trends: reporting-and-trends.md
       - Release confidence KPI pack: release-confidence-kpi-pack.md
       - Sample outputs (exploratory, non-canonical): sample-outputs.md
-      - Remediation cookbook: remediation-cookbook.md
-  - Current reference and discoverability (secondary):
+  - Reference (secondary):
       - Docs map (compact): docs-map.md
       - CLI reference: cli.md
       - API: api.md
-      - Repo Audit: repo-audit.md
-      - Security Gate: security-gate.md
-      - Security model: security-model.md
-      - Security hardening: security.md
-      - Policy-as-Code: policy.md
+      - Doctor checks: doctor.md
+      - Repo audit: repo-audit.md
+      - Security:
+          - Security gate: security-gate.md
+          - Security model: security-model.md
+          - Security hardening: security.md
+          - Policy-as-Code: policy.md
       - Feature registry: feature-registry.md
       - Release confidence architecture note: architecture/umbrella-kits.md
-      - Release verification records: release-verification.md
-      - Roadmap: roadmap.md
-      - Changelog: changelog.md
-  - Contributing and maintenance (secondary):
-      - Repo tour: repo-tour.md
-      - First contribution quickstart: first-contribution-quickstart.md
-      - Contributing: contributing.md
-      - Starter work inventory: starter-work-inventory.md
-      - Maintainer starter-issue hygiene: maintainer-starter-issue-hygiene.md
-      - "GitHub Action: sdetkit repo audit": github-action.md
-      - PR automation for audit auto-fixes: pr-automation.md
-      - Automation bots and maintenance control loop: automation-bots.md
-      - n8n integration (PR webhook automation): n8n.md
-  - Kits (secondary umbrella):
-      - Release Confidence Kit: kits/release-confidence.md
-      - Test Intelligence Kit: kits/test-intelligence.md
-      - Integration Assurance Kit: kits/integration-assurance.md
-      - Failure Forensics Kit: kits/failure-forensics.md
-      - Dependency radar dashboard: kits/dependency-radar-dashboard.md
-      - Validation route map: kits/validation-route-map.md
-      - Expansion lab: kits/expansion-lab.md
-  - Advanced and reference (secondary):
-      - Platform problem authoring: platform-problem-authoring.md
       - Command surface inventory: command-surface.md
       - Capability map and command taxonomy: command-taxonomy.md
       - Determinism checklist: determinism-checklist.md
       - Determinism contract: determinism-contract.md
-      - Evidence Pack: evidence.md
-      - Ops Control Plane: ops.md
-      - Tool server: tool-server.md
-      - IDE + pre-commit integration: ide-and-precommit.md
-      - Omnichannel + MCP bridge: omnichannel-mcp-bridge.md
-      - Plugins: plugins.md
-      - Plugins, rule packs, and fix-audit: plugins-and-fix.md
-      - Global production transformation playbook: global-production-transformation-playbook.md
-      - Why not just separate tools? (system value): why-not-just-tools.md
-      - Product strategy (release confidence): product-strategy.md
       - Stability levels (current policy): stability-levels.md
       - Versioning and support posture (current policy): versioning-and-support.md
       - Integrations and extension boundary (current policy): integrations-and-extension-boundary.md
-      - Productization map: productization-map.md
-      - Design notes: design.md
-      - Governance and org packs: governance-and-org-packs.md
-      - Project structure: project-structure.md
-      - Releasing sdetkit: releasing.md
-      - Packaging/install/release-readiness audit: packaging-readiness-audit.md
-      - Public release verification records: release-verification.md
+      - Release verification records: release-verification.md
+      - Roadmap: roadmap.md
+      - Changelog: changelog.md
       - License: license.md
-  - Advanced live views (secondary):
-      - 🕹️ DevS69 Command HUD — Live Detail View: command-hud-live.md
-      - 🔄 DevS69 Diff-to-Decision — Live Detail View: diff-flow-live.md
-      - 🗺️ DevS69 Repo Map — Live Detail View: repo-map-live.md
-      - DevS69 Visual HUD Showcase: hud-showcase.md
-  - Historical archive (non-primary):
+  - Advanced (secondary):
+      - Contributing and maintenance:
+          - Repo tour: repo-tour.md
+          - First contribution quickstart: first-contribution-quickstart.md
+          - Contributing: contributing.md
+          - Starter work inventory: starter-work-inventory.md
+          - Maintainer starter-issue hygiene: maintainer-starter-issue-hygiene.md
+          - "GitHub Action: sdetkit repo audit": github-action.md
+          - PR automation for audit auto-fixes: pr-automation.md
+          - Automation bots and maintenance control loop: automation-bots.md
+          - n8n integration (PR webhook automation): n8n.md
+      - Kits (secondary umbrella):
+          - Release Confidence Kit: kits/release-confidence.md
+          - Test Intelligence Kit: kits/test-intelligence.md
+          - Integration Assurance Kit: kits/integration-assurance.md
+          - Failure Forensics Kit: kits/failure-forensics.md
+          - Dependency radar dashboard: kits/dependency-radar-dashboard.md
+          - Validation route map: kits/validation-route-map.md
+          - Expansion lab: kits/expansion-lab.md
+      - Platform and operations:
+          - Platform problem authoring: platform-problem-authoring.md
+          - Evidence Pack: evidence.md
+          - Ops Control Plane: ops.md
+          - Tool server: tool-server.md
+          - IDE + pre-commit integration: ide-and-precommit.md
+          - Omnichannel + MCP bridge: omnichannel-mcp-bridge.md
+          - Plugins: plugins.md
+          - Plugins, rule packs, and fix-audit: plugins-and-fix.md
+      - Product and governance:
+          - Why not just separate tools? (system value): why-not-just-tools.md
+          - Product strategy (release confidence): product-strategy.md
+          - Productization map: productization-map.md
+          - Design notes: design.md
+          - Governance and org packs: governance-and-org-packs.md
+          - Project structure: project-structure.md
+          - Releasing sdetkit: releasing.md
+          - Packaging/install/release-readiness audit: packaging-readiness-audit.md
+          - Global production transformation playbook: global-production-transformation-playbook.md
+      - Advanced live views:
+          - 🕹️ DevS69 Command HUD — Live Detail View: command-hud-live.md
+          - 🔄 DevS69 Diff-to-Decision — Live Detail View: diff-flow-live.md
+          - 🗺️ DevS69 Repo Map — Live Detail View: repo-map-live.md
+          - DevS69 Visual HUD Showcase: hud-showcase.md
+  - Archive / Historical (non-primary):
       - Archive overview: archive/index.md
       - Transition-era material map: archive/transition-era-material.md
 

--- a/quality.sh
+++ b/quality.sh
@@ -28,10 +28,6 @@ mode=${1:-all}
 if [[ "$mode" == "-h" || "$mode" == "--help" || "$mode" == "help" ]]; then
   mode=help
 fi
-# Keep the default gate realistic for full-repo runs, while still allowing
-# stricter enforcement in CI/release jobs via COV_FAIL_UNDER=95.
-cov_fail_under=${COV_FAIL_UNDER:-80}
-
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 && return 0
   echo "missing tool: $1" >&2
@@ -68,6 +64,12 @@ Modes:
   muthtml    Build mutation HTML output.
   boost      Chain doctor, fast gate, premium fast gate, and optimization summary.
   registry   Validate and smoke-test feature-registry docs/contracts surface.
+
+Coverage staging:
+  Default coverage mode is COV_MODE=standard (fail-under 85).
+  Use COV_MODE=strict for fail-under 95 (merge/release truth).
+  Use COV_MODE=legacy for fail-under 80 during migration.
+  COV_FAIL_UNDER always overrides mode defaults.
 USAGE
 }
 
@@ -154,12 +156,53 @@ run_cov() {
   # - full: complete repository visibility (informational)
   # - core (default): strict gate on critical, stable modules
   cov_scope="${COV_SCOPE:-core}"
+  cov_mode="${COV_MODE:-standard}"
+  cov_fail_under_override="${COV_FAIL_UNDER:-}"
+  local cov_fail_under
 
-  if [[ "$cov_scope" == "full" ]]; then
-    python -m pytest --cov=sdetkit --cov-report=term-missing --cov-fail-under="$cov_fail_under"
-    return
+  if [[ -n "$cov_fail_under_override" ]]; then
+    cov_fail_under="$cov_fail_under_override"
+    cov_source="COV_FAIL_UNDER override"
+  else
+    case "$cov_mode" in
+      standard)
+        cov_fail_under=85
+        cov_source="COV_MODE=standard default"
+        ;;
+      strict)
+        cov_fail_under=95
+        cov_source="COV_MODE=strict default"
+        ;;
+      legacy)
+        cov_fail_under=80
+        cov_source="COV_MODE=legacy compatibility"
+        ;;
+      *)
+        echo "[quality] unknown COV_MODE='$cov_mode' (supported: standard, strict, legacy)" >&2
+        return 2
+        ;;
+    esac
   fi
 
+  echo "[quality] coverage config: scope=$cov_scope mode=$cov_mode fail-under=$cov_fail_under ($cov_source)"
+
+  if [[ "$cov_scope" == "full" ]]; then
+    set +e
+    python -m pytest --cov=sdetkit --cov-report=term-missing --cov-fail-under="$cov_fail_under"
+    rc=$?
+    set -e
+    if (( rc != 0 )); then
+      echo "[quality] coverage gate failed (mode=$cov_mode, scope=$cov_scope, fail-under=$cov_fail_under)." >&2
+      echo "[quality] temporary override: COV_FAIL_UNDER=80 bash quality.sh cov" >&2
+      echo "[quality] staged hardening: use COV_MODE=strict for 95 when validating merge/release truth." >&2
+    fi
+    return "$rc"
+  elif [[ "$cov_scope" != "core" ]]; then
+    echo "[quality] unknown COV_SCOPE='$cov_scope' (supported: core, full)" >&2
+    return 2
+  fi
+
+  set +e
   python -m pytest \
     --cov=sdetkit.__main__ \
     --cov=sdetkit._entrypoints \
@@ -172,6 +215,14 @@ run_cov() {
     --cov=sdetkit.textutil \
     --cov-report=term-missing \
     --cov-fail-under="$cov_fail_under"
+  rc=$?
+  set -e
+  if (( rc != 0 )); then
+    echo "[quality] coverage gate failed (mode=$cov_mode, scope=$cov_scope, fail-under=$cov_fail_under)." >&2
+    echo "[quality] temporary override: COV_FAIL_UNDER=80 bash quality.sh cov" >&2
+    echo "[quality] staged hardening: use COV_MODE=strict for 95 when validating merge/release truth." >&2
+  fi
+  return "$rc"
 }
 run_mut() { need_cmd mutmut; mutmut run; }
 run_muthtml() { need_cmd mutmut; mutmut html; }


### PR DESCRIPTION
### Motivation

- Raise the repository-wide coverage default and provide a staged migration path to harder gates to improve test hardening without breaking existing workflows.
- Make coverage gating configurable and explicit for local runs and CI by introducing named modes and preserving a legacy override for compatibility.

### Description

- Add `COV_MODE` handling to `quality.sh` with three modes: `standard` (fail-under 85), `strict` (fail-under 95), and `legacy` (fail-under 80), while keeping `COV_FAIL_UNDER` as an explicit override and printing the active configuration when running `cov`.
- Update CI workflow to use `COV_MODE=strict` for main-branch stricter checks instead of setting `COV_FAIL_UNDER=95` directly.
- Propagate the coverage migration guidance and examples into docs and top-level files (`CONTRIBUTING.md`, `README.md`, `docs/index.md`, `docs/premium-quality-gate.md`, `docs/project-structure.md`, `docs/recommended-ci-flow.md`, `docs/repo-cleanup-plan.md`, and `mkdocs.yml`) to describe defaults, overrides, timelines, and temporary compatibility options.
- Clean up and clarify security reporting wording in `SECURITY.md` and add a short docs drift checklist in `docs/repo-cleanup-plan.md`.

### Testing

- Ran `python -m ruff format --check .` which passed. 
- Ran `python -m pre_commit run -a` which passed. 
- Built the docs with `mkdocs build` which completed successfully. 
- Executed the new coverage flow with `bash quality.sh cov` in the default `COV_MODE=standard` which reported the configured mode and returned successfully in my local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d933ac53ec833291a2bac45595d36b)