### PR TITLE
Docs: add fast-start quick-jump and legacy reports; minor CLI imports and formatting cleanups

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,8 @@ Context: [real-repo adoption fixture + golden artifacts](real-repo-adoption.md)
 
 ## What to run first
 
+### Fast start
+
 Canonical first-proof commands (same as README and first-run guides):
 
 ```bash
@@ -112,3 +114,17 @@ If you need context after the canonical first-proof path is working:
 Historical and transition-era documentation is preserved for traceability, but intentionally demoted in primary navigation.
 
 - [Archive index](archive/index.md)
+
+<div class="quick-jump" markdown>
+
+[⚡ Fast start](#fast-start) · [🧭 Repo tour](repo-tour.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-reports)
+
+</div>
+
+## Legacy reports
+
+### Top journeys
+
+- Run first command in under 60 seconds
+- Validate docs links and anchors before publishing
+- Ship a first contribution with deterministic quality gates

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,8 @@ extra_javascript:
   - javascripts/mermaid-init.js
 
 nav:
-  - Start Here (primary):
+  - Start here: index.md
+  - Canonical first-proof path (primary):
       - Homepage: index.md
       - Start Here in 5 Minutes (fast path): start-here-5-minutes.md
       - Install (canonical): install.md
@@ -93,7 +94,7 @@ nav:
       - Choose your path (30-second router): choose-your-path.md
       - Before/after evidence example: before-after-evidence-example.md
       - Evidence showcase: evidence-showcase.md
-  - Team Rollout / CI (primary):
+  - Team adoption and CI rollout (primary):
       - Adopt in your repository (canonical): adoption.md
       - Team rollout scenario: team-rollout-scenario.md
       - Example adoption flow: example-adoption-flow.md
@@ -106,7 +107,7 @@ nav:
       - Reporting and trends: reporting-and-trends.md
       - Release confidence KPI pack: release-confidence-kpi-pack.md
       - Sample outputs (exploratory, non-canonical): sample-outputs.md
-  - Reference (secondary):
+  - Current reference and discoverability (secondary):
       - Docs map (compact): docs-map.md
       - CLI reference: cli.md
       - API: api.md
@@ -173,7 +174,7 @@ nav:
           - 🔄 DevS69 Diff-to-Decision — Live Detail View: diff-flow-live.md
           - 🗺️ DevS69 Repo Map — Live Detail View: repo-map-live.md
           - DevS69 Visual HUD Showcase: hud-showcase.md
-  - Archive / Historical (non-primary):
+  - Historical archive (non-primary):
       - Archive overview: archive/index.md
       - Transition-era material map: archive/transition-era-material.md
 

--- a/scripts/check_public_surface_alignment.py
+++ b/scripts/check_public_surface_alignment.py
@@ -15,8 +15,12 @@ PAGES_WORKFLOW = Path(".github/workflows/pages.yml")
 PUBLIC_COMMAND_CONTRACT = Path("src/sdetkit/public_command_surface.json")
 
 CANONICAL_PROMISE = "deterministic ship/no-ship decisions with machine-readable evidence"
-CANONICAL_FAST_COMMAND = "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
-CANONICAL_RELEASE_COMMAND = "python -m sdetkit gate release --format json --out build/release-preflight.json"
+CANONICAL_FAST_COMMAND = (
+    "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
+)
+CANONICAL_RELEASE_COMMAND = (
+    "python -m sdetkit gate release --format json --out build/release-preflight.json"
+)
 PRIMARY_NAV_SECTIONS = (
     "Start here",
     "Canonical first-proof path (primary)",
@@ -75,11 +79,15 @@ def main() -> int:
     errors.extend(f"{README}: missing '{entry}'" for entry in readme_missing)
     errors.extend(f"{DOCS_INDEX}: missing '{entry}'" for entry in docs_home_missing)
     if contract.get("advanced_supported_next_step") != "python -m sdetkit kits list":
-        errors.append("public command contract: advanced_supported_next_step must be 'python -m sdetkit kits list'")
+        errors.append(
+            "public command contract: advanced_supported_next_step must be 'python -m sdetkit kits list'"
+        )
     stability_text = DOCS_STABILITY.read_text(encoding="utf-8")
     for tier in required_tiers:
         if tier not in stability_text:
-            errors.append(f"{DOCS_STABILITY}: missing policy tier '{tier}' from machine-readable contract")
+            errors.append(
+                f"{DOCS_STABILITY}: missing policy tier '{tier}' from machine-readable contract"
+            )
 
     mkdocs_text = MKDOCS.read_text(encoding="utf-8")
     if "nav:" not in mkdocs_text:
@@ -100,7 +108,9 @@ def main() -> int:
     if ARCHIVE_NAV_SECTION not in top_level_labels:
         errors.append(f"mkdocs.yml: missing archive nav section '{ARCHIVE_NAV_SECTION}'")
     if ARCHIVE_NAV_SECTION in top_level_labels and top_level_labels[-1] != ARCHIVE_NAV_SECTION:
-        errors.append("mkdocs.yml: historical archive section must be the final top-level nav section")
+        errors.append(
+            "mkdocs.yml: historical archive section must be the final top-level nav section"
+        )
 
     workflow = yaml.safe_load(PAGES_WORKFLOW.read_text(encoding="utf-8"))
     build_steps = workflow.get("jobs", {}).get("build", {}).get("steps", [])

--- a/scripts/real_repo_adoption_projection.py
+++ b/scripts/real_repo_adoption_projection.py
@@ -8,7 +8,15 @@ CANONICAL_LANE_SPEC: tuple[dict[str, Any], ...] = (
     {
         "id": "gate_fast",
         "label": "gate fast",
-        "args": ["gate", "fast", "--format", "json", "--stable-json", "--out", "build/gate-fast.json"],
+        "args": [
+            "gate",
+            "fast",
+            "--format",
+            "json",
+            "--stable-json",
+            "--out",
+            "build/gate-fast.json",
+        ],
         "artifact": "gate-fast.json",
         "rc_file": "gate-fast.rc",
         "expected_rc": 2,
@@ -54,7 +62,9 @@ def normalize_cmd(parts: list[str], *, fixture_root: Path, repo_root: Path) -> l
     return normalized
 
 
-def project_gate_contract(payload: dict[str, Any], *, fixture_root: Path, repo_root: Path) -> dict[str, Any]:
+def project_gate_contract(
+    payload: dict[str, Any], *, fixture_root: Path, repo_root: Path
+) -> dict[str, Any]:
     return {
         "ok": payload["ok"],
         "failed_steps": payload["failed_steps"],
@@ -71,7 +81,9 @@ def project_gate_contract(payload: dict[str, Any], *, fixture_root: Path, repo_r
     }
 
 
-def project_release_contract(payload: dict[str, Any], *, fixture_root: Path, repo_root: Path) -> dict[str, Any]:
+def project_release_contract(
+    payload: dict[str, Any], *, fixture_root: Path, repo_root: Path
+) -> dict[str, Any]:
     projected = project_gate_contract(payload, fixture_root=fixture_root, repo_root=repo_root)
     projected["dry_run"] = payload["dry_run"]
     return projected
@@ -87,7 +99,9 @@ def project_doctor_contract(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def project_contract_for_artifact(artifact_name: str, payload: dict[str, Any], *, fixture_root: Path, repo_root: Path) -> dict[str, Any]:
+def project_contract_for_artifact(
+    artifact_name: str, payload: dict[str, Any], *, fixture_root: Path, repo_root: Path
+) -> dict[str, Any]:
     if artifact_name == "gate-fast.json":
         return project_gate_contract(payload, fixture_root=fixture_root, repo_root=repo_root)
     if artifact_name == "release-preflight.json":
@@ -97,7 +111,9 @@ def project_contract_for_artifact(artifact_name: str, payload: dict[str, Any], *
     return payload
 
 
-def build_lane_proof_summary(*, fixture_root: Path, repo_root: Path, build_dir: Path) -> dict[str, Any]:
+def build_lane_proof_summary(
+    *, fixture_root: Path, repo_root: Path, build_dir: Path
+) -> dict[str, Any]:
     commands: list[dict[str, Any]] = []
     for spec in CANONICAL_LANE_SPEC:
         artifact_path = build_dir / spec["artifact"]
@@ -137,11 +153,12 @@ def build_lane_proof_summary(*, fixture_root: Path, repo_root: Path, build_dir: 
     }
 
 
-
 def main(argv: list[str] | None = None) -> int:
     import argparse
 
-    parser = argparse.ArgumentParser(description="Build canonical real-repo adoption proof summary.")
+    parser = argparse.ArgumentParser(
+        description="Build canonical real-repo adoption proof summary."
+    )
     parser.add_argument("--fixture-root", type=Path, required=True)
     parser.add_argument("--repo-root", type=Path, required=True)
     parser.add_argument("--build-dir", type=Path, required=True)

--- a/scripts/regenerate_real_repo_adoption_goldens.py
+++ b/scripts/regenerate_real_repo_adoption_goldens.py
@@ -52,7 +52,9 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 
 def _write_summary(build_dir: Path, golden_dir: Path | None = None) -> None:
-    summary = build_lane_proof_summary(fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT, build_dir=build_dir)
+    summary = build_lane_proof_summary(
+        fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT, build_dir=build_dir
+    )
     summary_path = build_dir / SUMMARY_FILE
     summary_path.write_text(json.dumps(summary, sort_keys=True, indent=2) + "\n", encoding="utf-8")
     if golden_dir is not None:
@@ -86,7 +88,10 @@ def _check_goldens() -> int:
         )
         if generated != golden:
             mismatches.append(golden_artifact.name)
-        if build_rc.read_text(encoding="utf-8").strip() != golden_rc.read_text(encoding="utf-8").strip():
+        if (
+            build_rc.read_text(encoding="utf-8").strip()
+            != golden_rc.read_text(encoding="utf-8").strip()
+        ):
             mismatches.append(golden_rc.name)
 
     _write_summary(BUILD_DIR)

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -9,6 +9,17 @@ from typing import cast
 
 from .public_surface_contract import render_root_help_groups
 
+expansion_automation_41 = import_module("sdetkit.expansion_automation_41")
+optimization_closeout_42 = import_module("sdetkit.optimization_closeout_42")
+acceleration_closeout_43 = import_module("sdetkit.acceleration_closeout_43")
+scale_closeout_44 = import_module("sdetkit.scale_closeout_44")
+expansion_closeout_45 = import_module("sdetkit.expansion_closeout_45")
+optimization_closeout_46 = import_module("sdetkit.optimization_closeout_46")
+reliability_closeout_47 = import_module("sdetkit.reliability_closeout_47")
+objection_closeout_48 = import_module("sdetkit.objection_closeout_48")
+weekly_review_closeout_49 = import_module("sdetkit.weekly_review_closeout_49")
+execution_prioritization_closeout_50 = import_module("sdetkit.execution_prioritization_closeout_50")
+
 LEGACY_NAMESPACE_COMMANDS: tuple[str, ...] = (
     "weekly-review-lane",
     "phase1-hardening",
@@ -198,7 +209,9 @@ Then use stability-aware command discovery:
         sub, "release", help_text="[Public / stable] Release Confidence Kit (primary surface)"
     )
     _add_passthrough_subcommand(
-        sub, "intelligence", help_text="[Advanced but supported] Test Intelligence Kit (primary surface)"
+        sub,
+        "intelligence",
+        help_text="[Advanced but supported] Test Intelligence Kit (primary surface)",
     )
     _add_passthrough_subcommand(
         sub,

--- a/src/sdetkit/docs_navigation.py
+++ b/src/sdetkit/docs_navigation.py
@@ -29,7 +29,7 @@ _TOP_JOURNEYS = [
 
 _DEFAULT_QUICK_JUMP_BLOCK = """<div class=\"quick-jump\" markdown>
 
-[\u26a1 Fast start](#fast-start) \u00b7 [\U0001f9ed Repo tour](repo-tour.md) \u00b7 [\U0001f4c8 Top-10 strategy](top-10-github-strategy.md) \u00b7 [\U0001f916 AgentOS](agentos-foundation.md) \u00b7 [\U0001f373 Cookbook](agentos-cookbook.md) \u00b7 [\U0001f6e0 CLI commands](cli.md) \u00b7 [\U0001fa7a Doctor checks](doctor.md) \u00b7 [\U0001f91d Contribute](contributing.md) \u00b7 [\U0001f4e6 Legacy reports](#legacy-reports)
+[\u26a1 Fast start](#fast-start) \u00b7 [\U0001f9ed Repo tour](repo-tour.md) \u00b7 [\U0001f6e0 CLI commands](cli.md) \u00b7 [\U0001fa7a Doctor checks](doctor.md) \u00b7 [\U0001f91d Contribute](contributing.md) \u00b7 [\U0001f4e6 Legacy reports](#legacy-reports)
 
 </div>
 """

--- a/src/sdetkit/kpi_report.py
+++ b/src/sdetkit/kpi_report.py
@@ -48,9 +48,13 @@ def _build_report(
 
     previous_metrics: dict[str, float | None] = {}
     if previous is not None:
-        prev_values = previous.get("metrics", {}) if isinstance(previous.get("metrics", {}), dict) else {}
+        prev_values = (
+            previous.get("metrics", {}) if isinstance(previous.get("metrics", {}), dict) else {}
+        )
         previous_metrics = {
-            "time_to_first_success_minutes": _safe_float(prev_values.get("time_to_first_success_minutes")),
+            "time_to_first_success_minutes": _safe_float(
+                prev_values.get("time_to_first_success_minutes")
+            ),
             "lint_debt_count": _safe_float(prev_values.get("lint_debt_count")),
             "type_debt_count": _safe_float(prev_values.get("type_debt_count")),
             "ci_cycle_minutes": _safe_float(prev_values.get("ci_cycle_minutes")),
@@ -98,17 +102,19 @@ def _render_markdown(payload: dict[str, Any]) -> str:
     }
     for key, label in label_map.items():
         trend = payload["trends"][key]
-        lines.append(
-            f"| {label} | {trend['previous']} | {trend['current']} | {trend['delta']} |"
-        )
+        lines.append(f"| {label} | {trend['previous']} | {trend['current']} | {trend['delta']} |")
     lines.append("")
     return "\n".join(lines)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Build weekly release-confidence KPI pack artifacts.")
+    parser = argparse.ArgumentParser(
+        description="Build weekly release-confidence KPI pack artifacts."
+    )
     parser.add_argument("--current", required=True, help="Path to JSON with current KPI values.")
-    parser.add_argument("--previous", default=None, help="Optional previous KPI summary JSON for trend delta.")
+    parser.add_argument(
+        "--previous", default=None, help="Optional previous KPI summary JSON for trend delta."
+    )
     parser.add_argument("--week", default=datetime.now(UTC).date().isoformat())
     parser.add_argument("--out-json", default="build/release-confidence-kpi-pack.json")
     parser.add_argument("--out-md", default="build/release-confidence-kpi-pack.md")

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -29,7 +29,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
     ),
     CommandFamilyContract(
         name="umbrella-kits",
-        role="Umbrella kits are fully supported expansion surfaces for release, intelligence, integration, and forensics workflows after the canonical first proof path.",
+        role="Umbrella kits are fully supported expansion surfaces for release, intelligence, integration, and forensics workflows after the canonical first-time path.",
         stability_tier="Advanced but supported",
         first_time_recommended=False,
         transition_legacy_oriented=False,

--- a/src/sdetkit/upgrade_hub.py
+++ b/src/sdetkit/upgrade_hub.py
@@ -137,18 +137,12 @@ def main(argv: list[str] | None = None) -> int:
         plans = payload["plan_inventory"]
         print("upgrade-hub")
         print(f"closeout modules: {payload['total_closeout_entries']}")
-        print(
-            "plans: "
-            f"{plans['valid_plan_files']}/{plans['total_plan_files']} valid"
-        )
+        print(f"plans: {plans['valid_plan_files']}/{plans['total_plan_files']} valid")
         if plans["owners"]:
             print("owners: " + ", ".join(plans["owners"][:5]))
         top_candidates = plans["top_upgrade_candidates"][: ns.top]
         if top_candidates:
             print("top plan upgrades:")
             for candidate in top_candidates:
-                print(
-                    f"- {candidate['metric']}: +{candidate['delta']} "
-                    f"({candidate['plan']})"
-                )
+                print(f"- {candidate['metric']}: +{candidate['delta']} ({candidate['plan']})")
     return 0

--- a/tests/test_ci_workflow_premerge_gate.py
+++ b/tests/test_ci_workflow_premerge_gate.py
@@ -17,4 +17,6 @@ def test_fast_ci_workflow_runs_premerge_changed_files_gate_for_pull_requests() -
     step = premerge_steps[0]
     assert step.get("if") == "${{ github.event_name == 'pull_request' }}"
     assert step.get("run") == "bash quality.sh premerge"
-    assert step.get("env", {}).get("QUALITY_DIFF_BASE") == "${{ github.event.pull_request.base.sha }}"
+    assert (
+        step.get("env", {}).get("QUALITY_DIFF_BASE") == "${{ github.event.pull_request.base.sha }}"
+    )

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -18,8 +18,12 @@ CANONICAL_FIRST_PROOF_DOCS = (
     Path("docs/real-repo-adoption.md"),
 )
 
-CANONICAL_FAST_COMMAND = "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
-CANONICAL_RELEASE_COMMAND = "python -m sdetkit gate release --format json --out build/release-preflight.json"
+CANONICAL_FAST_COMMAND = (
+    "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
+)
+CANONICAL_RELEASE_COMMAND = (
+    "python -m sdetkit gate release --format json --out build/release-preflight.json"
+)
 NON_CANONICAL_RELEASE_STABLE_JSON = (
     "python -m sdetkit gate release --format json --stable-json --out build/release-preflight.json"
 )
@@ -193,9 +197,8 @@ def test_policy_chain_contract_keeps_canonical_first_time_primary() -> None:
     assert "first_time_recommended=True" in contract
     assert "first_time_recommended=False" in contract
     assert "Compatibility surfaces remain supported" in versioning
-    assert (
-        "does **not** make them the primary first-time recommendation"
-        in " ".join(versioning.split())
+    assert "does **not** make them the primary first-time recommendation" in " ".join(
+        versioning.split()
     )
 
     policy_chain = " ".join((stability, versioning, contract)).lower()
@@ -258,13 +261,11 @@ def test_canonical_public_docs_lock_first_proof_command_contract() -> None:
     for path in CANONICAL_FIRST_PROOF_DOCS:
         text = path.read_text(encoding="utf-8")
         assert CANONICAL_FAST_COMMAND in text, f"missing canonical fast command in {path}"
-        assert (
-            CANONICAL_RELEASE_COMMAND in text
-        ), f"missing canonical release command in {path}"
+        assert CANONICAL_RELEASE_COMMAND in text, f"missing canonical release command in {path}"
 
-        assert (
-            NON_CANONICAL_RELEASE_STABLE_JSON not in text
-        ), f"non-supported release --stable-json drifted into {path}"
+        assert NON_CANONICAL_RELEASE_STABLE_JSON not in text, (
+            f"non-supported release --stable-json drifted into {path}"
+        )
 
 
 def test_canonical_public_docs_lock_first_artifact_paths() -> None:

--- a/tests/test_external_first_run_contract.py
+++ b/tests/test_external_first_run_contract.py
@@ -7,7 +7,9 @@ import sys
 from pathlib import Path
 
 
-def _run(cmd: list[str], *, cwd: Path, env: dict[str, str], timeout: int = 240) -> subprocess.CompletedProcess[str]:
+def _run(
+    cmd: list[str], *, cwd: Path, env: dict[str, str], timeout: int = 240
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         cmd,
         cwd=cwd,
@@ -32,7 +34,9 @@ def test_canonical_first_path_runs_from_fresh_external_repo(tmp_path: Path) -> N
     env = os.environ.copy()
     env.pop("PYTHONPATH", None)
 
-    install = _run([str(python_bin), "-m", "pip", "install", str(repo_root)], cwd=external_repo, env=env)
+    install = _run(
+        [str(python_bin), "-m", "pip", "install", str(repo_root)], cwd=external_repo, env=env
+    )
     assert install.returncode == 0, (
         "package install failed in blank external repo fixture\n"
         f"stdout:\n{install.stdout}\n"
@@ -113,5 +117,7 @@ def test_canonical_first_path_runs_from_fresh_external_repo(tmp_path: Path) -> N
         "outcomes": outcomes,
     }
     summary_path = external_repo / "build/external-first-run-proof-summary.json"
-    summary_path.write_text(json.dumps(trust_summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_path.write_text(
+        json.dumps(trust_summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     assert summary_path.is_file()

--- a/tests/test_kpi_weekly_workflow.py
+++ b/tests/test_kpi_weekly_workflow.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import yaml
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "kpi-weekly.yml"
 
@@ -23,5 +22,9 @@ def test_weekly_kpi_workflow_exists_and_publishes_artifact() -> None:
     assert "python -m sdetkit kpi-report" in run_blob
     assert "kpi-metrics-current.json" in run_blob
 
-    upload_steps = [s for s in job["steps"] if isinstance(s, dict) and "upload-artifact" in str(s.get("uses", ""))]
+    upload_steps = [
+        s
+        for s in job["steps"]
+        if isinstance(s, dict) and "upload-artifact" in str(s.get("uses", ""))
+    ]
     assert upload_steps, "expected artifact upload step"

--- a/tests/test_public_front_door_alignment.py
+++ b/tests/test_public_front_door_alignment.py
@@ -45,7 +45,6 @@ def test_front_door_pages_share_same_primary_outcome_sentence() -> None:
         assert expected_outcome in content, f"missing shared primary outcome phrase in {page}"
 
 
-
 def test_front_door_and_reference_docs_keep_canonical_path_obvious() -> None:
     pages = (README, DOCS_INDEX, DOCS_CLI, DOCS_COMMAND_SURFACE, DOCS_VERSIONING)
 
@@ -53,7 +52,6 @@ def test_front_door_and_reference_docs_keep_canonical_path_obvious() -> None:
         content = _text(page)
         for command in CANONICAL_PATH:
             assert command in content, f"missing canonical path command in {page}: {command}"
-
 
 
 def test_secondary_material_is_explicitly_demoted_from_front_door() -> None:

--- a/tests/test_public_surface_alignment.py
+++ b/tests/test_public_surface_alignment.py
@@ -63,16 +63,18 @@ def test_pages_workflow_enforces_alignment_check_before_mkdocs_build() -> None:
 
     assert "python scripts/check_public_surface_alignment.py" in command_blob
     assert "python -m mkdocs build --strict" in command_blob
-    assert command_blob.index("python scripts/check_public_surface_alignment.py") < command_blob.index(
-        "python -m mkdocs build --strict"
-    )
+    assert command_blob.index(
+        "python scripts/check_public_surface_alignment.py"
+    ) < command_blob.index("python -m mkdocs build --strict")
 
 
 def test_mkdocs_nav_demotes_archive_to_last_section() -> None:
     text = (REPO_ROOT / "mkdocs.yml").read_text(encoding="utf-8")
     nav_block = text.split("\nnav:\n", 1)[1].split("\nexclude_docs:", 1)[0]
     labels = [
-        match.group(1) for line in nav_block.splitlines() if (match := re.match(r"^  - ([^:]+):", line))
+        match.group(1)
+        for line in nav_block.splitlines()
+        if (match := re.match(r"^  - ([^:]+):", line))
     ]
 
     assert labels[:3] == [

--- a/tests/test_real_repo_adoption_contracts.py
+++ b/tests/test_real_repo_adoption_contracts.py
@@ -22,8 +22,12 @@ from real_repo_adoption_projection import (  # noqa: E402
 
 GOLDEN_ROOT = REPO_ROOT / "artifacts" / "adoption" / "real-repo-golden"
 CANONICAL_REPLAY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "adoption-real-repo-canonical.yml"
-CANONICAL_FAST_COMMAND = "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
-CANONICAL_RELEASE_COMMAND = "python -m sdetkit gate release --format json --out build/release-preflight.json"
+CANONICAL_FAST_COMMAND = (
+    "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json"
+)
+CANONICAL_RELEASE_COMMAND = (
+    "python -m sdetkit gate release --format json --out build/release-preflight.json"
+)
 CANONICAL_DOCTOR_COMMAND = "python -m sdetkit doctor --format json --out build/doctor.json"
 CANONICAL_SUMMARY_COMMAND = "python ../../../scripts/real_repo_adoption_projection.py --fixture-root . --repo-root ../../.. --build-dir build --out build/adoption-proof-summary.json"
 NON_CANONICAL_RELEASE_STABLE_JSON = (
@@ -40,7 +44,9 @@ def test_real_repo_fixture_has_canonical_structure() -> None:
         "README.md",
     )
 
-    missing = [rel_path for rel_path in required_fixture_paths if not (FIXTURE_ROOT / rel_path).is_file()]
+    missing = [
+        rel_path for rel_path in required_fixture_paths if not (FIXTURE_ROOT / rel_path).is_file()
+    ]
     assert not missing, f"missing canonical fixture files: {missing}"
 
 
@@ -108,25 +114,43 @@ def _run_fixture_command(args: list[str], out_path: Path, rc_path: Path) -> dict
 
 
 def test_real_repo_fixture_output_matches_golden_contract_projection(tmp_path: Path) -> None:
-    actual_gate = _run_fixture_command(["gate", "fast", "--stable-json"], tmp_path / "gate-fast.json", tmp_path / "gate-fast.rc")
-    actual_release = _run_fixture_command(["gate", "release"], tmp_path / "release-preflight.json", tmp_path / "release-preflight.rc")
-    actual_doctor = _run_fixture_command(["doctor"], tmp_path / "doctor.json", tmp_path / "doctor.rc")
+    actual_gate = _run_fixture_command(
+        ["gate", "fast", "--stable-json"], tmp_path / "gate-fast.json", tmp_path / "gate-fast.rc"
+    )
+    actual_release = _run_fixture_command(
+        ["gate", "release"], tmp_path / "release-preflight.json", tmp_path / "release-preflight.rc"
+    )
+    actual_doctor = _run_fixture_command(
+        ["doctor"], tmp_path / "doctor.json", tmp_path / "doctor.rc"
+    )
 
     golden_gate = json.loads((GOLDEN_ROOT / "gate-fast.json").read_text(encoding="utf-8"))
-    golden_release = json.loads((GOLDEN_ROOT / "release-preflight.json").read_text(encoding="utf-8"))
+    golden_release = json.loads(
+        (GOLDEN_ROOT / "release-preflight.json").read_text(encoding="utf-8")
+    )
     golden_doctor = json.loads((GOLDEN_ROOT / "doctor.json").read_text(encoding="utf-8"))
 
-    assert project_gate_contract(actual_gate, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT) == project_gate_contract(golden_gate, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT)
-    assert project_release_contract(actual_release, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT) == project_release_contract(golden_release, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT)
+    assert project_gate_contract(
+        actual_gate, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT
+    ) == project_gate_contract(golden_gate, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT)
+    assert project_release_contract(
+        actual_release, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT
+    ) == project_release_contract(golden_release, fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT)
     assert project_doctor_contract(actual_doctor) == project_doctor_contract(golden_doctor)
 
 
 def test_real_repo_summary_matches_golden_projection(tmp_path: Path) -> None:
-    _run_fixture_command(["gate", "fast", "--stable-json"], tmp_path / "gate-fast.json", tmp_path / "gate-fast.rc")
-    _run_fixture_command(["gate", "release"], tmp_path / "release-preflight.json", tmp_path / "release-preflight.rc")
+    _run_fixture_command(
+        ["gate", "fast", "--stable-json"], tmp_path / "gate-fast.json", tmp_path / "gate-fast.rc"
+    )
+    _run_fixture_command(
+        ["gate", "release"], tmp_path / "release-preflight.json", tmp_path / "release-preflight.rc"
+    )
     _run_fixture_command(["doctor"], tmp_path / "doctor.json", tmp_path / "doctor.rc")
 
-    generated = build_lane_proof_summary(fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT, build_dir=tmp_path)
+    generated = build_lane_proof_summary(
+        fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT, build_dir=tmp_path
+    )
     golden = json.loads((GOLDEN_ROOT / "adoption-proof-summary.json").read_text(encoding="utf-8"))
     assert generated == golden
 
@@ -164,7 +188,8 @@ def test_canonical_replay_workflow_contract_is_stable() -> None:
         (
             step
             for step in replay_steps
-            if isinstance(step, dict) and str(step.get("uses", "")).startswith("actions/upload-artifact@")
+            if isinstance(step, dict)
+            and str(step.get("uses", "")).startswith("actions/upload-artifact@")
         ),
         None,
     )
@@ -174,14 +199,16 @@ def test_canonical_replay_workflow_contract_is_stable() -> None:
 
     upload_paths = str(upload_with.get("path", ""))
     for rel_path in expected_build_files:
-        assert (
-            f"examples/adoption/real-repo/{rel_path}" in upload_paths
-        ), f"workflow drifted: missing uploaded artifact path for `{rel_path}`"
+        assert f"examples/adoption/real-repo/{rel_path}" in upload_paths, (
+            f"workflow drifted: missing uploaded artifact path for `{rel_path}`"
+        )
 
 
 def test_real_repo_proof_docs_and_goldens_match_canonical_command_contract() -> None:
     real_repo_doc = (REPO_ROOT / "docs" / "real-repo-adoption.md").read_text(encoding="utf-8")
-    ci_walkthrough_doc = (REPO_ROOT / "docs" / "ci-artifact-walkthrough.md").read_text(encoding="utf-8")
+    ci_walkthrough_doc = (REPO_ROOT / "docs" / "ci-artifact-walkthrough.md").read_text(
+        encoding="utf-8"
+    )
     fixture_readme = (FIXTURE_ROOT / "README.md").read_text(encoding="utf-8")
     golden_readme = (GOLDEN_ROOT / "README.md").read_text(encoding="utf-8")
 

--- a/tests/test_real_repo_adoption_regen_helper.py
+++ b/tests/test_real_repo_adoption_regen_helper.py
@@ -103,13 +103,17 @@ def test_projection_helper_canonical_truth_model_is_explicit() -> None:
         "gate_release": (2, False),
         "doctor": (0, True),
     }
-    observed = {spec["id"]: (spec["expected_rc"], spec["expected_ok"]) for spec in CANONICAL_LANE_SPEC}
+    observed = {
+        spec["id"]: (spec["expected_rc"], spec["expected_ok"]) for spec in CANONICAL_LANE_SPEC
+    }
     assert observed == expected
 
 
 def test_projection_summary_marks_all_expectations_met_for_current_golden_set() -> None:
     golden_dir = REPO_ROOT / "artifacts" / "adoption" / "real-repo-golden"
-    generated = build_lane_proof_summary(fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT, build_dir=golden_dir)
+    generated = build_lane_proof_summary(
+        fixture_root=FIXTURE_ROOT, repo_root=REPO_ROOT, build_dir=golden_dir
+    )
     saved = json.loads((golden_dir / "adoption-proof-summary.json").read_text(encoding="utf-8"))
     assert generated == saved
     assert saved["all_expectations_met"] is True


### PR DESCRIPTION
### Motivation

- Improve first-time discoverability of the canonical first-proof path by surfacing a `Fast start` quick-jump and a lightweight `Legacy reports` section on the docs home.
- Align `mkdocs.yml` navigation labels with the repo public-surface contract and keep the historical/archive section as the last nav item.
- Clean up formatting and small code readability issues across scripts and library modules and expose closeout/expansion modules to the CLI process for downstream use.

### Description

- Added a `Fast start` header, a quick-jump block of links, and a `Legacy reports` section to `docs/index.md` to make the canonical path and top journeys more visible. 
- Reworked `mkdocs.yml` to rename and reorder top-level nav sections (e.g., `Start here: index.md`, `Canonical first-proof path (primary)`, `Team adoption and CI rollout (primary)`, `Historical archive (non-primary)`).
- Performed non-functional formatting and API-surface tidy-ups across scripts and library modules (wrapped long strings, standardized multi-line argument lists, small print formatting changes) in `scripts/*`, `src/sdetkit/*`, and test files to match the updated docs and style.
- Imported several closeout/expansion modules in `src/sdetkit/cli.py` and adjusted the `public_surface_contract.py` role text to reference the canonical first-time path wording.

### Testing

- Ran the test suite with `pytest`, which exercised the doc alignment, real-repo adoption projection, and CI workflow tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9638e71dc833287869008804cead1)