### PR TITLE
gate: add actionable remediation recommendations on failures

### DIFF
--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -121,6 +121,10 @@ def _format_text(payload: dict[str, Any]) -> str:
         lines.append("failed_steps:")
         for s in payload["failed_steps"]:
             lines.append(f"- {s}")
+    if payload.get("recommendations"):
+        lines.append("recommendations:")
+        for item in payload["recommendations"]:
+            lines.append(f"- {item}")
     return "\n".join(lines) + "\n"
 
 
@@ -143,7 +147,55 @@ def _format_md(payload: dict[str, Any]) -> str:
         lines.append("#### Failed steps")
         for s in payload["failed_steps"]:
             lines.append(f"- `{s}`")
+    if payload.get("recommendations"):
+        lines.append("")
+        lines.append("#### Recommendations")
+        for item in payload["recommendations"]:
+            lines.append(f"- {item}")
     return "\n".join(lines) + "\n"
+
+
+def _contains_missing_module(step: dict[str, Any], module_name: str) -> bool:
+    stderr = str(step.get("stderr", ""))
+    stdout = str(step.get("stdout", ""))
+    marker = f"No module named {module_name!r}"
+    return marker in stderr or marker in stdout
+
+
+def _fast_recommendations(steps: list[dict[str, Any]], failed_steps: list[str]) -> list[str]:
+    recommendations: list[str] = []
+    for step in steps:
+        step_id = str(step.get("id", ""))
+        if step_id not in failed_steps:
+            continue
+        if step_id in {"ruff_fix", "ruff_format_apply", "ruff", "ruff_format"} and _contains_missing_module(
+            step, "ruff"
+        ):
+            recommendations.append(
+                "Ruff is missing in this environment. Install dev tooling: python -m pip install -e .[dev,test]."
+            )
+            continue
+        if step_id == "mypy" and _contains_missing_module(step, "mypy"):
+            recommendations.append(
+                "Mypy is missing in this environment. Install dev tooling: python -m pip install -e .[dev,test]."
+            )
+            continue
+        if step_id == "pytest" and _contains_missing_module(step, "pytest"):
+            recommendations.append(
+                "Pytest is missing in this environment. Install test tooling: python -m pip install -e .[test]."
+            )
+            continue
+        if step_id == "doctor":
+            recommendations.append(
+                "Inspect doctor evidence first: python -m sdetkit doctor --format json --out build/doctor.json."
+            )
+            continue
+        if step_id == "ci_templates":
+            recommendations.append(
+                "Validate your CI templates under templates/ci or skip this step with --skip ci_templates."
+            )
+            continue
+    return list(dict.fromkeys(recommendations))
 
 
 def _run_fast(ns: argparse.Namespace) -> int:
@@ -283,6 +335,9 @@ def _run_fast(ns: argparse.Namespace) -> int:
         "failed_steps": failed,
         "steps": steps,
     }
+    recommendations = _fast_recommendations(steps, failed)
+    if recommendations:
+        payload["recommendations"] = recommendations
 
     if ns.format == "json":
         if getattr(ns, "stable_json", False):
@@ -344,7 +399,20 @@ def _format_release_text(payload: dict[str, Any]) -> str:
         lines.append("failed_steps:")
         for item in payload["failed_steps"]:
             lines.append(f"- {item}")
+    if payload.get("recommendations"):
+        lines.append("recommendations:")
+        for item in payload["recommendations"]:
+            lines.append(f"- {item}")
     return "\n".join(lines) + "\n"
+
+
+def _release_recommendations(failed_steps: list[str]) -> list[str]:
+    mapping = {
+        "doctor_release": "Inspect release readiness output: python -m sdetkit doctor --release --format json --out build/doctor-release.json.",
+        "playbooks_validate": "Run playbook validation directly for details: python -m sdetkit playbooks validate --recommended --format json.",
+        "gate_fast": "Inspect fast gate evidence: python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json.",
+    }
+    return [mapping[s] for s in failed_steps if s in mapping]
 
 
 def _normalize_release_steps(steps: list[dict[str, Any]], root: Path) -> list[dict[str, Any]]:
@@ -422,6 +490,9 @@ def _run_release(ns: argparse.Namespace) -> int:
         "failed_steps": failed,
         "steps": steps,
     }
+    recommendations = _release_recommendations(failed)
+    if recommendations:
+        payload["recommendations"] = recommendations
 
     rendered = (
         json.dumps(payload, sort_keys=True) + "\n"

--- a/tests/test_gate_fast.py
+++ b/tests/test_gate_fast.py
@@ -238,3 +238,30 @@ def test_gate_fast_full_pytest_uses_entire_suite(monkeypatch, tmp_path: Path, ca
     assert rc == 0
     _ = json.loads(capsys.readouterr().out)
     assert calls[0][3:] == ["-q"]
+
+
+def test_gate_fast_adds_recommendation_for_missing_pytest(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    def fake_run(cmd: list[str], cwd: Path) -> dict[str, object]:
+        return {
+            "cmd": cmd,
+            "rc": 1,
+            "ok": False,
+            "duration_ms": 1,
+            "stdout": "",
+            "stderr": "/usr/bin/python: No module named 'pytest'",
+        }
+
+    monkeypatch.setattr(gate, "_run", fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    rc = gate.main(
+        ["fast", "--format", "json", "--no-doctor", "--no-ci-templates", "--no-ruff", "--no-mypy"]
+    )
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["failed_steps"] == ["pytest"]
+    assert payload["recommendations"] == [
+        "Pytest is missing in this environment. Install test tooling: python -m pip install -e .[test]."
+    ]

--- a/tests/test_gate_release.py
+++ b/tests/test_gate_release.py
@@ -122,3 +122,29 @@ def test_gate_release_dry_run_normalizes_commands(monkeypatch, tmp_path: Path, c
     cmds = [step["cmd"] for step in payload["steps"]]
     assert all(cmd[0] == "python" for cmd in cmds)
     assert any("<repo>" in tok for tok in cmds[-1])
+
+
+def test_gate_release_adds_recommendation_for_failed_step(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    def fake_run(cmd: list[str], cwd: Path) -> dict[str, object]:
+        is_gate_fast = cmd[3:5] == ["gate", "fast"]
+        return {
+            "cmd": cmd,
+            "rc": 1 if is_gate_fast else 0,
+            "ok": not is_gate_fast,
+            "duration_ms": 1,
+            "stdout": "",
+            "stderr": "failed",
+        }
+
+    monkeypatch.setattr(gate, "_run", fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    rc = gate.main(["release", "--format", "json"])
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["failed_steps"] == ["gate_fast"]
+    assert payload["recommendations"] == [
+        "Inspect fast gate evidence: python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json."
+    ]


### PR DESCRIPTION
### Motivation
- First-run gate failures can be deterministic but unclear to beginners, especially when dev/test tooling is missing (e.g. `pytest`, `ruff`, `mypy`).
- Improve onboarding and triage while preserving the product promise of machine-readable evidence and deterministic gate behavior.

### Description
- Add `recommendations` to `gate fast` and `gate release` outputs (text, markdown, and JSON) when failed steps have actionable guidance. 
- Detect common missing-tool failures by scanning step `stderr`/`stdout` (e.g. "No module named 'pytest'") and emit explicit install guidance for `ruff`, `mypy`, and `pytest`.
- Add deterministic recommendations for `doctor` and `ci_templates` failures and mapping for release-gate failed steps to point users to the next evidence command.
- Files changed: `src/sdetkit/gate.py`, `tests/test_gate_fast.py`, `tests/test_gate_release.py`.

### Testing
- Ran targeted unit tests for the modified behavior with `python -m pytest -q tests/test_gate_fast.py tests/test_gate_release.py` and all tests passed (`17 passed`).
- Behavior note: change is additive (new `recommendations` field only when present) and preserves existing exit codes and payload fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96fe993ac83329ba342e4537848c0)