### PR TITLE
docs: add beginner troubleshooting for canonical gate path

### DIFF
--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -62,6 +62,53 @@ External repositories should use direct `python -m sdetkit ...` commands.
 - Trust breaks only when artifacts are missing or malformed.
 - Inspect `build/release-preflight.json` and `build/gate-fast.json` before raw logs.
 
+## Beginner troubleshooting for the canonical first path
+
+The first run often fails for practical setup reasons. That is normal.
+
+For `gate fast` and `gate release`, check both:
+- `failed_steps` (what failed)
+- `recommendations` (what to run next)
+
+The gate commands now include `recommendations` in both terminal output and JSON output. Start there before deeper debugging.
+
+### `python -m sdetkit gate fast`
+
+Common first-run failures:
+- **`ruff`, `mypy`, or `pytest` missing**: your environment does not have dev/test tools yet.
+  - Run next: `python -m pip install -e .[dev,test]`
+  - Then rerun: `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`
+- **`doctor` step failed**: repo health checks found issues.
+  - Run next: `python -m sdetkit doctor --format json --out build/doctor.json`
+  - Then fix the first failing check and rerun `gate fast`.
+
+### `python -m sdetkit gate release`
+
+Common first-run failures:
+- **`doctor_release` failed**: release readiness checks are not satisfied yet.
+  - Run next: `python -m sdetkit doctor --release --format json --out build/doctor-release.json`
+  - Then fix the first release check and rerun `gate release`.
+- **`gate_fast` failed inside release gate**: release gate depends on fast gate passing.
+  - Run next: `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`
+  - Then rerun: `python -m sdetkit gate release --format json --out build/release-preflight.json`
+
+### `python -m sdetkit doctor`
+
+Common first-run failures:
+- **Not in a virtual environment** (warning in recommendations/hints).
+  - Run next: `python -m venv .venv && source .venv/bin/activate`
+  - Then rerun: `python -m sdetkit doctor`
+- **Missing developer tools** listed in doctor recommendations.
+  - Run next: `python -m pip install -e .[dev,test]`
+  - Then rerun: `python -m sdetkit doctor --format json --out build/doctor.json`
+- **`pyproject.toml` parse error**.
+  - Run next: fix the TOML syntax shown by doctor, then rerun `python -m sdetkit doctor`.
+
+If you are unsure what to do first, follow this order:
+1. `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`
+2. `python -m sdetkit gate release --format json --out build/release-preflight.json`
+3. `python -m sdetkit doctor --format json --out build/doctor.json`
+
 ## Next step routing
 
 - Release-confidence model: [Release confidence](release-confidence.md)


### PR DESCRIPTION
### Motivation
- Add a concise, beginner-friendly troubleshooting section for the canonical first path (`gate fast` → `gate release` → `doctor`) that explains common first-run failures, the immediate next command to run, and aligns guidance with the gate `recommendations` behavior.

### Description
- Modified `docs/ready-to-use.md` to add a new “Beginner troubleshooting for the canonical first path” section that documents common failures and exact next commands for `python -m sdetkit gate fast`, `python -m sdetkit gate release`, and `python -m sdetkit doctor`, and instructs users to inspect `failed_steps` and `recommendations` first.

### Testing
- Ran the repository docs build with `make docs-build`, which completed successfully and produced the site output (`site/`) with informational warnings only; there were no test failures for this doc-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d972a3ae8c8332ae217390632e11ce)