### PR TITLE
Add contract test for canonical beginner CLI path

### DIFF
--- a/tests/test_external_first_run_contract.py
+++ b/tests/test_external_first_run_contract.py
@@ -121,3 +121,36 @@ def test_canonical_first_path_runs_from_fresh_external_repo(tmp_path: Path) -> N
         json.dumps(trust_summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
     assert summary_path.is_file()
+
+
+def test_canonical_beginner_path_exact_commands_keep_first_run_contract(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    external_repo = tmp_path / "external-repo"
+    external_repo.mkdir(parents=True)
+    (external_repo / "README.md").write_text("# external fixture\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+
+    commands = (
+        (["python", "-m", "sdetkit", "gate", "fast"], {0, 2}, "gate fast:"),
+        (["python", "-m", "sdetkit", "gate", "release"], {0, 2}, "gate release:"),
+        (["python", "-m", "sdetkit", "doctor"], {0, 1}, "doctor score:"),
+    )
+
+    for cmd, allowed_returncodes, required_output in commands:
+        proc = _run(cmd, cwd=external_repo, env=env)
+        assert proc.returncode in allowed_returncodes, (
+            f"unexpected return code for `{cmd}` in fresh repo\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+        assert required_output in proc.stdout, (
+            f"missing expected first-run output marker `{required_output}` for `{cmd}`\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+
+    assert not (external_repo / "build" / "gate-fast.json").exists()
+    assert not (external_repo / "build" / "release-preflight.json").exists()
+    assert not (external_repo / "build" / "doctor.json").exists()


### PR DESCRIPTION
### Motivation
- Ensure the exact public "first-run" CLI path (`python -m sdetkit gate fast`, `python -m sdetkit gate release`, `python -m sdetkit doctor`) is protected from regressions in dispatch, output shape, and side effects. 

### Description
- Added `test_canonical_beginner_path_exact_commands_keep_first_run_contract` to `tests/test_external_first_run_contract.py` that runs the three canonical commands from a fresh external-repo fixture with `PYTHONPATH` pointed to the local `src` tree. 
- The test asserts each command returns an allowed envelope of return codes, emits an expected top-level output marker (`"gate fast:"`, `"gate release:"`, `"doctor score:"`), and does not create JSON artifact files when `--out` is not provided. 
- Change summary: `tests/test_external_first_run_contract.py` modified; `1 file changed, 33 insertions(+)` (adds the single new test). 

### Testing
- Ran the targeted test: `python -m pytest -q tests/test_external_first_run_contract.py -k exact_commands_keep_first_run_contract` and it passed with `1 passed, 1 deselected`. 
- The test run verifies the commands behave as expected for a first-run path and that no unintended artifacts are produced, providing automated validation for the contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9750e7f3c8332865faa4b618f8c79)