### PR TITLE
gate: handle empty step selection for fast/release and extract release command builder

### DIFF
--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -217,6 +217,31 @@ def _run_fast(ns: argparse.Namespace) -> int:
             return False
         return step_id not in skip
 
+    selected_steps = [step_id for step_id in AVAILABLE_STEPS if should_run(step_id)]
+    if not selected_steps:
+        payload: dict[str, Any] = {
+            "profile": "fast",
+            "root": str(root),
+            "ok": False,
+            "steps": [],
+            "failed_steps": ["configuration"],
+            "recommendations": [
+                "No gate steps are enabled. Re-run with at least one step (example: python -m sdetkit gate fast --only doctor).",
+                "List available steps with: python -m sdetkit gate fast --list-steps.",
+            ],
+        }
+        text = (
+            _stable_json(payload)
+            if ns.format == "json" and ns.stable_json
+            else json.dumps(payload, sort_keys=True) + "\n"
+            if ns.format == "json"
+            else _format_md(payload)
+            if ns.format == "md"
+            else _format_text(payload)
+        )
+        _write_output(text, ns.out)
+        return 2
+
     steps: list[dict[str, Any]] = []
 
     if (ns.fix or ns.fix_only) and should_run("ruff_fix"):
@@ -429,8 +454,7 @@ def _normalize_release_steps(steps: list[dict[str, Any]], root: Path) -> list[di
     return normalized
 
 
-def _run_release(ns: argparse.Namespace) -> int:
-    root = Path(ns.root).resolve()
+def _release_commands(ns: argparse.Namespace, root: Path) -> list[tuple[str, list[str]]]:
     doctor_cmd = [sys.executable, "-m", "sdetkit", "doctor", "--release", "--format", "json"]
     if ns.release_full:
         doctor_cmd = [
@@ -443,7 +467,7 @@ def _run_release(ns: argparse.Namespace) -> int:
             "json",
         ]
 
-    commands: list[tuple[str, list[str]]] = [
+    return [
         ("doctor_release", doctor_cmd),
         (
             "playbooks_validate",
@@ -471,6 +495,27 @@ def _run_release(ns: argparse.Namespace) -> int:
             ],
         ),
     ]
+
+
+def _run_release(ns: argparse.Namespace) -> int:
+    root = Path(ns.root).resolve()
+    commands = _release_commands(ns, root)
+    if not commands:
+        payload: dict[str, Any] = {
+            "profile": "release",
+            "root": "<repo>",
+            "dry_run": bool(ns.dry_run),
+            "ok": False,
+            "failed_steps": ["configuration"],
+            "steps": [],
+            "recommendations": [
+                "No release checks are enabled. Re-run with default options: python -m sdetkit gate release.",
+                "Inspect available release checks by running: python -m sdetkit gate release --dry-run --format json.",
+            ],
+        }
+        rendered = json.dumps(payload, sort_keys=True) + "\n" if ns.format == "json" else _format_release_text(payload)
+        _write_output(rendered, ns.out)
+        return 2
 
     steps: list[dict[str, Any]] = []
     for step_id, cmd in commands:

--- a/tests/test_gate_fast.py
+++ b/tests/test_gate_fast.py
@@ -265,3 +265,26 @@ def test_gate_fast_adds_recommendation_for_missing_pytest(
     assert payload["recommendations"] == [
         "Pytest is missing in this environment. Install test tooling: python -m pip install -e .[test]."
     ]
+
+
+def test_gate_fast_fails_when_no_steps_are_enabled(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    proc = _run_sdetkit(
+        repo_root,
+        tmp_path,
+        "gate",
+        "fast",
+        "--format",
+        "json",
+        "--only",
+        "doctor",
+        "--skip",
+        "doctor",
+    )
+    assert proc.returncode == 2
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is False
+    assert payload["failed_steps"] == ["configuration"]
+    assert payload["steps"] == []
+    assert payload["recommendations"][0].startswith("No gate steps are enabled.")
+

--- a/tests/test_gate_release.py
+++ b/tests/test_gate_release.py
@@ -148,3 +148,17 @@ def test_gate_release_adds_recommendation_for_failed_step(
     assert payload["recommendations"] == [
         "Inspect fast gate evidence: python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json."
     ]
+
+
+def test_gate_release_fails_when_no_checks_are_enabled(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gate, "_release_commands", lambda ns, root: [])
+
+    rc = gate.main(["release", "--format", "json"])
+    assert rc == 2
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["failed_steps"] == ["configuration"]
+    assert payload["steps"] == []
+    assert payload["recommendations"][0].startswith("No release checks are enabled.")


### PR DESCRIPTION
### Motivation
- Ensure `gate fast` fails with a clear payload when an `--only`/`--skip` combination disables all steps and provide actionable recommendations.
- Ensure `gate release` can be introspected and fails cleanly when no release checks are enabled by extracting command construction into a helper and emitting a configuration failure payload.

### Description
- Add selection logic in `_run_fast` to detect when no steps are enabled and return a structured error payload with `failed_steps: ["configuration"]`, recommendations, and output formatted according to `ns.format` and `ns.stable_json`.
- Extract release command list construction into a new `_release_commands(ns, root)` function and make `_run_release` call it.
- Make `_run_release` emit a similar configuration error payload when `_release_commands` returns an empty list, formatting output with JSON or `_format_release_text` as appropriate.
- Keep step execution and normalization logic unchanged and preserve existing recommendation mapping for failed release steps.

### Testing
- Added `test_gate_fast_fails_when_no_steps_are_enabled` which runs `gate fast` with `--only` and `--skip` to disable all steps and asserts a `2` return code and the expected JSON payload, and the test passed.
- Added `test_gate_release_fails_when_no_checks_are_enabled` which monkeypatches `_release_commands` to return `[]` and asserts a `2` return code and the expected JSON payload, and the test passed.
- Existing fast/release unit tests in the modified files were run and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9764ec2008332a2bc1dece6503bbb)