### PR TITLE
inspect: tighten rules validation, add canonical `--rules-template`, and wire CLI support

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -231,11 +231,16 @@ Then use stability-aware command discovery:
     _add_passthrough_subcommand(
         sub, "kv", help_text="Utility: parse key=value input into JSON (supporting surface)"
     )
-    _add_passthrough_subcommand(
-        sub,
+    inspect_parser = sub.add_parser(
         "inspect",
-        help_text="[Advanced but supported] Inspect CSV/JSON evidence inputs for operational diagnostics",
+        help="[Advanced but supported] Inspect CSV/JSON evidence inputs for operational diagnostics",
     )
+    inspect_parser.add_argument(
+        "--rules-template",
+        action="store_true",
+        help="Print a canonical inspect rules JSON template and exit.",
+    )
+    inspect_parser.add_argument("args", nargs=argparse.REMAINDER)
 
     ag = sub.add_parser("apiget", help="Deterministic HTTP JSON fetch and replay helper")
     _add_apiget_args(ag)
@@ -1220,7 +1225,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _run_module_main("sdetkit.kvcli", ns.args)
 
     if ns.cmd == "inspect":
-        return _run_module_main("sdetkit.inspect_data", ns.args)
+        inspect_args = list(ns.args)
+        if ns.rules_template:
+            inspect_args = ["--rules-template", *inspect_args]
+        return _run_module_main("sdetkit.inspect_data", inspect_args)
 
     if ns.cmd == "patch":
         return _run_module_main("sdetkit.patch", ns.args)

--- a/src/sdetkit/inspect_data.py
+++ b/src/sdetkit/inspect_data.py
@@ -14,6 +14,30 @@ EXIT_OK = 0
 EXIT_FINDINGS = 2
 SUPPORTED_EXTENSIONS = {".csv", ".json"}
 SUPPORTED_CROSS_FILE_MODES = {"left_subset", "exact_match"}
+RULES_TEMPLATE: dict[str, Any] = {
+    "files": {
+        "orders.csv": {
+            "required_columns": ["id", "status", "amount"],
+            "key_columns": ["id"],
+            "schema_expectations": {"amount": ["numeric_string"], "status": ["string"]},
+            "id_column": "id",
+            "expected_ids": ["A100", "A101"],
+        },
+        "snapshot.json": {
+            "id_column": "entity_id",
+        },
+    },
+    "cross_file_rules": [
+        {
+            "name": "orders_covered_by_snapshot",
+            "left_file": "orders.csv",
+            "left_id_column": "id",
+            "right_file": "snapshot.json",
+            "right_id_column": "entity_id",
+            "mode": "left_subset",
+        }
+    ],
+}
 
 
 def _safe_slug(value: str) -> str:
@@ -525,7 +549,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         prog="sdetkit inspect",
         description="Inspect CSV/JSON business evidence and emit deterministic diagnostics.",
     )
-    p.add_argument("path", help="CSV/JSON file or folder containing evidence files")
+    p.add_argument("path", nargs="?", help="CSV/JSON file or folder containing evidence files")
     p.add_argument("--format", choices=["text", "json"], default="text")
     p.add_argument(
         "--out-dir",
@@ -535,15 +559,56 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--rules",
         default=None,
-        help="Optional JSON file with file-level and cross-file inspect rule expectations.",
+        help="Optional JSON rules file. Use --rules-template for the canonical shape.",
+    )
+    p.add_argument(
+        "--rules-template",
+        action="store_true",
+        help="Print a canonical inspect rules JSON template and exit.",
     )
     return p
 
 
 def _validate_rules_payload(rules_payload: dict[str, Any]) -> str | None:
+    unknown_top_level = sorted(k for k in rules_payload if k not in {"files", "cross_file_rules"})
+    if unknown_top_level:
+        return (
+            "inspect: invalid rules payload: unknown top-level key(s): "
+            + ", ".join(repr(key) for key in unknown_top_level)
+            + "; expected only 'files' and 'cross_file_rules'"
+        )
+
     file_rules = rules_payload.get("files", {})
     if not isinstance(file_rules, dict):
         return "inspect: invalid rules payload: 'files' must be an object keyed by file name or path"
+    for file_key, item in sorted(file_rules.items()):
+        key = str(file_key)
+        if not key:
+            return "inspect: invalid file rule key: empty file key is not allowed"
+        if not isinstance(item, dict):
+            return f"inspect: invalid files[{key!r}]: each file rule must be an object"
+        required_columns = item.get("required_columns")
+        if required_columns is not None and not isinstance(required_columns, list):
+            return f"inspect: invalid files[{key!r}].required_columns: must be an array of strings"
+        key_columns = item.get("key_columns")
+        if key_columns is not None and not isinstance(key_columns, list):
+            return f"inspect: invalid files[{key!r}].key_columns: must be an array of strings"
+        schema_expectations = item.get("schema_expectations")
+        if schema_expectations is not None and not isinstance(schema_expectations, dict):
+            return f"inspect: invalid files[{key!r}].schema_expectations: must be an object"
+        if isinstance(schema_expectations, dict):
+            for col_name, allowed_types in sorted(schema_expectations.items()):
+                if not isinstance(allowed_types, list):
+                    return (
+                        "inspect: invalid files["
+                        f"{key!r}].schema_expectations[{str(col_name)!r}]: must be an array of type tags"
+                    )
+        id_column = item.get("id_column")
+        if id_column is not None and (not isinstance(id_column, str) or not id_column.strip()):
+            return f"inspect: invalid files[{key!r}].id_column: must be a non-empty string"
+        expected_ids = item.get("expected_ids")
+        if expected_ids is not None and not isinstance(expected_ids, list):
+            return f"inspect: invalid files[{key!r}].expected_ids: must be an array"
 
     cross_file_rules = rules_payload.get("cross_file_rules", [])
     if not isinstance(cross_file_rules, list):
@@ -559,11 +624,30 @@ def _validate_rules_payload(rules_payload: dict[str, Any]) -> str | None:
                 f"inspect: invalid cross_file_rules[{idx}].mode: {mode!r}; "
                 f"supported values: {supported}"
             )
+        for field in ("left_file", "right_file", "left_id_column", "right_id_column"):
+            value = item.get(field)
+            if not isinstance(value, str) or not value.strip():
+                return (
+                    "inspect: invalid cross_file_rules["
+                    f"{idx}].{field}: must be a non-empty string"
+                )
     return None
 
 
 def main(argv: list[str] | None = None) -> int:
     ns = _build_arg_parser().parse_args(argv)
+    if ns.rules and ns.rules_template:
+        sys.stderr.write("inspect: --rules and --rules-template cannot be used together\n")
+        return EXIT_FINDINGS
+
+    if ns.rules_template:
+        sys.stdout.write(json.dumps(RULES_TEMPLATE, indent=2, sort_keys=True) + "\n")
+        return EXIT_OK
+
+    if not ns.path:
+        sys.stderr.write("inspect: missing input path (or use --rules-template)\n")
+        return EXIT_FINDINGS
+
     target = Path(ns.path).resolve()
     if not target.exists():
         sys.stderr.write(f"inspect: input path does not exist: {target}\n")
@@ -576,7 +660,17 @@ def main(argv: list[str] | None = None) -> int:
 
     rules_payload: dict[str, Any] = {}
     if ns.rules:
-        loaded = json.loads(Path(ns.rules).read_text(encoding="utf-8"))
+        try:
+            loaded = json.loads(Path(ns.rules).read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            sys.stderr.write(f"inspect: rules file does not exist: {ns.rules}\n")
+            return EXIT_FINDINGS
+        except json.JSONDecodeError as exc:
+            sys.stderr.write(
+                "inspect: invalid rules file JSON at "
+                f"line {exc.lineno}, column {exc.colno}: {exc.msg}\n"
+            )
+            return EXIT_FINDINGS
         if not isinstance(loaded, dict):
             sys.stderr.write("inspect: invalid rules payload: top-level JSON value must be an object\n")
             return EXIT_FINDINGS

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -190,3 +190,49 @@ def test_inspect_rejects_invalid_rules_mode(tmp_path: Path) -> None:
         "inspect: invalid cross_file_rules[0].mode: 'sideways'; supported values: exact_match, left_subset"
         in run.stderr
     )
+
+
+def test_inspect_rejects_invalid_file_rule_shape(tmp_path: Path) -> None:
+    data = tmp_path / "events.csv"
+    data.write_text("id,type\nA1,open\n", encoding="utf-8")
+    rules = tmp_path / "invalid-file-rules.json"
+    rules.write_text(
+        json.dumps(
+            {
+                "files": {"events.csv": {"required_columns": "id"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    run = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "inspect", str(data), "--rules", str(rules)],
+        text=True,
+        capture_output=True,
+    )
+    assert run.returncode == 2
+    assert "inspect: invalid files['events.csv'].required_columns: must be an array of strings" in run.stderr
+
+
+def test_inspect_rules_template_outputs_canonical_shape() -> None:
+    run = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "inspect", "--rules-template"],
+        text=True,
+        capture_output=True,
+    )
+    assert run.returncode == 0
+    assert run.stderr == ""
+    payload = json.loads(run.stdout)
+    assert sorted(payload) == ["cross_file_rules", "files"]
+    assert "orders.csv" in payload["files"]
+    assert payload["cross_file_rules"][0]["mode"] == "left_subset"
+
+
+def test_inspect_help_mentions_rules_template() -> None:
+    run = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "inspect", "--help"],
+        text=True,
+        capture_output=True,
+    )
+    assert run.returncode == 0
+    assert "--rules-template" in run.stdout


### PR DESCRIPTION
### Motivation
- Make `sdetkit inspect --rules` easier for teams to adopt by removing guesswork about JSON shape and surfacing clear validation errors.
- Provide a canonical rules example so teams can bootstrap valid rule files and avoid trial-and-error in CI.
- Fail fast and with actionable messages for malformed rules files to improve debuggability in automation.

### Description
- Added an in-code canonical rules template `RULES_TEMPLATE` and a `--rules-template` flag in `src/sdetkit/inspect_data.py` that prints the template and exits with `0`.
- Tightened validation in `_validate_rules_payload` to reject unknown top-level keys and to emit specific errors for malformed `files[...]` entries and missing/invalid `cross_file_rules` fields.
- Improved rules-file load errors to report missing files and JSON decode location (`line`, `column`, `message`), and made the `path` argument optional so `--rules-template` can run without an input path.
- Wired the public CLI in `src/sdetkit/cli.py` to forward `--rules-template` into the `inspect` module, and added tests in `tests/test_inspect_data.py` for the new validation and template/help behavior.

### Testing
- Ran `pytest -q tests/test_inspect_data.py tests/test_cli_help_lists_subcommands.py` and all tests passed (`11 passed`).
- Unit tests exercise invalid rules shapes, cross-file mode validation, `--rules-template` output, and the public `sdetkit inspect --help` surface to confirm behavior.
- Existing deterministic inspect artifact generation was preserved and validated by the inspect-focused tests that read `inspect.json` outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d99097b6c08332bf424f46a588b82f)