### PR TITLE
Add --rules-lint to `sdetkit inspect` and centralize rules validation

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -240,6 +240,11 @@ Then use stability-aware command discovery:
         action="store_true",
         help="Print a canonical inspect rules JSON template and exit.",
     )
+    inspect_parser.add_argument(
+        "--rules-lint",
+        default=None,
+        help="Validate an inspect rules JSON file and exit.",
+    )
     inspect_parser.add_argument("args", nargs=argparse.REMAINDER)
 
     ag = sub.add_parser("apiget", help="Deterministic HTTP JSON fetch and replay helper")
@@ -1228,6 +1233,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         inspect_args = list(ns.args)
         if ns.rules_template:
             inspect_args = ["--rules-template", *inspect_args]
+        if ns.rules_lint:
+            inspect_args = ["--rules-lint", ns.rules_lint, *inspect_args]
         return _run_module_main("sdetkit.inspect_data", inspect_args)
 
     if ns.cmd == "patch":

--- a/src/sdetkit/inspect_data.py
+++ b/src/sdetkit/inspect_data.py
@@ -566,6 +566,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print a canonical inspect rules JSON template and exit.",
     )
+    p.add_argument(
+        "--rules-lint",
+        default=None,
+        help="Validate an inspect rules JSON file and exit (no dataset scan).",
+    )
     return p
 
 
@@ -634,14 +639,46 @@ def _validate_rules_payload(rules_payload: dict[str, Any]) -> str | None:
     return None
 
 
+def _load_rules_payload(path: str) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        loaded = json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, f"inspect: rules file does not exist: {path}"
+    except json.JSONDecodeError as exc:
+        return None, (
+            "inspect: invalid rules file JSON at "
+            f"line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        )
+    if not isinstance(loaded, dict):
+        return None, "inspect: invalid rules payload: top-level JSON value must be an object"
+    validation_error = _validate_rules_payload(loaded)
+    if validation_error:
+        return None, validation_error
+    return loaded, None
+
+
 def main(argv: list[str] | None = None) -> int:
     ns = _build_arg_parser().parse_args(argv)
     if ns.rules and ns.rules_template:
         sys.stderr.write("inspect: --rules and --rules-template cannot be used together\n")
         return EXIT_FINDINGS
+    if ns.rules_lint and ns.rules_template:
+        sys.stderr.write("inspect: --rules-lint and --rules-template cannot be used together\n")
+        return EXIT_FINDINGS
+    if ns.rules_lint and ns.rules:
+        sys.stderr.write("inspect: --rules-lint and --rules cannot be used together\n")
+        return EXIT_FINDINGS
 
     if ns.rules_template:
         sys.stdout.write(json.dumps(RULES_TEMPLATE, indent=2, sort_keys=True) + "\n")
+        return EXIT_OK
+
+    if ns.rules_lint:
+        _, error = _load_rules_payload(ns.rules_lint)
+        if error:
+            sys.stderr.write(f"inspect: rules lint FAILED: {error}\n")
+            return EXIT_FINDINGS
+        sys.stdout.write("inspect: rules lint OK\n")
         return EXIT_OK
 
     if not ns.path:
@@ -660,25 +697,11 @@ def main(argv: list[str] | None = None) -> int:
 
     rules_payload: dict[str, Any] = {}
     if ns.rules:
-        try:
-            loaded = json.loads(Path(ns.rules).read_text(encoding="utf-8"))
-        except FileNotFoundError:
-            sys.stderr.write(f"inspect: rules file does not exist: {ns.rules}\n")
+        loaded, error = _load_rules_payload(ns.rules)
+        if error:
+            sys.stderr.write(error + "\n")
             return EXIT_FINDINGS
-        except json.JSONDecodeError as exc:
-            sys.stderr.write(
-                "inspect: invalid rules file JSON at "
-                f"line {exc.lineno}, column {exc.colno}: {exc.msg}\n"
-            )
-            return EXIT_FINDINGS
-        if not isinstance(loaded, dict):
-            sys.stderr.write("inspect: invalid rules payload: top-level JSON value must be an object\n")
-            return EXIT_FINDINGS
-        rules_payload = loaded
-        validation_error = _validate_rules_payload(rules_payload)
-        if validation_error:
-            sys.stderr.write(validation_error + "\n")
-            return EXIT_FINDINGS
+        rules_payload = loaded if loaded is not None else {}
     file_rules = rules_payload.get("files", {}) if isinstance(rules_payload, dict) else {}
     cross_file_rules = (
         rules_payload.get("cross_file_rules", []) if isinstance(rules_payload, dict) else []

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -236,3 +236,65 @@ def test_inspect_help_mentions_rules_template() -> None:
     )
     assert run.returncode == 0
     assert "--rules-template" in run.stdout
+
+
+def test_inspect_rules_lint_valid_rules(tmp_path: Path) -> None:
+    rules = tmp_path / "valid-rules.json"
+    rules.write_text(
+        json.dumps({"files": {"events.csv": {"id_column": "id"}}}),
+        encoding="utf-8",
+    )
+    run = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "inspect", "--rules-lint", str(rules)],
+        text=True,
+        capture_output=True,
+    )
+    assert run.returncode == 0
+    assert run.stdout == "inspect: rules lint OK\n"
+    assert run.stderr == ""
+
+
+def test_inspect_rules_lint_invalid_rules(tmp_path: Path) -> None:
+    rules = tmp_path / "invalid-rules.json"
+    rules.write_text(
+        json.dumps({"cross_file_rules": [{"mode": "sideways"}]}),
+        encoding="utf-8",
+    )
+    run = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "inspect", "--rules-lint", str(rules)],
+        text=True,
+        capture_output=True,
+    )
+    assert run.returncode == 2
+    assert run.stdout == ""
+    assert (
+        run.stderr
+        == "inspect: rules lint FAILED: inspect: invalid cross_file_rules[0].mode: 'sideways'; "
+        "supported values: exact_match, left_subset\n"
+    )
+
+
+def test_inspect_rules_lint_works_without_dataset_path(tmp_path: Path) -> None:
+    rules = tmp_path / "valid-rules.json"
+    rules.write_text(
+        json.dumps({"files": {"events.csv": {"required_columns": ["id"]}}}),
+        encoding="utf-8",
+    )
+    run = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "inspect", "--rules-lint", str(rules)],
+        text=True,
+        capture_output=True,
+    )
+    assert run.returncode == 0
+    assert "missing input path" not in run.stderr
+
+
+def test_inspect_requires_path_in_normal_mode() -> None:
+    run = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "inspect"],
+        text=True,
+        capture_output=True,
+    )
+    assert run.returncode == 2
+    assert run.stdout == ""
+    assert run.stderr == "inspect: missing input path (or use --rules-template)\n"


### PR DESCRIPTION
### Motivation
- Provide a fast way to validate an inspect rules JSON file without scanning a dataset and avoid duplicating JSON loading/validation logic.
- Make `inspect` CLI surface clearer by allowing rules-only linting and enforcing mutually exclusive flags.

### Description
- Add `--rules-lint` flag to the `sdetkit inspect` CLI in `src/sdetkit/cli.py` and forward it to the `sdetkit.inspect_data` module.
- Introduce `_load_rules_payload` helper in `src/sdetkit/inspect_data.py` to centralize JSON file loading and payload validation and reuse it from both lint and normal rules paths.
- Implement `--rules-lint` handling in `inspect_data.main` that validates a rules file, prints success or detailed failure messages, and returns appropriate exit codes, and add conflict checks against `--rules` and `--rules-template`.
- Add unit tests in `tests/test_inspect_data.py` to cover valid and invalid linting, linting without a dataset path, and the existing requirement for a path in normal run mode.

### Testing
- Ran the updated unit tests in `tests/test_inspect_data.py`, including the new `test_inspect_rules_lint_valid_rules`, `test_inspect_rules_lint_invalid_rules`, and `test_inspect_rules_lint_works_without_dataset_path` tests, and they all passed.
- Verified existing tests such as `test_inspect_rules_template_outputs_canonical_shape` still pass after the changes.
- Confirmed CLI exit codes and standard output/error messages match the assertions in the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9923064748332ac6726b1b3b1887f)