### PR TITLE
Add shared evidence workspace across doctor and inspect runs

### DIFF
--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from . import _toml, upgrade_audit
 from .bools import coerce_bool
+from .evidence_workspace import record_workspace_run
 from .import_hazards import find_stdlib_shadowing
 from .security import SecurityError, safe_path
 
@@ -2245,6 +2246,16 @@ def main(argv: list[str] | None = None) -> int:
         default="all",
         help="Filter evidence output to failed, actionable, or all checks (default: all).",
     )
+    parser.add_argument(
+        "--workspace-root",
+        default=".sdetkit/workspace",
+        help="Shared evidence workspace root for inspect/doctor run records.",
+    )
+    parser.add_argument(
+        "--no-workspace",
+        action="store_true",
+        help="Disable shared workspace run recording.",
+    )
 
     ns = parser.parse_args(list(argv) if argv is not None else None)
     if ns.format == "markdown":
@@ -2848,6 +2859,35 @@ def main(argv: list[str] | None = None) -> int:
                 sys.stdout.write(_stable_json(fail_payload))
             sys.stderr.write(f"doctor: evidence write failed: {evidence_error}\n")
             return EXIT_FAILED
+
+    if not ns.no_workspace:
+        workspace_artifacts: dict[str, str] = {}
+        if ns.out:
+            workspace_artifacts["doctor_output"] = str(ns.out)
+        if isinstance(ns.evidence_dir, str) and ns.evidence_dir.strip():
+            evidence_dir = Path(ns.evidence_dir.strip())
+            workspace_artifacts["doctor_evidence_json"] = (
+                evidence_dir / "doctor-evidence.json"
+            ).as_posix()
+            workspace_artifacts["doctor_evidence_markdown"] = (
+                evidence_dir / "doctor-evidence.md"
+            ).as_posix()
+            workspace_artifacts["doctor_evidence_manifest"] = (
+                evidence_dir / "doctor-evidence-manifest.json"
+            ).as_posix()
+        workspace_entry = record_workspace_run(
+            workspace_root=Path(ns.workspace_root),
+            workflow="doctor",
+            scope=root.name or "repo",
+            payload=data,
+            artifacts=workspace_artifacts,
+            recommendations=list(data.get("recommendations", [])),
+        )
+        data["workspace"] = workspace_entry
+        if is_json:
+            output = _stable_json(data)
+            if ns.out:
+                Path(ns.out).write_text(output, encoding="utf-8")
 
     sys.stdout.write(output)
 

--- a/src/sdetkit/evidence_workspace.py
+++ b/src/sdetkit/evidence_workspace.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+WORKSPACE_SCHEMA_VERSION = "sdetkit.evidence.workspace.v1"
+
+
+def _safe_slug(value: str) -> str:
+    out: list[str] = []
+    for ch in value.lower():
+        if ch.isalnum() or ch in {"-", "_", "."}:
+            out.append(ch)
+        else:
+            out.append("-")
+    slug = "".join(out).strip("-")
+    return slug or "default"
+
+
+def _stable_json_text(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _read_manifest(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "schema_version": WORKSPACE_SCHEMA_VERSION,
+            "workspace_version": 1,
+            "runs": [],
+            "latest": {},
+        }
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError("workspace manifest must be a JSON object")
+    loaded.setdefault("schema_version", WORKSPACE_SCHEMA_VERSION)
+    loaded.setdefault("workspace_version", 1)
+    loaded.setdefault("runs", [])
+    loaded.setdefault("latest", {})
+    return loaded
+
+
+def record_workspace_run(
+    *,
+    workspace_root: Path,
+    workflow: str,
+    scope: str,
+    payload: dict[str, Any],
+    artifacts: dict[str, str],
+    recommendations: list[str],
+) -> dict[str, Any]:
+    workflow_slug = _safe_slug(workflow)
+    scope_slug = _safe_slug(scope)
+    canonical_payload = _stable_json_text(payload)
+    run_hash = hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()[:16]
+
+    run_dir = workspace_root / "runs" / workflow_slug / scope_slug / run_hash
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    record_payload = {
+        "schema_version": WORKSPACE_SCHEMA_VERSION,
+        "workflow": workflow,
+        "scope": scope,
+        "run_hash": run_hash,
+        "payload": payload,
+        "artifacts": artifacts,
+        "recommendations": recommendations,
+    }
+    (run_dir / "record.json").write_text(
+        json.dumps(record_payload, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+
+    manifest_path = workspace_root / "manifest.json"
+    manifest = _read_manifest(manifest_path)
+    runs = manifest.get("runs", [])
+    if not isinstance(runs, list):
+        runs = []
+    entry = {
+        "workflow": workflow,
+        "scope": scope,
+        "run_hash": run_hash,
+        "record_path": run_dir.relative_to(workspace_root).as_posix() + "/record.json",
+    }
+    if entry not in runs:
+        runs.append(entry)
+    runs = sorted(
+        runs,
+        key=lambda item: (
+            str(item.get("workflow", "")),
+            str(item.get("scope", "")),
+            str(item.get("run_hash", "")),
+        ),
+    )
+
+    latest = manifest.get("latest", {})
+    if not isinstance(latest, dict):
+        latest = {}
+    latest[f"{workflow}:{scope}"] = {
+        "run_hash": run_hash,
+        "record_path": entry["record_path"],
+    }
+
+    manifest["runs"] = runs
+    manifest["latest"] = {k: latest[k] for k in sorted(latest)}
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    latest_dir = workspace_root / "latest" / workflow_slug
+    latest_dir.mkdir(parents=True, exist_ok=True)
+    (latest_dir / f"{scope_slug}.json").write_text(
+        json.dumps(
+            {
+                "schema_version": WORKSPACE_SCHEMA_VERSION,
+                "workflow": workflow,
+                "scope": scope,
+                "run_hash": run_hash,
+                "record_path": entry["record_path"],
+            },
+            sort_keys=True,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "workflow": workflow,
+        "scope": scope,
+        "run_hash": run_hash,
+        "record_path": entry["record_path"],
+        "workspace_manifest": manifest_path.as_posix(),
+    }

--- a/src/sdetkit/inspect_data.py
+++ b/src/sdetkit/inspect_data.py
@@ -9,6 +9,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from .evidence_workspace import record_workspace_run
+
 SCHEMA_VERSION = "sdetkit.inspect.v2"
 EXIT_OK = 0
 EXIT_FINDINGS = 2
@@ -571,6 +573,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         help="Validate an inspect rules JSON file and exit (no dataset scan).",
     )
+    p.add_argument(
+        "--workspace-root",
+        default=".sdetkit/workspace",
+        help="Shared evidence workspace root for inspect/doctor run records.",
+    )
+    p.add_argument(
+        "--no-workspace",
+        action="store_true",
+        help="Disable shared workspace run recording.",
+    )
     return p
 
 
@@ -767,6 +779,21 @@ def main(argv: list[str] | None = None) -> int:
     txt_path = out_dir / "inspect.txt"
     json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     txt_path.write_text(_render_text(payload), encoding="utf-8")
+
+    if not ns.no_workspace:
+        workspace_entry = record_workspace_run(
+            workspace_root=Path(ns.workspace_root),
+            workflow="inspect",
+            scope=_safe_slug(target.name),
+            payload=payload,
+            artifacts={
+                "inspect_json": json_path.as_posix(),
+                "inspect_text": txt_path.as_posix(),
+            },
+            recommendations=list(payload.get("recommendations", [])),
+        )
+        payload["workspace"] = workspace_entry
+        json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     output = json.dumps(payload, sort_keys=True) if ns.format == "json" else _render_text(payload)
     sys.stdout.write(output + ("\n" if not output.endswith("\n") else ""))

--- a/tests/test_evidence_workspace.py
+++ b/tests/test_evidence_workspace.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import doctor, inspect_data
+
+
+def test_inspect_records_shared_workspace_and_reuses_run_hash(tmp_path: Path) -> None:
+    data = tmp_path / "orders.csv"
+    data.write_text("id,amount\nA1,10\n", encoding="utf-8")
+    out_dir = tmp_path / "inspect-out"
+    workspace = tmp_path / "workspace"
+
+    rc1 = inspect_data.main(
+        [
+            str(data),
+            "--format",
+            "json",
+            "--out-dir",
+            str(out_dir),
+            "--workspace-root",
+            str(workspace),
+        ]
+    )
+    rc2 = inspect_data.main(
+        [
+            str(data),
+            "--format",
+            "json",
+            "--out-dir",
+            str(out_dir),
+            "--workspace-root",
+            str(workspace),
+        ]
+    )
+
+    assert rc1 == 0
+    assert rc2 == 0
+
+    payload = json.loads((out_dir / "inspect.json").read_text(encoding="utf-8"))
+    run_hash = payload["workspace"]["run_hash"]
+
+    manifest = json.loads((workspace / "manifest.json").read_text(encoding="utf-8"))
+    runs = [r for r in manifest["runs"] if r["workflow"] == "inspect"]
+    assert len(runs) == 1
+    assert runs[0]["run_hash"] == run_hash
+    assert (workspace / runs[0]["record_path"]).exists()
+    latest = json.loads((workspace / "latest" / "inspect" / "orders.csv.json").read_text(encoding="utf-8"))
+    assert latest["run_hash"] == run_hash
+
+
+def test_doctor_records_shared_workspace(tmp_path: Path, monkeypatch, capsys) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+
+    workspace = root / ".sdetkit" / "workspace"
+    rc = doctor.main(["--ci", "--json", "--workspace-root", str(workspace)])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert data["workspace"]["workflow"] == "doctor"
+
+    manifest = json.loads((workspace / "manifest.json").read_text(encoding="utf-8"))
+    assert any(row["workflow"] == "doctor" for row in manifest["runs"])
+    latest_files = list((workspace / "latest" / "doctor").glob("*.json"))
+    assert latest_files


### PR DESCRIPTION
### Motivation
- `doctor` and `inspect` each emitted useful artifacts but lacked a shared, deterministic index and cross-command “latest” pointers, making rerun comparison, CI triage, and handoff awkward. 
- Introduce a repo-native shared evidence workspace so diagnostic outputs become discoverable, comparable, and stable across repeated runs and across commands.

### Description
- Add `src/sdetkit/evidence_workspace.py`, a small deterministic workspace engine that writes `manifest.json`, per-run `runs/<workflow>/<scope>/<run_hash>/record.json`, and `latest/<workflow>/<scope>.json` with stable sorting. 
- Integrate workspace recording into `inspect` (`src/sdetkit/inspect_data.py`) with new flags `--workspace-root` and `--no-workspace`, and attach `workspace` metadata to JSON outputs. 
- Integrate matching workspace behavior into `doctor` (`src/sdetkit/doctor.py`) with the same flags and `workspace` metadata in JSON output. 
- Add `tests/test_evidence_workspace.py` validating repeated-run stability (same `run_hash` dedupes manifest) and `doctor` workspace emission.

### Testing
- Ran `pytest -q tests/test_evidence_workspace.py`, result: `2 passed`.
- Ran `pytest -q tests/test_inspect_data.py tests/test_doctor_diagnostics.py tests/test_doctor_md_and_out.py`, result: `21 passed`.
- All automated tests exercised the modified code and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9950811b08332ab06327cd317e656)