### PR TITLE
Add inspect-compare workflow to detect drift between inspect runs

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -246,6 +246,22 @@ Then use stability-aware command discovery:
         help="Validate an inspect rules JSON file and exit.",
     )
     inspect_parser.add_argument("args", nargs=argparse.REMAINDER)
+    inspect_compare_parser = sub.add_parser(
+        "inspect-compare",
+        help="[Advanced but supported] Compare inspect baseline/previous runs and drift evidence",
+    )
+    inspect_compare_parser.add_argument("--left", default=None)
+    inspect_compare_parser.add_argument("--right", default=None)
+    inspect_compare_parser.add_argument("--left-run", default=None)
+    inspect_compare_parser.add_argument("--right-run", default=None)
+    inspect_compare_parser.add_argument("--scope", default=None)
+    inspect_compare_parser.add_argument("--latest-vs-previous", action="store_true")
+    inspect_compare_parser.add_argument("--workspace-root", default=None)
+    inspect_compare_parser.add_argument("--workflow", default=None)
+    inspect_compare_parser.add_argument("--format", choices=["text", "json"], default=None)
+    inspect_compare_parser.add_argument("--out-dir", default=None)
+    inspect_compare_parser.add_argument("--no-workspace", action="store_true")
+    inspect_compare_parser.add_argument("args", nargs=argparse.REMAINDER)
 
     ag = sub.add_parser("apiget", help="Deterministic HTTP JSON fetch and replay helper")
     _add_apiget_args(ag)
@@ -1236,6 +1252,31 @@ def main(argv: Sequence[str] | None = None) -> int:
         if ns.rules_lint:
             inspect_args = ["--rules-lint", ns.rules_lint, *inspect_args]
         return _run_module_main("sdetkit.inspect_data", inspect_args)
+    if ns.cmd == "inspect-compare":
+        forwarded = list(ns.args)
+        if ns.left:
+            forwarded = ["--left", ns.left, *forwarded]
+        if ns.right:
+            forwarded = ["--right", ns.right, *forwarded]
+        if ns.left_run:
+            forwarded = ["--left-run", ns.left_run, *forwarded]
+        if ns.right_run:
+            forwarded = ["--right-run", ns.right_run, *forwarded]
+        if ns.scope:
+            forwarded = ["--scope", ns.scope, *forwarded]
+        if ns.latest_vs_previous:
+            forwarded = ["--latest-vs-previous", *forwarded]
+        if ns.workspace_root:
+            forwarded = ["--workspace-root", ns.workspace_root, *forwarded]
+        if ns.workflow:
+            forwarded = ["--workflow", ns.workflow, *forwarded]
+        if ns.format:
+            forwarded = ["--format", ns.format, *forwarded]
+        if ns.out_dir:
+            forwarded = ["--out-dir", ns.out_dir, *forwarded]
+        if ns.no_workspace:
+            forwarded = ["--no-workspace", *forwarded]
+        return _run_module_main("sdetkit.inspect_compare", forwarded)
 
     if ns.cmd == "patch":
         return _run_module_main("sdetkit.patch", ns.args)

--- a/src/sdetkit/evidence_workspace.py
+++ b/src/sdetkit/evidence_workspace.py
@@ -41,6 +41,10 @@ def _read_manifest(path: Path) -> dict[str, Any]:
     return loaded
 
 
+def load_workspace_manifest(workspace_root: Path) -> dict[str, Any]:
+    return _read_manifest(workspace_root / "manifest.json")
+
+
 def record_workspace_run(
     *,
     workspace_root: Path,
@@ -76,19 +80,50 @@ def record_workspace_run(
     runs = manifest.get("runs", [])
     if not isinstance(runs, list):
         runs = []
+    normalized_runs: list[dict[str, Any]] = []
+    max_run_order = 0
+    for idx, item in enumerate(runs):
+        if not isinstance(item, dict):
+            continue
+        run_order = int(item.get("run_order", idx + 1))
+        max_run_order = max(max_run_order, run_order)
+        normalized = dict(item)
+        normalized["run_order"] = run_order
+        normalized_runs.append(normalized)
+    runs = normalized_runs
     entry = {
         "workflow": workflow,
         "scope": scope,
         "run_hash": run_hash,
         "record_path": run_dir.relative_to(workspace_root).as_posix() + "/record.json",
+        "run_order": max_run_order + 1,
     }
-    if entry not in runs:
+    existing = next(
+        (
+            item
+            for item in runs
+            if str(item.get("workflow", "")) == workflow
+            and str(item.get("scope", "")) == scope
+            and str(item.get("run_hash", "")) == run_hash
+        ),
+        None,
+    )
+    if existing is None:
         runs.append(entry)
+    else:
+        entry = {
+            "workflow": str(existing.get("workflow", workflow)),
+            "scope": str(existing.get("scope", scope)),
+            "run_hash": str(existing.get("run_hash", run_hash)),
+            "record_path": str(existing.get("record_path", entry["record_path"])),
+            "run_order": int(existing.get("run_order", entry["run_order"])),
+        }
     runs = sorted(
         runs,
         key=lambda item: (
             str(item.get("workflow", "")),
             str(item.get("scope", "")),
+            int(item.get("run_order", 0)),
             str(item.get("run_hash", "")),
         ),
     )

--- a/src/sdetkit/inspect_compare.py
+++ b/src/sdetkit/inspect_compare.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from .evidence_workspace import load_workspace_manifest, record_workspace_run
+
+SCHEMA_VERSION = "sdetkit.inspect.compare.v1"
+EXIT_OK = 0
+EXIT_FINDINGS = 2
+
+
+def _safe_slug(value: str) -> str:
+    out = []
+    for ch in value.lower():
+        if ch.isalnum() or ch in {"-", "_", "."}:
+            out.append(ch)
+        else:
+            out.append("-")
+    slug = "".join(out).strip("-")
+    return slug or "compare"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"compare: expected JSON object at {path}")
+    return loaded
+
+
+def _read_workspace_record_payload(record_path: Path) -> dict[str, Any]:
+    record = _load_json(record_path)
+    payload = record.get("payload")
+    if not isinstance(payload, dict):
+        raise ValueError(f"compare: workspace record missing payload object: {record_path}")
+    return payload
+
+
+def _resolve_workspace_record_path(*, workspace_root: Path, workflow: str, scope: str, run_hash: str) -> Path:
+    manifest = load_workspace_manifest(workspace_root)
+    runs = manifest.get("runs", [])
+    if not isinstance(runs, list):
+        raise ValueError("compare: workspace manifest runs must be an array")
+    for item in runs:
+        if not isinstance(item, dict):
+            continue
+        if (
+            str(item.get("workflow", "")) == workflow
+            and str(item.get("scope", "")) == scope
+            and str(item.get("run_hash", "")) == run_hash
+        ):
+            record_path = workspace_root / str(item.get("record_path", ""))
+            if not record_path.exists():
+                raise ValueError(f"compare: workspace record path does not exist: {record_path}")
+            return record_path
+    raise ValueError(
+        f"compare: workspace run not found for workflow={workflow!r}, scope={scope!r}, run_hash={run_hash!r}"
+    )
+
+
+def _resolve_latest_previous_record_paths(*, workspace_root: Path, workflow: str, scope: str) -> tuple[Path, Path]:
+    manifest = load_workspace_manifest(workspace_root)
+    runs = manifest.get("runs", [])
+    if not isinstance(runs, list):
+        raise ValueError("compare: workspace manifest runs must be an array")
+
+    candidates: list[dict[str, Any]] = []
+    for item in runs:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("workflow", "")) != workflow or str(item.get("scope", "")) != scope:
+            continue
+        run_order = int(item.get("run_order", 0))
+        record_path = workspace_root / str(item.get("record_path", ""))
+        candidates.append(
+            {
+                "run_hash": str(item.get("run_hash", "")),
+                "run_order": run_order,
+                "record_path": record_path,
+            }
+        )
+
+    by_hash: dict[str, dict[str, Any]] = {}
+    for item in candidates:
+        by_hash[item["run_hash"]] = item
+
+    ordered = sorted(by_hash.values(), key=lambda row: (int(row["run_order"]), str(row["run_hash"])))
+    if len(ordered) < 2:
+        raise ValueError(
+            "compare: latest-vs-previous requires at least two distinct recorded runs for "
+            f"workflow={workflow!r}, scope={scope!r}"
+        )
+    previous = ordered[-2]
+    latest = ordered[-1]
+    for row in (previous, latest):
+        if not row["record_path"].exists():
+            raise ValueError(f"compare: workspace record path does not exist: {row['record_path']}")
+    return Path(previous["record_path"]), Path(latest["record_path"])
+
+
+def _diagnostics_delta(left: dict[str, Any], right: dict[str, Any]) -> dict[str, dict[str, int]]:
+    keys = sorted(set(left) | set(right))
+    return {
+        key: {
+            "baseline": int(left.get(key, 0)),
+            "compare": int(right.get(key, 0)),
+            "delta": int(right.get(key, 0)) - int(left.get(key, 0)),
+        }
+        for key in keys
+    }
+
+
+def _report_key(report: dict[str, Any]) -> str:
+    return Path(str(report.get("path", "unknown"))).name
+
+
+def _build_id_drift(left_reports: dict[str, dict[str, Any]], right_reports: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for key in sorted(set(left_reports) & set(right_reports)):
+        left_ids = set(str(v) for v in left_reports[key].get("record_ids", []) if str(v))
+        right_ids = set(str(v) for v in right_reports[key].get("record_ids", []) if str(v))
+        disappeared = sorted(left_ids - right_ids)
+        appeared = sorted(right_ids - left_ids)
+        if disappeared or appeared:
+            out.append(
+                {
+                    "file": key,
+                    "disappeared_count": len(disappeared),
+                    "appeared_count": len(appeared),
+                    "disappeared_examples": disappeared[:20],
+                    "appeared_examples": appeared[:20],
+                }
+            )
+    return out
+
+
+def _build_schema_drift(left_reports: dict[str, dict[str, Any]], right_reports: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    drift: list[dict[str, Any]] = []
+    for key in sorted(set(left_reports) & set(right_reports)):
+        left_cols = set(left_reports[key].get("schema_overview", {}).get("columns", []))
+        right_cols = set(right_reports[key].get("schema_overview", {}).get("columns", []))
+        removed = sorted(left_cols - right_cols)
+        added = sorted(right_cols - left_cols)
+        if removed or added:
+            drift.append(
+                {
+                    "file": key,
+                    "columns_removed": removed,
+                    "columns_added": added,
+                }
+            )
+    return drift
+
+
+def _coverage_gap(report: dict[str, Any]) -> int:
+    total = 0
+    for item in report.get("rule_checks", []):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("rule_type", "")) == "expected_id_coverage":
+            total += int(item.get("missing_expected_count", 0))
+    return total
+
+
+def _signal_counts(report: dict[str, Any]) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    counts["suspicious_rows"] += int(report.get("diagnostics", {}).get("suspicious_row_count", 0))
+    for item in report.get("suspicious_record_evidence", []):
+        if not isinstance(item, dict):
+            continue
+        counts[str(item.get("signal", "unknown"))] += 1
+    return counts
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    lines = [
+        f"SDETKit inspect compare: {'NO_DRIFT' if payload['ok'] else 'DRIFT_DETECTED'}",
+        f"baseline: {payload['baseline']['label']}",
+        f"compare: {payload['compare']['label']}",
+        f"files_added: {summary['files_added']}",
+        f"files_removed: {summary['files_removed']}",
+        f"id_drift_files: {summary['id_drift_files']}",
+        f"schema_drift_files: {summary['schema_drift_files']}",
+        "diagnostic_deltas:",
+    ]
+    for key, value in payload["diagnostic_deltas"].items():
+        lines.append(f"- {key}: baseline={value['baseline']} compare={value['compare']} delta={value['delta']}")
+    lines.append("recommendations:")
+    for rec in payload["recommendations"]:
+        lines.append(f"- {rec}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sdetkit inspect-compare",
+        description="Compare inspect evidence snapshots for baseline drift diagnostics.",
+    )
+    p.add_argument("--left", default=None, help="Path to baseline inspect.json or workspace record.json")
+    p.add_argument("--right", default=None, help="Path to compare inspect.json or workspace record.json")
+    p.add_argument("--left-run", default=None, help="Workspace run hash for baseline inspect run")
+    p.add_argument("--right-run", default=None, help="Workspace run hash for compare inspect run")
+    p.add_argument("--scope", default=None, help="Workspace scope (required for --left-run/--right-run)")
+    p.add_argument("--latest-vs-previous", action="store_true", help="Compare latest workspace run against previous run for a scope")
+    p.add_argument("--workspace-root", default=".sdetkit/workspace", help="Shared evidence workspace root")
+    p.add_argument("--workflow", default="inspect", help="Workspace workflow to resolve runs from")
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.add_argument("--out-dir", default=None, help="Directory for compare artifacts (default: .sdetkit/inspect-compare/<scope-or-input>)")
+    p.add_argument("--no-workspace", action="store_true", help="Disable shared workspace run recording")
+    return p
+
+
+def _resolve_pair(ns: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any], str, str]:
+    workspace_root = Path(ns.workspace_root)
+
+    if ns.latest_vs_previous:
+        if not ns.scope:
+            raise ValueError("compare: --scope is required with --latest-vs-previous")
+        left_record, right_record = _resolve_latest_previous_record_paths(
+            workspace_root=workspace_root,
+            workflow=str(ns.workflow),
+            scope=str(ns.scope),
+        )
+        return (
+            _read_workspace_record_payload(left_record),
+            _read_workspace_record_payload(right_record),
+            f"workspace:{left_record.as_posix()}",
+            f"workspace:{right_record.as_posix()}",
+        )
+
+    if ns.left_run or ns.right_run:
+        if not (ns.left_run and ns.right_run and ns.scope):
+            raise ValueError("compare: --left-run and --right-run require --scope")
+        left_record = _resolve_workspace_record_path(
+            workspace_root=workspace_root,
+            workflow=str(ns.workflow),
+            scope=str(ns.scope),
+            run_hash=str(ns.left_run),
+        )
+        right_record = _resolve_workspace_record_path(
+            workspace_root=workspace_root,
+            workflow=str(ns.workflow),
+            scope=str(ns.scope),
+            run_hash=str(ns.right_run),
+        )
+        return (
+            _read_workspace_record_payload(left_record),
+            _read_workspace_record_payload(right_record),
+            f"workspace:{left_record.as_posix()}",
+            f"workspace:{right_record.as_posix()}",
+        )
+
+    if ns.left and ns.right:
+        left_path = Path(ns.left)
+        right_path = Path(ns.right)
+
+        left_loaded = _load_json(left_path)
+        right_loaded = _load_json(right_path)
+
+        left_payload = left_loaded.get("payload") if left_path.name == "record.json" else left_loaded
+        right_payload = right_loaded.get("payload") if right_path.name == "record.json" else right_loaded
+        if not isinstance(left_payload, dict) or not isinstance(right_payload, dict):
+            raise ValueError("compare: expected inspect payload object for --left/--right")
+        return left_payload, right_payload, left_path.as_posix(), right_path.as_posix()
+
+    raise ValueError(
+        "compare: provide either --left/--right, --left-run/--right-run with --scope, or --latest-vs-previous"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_arg_parser().parse_args(argv)
+
+    try:
+        left_payload, right_payload, left_label, right_label = _resolve_pair(ns)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_FINDINGS
+
+    left_reports = {
+        _report_key(item): item
+        for item in left_payload.get("file_reports", [])
+        if isinstance(item, dict)
+    }
+    right_reports = {
+        _report_key(item): item
+        for item in right_payload.get("file_reports", [])
+        if isinstance(item, dict)
+    }
+
+    files_added = sorted(set(right_reports) - set(left_reports))
+    files_removed = sorted(set(left_reports) - set(right_reports))
+    schema_drift = _build_schema_drift(left_reports, right_reports)
+    id_drift = _build_id_drift(left_reports, right_reports)
+
+    left_diag = left_payload.get("summary", {}).get("diagnostics", {})
+    right_diag = right_payload.get("summary", {}).get("diagnostics", {})
+    if not isinstance(left_diag, dict) or not isinstance(right_diag, dict):
+        sys.stderr.write("compare: inspect payload missing summary.diagnostics object\n")
+        return EXIT_FINDINGS
+    diagnostic_deltas = _diagnostics_delta(left_diag, right_diag)
+
+    left_coverage_gap = sum(_coverage_gap(r) for r in left_reports.values())
+    right_coverage_gap = sum(_coverage_gap(r) for r in right_reports.values())
+
+    left_signals: Counter[str] = Counter()
+    right_signals: Counter[str] = Counter()
+    for key in sorted(set(left_reports) & set(right_reports)):
+        left_signals.update(_signal_counts(left_reports[key]))
+        right_signals.update(_signal_counts(right_reports[key]))
+
+    signal_drift = {
+        key: {
+            "baseline": int(left_signals.get(key, 0)),
+            "compare": int(right_signals.get(key, 0)),
+            "delta": int(right_signals.get(key, 0)) - int(left_signals.get(key, 0)),
+        }
+        for key in sorted(set(left_signals) | set(right_signals))
+        if int(right_signals.get(key, 0)) != int(left_signals.get(key, 0))
+    }
+
+    duplicate_row_delta = int(right_diag.get("duplicate_row_groups", 0)) - int(
+        left_diag.get("duplicate_row_groups", 0)
+    )
+    duplicate_record_id_delta = int(right_diag.get("duplicate_record_ids", 0)) - int(
+        left_diag.get("duplicate_record_ids", 0)
+    )
+
+    drift_score = (
+        len(files_added)
+        + len(files_removed)
+        + len(schema_drift)
+        + len(id_drift)
+        + abs(duplicate_row_delta)
+        + abs(duplicate_record_id_delta)
+        + abs(right_coverage_gap - left_coverage_gap)
+        + len(signal_drift)
+    )
+
+    recommendations: list[str] = []
+    if files_added or files_removed:
+        recommendations.append("Review evidence file set drift before release signoff.")
+    if schema_drift:
+        recommendations.append("Schema drift detected; update ingest contracts or mapping rules.")
+    if id_drift:
+        recommendations.append("Record ID drift detected; validate disappear/appear sets for data loss risk.")
+    if duplicate_row_delta > 0 or duplicate_record_id_delta > 0:
+        recommendations.append("Duplicate signals increased; investigate export or dedupe regressions.")
+    if right_coverage_gap > left_coverage_gap:
+        recommendations.append("Expected ID coverage regressed; restore baseline coverage before promotion.")
+    if not recommendations:
+        recommendations.append("No meaningful drift detected; compare run is baseline-compatible.")
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "tool": "sdetkit",
+        "workflow": "inspect-compare",
+        "ok": drift_score == 0,
+        "baseline": {
+            "label": left_label,
+            "summary": left_payload.get("summary", {}),
+        },
+        "compare": {
+            "label": right_label,
+            "summary": right_payload.get("summary", {}),
+        },
+        "summary": {
+            "files_added": len(files_added),
+            "files_removed": len(files_removed),
+            "schema_drift_files": len(schema_drift),
+            "id_drift_files": len(id_drift),
+            "coverage_gap_baseline": left_coverage_gap,
+            "coverage_gap_compare": right_coverage_gap,
+            "coverage_gap_delta": right_coverage_gap - left_coverage_gap,
+            "duplicate_row_groups_delta": duplicate_row_delta,
+            "duplicate_record_ids_delta": duplicate_record_id_delta,
+            "signal_types_changed": len(signal_drift),
+            "drift_score": drift_score,
+        },
+        "files_added": files_added,
+        "files_removed": files_removed,
+        "schema_drift": schema_drift,
+        "id_drift": id_drift,
+        "diagnostic_deltas": diagnostic_deltas,
+        "signal_drift": signal_drift,
+        "recommendations": recommendations,
+        "evidence": {
+            "machine_readable": "inspect-compare.json",
+            "human_readable": "inspect-compare.txt",
+        },
+    }
+
+    out_scope = ns.scope or _safe_slug(Path(left_label).name + "-vs-" + Path(right_label).name)
+    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect-compare" / _safe_slug(out_scope)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "inspect-compare.json"
+    txt_path = out_dir / "inspect-compare.txt"
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    txt_path.write_text(_render_text(payload), encoding="utf-8")
+
+    if not ns.no_workspace:
+        workspace_entry = record_workspace_run(
+            workspace_root=Path(ns.workspace_root),
+            workflow="inspect-compare",
+            scope=str(out_scope),
+            payload=payload,
+            artifacts={
+                "inspect_compare_json": json_path.as_posix(),
+                "inspect_compare_text": txt_path.as_posix(),
+            },
+            recommendations=list(payload.get("recommendations", [])),
+        )
+        payload["workspace"] = workspace_entry
+        json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    output = json.dumps(payload, sort_keys=True) if ns.format == "json" else _render_text(payload)
+    sys.stdout.write(output + ("\n" if not output.endswith("\n") else ""))
+    return EXIT_OK if payload["ok"] else EXIT_FINDINGS
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -16,6 +16,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     out = r.stdout
     assert "kv" in out
     assert "inspect" in out
+    assert "inspect-compare" in out
     assert "apiget" in out
     assert "doctor" in out
     assert "patch" in out

--- a/tests/test_inspect_compare.py
+++ b/tests/test_inspect_compare.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from sdetkit import inspect_compare, inspect_data
+
+
+def test_inspect_compare_with_two_paths_reports_drift(tmp_path: Path) -> None:
+    data = tmp_path / "orders.csv"
+    data.write_text("id,status\nA1,ok\nA2,ok\n", encoding="utf-8")
+    inspect_data.main([str(data), "--out-dir", str(tmp_path / "left")])
+    data.write_text("id,status\nA1,ok\nA2,ok\nA3,new\n", encoding="utf-8")
+    inspect_data.main([str(data), "--out-dir", str(tmp_path / "right")])
+
+    rc = inspect_compare.main(
+        [
+            "--left",
+            str(tmp_path / "left" / "inspect.json"),
+            "--right",
+            str(tmp_path / "right" / "inspect.json"),
+            "--format",
+            "json",
+            "--out-dir",
+            str(tmp_path / "compare"),
+            "--no-workspace",
+        ]
+    )
+
+    assert rc == 2
+    payload = json.loads((tmp_path / "compare" / "inspect-compare.json").read_text(encoding="utf-8"))
+    assert payload["summary"]["id_drift_files"] == 1
+    assert payload["summary"]["drift_score"] >= 1
+
+
+def test_inspect_compare_latest_vs_previous_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    out = tmp_path / "out"
+    data = tmp_path / "orders.csv"
+
+    data.write_text("id,amount\nA1,10\n", encoding="utf-8")
+    inspect_data.main([str(data), "--out-dir", str(out), "--workspace-root", str(workspace)])
+
+    data.write_text("id,amount\nA1,10\nA2,20\n", encoding="utf-8")
+    inspect_data.main([str(data), "--out-dir", str(out), "--workspace-root", str(workspace)])
+
+    rc = inspect_compare.main(
+        [
+            "--latest-vs-previous",
+            "--scope",
+            "orders.csv",
+            "--workspace-root",
+            str(workspace),
+            "--out-dir",
+            str(tmp_path / "cmp"),
+            "--format",
+            "json",
+            "--no-workspace",
+        ]
+    )
+    assert rc == 2
+    payload = json.loads((tmp_path / "cmp" / "inspect-compare.json").read_text(encoding="utf-8"))
+    assert payload["baseline"]["label"].startswith("workspace:")
+    assert payload["summary"]["id_drift_files"] == 1
+
+
+def test_inspect_compare_workspace_run_pair(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    data = tmp_path / "events.csv"
+    out = tmp_path / "inspect-out"
+
+    data.write_text("id,type\nA1,open\n", encoding="utf-8")
+    inspect_data.main([str(data), "--out-dir", str(out), "--workspace-root", str(workspace)])
+    first = json.loads((out / "inspect.json").read_text(encoding="utf-8"))["workspace"]["run_hash"]
+
+    data.write_text("id,type\nA1,open\nA1,open\n", encoding="utf-8")
+    inspect_data.main([str(data), "--out-dir", str(out), "--workspace-root", str(workspace)])
+    second = json.loads((out / "inspect.json").read_text(encoding="utf-8"))["workspace"]["run_hash"]
+
+    rc = inspect_compare.main(
+        [
+            "--left-run",
+            first,
+            "--right-run",
+            second,
+            "--scope",
+            "events.csv",
+            "--workspace-root",
+            str(workspace),
+            "--format",
+            "json",
+            "--out-dir",
+            str(tmp_path / "compare"),
+            "--no-workspace",
+        ]
+    )
+    assert rc == 2
+    payload = json.loads((tmp_path / "compare" / "inspect-compare.json").read_text(encoding="utf-8"))
+    assert payload["summary"]["duplicate_row_groups_delta"] == 1
+
+
+def test_cli_inspect_compare_command_executes(tmp_path: Path) -> None:
+    left = tmp_path / "left.json"
+    right = tmp_path / "right.json"
+    base_payload = {
+        "summary": {"diagnostics": {}, "files_analyzed": 0, "total_records": 0},
+        "file_reports": [],
+    }
+    left.write_text(json.dumps(base_payload), encoding="utf-8")
+    right.write_text(json.dumps(base_payload), encoding="utf-8")
+
+    run = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "inspect-compare",
+            "--left",
+            str(left),
+            "--right",
+            str(right),
+            "--format",
+            "json",
+            "--no-workspace",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert run.returncode == 0
+    payload = json.loads(run.stdout)
+    assert payload["workflow"] == "inspect-compare"
+    assert payload["ok"] is True


### PR DESCRIPTION
### Motivation

- Provide a first-class baseline/compare/drift workflow for `inspect` evidence so teams can answer what changed, what drifted, and which IDs/schema/coverage/duplicate signals regressed. 
- Support comparing two artifact paths, two workspace run hashes, or `latest` vs `previous` workspace runs in a deterministic, CI-friendly way. 
- Emit machine-readable and human-readable deterministic evidence that can be consumed in CI, PR checks, and release reviews.

### Description

- Add a new workflow module `src/sdetkit/inspect_compare.py` which computes file-set changes, schema drift, ID appear/disappear, duplicate deltas, expected-ID coverage deltas, suspicious-signal drift, diagnostic deltas, and a deterministic `drift_score`, and writes `inspect-compare.json` and `inspect-compare.txt` artifacts. 
- Wire the new CLI command `inspect-compare` into `src/sdetkit/cli.py` with argument forwarding for `--left/--right`, `--left-run/--right-run --scope`, and `--latest-vs-previous --scope`. 
- Extend workspace handling in `src/sdetkit/evidence_workspace.py` with `load_workspace_manifest()` and run-order normalization (`run_order`) so `latest-vs-previous` selection is stable and deterministic. 
- Add tests: `tests/test_inspect_compare.py` to validate the three compare modes and CLI execution, and update `tests/test_cli_help_lists_subcommands.py` to include `inspect-compare` in the help surface.

### Testing

- Ran the focused pytest invocation: `python -m pytest -q tests/test_inspect_compare.py tests/test_inspect_data.py tests/test_evidence_workspace.py tests/test_cli_help_lists_subcommands.py`. 
- All targeted tests passed: `21 passed` (previous transient adjustments were iterated until green). 
- Verified the CLI invocation path by running the `sdetkit` module invocation for `inspect-compare` in tests and asserting expected JSON artifact fields and exit codes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9969345a0833289e1070acd932e69)