### PR TITLE
Add `inspect-project` command and refactor inspect modules into callable run functions

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -262,6 +262,16 @@ Then use stability-aware command discovery:
     inspect_compare_parser.add_argument("--out-dir", default=None)
     inspect_compare_parser.add_argument("--no-workspace", action="store_true")
     inspect_compare_parser.add_argument("args", nargs=argparse.REMAINDER)
+    inspect_project_parser = sub.add_parser(
+        "inspect-project",
+        help="[Advanced but supported] Run reusable inspection policy packs over project datasets",
+    )
+    inspect_project_parser.add_argument("project_dir")
+    inspect_project_parser.add_argument("--policy", default=None)
+    inspect_project_parser.add_argument("--workspace-root", default=None)
+    inspect_project_parser.add_argument("--out-dir", default=None)
+    inspect_project_parser.add_argument("--format", choices=["text", "json"], default=None)
+    inspect_project_parser.add_argument("--no-workspace", action="store_true")
 
     ag = sub.add_parser("apiget", help="Deterministic HTTP JSON fetch and replay helper")
     _add_apiget_args(ag)
@@ -1277,6 +1287,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         if ns.no_workspace:
             forwarded = ["--no-workspace", *forwarded]
         return _run_module_main("sdetkit.inspect_compare", forwarded)
+    if ns.cmd == "inspect-project":
+        forwarded = [ns.project_dir]
+        if ns.policy:
+            forwarded.extend(["--policy", ns.policy])
+        if ns.workspace_root:
+            forwarded.extend(["--workspace-root", ns.workspace_root])
+        if ns.out_dir:
+            forwarded.extend(["--out-dir", ns.out_dir])
+        if ns.format:
+            forwarded.extend(["--format", ns.format])
+        if ns.no_workspace:
+            forwarded.append("--no-workspace")
+        return _run_module_main("sdetkit.inspect_project", forwarded)
 
     if ns.cmd == "patch":
         return _run_module_main("sdetkit.patch", ns.args)

--- a/src/sdetkit/inspect_compare.py
+++ b/src/sdetkit/inspect_compare.py
@@ -274,15 +274,17 @@ def _resolve_pair(ns: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any
     )
 
 
-def main(argv: list[str] | None = None) -> int:
-    ns = _build_arg_parser().parse_args(argv)
-
-    try:
-        left_payload, right_payload, left_label, right_label = _resolve_pair(ns)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        sys.stderr.write(str(exc) + "\n")
-        return EXIT_FINDINGS
-
+def run_compare(
+    *,
+    left_payload: dict[str, Any],
+    right_payload: dict[str, Any],
+    left_label: str,
+    right_label: str,
+    out_dir: Path,
+    out_scope: str,
+    workspace_root: Path = Path(".sdetkit/workspace"),
+    record_workspace: bool = True,
+) -> tuple[int, dict[str, Any], Path, Path]:
     left_reports = {
         _report_key(item): item
         for item in left_payload.get("file_reports", [])
@@ -302,8 +304,7 @@ def main(argv: list[str] | None = None) -> int:
     left_diag = left_payload.get("summary", {}).get("diagnostics", {})
     right_diag = right_payload.get("summary", {}).get("diagnostics", {})
     if not isinstance(left_diag, dict) or not isinstance(right_diag, dict):
-        sys.stderr.write("compare: inspect payload missing summary.diagnostics object\n")
-        return EXIT_FINDINGS
+        raise ValueError("compare: inspect payload missing summary.diagnostics object")
     diagnostic_deltas = _diagnostics_delta(left_diag, right_diag)
 
     left_coverage_gap = sum(_coverage_gap(r) for r in left_reports.values())
@@ -396,17 +397,15 @@ def main(argv: list[str] | None = None) -> int:
         },
     }
 
-    out_scope = ns.scope or _safe_slug(Path(left_label).name + "-vs-" + Path(right_label).name)
-    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect-compare" / _safe_slug(out_scope)
     out_dir.mkdir(parents=True, exist_ok=True)
     json_path = out_dir / "inspect-compare.json"
     txt_path = out_dir / "inspect-compare.txt"
     json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     txt_path.write_text(_render_text(payload), encoding="utf-8")
 
-    if not ns.no_workspace:
+    if record_workspace:
         workspace_entry = record_workspace_run(
-            workspace_root=Path(ns.workspace_root),
+            workspace_root=workspace_root,
             workflow="inspect-compare",
             scope=str(out_scope),
             payload=payload,
@@ -418,10 +417,38 @@ def main(argv: list[str] | None = None) -> int:
         )
         payload["workspace"] = workspace_entry
         json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return (EXIT_OK if payload["ok"] else EXIT_FINDINGS), payload, json_path, txt_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_arg_parser().parse_args(argv)
+
+    try:
+        left_payload, right_payload, left_label, right_label = _resolve_pair(ns)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_FINDINGS
+
+    out_scope = ns.scope or _safe_slug(Path(left_label).name + "-vs-" + Path(right_label).name)
+    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect-compare" / _safe_slug(out_scope)
+    try:
+        rc, payload, _, _ = run_compare(
+            left_payload=left_payload,
+            right_payload=right_payload,
+            left_label=left_label,
+            right_label=right_label,
+            out_dir=out_dir,
+            out_scope=str(out_scope),
+            workspace_root=Path(ns.workspace_root),
+            record_workspace=not ns.no_workspace,
+        )
+    except ValueError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_FINDINGS
 
     output = json.dumps(payload, sort_keys=True) if ns.format == "json" else _render_text(payload)
     sys.stdout.write(output + ("\n" if not output.endswith("\n") else ""))
-    return EXIT_OK if payload["ok"] else EXIT_FINDINGS
+    return rc
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/sdetkit/inspect_data.py
+++ b/src/sdetkit/inspect_data.py
@@ -669,57 +669,34 @@ def _load_rules_payload(path: str) -> tuple[dict[str, Any] | None, str | None]:
     return loaded, None
 
 
-def main(argv: list[str] | None = None) -> int:
-    ns = _build_arg_parser().parse_args(argv)
-    if ns.rules and ns.rules_template:
-        sys.stderr.write("inspect: --rules and --rules-template cannot be used together\n")
-        return EXIT_FINDINGS
-    if ns.rules_lint and ns.rules_template:
-        sys.stderr.write("inspect: --rules-lint and --rules-template cannot be used together\n")
-        return EXIT_FINDINGS
-    if ns.rules_lint and ns.rules:
-        sys.stderr.write("inspect: --rules-lint and --rules cannot be used together\n")
-        return EXIT_FINDINGS
-
-    if ns.rules_template:
-        sys.stdout.write(json.dumps(RULES_TEMPLATE, indent=2, sort_keys=True) + "\n")
-        return EXIT_OK
-
-    if ns.rules_lint:
-        _, error = _load_rules_payload(ns.rules_lint)
-        if error:
-            sys.stderr.write(f"inspect: rules lint FAILED: {error}\n")
-            return EXIT_FINDINGS
-        sys.stdout.write("inspect: rules lint OK\n")
-        return EXIT_OK
-
-    if not ns.path:
-        sys.stderr.write("inspect: missing input path (or use --rules-template)\n")
-        return EXIT_FINDINGS
-
-    target = Path(ns.path).resolve()
+def run_inspect(
+    *,
+    input_path: Path,
+    out_dir: Path,
+    rules_payload: dict[str, Any] | None = None,
+    workspace_root: Path = Path(".sdetkit/workspace"),
+    record_workspace: bool = True,
+    workspace_scope: str | None = None,
+) -> tuple[int, dict[str, Any], Path, Path]:
+    target = input_path.resolve()
     if not target.exists():
-        sys.stderr.write(f"inspect: input path does not exist: {target}\n")
-        return EXIT_FINDINGS
+        raise ValueError(f"inspect: input path does not exist: {target}")
 
     files, skipped = _discover_supported_files(target)
     if not files:
-        sys.stderr.write("inspect: no supported evidence files found (expected .csv or .json)\n")
-        return EXIT_FINDINGS
+        raise ValueError("inspect: no supported evidence files found (expected .csv or .json)")
 
-    rules_payload: dict[str, Any] = {}
-    if ns.rules:
-        loaded, error = _load_rules_payload(ns.rules)
-        if error:
-            sys.stderr.write(error + "\n")
-            return EXIT_FINDINGS
-        rules_payload = loaded if loaded is not None else {}
-    file_rules = rules_payload.get("files", {}) if isinstance(rules_payload, dict) else {}
-    cross_file_rules = (
-        rules_payload.get("cross_file_rules", []) if isinstance(rules_payload, dict) else []
-    )
+    loaded_rules = rules_payload if isinstance(rules_payload, dict) else {}
+    validation_error = _validate_rules_payload(loaded_rules)
+    if validation_error:
+        raise ValueError(validation_error)
 
-    reports = [_analyze_file(path, root=target if target.is_dir() else target.parent, file_rules=file_rules) for path in files]
+    file_rules = loaded_rules.get("files", {})
+    cross_file_rules = loaded_rules.get("cross_file_rules", [])
+    reports = [
+        _analyze_file(path, root=target if target.is_dir() else target.parent, file_rules=file_rules)
+        for path in files
+    ]
     cross_file = _cross_file_diagnostics(reports)
     cross_file_rule_results = _rule_cross_file_checks(reports, cross_file_rules)
 
@@ -732,7 +709,9 @@ def main(argv: list[str] | None = None) -> int:
             "missing_value_columns": sum(
                 int(r["diagnostics"]["missing_value_columns"]) for r in reports
             ),
-            "duplicate_row_groups": sum(int(r["diagnostics"]["duplicate_row_groups"]) for r in reports),
+            "duplicate_row_groups": sum(
+                int(r["diagnostics"]["duplicate_row_groups"]) for r in reports
+            ),
             "inconsistent_type_columns": sum(
                 int(r["diagnostics"]["inconsistent_type_columns"]) for r in reports
             ),
@@ -773,18 +752,18 @@ def main(argv: list[str] | None = None) -> int:
         },
     }
 
-    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect" / _safe_slug(target.name)
     out_dir.mkdir(parents=True, exist_ok=True)
     json_path = out_dir / "inspect.json"
     txt_path = out_dir / "inspect.txt"
     json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     txt_path.write_text(_render_text(payload), encoding="utf-8")
 
-    if not ns.no_workspace:
+    if record_workspace:
+        scope_name = workspace_scope if workspace_scope else _safe_slug(target.name)
         workspace_entry = record_workspace_run(
-            workspace_root=Path(ns.workspace_root),
+            workspace_root=workspace_root,
             workflow="inspect",
-            scope=_safe_slug(target.name),
+            scope=scope_name,
             payload=payload,
             artifacts={
                 "inspect_json": json_path.as_posix(),
@@ -794,10 +773,62 @@ def main(argv: list[str] | None = None) -> int:
         )
         payload["workspace"] = workspace_entry
         json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return (EXIT_OK if payload["ok"] else EXIT_FINDINGS), payload, json_path, txt_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_arg_parser().parse_args(argv)
+    if ns.rules and ns.rules_template:
+        sys.stderr.write("inspect: --rules and --rules-template cannot be used together\n")
+        return EXIT_FINDINGS
+    if ns.rules_lint and ns.rules_template:
+        sys.stderr.write("inspect: --rules-lint and --rules-template cannot be used together\n")
+        return EXIT_FINDINGS
+    if ns.rules_lint and ns.rules:
+        sys.stderr.write("inspect: --rules-lint and --rules cannot be used together\n")
+        return EXIT_FINDINGS
+
+    if ns.rules_template:
+        sys.stdout.write(json.dumps(RULES_TEMPLATE, indent=2, sort_keys=True) + "\n")
+        return EXIT_OK
+
+    if ns.rules_lint:
+        _, error = _load_rules_payload(ns.rules_lint)
+        if error:
+            sys.stderr.write(f"inspect: rules lint FAILED: {error}\n")
+            return EXIT_FINDINGS
+        sys.stdout.write("inspect: rules lint OK\n")
+        return EXIT_OK
+
+    if not ns.path:
+        sys.stderr.write("inspect: missing input path (or use --rules-template)\n")
+        return EXIT_FINDINGS
+
+    target = Path(ns.path).resolve()
+
+    rules_payload: dict[str, Any] = {}
+    if ns.rules:
+        loaded, error = _load_rules_payload(ns.rules)
+        if error:
+            sys.stderr.write(error + "\n")
+            return EXIT_FINDINGS
+        rules_payload = loaded if loaded is not None else {}
+    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect" / _safe_slug(target.name)
+    try:
+        rc, payload, _, _ = run_inspect(
+            input_path=target,
+            out_dir=out_dir,
+            rules_payload=rules_payload,
+            workspace_root=Path(ns.workspace_root),
+            record_workspace=not ns.no_workspace,
+        )
+    except ValueError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_FINDINGS
 
     output = json.dumps(payload, sort_keys=True) if ns.format == "json" else _render_text(payload)
     sys.stdout.write(output + ("\n" if not output.endswith("\n") else ""))
-    return EXIT_OK if payload["ok"] else EXIT_FINDINGS
+    return rc
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/sdetkit/inspect_project.py
+++ b/src/sdetkit/inspect_project.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .evidence_workspace import record_workspace_run
+from .inspect_compare import run_compare
+from .inspect_data import run_inspect
+
+SCHEMA_VERSION = "sdetkit.inspect.project.v1"
+EXIT_OK = 0
+EXIT_FINDINGS = 2
+
+
+def _safe_slug(value: str) -> str:
+    out: list[str] = []
+    for ch in value.lower():
+        if ch.isalnum() or ch in {"-", "_", "."}:
+            out.append(ch)
+        else:
+            out.append("-")
+    slug = "".join(out).strip("-")
+    return slug or "inspect-project"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"inspect-project: expected JSON object at {path}")
+    return loaded
+
+
+def _validate_policy(payload: dict[str, Any]) -> str | None:
+    allowed = {"inputs", "rules", "compare", "precedence", "outputs"}
+    unknown = sorted(k for k in payload if k not in allowed)
+    if unknown:
+        return "inspect-project: unknown policy section(s): " + ", ".join(repr(k) for k in unknown)
+
+    inputs = payload.get("inputs", {})
+    if not isinstance(inputs, dict):
+        return "inspect-project: inputs must be an object"
+    scopes = inputs.get("scopes", [])
+    if not isinstance(scopes, list) or not scopes:
+        return "inspect-project: inputs.scopes must be a non-empty array"
+    for idx, scope in enumerate(scopes):
+        if not isinstance(scope, dict):
+            return f"inspect-project: inputs.scopes[{idx}] must be an object"
+        name = str(scope.get("name", "")).strip()
+        if not name:
+            return f"inspect-project: inputs.scopes[{idx}].name is required"
+        include = scope.get("include", [])
+        if not isinstance(include, list) or not include:
+            return f"inspect-project: inputs.scopes[{idx}].include must be a non-empty array"
+
+    rules = payload.get("rules", {})
+    if not isinstance(rules, dict):
+        return "inspect-project: rules must be an object"
+    source_count = int("rules_file" in rules) + int("inline" in rules)
+    if source_count > 1:
+        return "inspect-project: rules may define only one source: rules_file or inline"
+
+    compare = payload.get("compare", {})
+    if not isinstance(compare, dict):
+        return "inspect-project: compare must be an object"
+    baseline = compare.get("baseline", "latest_vs_previous")
+    if str(baseline) not in {"latest_vs_previous", "none"}:
+        return "inspect-project: compare.baseline must be 'latest_vs_previous' or 'none'"
+    thresholds = compare.get("thresholds", {})
+    if thresholds is not None and not isinstance(thresholds, dict):
+        return "inspect-project: compare.thresholds must be an object"
+
+    precedence = payload.get("precedence", {})
+    if precedence is not None and not isinstance(precedence, dict):
+        return "inspect-project: precedence must be an object"
+
+    outputs = payload.get("outputs", {})
+    if outputs is not None and not isinstance(outputs, dict):
+        return "inspect-project: outputs must be an object"
+    if isinstance(outputs, dict):
+        for key in ("project_subdir", "scope_dir"):
+            value = outputs.get(key)
+            if value is not None and (not isinstance(value, str) or not value.strip()):
+                return f"inspect-project: outputs.{key} must be a non-empty string when provided"
+    return None
+
+
+def _resolve_rules_payload(project_dir: Path, policy: dict[str, Any]) -> dict[str, Any]:
+    rules_cfg = policy.get("rules", {})
+    if not isinstance(rules_cfg, dict):
+        return {}
+    if "inline" in rules_cfg:
+        inline = rules_cfg.get("inline")
+        if not isinstance(inline, dict):
+            raise ValueError("inspect-project: rules.inline must be an object")
+        return inline
+    if "rules_file" in rules_cfg:
+        rules_file = project_dir / str(rules_cfg.get("rules_file", ""))
+        if not rules_file.exists():
+            raise ValueError(f"inspect-project: rules file not found: {rules_file}")
+        return _load_json(rules_file)
+    return {}
+
+
+def _materialize_scope(project_dir: Path, scope: dict[str, Any], run_root: Path) -> tuple[list[Path], Path]:
+    include_patterns = sorted(str(p) for p in scope.get("include", []) if str(p).strip())
+    if not include_patterns:
+        raise ValueError(f"inspect-project: scope {scope.get('name', 'unknown')!r} has no include patterns")
+    discovered: set[Path] = set()
+    for pattern in include_patterns:
+        for candidate in project_dir.glob(pattern):
+            if candidate.is_file() and candidate.suffix.lower() in {".csv", ".json"}:
+                discovered.add(candidate.resolve())
+    files = sorted(discovered, key=lambda p: p.as_posix())
+    if not files:
+        raise ValueError(f"inspect-project: scope {scope['name']!r} matched no supported files")
+
+    scope_root_name = str(scope.get("_scope_dir_name", "scopes"))
+    scope_dir = run_root / scope_root_name / _safe_slug(str(scope["name"])) / "input"
+    scope_dir.mkdir(parents=True, exist_ok=True)
+    manifest_rows: list[dict[str, str]] = []
+    for src in files:
+        rel = src.relative_to(project_dir)
+        dst = scope_dir / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_bytes(src.read_bytes())
+        manifest_rows.append({"source": rel.as_posix(), "copied_to": dst.relative_to(run_root).as_posix()})
+    (scope_dir / "scope-input-manifest.json").write_text(
+        json.dumps({"scope": scope["name"], "files": manifest_rows}, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return files, scope_dir
+
+
+def _threshold_failures(compare_summary: dict[str, Any], thresholds: dict[str, Any]) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    for key in sorted(thresholds):
+        limit = int(thresholds.get(key, 0))
+        actual = int(compare_summary.get(key, 0))
+        if actual > limit:
+            failures.append(
+                {
+                    "kind": "compare_threshold",
+                    "metric": key,
+                    "actual": actual,
+                    "threshold": limit,
+                    "priority": 20,
+                }
+            )
+    return failures
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"SDETKit inspect-project: {'PASS' if payload['ok'] else 'FAIL'}",
+        f"project_dir: {payload['project_dir']}",
+        f"scopes: {payload['summary']['scopes']}",
+        f"inspect_fail_scopes: {payload['summary']['inspect_fail_scopes']}",
+        f"compare_fail_scopes: {payload['summary']['compare_fail_scopes']}",
+        "top_findings:",
+    ]
+    for item in payload.get("findings", [])[:20]:
+        lines.append(
+            f"- {item['scope']} [{item['kind']}] priority={item['priority']} "
+            f"message={item['message']}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sdetkit inspect-project",
+        description="Run reusable project inspection policy packs over dataset families.",
+    )
+    p.add_argument("project_dir", help="Directory containing evidence and policy pack")
+    p.add_argument("--policy", default="inspect-project.json", help="Policy JSON file relative to project_dir")
+    p.add_argument("--workspace-root", default=".sdetkit/workspace", help="Shared evidence workspace root")
+    p.add_argument("--out-dir", default=None, help="Project output directory (default .sdetkit/inspect-project/<project-name>)")
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.add_argument("--no-workspace", action="store_true", help="Disable shared workspace recording")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_arg_parser().parse_args(argv)
+    project_dir = Path(ns.project_dir).resolve()
+    if not project_dir.exists() or not project_dir.is_dir():
+        sys.stderr.write(f"inspect-project: project_dir does not exist or is not a directory: {project_dir}\n")
+        return EXIT_FINDINGS
+
+    policy_path = project_dir / ns.policy
+    if not policy_path.exists():
+        sys.stderr.write(f"inspect-project: policy file not found: {policy_path}\n")
+        return EXIT_FINDINGS
+
+    try:
+        policy = _load_json(policy_path)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_FINDINGS
+
+    error = _validate_policy(policy)
+    if error:
+        sys.stderr.write(error + "\n")
+        return EXIT_FINDINGS
+
+    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect-project" / _safe_slug(project_dir.name)
+    outputs_cfg = policy.get("outputs", {}) if isinstance(policy.get("outputs"), dict) else {}
+    project_subdir = str(outputs_cfg.get("project_subdir", "")).strip()
+    scope_dir_name = str(outputs_cfg.get("scope_dir", "scopes")).strip() or "scopes"
+    run_root = out_dir / _safe_slug(project_subdir) if project_subdir else out_dir
+    run_root.mkdir(parents=True, exist_ok=True)
+
+    try:
+        rules_payload = _resolve_rules_payload(project_dir, policy)
+    except ValueError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_FINDINGS
+
+    inputs = policy.get("inputs", {})
+    scopes = sorted(inputs.get("scopes", []), key=lambda item: str(item.get("name", "")))
+
+    inspect_runs: list[dict[str, Any]] = []
+    compare_runs: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+
+    compare_cfg = policy.get("compare", {}) if isinstance(policy.get("compare"), dict) else {}
+    thresholds = compare_cfg.get("thresholds", {}) if isinstance(compare_cfg.get("thresholds"), dict) else {}
+    baseline_mode = str(compare_cfg.get("baseline", "latest_vs_previous"))
+    precedence_cfg = policy.get("precedence", {}) if isinstance(policy.get("precedence"), dict) else {}
+    weights_cfg = precedence_cfg.get("weights", {}) if isinstance(precedence_cfg.get("weights"), dict) else {}
+
+    for scope in scopes:
+        scope = dict(scope)
+        scope["_scope_dir_name"] = scope_dir_name
+        scope_name = str(scope.get("name"))
+        scope_slug = _safe_slug(scope_name)
+        try:
+            matched_files, scope_input_dir = _materialize_scope(project_dir, scope, run_root)
+        except ValueError as exc:
+            findings.append(
+                {
+                    "scope": scope_name,
+                    "kind": "input_matching",
+                    "priority": 30,
+                    "message": str(exc),
+                }
+            )
+            continue
+
+        inspect_out = run_root / scope_dir_name / scope_slug / "inspect"
+        try:
+            inspect_rc, inspect_payload, inspect_json_path, inspect_txt_path = run_inspect(
+                input_path=scope_input_dir,
+                out_dir=inspect_out,
+                rules_payload=rules_payload,
+                workspace_root=Path(ns.workspace_root),
+                record_workspace=not ns.no_workspace,
+                workspace_scope=scope_slug,
+            )
+        except ValueError as exc:
+            findings.append(
+                {
+                    "scope": scope_name,
+                    "kind": "inspect_execution",
+                    "priority": 30,
+                    "message": str(exc),
+                }
+            )
+            continue
+
+        inspect_runs.append(
+            {
+                "scope": scope_name,
+                "scope_slug": scope_slug,
+                "matched_files": [p.relative_to(project_dir).as_posix() for p in matched_files],
+                "inspect_ok": inspect_payload["ok"],
+                "inspect_run_hash": inspect_payload.get("workspace", {}).get("run_hash"),
+                "inspect_artifacts": {
+                    "inspect_json": inspect_json_path.relative_to(run_root).as_posix(),
+                    "inspect_txt": inspect_txt_path.relative_to(run_root).as_posix(),
+                },
+            }
+        )
+        if inspect_rc != EXIT_OK:
+            findings.append(
+                {
+                    "scope": scope_name,
+                    "kind": "inspect_findings",
+                    "priority": 25,
+                    "message": "inspect reported findings for this scope",
+                }
+            )
+
+        if baseline_mode != "latest_vs_previous":
+            continue
+
+        compare_out = run_root / scope_dir_name / scope_slug / "compare"
+        compare_scope = f"inspect-project:{project_dir.name}:{scope_slug}"
+        try:
+            current_record = Path(inspect_payload.get("workspace", {}).get("record_path", ""))
+            if ns.no_workspace or not current_record:
+                continue
+            current_record_abs = Path(ns.workspace_root) / current_record
+            manifest = _load_json(Path(ns.workspace_root) / "manifest.json")
+            runs = [
+                item
+                for item in manifest.get("runs", [])
+                if isinstance(item, dict)
+                and str(item.get("workflow", "")) == "inspect"
+                and str(item.get("scope", "")) == scope_slug
+            ]
+            runs_sorted = sorted(
+                runs,
+                key=lambda item: (int(item.get("run_order", 0)), str(item.get("run_hash", ""))),
+            )
+            previous = None
+            current_hash = str(inspect_payload.get("workspace", {}).get("run_hash", ""))
+            for item in runs_sorted:
+                if str(item.get("run_hash", "")) == current_hash:
+                    break
+                previous = item
+            if previous is None:
+                continue
+            left_record = Path(ns.workspace_root) / str(previous.get("record_path", ""))
+            left_payload = _load_json(left_record).get("payload")
+            right_payload = _load_json(current_record_abs).get("payload")
+            if not isinstance(left_payload, dict) or not isinstance(right_payload, dict):
+                continue
+            compare_rc, compare_payload, compare_json, compare_txt = run_compare(
+                left_payload=left_payload,
+                right_payload=right_payload,
+                left_label=f"workspace:{left_record.as_posix()}",
+                right_label=f"workspace:{current_record_abs.as_posix()}",
+                out_dir=compare_out,
+                out_scope=compare_scope,
+                workspace_root=Path(ns.workspace_root),
+                record_workspace=not ns.no_workspace,
+            )
+            compare_runs.append(
+                {
+                    "scope": scope_name,
+                    "compare_ok": compare_payload["ok"],
+                    "summary": compare_payload.get("summary", {}),
+                    "compare_run_hash": compare_payload.get("workspace", {}).get("run_hash"),
+                    "compare_artifacts": {
+                        "inspect_compare_json": compare_json.relative_to(run_root).as_posix(),
+                        "inspect_compare_txt": compare_txt.relative_to(run_root).as_posix(),
+                    },
+                }
+            )
+            if compare_rc != EXIT_OK:
+                findings.append(
+                    {
+                        "scope": scope_name,
+                        "kind": "compare_drift",
+                        "priority": 15,
+                        "message": "compare detected drift against previous run",
+                    }
+                )
+            for failure in _threshold_failures(compare_payload.get("summary", {}), thresholds):
+                findings.append(
+                    {
+                        "scope": scope_name,
+                        "kind": failure["kind"],
+                        "priority": int(failure["priority"]),
+                        "message": (
+                            f"{failure['metric']}={failure['actual']} exceeds threshold={failure['threshold']}"
+                        ),
+                    }
+                )
+        except (OSError, ValueError, json.JSONDecodeError):
+            findings.append(
+                {
+                    "scope": scope_name,
+                    "kind": "compare_execution",
+                    "priority": 20,
+                    "message": "compare execution failed for this scope",
+                }
+            )
+
+    ordered_findings = sorted(
+        [
+            {
+                **item,
+                "priority": int(weights_cfg.get(str(item.get("kind", "")), int(item.get("priority", 0)))),
+            }
+            for item in findings
+        ],
+        key=lambda item: (
+            int(item.get("priority", 0)),
+            str(item.get("kind", "")),
+            str(item.get("scope", "")),
+            str(item.get("message", "")),
+        ),
+    )
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "tool": "sdetkit",
+        "workflow": "inspect-project",
+        "project_dir": project_dir.as_posix(),
+        "policy_path": policy_path.as_posix(),
+        "ok": len(ordered_findings) == 0,
+        "policy": policy,
+        "summary": {
+            "scopes": len(scopes),
+            "inspect_fail_scopes": len({f["scope"] for f in ordered_findings if f["kind"].startswith("inspect")}),
+            "compare_fail_scopes": len({f["scope"] for f in ordered_findings if f["kind"].startswith("compare")}),
+            "total_findings": len(ordered_findings),
+        },
+        "inspect_runs": inspect_runs,
+        "compare_runs": compare_runs,
+        "findings": ordered_findings,
+        "evidence": {
+            "machine_readable": "inspect-project.json",
+            "human_readable": "inspect-project.txt",
+            "manifest": "manifest.json",
+        },
+    }
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "project_dir": project_dir.as_posix(),
+        "artifacts": {
+            "inspect_project_json": "inspect-project.json",
+            "inspect_project_txt": "inspect-project.txt",
+        },
+        "scopes": [
+            {
+                "scope": row["scope"],
+                "inspect": row.get("inspect_artifacts", {}),
+                "matched_files": row.get("matched_files", []),
+            }
+            for row in sorted(inspect_runs, key=lambda item: str(item["scope"]))
+        ],
+        "compare": sorted(compare_runs, key=lambda item: str(item["scope"])),
+    }
+
+    inspect_project_json = run_root / "inspect-project.json"
+    inspect_project_txt = run_root / "inspect-project.txt"
+    manifest_json = run_root / "manifest.json"
+    inspect_project_json.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    inspect_project_txt.write_text(_render_text(payload), encoding="utf-8")
+    manifest_json.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    if not ns.no_workspace:
+        workspace_entry = record_workspace_run(
+            workspace_root=Path(ns.workspace_root),
+            workflow="inspect-project",
+            scope=_safe_slug(project_dir.name),
+            payload=payload,
+            artifacts={
+                "inspect_project_json": inspect_project_json.as_posix(),
+                "inspect_project_txt": inspect_project_txt.as_posix(),
+                "inspect_project_manifest": manifest_json.as_posix(),
+            },
+            recommendations=[f["message"] for f in ordered_findings[:10]],
+        )
+        payload["workspace"] = workspace_entry
+        inspect_project_json.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    output = json.dumps(payload, sort_keys=True) if ns.format == "json" else _render_text(payload)
+    sys.stdout.write(output + ("\n" if not output.endswith("\n") else ""))
+    return EXIT_OK if payload["ok"] else EXIT_FINDINGS
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -17,6 +17,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "kv" in out
     assert "inspect" in out
     assert "inspect-compare" in out
+    assert "inspect-project" in out
     assert "apiget" in out
     assert "doctor" in out
     assert "patch" in out

--- a/tests/test_inspect_project.py
+++ b/tests/test_inspect_project.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_project(project: Path) -> None:
+    (project / "data").mkdir(parents=True, exist_ok=True)
+    (project / "data" / "orders.csv").write_text(
+        "id,status,amount\nA1,ok,10\nA2,ok,20\n", encoding="utf-8"
+    )
+    (project / "data" / "snapshot.json").write_text(
+        json.dumps([{"entity_id": "A1"}, {"entity_id": "A2"}], indent=2), encoding="utf-8"
+    )
+    (project / "rules.json").write_text(
+        json.dumps(
+            {
+                "files": {
+                    "orders.csv": {
+                        "required_columns": ["id", "status", "amount"],
+                        "key_columns": ["id"],
+                        "id_column": "id",
+                        "expected_ids": ["A1", "A2"],
+                    },
+                    "snapshot.json": {
+                        "id_column": "entity_id",
+                    },
+                },
+                "cross_file_rules": [
+                    {
+                        "name": "orders_covered",
+                        "left_file": "orders.csv",
+                        "left_id_column": "id",
+                        "right_file": "snapshot.json",
+                        "right_id_column": "entity_id",
+                        "mode": "left_subset",
+                    }
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (project / "inspect-project.json").write_text(
+        json.dumps(
+            {
+                "inputs": {
+                    "scopes": [
+                        {
+                            "name": "core-data",
+                            "include": ["data/orders.csv", "data/snapshot.json"],
+                        }
+                    ]
+                },
+                "rules": {"rules_file": "rules.json"},
+                "compare": {
+                    "baseline": "latest_vs_previous",
+                    "thresholds": {
+                        "id_drift_files": 0,
+                        "schema_drift_files": 0,
+                    },
+                },
+                "precedence": {"weights": {"compare_threshold": 5, "compare_drift": 10}},
+                "outputs": {"scope_dir": "dataset-scopes"},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_inspect_project_cli_repeat_is_stable(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    workspace = tmp_path / "workspace"
+    out = tmp_path / "out"
+    _write_project(project)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "sdetkit",
+        "inspect-project",
+        str(project),
+        "--workspace-root",
+        str(workspace),
+        "--out-dir",
+        str(out),
+        "--format",
+        "json",
+    ]
+
+    first = subprocess.run(cmd, text=True, capture_output=True)
+    assert first.returncode == 0
+    payload1 = json.loads(first.stdout)
+    manifest1 = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert payload1["workflow"] == "inspect-project"
+    assert payload1["ok"] is True
+    assert manifest1["scopes"][0]["scope"] == "core-data"
+
+    second = subprocess.run(cmd, text=True, capture_output=True)
+    assert second.returncode == 0
+    payload2 = json.loads(second.stdout)
+    assert payload1["workspace"]["run_hash"] == payload2["workspace"]["run_hash"]
+
+
+def test_inspect_project_detects_compare_drift(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    workspace = tmp_path / "workspace"
+    out = tmp_path / "out"
+    _write_project(project)
+
+    base_cmd = [
+        sys.executable,
+        "-m",
+        "sdetkit",
+        "inspect-project",
+        str(project),
+        "--workspace-root",
+        str(workspace),
+        "--out-dir",
+        str(out),
+        "--format",
+        "json",
+    ]
+    first = subprocess.run(base_cmd, text=True, capture_output=True)
+    assert first.returncode == 0
+
+    (project / "data" / "orders.csv").write_text(
+        "id,status,amount\nA1,ok,10\nA2,ok,20\nA3,new,30\n", encoding="utf-8"
+    )
+
+    second = subprocess.run(base_cmd, text=True, capture_output=True)
+    assert second.returncode == 2
+    payload = json.loads(second.stdout)
+    assert payload["summary"]["compare_fail_scopes"] == 1
+    assert any(item["kind"] == "compare_threshold" for item in payload["findings"])
+    scope_manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert scope_manifest["compare"]


### PR DESCRIPTION
### Motivation
- Provide a reusable, higher-level workflow to run inspection policies over a project with multiple dataset scopes and automated compare baselines. 
- Make the inspect and inspect-compare logic programmatically usable so other commands (like `inspect-project`) can orchestrate runs and record workspace artifacts.

### Description
- Added a new CLI subcommand `inspect-project` and a new module `sdetkit.inspect_project` that materializes scopes, runs `inspect` per-scope, optionally compares against previous workspace runs, and emits a project manifest and summary payload. 
- Refactored `sdetkit.inspect_data` to expose `run_inspect(...)` which performs the inspect workflow and returns `(rc, payload, json_path, txt_path)` and to raise `ValueError` on validation errors instead of writing directly to `stderr`. 
- Refactored `sdetkit.inspect_compare` to expose `run_compare(...)` with the same return signature and updated behavior to raise `ValueError` for malformed inputs, while keeping a `main` wrapper for CLI compatibility. 
- Wired the new `inspect-project` subparser into the CLI in `sdetkit.cli` so `sdetkit inspect-project` dispatches to the new module, and updated help tests to include the new command.

### Testing
- Ran the test suite with `pytest` including the modified help test `tests/test_cli_help_lists_subcommands.py` and the new integration-style tests in `tests/test_inspect_project.py`. 
- `tests/test_cli_help_lists_subcommands.py` passed and now asserts that `inspect-project` appears in the top-level help. 
- `tests/test_inspect_project.py` (which exercises project creation, repeatable workspace runs, and compare drift detection) passed in local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d99da00d2c83329d2a06676e8ccc4e)