### PR TITLE
Add front-door `sdetkit review` orchestration workflow

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -272,6 +272,15 @@ Then use stability-aware command discovery:
     inspect_project_parser.add_argument("--out-dir", default=None)
     inspect_project_parser.add_argument("--format", choices=["text", "json"], default=None)
     inspect_project_parser.add_argument("--no-workspace", action="store_true")
+    review_parser = sub.add_parser(
+        "review",
+        help="[Public / stable] Front-door workflow that orchestrates doctor/inspect/judgment/history",
+    )
+    review_parser.add_argument("path")
+    review_parser.add_argument("--workspace-root", default=None)
+    review_parser.add_argument("--out-dir", default=None)
+    review_parser.add_argument("--format", choices=["text", "json"], default=None)
+    review_parser.add_argument("--no-workspace", action="store_true")
 
     ag = sub.add_parser("apiget", help="Deterministic HTTP JSON fetch and replay helper")
     _add_apiget_args(ag)
@@ -1300,6 +1309,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         if ns.no_workspace:
             forwarded.append("--no-workspace")
         return _run_module_main("sdetkit.inspect_project", forwarded)
+    if ns.cmd == "review":
+        forwarded = [ns.path]
+        if ns.workspace_root:
+            forwarded.extend(["--workspace-root", ns.workspace_root])
+        if ns.out_dir:
+            forwarded.extend(["--out-dir", ns.out_dir])
+        if ns.format:
+            forwarded.extend(["--format", ns.format])
+        if ns.no_workspace:
+            forwarded.append("--no-workspace")
+        return _run_module_main("sdetkit.review", forwarded)
 
     if ns.cmd == "patch":
         return _run_module_main("sdetkit.patch", ns.args)

--- a/src/sdetkit/public_command_surface.json
+++ b/src/sdetkit/public_command_surface.json
@@ -7,6 +7,7 @@
     "python -m sdetkit doctor"
   ],
   "public_stable_front_door_commands": [
+    "review",
     "gate",
     "doctor",
     "release"

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -56,6 +56,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
             "ci",
             "kv",
             "inspect",
+            "review",
             "apiget",
             "cassette-get",
             "patch",

--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import doctor, inspect_project
+from .evidence_workspace import load_workspace_manifest, record_workspace_run
+from .inspect_compare import run_compare
+from .inspect_data import run_inspect
+from .judgment import build_judgment, load_latest_previous_payload
+
+SCHEMA_VERSION = "sdetkit.review.v1"
+EXIT_OK = 0
+EXIT_FINDINGS = 2
+
+
+def _safe_slug(value: str) -> str:
+    out: list[str] = []
+    for ch in value.lower():
+        if ch.isalnum() or ch in {"-", "_", "."}:
+            out.append(ch)
+        else:
+            out.append("-")
+    slug = "".join(out).strip("-")
+    return slug or "review"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"review: expected JSON object at {path}")
+    return loaded
+
+
+def _detect_mode(target: Path) -> dict[str, bool]:
+    is_dir = target.is_dir()
+    repo_like = is_dir and ((target / ".git").exists() or (target / "pyproject.toml").exists())
+    policy_project = is_dir and (target / "inspect-project.json").exists()
+    data_like = False
+    if target.is_file() and target.suffix.lower() in {".csv", ".json"}:
+        data_like = True
+    elif is_dir:
+        data_files = [
+            p
+            for p in target.rglob("*")
+            if p.is_file() and p.suffix.lower() in {".csv", ".json"} and ".sdetkit" not in p.parts
+        ]
+        data_like = bool(data_files)
+    workspace_like = is_dir and ((target / ".sdetkit" / "workspace" / "manifest.json").exists())
+    return {
+        "repo_like": repo_like,
+        "policy_project": policy_project,
+        "data_like": data_like,
+        "workspace_like": workspace_like,
+    }
+
+
+def _run_doctor(target: Path, out_dir: Path, workspace_root: Path, no_workspace: bool) -> tuple[int, dict[str, Any], Path]:
+    doctor_json = out_dir / "doctor.json"
+    args = [
+        "--json",
+        "--repo",
+        "--ci",
+        "--deps",
+        "--clean-tree",
+        "--workspace-root",
+        str(workspace_root),
+        "--out",
+        str(doctor_json),
+    ]
+    if no_workspace:
+        args.append("--no-workspace")
+    buf_out = io.StringIO()
+    buf_err = io.StringIO()
+    # doctor operates on cwd repo state.
+    with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
+        try:
+            rc = doctor.main(args)
+        except SystemExit as exc:
+            rc = int(exc.code)
+    payload = _load_json(doctor_json)
+    return int(rc), payload, doctor_json
+
+
+def _review_scope_for_target(target: Path) -> str:
+    return _safe_slug(target.resolve().as_posix())
+
+
+def _summarize_changed(previous: dict[str, Any] | None, current: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(previous, dict):
+        return [{"kind": "baseline", "message": "No previous review run found for this scope."}]
+    changes: list[dict[str, Any]] = []
+    prev_actions = previous.get("prioritized_actions", [])
+    cur_actions = current.get("prioritized_actions", [])
+    prev_now = len([a for a in prev_actions if isinstance(a, dict) and a.get("tier") == "now"])
+    cur_now = len([a for a in cur_actions if isinstance(a, dict) and a.get("tier") == "now"])
+    if prev_now != cur_now:
+        changes.append(
+            {
+                "kind": "action_pressure",
+                "message": f"immediate_actions changed {prev_now} -> {cur_now}",
+            }
+        )
+    prev_status = str(previous.get("status", ""))
+    cur_status = str(current.get("status", ""))
+    if prev_status != cur_status:
+        changes.append({"kind": "status", "message": f"status changed {prev_status} -> {cur_status}"})
+    prev_sev = str(previous.get("severity", ""))
+    cur_sev = str(current.get("severity", ""))
+    if prev_sev != cur_sev:
+        changes.append({"kind": "severity", "message": f"severity changed {prev_sev} -> {cur_sev}"})
+    return changes or [{"kind": "stable", "message": "No material review-level changes detected."}]
+
+
+def run_review(
+    *,
+    target: Path,
+    out_dir: Path,
+    workspace_root: Path,
+    no_workspace: bool = False,
+) -> tuple[int, dict[str, Any], Path, Path]:
+    target = target.resolve()
+    if not target.exists():
+        raise ValueError(f"review: path does not exist: {target}")
+
+    detection = _detect_mode(target)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    source_workflows: list[dict[str, Any]] = []
+    supporting: list[dict[str, Any]] = []
+    conflicting: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+    healthy_controls: list[str] = []
+    prioritized_actions: list[dict[str, Any]] = []
+    artifact_index: dict[str, str] = {}
+
+    # deterministic order: doctor -> inspect -> inspect-compare -> inspect-project -> history
+    if detection["repo_like"]:
+        doctor_out = out_dir / "doctor"
+        doctor_out.mkdir(parents=True, exist_ok=True)
+        prev_cwd = Path.cwd()
+        try:
+            if target.is_dir():
+                import os
+
+                os.chdir(target)
+            doctor_rc, doctor_payload, doctor_json = _run_doctor(
+                target,
+                doctor_out,
+                workspace_root,
+                no_workspace,
+            )
+        finally:
+            import os
+
+            os.chdir(prev_cwd)
+        artifact_index["doctor_json"] = doctor_json.as_posix()
+        source_workflows.append({"workflow": "doctor", "status": "ok" if doctor_rc == 0 else "findings"})
+        if doctor_rc == 0:
+            healthy_controls.append("doctor checks passed for repo hygiene and release controls")
+        else:
+            findings.append(
+                {
+                    "id": "review:doctor",
+                    "kind": "doctor",
+                    "severity": "high",
+                    "priority": 70,
+                    "why_it_matters": "doctor reported repo-level release risks",
+                    "next_action": "Address failing doctor checks before promotion decisions.",
+                    "message": "doctor reported findings",
+                }
+            )
+            prioritized_actions.append(
+                {
+                    "tier": "now",
+                    "priority": 70,
+                    "action": "Fix doctor failures in repo governance and hygiene checks.",
+                }
+            )
+        supporting.append({"kind": "doctor_ok", "value": bool(doctor_payload.get("ok", False))})
+
+    inspect_payload: dict[str, Any] | None = None
+    if detection["data_like"] and not detection["policy_project"]:
+        inspect_out = out_dir / "inspect"
+        inspect_rc, inspect_payload, inspect_json_path, inspect_txt_path = run_inspect(
+            input_path=target,
+            out_dir=inspect_out,
+            workspace_root=workspace_root,
+            record_workspace=not no_workspace,
+            workspace_scope=_review_scope_for_target(target),
+        )
+        artifact_index["inspect_json"] = inspect_json_path.as_posix()
+        artifact_index["inspect_txt"] = inspect_txt_path.as_posix()
+        source_workflows.append({"workflow": "inspect", "status": "ok" if inspect_rc == 0 else "findings"})
+        supporting.append({"kind": "inspect_files", "value": inspect_payload.get("summary", {}).get("files_analyzed", 0)})
+        if inspect_rc == 0:
+            healthy_controls.append("inspect evidence diagnostics are stable")
+        else:
+            findings.append(
+                {
+                    "id": "review:inspect",
+                    "kind": "inspect",
+                    "severity": "high",
+                    "priority": 65,
+                    "why_it_matters": "inspect surfaced suspicious evidence or rule failures",
+                    "next_action": "Investigate inspect anomalies and resolve suspicious signals.",
+                    "message": "inspect reported findings",
+                }
+            )
+            prioritized_actions.append(
+                {
+                    "tier": "now",
+                    "priority": 65,
+                    "action": "Resolve inspect evidence anomalies and rerun review.",
+                }
+            )
+
+    if detection["policy_project"]:
+        project_out = out_dir / "inspect-project"
+        rc = inspect_project.main(
+            [
+                str(target),
+                "--workspace-root",
+                str(workspace_root),
+                "--out-dir",
+                str(project_out),
+                "--format",
+                "json",
+                *( ["--no-workspace"] if no_workspace else []),
+            ]
+        )
+        payload = _load_json(project_out / "inspect-project.json")
+        artifact_index["inspect_project_json"] = (project_out / "inspect-project.json").as_posix()
+        artifact_index["inspect_project_txt"] = (project_out / "inspect-project.txt").as_posix()
+        source_workflows.append({"workflow": "inspect-project", "status": "ok" if rc == 0 else "findings"})
+        supporting.append({"kind": "inspect_project_scopes", "value": payload.get("summary", {}).get("scopes", 0)})
+        if rc != 0:
+            findings.append(
+                {
+                    "id": "review:inspect-project",
+                    "kind": "inspect-project",
+                    "severity": "high",
+                    "priority": 60,
+                    "why_it_matters": "inspect-project policy pack found high-signal scope risks",
+                    "next_action": "Remediate failing scopes in inspect-project outputs.",
+                    "message": "inspect-project reported findings",
+                }
+            )
+
+    if inspect_payload and not no_workspace:
+        scope = _review_scope_for_target(target)
+        previous_inspect, _ = load_latest_previous_payload(
+            workspace_root=workspace_root,
+            workflow="inspect",
+            scope=scope,
+        )
+        if isinstance(previous_inspect, dict):
+            compare_out = out_dir / "inspect-compare"
+            compare_rc, compare_payload, compare_json, compare_txt = run_compare(
+                left_payload=previous_inspect,
+                right_payload=inspect_payload,
+                left_label="workspace:previous",
+                right_label="workspace:current",
+                out_dir=compare_out,
+                out_scope=scope,
+                workspace_root=workspace_root,
+                record_workspace=not no_workspace,
+            )
+            artifact_index["inspect_compare_json"] = compare_json.as_posix()
+            artifact_index["inspect_compare_txt"] = compare_txt.as_posix()
+            source_workflows.append(
+                {"workflow": "inspect-compare", "status": "ok" if compare_rc == 0 else "findings"}
+            )
+            drift_score = int(compare_payload.get("summary", {}).get("drift_score", 0))
+            supporting.append({"kind": "drift_score", "value": drift_score})
+            if compare_rc != 0:
+                findings.append(
+                    {
+                        "id": "review:inspect-compare",
+                        "kind": "inspect-compare",
+                        "severity": "medium",
+                        "priority": min(55, 20 + drift_score * 4),
+                        "why_it_matters": "recent evidence drift changed baseline behavior",
+                        "next_action": "Review drift files and approve intended changes.",
+                        "message": "inspect-compare detected drift",
+                    }
+                )
+
+    if detection["workspace_like"]:
+        manifest = load_workspace_manifest(target / ".sdetkit" / "workspace")
+        supporting.append({"kind": "workspace_runs", "value": len(manifest.get("runs", []))})
+        source_workflows.append({"workflow": "workspace-history", "status": "ok"})
+
+    # contradictions as first-class product output
+    has_doctor_failure = any(f.get("kind") == "doctor" for f in findings)
+    has_inspect_failure = any(f.get("kind") == "inspect" for f in findings)
+    if has_doctor_failure and not has_inspect_failure:
+        conflicting.append(
+            {
+                "id": "review:conflict:repo-vs-data",
+                "kind": "cross_surface_disagreement",
+                "message": "Repo controls fail while local evidence diagnostics appear healthy.",
+            }
+        )
+    if has_inspect_failure and not has_doctor_failure and detection["repo_like"]:
+        conflicting.append(
+            {
+                "id": "review:conflict:data-vs-repo",
+                "kind": "cross_surface_disagreement",
+                "message": "Repo controls pass while evidence diagnostics show anomalies.",
+            }
+        )
+
+    completeness = min(1.0, max(0.2, len(source_workflows) / 5.0))
+    stability = 0.7 if conflicting else 0.85
+    workflow_ok = len(findings) == 0
+    blocking = any(int(item.get("priority", 0)) >= 60 for item in findings) or bool(conflicting)
+
+    review_judgment = build_judgment(
+        workflow="review",
+        findings=findings,
+        supporting_evidence=supporting,
+        conflicting_evidence=conflicting,
+        completeness=completeness,
+        stability=stability,
+        previous_summary=None,
+        workflow_ok=workflow_ok,
+        blocking=blocking,
+    )
+
+    prioritized_actions.extend(review_judgment.get("recommendations", []))
+    review_scope = _review_scope_for_target(target)
+    previous_review = None
+    previous_hash = None
+    if not no_workspace:
+        previous_review, previous_hash = load_latest_previous_payload(
+            workspace_root=workspace_root,
+            workflow="review",
+            scope=review_scope,
+        )
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "tool": "sdetkit",
+        "workflow": "review",
+        "path": target.as_posix(),
+        "status": review_judgment.get("status"),
+        "severity": review_judgment.get("severity"),
+        "confidence": review_judgment.get("confidence", {}),
+        "review_status": "PASS" if workflow_ok else "ATTENTION",
+        "top_matters": review_judgment.get("top_judgment", {}).get("what_matters_most", []),
+        "supporting_evidence": supporting,
+        "conflicting_evidence": conflicting,
+        "healthy_controls": healthy_controls,
+        "changed_since_previous": [],
+        "prioritized_actions": prioritized_actions[:8],
+        "source_workflows_run": source_workflows,
+        "artifact_index": artifact_index,
+        "judgment": review_judgment,
+        "history": {
+            "workspace_root": workspace_root.as_posix(),
+            "has_previous_review": bool(previous_review),
+            "previous_review_run_hash": previous_hash,
+        },
+        "detection": detection,
+    }
+    payload["changed_since_previous"] = _summarize_changed(previous_review, payload)
+
+    json_path = out_dir / "review.json"
+    txt_path = out_dir / "review.txt"
+    json_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    txt_path.write_text(_render_text(payload), encoding="utf-8")
+
+    if not no_workspace:
+        workspace_entry = record_workspace_run(
+            workspace_root=workspace_root,
+            workflow="review",
+            scope=review_scope,
+            payload=payload,
+            artifacts={"review_json": json_path.as_posix(), "review_text": txt_path.as_posix()},
+            recommendations=[str(item.get("action", "")) for item in payload.get("prioritized_actions", []) if isinstance(item, dict)],
+        )
+        payload["workspace"] = workspace_entry
+        json_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    rc = EXIT_OK if payload["status"] == "pass" else EXIT_FINDINGS
+    return rc, payload, json_path, txt_path
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"SDETKit review: {payload['review_status']}",
+        f"path: {payload['path']}",
+        f"status: {payload['status']} severity: {payload['severity']}",
+        f"confidence: {payload.get('confidence', {}).get('score')}",
+        "top_matters:",
+    ]
+    for item in payload.get("top_matters", [])[:5]:
+        if not isinstance(item, dict):
+            continue
+        lines.append(f"- [{item.get('priority', 0)}] {item.get('kind')}: {item.get('message')}")
+    lines.append("what_to_do_now:")
+    for action in payload.get("prioritized_actions", []):
+        if not isinstance(action, dict):
+            continue
+        if str(action.get("tier")) == "now":
+            lines.append(f"- {action.get('action')}")
+    lines.append("what_to_do_next:")
+    for action in payload.get("prioritized_actions", []):
+        if not isinstance(action, dict):
+            continue
+        if str(action.get("tier")) == "next":
+            lines.append(f"- {action.get('action')}")
+    lines.append("what_to_monitor:")
+    for action in payload.get("prioritized_actions", []):
+        if not isinstance(action, dict):
+            continue
+        if str(action.get("tier")) == "monitor":
+            lines.append(f"- {action.get('action')}")
+    if payload.get("conflicting_evidence"):
+        lines.append(f"conflicts: {len(payload['conflicting_evidence'])}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sdetkit review",
+        description="Front-door SDETKit review workflow that orchestrates doctor/inspect/compare/project/history.",
+    )
+    p.add_argument("path", help="Repo/data/project/workspace path to review")
+    p.add_argument("--workspace-root", default=".sdetkit/workspace", help="Shared workspace root")
+    p.add_argument("--out-dir", default=None, help="Output directory (default: .sdetkit/review/<path-slug>)")
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.add_argument("--no-workspace", action="store_true", help="Disable workspace history recording")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_arg_parser().parse_args(argv)
+    target = Path(ns.path)
+    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "review" / _safe_slug(target.resolve().name)
+    try:
+        rc, payload, _, _ = run_review(
+            target=target,
+            out_dir=out_dir,
+            workspace_root=Path(ns.workspace_root),
+            no_workspace=ns.no_workspace,
+        )
+    except ValueError as exc:
+        sys.stderr.write(str(exc) + "\n")
+        return EXIT_FINDINGS
+
+    output = json.dumps(payload, sort_keys=True) if ns.format == "json" else _render_text(payload)
+    sys.stdout.write(output + ("\n" if not output.endswith("\n") else ""))
+    return rc
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -18,6 +18,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "inspect" in out
     assert "inspect-compare" in out
     assert "inspect-project" in out
+    assert "review" in out
     assert "apiget" in out
     assert "doctor" in out
     assert "patch" in out

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from sdetkit import review
+
+
+def test_review_repeated_run_tracks_changes_and_compare_artifacts(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    data = tmp_path / "orders.csv"
+    out = tmp_path / "review-out"
+
+    data.write_text("id,status\nA1,ok\n", encoding="utf-8")
+    rc1, payload1, _, _ = review.run_review(
+        target=data,
+        out_dir=out,
+        workspace_root=workspace,
+    )
+    assert rc1 == 0
+    assert payload1["workflow"] == "review"
+    assert payload1["history"]["has_previous_review"] is False
+
+    data.write_text("id,status\nA1,ok\nA1,ok\n", encoding="utf-8")
+    rc2, payload2, json_path, txt_path = review.run_review(
+        target=data,
+        out_dir=out,
+        workspace_root=workspace,
+    )
+
+    assert rc2 == 2
+    assert json_path.exists()
+    assert txt_path.exists()
+    assert payload2["history"]["has_previous_review"] is True
+    assert payload2["changed_since_previous"][0]["kind"] in {"status", "severity", "action_pressure", "stable"}
+    assert "inspect_compare_json" in payload2["artifact_index"]
+
+
+def test_review_repo_plus_data_surfaces_cross_surface_conflict(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "data.csv").write_text("id,status\nA1,ok\n", encoding="utf-8")
+
+    rc, payload, _, _ = review.run_review(
+        target=repo,
+        out_dir=tmp_path / "out",
+        workspace_root=tmp_path / "workspace",
+        no_workspace=True,
+    )
+
+    assert rc == 2
+    assert payload["detection"]["repo_like"] is True
+    assert payload["detection"]["data_like"] is True
+    assert payload["conflicting_evidence"]
+
+
+def test_cli_review_command_outputs_json(tmp_path: Path) -> None:
+    data = tmp_path / "events.csv"
+    data.write_text("id,type\nE1,open\n", encoding="utf-8")
+
+    run = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "review",
+            str(data),
+            "--workspace-root",
+            str(tmp_path / "workspace"),
+            "--format",
+            "json",
+            "--no-workspace",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert run.returncode == 0
+    payload = json.loads(run.stdout)
+    assert payload["workflow"] == "review"
+    assert payload["path"].endswith("events.csv")


### PR DESCRIPTION
### Motivation
- SDETKit exposed many strong individual surfaces (`doctor`, `inspect`, `inspect-compare`, `inspect-project`) but lacked a single front-door that synthesizes them into one product-style review.  
- Users had to manually run and stitch multiple commands to answer "what matters now", which made the product feel like a toolbox rather than a unified system.  
- A deterministic, history-aware orchestration that reuses existing logic and judgment is the natural next product step to provide a single actionable review contract.

### Description
- Added a new orchestration module `src/sdetkit/review.py` that auto-detects `repo|data|policy-project|workspace` modes and deterministically runs underlying surfaces in order: `doctor` -> `inspect` -> `inspect-compare` (when prior runs exist) -> `inspect-project` -> workspace history.  
- The `review` workflow builds a unified payload (and human text) that includes `status`, `severity`, `confidence`, `top_matters`, `supporting/conflicting_evidence`, `healthy_controls`, `changed_since_previous`, `prioritized_actions`, `source_workflows_run`, and an `artifact_index`, and records runs into the evidence workspace.  
- Surface-level CLI wiring and discoverability were added by registering `review` in `src/sdetkit/cli.py` and updating command metadata in `src/sdetkit/public_surface_contract.py` and `src/sdetkit/public_command_surface.json`.  
- Tests and a product-oriented test harness were added/updated under `tests/` (`tests/test_review.py`, updated `tests/test_cli_help_lists_subcommands.py`) to validate repeat-run history, cross-surface contradictions, artifact emission, and CLI behavior.

### Testing
- Ran targeted new tests: `pytest -q tests/test_review.py tests/test_cli_help_lists_subcommands.py`, result: `5 passed`.  
- Wider confidence pass on touched surfaces: `pytest -q tests/test_inspect_compare.py tests/test_cli_sdetkit.py tests/test_cli_doctor.py tests/test_doctor_baseline.py`, result: `24 passed`.  
- All exercised tests passed and verified CLI wiring, workspace history recording, inspect-compare artifact emission, and contradiction surfacing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9aadaeaf08332a1e1480f0fe0ff6f)