### PR TITLE
Add contradiction clustering and adaptive probe feedback to review engine

### DIFF
--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -15,11 +15,14 @@ from .inspect_compare import run_compare
 from .inspect_data import run_inspect
 from .judgment import build_judgment, load_latest_previous_payload
 from .review_engine import (
+    apply_probe_result_feedback,
     build_contradiction_graph,
+    build_contradiction_clusters,
     build_staged_plan,
     decide_escalation,
     decide_stop,
     investigation_confidence,
+    plan_adaptive_probes,
     profile_confidence_level,
     profile_priority_tier,
     profile_weighted_priority,
@@ -523,7 +526,8 @@ def run_review(
             )
 
     # contradictions as first-class product output (baseline signal set)
-    conflicting.extend(build_contradiction_graph(findings=findings, detection=detection))
+    contradiction_graph = build_contradiction_clusters(findings=findings, detection=detection)
+    conflicting.extend(contradiction_graph.get("flat_contradictions", []))
 
     baseline_confidence = investigation_confidence(
         source_workflows=source_workflows,
@@ -540,6 +544,16 @@ def run_review(
     adaptive_plan["escalation"] = escalation.as_dict()
     deepen_checks = list(deepen_stage.get("checks_planned", []))
     deepen_stage["ran"] = escalation.needed
+    probe_decision = plan_adaptive_probes(
+        detection=detection,
+        profile_name=selected_profile.name,
+        findings=findings,
+        contradiction_graph=contradiction_graph,
+        has_previous_review=False,
+        changed=[],
+    )
+    adaptive_plan["executed_probes"] = probe_decision["executed_probes"]
+    adaptive_plan["skipped_probes"] = probe_decision["skipped_probes"]
 
     if inspect_payload and "inspect-compare" in deepen_checks and escalation.needed and not no_workspace:
         scope = _review_scope_for_target(target)
@@ -582,12 +596,20 @@ def run_review(
                         "message": "inspect-compare detected drift",
                     }
                 )
+            for row in adaptive_plan.get("executed_probes", []):
+                if isinstance(row, dict) and row.get("probe_id") == "probe:inspect-compare":
+                    row["status"] = "executed"
+                    row["result"] = "findings" if compare_rc != 0 else "ok"
 
     if "workspace-history" in deepen_checks and escalation.needed and detection["workspace_like"]:
         manifest = load_workspace_manifest(target / ".sdetkit" / "workspace")
         supporting.append({"kind": "workspace_runs", "value": len(manifest.get("runs", []))})
         source_workflows.append({"workflow": "workspace-history", "status": "ok"})
         deepen_stage["checks_run"].append({"check": "workspace-history", "status": "ok"})
+        for row in adaptive_plan.get("executed_probes", []):
+            if isinstance(row, dict) and row.get("probe_id") == "probe:workspace-history":
+                row["status"] = "executed"
+                row["result"] = "ok"
 
     weighted_findings = [{**item, "priority": profile_weighted_priority(item, selected_profile)} for item in findings]
     weighted_conflicts = [
@@ -700,17 +722,64 @@ def run_review(
         "detection": detection,
     }
     payload["changed_since_previous"] = summarize_history_delta(previous_review, payload)
+    probe_decision = plan_adaptive_probes(
+        detection=detection,
+        profile_name=selected_profile.name,
+        findings=weighted_findings,
+        contradiction_graph=contradiction_graph,
+        has_previous_review=bool(previous_review),
+        changed=payload["changed_since_previous"],
+    )
+    existing_probe_results = {
+        str(row.get("probe_id")): row
+        for row in adaptive_plan.get("executed_probes", [])
+        if isinstance(row, dict) and row.get("status") == "executed"
+    }
+    merged_executed: list[dict[str, Any]] = []
+    for row in probe_decision["executed_probes"]:
+        existing = existing_probe_results.get(str(row.get("probe_id")))
+        merged_executed.append(existing if existing else row)
+    adaptive_plan["executed_probes"] = merged_executed
+    adaptive_plan["skipped_probes"] = probe_decision["skipped_probes"]
     likely_tracks = rank_likely_issue_tracks(
         findings=weighted_findings,
         conflicts=weighted_conflicts,
         changed=payload["changed_since_previous"],
     )
     payload["likely_issue_tracks"] = likely_tracks
+    payload["contradiction_graph"] = contradiction_graph
+    probe_feedback = apply_probe_result_feedback(
+        findings=weighted_findings,
+        conflicts=weighted_conflicts,
+        likely_tracks=likely_tracks,
+        executed_probes=[row for row in adaptive_plan.get("executed_probes", []) if row.get("status") == "executed"],
+    )
+    payload["adaptive_review"]["probe_feedback"] = probe_feedback
+    payload["adaptive_review"]["probe_rationale"] = [
+        {
+            "probe_id": row.get("probe_id"),
+            "why_chosen": row.get("reason"),
+        }
+        for row in adaptive_plan.get("executed_probes", [])
+        if isinstance(row, dict)
+    ]
+    for update in probe_feedback.get("track_updates", []):
+        if not isinstance(update, dict):
+            continue
+        for track in payload["likely_issue_tracks"]:
+            if isinstance(track, dict) and track.get("track_id") == update.get("track_id"):
+                track["likelihood"] = update.get("adjusted_likelihood", track.get("likelihood"))
+                track["probe_impact"] = {
+                    "base_likelihood": update.get("base_likelihood"),
+                    "adjusted_likelihood": update.get("adjusted_likelihood"),
+                }
+                break
     final_confidence = investigation_confidence(
         source_workflows=source_workflows,
         findings=weighted_findings,
         conflicts=weighted_conflicts,
     )
+    final_confidence = round(max(0.0, min(1.0, final_confidence + float(probe_feedback.get("confidence_delta", 0.0)))), 2)
     adaptive_plan["stop_decision"] = decide_stop(
         final_confidence=final_confidence,
         confidence_threshold=selected_profile.confidence_medium,
@@ -815,6 +884,11 @@ def _render_text(payload: dict[str, Any]) -> str:
             lines.append(f"- {action.get('action')}")
     if payload.get("conflicting_evidence"):
         lines.append(f"conflicts: {len(payload['conflicting_evidence'])}")
+    graph = payload.get("contradiction_graph", {})
+    if isinstance(graph, dict):
+        clusters = graph.get("clusters", [])
+        if isinstance(clusters, list) and clusters:
+            lines.append(f"contradiction_clusters: {len(clusters)}")
     adaptive = payload.get("adaptive_review", {})
     if isinstance(adaptive, dict):
         escalation = adaptive.get("escalation", {})
@@ -823,6 +897,7 @@ def _render_text(payload: dict[str, Any]) -> str:
         lines.append(f"- escalation_needed: {escalation.get('needed')}")
         for reason in escalation.get("reasons", [])[:3]:
             lines.append(f"  - reason: {reason}")
+        lines.append(f"- probes_executed: {len([p for p in adaptive.get('executed_probes', []) if p.get('status') == 'executed'])}")
         lines.append(f"- stop: {stop.get('stop')}")
         lines.append(f"- stop_reason: {stop.get('reason')}")
     tracks = payload.get("likely_issue_tracks", [])

--- a/src/sdetkit/review_engine.py
+++ b/src/sdetkit/review_engine.py
@@ -179,6 +179,157 @@ def build_contradiction_graph(
     )
 
 
+def build_contradiction_clusters(
+    *,
+    findings: list[dict[str, Any]],
+    detection: dict[str, bool] | None = None,
+) -> dict[str, Any]:
+    flat = build_contradiction_graph(findings=findings, detection=detection)
+    findings_by_kind: dict[str, list[dict[str, Any]]] = {}
+    for item in findings:
+        kind = str(item.get("kind", "unknown"))
+        findings_by_kind.setdefault(kind, []).append(item)
+    nodes: list[dict[str, Any]] = []
+    for kind, items in sorted(findings_by_kind.items()):
+        nodes.append(
+            {
+                "node_id": f"signal:{kind}",
+                "kind": kind,
+                "count": len(items),
+                "max_priority": max(int(entry.get("priority", 0)) for entry in items),
+            }
+        )
+    edges: list[dict[str, Any]] = []
+    for item in flat:
+        conflict_id = str(item.get("id", "conflict:unknown"))
+        for node in nodes:
+            edges.append(
+                {
+                    "edge_id": f"{conflict_id}->{node['node_id']}",
+                    "relation": "conflicts_with",
+                    "from": conflict_id,
+                    "to": node["node_id"],
+                    "weight": max(1, int(node.get("count", 1))),
+                }
+            )
+    clusters: list[dict[str, Any]] = []
+    if flat:
+        clusters.append(
+            {
+                "cluster_id": "cluster:cross-surface",
+                "kind": "cross_surface_disagreement",
+                "importance": min(100, 35 + len(flat) * 20 + len(nodes) * 8),
+                "contradictions": flat,
+                "signals": [node["kind"] for node in nodes],
+            }
+        )
+    elif len(nodes) >= 2:
+        clusters.append(
+            {
+                "cluster_id": "cluster:multi-signal-tension",
+                "kind": "multi_signal_tension",
+                "importance": min(100, 30 + len(nodes) * 10),
+                "contradictions": [],
+                "signals": [node["kind"] for node in nodes],
+            }
+        )
+    return {
+        "version": "sdetkit.contradiction-graph.v1",
+        "nodes": nodes,
+        "edges": edges,
+        "clusters": clusters,
+        "flat_contradictions": flat,
+    }
+
+
+def plan_adaptive_probes(
+    *,
+    detection: dict[str, bool],
+    profile_name: str,
+    findings: list[dict[str, Any]],
+    contradiction_graph: dict[str, Any],
+    has_previous_review: bool,
+    changed: list[dict[str, Any]],
+    max_probes: int = 2,
+) -> dict[str, list[dict[str, Any]]]:
+    contradictory = len(contradiction_graph.get("flat_contradictions", []))
+    cluster_pressure = len(contradiction_graph.get("clusters", []))
+    finding_pressure = sum(max(0, int(item.get("priority", 0))) for item in findings)
+    history_pressure = len([row for row in changed if str(row.get("kind")) in {"status", "severity"}])
+    candidates = [
+        {
+            "probe_id": "probe:inspect-compare",
+            "requires": "inspect_compare_available",
+            "score": (35 if contradictory else 0)
+            + (cluster_pressure * 12)
+            + (finding_pressure // 6)
+            + (15 if has_previous_review else 0),
+            "reason": "Resolve whether recent evidence drift explains current contradictions/findings.",
+        },
+        {
+            "probe_id": "probe:workspace-history",
+            "requires": "workspace_like",
+            "score": (20 if contradictory else 0) + (history_pressure * 20) + (10 if profile_name == "forensics" else 0),
+            "reason": "Use repeated-run history to verify whether risk is persistent or newly introduced.",
+        },
+    ]
+    executed: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for row in sorted(candidates, key=lambda item: (-int(item["score"]), str(item["probe_id"]))):
+        requires = str(row["requires"])
+        enabled = bool(detection.get("workspace_like")) if requires == "workspace_like" else bool(
+            detection.get("data_like")
+        )
+        should_run = enabled and int(row["score"]) >= 25 and len(executed) < max_probes
+        target = executed if should_run else skipped
+        target.append(
+            {
+                "probe_id": row["probe_id"],
+                "score": int(row["score"]),
+                "reason": row["reason"],
+                "requires": requires,
+                "status": "planned" if should_run else "skipped",
+                "skip_reason": "" if should_run else ("probe preconditions missing or score below threshold"),
+            }
+        )
+    return {"executed_probes": executed, "skipped_probes": skipped}
+
+
+def apply_probe_result_feedback(
+    *,
+    findings: list[dict[str, Any]],
+    conflicts: list[dict[str, Any]],
+    likely_tracks: list[dict[str, Any]],
+    executed_probes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    probe_pressure = len(executed_probes)
+    confidence_delta = 0.08 if probe_pressure > 0 and not findings and not conflicts else -0.03 * probe_pressure
+    status = "stable" if confidence_delta >= 0 else "risk-intensified"
+    track_updates: list[dict[str, Any]] = []
+    for track in likely_tracks[:3]:
+        if not isinstance(track, dict):
+            continue
+        base = float(track.get("likelihood", 0.0))
+        adjusted = round(max(0.0, min(0.99, base + (0.06 if confidence_delta < 0 else -0.04))), 2)
+        track_updates.append(
+            {
+                "track_id": str(track.get("track_id", "")),
+                "base_likelihood": base,
+                "adjusted_likelihood": adjusted,
+            }
+        )
+    return {
+        "confidence_delta": round(confidence_delta, 2),
+        "status": status,
+        "track_updates": track_updates,
+        "judgment_note": (
+            "Probe outcomes reduced uncertainty in critical tracks."
+            if confidence_delta >= 0
+            else "Probe outcomes found additional pressure that increases risk confidence."
+        ),
+    }
+
+
 def summarize_history_delta(previous: dict[str, Any] | None, current: dict[str, Any]) -> list[dict[str, Any]]:
     if not isinstance(previous, dict):
         return [{"kind": "baseline", "message": "No previous review run found for this scope."}]

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -58,6 +58,7 @@ def test_review_repo_plus_data_surfaces_cross_surface_conflict(tmp_path: Path) -
     assert payload["detection"]["repo_like"] is True
     assert payload["detection"]["data_like"] is True
     assert payload["conflicting_evidence"]
+    assert payload["contradiction_graph"]["clusters"]
     assert payload["adaptive_review"]["escalation"]["needed"] is True
 
 
@@ -173,6 +174,7 @@ def test_review_clean_evidence_stops_early_without_deepen_stage(tmp_path: Path) 
     assert payload["adaptive_review"]["escalation"]["needed"] is False
     assert payload["adaptive_review"]["stop_decision"]["stop"] is True
     assert "inspect_compare_json" not in payload["artifact_index"]
+    assert payload["adaptive_review"]["executed_probes"] == []
 
 
 def test_review_tracks_ranked_with_supporting_and_conflicting_evidence(tmp_path: Path) -> None:
@@ -191,3 +193,21 @@ def test_review_tracks_ranked_with_supporting_and_conflicting_evidence(tmp_path:
     assert tracks[0]["supporting_evidence"]
     assert "verification_steps" in tracks[0]
     assert isinstance(tracks[0]["conflicting_evidence"], list)
+    assert "probe_impact" in tracks[0]
+
+
+def test_review_contradiction_cluster_triggers_probe_selection(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    out = tmp_path / "out"
+    workspace = tmp_path / "workspace"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "events.csv").write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
+
+    rc, payload, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
+
+    assert rc == 2
+    clusters = payload["contradiction_graph"]["clusters"]
+    assert clusters
+    probe_ids = {row["probe_id"] for row in payload["adaptive_review"]["executed_probes"]}
+    assert "probe:inspect-compare" in probe_ids


### PR DESCRIPTION
### Motivation
- Improve the adaptive engine so the review understands and reasons about contradictions structurally rather than as a flat list. 
- Enable bounded, deterministic deeper-check probes that the engine can choose and explain to reduce uncertainty. 
- Feed probe outcomes back into confidence, likely-issue tracks, and stop/escalation decisions so probe results materially change judgment.

### Description
- Added `build_contradiction_clusters`, `plan_adaptive_probes`, and `apply_probe_result_feedback` helpers to `src/sdetkit/review_engine.py` to produce nodes/edges/clusters, score and select probes, and compute feedback impact. 
- Integrated contradiction graphing and probe planning into `review.run_review` in `src/sdetkit/review.py`, emitting `contradiction_graph`, `adaptive_review.executed_probes`, `adaptive_review.skipped_probes`, `adaptive_review.probe_rationale`, and `adaptive_review.probe_feedback`. 
- Applied probe results to update final `confidence` and adjust `likely_issue_tracks[*].likelihood` with a `probe_impact` artifact, while preserving backward compatibility via `flat_contradictions`. 
- Surface contradiction cluster counts and executed-probe counts in the textual review output and added unit tests in `tests/test_review.py` to assert clusters, probe selection, no-probe early-stop behavior, and probe impact on tracks.

### Testing
- Ran targeted unit tests with `pytest -q tests/test_review.py::test_review_contradiction_cluster_triggers_probe_selection tests/test_review.py::test_review_clean_evidence_stops_early_without_deepen_stage` and both tests passed (`2 passed`). 
- Ran the full review test file with `pytest -q tests/test_review.py` and it passed (`8 passed`). 
- All automated tests exercised for this change succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c802cfb08332bc950ef46c73a9ce)