### PR TITLE
Persist probe execution memory and use history to influence probe selection

### DIFF
--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -15,6 +15,7 @@ from .inspect_compare import run_compare
 from .inspect_data import run_inspect
 from .judgment import build_judgment, load_latest_previous_payload
 from .review_engine import (
+    apply_probe_memory_update,
     apply_probe_result_feedback,
     build_contradiction_graph,
     build_contradiction_clusters,
@@ -23,6 +24,7 @@ from .review_engine import (
     decide_escalation,
     decide_stop,
     investigation_confidence,
+    normalize_probe_execution_outcomes,
     plan_adaptive_probes,
     profile_confidence_level,
     profile_priority_tier,
@@ -298,6 +300,49 @@ def _load_json(path: Path) -> dict[str, Any]:
     return loaded
 
 
+def _probe_memory_path(*, workspace_root: Path, scope: str) -> Path:
+    return workspace_root / "probe-memory" / "review" / f"{_safe_slug(scope)}.json"
+
+
+def _load_probe_memory(*, workspace_root: Path, scope: str) -> dict[str, Any]:
+    path = _probe_memory_path(workspace_root=workspace_root, scope=scope)
+    if not path.exists():
+        return {"schema_version": "sdetkit.review.probe-memory.v1", "probes": {}}
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        return {"schema_version": "sdetkit.review.probe-memory.v1", "probes": {}}
+    probes = loaded.get("probes", {})
+    loaded["probes"] = probes if isinstance(probes, dict) else {}
+    loaded["schema_version"] = "sdetkit.review.probe-memory.v1"
+    return loaded
+
+
+def _write_probe_memory(*, workspace_root: Path, scope: str, memory: dict[str, Any]) -> str:
+    path = _probe_memory_path(workspace_root=workspace_root, scope=scope)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(memory, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return path.as_posix()
+
+
+def _finalize_probe_lifecycle(adaptive_plan: dict[str, Any]) -> None:
+    executed_rows = adaptive_plan.get("executed_probes", [])
+    skipped_rows = adaptive_plan.get("skipped_probes", [])
+    executed_out: list[dict[str, Any]] = []
+    skipped_out: list[dict[str, Any]] = [row for row in skipped_rows if isinstance(row, dict)]
+    for row in executed_rows if isinstance(executed_rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("status", "")) == "executed":
+            executed_out.append(row)
+            continue
+        moved = dict(row)
+        moved["status"] = "skipped"
+        moved["skip_reason"] = str(row.get("skip_reason", "")) or "probe planned but not executed in deepen stage"
+        skipped_out.append(moved)
+    adaptive_plan["executed_probes"] = executed_out
+    adaptive_plan["skipped_probes"] = skipped_out
+
+
 def _detect_mode(target: Path) -> dict[str, bool]:
     is_dir = target.is_dir()
     repo_like = is_dir and ((target / ".git").exists() or (target / "pyproject.toml").exists())
@@ -390,7 +435,12 @@ def run_review(
     detection = _detect_mode(target)
     selected_profile = _coerce_profile(profile)
     workflow_plan = _workflows_for_profile(detection, selected_profile)
+    review_scope = _review_scope_for_target(target)
     out_dir.mkdir(parents=True, exist_ok=True)
+    probe_memory = _load_probe_memory(workspace_root=workspace_root, scope=review_scope) if not no_workspace else {
+        "schema_version": "sdetkit.review.probe-memory.v1",
+        "probes": {},
+    }
 
     source_workflows: list[dict[str, Any]] = []
     supporting: list[dict[str, Any]] = []
@@ -554,6 +604,7 @@ def run_review(
         changed=[],
         confidence_score=baseline_confidence,
         confidence_threshold=selected_profile.confidence_medium,
+        probe_memory=probe_memory,
     )
     adaptive_plan["executed_probes"] = probe_decision["executed_probes"]
     adaptive_plan["skipped_probes"] = probe_decision["skipped_probes"]
@@ -680,7 +731,6 @@ def run_review(
     review_judgment["recommendations"] = profile_recs
 
     prioritized_actions.extend(review_judgment.get("recommendations", []))
-    review_scope = _review_scope_for_target(target)
     previous_review = None
     previous_hash = None
     if not no_workspace:
@@ -736,6 +786,7 @@ def run_review(
         changed=payload["changed_since_previous"],
         confidence_score=float(review_judgment.get("confidence", {}).get("score", 0.0)),
         confidence_threshold=selected_profile.confidence_medium,
+        probe_memory=probe_memory,
     )
     existing_probe_results = {
         str(row.get("probe_id")): row
@@ -750,6 +801,7 @@ def run_review(
     adaptive_plan["skipped_probes"] = probe_decision["skipped_probes"]
     adaptive_plan["probe_registry"] = probe_decision["registry"]
     adaptive_plan["probe_budget"] = probe_decision["budget"]
+    _finalize_probe_lifecycle(adaptive_plan)
     likely_tracks = rank_likely_issue_tracks(
         findings=weighted_findings,
         conflicts=weighted_conflicts,
@@ -772,6 +824,20 @@ def run_review(
         for row in adaptive_plan.get("executed_probes", [])
         if isinstance(row, dict)
     ]
+    normalized_probe_outcomes = normalize_probe_execution_outcomes(
+        executed_probes=[row for row in adaptive_plan.get("executed_probes", []) if isinstance(row, dict)],
+        findings=weighted_findings,
+        conflicts=weighted_conflicts,
+    )
+    updated_probe_memory, probe_memory_update = apply_probe_memory_update(
+        previous_memory=probe_memory,
+        normalized_outcomes=normalized_probe_outcomes,
+    )
+    payload["adaptive_review"]["probe_memory"] = {
+        "schema_version": updated_probe_memory.get("schema_version"),
+        "normalized_outcomes": normalized_probe_outcomes,
+        "updates": probe_memory_update.get("updates", []),
+    }
     for update in probe_feedback.get("track_updates", []):
         if not isinstance(update, dict):
             continue
@@ -820,6 +886,13 @@ def run_review(
     review_tracks_path.write_text(json.dumps({"tracks": likely_tracks}, sort_keys=True, indent=2) + "\n", encoding="utf-8")
     json_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
     txt_path.write_text(_render_text(payload), encoding="utf-8")
+
+    if not no_workspace:
+        payload["adaptive_review"]["probe_memory"]["workspace_artifact"] = _write_probe_memory(
+            workspace_root=workspace_root,
+            scope=review_scope,
+            memory=updated_probe_memory,
+        )
 
     if not no_workspace:
         workspace_entry = record_workspace_run(

--- a/src/sdetkit/review_engine.py
+++ b/src/sdetkit/review_engine.py
@@ -15,6 +15,146 @@ class ProbeDefinition:
     reason: str
 
 
+def _round2(value: float) -> float:
+    return round(float(value), 2)
+
+
+def derive_probe_score_history_inputs(
+    *,
+    probe_id: str,
+    probe_memory: dict[str, Any] | None,
+    current_track: str,
+) -> tuple[list[dict[str, Any]], int]:
+    memory = probe_memory if isinstance(probe_memory, dict) else {}
+    probes = memory.get("probes", {})
+    probe_stats = probes.get(probe_id, {}) if isinstance(probes, dict) else {}
+    aggregates = probe_stats.get("aggregates", {}) if isinstance(probe_stats, dict) else {}
+    has_history = int(aggregates.get("runs", 0)) > 0
+    avg_usefulness = float(aggregates.get("avg_usefulness", 0.0))
+    avg_cost = float(aggregates.get("avg_cost", 0.0))
+    saturation = float(aggregates.get("repeat_hit_saturation", 0.0))
+    track_payoff_map = aggregates.get("track_payoff", {}) if isinstance(aggregates, dict) else {}
+    track_payoff = float(track_payoff_map.get(current_track, avg_usefulness if avg_usefulness > 0 else 0.5))
+
+    usefulness_delta = int(round((avg_usefulness - 0.5) * 40)) if has_history else 0
+    cost_penalty = int(round((avg_cost / 100.0) * 12)) if has_history else 0
+    saturation_penalty = int(round(saturation * 18)) if has_history else 0
+    track_delta = int(round((track_payoff - 0.5) * 20)) if has_history else 0
+    history_delta = usefulness_delta + track_delta - cost_penalty - saturation_penalty
+    score_inputs = [
+        {"input": "history_avg_usefulness", "value": _round2(avg_usefulness), "weight": "((value-0.5)*40)"},
+        {"input": "history_avg_cost", "value": _round2(avg_cost), "weight": "-((value/100)*12)"},
+        {"input": "history_repeat_hit_saturation", "value": _round2(saturation), "weight": "-(value*18)"},
+        {
+            "input": f"history_track_payoff[{current_track}]",
+            "value": _round2(track_payoff),
+            "weight": "((value-0.5)*20)",
+        },
+        {"input": "history_net_delta", "value": history_delta, "weight": "derived"},
+    ]
+    return score_inputs, history_delta
+
+
+def normalize_probe_execution_outcomes(
+    *,
+    executed_probes: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
+    conflicts: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    findings_count = len(findings)
+    conflicts_count = len(conflicts)
+    context_track = "risk_pressure" if findings_count > 0 or conflicts_count > 0 else "stability"
+    normalized: list[dict[str, Any]] = []
+    for probe in sorted(executed_probes, key=lambda row: str(row.get("probe_id", ""))):
+        if not isinstance(probe, dict):
+            continue
+        if str(probe.get("status", "")) != "executed":
+            continue
+        probe_id = str(probe.get("probe_id", "probe:unknown"))
+        result = str(probe.get("result", "unknown"))
+        cost = int(probe.get("cost", 0))
+        if result == "findings":
+            usefulness = 0.85 if findings_count > 0 or conflicts_count > 0 else 0.7
+        elif result == "ok":
+            usefulness = 0.7 if findings_count == 0 and conflicts_count == 0 else 0.45
+        else:
+            usefulness = 0.3
+        normalized.append(
+            {
+                "probe_id": probe_id,
+                "result": result,
+                "status": "executed",
+                "cost": cost,
+                "usefulness": _round2(usefulness),
+                "cost_normalized": _round2(min(1.0, max(0.0, cost / 100.0))),
+                "hit_key": f"{result}:{context_track}",
+                "context_track": context_track,
+            }
+        )
+    return normalized
+
+
+def apply_probe_memory_update(
+    *,
+    previous_memory: dict[str, Any] | None,
+    normalized_outcomes: list[dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    memory: dict[str, Any] = {"schema_version": "sdetkit.review.probe-memory.v1", "probes": {}}
+    if isinstance(previous_memory, dict):
+        memory["probes"] = previous_memory.get("probes", {}) if isinstance(previous_memory.get("probes"), dict) else {}
+    probes = memory["probes"]
+    run_updates: list[dict[str, Any]] = []
+    for outcome in sorted(normalized_outcomes, key=lambda item: str(item.get("probe_id", ""))):
+        probe_id = str(outcome.get("probe_id", "probe:unknown"))
+        probe_entry = probes.get(probe_id, {}) if isinstance(probes.get(probe_id), dict) else {}
+        history = probe_entry.get("outcomes", [])
+        if not isinstance(history, list):
+            history = []
+        history = [row for row in history if isinstance(row, dict)]
+        history.append(outcome)
+        history = history[-30:]
+
+        uses = [float(row.get("usefulness", 0.0)) for row in history]
+        costs = [int(row.get("cost", 0)) for row in history]
+        avg_usefulness = _round2(sum(uses) / len(uses))
+        avg_cost = _round2(sum(costs) / len(costs))
+
+        tail_result = str(history[-1].get("result", "unknown"))
+        repeat_hits = 1
+        for row in reversed(history[:-1]):
+            if str(row.get("result", "")) == tail_result:
+                repeat_hits += 1
+            else:
+                break
+        saturation = _round2(min(1.0, max(0.0, (repeat_hits - 1) / 3.0)))
+
+        track_buckets: dict[str, list[float]] = {}
+        for row in history:
+            track = str(row.get("context_track", "stability"))
+            track_buckets.setdefault(track, []).append(float(row.get("usefulness", 0.0)))
+        track_payoff = {track: _round2(sum(values) / len(values)) for track, values in sorted(track_buckets.items())}
+
+        aggregates = {
+            "runs": len(history),
+            "avg_usefulness": avg_usefulness,
+            "avg_cost": avg_cost,
+            "repeat_hit_result": tail_result,
+            "repeat_hit_count": repeat_hits,
+            "repeat_hit_saturation": saturation,
+            "track_payoff": track_payoff,
+        }
+        probe_entry["outcomes"] = history
+        probe_entry["aggregates"] = aggregates
+        probes[probe_id] = probe_entry
+        run_updates.append({"probe_id": probe_id, "aggregates": aggregates, "latest_outcome": outcome})
+
+    summary = {
+        "normalized_outcomes": normalized_outcomes,
+        "updates": run_updates,
+    }
+    return memory, summary
+
+
 @dataclass(frozen=True)
 class AdaptiveEscalationDecision:
     needed: bool
@@ -265,11 +405,13 @@ def plan_adaptive_probes(
     budget_total: int = 100,
     confidence_score: float = 0.0,
     confidence_threshold: float = 0.7,
+    probe_memory: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     contradictory = len(contradiction_graph.get("flat_contradictions", []))
     cluster_pressure = len(contradiction_graph.get("clusters", []))
     finding_pressure = sum(max(0, int(item.get("priority", 0))) for item in findings)
     history_pressure = len([row for row in changed if str(row.get("kind")) in {"status", "severity"}])
+    current_track = "risk_pressure" if contradictory > 0 or finding_pressure > 0 else "stability"
     registry = [
         ProbeDefinition(
             probe_id="probe:inspect-compare",
@@ -318,6 +460,13 @@ def plan_adaptive_probes(
                     "weight": 8,
                 }
             )
+        history_inputs, history_delta = derive_probe_score_history_inputs(
+            probe_id=probe.probe_id,
+            probe_memory=probe_memory,
+            current_track=current_track,
+        )
+        score += history_delta
+        score_inputs.extend(history_inputs)
         candidates.append(
             {
                 "probe_id": probe.probe_id,

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -241,3 +241,72 @@ def test_probe_budget_skips_when_budget_is_exhausted() -> None:
     )
     assert decision["executed_probes"]
     assert any(row["skip_reason"] == "probe budget exhausted by higher-value probes" for row in decision["skipped_probes"])
+
+
+def test_probe_memory_artifact_written_and_exposed(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    repo = tmp_path / "repo"
+    data = repo / "events.csv"
+    out = tmp_path / "out"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    data.write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
+
+    rc, payload, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
+
+    assert rc in {0, 2}
+    probe_memory = payload["adaptive_review"]["probe_memory"]
+    assert probe_memory["schema_version"] == "sdetkit.review.probe-memory.v1"
+    assert isinstance(probe_memory["normalized_outcomes"], list)
+    artifact = Path(probe_memory["workspace_artifact"])
+    assert artifact.exists()
+    stored = json.loads(artifact.read_text(encoding="utf-8"))
+    assert stored["schema_version"] == "sdetkit.review.probe-memory.v1"
+    assert "probe:inspect-compare" in stored.get("probes", {})
+
+
+def test_probe_memory_history_adjusts_next_run_score_inputs(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    repo = tmp_path / "repo"
+    data = repo / "events.csv"
+    out = tmp_path / "out"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    data.write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
+
+    rc1, payload1, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
+    assert rc1 in {0, 2}
+    first_probe = next(
+        row for row in payload1["adaptive_review"]["executed_probes"] if row["probe_id"] == "probe:inspect-compare"
+    )
+    first_score = first_probe["score"]
+
+    rc2, payload2, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
+    assert rc2 in {0, 2}
+    second_probe = next(row for row in payload2["adaptive_review"]["skipped_probes"] if row["probe_id"] == "probe:inspect-compare")
+    second_score = second_probe["score"]
+
+    assert second_score != first_score
+    history_inputs = {row["input"] for row in second_probe["score_inputs"]}
+    assert "history_avg_usefulness" in history_inputs
+    assert "history_repeat_hit_saturation" in history_inputs
+
+
+def test_review_executed_probe_list_contains_only_executed_rows(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    repo = tmp_path / "repo"
+    out1 = tmp_path / "out1"
+    out2 = tmp_path / "out2"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "events.csv").write_text("id,type\nE1,open\n", encoding="utf-8")
+
+    review.run_review(target=repo, out_dir=out1, workspace_root=workspace)
+    (repo / "events.csv").write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
+    _, payload, _, _ = review.run_review(target=repo, out_dir=out2, workspace_root=workspace)
+
+    assert all(row.get("status") == "executed" for row in payload["adaptive_review"]["executed_probes"])
+    assert any(row.get("probe_id") == "probe:inspect-compare" for row in payload["adaptive_review"]["skipped_probes"])
+    moved = [row for row in payload["adaptive_review"]["skipped_probes"] if row.get("probe_id") == "probe:inspect-compare"]
+    assert moved
+    assert moved[0]["skip_reason"] == "probe planned but not executed in deepen stage"


### PR DESCRIPTION
### Motivation
- Record probe execution outcomes across review runs to adapt future probe selection based on historical usefulness, cost, and repeat-hit saturation.
- Normalize probe outcomes and expose a workspace artifact so subsequent reviews can use aggregated probe statistics to bias scores and budget decisions.

### Description
- Added probe memory file utilities in `review.py` including `_probe_memory_path`, `_load_probe_memory`, `_write_probe_memory`, and integrated loading/writing into `run_review` with a per-scope review file location and workspace artifact exposure. 
- Introduced lifecycle normalization and finalization in `review.py` via `_finalize_probe_lifecycle`, and integrated normalization, memory update application, and payload enrichment (`adaptive_review.probe_memory`) in `run_review`.
- Implemented history-aware scoring and memory update logic in `review_engine.py` with `_round2`, `derive_probe_score_history_inputs`, `normalize_probe_execution_outcomes`, and `apply_probe_memory_update`, and threaded `probe_memory` through `plan_adaptive_probes` to influence probe `score` using historical aggregates.
- Ensured executed vs skipped probe lists are finalized and preserved correctly, and added the updated imports to `review.py` to use the new engine functions.

### Testing
- Ran unit tests with `pytest tests/test_review.py` which include new tests that assert probe memory artifact creation, that memory influences subsequent probe score inputs, and that only executed rows are kept in the executed list; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d8de87348332a0065bf64cef6902)