### PR TITLE
Stabilize review probe lifecycle and probe-memory recovery

### DIFF
--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -305,12 +305,16 @@ def _probe_memory_path(*, workspace_root: Path, scope: str) -> Path:
 
 
 def _load_probe_memory(*, workspace_root: Path, scope: str) -> dict[str, Any]:
+    default = {"schema_version": "sdetkit.review.probe-memory.v1", "probes": {}}
     path = _probe_memory_path(workspace_root=workspace_root, scope=scope)
     if not path.exists():
-        return {"schema_version": "sdetkit.review.probe-memory.v1", "probes": {}}
-    loaded = json.loads(path.read_text(encoding="utf-8"))
+        return default
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default
     if not isinstance(loaded, dict):
-        return {"schema_version": "sdetkit.review.probe-memory.v1", "probes": {}}
+        return default
     probes = loaded.get("probes", {})
     loaded["probes"] = probes if isinstance(probes, dict) else {}
     loaded["schema_version"] = "sdetkit.review.probe-memory.v1"
@@ -328,17 +332,35 @@ def _finalize_probe_lifecycle(adaptive_plan: dict[str, Any]) -> None:
     executed_rows = adaptive_plan.get("executed_probes", [])
     skipped_rows = adaptive_plan.get("skipped_probes", [])
     executed_out: list[dict[str, Any]] = []
-    skipped_out: list[dict[str, Any]] = [row for row in skipped_rows if isinstance(row, dict)]
+    skipped_out: list[dict[str, Any]] = []
+    skipped_ids: set[str] = set()
     for row in executed_rows if isinstance(executed_rows, list) else []:
         if not isinstance(row, dict):
             continue
+        probe_id = str(row.get("probe_id", ""))
         if str(row.get("status", "")) == "executed":
             executed_out.append(row)
+            skipped_ids.add(probe_id)
             continue
         moved = dict(row)
         moved["status"] = "skipped"
         moved["skip_reason"] = str(row.get("skip_reason", "")) or "probe planned but not executed in deepen stage"
+        if probe_id and probe_id in skipped_ids:
+            continue
         skipped_out.append(moved)
+        if probe_id:
+            skipped_ids.add(probe_id)
+    for row in skipped_rows if isinstance(skipped_rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        probe_id = str(row.get("probe_id", ""))
+        if probe_id and probe_id in skipped_ids:
+            continue
+        skipped_out.append(row)
+        if probe_id:
+            skipped_ids.add(probe_id)
+    executed_out = sorted(executed_out, key=lambda item: str(item.get("probe_id", "")))
+    skipped_out = sorted(skipped_out, key=lambda item: str(item.get("probe_id", "")))
     adaptive_plan["executed_probes"] = executed_out
     adaptive_plan["skipped_probes"] = skipped_out
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -310,3 +310,49 @@ def test_review_executed_probe_list_contains_only_executed_rows(tmp_path: Path) 
     moved = [row for row in payload["adaptive_review"]["skipped_probes"] if row.get("probe_id") == "probe:inspect-compare"]
     assert moved
     assert moved[0]["skip_reason"] == "probe planned but not executed in deepen stage"
+
+
+def test_review_no_workspace_reruns_are_deterministic(tmp_path: Path) -> None:
+    data = tmp_path / "events.csv"
+    out_dir = tmp_path / "out"
+    workspace = tmp_path / "workspace"
+    data.write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
+
+    rc1, payload1, _, _ = review.run_review(
+        target=data,
+        out_dir=out_dir,
+        workspace_root=workspace,
+        no_workspace=True,
+    )
+    rc2, payload2, _, _ = review.run_review(
+        target=data,
+        out_dir=out_dir,
+        workspace_root=workspace,
+        no_workspace=True,
+    )
+
+    assert rc1 == rc2
+    assert payload1["status"] == payload2["status"]
+    assert payload1["top_matters"] == payload2["top_matters"]
+    assert payload1["prioritized_actions"] == payload2["prioritized_actions"]
+    assert payload1["adaptive_review"]["executed_probes"] == payload2["adaptive_review"]["executed_probes"]
+    assert payload1["adaptive_review"]["skipped_probes"] == payload2["adaptive_review"]["skipped_probes"]
+
+
+def test_review_recovers_from_corrupt_probe_memory(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    repo = tmp_path / "repo"
+    out = tmp_path / "out"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "events.csv").write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
+    scope = review._review_scope_for_target(repo)
+    probe_mem = workspace / "probe-memory" / "review" / f"{scope}.json"
+    probe_mem.parent.mkdir(parents=True, exist_ok=True)
+    probe_mem.write_text("{not-json", encoding="utf-8")
+
+    rc, payload, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
+
+    assert rc in {0, 2}
+    assert payload["adaptive_review"]["probe_memory"]["schema_version"] == "sdetkit.review.probe-memory.v1"
+    assert isinstance(payload["adaptive_review"]["probe_memory"]["normalized_outcomes"], list)


### PR DESCRIPTION
### Motivation
- Recover gracefully when workspace `probe-memory` artifacts are unreadable or corrupt to preserve review contract integrity.
- Remove non-determinism and duplicated probe entries in adaptive probe lifecycle outputs so reruns produce stable results.
- Add regression coverage to ensure deterministic `review` reruns in `--no-workspace` mode and safe recovery from corrupt probe-memory.

### Description
- Hardened `_load_probe_memory` to return a v1 default contract and to catch `OSError`/`JSONDecodeError` instead of propagating failures.
- Reworked `_finalize_probe_lifecycle` to deduplicate probe IDs across executed/skipped lists and to sort both lists deterministically by `probe_id`.
- Added regression tests in `tests/test_review.py` to assert deterministic `--no-workspace` reruns and recovery from corrupt probe-memory artifacts.

### Testing
- Ran `pytest -q tests/test_review.py` which resulted in `14 passed`.
- Ran `pytest -q tests/test_cli_doctor.py tests/test_cli_help_lists_subcommands.py` which resulted in `7 passed`.
- All targeted checks on the modified review/probe paths passed locally without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9e3143d508332859d3931964d46e9)