### PR TITLE
Add operator-json output mode for `sdetkit review`

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -280,7 +280,7 @@ Then use stability-aware command discovery:
     review_parser.add_argument("--workspace-root", default=None)
     review_parser.add_argument("--out-dir", default=None)
     review_parser.add_argument("--profile", choices=["release", "triage", "forensics", "monitor"], default=None)
-    review_parser.add_argument("--format", choices=["text", "json"], default=None)
+    review_parser.add_argument("--format", choices=["text", "json", "operator-json"], default=None)
     review_parser.add_argument("--interactive", action="store_true")
     review_parser.add_argument("--no-workspace", action="store_true")
 

--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -1158,7 +1158,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         choices=sorted(REVIEW_PROFILES),
         help="Review operating profile: release, triage, forensics, monitor.",
     )
-    p.add_argument("--format", choices=["text", "json"], default="text")
+    p.add_argument(
+        "--format",
+        choices=["text", "json", "operator-json"],
+        default="text",
+        help="Output format: text (operator narrative), json (full review payload), or operator-json (operator summary contract only).",
+    )
     p.add_argument(
         "--interactive",
         action="store_true",
@@ -1184,7 +1189,12 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(str(exc) + "\n")
         return EXIT_FINDINGS
 
-    output = json.dumps(payload, sort_keys=True) if ns.format == "json" else _render_text(payload)
+    if ns.format == "json":
+        output = json.dumps(payload, sort_keys=True)
+    elif ns.format == "operator-json":
+        output = json.dumps(payload.get("operator_summary", {}), sort_keys=True)
+    else:
+        output = _render_text(payload)
     sys.stdout.write(output + ("\n" if not output.endswith("\n") else ""))
     if ns.interactive:
         _run_interactive_review(payload)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -93,6 +93,40 @@ def test_cli_review_command_outputs_json(tmp_path: Path) -> None:
     assert "operator_summary" in payload
 
 
+def test_cli_review_command_outputs_operator_json_contract_only(tmp_path: Path) -> None:
+    data = tmp_path / "events.csv"
+    out_dir = tmp_path / "out"
+    data.write_text("id,type\nE1,open\n", encoding="utf-8")
+
+    run = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "review",
+            str(data),
+            "--workspace-root",
+            str(tmp_path / "workspace"),
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "operator-json",
+            "--no-workspace",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert run.returncode == 0
+    payload = json.loads(run.stdout)
+    assert payload["contract_version"] == "sdetkit.review.contract.v1"
+    assert "situation" in payload
+    assert "actions" in payload
+    assert "workflow" not in payload
+    artifact_payload = json.loads((out_dir / "review-operator-summary.json").read_text(encoding="utf-8"))
+    assert payload == artifact_payload
+
+
 def test_review_profiles_change_judgment_and_artifacts_for_same_input(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     data = tmp_path / "events.csv"


### PR DESCRIPTION
### Motivation
- Provide a machine-friendly, deterministic operator-facing output for `sdetkit review` so dashboards and integrations can consume the operator contract without parsing the full review payload.
- Reuse the existing `operator_summary` artifact to avoid exposing internal engine details and to keep the operator contract stable and versioned.

### Description
- Added a new `--format operator-json` option to the `sdetkit review` subcommand which prints only `payload["operator_summary"]` to stdout (same content as `review-operator-summary.json`).
- Updated the review module CLI parser and output routing in `src/sdetkit/review.py` to support `operator-json` and to select stdout accordingly.
- Forwarded the new format through the top-level CLI by accepting and forwarding `operator-json` in `src/sdetkit/cli.py`.
- Added a unit/CLI test in `tests/test_review.py` to assert the CLI returns the operator contract-only JSON and that it equals the `review-operator-summary.json` artifact.

### Testing
- Ran the focused tests: `pytest -q tests/test_review.py -k 'outputs_json or operator_json_contract_only'` which returned `2 passed`.
- Verified the whole review test module: `pytest -q tests/test_review.py` which returned `17 passed`.
- Manual CLI smoke: `python -m sdetkit review <tmp>/events.csv --workspace-root <tmp>/workspace --out-dir <tmp>/out --format operator-json --no-workspace` printed operator-only JSON and exit code behavior remained review-driven (example run printed keys `situation`, `actions`, `tracks`, `contradictions`, `contract_version` and returned `EXIT:0`).
- Confirmed artifact parity by reading `out/review-operator-summary.json` and asserting it matches CLI stdout exactly during the test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f3db8f6c833281e0d7622ef1cb6d)