### PR TITLE
Clarify `sdetkit review` output formats and add operator-focused README guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,31 @@ Context: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
 - Canonical CI rollout path: [`docs/recommended-ci-flow.md`](docs/recommended-ci-flow.md)
 - Canonical artifact decoder: [`docs/ci-artifact-walkthrough.md`](docs/ci-artifact-walkthrough.md)
 
+## Review command format quick guide (operator adoption)
+
+Use `sdetkit review` when you need one front-door decision pass over doctor/inspect/compare/project/history.
+
+- Use `--format json` when you need the **full review payload** (deep debugging, custom analytics, or internal tooling that consumes all sections).
+- Use `--format operator-json` when you need the **stable operator-facing integration contract** for CI jobs, dashboards, and operator automations.
+- For operator integrations, prefer `operator-json` as the long-lived parsing surface.
+
+Short deterministic examples:
+
+```bash
+python -m sdetkit review . --no-workspace --format json
+python -m sdetkit review . --no-workspace --format operator-json
+```
+
+Practical machine-consumption examples:
+
+```bash
+# Full payload: inspect status + top-level counts for deeper triage scripts
+python -m sdetkit review . --no-workspace --format json | jq '{status, severity, findings: (.top_matters | length)}'
+
+# Stable operator contract: gate on operator-facing situation/actions fields
+python -m sdetkit review . --no-workspace --format operator-json | jq '{status: .situation.status, severity: .situation.severity, now_actions: (.actions.now | length)}'
+```
+
 ## Who this is for / not for
 
 **Best fit**

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -280,7 +280,15 @@ Then use stability-aware command discovery:
     review_parser.add_argument("--workspace-root", default=None)
     review_parser.add_argument("--out-dir", default=None)
     review_parser.add_argument("--profile", choices=["release", "triage", "forensics", "monitor"], default=None)
-    review_parser.add_argument("--format", choices=["text", "json", "operator-json"], default=None)
+    review_parser.add_argument(
+        "--format",
+        choices=["text", "json", "operator-json"],
+        default=None,
+        help=(
+            "Output format: json for full payload/debug automation; "
+            "operator-json for the stable operator-facing integration contract."
+        ),
+    )
     review_parser.add_argument("--interactive", action="store_true")
     review_parser.add_argument("--no-workspace", action="store_true")
 

--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -1162,7 +1162,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--format",
         choices=["text", "json", "operator-json"],
         default="text",
-        help="Output format: text (operator narrative), json (full review payload), or operator-json (operator summary contract only).",
+        help=(
+            "Output format: text (operator narrative), json (full payload for deep/debug automation), "
+            "or operator-json (stable operator-facing integration contract; preferred for CI/operator parsers)."
+        ),
     )
     p.add_argument(
         "--interactive",


### PR DESCRIPTION
### Motivation
- Make the distinction between the full JSON payload and the stable operator-facing contract explicit so operators and CI jobs can pick the right output format. 
- Provide concrete, deterministic examples for machine consumption and operator integrations to reduce ad-hoc parsing and drift. 

### Description
- Add a new README section `Review command format quick guide (operator adoption)` with short examples and `jq` snippets demonstrating `--format json` and `--format operator-json` usage. 
- Improve CLI argument help for the top-level `review` command in `src/sdetkit/cli.py` to describe the difference between `json` and `operator-json`. 
- Update the `sdetkit review` internal parser in `src/sdetkit/review.py` to expand the `--format` help text to emphasize that `operator-json` is the preferred stable contract for CI/operator parsers. 

### Testing
- Ran the repository test suite with `python -m pytest -q`, and the tests completed successfully. 
- Verified the `sdetkit review --help` output to ensure the updated `--format` descriptions appear as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f5b957f483329f815c47557e07c3)