### PR TITLE
Add local deterministic `serve` API for review workflow

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -292,6 +292,13 @@ Then use stability-aware command discovery:
     review_parser.add_argument("--interactive", action="store_true")
     review_parser.add_argument("--no-workspace", action="store_true")
 
+    serve_parser = sub.add_parser(
+        "serve",
+        help="[Public / stable] Run local API server for deterministic review automation",
+    )
+    serve_parser.add_argument("--host", default=None)
+    serve_parser.add_argument("--port", type=int, default=None)
+
     ag = sub.add_parser("apiget", help="Deterministic HTTP JSON fetch and replay helper")
     _add_apiget_args(ag)
 
@@ -1334,6 +1341,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         if ns.no_workspace:
             forwarded.append("--no-workspace")
         return _run_module_main("sdetkit.review", forwarded)
+
+    if ns.cmd == "serve":
+        forwarded: list[str] = []
+        if ns.host:
+            forwarded.extend(["--host", ns.host])
+        if ns.port is not None:
+            forwarded.extend(["--port", str(ns.port)])
+        return _run_module_main("sdetkit.serve", forwarded)
 
     if ns.cmd == "patch":
         return _run_module_main("sdetkit.patch", ns.args)

--- a/src/sdetkit/serve.py
+++ b/src/sdetkit/serve.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import argparse
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from . import review
+
+SERVE_CONTRACT_VERSION = "sdetkit.serve.contract.v1"
+_MAX_BODY_BYTES = 1_048_576
+
+
+class RequestValidationError(ValueError):
+    """Raised when a review API request is syntactically valid JSON but fails validation."""
+
+
+def _default_out_dir(target: Path) -> Path:
+    return Path(".sdetkit") / "review" / review._safe_slug(target.resolve().name)
+
+
+def _build_error(*, code: str, message: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": "error",
+        "contract_version": SERVE_CONTRACT_VERSION,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+    if details:
+        payload["error"]["details"] = details
+    return payload
+
+
+def _parse_review_request(body: bytes) -> dict[str, Any]:
+    if not body:
+        raise RequestValidationError("Request body must be valid JSON object with a required 'path' field.")
+    try:
+        raw = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RequestValidationError(f"Invalid JSON body: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise RequestValidationError("Request body must be a JSON object.")
+
+    path = raw.get("path")
+    if not isinstance(path, str) or not path.strip():
+        raise RequestValidationError("Field 'path' is required and must be a non-empty string.")
+
+    profile = raw.get("profile", "release")
+    if profile not in review.REVIEW_PROFILES:
+        raise RequestValidationError(
+            "Field 'profile' must be one of: " + ", ".join(sorted(review.REVIEW_PROFILES))
+        )
+
+    response_mode = raw.get("response_mode", "full")
+    if response_mode not in {"full", "operator-summary"}:
+        raise RequestValidationError("Field 'response_mode' must be either 'full' or 'operator-summary'.")
+
+    no_workspace = raw.get("no_workspace", False)
+    if not isinstance(no_workspace, bool):
+        raise RequestValidationError("Field 'no_workspace' must be a boolean.")
+
+    workspace_root = raw.get("workspace_root", ".sdetkit/workspace")
+    if not isinstance(workspace_root, str) or not workspace_root.strip():
+        raise RequestValidationError("Field 'workspace_root' must be a non-empty string.")
+
+    out_dir = raw.get("out_dir")
+    if out_dir is not None and (not isinstance(out_dir, str) or not out_dir.strip()):
+        raise RequestValidationError("Field 'out_dir' must be a non-empty string when provided.")
+
+    return {
+        "path": path,
+        "profile": profile,
+        "response_mode": response_mode,
+        "no_workspace": no_workspace,
+        "workspace_root": workspace_root,
+        "out_dir": out_dir,
+    }
+
+
+def _run_review_request(req: dict[str, Any]) -> dict[str, Any]:
+    target = Path(req["path"])
+    if not target.exists():
+        raise FileNotFoundError(f"Review target does not exist: {target}")
+
+    out_dir = Path(req["out_dir"]) if req["out_dir"] else _default_out_dir(target)
+    rc, payload, json_path, txt_path = review.run_review(
+        target=target,
+        out_dir=out_dir,
+        workspace_root=Path(req["workspace_root"]),
+        profile=req["profile"],
+        no_workspace=bool(req["no_workspace"]),
+    )
+    operator_summary = payload.get("operator_summary", {})
+    result: dict[str, Any] = {
+        "exit_code": rc,
+        "review_status": payload.get("review_status"),
+        "status": payload.get("status"),
+        "severity": payload.get("severity"),
+        "profile": payload.get("profile", {}).get("name"),
+        "contract_version": payload.get("contract_version"),
+        "operator_summary": operator_summary,
+        "artifacts": {
+            "review_json": json_path.as_posix(),
+            "review_text": txt_path.as_posix(),
+            **(payload.get("artifact_index", {}) if isinstance(payload.get("artifact_index", {}), dict) else {}),
+        },
+    }
+    if "workspace" in payload:
+        result["workspace"] = payload["workspace"]
+    if req["response_mode"] == "full":
+        result["payload"] = payload
+    return {
+        "status": "ok",
+        "contract_version": SERVE_CONTRACT_VERSION,
+        "result": result,
+    }
+
+
+def _make_handler() -> type[BaseHTTPRequestHandler]:
+    class SdetkitHandler(BaseHTTPRequestHandler):
+        server_version = "SDETKitServe/1.0"
+
+        def _send_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+            wire = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(wire)))
+            self.end_headers()
+            self.wfile.write(wire)
+
+        def log_message(self, format: str, *args: Any) -> None:  # pragma: no cover
+            return
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path != "/healthz":
+                self._send_json(
+                    HTTPStatus.NOT_FOUND,
+                    _build_error(code="not_found", message=f"Route not found: {self.path}"),
+                )
+                return
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "status": "ok",
+                    "contract_version": SERVE_CONTRACT_VERSION,
+                    "service": "sdetkit",
+                    "review_contract_version": review.REVIEW_CONTRACT_VERSION,
+                    "endpoints": {
+                        "health": "/healthz",
+                        "review": "/v1/review",
+                    },
+                },
+            )
+
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path != "/v1/review":
+                self._send_json(
+                    HTTPStatus.NOT_FOUND,
+                    _build_error(code="not_found", message=f"Route not found: {self.path}"),
+                )
+                return
+
+            content_length = int(self.headers.get("Content-Length", "0"))
+            if content_length > _MAX_BODY_BYTES:
+                self._send_json(
+                    HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                    _build_error(
+                        code="request_too_large",
+                        message=f"Request body exceeds {_MAX_BODY_BYTES} bytes.",
+                    ),
+                )
+                return
+            body = self.rfile.read(content_length)
+            try:
+                req = _parse_review_request(body)
+                payload = _run_review_request(req)
+            except RequestValidationError as exc:
+                self._send_json(
+                    HTTPStatus.BAD_REQUEST,
+                    _build_error(code="validation_error", message=str(exc)),
+                )
+                return
+            except FileNotFoundError as exc:
+                self._send_json(
+                    HTTPStatus.NOT_FOUND,
+                    _build_error(code="path_not_found", message=str(exc)),
+                )
+                return
+            except ValueError as exc:
+                self._send_json(
+                    HTTPStatus.BAD_REQUEST,
+                    _build_error(code="review_invalid_request", message=str(exc)),
+                )
+                return
+            except Exception as exc:  # pragma: no cover
+                self._send_json(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    _build_error(code="internal_error", message=str(exc)),
+                )
+                return
+
+            self._send_json(HTTPStatus.OK, payload)
+
+    return SdetkitHandler
+
+
+def build_server(*, host: str, port: int) -> ThreadingHTTPServer:
+    return ThreadingHTTPServer((host, port), _make_handler())
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit serve",
+        description="Run SDETKit as a local deterministic review API service.",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1).")
+    parser.add_argument("--port", type=int, default=8765, help="Bind port (default: 8765).")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_arg_parser().parse_args(argv)
+    server = build_server(host=str(ns.host), port=int(ns.port))
+    print(f"sdetkit serve listening on http://{ns.host}:{ns.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_serve_api.py
+++ b/tests/test_serve_api.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from sdetkit import cli, serve
+
+
+def _post_json(url: str, payload: dict[str, object]) -> tuple[int, dict[str, object]]:
+    data = json.dumps(payload, sort_keys=True).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST", headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req) as resp:  # noqa: S310 - local server in test
+        body = json.loads(resp.read().decode("utf-8"))
+        return int(resp.status), body
+
+
+def test_cli_dispatches_serve(monkeypatch) -> None:
+    called: dict[str, object] = {}
+
+    def fake_run(module_name: str, args: list[str]) -> int:
+        called["module"] = module_name
+        called["args"] = args
+        return 0
+
+    monkeypatch.setattr(cli, "_run_module_main", fake_run)
+    rc = cli.main(["serve", "--host", "0.0.0.0", "--port", "9999"])
+
+    assert rc == 0
+    assert called["module"] == "sdetkit.serve"
+    assert called["args"] == ["--host", "0.0.0.0", "--port", "9999"]
+
+
+def test_serve_health_review_operator_mode_and_validation(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[tool.sdetkit]\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    server = serve.build_server(host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = int(server.server_address[1])
+
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/healthz") as resp:  # noqa: S310
+            health = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert health["status"] == "ok"
+        assert health["review_contract_version"] == "sdetkit.review.contract.v1"
+
+        status, response = _post_json(
+            f"http://127.0.0.1:{port}/v1/review",
+            {
+                "path": str(repo),
+                "profile": "release",
+                "response_mode": "operator-summary",
+                "no_workspace": True,
+                "out_dir": str(out_dir),
+            },
+        )
+        assert status == 200
+        assert response["status"] == "ok"
+        result = response["result"]
+        assert "payload" not in result
+        assert result["operator_summary"]["contract_version"] == "sdetkit.review.contract.v1"
+
+        _, response2 = _post_json(
+            f"http://127.0.0.1:{port}/v1/review",
+            {
+                "path": str(repo),
+                "profile": "release",
+                "response_mode": "operator-summary",
+                "no_workspace": True,
+                "out_dir": str(out_dir),
+            },
+        )
+        assert response2["result"]["operator_summary"] == result["operator_summary"]
+
+        bad_req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/v1/review",
+            data=json.dumps({"profile": "release"}).encode("utf-8"),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            urllib.request.urlopen(bad_req)  # noqa: S310
+            raise AssertionError("expected validation error")
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 400
+            err = json.loads(exc.read().decode("utf-8"))
+            assert err["error"]["code"] == "validation_error"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)


### PR DESCRIPTION
### Motivation
- Operators and integrations require a stable programmatic surface instead of brittle shelling-out and ad-hoc stdout parsing.  
- Provide a minimal, local-first HTTP entrypoint that reuses the existing deterministic review engine and operator contract.  
- Keep surface area small and deterministic so dashboards and local services can call SDETKit reliably.  

### Description
- Added a new lightweight HTTP server module `src/sdetkit/serve.py` exposing `GET /healthz` and `POST /v1/review` and a stable JSON envelope for success/error responses.  
- Wire `serve` into the CLI by updating `src/sdetkit/cli.py` so `python -m sdetkit serve` dispatches to the server module.  
- Implemented strict request parsing/validation (required `path`, optional `profile`, `response_mode` = `full|operator-summary`, `workspace_root`, `out_dir`, `no_workspace`) and explicit error envelopes with appropriate HTTP status codes.  
- Added tests `tests/test_serve_api.py` that cover CLI dispatch, health endpoint, operator-summary mode, determinism for repeated no-workspace runs, and invalid-request handling; the server delegates execution to the existing `review.run_review` to preserve frozen engine behavior and deterministic artifacts.  

### Testing
- Ran unit tests for the new API: `pytest -q tests/test_serve_api.py` — result: `2 passed`.  
- Ran regression tests for touched workflows: `pytest -q tests/test_review.py tests/test_cli_help_lists_subcommands.py` — result: `19 passed`.  
- Performed manual local server checks using `python -m sdetkit serve` plus `curl` for `GET /healthz` (returned `status: ok` and included `review_contract_version`) and `POST /v1/review` (returned `status: ok` with `operator_summary` and deterministic artifact paths); invalid request returned HTTP 400 with error code `validation_error`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fa816168833284b5186a4db17a08)