### PR TITLE
Add adopter-focused runtime contract: Dockerfile.runtime, `contract` CLI, docs and tests

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /opt/sdetkit
+
+RUN groupadd -r sdetkit && useradd -r -g sdetkit -u 10001 sdetkit
+
+COPY pyproject.toml README.md LICENSE /opt/sdetkit/
+COPY src /opt/sdetkit/src
+
+RUN python -m pip install --no-cache-dir --upgrade pip \
+ && python -m pip install --no-cache-dir .
+
+USER sdetkit
+WORKDIR /workspace
+
+ENTRYPOINT ["sdetkit"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ python -m sdetkit review . --no-workspace --format operator-json | jq '{status: 
 ## Start here (canonical first path)
 
 - Install (canonical): [`docs/install.md`](docs/install.md)
+- Container runtime adoption: [`docs/container-runtime.md`](docs/container-runtime.md)
 - Blank repo proof in 60 seconds (recommended first run): [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
 - Guided run (same canonical path): [`docs/ready-to-use.md`](docs/ready-to-use.md)
 - Release-confidence model (why this product exists): [`docs/release-confidence.md`](docs/release-confidence.md)

--- a/docs/container-runtime.md
+++ b/docs/container-runtime.md
@@ -1,0 +1,38 @@
+# Container runtime contract (adoption-focused)
+
+SDETKit now includes an adopter-oriented runtime container definition: `Dockerfile.runtime`.
+
+This is distinct from the repository's maintainer/test container workflow and is intended for external teams that want a predictable CLI runtime surface.
+
+## Build runtime image
+
+```bash
+docker build -f Dockerfile.runtime -t sdetkit-runtime .
+```
+
+## Verify runtime contract (machine-readable)
+
+```bash
+docker run --rm -v "$PWD":/workspace -w /workspace sdetkit-runtime contract runtime --format json
+```
+
+Expected high-value fields in output:
+- `runtime_contract_version`
+- `tool` (`name`, `version`)
+- `canonical_first_path`
+- `stable_machine_outputs.review_operator_json.contract_version`
+
+## Run stable operator integration surface
+
+```bash
+docker run --rm -v "$PWD":/workspace -w /workspace sdetkit-runtime review . --no-workspace --format operator-json
+```
+
+Use this command in CI/jobs when you want a long-lived operator-facing JSON parsing surface.
+
+## Local (non-container) equivalent
+
+```bash
+python -m sdetkit contract runtime --format json
+python -m sdetkit review . --no-workspace --format operator-json
+```

--- a/docs/install.md
+++ b/docs/install.md
@@ -47,6 +47,22 @@ python -m pip install .
 python -m sdetkit --help
 ```
 
+## Runtime contract check (adopters and CI)
+
+Use the adopter-focused runtime contract command to discover stable install/run surfaces:
+
+```bash
+python -m sdetkit contract runtime --format json
+```
+
+This prints:
+- `runtime_contract_version` (versioned install/run contract identifier)
+- canonical first path commands
+- stable machine output contract details for `review --format operator-json`
+- container runtime invocation examples
+
+Use this as a first CI/script check before running gates.
+
 ## External repository usage (canonical handoff)
 
 From the root of the repository you want to gate:

--- a/docs/recommended-ci-flow.md
+++ b/docs/recommended-ci-flow.md
@@ -42,6 +42,9 @@ jobs:
       - name: Install project + CI extras
         run: python -m pip install -e .[dev,test,docs]
 
+      - name: Runtime contract preflight (stable install/run surface)
+        run: python -m sdetkit contract runtime --format json
+
       - name: Fast gate
         run: bash ci.sh quick --skip-docs --artifact-dir build
 
@@ -104,6 +107,16 @@ jobs:
 - `build/release-preflight.json`
 - `build/gate-fast.json`
 - `build/security-enforce.json`
+
+## Optional containerized invocation path
+
+If your org runs CLI tools in containers, use `Dockerfile.runtime` and keep command invocation stable:
+
+```bash
+docker build -f Dockerfile.runtime -t sdetkit-runtime .
+docker run --rm -v "$PWD":/workspace -w /workspace sdetkit-runtime contract runtime --format json
+docker run --rm -v "$PWD":/workspace -w /workspace sdetkit-runtime review . --no-workspace --format operator-json
+```
 
 Current workflow upload names in this repo:
 - `ci-gate-diagnostics-py3.11`

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -345,6 +345,11 @@ Then use stability-aware command discovery:
     _add_passthrough_subcommand(
         sub, "feature-registry", help_text="Inspect feature-registry entries and filters"
     )
+    _add_passthrough_subcommand(
+        sub,
+        "contract",
+        help_text="[Public / stable] Runtime/install integration contract surfaces for adopters",
+    )
 
     rpt = sub.add_parser("report", help="Reporting workflows and output packs")
     rpt.add_argument("args", nargs=argparse.REMAINDER)
@@ -803,6 +808,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if argv and argv[0] == "report":
         return _run_module_main("sdetkit.report", list(argv[1:]))
+
+    if argv and argv[0] == "contract":
+        return _run_module_main("sdetkit.contract", list(argv[1:]))
 
     if argv and argv[0] == "maintenance":
         return _run_module_main("sdetkit.maintenance", list(argv[1:]))

--- a/src/sdetkit/contract.py
+++ b/src/sdetkit/contract.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import argparse
+import json
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+from .review import REVIEW_CONTRACT_VERSION
+
+RUNTIME_CONTRACT_VERSION = "sdetkit.runtime.contract.v1"
+
+
+def _tool_version() -> str:
+    try:
+        return metadata.version("sdetkit")
+    except metadata.PackageNotFoundError:
+        return "0+unknown"
+
+
+def _public_surface_contract(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / "src" / "sdetkit" / "public_command_surface.json"
+    if not path.exists():
+        return {}
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _runtime_payload(repo_root: Path) -> dict[str, Any]:
+    command_contract = _public_surface_contract(repo_root)
+    return {
+        "runtime_contract_version": RUNTIME_CONTRACT_VERSION,
+        "tool": {
+            "name": "sdetkit",
+            "version": _tool_version(),
+        },
+        "recommended_install": {
+            "pip_git": 'python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"',
+            "verify": "python -m sdetkit --help",
+        },
+        "canonical_first_path": command_contract.get(
+            "canonical_first_path",
+            [
+                "python -m sdetkit gate fast",
+                "python -m sdetkit gate release",
+                "python -m sdetkit doctor",
+            ],
+        ),
+        "stable_machine_outputs": {
+            "review_operator_json": {
+                "command": "python -m sdetkit review . --no-workspace --format operator-json",
+                "contract_version": REVIEW_CONTRACT_VERSION,
+                "notes": "Preferred stable operator-facing parsing surface for CI and automations.",
+            }
+        },
+        "stability_surfaces": {
+            "public_command_surface_version": command_contract.get("contract_version"),
+            "public_stable_front_door_commands": command_contract.get(
+                "public_stable_front_door_commands", []
+            ),
+            "advanced_supported_next_step": command_contract.get("advanced_supported_next_step"),
+        },
+        "container_runtime": {
+            "dockerfile": "Dockerfile.runtime",
+            "default_entrypoint": "sdetkit",
+            "example_contract_check": (
+                "docker run --rm -v \"$PWD\":/workspace -w /workspace sdetkit-runtime "
+                "contract runtime --format json"
+            ),
+            "example_review_operator_json": (
+                "docker run --rm -v \"$PWD\":/workspace -w /workspace sdetkit-runtime "
+                "review . --no-workspace --format operator-json"
+            ),
+        },
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"runtime_contract_version: {payload['runtime_contract_version']}",
+        f"tool: {payload['tool']['name']}@{payload['tool']['version']}",
+        "install:",
+        f"  {payload['recommended_install']['pip_git']}",
+        f"  {payload['recommended_install']['verify']}",
+        "canonical_first_path:",
+    ]
+    for step in payload.get("canonical_first_path", []):
+        lines.append(f"  - {step}")
+    review_out = payload["stable_machine_outputs"]["review_operator_json"]
+    lines.extend(
+        [
+            "stable_machine_output:",
+            f"  command: {review_out['command']}",
+            f"  contract_version: {review_out['contract_version']}",
+            "container_runtime:",
+            f"  dockerfile: {payload['container_runtime']['dockerfile']}",
+            f"  entrypoint: {payload['container_runtime']['default_entrypoint']}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="SDETKit runtime/integration contracts")
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    runtime = sub.add_parser("runtime", help="Show adopter-focused install/run integration contract")
+    runtime.add_argument("--format", choices=["text", "json"], default="text")
+    runtime.add_argument("--repo-root", default=".")
+
+    ns = parser.parse_args(argv)
+    if ns.action != "runtime":
+        return 2
+
+    payload = _runtime_payload(Path(ns.repo_root).resolve())
+    if ns.format == "json":
+        print(json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2))
+    else:
+        print(_render_text(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -59,6 +59,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "release-narrative" not in out
     assert "trust-assets" in out
     assert "feature-registry" in out
+    assert "contract" in out
     assert "trust-signal-upgrade" not in out
     assert "objection-handling" in out
     assert "faq-objections" not in out

--- a/tests/test_contract_runtime_cli.py
+++ b/tests/test_contract_runtime_cli.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def test_contract_runtime_json_is_adopter_focused_and_versioned() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "contract", "runtime", "--format", "json"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+
+    assert payload["runtime_contract_version"] == "sdetkit.runtime.contract.v1"
+    assert payload["tool"]["name"] == "sdetkit"
+    assert payload["recommended_install"]["pip_git"].startswith("python -m pip install")
+    assert payload["stable_machine_outputs"]["review_operator_json"]["contract_version"] == (
+        "sdetkit.review.contract.v1"
+    )
+    assert payload["container_runtime"]["dockerfile"] == "Dockerfile.runtime"
+    assert payload["container_runtime"]["default_entrypoint"] == "sdetkit"
+
+
+def test_contract_runtime_text_includes_core_adoption_fields() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "sdetkit", "contract", "runtime"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    out = result.stdout
+    assert "runtime_contract_version: sdetkit.runtime.contract.v1" in out
+    assert "stable_machine_output:" in out
+    assert "contract_version: sdetkit.review.contract.v1" in out

--- a/tests/test_runtime_container_contract.py
+++ b/tests/test_runtime_container_contract.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_runtime_dockerfile_uses_sdetkit_entrypoint() -> None:
+    dockerfile = Path("Dockerfile.runtime")
+    assert dockerfile.exists()
+    text = dockerfile.read_text(encoding="utf-8")
+    assert 'ENTRYPOINT ["sdetkit"]' in text
+    assert 'CMD ["--help"]' in text
+    assert "python -m pip install --no-cache-dir ." in text


### PR DESCRIPTION
### Motivation

- Provide an adopter-oriented container runtime and a stable, machine-readable install/run contract for external teams and CI.
- Expose the runtime/install contract via a public CLI surface so downstream users can verify stable invocation and outputs.
- Document container usage and supply a minimal runtime image to ensure the entrypoint and operator-facing outputs remain stable.

### Description

- Add a runtime image definition in `Dockerfile.runtime` that installs the package and exposes `ENTRYPOINT ["sdetkit"]` with `CMD ["--help"]`.
- Introduce a new CLI subcommand `contract` (wired in `src/sdetkit/cli.py`) that forwards to a new module `src/sdetkit/contract.py` which emits a versioned runtime/install contract in `text` or `json` formats.
- Add adopter-facing documentation in `docs/container-runtime.md`, surface the runtime contract in `docs/install.md` and `docs/recommended-ci-flow.md`, and add a README pointer to the container runtime docs.
- Add tests and test adjustments: new tests `tests/test_contract_runtime_cli.py` and `tests/test_runtime_container_contract.py`, and update `tests/test_cli_help_lists_subcommands.py` to include the `contract` subcommand.

### Testing

- Ran `pytest -q` including `tests/test_contract_runtime_cli.py`, `tests/test_runtime_container_contract.py`, and `tests/test_cli_help_lists_subcommands.py`, and the test suite completed successfully.
- Verified the runtime text output contains `runtime_contract_version: sdetkit.runtime.contract.v1` and `contract_version: sdetkit.review.contract.v1` via the new JSON/text contract tests.
- Confirmed `Dockerfile.runtime` contains the expected `ENTRYPOINT`/`CMD` and the package install line via `tests/test_runtime_container_contract.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fc71ed708332a8c4dd4aba424f5c)