### PR TITLE
Fix formatting and mypy blockers in quality gate

### DIFF
--- a/scripts/pr_clean.py
+++ b/scripts/pr_clean.py
@@ -100,7 +100,9 @@ def main(argv: list[str] | None = None) -> int:
         "profile": profile.name,
         "run": bool(ns.run),
         "ok": True,
-        "steps": [{"id": step.id, "cmd": step.cmd, "rc": None, "ok": None} for step in profile.steps],
+        "steps": [
+            {"id": step.id, "cmd": step.cmd, "rc": None, "ok": None} for step in profile.steps
+        ],
     }
 
     if not ns.run:

--- a/scripts/real_repo_adoption_projection.py
+++ b/scripts/real_repo_adoption_projection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -55,7 +56,8 @@ def normalize_cmd(parts: list[str], *, fixture_root: Path, repo_root: Path) -> l
         if part in {fixture_root_str, repo_root_str}:
             normalized.append("<repo>")
             continue
-        if part.endswith("/python") or part.endswith("\\python.exe"):
+        basename = Path(part).name.lower()
+        if re.fullmatch(r"python(\d+(?:\.\d+)*)?(\.exe)?", basename):
             normalized.append("python")
             continue
         normalized.append(part.replace(fixture_root_str, "<repo>").replace(repo_root_str, "<repo>"))

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -280,7 +280,9 @@ Then use stability-aware command discovery:
     review_parser.add_argument("path")
     review_parser.add_argument("--workspace-root", default=None)
     review_parser.add_argument("--out-dir", default=None)
-    review_parser.add_argument("--profile", choices=["release", "triage", "forensics", "monitor"], default=None)
+    review_parser.add_argument(
+        "--profile", choices=["release", "triage", "forensics", "monitor"], default=None
+    )
     review_parser.add_argument(
         "--format",
         choices=["text", "json", "operator-json"],
@@ -1352,12 +1354,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _run_module_main("sdetkit.review", forwarded)
 
     if ns.cmd == "serve":
-        forwarded: list[str] = []
+        serve_args: list[str] = []
         if ns.host:
-            forwarded.extend(["--host", ns.host])
+            serve_args.extend(["--host", ns.host])
         if ns.port is not None:
-            forwarded.extend(["--port", str(ns.port)])
-        return _run_module_main("sdetkit.serve", forwarded)
+            serve_args.extend(["--port", str(ns.port)])
+        return _run_module_main("sdetkit.serve", serve_args)
 
     if ns.cmd == "patch":
         return _run_module_main("sdetkit.patch", ns.args)

--- a/src/sdetkit/contract.py
+++ b/src/sdetkit/contract.py
@@ -64,11 +64,11 @@ def _runtime_payload(repo_root: Path) -> dict[str, Any]:
             "dockerfile": "Dockerfile.runtime",
             "default_entrypoint": "sdetkit",
             "example_contract_check": (
-                "docker run --rm -v \"$PWD\":/workspace -w /workspace sdetkit-runtime "
+                'docker run --rm -v "$PWD":/workspace -w /workspace sdetkit-runtime '
                 "contract runtime --format json"
             ),
             "example_review_operator_json": (
-                "docker run --rm -v \"$PWD\":/workspace -w /workspace sdetkit-runtime "
+                'docker run --rm -v "$PWD":/workspace -w /workspace sdetkit-runtime '
                 "review . --no-workspace --format operator-json"
             ),
         },
@@ -104,7 +104,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="SDETKit runtime/integration contracts")
     sub = parser.add_subparsers(dest="action", required=True)
 
-    runtime = sub.add_parser("runtime", help="Show adopter-focused install/run integration contract")
+    runtime = sub.add_parser(
+        "runtime", help="Show adopter-focused install/run integration contract"
+    )
     runtime.add_argument("--format", choices=["text", "json"], default="text")
     runtime.add_argument("--repo-root", default=".")
 

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -2921,6 +2921,7 @@ def main(argv: list[str] | None = None) -> int:
             output = _stable_json(data)
 
     out_path: Path | None = None
+    out_path_display: str | None = None
     if ns.out:
         try:
             out_path = safe_path(root, str(ns.out), allow_absolute=True)
@@ -2928,7 +2929,8 @@ def main(argv: list[str] | None = None) -> int:
             sys.stderr.write(f"doctor: --out rejected: {exc}\n")
             return EXIT_FAILED
         out_path.write_text(output, encoding="utf-8")
-        data["output_path"] = out_path.as_posix()
+        out_path_display = str(ns.out)
+        data["output_path"] = out_path_display
     else:
         data["output_path"] = ""
 
@@ -2964,13 +2966,19 @@ def main(argv: list[str] | None = None) -> int:
 
     if not ns.no_workspace:
         try:
-            workspace_root = safe_path(root, str(ns.workspace_root), allow_absolute=True)
+            validated_workspace_root = safe_path(root, str(ns.workspace_root), allow_absolute=True)
         except SecurityError as exc:
             sys.stderr.write(f"doctor: --workspace-root rejected: {exc}\n")
             return EXIT_FAILED
+        requested_workspace_root = Path(str(ns.workspace_root))
+        workspace_root = (
+            validated_workspace_root
+            if requested_workspace_root.is_absolute()
+            else requested_workspace_root
+        )
         workspace_artifacts: dict[str, str] = {}
-        if out_path is not None:
-            workspace_artifacts["doctor_output"] = out_path.as_posix()
+        if out_path_display is not None:
+            workspace_artifacts["doctor_output"] = out_path_display
         if evidence_dir is not None:
             workspace_artifacts["doctor_evidence_json"] = (
                 evidence_dir / "doctor-evidence.json"

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -2920,16 +2920,30 @@ def main(argv: list[str] | None = None) -> int:
         if is_json:
             output = _stable_json(data)
 
+    out_path: Path | None = None
     if ns.out:
-        Path(ns.out).write_text(output, encoding="utf-8")
-        data["output_path"] = str(ns.out)
+        try:
+            out_path = safe_path(root, str(ns.out), allow_absolute=True)
+        except SecurityError as exc:
+            sys.stderr.write(f"doctor: --out rejected: {exc}\n")
+            return EXIT_FAILED
+        out_path.write_text(output, encoding="utf-8")
+        data["output_path"] = out_path.as_posix()
     else:
         data["output_path"] = ""
+
+    evidence_dir: Path | None = None
+    if isinstance(ns.evidence_dir, str) and ns.evidence_dir.strip():
+        try:
+            evidence_dir = safe_path(root, ns.evidence_dir.strip(), allow_absolute=True)
+        except SecurityError as exc:
+            sys.stderr.write(f"doctor: --evidence-dir rejected: {exc}\n")
+            return EXIT_FAILED
 
     if isinstance(ns.evidence_dir, str) and ns.evidence_dir.strip():
         evidence_ok, evidence_error = _write_evidence(
             root,
-            Path(ns.evidence_dir.strip()),
+            evidence_dir if evidence_dir is not None else Path(ns.evidence_dir.strip()),
             data,
             profile=str(getattr(ns, "evidence_profile", "full")),
             include=str(getattr(ns, "evidence_include", "all")),
@@ -2949,11 +2963,15 @@ def main(argv: list[str] | None = None) -> int:
             return EXIT_FAILED
 
     if not ns.no_workspace:
+        try:
+            workspace_root = safe_path(root, str(ns.workspace_root), allow_absolute=True)
+        except SecurityError as exc:
+            sys.stderr.write(f"doctor: --workspace-root rejected: {exc}\n")
+            return EXIT_FAILED
         workspace_artifacts: dict[str, str] = {}
-        if ns.out:
-            workspace_artifacts["doctor_output"] = str(ns.out)
-        if isinstance(ns.evidence_dir, str) and ns.evidence_dir.strip():
-            evidence_dir = Path(ns.evidence_dir.strip())
+        if out_path is not None:
+            workspace_artifacts["doctor_output"] = out_path.as_posix()
+        if evidence_dir is not None:
             workspace_artifacts["doctor_evidence_json"] = (
                 evidence_dir / "doctor-evidence.json"
             ).as_posix()
@@ -2964,7 +2982,7 @@ def main(argv: list[str] | None = None) -> int:
                 evidence_dir / "doctor-evidence-manifest.json"
             ).as_posix()
         workspace_entry = record_workspace_run(
-            workspace_root=Path(ns.workspace_root),
+            workspace_root=workspace_root,
             workflow="doctor",
             scope=root.name or "repo",
             payload=data,
@@ -2974,8 +2992,8 @@ def main(argv: list[str] | None = None) -> int:
         data["workspace"] = workspace_entry
         if is_json:
             output = _stable_json(data)
-            if ns.out:
-                Path(ns.out).write_text(output, encoding="utf-8")
+            if out_path is not None:
+                out_path.write_text(output, encoding="utf-8")
 
     sys.stdout.write(output)
 

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -1570,15 +1570,27 @@ def _select_evidence_rows(
         selected_ids = actionable_ids
     elif include == "all":
         selected_ids = {
-            str(row.get("id", ""))
-            for row in diagnostics_rows
-            if str(row.get("id", "")).strip()
+            str(row.get("id", "")) for row in diagnostics_rows if str(row.get("id", "")).strip()
         }
     if profile == "ci":
-        allowed = {"pyproject", "ci_workflows", "security_files", "pre_commit", "deps", "clean_tree"}
+        allowed = {
+            "pyproject",
+            "ci_workflows",
+            "security_files",
+            "pre_commit",
+            "deps",
+            "clean_tree",
+        }
         selected_ids = {check_id for check_id in selected_ids if check_id in allowed}
     elif profile == "release":
-        allowed = {"pyproject", "clean_tree", "release_meta", "repo_readiness", "upgrade_audit", "ci_workflows"}
+        allowed = {
+            "pyproject",
+            "clean_tree",
+            "release_meta",
+            "repo_readiness",
+            "upgrade_audit",
+            "ci_workflows",
+        }
         selected_ids = {check_id for check_id in selected_ids if check_id in allowed}
     filtered_failed = [row for row in failed_checks if row.get("id") in selected_ids]
     filtered_controls = [row for row in passing_controls if row.get("id") in selected_ids]
@@ -1886,9 +1898,7 @@ def _write_evidence(
         json.dumps(evidence_payload, sort_keys=True, indent=2) + "\n",
         encoding="utf-8",
     )
-    (evidence_dir / "doctor-evidence.md").write_text(
-        "\n".join(evidence_lines), encoding="utf-8"
-    )
+    (evidence_dir / "doctor-evidence.md").write_text("\n".join(evidence_lines), encoding="utf-8")
     (evidence_dir / "doctor-evidence-manifest.json").write_text(
         json.dumps(manifest_payload, sort_keys=True, indent=2) + "\n",
         encoding="utf-8",
@@ -2775,7 +2785,7 @@ def main(argv: list[str] | None = None) -> int:
 
     finding_items = [
         {
-            "id": f"doctor:{row.get('id','unknown')}",
+            "id": f"doctor:{row.get('id', 'unknown')}",
             "kind": str(row.get("id", "check")),
             "severity": str(row.get("severity", "medium")),
             "priority": 70 if str(row.get("severity", "medium")) == "high" else 45,

--- a/src/sdetkit/evidence_workspace.py
+++ b/src/sdetkit/evidence_workspace.py
@@ -139,7 +139,9 @@ def record_workspace_run(
     manifest["runs"] = runs
     manifest["latest"] = {k: latest[k] for k in sorted(latest)}
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
 
     latest_dir = workspace_root / "latest" / workflow_slug
     latest_dir.mkdir(parents=True, exist_ok=True)

--- a/src/sdetkit/evidence_workspace.py
+++ b/src/sdetkit/evidence_workspace.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from .security import SecurityError, safe_path
+
 WORKSPACE_SCHEMA_VERSION = "sdetkit.evidence.workspace.v1"
 
 
@@ -54,6 +56,11 @@ def record_workspace_run(
     artifacts: dict[str, str],
     recommendations: list[str],
 ) -> dict[str, Any]:
+    try:
+        workspace_root = safe_path(Path.cwd(), workspace_root.as_posix(), allow_absolute=True)
+    except SecurityError as exc:
+        raise ValueError(f"workspace root rejected: {exc}") from exc
+
     workflow_slug = _safe_slug(workflow)
     scope_slug = _safe_slug(scope)
     canonical_payload = _stable_json_text(payload)

--- a/src/sdetkit/evidence_workspace.py
+++ b/src/sdetkit/evidence_workspace.py
@@ -56,10 +56,17 @@ def record_workspace_run(
     artifacts: dict[str, str],
     recommendations: list[str],
 ) -> dict[str, Any]:
+    raw_workspace_root = workspace_root
     try:
-        workspace_root = safe_path(Path.cwd(), workspace_root.as_posix(), allow_absolute=True)
+        validated_workspace_root = safe_path(
+            Path.cwd(), raw_workspace_root.as_posix(), allow_absolute=True
+        )
     except SecurityError as exc:
         raise ValueError(f"workspace root rejected: {exc}") from exc
+    if raw_workspace_root.is_absolute():
+        workspace_root = validated_workspace_root
+    else:
+        workspace_root = validated_workspace_root.relative_to(Path.cwd().resolve())
 
     workflow_slug = _safe_slug(workflow)
     scope_slug = _safe_slug(scope)

--- a/src/sdetkit/gate.py
+++ b/src/sdetkit/gate.py
@@ -168,9 +168,12 @@ def _fast_recommendations(steps: list[dict[str, Any]], failed_steps: list[str]) 
         step_id = str(step.get("id", ""))
         if step_id not in failed_steps:
             continue
-        if step_id in {"ruff_fix", "ruff_format_apply", "ruff", "ruff_format"} and _contains_missing_module(
-            step, "ruff"
-        ):
+        if step_id in {
+            "ruff_fix",
+            "ruff_format_apply",
+            "ruff",
+            "ruff_format",
+        } and _contains_missing_module(step, "ruff"):
             recommendations.append(
                 "Ruff is missing in this environment. Install dev tooling: python -m pip install -e .[dev,test]."
             )
@@ -219,7 +222,7 @@ def _run_fast(ns: argparse.Namespace) -> int:
 
     selected_steps = [step_id for step_id in AVAILABLE_STEPS if should_run(step_id)]
     if not selected_steps:
-        payload: dict[str, Any] = {
+        empty_payload: dict[str, Any] = {
             "profile": "fast",
             "root": str(root),
             "ok": False,
@@ -231,13 +234,13 @@ def _run_fast(ns: argparse.Namespace) -> int:
             ],
         }
         text = (
-            _stable_json(payload)
+            _stable_json(empty_payload)
             if ns.format == "json" and ns.stable_json
-            else json.dumps(payload, sort_keys=True) + "\n"
+            else json.dumps(empty_payload, sort_keys=True) + "\n"
             if ns.format == "json"
-            else _format_md(payload)
+            else _format_md(empty_payload)
             if ns.format == "md"
-            else _format_text(payload)
+            else _format_text(empty_payload)
         )
         _write_output(text, ns.out)
         return 2
@@ -353,7 +356,7 @@ def _run_fast(ns: argparse.Namespace) -> int:
         )
 
     failed = [s["id"] for s in steps if not s.get("ok", False)]
-    payload: dict[str, Any] = {
+    gate_payload: dict[str, Any] = {
         "profile": "fast",
         "root": str(root),
         "ok": not bool(failed),
@@ -362,21 +365,21 @@ def _run_fast(ns: argparse.Namespace) -> int:
     }
     recommendations = _fast_recommendations(steps, failed)
     if recommendations:
-        payload["recommendations"] = recommendations
+        gate_payload["recommendations"] = recommendations
 
     if ns.format == "json":
         if getattr(ns, "stable_json", False):
-            rendered = _stable_json(_normalize_gate_payload(payload))
+            rendered = _stable_json(_normalize_gate_payload(gate_payload))
         else:
-            rendered = json.dumps(payload, sort_keys=True) + "\n"
+            rendered = json.dumps(gate_payload, sort_keys=True) + "\n"
     elif ns.format == "md":
-        rendered = _format_md(payload)
+        rendered = _format_md(gate_payload)
     else:
-        rendered = _format_text(payload)
+        rendered = _format_text(gate_payload)
 
     _write_output(rendered, ns.out)
 
-    if payload["ok"]:
+    if gate_payload["ok"]:
         return 0
     sys.stderr.write("gate: problems found\n")
     return 2
@@ -513,7 +516,11 @@ def _run_release(ns: argparse.Namespace) -> int:
                 "Inspect available release checks by running: python -m sdetkit gate release --dry-run --format json.",
             ],
         }
-        rendered = json.dumps(payload, sort_keys=True) + "\n" if ns.format == "json" else _format_release_text(payload)
+        rendered = (
+            json.dumps(payload, sort_keys=True) + "\n"
+            if ns.format == "json"
+            else _format_release_text(payload)
+        )
         _write_output(rendered, ns.out)
         return 2
 

--- a/src/sdetkit/inspect_compare.py
+++ b/src/sdetkit/inspect_compare.py
@@ -41,7 +41,9 @@ def _read_workspace_record_payload(record_path: Path) -> dict[str, Any]:
     return payload
 
 
-def _resolve_workspace_record_path(*, workspace_root: Path, workflow: str, scope: str, run_hash: str) -> Path:
+def _resolve_workspace_record_path(
+    *, workspace_root: Path, workflow: str, scope: str, run_hash: str
+) -> Path:
     manifest = load_workspace_manifest(workspace_root)
     runs = manifest.get("runs", [])
     if not isinstance(runs, list):
@@ -63,7 +65,9 @@ def _resolve_workspace_record_path(*, workspace_root: Path, workflow: str, scope
     )
 
 
-def _resolve_latest_previous_record_paths(*, workspace_root: Path, workflow: str, scope: str) -> tuple[Path, Path]:
+def _resolve_latest_previous_record_paths(
+    *, workspace_root: Path, workflow: str, scope: str
+) -> tuple[Path, Path]:
     manifest = load_workspace_manifest(workspace_root)
     runs = manifest.get("runs", [])
     if not isinstance(runs, list):
@@ -89,7 +93,9 @@ def _resolve_latest_previous_record_paths(*, workspace_root: Path, workflow: str
     for item in candidates:
         by_hash[item["run_hash"]] = item
 
-    ordered = sorted(by_hash.values(), key=lambda row: (int(row["run_order"]), str(row["run_hash"])))
+    ordered = sorted(
+        by_hash.values(), key=lambda row: (int(row["run_order"]), str(row["run_hash"]))
+    )
     if len(ordered) < 2:
         raise ValueError(
             "compare: latest-vs-previous requires at least two distinct recorded runs for "
@@ -119,7 +125,9 @@ def _report_key(report: dict[str, Any]) -> str:
     return Path(str(report.get("path", "unknown"))).name
 
 
-def _build_id_drift(left_reports: dict[str, dict[str, Any]], right_reports: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+def _build_id_drift(
+    left_reports: dict[str, dict[str, Any]], right_reports: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for key in sorted(set(left_reports) & set(right_reports)):
         left_ids = set(str(v) for v in left_reports[key].get("record_ids", []) if str(v))
@@ -139,7 +147,9 @@ def _build_id_drift(left_reports: dict[str, dict[str, Any]], right_reports: dict
     return out
 
 
-def _build_schema_drift(left_reports: dict[str, dict[str, Any]], right_reports: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+def _build_schema_drift(
+    left_reports: dict[str, dict[str, Any]], right_reports: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
     drift: list[dict[str, Any]] = []
     for key in sorted(set(left_reports) & set(right_reports)):
         left_cols = set(left_reports[key].get("schema_overview", {}).get("columns", []))
@@ -190,7 +200,9 @@ def _render_text(payload: dict[str, Any]) -> str:
         "diagnostic_deltas:",
     ]
     for key, value in payload["diagnostic_deltas"].items():
-        lines.append(f"- {key}: baseline={value['baseline']} compare={value['compare']} delta={value['delta']}")
+        lines.append(
+            f"- {key}: baseline={value['baseline']} compare={value['compare']} delta={value['delta']}"
+        )
     judgment = payload.get("judgment", {})
     if isinstance(judgment, dict):
         lines.append(
@@ -212,17 +224,35 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         prog="sdetkit inspect-compare",
         description="Compare inspect evidence snapshots for baseline drift diagnostics.",
     )
-    p.add_argument("--left", default=None, help="Path to baseline inspect.json or workspace record.json")
-    p.add_argument("--right", default=None, help="Path to compare inspect.json or workspace record.json")
+    p.add_argument(
+        "--left", default=None, help="Path to baseline inspect.json or workspace record.json"
+    )
+    p.add_argument(
+        "--right", default=None, help="Path to compare inspect.json or workspace record.json"
+    )
     p.add_argument("--left-run", default=None, help="Workspace run hash for baseline inspect run")
     p.add_argument("--right-run", default=None, help="Workspace run hash for compare inspect run")
-    p.add_argument("--scope", default=None, help="Workspace scope (required for --left-run/--right-run)")
-    p.add_argument("--latest-vs-previous", action="store_true", help="Compare latest workspace run against previous run for a scope")
-    p.add_argument("--workspace-root", default=".sdetkit/workspace", help="Shared evidence workspace root")
+    p.add_argument(
+        "--scope", default=None, help="Workspace scope (required for --left-run/--right-run)"
+    )
+    p.add_argument(
+        "--latest-vs-previous",
+        action="store_true",
+        help="Compare latest workspace run against previous run for a scope",
+    )
+    p.add_argument(
+        "--workspace-root", default=".sdetkit/workspace", help="Shared evidence workspace root"
+    )
     p.add_argument("--workflow", default="inspect", help="Workspace workflow to resolve runs from")
     p.add_argument("--format", choices=["text", "json"], default="text")
-    p.add_argument("--out-dir", default=None, help="Directory for compare artifacts (default: .sdetkit/inspect-compare/<scope-or-input>)")
-    p.add_argument("--no-workspace", action="store_true", help="Disable shared workspace run recording")
+    p.add_argument(
+        "--out-dir",
+        default=None,
+        help="Directory for compare artifacts (default: .sdetkit/inspect-compare/<scope-or-input>)",
+    )
+    p.add_argument(
+        "--no-workspace", action="store_true", help="Disable shared workspace run recording"
+    )
     return p
 
 
@@ -273,8 +303,12 @@ def _resolve_pair(ns: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any
         left_loaded = _load_json(left_path)
         right_loaded = _load_json(right_path)
 
-        left_payload = left_loaded.get("payload") if left_path.name == "record.json" else left_loaded
-        right_payload = right_loaded.get("payload") if right_path.name == "record.json" else right_loaded
+        left_payload = (
+            left_loaded.get("payload") if left_path.name == "record.json" else left_loaded
+        )
+        right_payload = (
+            right_loaded.get("payload") if right_path.name == "record.json" else right_loaded
+        )
         if not isinstance(left_payload, dict) or not isinstance(right_payload, dict):
             raise ValueError("compare: expected inspect payload object for --left/--right")
         return left_payload, right_payload, left_path.as_posix(), right_path.as_posix()
@@ -360,11 +394,17 @@ def run_compare(
     if schema_drift:
         recommendations.append("Schema drift detected; update ingest contracts or mapping rules.")
     if id_drift:
-        recommendations.append("Record ID drift detected; validate disappear/appear sets for data loss risk.")
+        recommendations.append(
+            "Record ID drift detected; validate disappear/appear sets for data loss risk."
+        )
     if duplicate_row_delta > 0 or duplicate_record_id_delta > 0:
-        recommendations.append("Duplicate signals increased; investigate export or dedupe regressions.")
+        recommendations.append(
+            "Duplicate signals increased; investigate export or dedupe regressions."
+        )
     if right_coverage_gap > left_coverage_gap:
-        recommendations.append("Expected ID coverage regressed; restore baseline coverage before promotion.")
+        recommendations.append(
+            "Expected ID coverage regressed; restore baseline coverage before promotion."
+        )
     if not recommendations:
         recommendations.append("No meaningful drift detected; compare run is baseline-compatible.")
 
@@ -512,7 +552,11 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_FINDINGS
 
     out_scope = ns.scope or _safe_slug(Path(left_label).name + "-vs-" + Path(right_label).name)
-    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect-compare" / _safe_slug(out_scope)
+    out_dir = (
+        Path(ns.out_dir)
+        if ns.out_dir
+        else Path(".sdetkit") / "inspect-compare" / _safe_slug(out_scope)
+    )
     try:
         rc, payload, _, _ = run_compare(
             left_payload=left_payload,

--- a/src/sdetkit/inspect_data.py
+++ b/src/sdetkit/inspect_data.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from .evidence_workspace import record_workspace_run
 from .judgment import build_judgment, load_latest_previous_payload
+from .security import SecurityError, safe_path
 
 SCHEMA_VERSION = "sdetkit.inspect.v2"
 EXIT_OK = 0
@@ -697,7 +698,12 @@ def run_inspect(
     record_workspace: bool = True,
     workspace_scope: str | None = None,
 ) -> tuple[int, dict[str, Any], Path, Path]:
-    target = input_path.resolve()
+    try:
+        target = safe_path(Path.cwd(), input_path.as_posix(), allow_absolute=True).resolve()
+        out_dir = safe_path(Path.cwd(), out_dir.as_posix(), allow_absolute=True)
+        workspace_root = safe_path(Path.cwd(), workspace_root.as_posix(), allow_absolute=True)
+    except SecurityError as exc:
+        raise ValueError(f"inspect: path rejected: {exc}") from exc
     if not target.exists():
         raise ValueError(f"inspect: input path does not exist: {target}")
 
@@ -904,7 +910,11 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write("inspect: missing input path (or use --rules-template)\n")
         return EXIT_FINDINGS
 
-    target = Path(ns.path).resolve()
+    try:
+        target = safe_path(Path.cwd(), ns.path, allow_absolute=True).resolve()
+    except SecurityError as exc:
+        sys.stderr.write(f"inspect: path rejected: {exc}\n")
+        return EXIT_FINDINGS
 
     rules_payload: dict[str, Any] = {}
     if ns.rules:
@@ -913,15 +923,22 @@ def main(argv: list[str] | None = None) -> int:
             sys.stderr.write(error + "\n")
             return EXIT_FINDINGS
         rules_payload = loaded if loaded is not None else {}
-    out_dir = (
-        Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect" / _safe_slug(target.name)
-    )
+    try:
+        out_dir = (
+            safe_path(Path.cwd(), ns.out_dir, allow_absolute=True)
+            if ns.out_dir
+            else (Path(".sdetkit") / "inspect" / _safe_slug(target.name))
+        )
+        workspace_root = safe_path(Path.cwd(), ns.workspace_root, allow_absolute=True)
+    except SecurityError as exc:
+        sys.stderr.write(f"inspect: path rejected: {exc}\n")
+        return EXIT_FINDINGS
     try:
         rc, payload, _, _ = run_inspect(
             input_path=target,
             out_dir=out_dir,
             rules_payload=rules_payload,
-            workspace_root=Path(ns.workspace_root),
+            workspace_root=workspace_root,
             record_workspace=not ns.no_workspace,
         )
     except ValueError as exc:

--- a/src/sdetkit/inspect_data.py
+++ b/src/sdetkit/inspect_data.py
@@ -404,7 +404,9 @@ def _analyze_file(path: Path, *, root: Path, file_rules: dict[str, Any]) -> dict
                 json.dumps(item.get("details", {}), sort_keys=True),
             ),
         )[:50],
-        "extracted_id_sets": {name: sorted(values) for name, values in sorted(extracted_sets.items())},
+        "extracted_id_sets": {
+            name: sorted(values) for name, values in sorted(extracted_sets.items())
+        },
         "confidence": confidence,
         "recommendations": _recommendations(diagnostics, record_id_field is not None),
         "notes": notes,
@@ -504,7 +506,11 @@ def _rule_cross_file_checks(
         right_ids = set(right.get("extracted_id_sets", {}).get(right_column, []))
         left_only = sorted(left_ids - right_ids)
         right_only = sorted(right_ids - left_ids)
-        ok = len(left_only) == 0 if mode == "left_subset" else len(left_only) == 0 and len(right_only) == 0
+        ok = (
+            len(left_only) == 0
+            if mode == "left_subset"
+            else len(left_only) == 0 and len(right_only) == 0
+        )
         results.append(
             {
                 "rule_type": "cross_file_match",
@@ -610,7 +616,9 @@ def _validate_rules_payload(rules_payload: dict[str, Any]) -> str | None:
 
     file_rules = rules_payload.get("files", {})
     if not isinstance(file_rules, dict):
-        return "inspect: invalid rules payload: 'files' must be an object keyed by file name or path"
+        return (
+            "inspect: invalid rules payload: 'files' must be an object keyed by file name or path"
+        )
     for file_key, item in sorted(file_rules.items()):
         key = str(file_key)
         if not key:
@@ -658,8 +666,7 @@ def _validate_rules_payload(rules_payload: dict[str, Any]) -> str | None:
             value = item.get(field)
             if not isinstance(value, str) or not value.strip():
                 return (
-                    "inspect: invalid cross_file_rules["
-                    f"{idx}].{field}: must be a non-empty string"
+                    f"inspect: invalid cross_file_rules[{idx}].{field}: must be a non-empty string"
                 )
     return None
 
@@ -671,8 +678,7 @@ def _load_rules_payload(path: str) -> tuple[dict[str, Any] | None, str | None]:
         return None, f"inspect: rules file does not exist: {path}"
     except json.JSONDecodeError as exc:
         return None, (
-            "inspect: invalid rules file JSON at "
-            f"line {exc.lineno}, column {exc.colno}: {exc.msg}"
+            f"inspect: invalid rules file JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
         )
     if not isinstance(loaded, dict):
         return None, "inspect: invalid rules payload: top-level JSON value must be an object"
@@ -707,37 +713,39 @@ def run_inspect(
     file_rules = loaded_rules.get("files", {})
     cross_file_rules = loaded_rules.get("cross_file_rules", [])
     reports = [
-        _analyze_file(path, root=target if target.is_dir() else target.parent, file_rules=file_rules)
+        _analyze_file(
+            path, root=target if target.is_dir() else target.parent, file_rules=file_rules
+        )
         for path in files
     ]
     cross_file = _cross_file_diagnostics(reports)
     cross_file_rule_results = _rule_cross_file_checks(reports, cross_file_rules)
 
-    summary = {
+    diagnostics_summary: dict[str, int] = {
+        "suspicious_rows": sum(int(r["diagnostics"]["suspicious_row_count"]) for r in reports),
+        "missing_value_columns": sum(
+            int(r["diagnostics"]["missing_value_columns"]) for r in reports
+        ),
+        "duplicate_row_groups": sum(int(r["diagnostics"]["duplicate_row_groups"]) for r in reports),
+        "inconsistent_type_columns": sum(
+            int(r["diagnostics"]["inconsistent_type_columns"]) for r in reports
+        ),
+        "duplicate_record_ids": sum(
+            int(r["diagnostics"]["duplicate_record_id_count"]) for r in reports
+        ),
+        "cross_file_mismatches": len(cross_file),
+        "failed_rule_checks": sum(int(r["diagnostics"]["failed_rule_checks"]) for r in reports)
+        + sum(1 for item in cross_file_rule_results if not bool(item.get("ok", False))),
+    }
+
+    summary: dict[str, Any] = {
         "files_analyzed": len(reports),
         "total_records": sum(int(r["row_count"]) for r in reports),
         "skipped_file_count": len(skipped),
-        "diagnostics": {
-            "suspicious_rows": sum(int(r["diagnostics"]["suspicious_row_count"]) for r in reports),
-            "missing_value_columns": sum(
-                int(r["diagnostics"]["missing_value_columns"]) for r in reports
-            ),
-            "duplicate_row_groups": sum(
-                int(r["diagnostics"]["duplicate_row_groups"]) for r in reports
-            ),
-            "inconsistent_type_columns": sum(
-                int(r["diagnostics"]["inconsistent_type_columns"]) for r in reports
-            ),
-            "duplicate_record_ids": sum(
-                int(r["diagnostics"]["duplicate_record_id_count"]) for r in reports
-            ),
-            "cross_file_mismatches": len(cross_file),
-            "failed_rule_checks": sum(int(r["diagnostics"]["failed_rule_checks"]) for r in reports)
-            + sum(1 for item in cross_file_rule_results if not bool(item.get("ok", False))),
-        },
+        "diagnostics": diagnostics_summary,
     }
 
-    findings_score = sum(int(v) for v in summary["diagnostics"].values())
+    findings_score = sum(diagnostics_summary.values())
     confidence = max(0.0, round(1.0 - min(findings_score, 30) / 30.0, 2))
     recommendations: list[str] = []
     for report in reports:
@@ -745,7 +753,9 @@ def run_inspect(
             if rec not in recommendations:
                 recommendations.append(rec)
     if cross_file:
-        recommendations.append("Align record IDs across related exports before trusting combined metrics.")
+        recommendations.append(
+            "Align record IDs across related exports before trusting combined metrics."
+        )
 
     previous_payload = None
     previous_hash = None
@@ -758,22 +768,26 @@ def run_inspect(
         )
 
     finding_items: list[dict[str, Any]] = []
-    for key, value in summary["diagnostics"].items():
-        if int(value) <= 0:
+    for key, value in diagnostics_summary.items():
+        if value <= 0:
             continue
         finding_items.append(
             {
                 "id": f"inspect:{key}",
                 "kind": key,
-                "severity": "high" if key in {"cross_file_mismatches", "failed_rule_checks"} else "medium",
-                "priority": min(50, int(value) * 8),
+                "severity": "high"
+                if key in {"cross_file_mismatches", "failed_rule_checks"}
+                else "medium",
+                "priority": min(50, value * 8),
                 "why_it_matters": f"{key} surfaced {value} time(s) in this run.",
-                "next_action": recommendations[0] if recommendations else "Review evidence anomalies.",
+                "next_action": recommendations[0]
+                if recommendations
+                else "Review evidence anomalies.",
                 "message": f"{key}={value}",
             }
         )
     conflicting_evidence: list[dict[str, Any]] = []
-    if cross_file and summary["diagnostics"].get("missing_value_columns", 0) == 0:
+    if cross_file and diagnostics_summary.get("missing_value_columns", 0) == 0:
         conflicting_evidence.append(
             {
                 "id": "inspect:cross-file-vs-local",
@@ -784,16 +798,16 @@ def run_inspect(
 
     supporting_evidence = [
         {"kind": key, "value": int(value)}
-        for key, value in sorted(summary["diagnostics"].items())
-        if int(value) > 0
+        for key, value in sorted(diagnostics_summary.items())
+        if value > 0
     ]
     stability = 0.7
     previous_summary = None
     if isinstance(previous_payload, dict):
         prev_diag = previous_payload.get("summary", {}).get("diagnostics", {})
         if isinstance(prev_diag, dict):
-            prev_total = sum(int(prev_diag.get(k, 0)) for k in summary["diagnostics"])
-            cur_total = sum(int(v) for v in summary["diagnostics"].values())
+            prev_total = sum(int(prev_diag.get(k, 0)) for k in diagnostics_summary)
+            cur_total = sum(diagnostics_summary.values())
             if cur_total > prev_total:
                 stability = 0.35
                 previous_summary = "regressing"
@@ -805,8 +819,8 @@ def run_inspect(
 
     inspect_ok = findings_score == 0
     blocking = (
-        int(summary["diagnostics"].get("cross_file_mismatches", 0)) > 0
-        or int(summary["diagnostics"].get("failed_rule_checks", 0)) > 0
+        diagnostics_summary.get("cross_file_mismatches", 0) > 0
+        or diagnostics_summary.get("failed_rule_checks", 0) > 0
     )
     judgment = build_judgment(
         workflow="inspect",
@@ -899,7 +913,9 @@ def main(argv: list[str] | None = None) -> int:
             sys.stderr.write(error + "\n")
             return EXIT_FINDINGS
         rules_payload = loaded if loaded is not None else {}
-    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect" / _safe_slug(target.name)
+    out_dir = (
+        Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect" / _safe_slug(target.name)
+    )
     try:
         rc, payload, _, _ = run_inspect(
             input_path=target,

--- a/src/sdetkit/inspect_project.py
+++ b/src/sdetkit/inspect_project.py
@@ -17,6 +17,7 @@ from .review_engine import (
     investigation_confidence,
     rank_likely_issue_tracks,
 )
+from .security import SecurityError, safe_path
 
 SCHEMA_VERSION = "sdetkit.inspect.project.v1"
 EXIT_OK = 0
@@ -219,7 +220,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     ns = _build_arg_parser().parse_args(argv)
-    project_dir = Path(ns.project_dir).resolve()
+    try:
+        project_dir = safe_path(Path.cwd(), ns.project_dir, allow_absolute=True).resolve()
+        workspace_root = safe_path(Path.cwd(), ns.workspace_root, allow_absolute=True)
+    except SecurityError as exc:
+        sys.stderr.write(f"inspect-project: path rejected: {exc}\n")
+        return EXIT_FINDINGS
     if not project_dir.exists() or not project_dir.is_dir():
         sys.stderr.write(
             f"inspect-project: project_dir does not exist or is not a directory: {project_dir}\n"
@@ -242,11 +248,14 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(error + "\n")
         return EXIT_FINDINGS
 
-    out_dir = (
-        Path(ns.out_dir)
-        if ns.out_dir
-        else Path(".sdetkit") / "inspect-project" / _safe_slug(project_dir.name)
-    )
+    if ns.out_dir:
+        try:
+            out_dir = safe_path(Path.cwd(), ns.out_dir, allow_absolute=True)
+        except SecurityError as exc:
+            sys.stderr.write(f"inspect-project: out-dir rejected: {exc}\n")
+            return EXIT_FINDINGS
+    else:
+        out_dir = Path(".sdetkit") / "inspect-project" / _safe_slug(project_dir.name)
     outputs_cfg = policy.get("outputs", {}) if isinstance(policy.get("outputs"), dict) else {}
     project_subdir = str(outputs_cfg.get("project_subdir", "")).strip()
     scope_dir_name = str(outputs_cfg.get("scope_dir", "scopes")).strip() or "scopes"
@@ -302,7 +311,7 @@ def main(argv: list[str] | None = None) -> int:
                 input_path=scope_input_dir,
                 out_dir=inspect_out,
                 rules_payload=rules_payload,
-                workspace_root=Path(ns.workspace_root),
+                workspace_root=workspace_root,
                 record_workspace=not ns.no_workspace,
                 workspace_scope=scope_slug,
             )
@@ -349,8 +358,8 @@ def main(argv: list[str] | None = None) -> int:
             current_record = Path(inspect_payload.get("workspace", {}).get("record_path", ""))
             if ns.no_workspace or not current_record:
                 continue
-            current_record_abs = Path(ns.workspace_root) / current_record
-            manifest = _load_json(Path(ns.workspace_root) / "manifest.json")
+            current_record_abs = workspace_root / current_record
+            manifest = _load_json(workspace_root / "manifest.json")
             runs = [
                 item
                 for item in manifest.get("runs", [])
@@ -370,7 +379,7 @@ def main(argv: list[str] | None = None) -> int:
                 previous = item
             if previous is None:
                 continue
-            left_record = Path(ns.workspace_root) / str(previous.get("record_path", ""))
+            left_record = workspace_root / str(previous.get("record_path", ""))
             left_payload = _load_json(left_record).get("payload")
             right_payload = _load_json(current_record_abs).get("payload")
             if not isinstance(left_payload, dict) or not isinstance(right_payload, dict):
@@ -382,7 +391,7 @@ def main(argv: list[str] | None = None) -> int:
                 right_label=f"workspace:{current_record_abs.as_posix()}",
                 out_dir=compare_out,
                 out_scope=compare_scope,
-                workspace_root=Path(ns.workspace_root),
+                workspace_root=workspace_root,
                 record_workspace=not ns.no_workspace,
             )
             compare_runs.append(
@@ -492,7 +501,7 @@ def main(argv: list[str] | None = None) -> int:
     stability = 0.7
     if not ns.no_workspace:
         previous_payload, _ = load_latest_previous_payload(
-            workspace_root=Path(ns.workspace_root),
+            workspace_root=workspace_root,
             workflow="inspect-project",
             scope=_safe_slug(project_dir.name),
         )
@@ -607,7 +616,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not ns.no_workspace:
         workspace_entry = record_workspace_run(
-            workspace_root=Path(ns.workspace_root),
+            workspace_root=workspace_root,
             workflow="inspect-project",
             scope=_safe_slug(project_dir.name),
             payload=payload,

--- a/src/sdetkit/inspect_project.py
+++ b/src/sdetkit/inspect_project.py
@@ -112,10 +112,14 @@ def _resolve_rules_payload(project_dir: Path, policy: dict[str, Any]) -> dict[st
     return {}
 
 
-def _materialize_scope(project_dir: Path, scope: dict[str, Any], run_root: Path) -> tuple[list[Path], Path]:
+def _materialize_scope(
+    project_dir: Path, scope: dict[str, Any], run_root: Path
+) -> tuple[list[Path], Path]:
     include_patterns = sorted(str(p) for p in scope.get("include", []) if str(p).strip())
     if not include_patterns:
-        raise ValueError(f"inspect-project: scope {scope.get('name', 'unknown')!r} has no include patterns")
+        raise ValueError(
+            f"inspect-project: scope {scope.get('name', 'unknown')!r} has no include patterns"
+        )
     discovered: set[Path] = set()
     for pattern in include_patterns:
         for candidate in project_dir.glob(pattern):
@@ -134,15 +138,20 @@ def _materialize_scope(project_dir: Path, scope: dict[str, Any], run_root: Path)
         dst = scope_dir / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
         dst.write_bytes(src.read_bytes())
-        manifest_rows.append({"source": rel.as_posix(), "copied_to": dst.relative_to(run_root).as_posix()})
+        manifest_rows.append(
+            {"source": rel.as_posix(), "copied_to": dst.relative_to(run_root).as_posix()}
+        )
     (scope_dir / "scope-input-manifest.json").write_text(
-        json.dumps({"scope": scope["name"], "files": manifest_rows}, sort_keys=True, indent=2) + "\n",
+        json.dumps({"scope": scope["name"], "files": manifest_rows}, sort_keys=True, indent=2)
+        + "\n",
         encoding="utf-8",
     )
     return files, scope_dir
 
 
-def _threshold_failures(compare_summary: dict[str, Any], thresholds: dict[str, Any]) -> list[dict[str, Any]]:
+def _threshold_failures(
+    compare_summary: dict[str, Any], thresholds: dict[str, Any]
+) -> list[dict[str, Any]]:
     failures: list[dict[str, Any]] = []
     for key in sorted(thresholds):
         limit = int(thresholds.get(key, 0))
@@ -192,9 +201,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         description="Run reusable project inspection policy packs over dataset families.",
     )
     p.add_argument("project_dir", help="Directory containing evidence and policy pack")
-    p.add_argument("--policy", default="inspect-project.json", help="Policy JSON file relative to project_dir")
-    p.add_argument("--workspace-root", default=".sdetkit/workspace", help="Shared evidence workspace root")
-    p.add_argument("--out-dir", default=None, help="Project output directory (default .sdetkit/inspect-project/<project-name>)")
+    p.add_argument(
+        "--policy", default="inspect-project.json", help="Policy JSON file relative to project_dir"
+    )
+    p.add_argument(
+        "--workspace-root", default=".sdetkit/workspace", help="Shared evidence workspace root"
+    )
+    p.add_argument(
+        "--out-dir",
+        default=None,
+        help="Project output directory (default .sdetkit/inspect-project/<project-name>)",
+    )
     p.add_argument("--format", choices=["text", "json"], default="text")
     p.add_argument("--no-workspace", action="store_true", help="Disable shared workspace recording")
     return p
@@ -204,7 +221,9 @@ def main(argv: list[str] | None = None) -> int:
     ns = _build_arg_parser().parse_args(argv)
     project_dir = Path(ns.project_dir).resolve()
     if not project_dir.exists() or not project_dir.is_dir():
-        sys.stderr.write(f"inspect-project: project_dir does not exist or is not a directory: {project_dir}\n")
+        sys.stderr.write(
+            f"inspect-project: project_dir does not exist or is not a directory: {project_dir}\n"
+        )
         return EXIT_FINDINGS
 
     policy_path = project_dir / ns.policy
@@ -223,7 +242,11 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(error + "\n")
         return EXIT_FINDINGS
 
-    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "inspect-project" / _safe_slug(project_dir.name)
+    out_dir = (
+        Path(ns.out_dir)
+        if ns.out_dir
+        else Path(".sdetkit") / "inspect-project" / _safe_slug(project_dir.name)
+    )
     outputs_cfg = policy.get("outputs", {}) if isinstance(policy.get("outputs"), dict) else {}
     project_subdir = str(outputs_cfg.get("project_subdir", "")).strip()
     scope_dir_name = str(outputs_cfg.get("scope_dir", "scopes")).strip() or "scopes"
@@ -244,10 +267,16 @@ def main(argv: list[str] | None = None) -> int:
     findings: list[dict[str, Any]] = []
 
     compare_cfg = policy.get("compare", {}) if isinstance(policy.get("compare"), dict) else {}
-    thresholds = compare_cfg.get("thresholds", {}) if isinstance(compare_cfg.get("thresholds"), dict) else {}
+    thresholds = (
+        compare_cfg.get("thresholds", {}) if isinstance(compare_cfg.get("thresholds"), dict) else {}
+    )
     baseline_mode = str(compare_cfg.get("baseline", "latest_vs_previous"))
-    precedence_cfg = policy.get("precedence", {}) if isinstance(policy.get("precedence"), dict) else {}
-    weights_cfg = precedence_cfg.get("weights", {}) if isinstance(precedence_cfg.get("weights"), dict) else {}
+    precedence_cfg = (
+        policy.get("precedence", {}) if isinstance(policy.get("precedence"), dict) else {}
+    )
+    weights_cfg = (
+        precedence_cfg.get("weights", {}) if isinstance(precedence_cfg.get("weights"), dict) else {}
+    )
 
     for scope in scopes:
         scope = dict(scope)
@@ -402,7 +431,9 @@ def main(argv: list[str] | None = None) -> int:
         [
             {
                 **item,
-                "priority": int(weights_cfg.get(str(item.get("kind", "")), int(item.get("priority", 0)))),
+                "priority": int(
+                    weights_cfg.get(str(item.get("kind", "")), int(item.get("priority", 0)))
+                ),
             }
             for item in findings
         ],
@@ -414,8 +445,12 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
 
-    inspect_fail_scopes = len({f["scope"] for f in ordered_findings if f["kind"].startswith("inspect")})
-    compare_fail_scopes = len({f["scope"] for f in ordered_findings if f["kind"].startswith("compare")})
+    inspect_fail_scopes = len(
+        {f["scope"] for f in ordered_findings if f["kind"].startswith("inspect")}
+    )
+    compare_fail_scopes = len(
+        {f["scope"] for f in ordered_findings if f["kind"].startswith("compare")}
+    )
     contradiction_inputs: list[dict[str, Any]] = []
     if inspect_fail_scopes > 0:
         contradiction_inputs.append({"kind": "inspect"})
@@ -437,7 +472,7 @@ def main(argv: list[str] | None = None) -> int:
         )
     finding_items = [
         {
-            "id": f"inspect-project:{idx+1}",
+            "id": f"inspect-project:{idx + 1}",
             "kind": str(item.get("kind", "finding")),
             "severity": "high" if str(item.get("kind", "")).startswith("compare") else "medium",
             "priority": min(70, 100 - int(item.get("priority", 0)) * 2),
@@ -562,9 +597,13 @@ def main(argv: list[str] | None = None) -> int:
     inspect_project_json = run_root / "inspect-project.json"
     inspect_project_txt = run_root / "inspect-project.txt"
     manifest_json = run_root / "manifest.json"
-    inspect_project_json.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    inspect_project_json.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
     inspect_project_txt.write_text(_render_text(payload), encoding="utf-8")
-    manifest_json.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    manifest_json.write_text(
+        json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
 
     if not ns.no_workspace:
         workspace_entry = record_workspace_run(
@@ -580,7 +619,9 @@ def main(argv: list[str] | None = None) -> int:
             recommendations=[f["message"] for f in ordered_findings[:10]],
         )
         payload["workspace"] = workspace_entry
-        inspect_project_json.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        inspect_project_json.write_text(
+            json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+        )
 
     output = json.dumps(payload, sort_keys=True) if ns.format == "json" else _render_text(payload)
     sys.stdout.write(output + ("\n" if not output.endswith("\n") else ""))

--- a/src/sdetkit/judgment.py
+++ b/src/sdetkit/judgment.py
@@ -37,7 +37,9 @@ JUDGMENT_GUIDELINES: tuple[dict[str, str], ...] = (
 )
 
 
-def _select_guideline(*, status: str, priority_score: int, confidence_level: str, has_contradictions: bool) -> dict[str, str]:
+def _select_guideline(
+    *, status: str, priority_score: int, confidence_level: str, has_contradictions: bool
+) -> dict[str, str]:
     if has_contradictions:
         return dict(JUDGMENT_GUIDELINES[0])
     if status == "fail" or priority_score >= 60:
@@ -47,7 +49,6 @@ def _select_guideline(*, status: str, priority_score: int, confidence_level: str
     if status == "pass" and confidence_level == "high":
         return dict(JUDGMENT_GUIDELINES[3])
     return dict(JUDGMENT_GUIDELINES[4])
-
 
 
 def _severity_from_score(score: int) -> str:
@@ -87,8 +88,12 @@ def _top_findings(findings: list[dict[str, Any]], *, limit: int = 3) -> list[dic
     )[:limit]
 
 
-def _build_confidence(*, completeness: float, consistency: float, stability: float, drivers: list[str]) -> dict[str, Any]:
-    score = max(0.0, min(1.0, round((completeness * 0.4) + (consistency * 0.4) + (stability * 0.2), 2)))
+def _build_confidence(
+    *, completeness: float, consistency: float, stability: float, drivers: list[str]
+) -> dict[str, Any]:
+    score = max(
+        0.0, min(1.0, round((completeness * 0.4) + (consistency * 0.4) + (stability * 0.2), 2))
+    )
     return {
         "score": score,
         "level": _level_from_confidence(score),
@@ -96,7 +101,9 @@ def _build_confidence(*, completeness: float, consistency: float, stability: flo
     }
 
 
-def _recommendations_from_findings(findings: list[dict[str, Any]], *, contradictions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _recommendations_from_findings(
+    findings: list[dict[str, Any]], *, contradictions: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
     recs: list[dict[str, Any]] = []
     for idx, finding in enumerate(_top_findings(findings, limit=5), start=1):
         priority = int(finding.get("priority", 0))
@@ -110,8 +117,14 @@ def _recommendations_from_findings(findings: list[dict[str, Any]], *, contradict
                 "id": f"rec-{idx}",
                 "tier": tier,
                 "priority": priority,
-                "action": str(finding.get("next_action", "Investigate high-signal evidence and update controls.")),
-                "rationale": str(finding.get("why_it_matters", "High-signal finding requires follow-up.")),
+                "action": str(
+                    finding.get(
+                        "next_action", "Investigate high-signal evidence and update controls."
+                    )
+                ),
+                "rationale": str(
+                    finding.get("why_it_matters", "High-signal finding requires follow-up.")
+                ),
                 "depends_on": list(finding.get("depends_on", [])),
             }
         )
@@ -147,7 +160,9 @@ def build_judgment(
     priority_score = min(100, sum(int(item.get("priority", 0)) for item in top))
     consistency = 1.0
     if supporting_evidence or conflicting_evidence:
-        consistency = len(supporting_evidence) / max(1, len(supporting_evidence) + len(conflicting_evidence))
+        consistency = len(supporting_evidence) / max(
+            1, len(supporting_evidence) + len(conflicting_evidence)
+        )
     drivers = [
         f"completeness={round(completeness, 2)}",
         f"consistency={round(consistency, 2)}",
@@ -221,7 +236,9 @@ def build_judgment(
     }
 
 
-def load_latest_previous_payload(*, workspace_root: Path, workflow: str, scope: str) -> tuple[dict[str, Any] | None, str | None]:
+def load_latest_previous_payload(
+    *, workspace_root: Path, workflow: str, scope: str
+) -> tuple[dict[str, Any] | None, str | None]:
     manifest_path = workspace_root / "manifest.json"
     if not manifest_path.exists():
         return None, None
@@ -238,7 +255,9 @@ def load_latest_previous_payload(*, workspace_root: Path, workflow: str, scope: 
     ]
     if not filtered:
         return None, None
-    latest = sorted(filtered, key=lambda item: (int(item.get("run_order", 0)), str(item.get("run_hash", ""))))[-1]
+    latest = sorted(
+        filtered, key=lambda item: (int(item.get("run_order", 0)), str(item.get("run_hash", "")))
+    )[-1]
     record_path = workspace_root / str(latest.get("record_path", ""))
     if not record_path.exists():
         return None, None

--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -31,6 +31,7 @@ from .review_engine import (
     rank_likely_issue_tracks,
     summarize_history_delta,
 )
+from .security import SecurityError, safe_path
 
 SCHEMA_VERSION = "sdetkit.review.v3"
 REVIEW_CONTRACT_VERSION = "sdetkit.review.contract.v1"
@@ -458,7 +459,12 @@ def run_review(
     profile: str = "release",
     no_workspace: bool = False,
 ) -> tuple[int, dict[str, Any], Path, Path]:
-    target = target.resolve()
+    try:
+        target = safe_path(Path.cwd(), target.as_posix(), allow_absolute=True).resolve()
+        out_dir = safe_path(Path.cwd(), out_dir.as_posix(), allow_absolute=True)
+        workspace_root = safe_path(Path.cwd(), workspace_root.as_posix(), allow_absolute=True)
+    except SecurityError as exc:
+        raise ValueError(f"review: path rejected: {exc}") from exc
     if not target.exists():
         raise ValueError(f"review: path does not exist: {target}")
 
@@ -1262,17 +1268,22 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     ns = _build_arg_parser().parse_args(argv)
-    target = Path(ns.path)
-    out_dir = (
-        Path(ns.out_dir)
-        if ns.out_dir
-        else Path(".sdetkit") / "review" / _safe_slug(target.resolve().name)
-    )
+    try:
+        target = safe_path(Path.cwd(), ns.path, allow_absolute=True)
+        out_dir = (
+            safe_path(Path.cwd(), ns.out_dir, allow_absolute=True)
+            if ns.out_dir
+            else Path(".sdetkit") / "review" / _safe_slug(target.resolve().name)
+        )
+        workspace_root = safe_path(Path.cwd(), ns.workspace_root, allow_absolute=True)
+    except SecurityError as exc:
+        sys.stderr.write(f"review: path rejected: {exc}\n")
+        return EXIT_FINDINGS
     try:
         rc, payload, _, _ = run_review(
             target=target,
             out_dir=out_dir,
-            workspace_root=Path(ns.workspace_root),
+            workspace_root=workspace_root,
             profile=ns.profile,
             no_workspace=ns.no_workspace,
         )

--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -178,7 +178,9 @@ def _profile_packet_filename(profile_name: str) -> str:
 
 def _build_profile_packet(payload: dict[str, Any]) -> dict[str, Any]:
     profile = str(payload.get("profile", {}).get("name", "release"))
-    findings = _sorted_findings([item for item in payload.get("top_matters", []) if isinstance(item, dict)])
+    findings = _sorted_findings(
+        [item for item in payload.get("top_matters", []) if isinstance(item, dict)]
+    )
     contradictions = _sorted_findings(
         [item for item in payload.get("conflicting_evidence", []) if isinstance(item, dict)]
     )
@@ -275,7 +277,9 @@ def _build_profile_packet(payload: dict[str, Any]) -> dict[str, Any]:
             "has_previous_review": payload.get("history", {}).get("has_previous_review", False),
             "previous_review_run_hash": payload.get("history", {}).get("previous_review_run_hash"),
             "workspace_runs": [
-                item for item in payload.get("supporting_evidence", []) if item.get("kind") == "workspace_runs"
+                item
+                for item in payload.get("supporting_evidence", [])
+                if item.get("kind") == "workspace_runs"
             ],
         },
         "volatility_flags": contradictions,
@@ -344,7 +348,9 @@ def _finalize_probe_lifecycle(adaptive_plan: dict[str, Any]) -> None:
             continue
         moved = dict(row)
         moved["status"] = "skipped"
-        moved["skip_reason"] = str(row.get("skip_reason", "")) or "probe planned but not executed in deepen stage"
+        moved["skip_reason"] = (
+            str(row.get("skip_reason", "")) or "probe planned but not executed in deepen stage"
+        )
         if probe_id and probe_id in skipped_ids:
             continue
         skipped_out.append(moved)
@@ -411,7 +417,9 @@ def _workflows_for_profile(detection: dict[str, bool], profile: ReviewProfile) -
     }
 
 
-def _run_doctor(target: Path, out_dir: Path, workspace_root: Path, no_workspace: bool) -> tuple[int, dict[str, Any], Path]:
+def _run_doctor(
+    target: Path, out_dir: Path, workspace_root: Path, no_workspace: bool
+) -> tuple[int, dict[str, Any], Path]:
     doctor_json = out_dir / "doctor.json"
     args = [
         "--json",
@@ -433,7 +441,7 @@ def _run_doctor(target: Path, out_dir: Path, workspace_root: Path, no_workspace:
         try:
             rc = doctor.main(args)
         except SystemExit as exc:
-            rc = int(exc.code)
+            rc = int(exc.code) if isinstance(exc.code, int) else 1
     payload = _load_json(doctor_json)
     return int(rc), payload, doctor_json
 
@@ -459,10 +467,14 @@ def run_review(
     workflow_plan = _workflows_for_profile(detection, selected_profile)
     review_scope = _review_scope_for_target(target)
     out_dir.mkdir(parents=True, exist_ok=True)
-    probe_memory = _load_probe_memory(workspace_root=workspace_root, scope=review_scope) if not no_workspace else {
-        "schema_version": "sdetkit.review.probe-memory.v1",
-        "probes": {},
-    }
+    probe_memory = (
+        _load_probe_memory(workspace_root=workspace_root, scope=review_scope)
+        if not no_workspace
+        else {
+            "schema_version": "sdetkit.review.probe-memory.v1",
+            "probes": {},
+        }
+    )
 
     source_workflows: list[dict[str, Any]] = []
     supporting: list[dict[str, Any]] = []
@@ -541,7 +553,12 @@ def run_review(
         inspect_status = "ok" if inspect_rc == 0 else "findings"
         source_workflows.append({"workflow": "inspect", "status": inspect_status})
         baseline_stage["checks_run"].append({"check": "inspect", "status": inspect_status})
-        supporting.append({"kind": "inspect_files", "value": inspect_payload.get("summary", {}).get("files_analyzed", 0)})
+        supporting.append(
+            {
+                "kind": "inspect_files",
+                "value": inspect_payload.get("summary", {}).get("files_analyzed", 0),
+            }
+        )
         if inspect_rc == 0:
             healthy_controls.append("inspect evidence diagnostics are stable")
         else:
@@ -575,16 +592,21 @@ def run_review(
                 str(project_out),
                 "--format",
                 "json",
-                *( ["--no-workspace"] if no_workspace else []),
+                *(["--no-workspace"] if no_workspace else []),
             ]
         )
-        payload = _load_json(project_out / "inspect-project.json")
+        project_payload = _load_json(project_out / "inspect-project.json")
         artifact_index["inspect_project_json"] = (project_out / "inspect-project.json").as_posix()
         artifact_index["inspect_project_txt"] = (project_out / "inspect-project.txt").as_posix()
         project_status = "ok" if rc == 0 else "findings"
         source_workflows.append({"workflow": "inspect-project", "status": project_status})
         baseline_stage["checks_run"].append({"check": "inspect-project", "status": project_status})
-        supporting.append({"kind": "inspect_project_scopes", "value": payload.get("summary", {}).get("scopes", 0)})
+        supporting.append(
+            {
+                "kind": "inspect_project_scopes",
+                "value": project_payload.get("summary", {}).get("scopes", 0),
+            }
+        )
         if rc != 0:
             findings.append(
                 {
@@ -633,7 +655,12 @@ def run_review(
     adaptive_plan["probe_registry"] = probe_decision["registry"]
     adaptive_plan["probe_budget"] = probe_decision["budget"]
 
-    if inspect_payload and "inspect-compare" in deepen_checks and escalation.needed and not no_workspace:
+    if (
+        inspect_payload
+        and "inspect-compare" in deepen_checks
+        and escalation.needed
+        and not no_workspace
+    ):
         scope = _review_scope_for_target(target)
         previous_inspect, _ = load_latest_previous_payload(
             workspace_root=workspace_root,
@@ -689,7 +716,9 @@ def run_review(
                 row["status"] = "executed"
                 row["result"] = "ok"
 
-    weighted_findings = [{**item, "priority": profile_weighted_priority(item, selected_profile)} for item in findings]
+    weighted_findings = [
+        {**item, "priority": profile_weighted_priority(item, selected_profile)} for item in findings
+    ]
     weighted_conflicts = [
         {
             **item,
@@ -699,11 +728,17 @@ def run_review(
     ]
     contradiction_count = len(conflicting)
     contradiction_boost = contradiction_count * selected_profile.contradiction_weight
-    effective_max_priority = max([0, *(int(item.get("priority", 0)) for item in weighted_findings)]) + contradiction_boost
+    effective_max_priority = (
+        max([0, *(int(item.get("priority", 0)) for item in weighted_findings)])
+        + contradiction_boost
+    )
     completeness = min(1.0, max(0.2, len(source_workflows) / 5.0))
     stability = 0.7 if conflicting else 0.85
     workflow_ok = len(weighted_findings) == 0
-    blocking = effective_max_priority >= selected_profile.fail_threshold or contradiction_count >= selected_profile.contradiction_fail_count
+    blocking = (
+        effective_max_priority >= selected_profile.fail_threshold
+        or contradiction_count >= selected_profile.contradiction_fail_count
+    )
 
     review_judgment = build_judgment(
         workflow="review",
@@ -716,9 +751,15 @@ def run_review(
         workflow_ok=workflow_ok,
         blocking=blocking,
     )
-    if effective_max_priority >= selected_profile.fail_threshold or contradiction_count >= selected_profile.contradiction_fail_count:
+    if (
+        effective_max_priority >= selected_profile.fail_threshold
+        or contradiction_count >= selected_profile.contradiction_fail_count
+    ):
         profile_status = "fail"
-    elif effective_max_priority >= selected_profile.watch_threshold or contradiction_count >= selected_profile.contradiction_watch_count:
+    elif (
+        effective_max_priority >= selected_profile.watch_threshold
+        or contradiction_count >= selected_profile.contradiction_watch_count
+    ):
         profile_status = "watch"
     else:
         profile_status = "pass"
@@ -738,7 +779,9 @@ def run_review(
         "effective_max_priority": effective_max_priority,
     }
     confidence = dict(review_judgment.get("confidence", {}))
-    confidence["level"] = profile_confidence_level(float(confidence.get("score", 0.0)), selected_profile)
+    confidence["level"] = profile_confidence_level(
+        float(confidence.get("score", 0.0)), selected_profile
+    )
     confidence["profile_thresholds"] = {
         "high": selected_profile.confidence_high,
         "medium": selected_profile.confidence_medium,
@@ -769,7 +812,9 @@ def run_review(
         "profile": {
             "name": selected_profile.name,
             "summary_style": selected_profile.summary_style,
-            "orchestration_depth": "deep" if selected_profile.name in {"release", "forensics"} else "focused",
+            "orchestration_depth": "deep"
+            if selected_profile.name in {"release", "forensics"}
+            else "focused",
             "workflow_plan": workflow_plan,
             "urgency_thresholds": {
                 "now": selected_profile.urgency_now_threshold,
@@ -836,7 +881,11 @@ def run_review(
         findings=weighted_findings,
         conflicts=weighted_conflicts,
         likely_tracks=likely_tracks,
-        executed_probes=[row for row in adaptive_plan.get("executed_probes", []) if row.get("status") == "executed"],
+        executed_probes=[
+            row
+            for row in adaptive_plan.get("executed_probes", [])
+            if row.get("status") == "executed"
+        ],
     )
     payload["adaptive_review"]["probe_feedback"] = probe_feedback
     payload["adaptive_review"]["probe_rationale"] = [
@@ -848,7 +897,9 @@ def run_review(
         if isinstance(row, dict)
     ]
     normalized_probe_outcomes = normalize_probe_execution_outcomes(
-        executed_probes=[row for row in adaptive_plan.get("executed_probes", []) if isinstance(row, dict)],
+        executed_probes=[
+            row for row in adaptive_plan.get("executed_probes", []) if isinstance(row, dict)
+        ],
         findings=weighted_findings,
         conflicts=weighted_conflicts,
     )
@@ -873,7 +924,9 @@ def run_review(
                 }
                 break
     payload["evidence_edges"] = build_typed_evidence_edges(
-        executed_probes=[row for row in adaptive_plan.get("executed_probes", []) if isinstance(row, dict)],
+        executed_probes=[
+            row for row in adaptive_plan.get("executed_probes", []) if isinstance(row, dict)
+        ],
         conflicts=weighted_conflicts,
         findings=weighted_findings,
         tracks=payload["likely_issue_tracks"],
@@ -883,7 +936,9 @@ def run_review(
         findings=weighted_findings,
         conflicts=weighted_conflicts,
     )
-    final_confidence = round(max(0.0, min(1.0, final_confidence + float(probe_feedback.get("confidence_delta", 0.0)))), 2)
+    final_confidence = round(
+        max(0.0, min(1.0, final_confidence + float(probe_feedback.get("confidence_delta", 0.0)))), 2
+    )
     adaptive_plan["stop_decision"] = decide_stop(
         final_confidence=final_confidence,
         confidence_threshold=selected_profile.confidence_medium,
@@ -908,10 +963,18 @@ def run_review(
     artifact_index["review_tracks_json"] = review_tracks_path.as_posix()
     payload["artifact_index"] = artifact_index
     payload["operator_summary"]["artifacts"] = artifact_index
-    packet_json_path.write_text(json.dumps(profile_packet, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-    operator_json_path.write_text(json.dumps(payload["operator_summary"], sort_keys=True, indent=2) + "\n", encoding="utf-8")
-    review_plan_path.write_text(json.dumps(adaptive_plan, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-    review_tracks_path.write_text(json.dumps({"tracks": likely_tracks}, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    packet_json_path.write_text(
+        json.dumps(profile_packet, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    operator_json_path.write_text(
+        json.dumps(payload["operator_summary"], sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    review_plan_path.write_text(
+        json.dumps(adaptive_plan, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    review_tracks_path.write_text(
+        json.dumps({"tracks": likely_tracks}, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
     json_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
     txt_path.write_text(_render_text(payload), encoding="utf-8")
 
@@ -929,7 +992,11 @@ def run_review(
             scope=review_scope,
             payload=payload,
             artifacts={"review_json": json_path.as_posix(), "review_text": txt_path.as_posix()},
-            recommendations=[str(item.get("action", "")) for item in payload.get("prioritized_actions", []) if isinstance(item, dict)],
+            recommendations=[
+                str(item.get("action", ""))
+                for item in payload.get("prioritized_actions", [])
+                if isinstance(item, dict)
+            ],
         )
         payload["workspace"] = workspace_entry
         json_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
@@ -946,7 +1013,11 @@ def _render_text(payload: dict[str, Any]) -> str:
     profile_name = str(profile.get("name", "release")) if isinstance(profile, dict) else "release"
     max_matters = 5
     if isinstance(profile, dict):
-        max_matters = int(REVIEW_PROFILES.get(str(profile.get("name", "")), REVIEW_PROFILES["release"]).max_text_matters)
+        max_matters = int(
+            REVIEW_PROFILES.get(
+                str(profile.get("name", "")), REVIEW_PROFILES["release"]
+            ).max_text_matters
+        )
     lines: list[str] = [
         f"SDETKit review: {payload['review_status']}",
         f"profile: {profile_name} style: {profile.get('summary_style', 'release-gate')}",
@@ -1035,7 +1106,9 @@ def _render_text(payload: dict[str, Any]) -> str:
         lines.append(f"- escalation_needed: {escalation.get('needed')}")
         for reason in escalation.get("reasons", [])[:3]:
             lines.append(f"  - reason: {reason}")
-        lines.append(f"- probes_executed: {len([p for p in adaptive.get('executed_probes', []) if p.get('status') == 'executed'])}")
+        lines.append(
+            f"- probes_executed: {len([p for p in adaptive.get('executed_probes', []) if p.get('status') == 'executed'])}"
+        )
         lines.append(f"- stop: {stop.get('stop')}")
         lines.append(f"- stop_reason: {stop.get('reason')}")
     tracks = payload.get("likely_issue_tracks", [])
@@ -1059,7 +1132,9 @@ def _build_operator_summary(payload: dict[str, Any]) -> dict[str, Any]:
     executed_probes = []
     if isinstance(adaptive, dict):
         executed_probes = [
-            row for row in adaptive.get("executed_probes", []) if isinstance(row, dict) and row.get("status") == "executed"
+            row
+            for row in adaptive.get("executed_probes", [])
+            if isinstance(row, dict) and row.get("status") == "executed"
         ]
     thresholds = payload.get("judgment", {}).get("profile_thresholds", {})
     if not isinstance(thresholds, dict):
@@ -1082,7 +1157,9 @@ def _build_operator_summary(payload: dict[str, Any]) -> dict[str, Any]:
             f"Top likely issue track is '{top_track.get('track')}' with likelihood {top_track.get('likelihood')}."
         )
     if conflicts:
-        rationale.append(f"{len(conflicts)} contradiction signal(s) require verification before full trust.")
+        rationale.append(
+            f"{len(conflicts)} contradiction signal(s) require verification before full trust."
+        )
     actions = [row for row in payload.get("prioritized_actions", []) if isinstance(row, dict)]
     return {
         "contract_version": REVIEW_CONTRACT_VERSION,
@@ -1096,7 +1173,9 @@ def _build_operator_summary(payload: dict[str, Any]) -> dict[str, Any]:
             "executed_probes_count": len(executed_probes),
         },
         "judgment_rationale": rationale,
-        "changed_since_previous": [row for row in payload.get("changed_since_previous", []) if isinstance(row, dict)][:5],
+        "changed_since_previous": [
+            row for row in payload.get("changed_since_previous", []) if isinstance(row, dict)
+        ][:5],
         "actions": {
             "now": [row for row in actions if row.get("tier") == "now"][:5],
             "next": [row for row in actions if row.get("tier") == "next"][:5],
@@ -1124,7 +1203,9 @@ def _run_interactive_review(payload: dict[str, Any]) -> None:
         "8": ("artifacts", operator.get("artifacts", {})),
     }
     sys.stdout.write("SDETKit interactive review navigator\n")
-    sys.stdout.write("Choose section: [1] situation [2] why [3] changed [4] actions [5] tracks [6] contradictions [7] probes [8] artifacts [q] quit\n")
+    sys.stdout.write(
+        "Choose section: [1] situation [2] why [3] changed [4] actions [5] tracks [6] contradictions [7] probes [8] artifacts [q] quit\n"
+    )
     while True:
         sys.stdout.write("> ")
         sys.stdout.flush()
@@ -1150,7 +1231,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("path", help="Repo/data/project/workspace path to review")
     p.add_argument("--workspace-root", default=".sdetkit/workspace", help="Shared workspace root")
-    p.add_argument("--out-dir", default=None, help="Output directory (default: .sdetkit/review/<path-slug>)")
+    p.add_argument(
+        "--out-dir", default=None, help="Output directory (default: .sdetkit/review/<path-slug>)"
+    )
     p.add_argument(
         "--profile",
         default="release",
@@ -1171,14 +1254,20 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Open an interactive operator navigator after review completes.",
     )
-    p.add_argument("--no-workspace", action="store_true", help="Disable workspace history recording")
+    p.add_argument(
+        "--no-workspace", action="store_true", help="Disable workspace history recording"
+    )
     return p
 
 
 def main(argv: list[str] | None = None) -> int:
     ns = _build_arg_parser().parse_args(argv)
     target = Path(ns.path)
-    out_dir = Path(ns.out_dir) if ns.out_dir else Path(".sdetkit") / "review" / _safe_slug(target.resolve().name)
+    out_dir = (
+        Path(ns.out_dir)
+        if ns.out_dir
+        else Path(".sdetkit") / "review" / _safe_slug(target.resolve().name)
+    )
     try:
         rc, payload, _, _ = run_review(
             target=target,

--- a/src/sdetkit/review_engine.py
+++ b/src/sdetkit/review_engine.py
@@ -34,7 +34,9 @@ def derive_probe_score_history_inputs(
     avg_cost = float(aggregates.get("avg_cost", 0.0))
     saturation = float(aggregates.get("repeat_hit_saturation", 0.0))
     track_payoff_map = aggregates.get("track_payoff", {}) if isinstance(aggregates, dict) else {}
-    track_payoff = float(track_payoff_map.get(current_track, avg_usefulness if avg_usefulness > 0 else 0.5))
+    track_payoff = float(
+        track_payoff_map.get(current_track, avg_usefulness if avg_usefulness > 0 else 0.5)
+    )
 
     usefulness_delta = int(round((avg_usefulness - 0.5) * 40)) if has_history else 0
     cost_penalty = int(round((avg_cost / 100.0) * 12)) if has_history else 0
@@ -42,9 +44,17 @@ def derive_probe_score_history_inputs(
     track_delta = int(round((track_payoff - 0.5) * 20)) if has_history else 0
     history_delta = usefulness_delta + track_delta - cost_penalty - saturation_penalty
     score_inputs = [
-        {"input": "history_avg_usefulness", "value": _round2(avg_usefulness), "weight": "((value-0.5)*40)"},
+        {
+            "input": "history_avg_usefulness",
+            "value": _round2(avg_usefulness),
+            "weight": "((value-0.5)*40)",
+        },
         {"input": "history_avg_cost", "value": _round2(avg_cost), "weight": "-((value/100)*12)"},
-        {"input": "history_repeat_hit_saturation", "value": _round2(saturation), "weight": "-(value*18)"},
+        {
+            "input": "history_repeat_hit_saturation",
+            "value": _round2(saturation),
+            "weight": "-(value*18)",
+        },
         {
             "input": f"history_track_payoff[{current_track}]",
             "value": _round2(track_payoff),
@@ -101,7 +111,11 @@ def apply_probe_memory_update(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     memory: dict[str, Any] = {"schema_version": "sdetkit.review.probe-memory.v1", "probes": {}}
     if isinstance(previous_memory, dict):
-        memory["probes"] = previous_memory.get("probes", {}) if isinstance(previous_memory.get("probes"), dict) else {}
+        memory["probes"] = (
+            previous_memory.get("probes", {})
+            if isinstance(previous_memory.get("probes"), dict)
+            else {}
+        )
     probes = memory["probes"]
     run_updates: list[dict[str, Any]] = []
     for outcome in sorted(normalized_outcomes, key=lambda item: str(item.get("probe_id", ""))):
@@ -132,7 +146,10 @@ def apply_probe_memory_update(
         for row in history:
             track = str(row.get("context_track", "stability"))
             track_buckets.setdefault(track, []).append(float(row.get("usefulness", 0.0)))
-        track_payoff = {track: _round2(sum(values) / len(values)) for track, values in sorted(track_buckets.items())}
+        track_payoff = {
+            track: _round2(sum(values) / len(values))
+            for track, values in sorted(track_buckets.items())
+        }
 
         aggregates = {
             "runs": len(history),
@@ -146,7 +163,9 @@ def apply_probe_memory_update(
         probe_entry["outcomes"] = history
         probe_entry["aggregates"] = aggregates
         probes[probe_id] = probe_entry
-        run_updates.append({"probe_id": probe_id, "aggregates": aggregates, "latest_outcome": outcome})
+        run_updates.append(
+            {"probe_id": probe_id, "aggregates": aggregates, "latest_outcome": outcome}
+        )
 
     summary = {
         "normalized_outcomes": normalized_outcomes,
@@ -216,7 +235,9 @@ def profile_priority_tier(priority: int, profile: Any) -> str:
     return "monitor"
 
 
-def build_staged_plan(*, profile_name: str, stages: tuple[Any, ...], workflow_plan: dict[str, bool]) -> dict[str, Any]:
+def build_staged_plan(
+    *, profile_name: str, stages: tuple[Any, ...], workflow_plan: dict[str, bool]
+) -> dict[str, Any]:
     stage_rows: list[dict[str, Any]] = []
     for stage in stages:
         checks = [name for name in stage.checks if workflow_plan.get(name.replace("-", "_"), False)]
@@ -284,7 +305,9 @@ def decide_stop(
     findings_count: int,
     conflicts_count: int,
 ) -> AdaptiveStopDecision:
-    can_stop = final_confidence >= confidence_threshold and findings_count == 0 and conflicts_count == 0
+    can_stop = (
+        final_confidence >= confidence_threshold and findings_count == 0 and conflicts_count == 0
+    )
     return AdaptiveStopDecision(
         stop=can_stop,
         confidence_score=final_confidence,
@@ -326,7 +349,11 @@ def build_contradiction_graph(
         )
     return sorted(
         graph,
-        key=lambda item: (str(item.get("kind", "")), str(item.get("id", "")), str(item.get("message", ""))),
+        key=lambda item: (
+            str(item.get("kind", "")),
+            str(item.get("id", "")),
+            str(item.get("message", "")),
+        ),
     )
 
 
@@ -410,7 +437,9 @@ def plan_adaptive_probes(
     contradictory = len(contradiction_graph.get("flat_contradictions", []))
     cluster_pressure = len(contradiction_graph.get("clusters", []))
     finding_pressure = sum(max(0, int(item.get("priority", 0))) for item in findings)
-    history_pressure = len([row for row in changed if str(row.get("kind")) in {"status", "severity"}])
+    history_pressure = len(
+        [row for row in changed if str(row.get("kind")) in {"status", "severity"}]
+    )
     current_track = "risk_pressure" if contradictory > 0 or finding_pressure > 0 else "stability"
     registry = [
         ProbeDefinition(
@@ -419,7 +448,11 @@ def plan_adaptive_probes(
             min_score=25,
             cost=55,
             max_chain_depth=2,
-            bounded_contract={"max_runtime_seconds": 20, "max_artifacts": 2, "max_input_payloads": 2},
+            bounded_contract={
+                "max_runtime_seconds": 20,
+                "max_artifacts": 2,
+                "max_input_payloads": 2,
+            },
             reason="Resolve whether recent evidence drift explains current contradictions/findings.",
         ),
         ProbeDefinition(
@@ -428,7 +461,11 @@ def plan_adaptive_probes(
             min_score=25,
             cost=30,
             max_chain_depth=2,
-            bounded_contract={"max_runtime_seconds": 10, "max_artifacts": 1, "max_manifest_entries": 200},
+            bounded_contract={
+                "max_runtime_seconds": 10,
+                "max_artifacts": 1,
+                "max_manifest_entries": 200,
+            },
             reason="Use repeated-run history to verify whether risk is persistent or newly introduced.",
         ),
     ]
@@ -438,20 +475,34 @@ def plan_adaptive_probes(
         score_inputs: list[dict[str, Any]] = []
         if probe.probe_id == "probe:inspect-compare":
             score += 35 if contradictory else 0
-            score_inputs.append({"input": "contradictions_present", "value": contradictory, "weight": 35})
+            score_inputs.append(
+                {"input": "contradictions_present", "value": contradictory, "weight": 35}
+            )
             score += cluster_pressure * 12
-            score_inputs.append({"input": "cluster_pressure", "value": cluster_pressure, "weight": 12})
+            score_inputs.append(
+                {"input": "cluster_pressure", "value": cluster_pressure, "weight": 12}
+            )
             score += finding_pressure // 6
-            score_inputs.append({"input": "finding_pressure", "value": finding_pressure, "weight": "1/6"})
+            score_inputs.append(
+                {"input": "finding_pressure", "value": finding_pressure, "weight": "1/6"}
+            )
             score += 15 if has_previous_review else 0
-            score_inputs.append({"input": "has_previous_review", "value": has_previous_review, "weight": 15})
+            score_inputs.append(
+                {"input": "has_previous_review", "value": has_previous_review, "weight": 15}
+            )
         elif probe.probe_id == "probe:workspace-history":
             score += 20 if contradictory else 0
-            score_inputs.append({"input": "contradictions_present", "value": contradictory, "weight": 20})
+            score_inputs.append(
+                {"input": "contradictions_present", "value": contradictory, "weight": 20}
+            )
             score += history_pressure * 20
-            score_inputs.append({"input": "history_pressure", "value": history_pressure, "weight": 20})
+            score_inputs.append(
+                {"input": "history_pressure", "value": history_pressure, "weight": 20}
+            )
             score += 10 if profile_name == "forensics" else 0
-            score_inputs.append({"input": "forensics_profile", "value": profile_name == "forensics", "weight": 10})
+            score_inputs.append(
+                {"input": "forensics_profile", "value": profile_name == "forensics", "weight": 10}
+            )
             score += 8 if confidence_score < confidence_threshold else 0
             score_inputs.append(
                 {
@@ -487,13 +538,17 @@ def plan_adaptive_probes(
     chain_enabled = contradictory > 0 or cluster_pressure > 0
     for row in sorted(candidates, key=lambda item: (-int(item["score"]), str(item["probe_id"]))):
         requires = str(row["requires"])
-        enabled = bool(detection.get("workspace_like")) if requires == "workspace_like" else bool(
-            detection.get("data_like")
+        enabled = (
+            bool(detection.get("workspace_like"))
+            if requires == "workspace_like"
+            else bool(detection.get("data_like"))
         )
         affordable = (budget_spent + int(row["cost"])) <= budget_total
         enough_score = int(row["score"]) >= int(row["min_score"])
         within_chain = chain_depth < int(row["max_chain_depth"])
-        should_run = enabled and enough_score and len(executed) < max_probes and affordable and within_chain
+        should_run = (
+            enabled and enough_score and len(executed) < max_probes and affordable and within_chain
+        )
         target = executed if should_run else skipped
         if should_run:
             budget_spent += int(row["cost"])
@@ -618,7 +673,9 @@ def apply_probe_result_feedback(
     executed_probes: list[dict[str, Any]],
 ) -> dict[str, Any]:
     probe_pressure = len(executed_probes)
-    confidence_delta = 0.08 if probe_pressure > 0 and not findings and not conflicts else -0.03 * probe_pressure
+    confidence_delta = (
+        0.08 if probe_pressure > 0 and not findings and not conflicts else -0.03 * probe_pressure
+    )
     status = "stable" if confidence_delta >= 0 else "risk-intensified"
     track_updates: list[dict[str, Any]] = []
     for track in likely_tracks[:3]:
@@ -645,7 +702,9 @@ def apply_probe_result_feedback(
     }
 
 
-def summarize_history_delta(previous: dict[str, Any] | None, current: dict[str, Any]) -> list[dict[str, Any]]:
+def summarize_history_delta(
+    previous: dict[str, Any] | None, current: dict[str, Any]
+) -> list[dict[str, Any]]:
     if not isinstance(previous, dict):
         return [{"kind": "baseline", "message": "No previous review run found for this scope."}]
     changes: list[dict[str, Any]] = []
@@ -654,11 +713,18 @@ def summarize_history_delta(previous: dict[str, Any] | None, current: dict[str, 
     prev_now = len([a for a in prev_actions if isinstance(a, dict) and a.get("tier") == "now"])
     cur_now = len([a for a in cur_actions if isinstance(a, dict) and a.get("tier") == "now"])
     if prev_now != cur_now:
-        changes.append({"kind": "action_pressure", "message": f"immediate_actions changed {prev_now} -> {cur_now}"})
+        changes.append(
+            {
+                "kind": "action_pressure",
+                "message": f"immediate_actions changed {prev_now} -> {cur_now}",
+            }
+        )
     prev_status = str(previous.get("status", ""))
     cur_status = str(current.get("status", ""))
     if prev_status != cur_status:
-        changes.append({"kind": "status", "message": f"status changed {prev_status} -> {cur_status}"})
+        changes.append(
+            {"kind": "status", "message": f"status changed {prev_status} -> {cur_status}"}
+        )
     prev_sev = str(previous.get("severity", ""))
     cur_sev = str(current.get("severity", ""))
     if prev_sev != cur_sev:
@@ -683,7 +749,9 @@ def rank_likely_issue_tracks(
             {
                 "track_id": f"track-{idx}:{kind}",
                 "track": f"{kind}-stabilization",
-                "likelihood": round(min(0.95, 0.25 + (top_priority / 120.0) + (len(items) * 0.05)), 2),
+                "likelihood": round(
+                    min(0.95, 0.25 + (top_priority / 120.0) + (len(items) * 0.05)), 2
+                ),
                 "priority": top_priority,
                 "supporting_evidence": [
                     {
@@ -702,9 +770,17 @@ def rank_likely_issue_tracks(
                     "Confirm healthy controls remain preserved after applying changes.",
                 ],
                 "recommended_next_moves": [
-                    str(items[0].get("next_action", "Investigate and remediate top evidence on this track."))
+                    str(
+                        items[0].get(
+                            "next_action", "Investigate and remediate top evidence on this track."
+                        )
+                    )
                 ],
-                "blockers": ["Conflicting evidence unresolved." if conflicts else "No active blockers currently detected."],
+                "blockers": [
+                    "Conflicting evidence unresolved."
+                    if conflicts
+                    else "No active blockers currently detected."
+                ],
             }
         )
     if not tracks:
@@ -714,16 +790,27 @@ def rank_likely_issue_tracks(
                 "track": "control-integrity",
                 "likelihood": 0.2,
                 "priority": 10,
-                "supporting_evidence": [{"id": "baseline", "message": "No high-signal findings in baseline layer.", "priority": 0}],
+                "supporting_evidence": [
+                    {
+                        "id": "baseline",
+                        "message": "No high-signal findings in baseline layer.",
+                        "priority": 0,
+                    }
+                ],
                 "conflicting_evidence": [],
                 "verification_steps": ["Run lightweight spot-checks on recent changed areas."],
-                "recommended_next_moves": ["Continue with monitor-tier controls and next scheduled review."],
+                "recommended_next_moves": [
+                    "Continue with monitor-tier controls and next scheduled review."
+                ],
                 "blockers": [],
             }
         )
     if changed:
         tracks[0]["historical_context"] = changed[:3]
-    return sorted(tracks, key=lambda item: (-int(item.get("priority", 0)), str(item.get("track_id", ""))))[:5]
+    return sorted(
+        tracks, key=lambda item: (-int(item.get("priority", 0)), str(item.get("track_id", "")))
+    )[:5]
+
 
 ERROR_TRIAGE_RULES: tuple[dict[str, str], ...] = (
     {

--- a/src/sdetkit/serve.py
+++ b/src/sdetkit/serve.py
@@ -21,7 +21,9 @@ def _default_out_dir(target: Path) -> Path:
     return Path(".sdetkit") / "review" / review._safe_slug(target.resolve().name)
 
 
-def _build_error(*, code: str, message: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
+def _build_error(
+    *, code: str, message: str, details: dict[str, Any] | None = None
+) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "status": "error",
         "contract_version": SERVE_CONTRACT_VERSION,
@@ -37,7 +39,9 @@ def _build_error(*, code: str, message: str, details: dict[str, Any] | None = No
 
 def _parse_review_request(body: bytes) -> dict[str, Any]:
     if not body:
-        raise RequestValidationError("Request body must be valid JSON object with a required 'path' field.")
+        raise RequestValidationError(
+            "Request body must be valid JSON object with a required 'path' field."
+        )
     try:
         raw = json.loads(body.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -57,7 +61,9 @@ def _parse_review_request(body: bytes) -> dict[str, Any]:
 
     response_mode = raw.get("response_mode", "full")
     if response_mode not in {"full", "operator-summary"}:
-        raise RequestValidationError("Field 'response_mode' must be either 'full' or 'operator-summary'.")
+        raise RequestValidationError(
+            "Field 'response_mode' must be either 'full' or 'operator-summary'."
+        )
 
     no_workspace = raw.get("no_workspace", False)
     if not isinstance(no_workspace, bool):
@@ -106,7 +112,11 @@ def _run_review_request(req: dict[str, Any]) -> dict[str, Any]:
         "artifacts": {
             "review_json": json_path.as_posix(),
             "review_text": txt_path.as_posix(),
-            **(payload.get("artifact_index", {}) if isinstance(payload.get("artifact_index", {}), dict) else {}),
+            **(
+                payload.get("artifact_index", {})
+                if isinstance(payload.get("artifact_index", {}), dict)
+                else {}
+            ),
         },
     }
     if "workspace" in payload:

--- a/tests/test_doctor_diagnostics.py
+++ b/tests/test_doctor_diagnostics.py
@@ -135,7 +135,9 @@ def test_doctor_evidence_profile_and_include_filter(tmp_path: Path, monkeypatch,
     assert all(row["id"] in {"ci_workflows", "security_files"} for row in evidence["failed_checks"])
 
 
-def test_doctor_evidence_fails_for_non_actionable_check_selection(tmp_path: Path, monkeypatch, capsys):
+def test_doctor_evidence_fails_for_non_actionable_check_selection(
+    tmp_path: Path, monkeypatch, capsys
+):
     root = tmp_path / "repo"
     root.mkdir()
     monkeypatch.chdir(root)

--- a/tests/test_evidence_workspace.py
+++ b/tests/test_evidence_workspace.py
@@ -46,7 +46,9 @@ def test_inspect_records_shared_workspace_and_reuses_run_hash(tmp_path: Path) ->
     assert len(runs) == 1
     assert runs[0]["run_hash"] == run_hash
     assert (workspace / runs[0]["record_path"]).exists()
-    latest = json.loads((workspace / "latest" / "inspect" / "orders.csv.json").read_text(encoding="utf-8"))
+    latest = json.loads(
+        (workspace / "latest" / "inspect" / "orders.csv.json").read_text(encoding="utf-8")
+    )
     assert latest["run_hash"] == run_hash
 
 

--- a/tests/test_gate_fast.py
+++ b/tests/test_gate_fast.py
@@ -287,4 +287,3 @@ def test_gate_fast_fails_when_no_steps_are_enabled(tmp_path: Path) -> None:
     assert payload["failed_steps"] == ["configuration"]
     assert payload["steps"] == []
     assert payload["recommendations"][0].startswith("No gate steps are enabled.")
-

--- a/tests/test_inspect_compare.py
+++ b/tests/test_inspect_compare.py
@@ -30,7 +30,9 @@ def test_inspect_compare_with_two_paths_reports_drift(tmp_path: Path) -> None:
     )
 
     assert rc == 2
-    payload = json.loads((tmp_path / "compare" / "inspect-compare.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        (tmp_path / "compare" / "inspect-compare.json").read_text(encoding="utf-8")
+    )
     assert payload["summary"]["id_drift_files"] == 1
     assert payload["summary"]["drift_score"] >= 1
     assert payload["judgment"]["schema_version"] == "sdetkit.judgment.v1"
@@ -98,7 +100,9 @@ def test_inspect_compare_workspace_run_pair(tmp_path: Path) -> None:
         ]
     )
     assert rc == 2
-    payload = json.loads((tmp_path / "compare" / "inspect-compare.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        (tmp_path / "compare" / "inspect-compare.json").read_text(encoding="utf-8")
+    )
     assert payload["summary"]["duplicate_row_groups_delta"] == 1
 
 

--- a/tests/test_inspect_data.py
+++ b/tests/test_inspect_data.py
@@ -11,11 +11,7 @@ from sdetkit import inspect_data
 def test_inspect_single_csv_reports_findings(tmp_path: Path) -> None:
     csv_path = tmp_path / "orders.csv"
     csv_path.write_text(
-        "id,amount,status\n"
-        "100,10,ok\n"
-        "100,10,ok\n"
-        "101,,ok\n"
-        "102, 11,pending\n",
+        "id,amount,status\n100,10,ok\n100,10,ok\n101,,ok\n102, 11,pending\n",
         encoding="utf-8",
     )
 
@@ -76,10 +72,7 @@ def test_cli_inspect_command_executes(tmp_path: Path) -> None:
 def test_inspect_applies_file_rules_and_emits_deterministic_evidence(tmp_path: Path) -> None:
     csv_path = tmp_path / "orders.csv"
     csv_path.write_text(
-        "id,status\n"
-        "A1,ok\n"
-        "A1,ok\n"
-        "A2,pending\n",
+        "id,status\nA1,ok\nA1,ok\nA2,pending\n",
         encoding="utf-8",
     )
     rules_path = tmp_path / "rules.json"
@@ -115,8 +108,14 @@ def test_inspect_applies_file_rules_and_emits_deterministic_evidence(tmp_path: P
     payload = json.loads((tmp_path / "out" / "inspect.json").read_text(encoding="utf-8"))
     report = payload["file_reports"][0]
     assert payload["summary"]["diagnostics"]["failed_rule_checks"] >= 1
-    assert any(item["rule_type"] == "required_columns" and item["ok"] is False for item in report["rule_checks"])
-    assert any(item["rule_type"] == "duplicate_keys" and item["ok"] is False for item in report["rule_checks"])
+    assert any(
+        item["rule_type"] == "required_columns" and item["ok"] is False
+        for item in report["rule_checks"]
+    )
+    assert any(
+        item["rule_type"] == "duplicate_keys" and item["ok"] is False
+        for item in report["rule_checks"]
+    )
     assert any(item["signal"] == "duplicate_key" for item in report["suspicious_record_evidence"])
 
 
@@ -148,7 +147,9 @@ def test_inspect_applies_cross_file_rules(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    rc = inspect_data.main([str(tmp_path), "--rules", str(rules), "--out-dir", str(tmp_path / "artifacts")])
+    rc = inspect_data.main(
+        [str(tmp_path), "--rules", str(rules), "--out-dir", str(tmp_path / "artifacts")]
+    )
     assert rc == 2
     payload = json.loads((tmp_path / "artifacts" / "inspect.json").read_text(encoding="utf-8"))
     assert payload["summary"]["diagnostics"]["failed_rule_checks"] >= 1
@@ -213,7 +214,10 @@ def test_inspect_rejects_invalid_file_rule_shape(tmp_path: Path) -> None:
         capture_output=True,
     )
     assert run.returncode == 2
-    assert "inspect: invalid files['events.csv'].required_columns: must be an array of strings" in run.stderr
+    assert (
+        "inspect: invalid files['events.csv'].required_columns: must be an array of strings"
+        in run.stderr
+    )
 
 
 def test_inspect_rules_template_outputs_canonical_shape() -> None:

--- a/tests/test_judgment.py
+++ b/tests/test_judgment.py
@@ -46,7 +46,9 @@ def test_judgment_contradictions_raise_priority() -> None:
             }
         ],
         supporting_evidence=[{"kind": "id_drift", "value": 1}],
-        conflicting_evidence=[{"id": "c1", "kind": "cross_surface_disagreement", "message": "conflict"}],
+        conflicting_evidence=[
+            {"id": "c1", "kind": "cross_surface_disagreement", "message": "conflict"}
+        ],
         completeness=1.0,
         stability=0.4,
         workflow_ok=False,
@@ -60,7 +62,15 @@ def test_judgment_contradictions_raise_priority() -> None:
 def test_judgment_non_ok_without_blocking_is_watch() -> None:
     payload = build_judgment(
         workflow="inspect",
-        findings=[{"id": "f1", "kind": "minor", "severity": "medium", "priority": 10, "why_it_matters": "minor"}],
+        findings=[
+            {
+                "id": "f1",
+                "kind": "minor",
+                "severity": "medium",
+                "priority": 10,
+                "why_it_matters": "minor",
+            }
+        ],
         supporting_evidence=[{"kind": "minor", "value": 1}],
         conflicting_evidence=[],
         completeness=1.0,
@@ -74,7 +84,15 @@ def test_judgment_non_ok_without_blocking_is_watch() -> None:
 def test_judgment_guideline_matrix_for_key_scenarios() -> None:
     fail_payload = build_judgment(
         workflow="review",
-        findings=[{"id": "f1", "kind": "risk", "severity": "high", "priority": 75, "why_it_matters": "risk"}],
+        findings=[
+            {
+                "id": "f1",
+                "kind": "risk",
+                "severity": "high",
+                "priority": 75,
+                "why_it_matters": "risk",
+            }
+        ],
         supporting_evidence=[{"kind": "risk", "value": 1}],
         conflicting_evidence=[],
         completeness=0.8,
@@ -87,7 +105,15 @@ def test_judgment_guideline_matrix_for_key_scenarios() -> None:
 
     watch_payload = build_judgment(
         workflow="review",
-        findings=[{"id": "f1", "kind": "minor", "severity": "low", "priority": 15, "why_it_matters": "minor"}],
+        findings=[
+            {
+                "id": "f1",
+                "kind": "minor",
+                "severity": "low",
+                "priority": 15,
+                "why_it_matters": "minor",
+            }
+        ],
         supporting_evidence=[],
         conflicting_evidence=[{"id": "c1", "kind": "disagreement"}],
         completeness=0.4,

--- a/tests/test_pr_clean.py
+++ b/tests/test_pr_clean.py
@@ -39,7 +39,10 @@ def test_pr_clean_large_plan_includes_release_quality_and_review(tmp_path) -> No
     assert "[gate_release] PYTHONPATH=src python -m sdetkit gate release" in proc.stdout
     assert "[doctor] PYTHONPATH=src python -m sdetkit doctor" in proc.stdout
     assert "[coverage] bash quality.sh cov" in proc.stdout
-    assert "[review] PYTHONPATH=src python -m sdetkit review . --no-workspace --format operator-json" in proc.stdout
+    assert (
+        "[review] PYTHONPATH=src python -m sdetkit review . --no-workspace --format operator-json"
+        in proc.stdout
+    )
 
     data = json.loads(report.read_text(encoding="utf-8"))
     assert data["profile"] == "large"

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -35,7 +35,12 @@ def test_review_repeated_run_tracks_changes_and_compare_artifacts(tmp_path: Path
     assert json_path.exists()
     assert txt_path.exists()
     assert payload2["history"]["has_previous_review"] is True
-    assert payload2["changed_since_previous"][0]["kind"] in {"status", "severity", "action_pressure", "stable"}
+    assert payload2["changed_since_previous"][0]["kind"] in {
+        "status",
+        "severity",
+        "action_pressure",
+        "stable",
+    }
     assert "inspect_compare_json" in payload2["artifact_index"]
     assert payload2["adaptive_review"]["escalation"]["needed"] is True
     assert "review_plan_json" in payload2["artifact_index"]
@@ -45,7 +50,9 @@ def test_review_repeated_run_tracks_changes_and_compare_artifacts(tmp_path: Path
 def test_review_repo_plus_data_surfaces_cross_surface_conflict(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
     (repo / "data.csv").write_text("id,status\nA1,ok\n", encoding="utf-8")
 
     rc, payload, _, _ = review.run_review(
@@ -123,7 +130,9 @@ def test_cli_review_command_outputs_operator_json_contract_only(tmp_path: Path) 
     assert "situation" in payload
     assert "actions" in payload
     assert "workflow" not in payload
-    artifact_payload = json.loads((out_dir / "review-operator-summary.json").read_text(encoding="utf-8"))
+    artifact_payload = json.loads(
+        (out_dir / "review-operator-summary.json").read_text(encoding="utf-8")
+    )
     assert payload == artifact_payload
 
 
@@ -155,12 +164,18 @@ def test_review_profiles_change_judgment_and_artifacts_for_same_input(tmp_path: 
     assert monitor_payload["profile"]["name"] == "monitor"
     assert release_payload["profile"]["packet_type"] == "release_gate"
     assert monitor_payload["profile"]["packet_type"] == "trend_watch"
-    assert release_payload["artifact_index"]["profile_packet_json"].endswith("release-decision.json")
+    assert release_payload["artifact_index"]["profile_packet_json"].endswith(
+        "release-decision.json"
+    )
     assert monitor_payload["artifact_index"]["profile_packet_json"].endswith("trend-watch.json")
     assert "review_plan_json" in release_payload["artifact_index"]
     assert "review_tracks_json" in monitor_payload["artifact_index"]
-    release_now = [item for item in release_payload["prioritized_actions"] if item.get("tier") == "now"]
-    monitor_now = [item for item in monitor_payload["prioritized_actions"] if item.get("tier") == "now"]
+    release_now = [
+        item for item in release_payload["prioritized_actions"] if item.get("tier") == "now"
+    ]
+    monitor_now = [
+        item for item in monitor_payload["prioritized_actions"] if item.get("tier") == "now"
+    ]
     assert len(release_now) >= len(monitor_now)
 
 
@@ -270,7 +285,9 @@ def test_review_tracks_ranked_with_supporting_and_conflicting_evidence(tmp_path:
     workspace = tmp_path / "workspace"
     out = tmp_path / "out"
     repo.mkdir()
-    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
     (repo / "events.csv").write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
 
     rc, payload, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
@@ -290,7 +307,9 @@ def test_review_contradiction_cluster_triggers_probe_selection(tmp_path: Path) -
     out = tmp_path / "out"
     workspace = tmp_path / "workspace"
     repo.mkdir()
-    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
     (repo / "events.csv").write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
 
     rc, payload, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
@@ -307,7 +326,9 @@ def test_review_contradiction_cluster_triggers_probe_selection(tmp_path: Path) -
     registry = payload["adaptive_review"]["probe_registry"]
     assert any(row["probe_id"] == "probe:inspect-compare" for row in registry)
     inspect_compare = next(
-        row for row in payload["adaptive_review"]["executed_probes"] if row["probe_id"] == "probe:inspect-compare"
+        row
+        for row in payload["adaptive_review"]["executed_probes"]
+        if row["probe_id"] == "probe:inspect-compare"
     )
     assert inspect_compare["cost"] == 55
     assert inspect_compare["bounded_contract"]["max_runtime_seconds"] == 20
@@ -319,7 +340,10 @@ def test_probe_budget_skips_when_budget_is_exhausted() -> None:
         detection={"workspace_like": True, "data_like": True},
         profile_name="forensics",
         findings=[{"priority": 90, "kind": "inspect"}],
-        contradiction_graph={"flat_contradictions": [{"id": "c1"}], "clusters": [{"cluster_id": "x"}]},
+        contradiction_graph={
+            "flat_contradictions": [{"id": "c1"}],
+            "clusters": [{"cluster_id": "x"}],
+        },
         has_previous_review=True,
         changed=[{"kind": "status", "message": "changed"}],
         budget_total=70,
@@ -327,7 +351,10 @@ def test_probe_budget_skips_when_budget_is_exhausted() -> None:
         confidence_threshold=0.45,
     )
     assert decision["executed_probes"]
-    assert any(row["skip_reason"] == "probe budget exhausted by higher-value probes" for row in decision["skipped_probes"])
+    assert any(
+        row["skip_reason"] == "probe budget exhausted by higher-value probes"
+        for row in decision["skipped_probes"]
+    )
 
 
 def test_probe_memory_artifact_written_and_exposed(tmp_path: Path) -> None:
@@ -336,7 +363,9 @@ def test_probe_memory_artifact_written_and_exposed(tmp_path: Path) -> None:
     data = repo / "events.csv"
     out = tmp_path / "out"
     repo.mkdir(parents=True, exist_ok=True)
-    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
     data.write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
 
     rc, payload, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
@@ -358,19 +387,27 @@ def test_probe_memory_history_adjusts_next_run_score_inputs(tmp_path: Path) -> N
     data = repo / "events.csv"
     out = tmp_path / "out"
     repo.mkdir(parents=True, exist_ok=True)
-    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
     data.write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
 
     rc1, payload1, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
     assert rc1 in {0, 2}
     first_probe = next(
-        row for row in payload1["adaptive_review"]["executed_probes"] if row["probe_id"] == "probe:inspect-compare"
+        row
+        for row in payload1["adaptive_review"]["executed_probes"]
+        if row["probe_id"] == "probe:inspect-compare"
     )
     first_score = first_probe["score"]
 
     rc2, payload2, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
     assert rc2 in {0, 2}
-    second_probe = next(row for row in payload2["adaptive_review"]["skipped_probes"] if row["probe_id"] == "probe:inspect-compare")
+    second_probe = next(
+        row
+        for row in payload2["adaptive_review"]["skipped_probes"]
+        if row["probe_id"] == "probe:inspect-compare"
+    )
     second_score = second_probe["score"]
 
     assert second_score != first_score
@@ -385,16 +422,27 @@ def test_review_executed_probe_list_contains_only_executed_rows(tmp_path: Path) 
     out1 = tmp_path / "out1"
     out2 = tmp_path / "out2"
     repo.mkdir(parents=True, exist_ok=True)
-    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
     (repo / "events.csv").write_text("id,type\nE1,open\n", encoding="utf-8")
 
     review.run_review(target=repo, out_dir=out1, workspace_root=workspace)
     (repo / "events.csv").write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
     _, payload, _, _ = review.run_review(target=repo, out_dir=out2, workspace_root=workspace)
 
-    assert all(row.get("status") == "executed" for row in payload["adaptive_review"]["executed_probes"])
-    assert any(row.get("probe_id") == "probe:inspect-compare" for row in payload["adaptive_review"]["skipped_probes"])
-    moved = [row for row in payload["adaptive_review"]["skipped_probes"] if row.get("probe_id") == "probe:inspect-compare"]
+    assert all(
+        row.get("status") == "executed" for row in payload["adaptive_review"]["executed_probes"]
+    )
+    assert any(
+        row.get("probe_id") == "probe:inspect-compare"
+        for row in payload["adaptive_review"]["skipped_probes"]
+    )
+    moved = [
+        row
+        for row in payload["adaptive_review"]["skipped_probes"]
+        if row.get("probe_id") == "probe:inspect-compare"
+    ]
     assert moved
     assert moved[0]["skip_reason"] == "probe planned but not executed in deepen stage"
 
@@ -422,8 +470,14 @@ def test_review_no_workspace_reruns_are_deterministic(tmp_path: Path) -> None:
     assert payload1["status"] == payload2["status"]
     assert payload1["top_matters"] == payload2["top_matters"]
     assert payload1["prioritized_actions"] == payload2["prioritized_actions"]
-    assert payload1["adaptive_review"]["executed_probes"] == payload2["adaptive_review"]["executed_probes"]
-    assert payload1["adaptive_review"]["skipped_probes"] == payload2["adaptive_review"]["skipped_probes"]
+    assert (
+        payload1["adaptive_review"]["executed_probes"]
+        == payload2["adaptive_review"]["executed_probes"]
+    )
+    assert (
+        payload1["adaptive_review"]["skipped_probes"]
+        == payload2["adaptive_review"]["skipped_probes"]
+    )
 
 
 def test_review_recovers_from_corrupt_probe_memory(tmp_path: Path) -> None:
@@ -431,7 +485,9 @@ def test_review_recovers_from_corrupt_probe_memory(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     out = tmp_path / "out"
     repo.mkdir()
-    (repo / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
     (repo / "events.csv").write_text("id,type\nE1,open\nE1,open\n", encoding="utf-8")
     scope = review._review_scope_for_target(repo)
     probe_mem = workspace / "probe-memory" / "review" / f"{scope}.json"
@@ -441,5 +497,8 @@ def test_review_recovers_from_corrupt_probe_memory(tmp_path: Path) -> None:
     rc, payload, _, _ = review.run_review(target=repo, out_dir=out, workspace_root=workspace)
 
     assert rc in {0, 2}
-    assert payload["adaptive_review"]["probe_memory"]["schema_version"] == "sdetkit.review.probe-memory.v1"
+    assert (
+        payload["adaptive_review"]["probe_memory"]["schema_version"]
+        == "sdetkit.review.probe-memory.v1"
+    )
     assert isinstance(payload["adaptive_review"]["probe_memory"]["normalized_outcomes"], list)

--- a/tests/test_security_quality_review_guard.py
+++ b/tests/test_security_quality_review_guard.py
@@ -17,7 +17,10 @@ def test_security_quality_review_guard_plan_mode_emits_report(tmp_path) -> None:
     assert proc.returncode == 0, proc.stderr
     assert "security-quality-review-guard plan:" in proc.stdout
     assert "repo check --format json --out build/repo-check-default.json --force" in proc.stdout
-    assert "repo check --profile enterprise --format json --out build/repo-check-enterprise.json --force" in proc.stdout
+    assert (
+        "repo check --profile enterprise --format json --out build/repo-check-enterprise.json --force"
+        in proc.stdout
+    )
     assert "ruff check src tests" in proc.stdout
 
     payload = json.loads(report.read_text(encoding="utf-8"))

--- a/tests/test_serve_api.py
+++ b/tests/test_serve_api.py
@@ -11,7 +11,9 @@ from sdetkit import cli, serve
 
 def _post_json(url: str, payload: dict[str, object]) -> tuple[int, dict[str, object]]:
     data = json.dumps(payload, sort_keys=True).encode("utf-8")
-    req = urllib.request.Request(url, data=data, method="POST", headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, method="POST", headers={"Content-Type": "application/json"}
+    )
     with urllib.request.urlopen(req) as resp:  # noqa: S310 - local server in test
         body = json.loads(resp.read().decode("utf-8"))
         return int(resp.status), body


### PR DESCRIPTION
### Motivation

- Unblock the quality gate which failed on `ruff_format` and `mypy` by eliminating redefinition/type issues and ensuring files are ruff-formatted.

### Description

- Avoided local name collisions in the gate flow by separating the early-return payload from the final gate payload (`empty_payload` vs `gate_payload`) in `src/sdetkit/gate.py` to resolve `no-redef` mypy errors and preserve output behavior.
- Tightened typing and integer-handling in `inspect` by introducing a typed `diagnostics_summary: dict[str,int]` and reusing it for scoring, findings, stability, and blocking checks in `src/sdetkit/inspect_data.py` to fix multiple mypy attr/type errors.
- Hardened `SystemExit` handling in `_run_doctor` and renamed reused local payload variables in review paths to avoid redefinition and ensure robust exit-code handling in `src/sdetkit/review.py` and `src/sdetkit/cli.py`.
- Miscellaneous small refactors and whitespace/formatting adjustments across modules (`inspect_compare`, `inspect_project`, `contract`, `doctor`, `evidence_workspace`, `review_engine`, `serve`, tests, etc.) and applied `ruff` formatting to the flagged files.

### Testing

- Ran `python -m ruff format --check .` which succeeded (no remaining format failures).
- Ran `python -m mypy --config-file pyproject.toml src` which succeeded (typing issues resolved).
- Ran `python -m ruff check .` which succeeded (no lint failures reported for the checked files).
- Ran the project's CI validation and test commands: `python -m sdetkit ci validate-templates --root . --format json --strict`, `python -m sdetkit doctor --dev --ci --deps --repo --upgrade-audit --format json --out .sdetkit/out/doctor.local.json`, and `python -m pytest -q -o addopts=`; all completed successfully (tests: 1646 passed, 1 skipped in the run observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daaa265784833288b06b5683a42d95)