### PR TITLE
Harden agent write allowlist path validation

### DIFF
--- a/src/sdetkit/agent/actions.py
+++ b/src/sdetkit/agent/actions.py
@@ -79,7 +79,10 @@ class ActionRegistry:
         return resolved
 
     def _is_write_allowed(self, rel: str) -> bool:
-        normalized = rel.replace("\\", "/").lstrip("/")
+        try:
+            normalized = self._safe_rel(rel).relative_to(self.root.resolve()).as_posix()
+        except ValueError:
+            return False
         return any(
             normalized == item or normalized.startswith(item.rstrip("/") + "/")
             for item in self.write_allowlist

--- a/tests/test_agent_actions_extra.py
+++ b/tests/test_agent_actions_extra.py
@@ -67,6 +67,25 @@ def test_action_registry_success_paths(tmp_path: Path, monkeypatch) -> None:
     assert shell_res.payload["stdout"] == "ok"
 
 
+def test_action_registry_write_allowlist_rejects_traversal(tmp_path: Path) -> None:
+    reg = ActionRegistry(
+        root=tmp_path,
+        write_allowlist=("allowed",),
+        shell_allowlist=(),
+    )
+    (tmp_path / "allowed").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "elsewhere").mkdir(parents=True, exist_ok=True)
+
+    result = reg.run(
+        "fs.write",
+        {"path": "allowed/../elsewhere/out.txt", "content": "blocked"},
+    )
+
+    assert result.ok is False
+    assert "write denied by allowlist" in str(result.payload.get("error", ""))
+    assert not (tmp_path / "elsewhere" / "out.txt").exists()
+
+
 def test_action_registry_repo_audit_and_report_build(tmp_path: Path, monkeypatch) -> None:
     reg = ActionRegistry(root=tmp_path, write_allowlist=(".sdetkit",), shell_allowlist=("python",))
 


### PR DESCRIPTION
### Motivation
- Prevent path traversal or symlink tricks from allowing writes outside of allowed directories when agents or automated bots perform `fs.write` actions.

### Description
- Change `_is_write_allowed` to normalize and resolve the requested path via `_safe_rel(...)` and compute a repository-relative POSIX path before matching against `write_allowlist` to avoid raw string-prefix bypasses.
- Return `False` from `_is_write_allowed` for paths that cannot be resolved or are outside the repository root so writes are rejected early.
- Add a regression test `test_action_registry_write_allowlist_rejects_traversal` to validate that `allowed/../elsewhere/out.txt` is denied and no file is written.
- Modified files: `src/sdetkit/agent/actions.py` and `tests/test_agent_actions_extra.py`.

### Testing
- Ran `pytest -q tests/test_agent_actions_extra.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2c9c132083328504ae1a2eab950e)