### PR TITLE
Add missing json import and apply Ruff formatting to agent files

### DIFF
--- a/src/sdetkit/agent/actions.py
+++ b/src/sdetkit/agent/actions.py
@@ -376,9 +376,7 @@ class ActionRegistry:
             "schema_version": "1.0",
             "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
             "records": records,
-            "recurring_failures": [
-                {"action": name, "count": count} for name, count in top_actions
-            ],
+            "recurring_failures": [{"action": name, "count": count} for name, count in top_actions],
             "top_errors": [{"error": message, "count": count} for message, count in top_errors],
             "recommendations": recommendations,
         }

--- a/src/sdetkit/agent/templates.py
+++ b/src/sdetkit/agent/templates.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import hashlib
 import io
+import json
 import os
 import re
 import shlex
@@ -467,7 +468,9 @@ def run_template(
             payload = {"output": output.as_posix(), "format": fmt}
             artifacts.append(output.as_posix())
         elif step.action == "review.adaptive":
-            history_dir = Path(str(params.get("history_dir", root / ".sdetkit" / "agent" / "history")))
+            history_dir = Path(
+                str(params.get("history_dir", root / ".sdetkit" / "agent" / "history"))
+            )
             output = Path(str(params.get("output", output_dir / "adaptive-review-kb.json")))
             limit = int(params.get("limit", 10) or 10)
             adaptive_payload = _adaptive_review_payload(history_dir=history_dir, limit=limit)


### PR DESCRIPTION
### Motivation
- Resolve a Ruff `F821` lint error caused by `json` being referenced but not imported in the agent template code.
- Ensure CI formatting checks pass by applying Ruff formatting to the modified agent files.

### Description
- Add `import json` to `src/sdetkit/agent/templates.py` so `_adaptive_review_payload` can call `json.loads(...)` without error.
- Run Ruff formatting updates on `src/sdetkit/agent/templates.py` and `src/sdetkit/agent/actions.py` to satisfy `ruff format --check`.
- Small formatting/line-wrap adjustments were applied where needed to match the project's Ruff rules.

### Testing
- Ran `python -m ruff check src tests` and `python3 -m ruff format --check .`, both of which passed successfully.
- Ran the full test suite with `pytest -q`, which completed successfully (`1654 passed, 1 skipped, 3 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3507b7f483328d1f77f469888a0f)