### PR TITLE
Harden plugin discovery diagnostics with opt-in debug output

### DIFF
--- a/src/sdetkit/plugin_system.py
+++ b/src/sdetkit/plugin_system.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import os
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from importlib import import_module, metadata
@@ -31,7 +34,35 @@ def _load_ref(ref: str) -> Callable[[], Any]:
     return _const
 
 
-def _registry_entries(root: Path, section: str) -> list[PluginRecord]:
+def _debug_enabled(debug: bool | None) -> bool:
+    if debug is not None:
+        return debug
+    raw = str(os.environ.get("SDETKIT_PLUGIN_DEBUG", "")).strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _emit_discovery_error(
+    *,
+    source: str,
+    group: str | None,
+    section: str | None,
+    name: str,
+    ref: str | None,
+    exc: Exception,
+) -> None:
+    payload = {
+        "event": "plugin_discovery_load_failure",
+        "source": source,
+        "group": group,
+        "section": section,
+        "name": name,
+        "ref": ref,
+        "reason": f"{type(exc).__name__}: {exc}",
+    }
+    print(json.dumps(payload, sort_keys=True), file=sys.stderr)
+
+
+def _registry_entries(root: Path, section: str, *, debug: bool = False) -> list[PluginRecord]:
     path = root / ".sdetkit" / "plugins.toml"
     if not path.is_file():
         return []
@@ -46,12 +77,28 @@ def _registry_entries(root: Path, section: str) -> list[PluginRecord]:
             continue
         try:
             out.append(PluginRecord(name=name, source="registry", factory=_load_ref(ref)))
-        except Exception:
+        except Exception as exc:
+            if debug:
+                _emit_discovery_error(
+                    source="registry",
+                    group=None,
+                    section=section,
+                    name=name,
+                    ref=ref,
+                    exc=exc,
+                )
             continue
     return out
 
 
-def discover(group: str, section: str, root: Path | None = None) -> list[PluginRecord]:
+def discover(
+    group: str,
+    section: str,
+    root: Path | None = None,
+    *,
+    debug: bool | None = None,
+) -> list[PluginRecord]:
+    plugin_debug = _debug_enabled(debug)
     records: list[PluginRecord] = []
     for ep in sorted(metadata.entry_points().select(group=group), key=lambda i: i.name):
         try:
@@ -65,10 +112,19 @@ def discover(group: str, section: str, root: Path | None = None) -> list[PluginR
 
                 factory = _const
             records.append(PluginRecord(name=ep.name, source="entrypoint", factory=factory))
-        except Exception:
+        except Exception as exc:
+            if plugin_debug:
+                _emit_discovery_error(
+                    source="entrypoint",
+                    group=group,
+                    section=section,
+                    name=ep.name,
+                    ref=None,
+                    exc=exc,
+                )
             continue
     if root is not None:
-        records.extend(_registry_entries(root, section))
+        records.extend(_registry_entries(root, section, debug=plugin_debug))
     dedup: dict[str, PluginRecord] = {}
     for record in records:
         dedup[record.name] = record

--- a/tests/test_plugin_system_extra.py
+++ b/tests/test_plugin_system_extra.py
@@ -6,7 +6,7 @@ from sdetkit import plugin_system as ps
 
 
 class _EP:
-    def init_(self, name, value, boom=False):
+    def __init__(self, name, value, boom=False):
         self.name = name
         self._value = value
         self._boom = boom
@@ -61,3 +61,49 @@ def test_discover_entrypoints_and_registry_dedupe(monkeypatch, tmp_path: Path) -
     assert names == ["a", "b", "c"]
     # registry dedupe should override entrypoint for same name "a"
     assert records[0].source == "registry"
+
+
+def test_discovery_failures_silent_by_default(monkeypatch, tmp_path: Path, capsys) -> None:
+    eps = _EPSet([_EP("ok", lambda: "entry-ok"), _EP("bad-ep", None, boom=True)])
+    monkeypatch.setattr(ps.metadata, "entry_points", lambda: eps)
+
+    cfg = tmp_path / ".sdetkit/plugins.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('[plugins]\nok = "json:loads"\nbad-reg = "oops"\n', encoding="utf-8")
+
+    records = ps.discover("g", "plugins", root=tmp_path)
+    assert [r.name for r in records] == ["ok"]
+    assert capsys.readouterr().err == ""
+
+
+def test_discovery_failures_emit_diagnostics_in_debug_mode(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    eps = _EPSet([_EP("ok", lambda: "entry-ok"), _EP("bad-ep", None, boom=True)])
+    monkeypatch.setattr(ps.metadata, "entry_points", lambda: eps)
+
+    cfg = tmp_path / ".sdetkit/plugins.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('[plugins]\nok = "json:loads"\nbad-reg = "oops"\n', encoding="utf-8")
+
+    records = ps.discover("g", "plugins", root=tmp_path, debug=True)
+    assert [r.name for r in records] == ["ok"]
+
+    err = capsys.readouterr().err
+    assert '"event": "plugin_discovery_load_failure"' in err
+    assert '"source": "entrypoint"' in err
+    assert '"source": "registry"' in err
+    assert '"group": "g"' in err
+    assert '"section": "plugins"' in err
+    assert '"name": "bad-ep"' in err
+    assert '"name": "bad-reg"' in err
+
+
+def test_discovery_debug_env_var(monkeypatch, tmp_path: Path, capsys) -> None:
+    eps = _EPSet([_EP("bad-ep", None, boom=True)])
+    monkeypatch.setattr(ps.metadata, "entry_points", lambda: eps)
+    monkeypatch.setenv("SDETKIT_PLUGIN_DEBUG", "yes")
+
+    ps.discover("g", "plugins", root=tmp_path)
+    err = capsys.readouterr().err
+    assert '"source": "entrypoint"' in err


### PR DESCRIPTION
### Motivation
- Plugin discovery currently swallows plugin load failures, making troubleshooting in operator environments difficult. 
- Provide an opt-in diagnostics mode to improve observability while keeping default behavior unchanged.

### Description
- Add `discover(..., debug: bool | None = None)` and a fallback environment toggle `SDETKIT_PLUGIN_DEBUG` that accepts `1|true|yes|on` (case-insensitive) via `_debug_enabled` to control debug behavior. 
- Emit structured JSON diagnostics to `stderr` for entrypoint and registry plugin load failures when debug is enabled via a new `_emit_discovery_error` helper. 
- Wire debug behavior into registry parsing (`_registry_entries(..., debug=...)`) and entrypoint loading to avoid noisy output by default. 
- Add tests in `tests/test_plugin_system_extra.py` covering default silent behavior, debug diagnostics emission, and env-var based debug toggling; no changes were made to plugin precedence or hard-fail semantics.

### Testing
- ✅ Ran `pytest -q tests/test_plugin_system_extra.py` and all tests passed (`5 passed`).
- ✅ Ran `ruff check` which initially flagged an import ordering issue that was fixed with `ruff --fix`, and the final `ruff check` passed. 
- ✅ Final run of tests and lint on the modified files completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2fe965dc83328c8888b13ac1476a)