### PR TITLE
Pass explicit httpx options in __main__, add plugin debug logging, and tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# SDETKit architecture map (contributor quick guide)
+
+This file is the shortest maintainer-oriented map of how the repo is organized so new contributors can quickly place changes in the right layer.
+
+## 1) Stable first path (public contract)
+
+The product's front door is intentionally narrow and stable:
+
+1. `python -m sdetkit gate fast`
+2. `python -m sdetkit gate release`
+3. `python -m sdetkit doctor`
+
+If your change can impact first-time adoption, validate this path first.
+
+## 2) Command-surface tiers
+
+- **Public / stable:** canonical release-confidence flows and their machine-readable artifact contracts.
+- **Advanced but supported:** deeper operational lanes (`kits`, advanced review/gate/operator workflows).
+- **Legacy / historical:** transition-era and hidden surfaces kept for compatibility and migration support.
+
+Design intent: keep first-run confidence simple while preserving power surfaces for advanced operators.
+
+## 3) Core runtime relationships
+
+- `sdetkit.cli` is the root command router and entrypoint.
+- `sdetkit.gate` orchestrates deterministic gate profiles and evidence output.
+- `sdetkit.review` / `sdetkit.review_engine` provide unified review-state synthesis and operator-facing summaries.
+- `sdetkit.doctor` gives remediation-oriented diagnostics and local environment checks.
+
+## 4) Checks framework model (gate/review execution backbone)
+
+The checks framework is profile-driven:
+
+- check definitions and metadata
+- planning and dependency ordering
+- bounded execution and result collection
+- stable artifact emission for CI/operator tooling
+
+When changing checks behavior, prefer preserving schema and command-level contracts unless intentionally versioning them.
+
+## 5) Plugin extension points
+
+Plugins are discoverable via:
+
+- Python entry points (packaging-time integrations)
+- optional repository registry (`.sdetkit/plugins.toml`)
+
+Plugin loading is resilience-first (skip failing plugins), with optional debug diagnostics to surface load failures when troubleshooting.
+
+## 6) Legacy boundary policy
+
+Legacy commands are supported for continuity but are not the preferred onboarding surface.
+
+Contributor policy:
+
+- avoid adding new features only to legacy lanes,
+- route new capability through stable/advanced surfaces first,
+- keep compatibility shims focused and observable.
+
+## 7) Where to read next
+
+- Product/usage front door: `README.md`
+- Stability policy: `docs/stability-levels.md`
+- CLI details: `docs/cli.md`
+- Docs hub: `docs/index.md`

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ artifacts/     # generated evidence packs
 ## Documentation and references
 
 - Docs hub: [`docs/index.md`](docs/index.md)
+- Architecture quick map for contributors: [`ARCHITECTURE.md`](ARCHITECTURE.md)
 - Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Release process: [`RELEASE.md`](RELEASE.md)
 - Git workflow (branch tracking + ahead/behind): [`docs/git-workflow.md`](docs/git-workflow.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-  "sdetkit.__main__",
   "sdetkit.apiget",
   "sdetkit.patch",
 ]

--- a/src/sdetkit/__main__.py
+++ b/src/sdetkit/__main__.py
@@ -40,11 +40,9 @@ def _cassette_get(argv: list[str]) -> int:
     if ns.insecure:
         sys.stderr.write("warning: TLS verification disabled (--insecure)\n")
 
-    client_opts = {
-        "timeout": default_http_timeout(ns.timeout),
-        "follow_redirects": bool(ns.follow_redirects),
-        "verify": not bool(ns.insecure),
-    }
+    timeout = default_http_timeout(ns.timeout)
+    follow_redirects = bool(ns.follow_redirects)
+    verify = not bool(ns.insecure)
 
     if ns.replay:
         try:
@@ -58,12 +56,17 @@ def _cassette_get(argv: list[str]) -> int:
         except (SecurityError, ValueError, OSError) as exc:
             sys.stderr.write(str(exc) + "\n")
             return 2
-        transport = CassetteReplayTransport(cass)
-        with httpx.Client(transport=transport, **client_opts) as client:
+        replay_transport = CassetteReplayTransport(cass)
+        with httpx.Client(
+            transport=replay_transport,
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+            verify=verify,
+        ) as client:
             r = client.get(ns.url)
             r.raise_for_status()
             sys.stdout.write(json.dumps(r.json(), ensure_ascii=True))
-        f = getattr(transport, "assert_exhausted", None)
+        f = getattr(replay_transport, "assert_exhausted", None)
         if callable(f):
             f()
         return 0
@@ -81,8 +84,13 @@ def _cassette_get(argv: list[str]) -> int:
             return 2
         cass = Cassette()
         inner = httpx.HTTPTransport()
-        transport = CassetteRecordTransport(cass, inner)
-        with httpx.Client(transport=transport, **client_opts) as client:
+        record_transport = CassetteRecordTransport(cass, inner)
+        with httpx.Client(
+            transport=record_transport,
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+            verify=verify,
+        ) as client:
             r = client.get(ns.url)
             r.raise_for_status()
             sys.stdout.write(json.dumps(r.json(), ensure_ascii=True))
@@ -90,7 +98,11 @@ def _cassette_get(argv: list[str]) -> int:
         atomic_write_text(record_path, payload)
         return 0
 
-    with httpx.Client(**client_opts) as client:
+    with httpx.Client(
+        timeout=timeout,
+        follow_redirects=follow_redirects,
+        verify=verify,
+    ) as client:
         r = client.get(ns.url)
         r.raise_for_status()
         sys.stdout.write(json.dumps(r.json(), ensure_ascii=True))

--- a/src/sdetkit/plugin_system.py
+++ b/src/sdetkit/plugin_system.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import os
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from importlib import import_module, metadata
@@ -14,6 +17,19 @@ class PluginRecord:
     name: str
     source: str
     factory: Callable[[], Any]
+
+
+def _plugin_debug_enabled(debug: bool | None = None) -> bool:
+    if debug is not None:
+        return debug
+    raw = os.environ.get("SDETKIT_PLUGIN_DEBUG", "")
+    return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _plugin_debug(payload: dict[str, Any], *, debug: bool | None = None) -> None:
+    if not _plugin_debug_enabled(debug):
+        return
+    sys.stderr.write(f"{json.dumps(payload, sort_keys=True)}\n")
 
 
 def _load_ref(ref: str) -> Callable[[], Any]:
@@ -31,7 +47,7 @@ def _load_ref(ref: str) -> Callable[[], Any]:
     return _const
 
 
-def _registry_entries(root: Path, section: str) -> list[PluginRecord]:
+def _registry_entries(root: Path, section: str, *, debug: bool | None = None) -> list[PluginRecord]:
     path = root / ".sdetkit" / "plugins.toml"
     if not path.is_file():
         return []
@@ -46,12 +62,25 @@ def _registry_entries(root: Path, section: str) -> list[PluginRecord]:
             continue
         try:
             out.append(PluginRecord(name=name, source="registry", factory=_load_ref(ref)))
-        except Exception:
+        except Exception as exc:
+            _plugin_debug(
+                {
+                    "event": "plugin_load_error",
+                    "source": "registry",
+                    "section": section,
+                    "name": name,
+                    "ref": ref,
+                    "reason": str(exc),
+                },
+                debug=debug,
+            )
             continue
     return out
 
 
-def discover(group: str, section: str, root: Path | None = None) -> list[PluginRecord]:
+def discover(
+    group: str, section: str, root: Path | None = None, *, debug: bool | None = None
+) -> list[PluginRecord]:
     records: list[PluginRecord] = []
     for ep in sorted(metadata.entry_points().select(group=group), key=lambda i: i.name):
         try:
@@ -65,10 +94,20 @@ def discover(group: str, section: str, root: Path | None = None) -> list[PluginR
 
                 factory = _const
             records.append(PluginRecord(name=ep.name, source="entrypoint", factory=factory))
-        except Exception:
+        except Exception as exc:
+            _plugin_debug(
+                {
+                    "event": "plugin_load_error",
+                    "source": "entrypoint",
+                    "group": group,
+                    "name": ep.name,
+                    "reason": str(exc),
+                },
+                debug=debug,
+            )
             continue
     if root is not None:
-        records.extend(_registry_entries(root, section))
+        records.extend(_registry_entries(root, section, debug=debug))
     dedup: dict[str, PluginRecord] = {}
     for record in records:
         dedup[record.name] = record

--- a/tests/test_main_cassette_get_extra.py
+++ b/tests/test_main_cassette_get_extra.py
@@ -36,6 +36,14 @@ class _Client:
         return _Resp({"ok": True})
 
 
+class _ClientCaptureKwargs(_Client):
+    last_kwargs: dict[str, object] | None = None
+
+    def init_(self, *args, **kwargs) -> None:
+        type(self).last_kwargs = dict(kwargs)
+        super().init_(*args, **kwargs)
+
+
 def test_cassette_get_record_refuses_overwrite_without_force(tmp_path: Path, capsys) -> None:
     existing = tmp_path / "cassette.json"
     existing.write_text("{}", encoding="utf-8")
@@ -234,3 +242,59 @@ def test_cassette_get_record_safe_path_security_error(
     io = capsys.readouterr()
     assert rc == 2
     assert "blocked path" in io.err
+
+
+def test_cassette_get_plain_mode_passes_explicit_httpx_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "Client", _ClientCaptureKwargs)
+    _ClientCaptureKwargs.last_kwargs = None
+
+    rc = mainmod._cassette_get(["https://example.invalid", "--insecure", "--follow-redirects"])
+
+    assert rc == 0
+    assert _ClientCaptureKwargs.last_kwargs is not None
+    assert _ClientCaptureKwargs.last_kwargs["verify"] is False
+    assert _ClientCaptureKwargs.last_kwargs["follow_redirects"] is True
+    assert "timeout" in _ClientCaptureKwargs.last_kwargs
+
+
+def test_cassette_get_replay_mode_passes_transport_and_explicit_options(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import httpx
+
+    import sdetkit.cassette as cassette_mod
+
+    class _ReplayTransport:
+        def init_(self, _cass) -> None:
+            pass
+
+        def assert_exhausted(self) -> None:
+            return None
+
+    monkeypatch.setattr(httpx, "Client", _ClientCaptureKwargs)
+    monkeypatch.setattr(cassette_mod.Cassette, "load", staticmethod(lambda *_a, **_k: object()))
+    monkeypatch.setattr(cassette_mod, "CassetteReplayTransport", _ReplayTransport)
+    _ClientCaptureKwargs.last_kwargs = None
+
+    p = tmp_path / "replay.json"
+    p.write_text("{}", encoding="utf-8")
+
+    rc = mainmod._cassette_get(
+        [
+            "https://example.invalid",
+            "--replay",
+            str(p),
+            "--allow-absolute-path",
+            "--follow-redirects",
+        ]
+    )
+
+    assert rc == 0
+    assert _ClientCaptureKwargs.last_kwargs is not None
+    assert _ClientCaptureKwargs.last_kwargs["follow_redirects"] is True
+    assert _ClientCaptureKwargs.last_kwargs["verify"] is True
+    assert "transport" in _ClientCaptureKwargs.last_kwargs

--- a/tests/test_plugin_system_extra.py
+++ b/tests/test_plugin_system_extra.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from sdetkit import plugin_system as ps
@@ -61,3 +62,53 @@ def test_discover_entrypoints_and_registry_dedupe(monkeypatch, tmp_path: Path) -
     assert names == ["a", "b", "c"]
     # registry dedupe should override entrypoint for same name "a"
     assert records[0].source == "registry"
+
+
+def test_discover_plugin_debug_logs_failures(monkeypatch, tmp_path: Path, capsys) -> None:
+    eps = _EPSet([_EP("z", None, boom=True)])
+    monkeypatch.setattr(ps.metadata, "entry_points", lambda: eps)
+
+    cfg = tmp_path / ".sdetkit/plugins.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('[plugins]\nbad = "oops"\n', encoding="utf-8")
+
+    records = ps.discover("g", "plugins", root=tmp_path, debug=True)
+    assert records == []
+    err = capsys.readouterr().err
+    lines = [json.loads(line) for line in err.strip().splitlines()]
+    assert len(lines) == 2
+    assert lines[0]["source"] == "entrypoint"
+    assert lines[0]["group"] == "g"
+    assert lines[0]["name"] == "z"
+    assert lines[1]["source"] == "registry"
+    assert lines[1]["section"] == "plugins"
+    assert lines[1]["name"] == "bad"
+    assert lines[1]["ref"] == "oops"
+
+
+def test_discover_plugin_failures_silent_by_default(monkeypatch, tmp_path: Path, capsys) -> None:
+    eps = _EPSet([_EP("z", None, boom=True)])
+    monkeypatch.setattr(ps.metadata, "entry_points", lambda: eps)
+
+    cfg = tmp_path / ".sdetkit/plugins.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('[plugins]\nbad = "oops"\n', encoding="utf-8")
+
+    records = ps.discover("g", "plugins", root=tmp_path)
+    assert records == []
+    assert capsys.readouterr().err == ""
+
+
+def test_discover_plugin_debug_enabled_by_env(monkeypatch, tmp_path: Path, capsys) -> None:
+    eps = _EPSet([_EP("z", None, boom=True)])
+    monkeypatch.setattr(ps.metadata, "entry_points", lambda: eps)
+    monkeypatch.setenv("SDETKIT_PLUGIN_DEBUG", "YeS")
+
+    cfg = tmp_path / ".sdetkit/plugins.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('[plugins]\nbad = "oops"\n', encoding="utf-8")
+
+    records = ps.discover("g", "plugins", root=tmp_path)
+    assert records == []
+    lines = [json.loads(line) for line in capsys.readouterr().err.strip().splitlines()]
+    assert {line["source"] for line in lines} == {"entrypoint", "registry"}


### PR DESCRIPTION
### Motivation
- Ensure `httpx.Client` receives explicit connection options in all `cassette-get` modes and improve observability for plugin load failures when debugging is enabled.

### Description
- Replace the `client_opts` dict in `src/sdetkit/__main__.py` with explicit `timeout`, `follow_redirects`, and `verify` variables and pass them to `httpx.Client` for plain, record, and replay flows, and rename transport variables for clarity.
- Add `_plugin_debug_enabled` and `_plugin_debug` helpers and wire JSON-formatted debug logging into `discover` and `_registry_entries` in `src/sdetkit/plugin_system.py` to emit plugin load failure details to `stderr` when debug is enabled.
- Update `pyproject.toml` to remove `sdetkit.__main__` from the mypy overrides list.
- Add unit tests to `tests/test_main_cassette_get_extra.py` and `tests/test_plugin_system_extra.py` to verify `httpx.Client` receives expected kwargs and that plugin discovery logs failures under debug.

### Testing
- Ran `tests/test_main_cassette_get_extra.py` which asserts explicit `httpx.Client` options are passed and the tests passed.
- Ran `tests/test_plugin_system_extra.py` which validates plugin debug logging behavior and the tests passed.
- Ran the test suite with `pytest -q` and there were no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2084e12c833299080d302d4e2be3)