### PR TITLE
Add optional CLI timing observability (SDETKIT_CLI_TIMING) and tests

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from collections.abc import Sequence
 from importlib import import_module, metadata
 from typing import cast
@@ -59,8 +60,25 @@ def _add_apiget_args(p: argparse.ArgumentParser) -> None:
 
 
 def _run_module_main(module_name: str, args: Sequence[str]) -> int:
+    started = time.perf_counter()
+    arg_list = list(args)
     module = import_module(module_name)
-    return cast(int, module.main(list(args)))
+    rc = cast(int, module.main(arg_list))
+    _emit_cli_timing(
+        f"event=dispatch module={module_name} argc={len(arg_list)} elapsed_ms={(time.perf_counter() - started) * 1000.0:.3f}"
+    )
+    return rc
+
+
+def _cli_timing_enabled() -> bool:
+    raw = os.environ.get("SDETKIT_CLI_TIMING", "")
+    return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _emit_cli_timing(message: str) -> None:
+    if not _cli_timing_enabled():
+        return
+    sys.stderr.write(f"[sdetkit.cli.timing] {message}\n")
 
 
 def _is_hidden_cmd(name: str) -> bool:
@@ -153,6 +171,7 @@ def _add_passthrough_subcommand(
 def _build_root_parser(
     *, show_hidden_commands: bool = False
 ) -> tuple[argparse.ArgumentParser, object]:
+    started = time.perf_counter()
     help_description = """\
 DevS69 SDETKit is an operator-grade SDET platform for deterministic release confidence
 and shipping readiness.
@@ -758,6 +777,9 @@ Then use stability-aware command discovery:
     tsa.add_argument("args", nargs=argparse.REMAINDER)
     if not show_hidden_commands:
         _filter_hidden_subcommands(p)
+    _emit_cli_timing(
+        f"event=parser-build show_hidden={str(show_hidden_commands).lower()} elapsed_ms={(time.perf_counter() - started) * 1000.0:.3f}"
+    )
     return p, sub
 
 

--- a/tests/test_cli_timing_observability.py
+++ b/tests/test_cli_timing_observability.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sdetkit import cli
+
+
+def test_run_module_main_silent_by_default(monkeypatch, capsys) -> None:
+    monkeypatch.delenv("SDETKIT_CLI_TIMING", raising=False)
+    monkeypatch.setattr(cli, "import_module", lambda _name: SimpleNamespace(main=lambda _a: 0))
+
+    rc = cli._run_module_main("sdetkit.fake", ["--x"])
+
+    assert rc == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_run_module_main_emits_timing_when_enabled(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("SDETKIT_CLI_TIMING", "1")
+    monkeypatch.setattr(cli, "import_module", lambda _name: SimpleNamespace(main=lambda _a: 0))
+
+    rc = cli._run_module_main("sdetkit.fake", ["--x", "--y"])
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "[sdetkit.cli.timing]" in err
+    assert "event=dispatch" in err
+    assert "module=sdetkit.fake" in err
+
+
+def test_build_root_parser_emits_timing_when_enabled(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("SDETKIT_CLI_TIMING", "yes")
+
+    cli._build_root_parser(show_hidden_commands=False)
+
+    err = capsys.readouterr().err
+    assert "[sdetkit.cli.timing]" in err
+    assert "event=parser-build" in err


### PR DESCRIPTION
### Motivation

- Provide lightweight timing observability for CLI operations to aid performance debugging and telemetry without changing normal output.

### Description

- Add timing measurements around command dispatch in `_run_module_main` and around parser construction in `_build_root_parser` using `time.perf_counter()` and include elapsed milliseconds in messages. 
- Introduce `SDETKIT_CLI_TIMING` feature gate with helper ` _cli_timing_enabled()` and ` _emit_cli_timing()` which write structured timing lines to `stderr` when enabled. 
- Small argument-list normalization in `_run_module_main` so the called module receives a concrete list and the measured `argc` is accurate. 
- Add unit tests in `tests/test_cli_timing_observability.py` that verify timing is silent by default and that timing lines are emitted when `SDETKIT_CLI_TIMING` is enabled.

### Testing

- Ran the new test module `tests/test_cli_timing_observability.py` which contains three unit tests covering default-silent behavior and enabled timing for `_run_module_main` and `_build_root_parser`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2084e12c833299080d302d4e2be3)