### PR TITLE
Complete PR7: artifact contract index sync, tests, and docs refresh

### DIFF
--- a/docs/artifact-contract-index.json
+++ b/docs/artifact-contract-index.json
@@ -30,8 +30,36 @@
       "path": "build/doctor.json",
       "produced_by": "python -m sdetkit doctor --format json --out build/doctor.json",
       "schema_version": "sdetkit.doctor.v2",
-      "required_fields": ["schema_version", "ok", "checks"],
+      "required_fields": [
+        "schema_version",
+        "ok",
+        "checks"
+      ],
       "stability": "public"
+    },
+    {
+      "id": "doctor-evidence-json",
+      "path": "build/doctor-evidence.json",
+      "produced_by": "python -m sdetkit doctor --emit-evidence --format json --out build/doctor.json",
+      "schema_version": "sdetkit.doctor.evidence.v2",
+      "required_fields": [
+        "schema_version",
+        "doctor_schema_version",
+        "summary"
+      ],
+      "stability": "advanced"
+    },
+    {
+      "id": "doctor-evidence-manifest-json",
+      "path": "build/doctor-evidence-manifest.json",
+      "produced_by": "python -m sdetkit doctor --emit-evidence --format json --out build/doctor.json",
+      "schema_version": "sdetkit.doctor.evidence.manifest.v1",
+      "required_fields": [
+        "schema_version",
+        "doctor_schema_version",
+        "artifacts"
+      ],
+      "stability": "advanced"
     },
     {
       "id": "review-json",
@@ -87,7 +115,11 @@
       "path": "build/risk-summary.json",
       "produced_by": "python -m sdetkit gate release --format json --out build/release-preflight.json",
       "schema_version": "sdetkit.artifacts.risk-summary.v1",
-      "required_fields": ["schema_version", "risk", "summary"],
+      "required_fields": [
+        "schema_version",
+        "risk",
+        "summary"
+      ],
       "stability": "public"
     },
     {
@@ -95,7 +127,9 @@
       "path": "build/evidence.zip",
       "produced_by": "python -m sdetkit gate release --format json --out build/release-preflight.json",
       "schema_version": "sdetkit.artifacts.evidence.v1",
-      "required_fields": ["schema_version"],
+      "required_fields": [
+        "schema_version"
+      ],
       "stability": "public"
     }
   ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Need fast troubleshooting: [First failure triage](first-failure-triage.md), [Adoption troubleshooting](adoption-troubleshooting.md), [Remediation cookbook](remediation-cookbook.md)
 - Need compact navigation: [Docs map (compact)](docs-map.md)
 - Need current references: [CLI reference](cli.md), [API](api.md), and [repo audit reference](repo-audit.md)
-- Need artifact contract inventory: [Artifact contract index](artifact-contract-index.json)
+- Need artifact contract inventory: [Artifact contract index](artifact-contract-index.json) (refresh with `python scripts/generate_artifact_contract_index.py`).
 - Need contributor workflow: [Contributing](contributing.md)
 - Need boundary guidance: [Stability levels](stability-levels.md) for adopters and contributors
 

--- a/tests/test_artifact_contract_index.py
+++ b/tests/test_artifact_contract_index.py
@@ -4,11 +4,12 @@ import json
 from pathlib import Path
 
 from sdetkit import doctor, review
+from sdetkit.artifact_contract_index import INDEX_SCHEMA_VERSION, build_index, write_index
 from sdetkit.checks import artifacts as check_artifacts
 
 
 def test_artifact_contract_index_schema_versions_are_in_sync() -> None:
-    payload = json.loads(Path("docs/artifact-contract-index.json").read_text(encoding="utf-8"))
+    payload = build_index()
     assert payload["schema_version"] == INDEX_SCHEMA_VERSION
 
     entries = {item["id"]: item for item in payload["artifacts"]}
@@ -29,10 +30,22 @@ def test_artifact_contract_index_schema_versions_are_in_sync() -> None:
 
 
 def test_artifact_contract_index_includes_canonical_gate_artifacts() -> None:
-    payload = json.loads(Path("docs/artifact-contract-index.json").read_text(encoding="utf-8"))
+    payload = build_index()
     entries = {item["id"]: item for item in payload["artifacts"]}
 
     for artifact_id in ("gate-fast-json", "release-preflight-json"):
         assert artifact_id in entries
         required = set(entries[artifact_id]["required_fields"])
         assert {"ok", "failed_steps", "profile"}.issubset(required)
+
+
+def test_artifact_contract_index_docs_json_matches_generator_payload() -> None:
+    docs_payload = json.loads(Path("docs/artifact-contract-index.json").read_text(encoding="utf-8"))
+    assert docs_payload == build_index()
+
+
+def test_artifact_contract_index_write_index_roundtrip(tmp_path: Path) -> None:
+    out = tmp_path / "artifact-contract-index.json"
+    write_index(out)
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload == build_index()


### PR DESCRIPTION
### Motivation
- Finalize PR7 to deliver a generator-backed artifact contract index that is deterministic and maintainable by making the generator the single source of truth and ensuring docs/tests stay in sync.【F:src/sdetkit/artifact_contract_index.py†L12-L15】【F:scripts/generate_artifact_contract_index.py†L9-L12】
- Close small gaps found during the audit: test import/validation of index constants, docs drift where generated JSON differed from checked-in JSON, and discoverability of the refresh command in docs.【F:tests/test_artifact_contract_index.py†L7-L13】【F:docs/artifact-contract-index.json†L41-L63】

### Description
- Tightened tests by importing `INDEX_SCHEMA_VERSION`, `build_index`, and `write_index` and by adding assertions for docs/generator parity and `write_index()` roundtrip behavior in `tests/test_artifact_contract_index.py`.【F:tests/test_artifact_contract_index.py†L7-L51】
- Regenerated and committed `docs/artifact-contract-index.json` so the checked-in contract matches `build_index()` output (added doctor evidence and manifest entries and normalized formatting).【F:docs/artifact-contract-index.json†L41-L63】【F:docs/artifact-contract-index.json†L53-L62】
- Left `build_index()` and `write_index()` as the single source-of-truth and ensured the refresh script `scripts/generate_artifact_contract_index.py` invokes `write_index()` to update the docs file deterministically.【F:src/sdetkit/artifact_contract_index.py†L12-L15】【F:scripts/generate_artifact_contract_index.py†L6-L12】
- Improved docs discoverability by adding an explicit refresh command next to the artifact index link in `docs/index.md`.【F:docs/index.md†L93-L100】

### Testing
- Ran `python -m pytest -q tests/test_artifact_contract_index.py tests/test_docs_qa.py -o addopts=` and fixed an initial failure (missing import in tests), then re-ran and observed `20 passed` for the combined test set.【F:tests/test_artifact_contract_index.py†L1-L51】
- Executed `python scripts/generate_artifact_contract_index.py` to regenerate `docs/artifact-contract-index.json` and verified the `git diff` shows only the intended artifact additions/formatting changes.【F:docs/artifact-contract-index.json†L41-L63】
- Ran `python -m ruff check src/sdetkit/artifact_contract_index.py tests/test_artifact_contract_index.py scripts/generate_artifact_contract_index.py` and confirmed static checks passed after the test fix.【F:src/sdetkit/artifact_contract_index.py†L108-L112】【F:tests/test_artifact_contract_index.py†L42-L45】
- Performed a final repository check that the working diff contains only PR7-scoped files: `docs/artifact-contract-index.json`, `docs/index.md`, and `tests/test_artifact_contract_index.py`.【F:docs/artifact-contract-index.json†L1-L136】【F:docs/index.md†L93-L100】

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd44d8b97c83329e570a18a4223775)