### PR TITLE
Add canonical-path observability, legacy migration hints, CLI and serve integrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # --- dev targets (bootstrap) ---
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer adoption-scorecard operator-onboarding-wizard primary-docs-map
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -60,3 +60,27 @@ upgrade-audit: venv
 
 upgrade-audit-ci: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && python scripts/upgrade_audit.py --fail-on high'
+
+
+golden-path-health: venv
+	@bash -lc '. .venv/bin/activate && python scripts/golden_path_health.py --out .sdetkit/out/golden-path-health.json'
+
+
+canonical-path-drift: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_canonical_path_drift.py --format json'
+
+
+legacy-command-analyzer: venv
+	@bash -lc '. .venv/bin/activate && python scripts/legacy_command_analyzer.py --format json'
+
+
+adoption-scorecard: venv
+	@bash -lc '. .venv/bin/activate && python scripts/adoption_scorecard.py --format json'
+
+
+operator-onboarding-wizard: venv
+	@bash -lc '. .venv/bin/activate && python scripts/operator_onboarding_wizard.py --format json'
+
+
+primary-docs-map: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_primary_docs_map.py --format json'

--- a/docs/adoption-scorecard.md
+++ b/docs/adoption-scorecard.md
@@ -1,0 +1,33 @@
+# Adoption scorecard
+
+This scorecard gives one compact maturity snapshot from existing governance artifacts:
+
+- onboarding
+- quality
+- release
+- ops
+
+Each dimension is scored out of 25 (`0` or `25` currently), total score is out of 100.
+
+## Generate scorecard
+
+```bash
+python scripts/adoption_scorecard.py --format json
+```
+
+Default inputs:
+
+- `.sdetkit/out/golden-path-health.json`
+- `.sdetkit/out/canonical-path-drift.json`
+- `.sdetkit/out/legacy-command-analyzer.json`
+
+Default output:
+
+- `.sdetkit/out/adoption-scorecard.json`
+
+## Output contract
+
+- `schema_version`
+- `score`
+- `band` (`early`, `developing`, `strong`, `excellent`)
+- `dimensions` (`onboarding`, `quality`, `release`, `ops`)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,6 +55,38 @@ Transition-era and archived lanes remain available for compatibility, but they a
 - canonical rename map: [public-surface-rename-map](public-surface-rename-map.md)
 - historical material: [archive index](archive/index.md)
 
+## Legacy migration hints (runtime behavior)
+
+When a legacy compatibility command is invoked, the CLI can emit a migration hint to stderr with a preferred next surface and a canonical-path reminder.
+
+Controls:
+
+- **Default behavior:** hints are enabled.
+- **Environment toggle:** set `SDETKIT_LEGACY_HINTS=0` (also `false|no|off`) to disable.
+- **Per-invocation override:** pass `--no-legacy-hint` for one command run.
+
+Examples:
+
+```bash
+# one command only (preferred in CI scripts when needed)
+python -m sdetkit --no-legacy-hint phase1-hardening
+
+# shell/session level behavior
+SDETKIT_LEGACY_HINTS=0 python -m sdetkit phase1-hardening
+```
+
+For migration planning and lane mapping, see [Legacy command migration map](legacy-command-migration-map.md).
+
+You can also query migration guidance directly:
+
+```bash
+python -m sdetkit legacy migrate-hint phase1-hardening
+python -m sdetkit legacy migrate-hint --format json phase1-hardening
+python -m sdetkit legacy migrate-hint --all --format json
+```
+
+JSON output includes `schema_version`, `mode`, and migration recommendation fields (including `deprecation_horizon`) for automation parsing.
+
 ## Contract expectations
 
 Public kit commands are contract-oriented:

--- a/docs/command-taxonomy.md
+++ b/docs/command-taxonomy.md
@@ -2,16 +2,39 @@
 
 ## Product thesis
 
-SDETKit is a unified SDET platform with four flagship kits:
+SDETKit's primary product promise is deterministic release confidence from one canonical first path:
+
+1. `sdetkit gate fast`
+2. `sdetkit gate release`
+3. `sdetkit doctor`
+
+After this path is trusted in your repo, expand into umbrella kit workflows for deeper operational outcomes:
 
 - **Release confidence** (`sdetkit release ...`)
 - **Test intelligence** (`sdetkit intelligence ...`)
 - **Integration assurance** (`sdetkit integration ...`)
 - **Failure forensics** (`sdetkit forensics ...`)
 
-Start with `sdetkit kits discover --goal "align all repo capabilities"` (or `sdetkit kits list` if you want a compact catalog view).
+Use `sdetkit kits list` to discover these expansion surfaces.
 
-## Layer 1: Umbrella kits (primary)
+## Command discovery order (recommended)
+
+Use this order to reduce decision fatigue during adoption:
+
+1. **First run (always):** `sdetkit gate fast` -> `sdetkit gate release` -> `sdetkit doctor`
+2. **Capability expansion:** `sdetkit kits list` then choose `release|intelligence|integration|forensics`
+3. **Operational depth:** move into stable supporting lanes (`security`, `repo`, `evidence`, `report`, `policy`)
+4. **Advanced/legacy lanes:** use playbooks or transition-era lanes only with explicit intent
+
+## Layer 1: Canonical release-confidence path (public/stable first-run)
+
+- `sdetkit gate fast`
+- `sdetkit gate release`
+- `sdetkit doctor`
+
+These commands are the default onboarding and adoption lane.
+
+## Layer 2: Umbrella kits (advanced but supported expansion)
 
 - `sdetkit kits list`
 - `sdetkit kits discover --goal "<goal>" --query "<query>"`
@@ -21,28 +44,33 @@ Start with `sdetkit kits discover --goal "align all repo capabilities"` (or `sde
 - `sdetkit integration ...`
 - `sdetkit forensics ...`
 
-## Layer 2: Compatibility aliases (stable)
+## Layer 3: Stable supporting lanes (post-first-run)
 
-These remain supported for existing automation, but are no longer first-run discovery:
+These remain fully supported for daily operations and automation after the canonical first run:
 
-- `sdetkit gate ...`
-- `sdetkit doctor ...`
 - `sdetkit security ...`
 - `sdetkit repo ...`
 - `sdetkit evidence ...`
 - `sdetkit report ...`
 - `sdetkit policy ...`
 
-## Layer 3: Supporting utilities and integrations
+## Layer 4: Supporting utilities and integrations
 
 - Utilities: `kv`, `apiget`, `cassette-get`, `patch`
 - Operations: `maintenance`, `ops`, `notify`, `agent`, `ci`, `dev`
 
-## Layer 4: Playbooks and transition-era lanes
+## Layer 5: Playbooks and transition-era lanes
 
 - Guided lanes: `sdetkit playbooks`
 - Transition-era compatibility lanes: `dayNN-*`, `*-closeout`, `continuous-upgrade-cycleX-closeout`
 
-Use these intentionally; they are not the flagship product surface.
+Use these intentionally; they are not the default first-run product surface.
+
+## Legacy and transition-lane boundary
+
+- Prefer stable lanes when an equivalent command exists.
+- Treat transition-era lanes as compatibility workflows for existing automation and historical continuity.
+- For inventory/debugging only, use `sdetkit --help --show-hidden` to inspect the full long-tail surface.
+- For practical migration patterns, use [Legacy command migration map](legacy-command-migration-map.md).
 
 For a full command inventory (including hidden/legacy lanes), run `sdetkit --help --show-hidden`.

--- a/docs/golden-path-health.md
+++ b/docs/golden-path-health.md
@@ -1,0 +1,37 @@
+# Golden-path health signal
+
+This page defines a lightweight health signal for the canonical release-confidence path:
+
+1. `python -m sdetkit gate fast`
+2. `python -m sdetkit gate release`
+3. `python -m sdetkit doctor`
+
+## Why
+
+Use this to make canonical-path health explicit in CI and docs workflows.
+
+## Generate health artifact
+
+After running the canonical path and producing JSON outputs:
+
+```bash
+python scripts/golden_path_health.py \
+  --gate-fast build/gate-fast.json \
+  --gate-release build/release-preflight.json \
+  --doctor build/doctor.json \
+  --out .sdetkit/out/golden-path-health.json
+```
+
+Exit code behavior:
+
+- `0` => all three artifacts are present and `ok: true`
+- `2` => any artifact is missing/invalid/not `ok: true`
+
+## Output contract
+
+`golden-path-health.json` includes:
+
+- `schema_version`
+- `canonical_path`
+- `overall_ok`
+- `checks` (`gate_fast`, `gate_release`, `doctor`) with `state`, `ok`, and `path`

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,14 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Need fast troubleshooting: [First failure triage](first-failure-triage.md), [Adoption troubleshooting](adoption-troubleshooting.md), [Remediation cookbook](remediation-cookbook.md)
 - Need compact navigation: [Docs map (compact)](docs-map.md)
 - Need current references: [CLI reference](cli.md), [API](api.md), and [repo audit reference](repo-audit.md)
+- Migrating older automation? Use [Legacy command migration map](legacy-command-migration-map.md)
+- Need canonical-path health status? Use [Golden-path health signal](golden-path-health.md)
+- Need drift enforcement? Run canonical path drift guard (`python scripts/check_canonical_path_drift.py --format json`)
+- Need legacy usage inventory? Run legacy command analyzer (`python scripts/legacy_command_analyzer.py --format json`)
+- Need one maturity number? Generate [Adoption scorecard](adoption-scorecard.md)
+- Need guided canonical triage? Use [Operator onboarding wizard](operator-onboarding-wizard.md)
+- Need API snapshot? Query serve observability endpoint (`GET /v1/observability`)
+- Need docs IA guardrails? Use [Primary docs map](primary-docs-map.md)
 - Need artifact contract inventory: [Artifact contract index](artifact-contract-index.json) (refresh with `python scripts/generate_artifact_contract_index.py`).
 - Need contributor workflow: [Contributing](contributing.md)
 - Need boundary guidance: [Stability levels](stability-levels.md) for adopters and contributors

--- a/docs/legacy-command-migration-map.md
+++ b/docs/legacy-command-migration-map.md
@@ -1,0 +1,68 @@
+# Legacy command migration map (compatibility -> preferred lanes)
+
+Use this page when you inherit existing automation that still uses transition-era or legacy command families.
+
+## Migration policy
+
+1. Keep production automation running first (do not break working pipelines abruptly).
+2. Prefer the public/stable canonical path for first-run and release-go/no-go decisions:
+   - `python -m sdetkit gate fast`
+   - `python -m sdetkit gate release`
+   - `python -m sdetkit doctor`
+3. Migrate in small batches and validate artifacts after each move.
+4. Keep `python -m sdetkit --help --show-hidden` for inventory/debugging only.
+
+## Quick mapping table
+
+| If you currently run | Preferred target lane | Why |
+|---|---|---|
+| `sdetkit weekly-review-lane` / historical weekly closeout variants | `sdetkit weekly-review` (or `sdetkit playbooks`) | Keeps workflow intent while moving to maintained surfaces. |
+| `sdetkit phase1-*` / `phase2-*` / `phase3-*` closeout commands | `sdetkit playbooks` + stable command families (`gate`, `doctor`, `report`, `evidence`) | Reduces dependency on transition-era naming. |
+| `sdetkit *-closeout` command families | `sdetkit playbooks` or umbrella kits (`release`, `intelligence`, `integration`, `forensics`) | Preserves outcomes while using clearer capability groupings. |
+| Legacy quality-only invocations without explicit release decision flow | `gate fast` -> `gate release` -> `doctor` | Aligns with canonical ship/no-ship contract. |
+| Hidden inventory-driven discovery in day-to-day use | `sdetkit kits list` and public help surfaces | Lowers cognitive load for new operators. |
+
+## Suggested migration sequence
+
+### Step 1: Inventory
+
+Capture current usage from CI/scripts:
+
+```bash
+python -m sdetkit --help --show-hidden
+```
+
+Preview a recommendation for one legacy command:
+
+```bash
+python -m sdetkit legacy migrate-hint phase1-hardening
+python -m sdetkit legacy migrate-hint --format json phase1-hardening
+python -m sdetkit legacy migrate-hint --all --format json
+```
+
+Use `--format json` for automation workflows; payloads include `schema_version`, mode metadata, and `deprecation_horizon`.
+
+Scan your repo/scripts for legacy command usage:
+
+```bash
+python scripts/legacy_command_analyzer.py --format json
+```
+
+### Step 2: Route by intent
+
+- Release decision intent -> canonical gate/doctor path.
+- Capability exploration intent -> `sdetkit kits list`.
+- Team/process rollout intent -> `sdetkit playbooks`.
+
+### Step 3: Validate in one branch
+
+Run the same checks before/after migration and compare output artifacts (`ok`, `failed_steps`, profile and recommendations).
+
+### Step 4: Keep compatibility fallback briefly
+
+For high-risk repos, keep old command wrappers for one release cycle and remove after stable evidence is confirmed.
+
+## Notes
+
+- This page is guidance, not a forced deprecation policy.
+- Legacy commands remain available for compatibility and traceability.

--- a/docs/operator-onboarding-wizard.md
+++ b/docs/operator-onboarding-wizard.md
@@ -1,0 +1,28 @@
+# Operator onboarding wizard
+
+This helper gives a deterministic onboarding summary for the canonical path:
+
+1. `gate fast`
+2. `gate release`
+3. `doctor`
+
+## Run mode
+
+Use existing artifacts only:
+
+```bash
+python scripts/operator_onboarding_wizard.py --format json
+```
+
+Force execution of the canonical path before summarizing:
+
+```bash
+python scripts/operator_onboarding_wizard.py --run --format json
+```
+
+## Output
+
+- `overall_ready`
+- `checks` for `gate_fast`, `gate_release`, `doctor` (`state`, `ok`, `failed_steps`)
+- `actions` list with next remediation steps
+- `run_results` (when `--run` is used)

--- a/docs/primary-docs-map.md
+++ b/docs/primary-docs-map.md
@@ -1,0 +1,15 @@
+# Primary docs map (hard-limit view)
+
+This map keeps top-level onboarding/navigation focused on one primary page per core intent:
+
+1. **Start page**: [Start Here in 5 Minutes](start-here-5-minutes.md)
+2. **CI path page**: [Recommended CI flow](recommended-ci-flow.md)
+3. **Troubleshooting funnel**: [First failure triage](first-failure-triage.md)
+
+## Guard command
+
+Validate this mapping stays present and linked from `docs/index.md`:
+
+```bash
+python scripts/check_primary_docs_map.py --format json
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,11 @@ nav:
       - Release confidence architecture note: architecture/umbrella-kits.md
       - Command surface inventory: command-surface.md
       - Capability map and command taxonomy: command-taxonomy.md
+      - Legacy command migration map: legacy-command-migration-map.md
+      - Golden-path health signal: golden-path-health.md
+      - Adoption scorecard: adoption-scorecard.md
+      - Operator onboarding wizard: operator-onboarding-wizard.md
+      - Primary docs map: primary-docs-map.md
       - Determinism checklist: determinism-checklist.md
       - Determinism contract: determinism-contract.md
       - Stability levels (current policy): stability-levels.md

--- a/scripts/adoption_scorecard.py
+++ b/scripts/adoption_scorecard.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _bool_score(value: bool) -> int:
+    return 25 if value else 0
+
+
+def _build_scorecard(golden: dict[str, Any] | None, drift: dict[str, Any] | None, legacy: dict[str, Any] | None) -> dict[str, Any]:
+    onboarding_ok = bool(golden and golden.get("overall_ok") is True)
+    release_ok = bool(
+        golden
+        and isinstance(golden.get("checks"), dict)
+        and isinstance(golden["checks"].get("gate_release"), dict)
+        and golden["checks"]["gate_release"].get("ok") is True
+    )
+    quality_ok = bool(drift and drift.get("overall_ok") is True)
+    ops_ok = bool(legacy and legacy.get("overall_ok") is True)
+
+    dimensions = {
+        "onboarding": _bool_score(onboarding_ok),
+        "quality": _bool_score(quality_ok),
+        "release": _bool_score(release_ok),
+        "ops": _bool_score(ops_ok),
+    }
+    total = sum(dimensions.values())
+    if total >= 90:
+        band = "excellent"
+    elif total >= 70:
+        band = "strong"
+    elif total >= 40:
+        band = "developing"
+    else:
+        band = "early"
+    return {
+        "schema_version": "1",
+        "score": total,
+        "band": band,
+        "dimensions": dimensions,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python scripts/adoption_scorecard.py")
+    parser.add_argument("--golden", default=".sdetkit/out/golden-path-health.json")
+    parser.add_argument("--drift", default=".sdetkit/out/canonical-path-drift.json")
+    parser.add_argument("--legacy", default=".sdetkit/out/legacy-command-analyzer.json")
+    parser.add_argument("--out", default=".sdetkit/out/adoption-scorecard.json")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(argv)
+
+    scorecard = _build_scorecard(
+        _load_json(Path(ns.golden)),
+        _load_json(Path(ns.drift)),
+        _load_json(Path(ns.legacy)),
+    )
+    out = Path(ns.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(scorecard, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if ns.format == "json":
+        print(json.dumps(scorecard, sort_keys=True))
+    else:
+        print(f"adoption-scorecard: score={scorecard['score']} band={scorecard['band']}")
+        for k, v in scorecard["dimensions"].items():
+            print(f"- {k}: {v}/25")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_canonical_path_drift.py
+++ b/scripts/check_canonical_path_drift.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+CANONICAL_TOKENS = (
+    "gate fast",
+    "gate release",
+    "doctor",
+)
+
+CHECKS = (
+    ("README", Path("README.md")),
+    ("docs_index", Path("docs/index.md")),
+    ("docs_cli", Path("docs/cli.md")),
+    ("docs_taxonomy", Path("docs/command-taxonomy.md")),
+    ("cli_help_source", Path("src/sdetkit/cli.py")),
+)
+
+
+def _contains_all(text: str, tokens: tuple[str, ...]) -> tuple[bool, list[str]]:
+    lowered = text.lower()
+    missing = [token for token in tokens if token not in lowered]
+    return (len(missing) == 0, missing)
+
+
+def _build_report(root: Path) -> dict[str, Any]:
+    checks: dict[str, dict[str, Any]] = {}
+    for name, rel in CHECKS:
+        path = root / rel
+        if not path.exists():
+            checks[name] = {"path": str(rel), "ok": False, "missing_tokens": list(CANONICAL_TOKENS)}
+            continue
+        ok, missing = _contains_all(path.read_text(encoding="utf-8"), CANONICAL_TOKENS)
+        checks[name] = {"path": str(rel), "ok": ok, "missing_tokens": missing}
+    overall_ok = all(item["ok"] for item in checks.values())
+    return {
+        "schema_version": "1",
+        "canonical_tokens": list(CANONICAL_TOKENS),
+        "overall_ok": overall_ok,
+        "checks": checks,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python scripts/check_canonical_path_drift.py")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    ns = parser.parse_args(argv)
+    report = _build_report(Path(ns.root).resolve())
+    if ns.format == "json":
+        print(json.dumps(report, sort_keys=True))
+    else:
+        print(f"canonical-path-drift: {'OK' if report['overall_ok'] else 'FAIL'}")
+        for name, item in report["checks"].items():
+            status = "OK" if item["ok"] else "FAIL"
+            missing = ", ".join(item["missing_tokens"]) if item["missing_tokens"] else "-"
+            print(f"[{status}] {name} ({item['path']}) missing: {missing}")
+    return 0 if report["overall_ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_primary_docs_map.py
+++ b/scripts/check_primary_docs_map.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+PRIMARY_MAP = {
+    "start_page": "start-here-5-minutes.md",
+    "ci_page": "recommended-ci-flow.md",
+    "troubleshooting_page": "first-failure-triage.md",
+}
+
+
+def _build_report(root: Path) -> dict[str, Any]:
+    index_path = root / "docs" / "index.md"
+    index_text = index_path.read_text(encoding="utf-8") if index_path.exists() else ""
+    checks: dict[str, dict[str, Any]] = {}
+    for key, rel_name in PRIMARY_MAP.items():
+        path = root / "docs" / rel_name
+        checks[key] = {
+            "path": str(path.relative_to(root)),
+            "exists": path.exists(),
+            "linked_in_index": rel_name in index_text,
+        }
+        checks[key]["ok"] = checks[key]["exists"] and checks[key]["linked_in_index"]
+    overall_ok = all(item["ok"] for item in checks.values())
+    return {"schema_version": "1", "overall_ok": overall_ok, "checks": checks}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python scripts/check_primary_docs_map.py")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    ns = parser.parse_args(argv)
+    report = _build_report(Path(ns.root).resolve())
+    if ns.format == "json":
+        print(json.dumps(report, sort_keys=True))
+    else:
+        print(f"primary-docs-map: {'OK' if report['overall_ok'] else 'FAIL'}")
+        for key, item in report["checks"].items():
+            status = "OK" if item["ok"] else "FAIL"
+            print(
+                f"[{status}] {key}: exists={item['exists']} linked_in_index={item['linked_in_index']} ({item['path']})"
+            )
+    return 0 if report["overall_ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/golden_path_health.py
+++ b/scripts/golden_path_health.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_ok(path: Path) -> tuple[str, bool | None]:
+    if not path.exists():
+        return "missing", None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return "invalid-json", None
+    ok = payload.get("ok")
+    if isinstance(ok, bool):
+        return "present", ok
+    return "missing-ok", None
+
+
+def _build_payload(gate_fast: Path, gate_release: Path, doctor: Path) -> dict[str, Any]:
+    checks = {
+        "gate_fast": {"path": str(gate_fast)},
+        "gate_release": {"path": str(gate_release)},
+        "doctor": {"path": str(doctor)},
+    }
+    for key, path in (
+        ("gate_fast", gate_fast),
+        ("gate_release", gate_release),
+        ("doctor", doctor),
+    ):
+        state, ok = _load_ok(path)
+        checks[key]["state"] = state
+        checks[key]["ok"] = ok
+
+    all_states_present = all(item["state"] == "present" for item in checks.values())
+    all_ok = all(item["ok"] is True for item in checks.values())
+    return {
+        "schema_version": "1",
+        "canonical_path": ["gate fast", "gate release", "doctor"],
+        "overall_ok": bool(all_states_present and all_ok),
+        "checks": checks,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python scripts/golden_path_health.py")
+    parser.add_argument("--gate-fast", default="build/gate-fast.json")
+    parser.add_argument("--gate-release", default="build/release-preflight.json")
+    parser.add_argument("--doctor", default="build/doctor.json")
+    parser.add_argument("--out", default=".sdetkit/out/golden-path-health.json")
+    ns = parser.parse_args(argv)
+
+    payload = _build_payload(
+        gate_fast=Path(ns.gate_fast),
+        gate_release=Path(ns.gate_release),
+        doctor=Path(ns.doctor),
+    )
+    out = Path(ns.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if payload["overall_ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legacy_command_analyzer.py
+++ b/scripts/legacy_command_analyzer.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from sdetkit.cli import LEGACY_COMMAND_MODULES
+
+
+def _preferred_surface(command: str) -> str:
+    if command.startswith("weekly-review"):
+        return "python -m sdetkit weekly-review"
+    if command.startswith(("phase1-", "phase2-", "phase3-")):
+        return "python -m sdetkit playbooks --help"
+    if command.endswith("-closeout"):
+        return "python -m sdetkit playbooks --help"
+    return "python -m sdetkit kits list"
+
+
+def _candidate_files(root: Path) -> list[Path]:
+    globs = ("*.md", "*.yml", "*.yaml", "*.sh", "*.txt", "*.py")
+    seen: set[Path] = set()
+    files: list[Path] = []
+    for pattern in globs:
+        for path in root.rglob(pattern):
+            if any(part in {".git", ".venv", "site"} for part in path.parts):
+                continue
+            if path in seen or not path.is_file():
+                continue
+            seen.add(path)
+            files.append(path)
+    return files
+
+
+def _analyze(root: Path) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    legacy_commands = sorted(LEGACY_COMMAND_MODULES.keys(), key=len, reverse=True)
+    for path in _candidate_files(root):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for cmd in legacy_commands:
+            patterns = (
+                re.compile(rf"\bpython\s+-m\s+sdetkit\s+{re.escape(cmd)}\b"),
+                re.compile(rf"\bsdetkit\s+{re.escape(cmd)}\b"),
+            )
+            if any(p.search(text) for p in patterns):
+                findings.append(
+                    {
+                        "path": str(path.relative_to(root)),
+                        "command": cmd,
+                        "preferred_surface": _preferred_surface(cmd),
+                    }
+                )
+    findings.sort(key=lambda item: (item["path"], item["command"]))
+    return {
+        "schema_version": "1",
+        "overall_ok": len(findings) == 0,
+        "count": len(findings),
+        "findings": findings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python scripts/legacy_command_analyzer.py")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    ns = parser.parse_args(argv)
+    root = Path(ns.root).resolve()
+    report = _analyze(root)
+    if ns.format == "json":
+        print(json.dumps(report, sort_keys=True))
+    else:
+        print(f"legacy-command-analyzer: {'OK' if report['overall_ok'] else 'FOUND'}")
+        for item in report["findings"]:
+            print(f"- {item['path']}: {item['command']} -> {item['preferred_surface']}")
+    return 0 if report["overall_ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operator_onboarding_wizard.py
+++ b/scripts/operator_onboarding_wizard.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _run_canonical(repo_root: Path, python_bin: str) -> list[dict[str, Any]]:
+    commands = [
+        ("gate_fast", [python_bin, "-m", "sdetkit", "gate", "fast", "--format", "json", "--out", "build/gate-fast.json"]),
+        (
+            "gate_release",
+            [
+                python_bin,
+                "-m",
+                "sdetkit",
+                "gate",
+                "release",
+                "--format",
+                "json",
+                "--out",
+                "build/release-preflight.json",
+            ],
+        ),
+        ("doctor", [python_bin, "-m", "sdetkit", "doctor", "--format", "json", "--out", "build/doctor.json"]),
+    ]
+    results: list[dict[str, Any]] = []
+    for step_id, cmd in commands:
+        proc = subprocess.run(cmd, cwd=repo_root, text=True, capture_output=True)
+        results.append({"id": step_id, "cmd": cmd, "rc": proc.returncode})
+    return results
+
+
+def _load_artifact(path: Path) -> tuple[str, bool | None, list[str]]:
+    if not path.exists():
+        return "missing", None, []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return "invalid-json", None, []
+    ok = payload.get("ok")
+    failed_steps = payload.get("failed_steps")
+    return (
+        "present",
+        ok if isinstance(ok, bool) else None,
+        list(failed_steps) if isinstance(failed_steps, list) else [],
+    )
+
+
+def _build_summary(repo_root: Path) -> dict[str, Any]:
+    artifact_map = {
+        "gate_fast": repo_root / "build" / "gate-fast.json",
+        "gate_release": repo_root / "build" / "release-preflight.json",
+        "doctor": repo_root / "build" / "doctor.json",
+    }
+    checks: dict[str, dict[str, Any]] = {}
+    actions: list[str] = []
+    for key, path in artifact_map.items():
+        state, ok, failed_steps = _load_artifact(path)
+        checks[key] = {"path": str(path.relative_to(repo_root)), "state": state, "ok": ok, "failed_steps": failed_steps}
+        if state != "present":
+            actions.append(f"Run canonical step for {key}: missing artifact.")
+        elif ok is False:
+            actions.append(f"Triage {key}: inspect failed_steps in {path.name}.")
+    overall_ready = all(item["ok"] is True for item in checks.values())
+    if overall_ready:
+        actions.append("Canonical onboarding path is green.")
+    return {"schema_version": "1", "overall_ready": overall_ready, "checks": checks, "actions": actions}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python scripts/operator_onboarding_wizard.py")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--run", action="store_true")
+    parser.add_argument("--python", default=sys.executable)
+    parser.add_argument("--out", default=".sdetkit/out/operator-onboarding-summary.json")
+    parser.add_argument("--format", choices=["json", "text"], default="json")
+    ns = parser.parse_args(argv)
+
+    repo_root = Path(ns.repo_root).resolve()
+    run_results = _run_canonical(repo_root, ns.python) if ns.run else []
+    summary = _build_summary(repo_root)
+    summary["run_results"] = run_results
+    out = Path(ns.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if ns.format == "json":
+        print(json.dumps(summary, sort_keys=True))
+    else:
+        print(f"operator-onboarding: {'READY' if summary['overall_ready'] else 'NOT_READY'}")
+        for action in summary["actions"]:
+            print(f"- {action}")
+    return 0 if summary["overall_ready"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 import time
@@ -157,6 +158,94 @@ def _emit_cli_timing(message: str) -> None:
     sys.stderr.write(f"[sdetkit.cli.timing] {message}\n")
 
 
+def _legacy_hints_enabled() -> bool:
+    raw = os.environ.get("SDETKIT_LEGACY_HINTS", "1")
+    return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _legacy_preferred_surface(command: str) -> str:
+    if command.startswith("weekly-review"):
+        return "python -m sdetkit weekly-review"
+    if command.startswith(("phase1-", "phase2-", "phase3-")):
+        return "python -m sdetkit playbooks --help"
+    if command.endswith("-closeout"):
+        return "python -m sdetkit playbooks --help"
+    return "python -m sdetkit kits list"
+
+
+def _legacy_deprecation_horizon(command: str) -> str:
+    if command.startswith(("phase1-", "phase2-", "phase3-")):
+        return "transition lane: migrate within 1-2 release cycles"
+    if command.endswith("-closeout"):
+        return "transition lane: migrate within 1-2 release cycles"
+    if command.startswith("weekly-review"):
+        return "compatibility lane: review migration quarterly"
+    return "compatibility lane: migrate when feasible"
+
+
+def _legacy_migration_hint(command: str) -> str:
+    preferred = _legacy_preferred_surface(command)
+    horizon = _legacy_deprecation_horizon(command)
+    return (
+        f"[legacy-hint] '{command}' is a compatibility lane. "
+        f"Preferred next surface: {preferred}. "
+        f"Deprecation horizon: {horizon}. "
+        "Canonical release-confidence path: python -m sdetkit gate fast -> gate release -> doctor."
+    )
+
+
+def _emit_legacy_migration_hint(command: str) -> None:
+    if not _legacy_hints_enabled():
+        return
+    sys.stderr.write(_legacy_migration_hint(command) + "\n")
+
+
+def _extract_global_flag(argv: Sequence[str], flag: str) -> tuple[list[str], bool]:
+    args = list(argv)
+    found = False
+    filtered: list[str] = []
+    for token in args:
+        if token == flag:
+            found = True
+            continue
+        filtered.append(token)
+    return filtered, found
+
+
+def _legacy_migrate_hint(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(prog="sdetkit legacy migrate-hint")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument("command", nargs="?")
+    ns = parser.parse_args(list(argv))
+    if not ns.command and not ns.all:
+        sys.stderr.write("legacy error: expected command name after migrate-hint (or pass --all)\n")
+        return 2
+    if ns.command and ns.all:
+        sys.stderr.write("legacy error: use either <command> or --all for migrate-hint\n")
+        return 2
+    commands = [str(ns.command)] if ns.command else list(LEGACY_NAMESPACE_COMMANDS)
+    items = [
+        {
+            "command": command,
+            "preferred_surface": _legacy_preferred_surface(command),
+            "deprecation_horizon": _legacy_deprecation_horizon(command),
+            "canonical_path": ["gate fast", "gate release", "doctor"],
+            "hint": _legacy_migration_hint(command),
+        }
+        for command in commands
+    ]
+    if ns.format == "json":
+        if len(items) == 1:
+            payload = {"schema_version": "1", "mode": "single", **items[0]}
+        else:
+            payload = {"schema_version": "1", "mode": "all", "count": len(items), "items": items}
+        sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
+        return 0
+    sys.stdout.write("\n".join(item["hint"] for item in items) + "\n")
+    return 0
+
+
 def _is_hidden_cmd(name: str) -> bool:
     if name == "playbooks":
         return False
@@ -277,6 +366,11 @@ Then use stability-aware command discovery:
         "--show-hidden",
         action="store_true",
         help="Include hidden/legacy playbook commands in `sdetkit --help` output.",
+    )
+    p.add_argument(
+        "--no-legacy-hint",
+        action="store_true",
+        help="Suppress legacy migration hints for this invocation.",
     )
     sub = p.add_subparsers(
         dest="cmd",
@@ -864,6 +958,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
 
+    argv, no_legacy_hint = _extract_global_flag(argv, "--no-legacy-hint")
+
     if argv:
         argv = list(argv)
         argv[0] = _resolve_non_day_playbook_alias(str(argv[0]))
@@ -875,6 +971,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         if argv[1] == "list":
             sys.stdout.write("\n".join(LEGACY_NAMESPACE_COMMANDS) + "\n")
             return 0
+        if argv[1] == "migrate-hint":
+            return _legacy_migrate_hint(list(argv[2:]))
         return main(list(argv[1:]))
 
     if argv and argv[0] == "cassette-get":
@@ -963,6 +1061,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if argv:
         legacy_module = LEGACY_COMMAND_MODULES.get(str(argv[0]))
         if legacy_module:
+            if not no_legacy_hint:
+                _emit_legacy_migration_hint(str(argv[0]))
             return _run_module_main(legacy_module, list(argv[1:]))
 
     if argv and argv[0] == "objection-handling":
@@ -1111,6 +1211,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         if ns.args[0] == "list":
             sys.stdout.write("\n".join(LEGACY_NAMESPACE_COMMANDS) + "\n")
             return 0
+        if ns.args[0] == "migrate-hint":
+            return _legacy_migrate_hint(list(ns.args[1:]))
         return main(list(ns.args))
 
     if ns.cmd == "kits":

--- a/src/sdetkit/serve.py
+++ b/src/sdetkit/serve.py
@@ -161,6 +161,40 @@ def _run_review_request(req: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _observability_snapshot(root: Path) -> dict[str, Any]:
+    artifacts = {
+        "golden_path_health": root / ".sdetkit" / "out" / "golden-path-health.json",
+        "canonical_path_drift": root / ".sdetkit" / "out" / "canonical-path-drift.json",
+        "legacy_command_analyzer": root / ".sdetkit" / "out" / "legacy-command-analyzer.json",
+        "adoption_scorecard": root / ".sdetkit" / "out" / "adoption-scorecard.json",
+        "operator_onboarding_summary": root / ".sdetkit" / "out" / "operator-onboarding-summary.json",
+    }
+    checks: dict[str, dict[str, Any]] = {}
+    for key, path in artifacts.items():
+        if not path.exists():
+            checks[key] = {"state": "missing", "path": str(path)}
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            checks[key] = {"state": "invalid-json", "path": str(path)}
+            continue
+        checks[key] = {
+            "state": "present",
+            "path": str(path),
+            "overall_ok": payload.get("overall_ok"),
+            "overall_ready": payload.get("overall_ready"),
+            "score": payload.get("score"),
+            "band": payload.get("band"),
+        }
+    return {
+        "status": "ok",
+        "contract_version": SERVE_CONTRACT_VERSION,
+        "service": "sdetkit",
+        "observability": checks,
+    }
+
+
 def _make_handler() -> type[BaseHTTPRequestHandler]:
     class SdetkitHandler(BaseHTTPRequestHandler):
         server_version = "SDETKitServe/1.0"
@@ -177,6 +211,9 @@ def _make_handler() -> type[BaseHTTPRequestHandler]:
             return
 
         def do_GET(self) -> None:  # noqa: N802
+            if self.path == "/v1/observability":
+                self._send_json(HTTPStatus.OK, _observability_snapshot(Path(".")))
+                return
             if self.path != "/healthz":
                 self._send_json(
                     HTTPStatus.NOT_FOUND,
@@ -193,6 +230,7 @@ def _make_handler() -> type[BaseHTTPRequestHandler]:
                     "endpoints": {
                         "health": "/healthz",
                         "review": "/v1/review",
+                        "observability": "/v1/observability",
                     },
                 },
             )

--- a/tests/test_adoption_scorecard_script.py
+++ b/tests/test_adoption_scorecard_script.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    root = Path(__file__).resolve().parents[1]
+    return subprocess.run(
+        [sys.executable, "scripts/adoption_scorecard.py", *args],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        env={"PYTHONPATH": str(root / "src")},
+    )
+
+
+def test_adoption_scorecard_reports_excellent_when_all_inputs_ok(tmp_path: Path) -> None:
+    golden = tmp_path / "golden.json"
+    drift = tmp_path / "drift.json"
+    legacy = tmp_path / "legacy.json"
+    out = tmp_path / "score.json"
+    golden.write_text(
+        json.dumps({"overall_ok": True, "checks": {"gate_release": {"ok": True}}}), encoding="utf-8"
+    )
+    drift.write_text(json.dumps({"overall_ok": True}), encoding="utf-8")
+    legacy.write_text(json.dumps({"overall_ok": True}), encoding="utf-8")
+    proc = _run(
+        "--golden",
+        str(golden),
+        "--drift",
+        str(drift),
+        "--legacy",
+        str(legacy),
+        "--out",
+        str(out),
+        "--format",
+        "json",
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["score"] == 100
+    assert payload["band"] == "excellent"
+
+
+def test_adoption_scorecard_reports_early_when_inputs_missing(tmp_path: Path) -> None:
+    out = tmp_path / "score.json"
+    proc = _run("--out", str(out), "--format", "json")
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["score"] == 0
+    assert payload["band"] == "early"

--- a/tests/test_canonical_path_drift_script.py
+++ b/tests/test_canonical_path_drift_script.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    root = Path(__file__).resolve().parents[1]
+    return subprocess.run(
+        [sys.executable, "scripts/check_canonical_path_drift.py", *args],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        env={"PYTHONPATH": str(root / "src")},
+    )
+
+
+def test_canonical_path_drift_guard_reports_ok_for_repo_state() -> None:
+    proc = _run("--format", "json")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["overall_ok"] is True
+    assert payload["schema_version"] == "1"
+    assert payload["checks"]["README"]["ok"] is True

--- a/tests/test_cli_help_discoverability_contract.py
+++ b/tests/test_cli_help_discoverability_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
@@ -77,6 +78,55 @@ def test_legacy_namespace_lists_contained_legacy_commands() -> None:
     assert "weekly-review-lane" in listed
     assert "phase1-hardening" in listed
     assert "optimization-closeout-foundation" in listed
+
+
+def test_legacy_namespace_migrate_hint_renders_recommendation() -> None:
+    proc = _run("legacy", "migrate-hint", "phase1-hardening")
+    assert proc.returncode == 0
+    assert "[legacy-hint]" in proc.stdout
+    assert "phase1-hardening" in proc.stdout
+    assert "Deprecation horizon:" in proc.stdout
+    assert "gate fast -> gate release -> doctor" in proc.stdout
+
+
+def test_legacy_namespace_migrate_hint_requires_command_name() -> None:
+    proc = _run("legacy", "migrate-hint")
+    assert proc.returncode == 2
+    assert "expected command name after migrate-hint" in proc.stderr.lower()
+
+
+def test_legacy_namespace_migrate_hint_json_format() -> None:
+    proc = _run("legacy", "migrate-hint", "--format", "json", "phase1-hardening")
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "1"
+    assert payload["mode"] == "single"
+    assert payload["command"] == "phase1-hardening"
+    assert payload["preferred_surface"] == "python -m sdetkit playbooks --help"
+    assert "deprecation_horizon" in payload
+    assert payload["canonical_path"] == ["gate fast", "gate release", "doctor"]
+    assert "legacy-hint" in payload["hint"]
+
+
+def test_legacy_namespace_migrate_hint_all_json_format() -> None:
+    proc = _run("legacy", "migrate-hint", "--all", "--format", "json")
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "1"
+    assert payload["mode"] == "all"
+    assert payload["count"] >= 1
+    assert isinstance(payload["items"], list)
+    first = payload["items"][0]
+    assert "command" in first
+    assert "preferred_surface" in first
+    assert "deprecation_horizon" in first
+    assert "hint" in first
+
+
+def test_legacy_namespace_migrate_hint_rejects_command_and_all_together() -> None:
+    proc = _run("legacy", "migrate-hint", "--all", "phase1-hardening")
+    assert proc.returncode == 2
+    assert "use either <command> or --all" in proc.stderr.lower()
 
 
 def test_policy_tier_vocabulary_matches_public_contract_and_docs() -> None:

--- a/tests/test_cli_productized_closeout_aliases.py
+++ b/tests/test_cli_productized_closeout_aliases.py
@@ -59,3 +59,40 @@ def test_legacy_dispatch_uses_central_mapping(monkeypatch) -> None:
 
     assert cli.main(["phase1-hardening", "--format", "json"]) == 0
     assert captured == [("sdetkit.phase1_hardening_29", ["--format", "json"])]
+
+
+def test_legacy_dispatch_emits_migration_hint(monkeypatch, capsys) -> None:
+    def _fake_run(module_name: str, args: list[str]) -> int:
+        return 0
+
+    monkeypatch.setattr(cli, "_run_module_main", _fake_run)
+
+    assert cli.main(["phase1-hardening"]) == 0
+    err = capsys.readouterr().err
+    assert "[legacy-hint]" in err
+    assert "phase1-hardening" in err
+    assert "gate fast -> gate release -> doctor" in err
+
+
+def test_legacy_dispatch_can_disable_migration_hint(monkeypatch, capsys) -> None:
+    def _fake_run(module_name: str, args: list[str]) -> int:
+        return 0
+
+    monkeypatch.setattr(cli, "_run_module_main", _fake_run)
+    monkeypatch.setenv("SDETKIT_LEGACY_HINTS", "0")
+
+    assert cli.main(["phase1-hardening"]) == 0
+    err = capsys.readouterr().err
+    assert "[legacy-hint]" not in err
+
+
+def test_legacy_dispatch_can_disable_migration_hint_per_invocation(monkeypatch, capsys) -> None:
+    def _fake_run(module_name: str, args: list[str]) -> int:
+        return 0
+
+    monkeypatch.setattr(cli, "_run_module_main", _fake_run)
+    monkeypatch.delenv("SDETKIT_LEGACY_HINTS", raising=False)
+
+    assert cli.main(["--no-legacy-hint", "phase1-hardening"]) == 0
+    err = capsys.readouterr().err
+    assert "[legacy-hint]" not in err

--- a/tests/test_golden_path_health_script.py
+++ b/tests/test_golden_path_health_script.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    root = Path(__file__).resolve().parents[1]
+    return subprocess.run(
+        [sys.executable, "scripts/golden_path_health.py", *args],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        env={"PYTHONPATH": str(root / "src")},
+    )
+
+
+def test_golden_path_health_reports_ok_when_all_artifacts_are_ok(tmp_path: Path) -> None:
+    gate_fast = tmp_path / "gate-fast.json"
+    gate_release = tmp_path / "release-preflight.json"
+    doctor = tmp_path / "doctor.json"
+    out = tmp_path / "golden-path-health.json"
+    for path in (gate_fast, gate_release, doctor):
+        path.write_text(json.dumps({"ok": True}), encoding="utf-8")
+
+    proc = _run(
+        tmp_path,
+        "--gate-fast",
+        str(gate_fast),
+        "--gate-release",
+        str(gate_release),
+        "--doctor",
+        str(doctor),
+        "--out",
+        str(out),
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["overall_ok"] is True
+    assert payload["checks"]["gate_fast"]["ok"] is True
+
+
+def test_golden_path_health_reports_failure_when_artifact_missing(tmp_path: Path) -> None:
+    out = tmp_path / "golden-path-health.json"
+    proc = _run(tmp_path, "--out", str(out))
+    assert proc.returncode == 2
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["overall_ok"] is False
+    assert payload["checks"]["gate_fast"]["state"] == "missing"

--- a/tests/test_legacy_command_analyzer_script.py
+++ b/tests/test_legacy_command_analyzer_script.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    return subprocess.run(
+        [sys.executable, str(repo_root / "scripts/legacy_command_analyzer.py"), *args],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        env={"PYTHONPATH": str(repo_root / "src")},
+    )
+
+
+def test_legacy_command_analyzer_finds_legacy_command_usage(tmp_path: Path) -> None:
+    (tmp_path / "ci.sh").write_text("python -m sdetkit phase1-hardening\n", encoding="utf-8")
+    proc = _run(tmp_path, "--root", str(tmp_path), "--format", "json")
+    assert proc.returncode == 2
+    payload = json.loads(proc.stdout)
+    assert payload["overall_ok"] is False
+    assert payload["count"] >= 1
+    first = payload["findings"][0]
+    assert first["command"] == "phase1-hardening"
+    assert "playbooks" in first["preferred_surface"]

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -8,3 +8,45 @@ def test_makefile_has_bootstrap_and_max_targets() -> None:
     assert "max: bootstrap" in text
     assert "bash scripts/bootstrap.sh" in text
     assert "bash quality.sh boost" in text
+
+
+def test_makefile_has_golden_path_health_target() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "Makefile").read_text(encoding="utf-8")
+    assert "golden-path-health: venv" in text
+    assert "python scripts/golden_path_health.py" in text
+
+
+def test_makefile_has_canonical_path_drift_target() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "Makefile").read_text(encoding="utf-8")
+    assert "canonical-path-drift: venv" in text
+    assert "python scripts/check_canonical_path_drift.py --format json" in text
+
+
+def test_makefile_has_legacy_command_analyzer_target() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "Makefile").read_text(encoding="utf-8")
+    assert "legacy-command-analyzer: venv" in text
+    assert "python scripts/legacy_command_analyzer.py --format json" in text
+
+
+def test_makefile_has_adoption_scorecard_target() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "Makefile").read_text(encoding="utf-8")
+    assert "adoption-scorecard: venv" in text
+    assert "python scripts/adoption_scorecard.py --format json" in text
+
+
+def test_makefile_has_operator_onboarding_wizard_target() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "Makefile").read_text(encoding="utf-8")
+    assert "operator-onboarding-wizard: venv" in text
+    assert "python scripts/operator_onboarding_wizard.py --format json" in text
+
+
+def test_makefile_has_primary_docs_map_target() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "Makefile").read_text(encoding="utf-8")
+    assert "primary-docs-map: venv" in text
+    assert "python scripts/check_primary_docs_map.py --format json" in text

--- a/tests/test_operator_onboarding_wizard_script.py
+++ b/tests/test_operator_onboarding_wizard_script.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    project_root = Path(__file__).resolve().parents[1]
+    return subprocess.run(
+        [sys.executable, "scripts/operator_onboarding_wizard.py", "--repo-root", str(repo_root), *args],
+        cwd=project_root,
+        text=True,
+        capture_output=True,
+        env={"PYTHONPATH": str(project_root / "src")},
+    )
+
+
+def test_operator_onboarding_wizard_reports_ready_with_green_artifacts(tmp_path: Path) -> None:
+    build = tmp_path / "build"
+    build.mkdir(parents=True)
+    for name in ("gate-fast.json", "release-preflight.json", "doctor.json"):
+        (build / name).write_text(json.dumps({"ok": True, "failed_steps": []}), encoding="utf-8")
+    out = tmp_path / "summary.json"
+    proc = _run(tmp_path, "--out", str(out), "--format", "json")
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["overall_ready"] is True
+    assert payload["checks"]["gate_fast"]["ok"] is True
+
+
+def test_operator_onboarding_wizard_reports_not_ready_when_missing_artifacts(tmp_path: Path) -> None:
+    out = tmp_path / "summary.json"
+    proc = _run(tmp_path, "--out", str(out), "--format", "json")
+    assert proc.returncode == 2
+    payload = json.loads(proc.stdout)
+    assert payload["overall_ready"] is False
+    assert payload["checks"]["gate_fast"]["state"] == "missing"

--- a/tests/test_primary_docs_map_script.py
+++ b/tests/test_primary_docs_map_script.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_primary_docs_map_guard_reports_ok_for_repo() -> None:
+    root = Path(__file__).resolve().parents[1]
+    proc = subprocess.run(
+        [sys.executable, "scripts/check_primary_docs_map.py", "--format", "json"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        env={"PYTHONPATH": str(root / "src")},
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["overall_ok"] is True
+    assert payload["schema_version"] == "1"

--- a/tests/test_serve_api.py
+++ b/tests/test_serve_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 import urllib.error
 import urllib.request
@@ -152,6 +153,38 @@ def test_serve_review_accepts_code_scan_json_and_returns_summary(tmp_path: Path)
         assert payload["code_scanning"]["blocking_alerts"] == 1
         assert payload["artifact_index"]["code_scan_json"] == str(scan)
     finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_serve_observability_endpoint_reports_artifact_snapshot(tmp_path: Path) -> None:
+    out = tmp_path / ".sdetkit" / "out"
+    out.mkdir(parents=True)
+    (out / "adoption-scorecard.json").write_text(
+        json.dumps({"score": 75, "band": "strong", "overall_ok": True}),
+        encoding="utf-8",
+    )
+    (out / "golden-path-health.json").write_text(
+        json.dumps({"overall_ok": True}),
+        encoding="utf-8",
+    )
+
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    server = serve.build_server(host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = int(server.server_address[1])
+    try:
+        status_url = f"http://127.0.0.1:{port}/v1/observability"
+        with urllib.request.urlopen(status_url) as resp:  # noqa: S310
+            payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["status"] == "ok"
+        assert "adoption_scorecard" in payload["observability"]
+    finally:
+        os.chdir(cwd)
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)


### PR DESCRIPTION
### Motivation
- Provide lightweight health/drift signals and a compact adoption score to make the canonical release-confidence path explicit and automatable.
- Offer migration guidance for transition-era/legacy commands to reduce accidental discovery and ease repo migrations.
- Surface those signals in documentation, Makefile targets, CLI utilities and the local serve observability API for CI and operator workflows.

### Description
- Added guard and reporting scripts: `scripts/golden_path_health.py`, `scripts/check_canonical_path_drift.py`, `scripts/legacy_command_analyzer.py`, `scripts/adoption_scorecard.py`, `scripts/operator_onboarding_wizard.py`, and `scripts/check_primary_docs_map.py` with JSON/text output contracts. 
- Added documentation pages and navigation entries: `docs/golden-path-health.md`, `docs/adoption-scorecard.md`, `docs/operator-onboarding-wizard.md`, `docs/legacy-command-migration-map.md`, `docs/primary-docs-map.md`, and updates to `docs/cli.md`, `docs/command-taxonomy.md`, and `docs/index.md` and `mkdocs.yml`.
- Made developer ergonomics updates: new `Makefile` targets for each script and `primary-docs-map`/`golden-path-health` targets, and new tests under `tests/` exercising the scripts, CLI behavior, Makefile targets, and serve API.
- CLI changes in `src/sdetkit/cli.py`: added legacy migration hint generation and emission, a per-invocation `--no-legacy-hint` flag, a `legacy migrate-hint` subcommand (JSON/text modes), and logic to suppress hints via `SDETKIT_LEGACY_HINTS` env var.
- Serve integration in `src/sdetkit/serve.py`: added `_observability_snapshot` and a new HTTP route `GET /v1/observability` that returns a snapshot of artifact health/score files.

### Testing
- Ran the automated test suite with `pytest`, including new tests for the scripts and integrations such as `tests/test_golden_path_health_script.py`, `tests/test_canonical_path_drift_script.py`, `tests/test_legacy_command_analyzer_script.py`, `tests/test_adoption_scorecard_script.py`, `tests/test_operator_onboarding_wizard_script.py`, `tests/test_primary_docs_map_script.py`, `tests/test_makefile_targets.py`, `tests/test_cli_help_discoverability_contract.py`, and `tests/test_serve_api.py`, and all tests passed.
- Exercised the CLI behaviors verifying `legacy migrate-hint` JSON/text output and the `--no-legacy-hint` override via unit tests, and they succeeded.
- Validated the new `GET /v1/observability` endpoint with an integration test that confirmed artifact snapshots are reported, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd46429e248332a598590cd380d4aa)