### PR TITLE
Restore legacy CLI exports and fix CI failures (typing, aliases, tests)

### DIFF
--- a/docs/adoption-scorecard.md
+++ b/docs/adoption-scorecard.md
@@ -11,7 +11,7 @@ Scorecard v2 keeps backward-compatible top-level fields (`score`, `band`, `dimen
 - **ops**: legacy density + reduction trend vs baseline
 - **quality**: canonical drift guard + test signal
 
-`dimensions` remains a legacy compatibility view (`0..25`).  
+`dimensions` remains a legacy compatibility view (`0..25`).
 `graded_dimensions` is the v2 score (`0..100`) per dimension with explicit `weights`.
 
 ## Generate scorecard

--- a/src/sdetkit/baseline_dispatch.py
+++ b/src/sdetkit/baseline_dispatch.py
@@ -58,7 +58,9 @@ def run_baseline(
     ok = not failed
     payload: dict[str, object] = {"ok": ok, "steps": steps, "failed_steps": failed}
     if bns.format == "json":
-        sys.stdout.write(json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n")
+        sys.stdout.write(
+            json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n"
+        )
     else:
         lines: list[str] = []
         lines.append(f"baseline: {'OK' if ok else 'FAIL'}")

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -7,6 +7,36 @@ from collections.abc import Sequence
 from importlib import import_module
 from typing import cast
 
+from . import (
+    acceleration_closeout_43 as acceleration_closeout_43,
+)
+from . import (
+    execution_prioritization_closeout_50 as execution_prioritization_closeout_50,
+)
+from . import (
+    expansion_automation_41 as expansion_automation_41,
+)
+from . import (
+    expansion_closeout_45 as expansion_closeout_45,
+)
+from . import (
+    objection_closeout_48 as objection_closeout_48,
+)
+from . import (
+    optimization_closeout_42 as optimization_closeout_42,
+)
+from . import (
+    optimization_closeout_46 as optimization_closeout_46,
+)
+from . import (
+    reliability_closeout_47 as reliability_closeout_47,
+)
+from . import (
+    scale_closeout_44 as scale_closeout_44,
+)
+from . import (
+    weekly_review_closeout_49 as weekly_review_closeout_49,
+)
 from .apiget_dispatch import run_apiget_with_cassette
 from .argv_flags import extract_global_flag
 from .baseline_dispatch import run_baseline
@@ -17,6 +47,12 @@ from .help_surface import filter_hidden_subcommands, hide_help_subcommands
 from .inspect_compare_forwarding import build_inspect_compare_forwarded_args
 from .inspect_forwarding import build_inspect_forwarded_args
 from .inspect_project_forwarding import build_inspect_project_forwarded_args
+from .legacy_commands import (
+    LEGACY_COMMAND_MODULES as LEGACY_COMMAND_MODULES,
+)
+from .legacy_commands import (
+    LEGACY_NAMESPACE_COMMANDS as LEGACY_NAMESPACE_COMMANDS,
+)
 from .legacy_namespace import handle_legacy_namespace
 from .parsed_shortcuts import dispatch_parsed_shortcut
 from .parser_helpers import add_passthrough_subcommand as _add_passthrough_subcommand
@@ -27,6 +63,9 @@ from .repo_init_forwarding import build_repo_init_forwarded_args
 from .review_forwarding import build_review_forwarded_args
 from .serve_forwarding import build_serve_args
 from .versioning import tool_version
+
+# Backward-compatible alias used by tests and downstream monkeypatching.
+_resolve_non_day_playbook_alias = resolve_non_day_playbook_alias
 
 
 def _add_apiget_args(p: argparse.ArgumentParser) -> None:

--- a/src/sdetkit/cli_shortcuts.py
+++ b/src/sdetkit/cli_shortcuts.py
@@ -39,9 +39,15 @@ _MODULE_SHORTCUTS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("upgrade-hub",), "sdetkit.upgrade_hub"),
     (("sdet-package",), "sdetkit.sdet_package"),
     (("enterprise-readiness",), "sdetkit.enterprise_readiness"),
-    (("github-actions-onboarding", "github-actions-quickstart"), "sdetkit.github_actions_quickstart"),
+    (
+        ("github-actions-onboarding", "github-actions-quickstart"),
+        "sdetkit.github_actions_quickstart",
+    ),
     (("gitlab-ci-onboarding", "gitlab-ci-quickstart"), "sdetkit.gitlab_ci_quickstart"),
-    (("contribution-quality-report", "quality-contribution-delta"), "sdetkit.quality_contribution_delta"),
+    (
+        ("contribution-quality-report", "quality-contribution-delta"),
+        "sdetkit.quality_contribution_delta",
+    ),
     (("reliability-evidence-pack",), "sdetkit.reliability_evidence_pack"),
     (("release-readiness",), "sdetkit.release_readiness"),
     (("release-communications",), "sdetkit.release_communications"),

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -565,9 +565,13 @@ def _build_explain_payload(data: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(action, dict):
             continue
         severity = str(action.get("severity", "medium"))
-        weighted = round(min(0.99, max(0.05, base_confidence * severity_weight.get(severity, 0.7))), 2)
+        weighted = round(
+            min(0.99, max(0.05, base_confidence * severity_weight.get(severity, 0.7))), 2
+        )
         fix_list = action.get("fix", [])
-        first_fix = fix_list[0] if isinstance(fix_list, list) and fix_list else "Review check output"
+        first_fix = (
+            fix_list[0] if isinstance(fix_list, list) and fix_list else "Review check output"
+        )
         explain_steps.append(
             {
                 "priority": index,

--- a/src/sdetkit/inspect_forwarding.py
+++ b/src/sdetkit/inspect_forwarding.py
@@ -4,7 +4,9 @@ import argparse
 from collections.abc import Sequence
 
 
-def build_inspect_forwarded_args(ns: argparse.Namespace, args: Sequence[str] | None = None) -> list[str]:
+def build_inspect_forwarded_args(
+    ns: argparse.Namespace, args: Sequence[str] | None = None
+) -> list[str]:
     inspect_args = list(args or [])
     if ns.rules_template:
         inspect_args = ["--rules-template", *inspect_args]

--- a/src/sdetkit/legacy_adapters/__init__.py
+++ b/src/sdetkit/legacy_adapters/__init__.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from .closeout import LEGACY_CLOSEOUT_COMMAND_MODULES
 from .continuous_upgrade import LEGACY_CONTINUOUS_UPGRADE_COMMAND_MODULES
-from .foundation import LEGACY_FOUNDATION_COMMAND_MODULES, LEGACY_NAMESPACE_COMMANDS
+from .foundation import (
+    LEGACY_FOUNDATION_COMMAND_MODULES,
+)
+from .foundation import (
+    LEGACY_NAMESPACE_COMMANDS as LEGACY_NAMESPACE_COMMANDS,
+)
 
 LEGACY_COMMAND_MODULES: dict[str, str] = {
     **LEGACY_FOUNDATION_COMMAND_MODULES,

--- a/src/sdetkit/legacy_cli.py
+++ b/src/sdetkit/legacy_cli.py
@@ -33,7 +33,7 @@ def run_legacy_migrate_hint(argv: Sequence[str]) -> int:
         sys.stderr.write("legacy error: use either <command> or --all for migrate-hint\n")
         return 2
     commands = [str(ns.command)] if ns.command else list(LEGACY_NAMESPACE_COMMANDS)
-    items = [
+    items: list[dict[str, object]] = [
         {
             "command": command,
             "preferred_surface": legacy_preferred_surface(command),
@@ -45,10 +45,10 @@ def run_legacy_migrate_hint(argv: Sequence[str]) -> int:
     ]
     if ns.format == "json":
         if len(items) == 1:
-            payload = {"schema_version": "1", "mode": "single", **items[0]}
+            payload: dict[str, object] = {"schema_version": "1", "mode": "single", **items[0]}
         else:
             payload = {"schema_version": "1", "mode": "all", "count": len(items), "items": items}
         sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
         return 0
-    sys.stdout.write("\n".join(item["hint"] for item in items) + "\n")
+    sys.stdout.write("\n".join(str(item["hint"]) for item in items) + "\n")
     return 0

--- a/src/sdetkit/legacy_commands.py
+++ b/src/sdetkit/legacy_commands.py
@@ -2,7 +2,21 @@ from __future__ import annotations
 
 import os
 
-from .legacy_adapters import LEGACY_COMMAND_MODULES, LEGACY_NAMESPACE_COMMANDS
+from .legacy_adapters import (
+    LEGACY_COMMAND_MODULES as LEGACY_COMMAND_MODULES,
+)
+from .legacy_adapters import (
+    LEGACY_NAMESPACE_COMMANDS as LEGACY_NAMESPACE_COMMANDS,
+)
+
+__all__ = [
+    "LEGACY_COMMAND_MODULES",
+    "LEGACY_NAMESPACE_COMMANDS",
+    "legacy_hints_enabled",
+    "legacy_preferred_surface",
+    "legacy_deprecation_horizon",
+    "legacy_migration_hint",
+]
 
 
 def legacy_hints_enabled() -> bool:

--- a/src/sdetkit/playbook_aliases.py
+++ b/src/sdetkit/playbook_aliases.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from importlib import import_module
+from typing import cast
 
 
 def resolve_non_day_playbook_alias(cmd: str) -> str:
     """Resolve product/legacy playbook names to a parser-backed command."""
     try:
         playbooks_cli = import_module("sdetkit.playbooks_cli")
-        cmd_to_mod, alias_to_canonical = playbooks_cli._build_registry(playbooks_cli._pkg_dir())
+        cmd_to_mod, alias_to_canonical = cast(
+            tuple[dict[str, str], dict[str, str]],
+            playbooks_cli._build_registry(playbooks_cli._pkg_dir()),
+        )
     except Exception:
         return cmd
 

--- a/src/sdetkit/release_dispatch.py
+++ b/src/sdetkit/release_dispatch.py
@@ -10,7 +10,9 @@ def dispatch_release_subcommand(
     run_module_main: Callable[[str, Sequence[str]], int],
 ) -> int:
     if not args:
-        sys.stderr.write("release error: expected subcommand (gate|doctor|security|evidence|repo)\n")
+        sys.stderr.write(
+            "release error: expected subcommand (gate|doctor|security|evidence|repo)\n"
+        )
         return 2
     subcmd = args[0]
     rest = list(args[1:])
@@ -24,5 +26,7 @@ def dispatch_release_subcommand(
         return run_module_main("sdetkit.evidence", rest)
     if subcmd == "repo":
         return run_module_main("sdetkit.repo", rest)
-    sys.stderr.write("release error: supported subcommands are gate|doctor|security|evidence|repo\n")
+    sys.stderr.write(
+        "release error: supported subcommands are gate|doctor|security|evidence|repo\n"
+    )
     return 2

--- a/tests/test_apiget_dispatch.py
+++ b/tests/test_apiget_dispatch.py
@@ -13,7 +13,15 @@ def test_run_apiget_with_cassette_strips_cassette_flags() -> None:
         return 0
 
     rc = apiget_dispatch.run_apiget_with_cassette(
-        ["apiget", "https://x", "--cassette", "file.json", "--cassette-mode=record", "--timeout", "5"],
+        [
+            "apiget",
+            "https://x",
+            "--cassette",
+            "file.json",
+            "--cassette-mode=record",
+            "--timeout",
+            "5",
+        ],
         cassette=None,
         cassette_mode=None,
         run_module_main=_runner,

--- a/tests/test_generated_artifacts_freshness.py
+++ b/tests/test_generated_artifacts_freshness.py
@@ -4,7 +4,9 @@ import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 
-_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_generated_artifacts_freshness.py"
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_generated_artifacts_freshness.py"
+)
 _SPEC = importlib.util.spec_from_file_location("check_generated_artifacts_freshness", _SCRIPT_PATH)
 assert _SPEC and _SPEC.loader
 freshness = importlib.util.module_from_spec(_SPEC)

--- a/tests/test_golden_path_health_script.py
+++ b/tests/test_golden_path_health_script.py
@@ -44,7 +44,20 @@ def test_golden_path_health_reports_ok_when_all_artifacts_are_ok(tmp_path: Path)
 
 def test_golden_path_health_reports_failure_when_artifact_missing(tmp_path: Path) -> None:
     out = tmp_path / "golden-path-health.json"
-    proc = _run(tmp_path, "--out", str(out))
+    missing_gate_fast = tmp_path / "missing-gate-fast.json"
+    missing_gate_release = tmp_path / "missing-gate-release.json"
+    missing_doctor = tmp_path / "missing-doctor.json"
+    proc = _run(
+        tmp_path,
+        "--gate-fast",
+        str(missing_gate_fast),
+        "--gate-release",
+        str(missing_gate_release),
+        "--doctor",
+        str(missing_doctor),
+        "--out",
+        str(out),
+    )
     assert proc.returncode == 2
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["overall_ok"] is False

--- a/tests/test_legacy_commands.py
+++ b/tests/test_legacy_commands.py
@@ -19,10 +19,7 @@ def test_legacy_preferred_surface_routes_weekly_review() -> None:
 
 
 def test_legacy_preferred_surface_routes_closeout_to_playbooks() -> None:
-    assert (
-        legacy_preferred_surface("scale-closeout")
-        == "python -m sdetkit playbooks --help"
-    )
+    assert legacy_preferred_surface("scale-closeout") == "python -m sdetkit playbooks --help"
 
 
 def test_legacy_deprecation_horizon_phase_lane() -> None:


### PR DESCRIPTION
### Motivation
- Several CI lanes were failing due to missing backward-compatible exports and typing/alias issues that broke downstream imports and unit tests.
- Tests depended on module-level symbols and an internal alias resolver that were no longer available after prior refactors.
- Strict typing and linting (mypy/ruff) also surfaced issues in playbook alias resolution and legacy CLI payload shaping.

### Description
- Restored explicit legacy symbol re-exports by exporting `LEGACY_COMMAND_MODULES` and `LEGACY_NAMESPACE_COMMANDS` and adding a clear `__all__` contract in `src/sdetkit/legacy_commands.py`.
- Reintroduced backward-compatible compatibility exports and aliases in `src/sdetkit/cli.py` (closeout module stubs and `_resolve_non_day_playbook_alias`) so tests and downstream monkeypatching can access expected attributes.
- Made playbook registry loading and legacy CLI JSON payloads typing-safe by adding `cast` and concrete `list[dict[str, object]]`/`dict[str, object]` annotations and ensured the legacy CLI join casts to `str` for robust output.
- Fixed repo-audit/trailing-whitespace by removing stray trailing whitespace in `docs/adoption-scorecard.md` and hardened `tests/test_golden_path_health_script.py` to use explicit missing artifact paths under `tmp_path` to avoid environment-dependent flakes.

### Testing
- Ran linter and auto-fix: `python -m ruff check --fix src tests` and `python -m ruff check src tests`, which passed.
- Ran static typing: `python -m mypy src`, which reported no issues (success).
- Ran targeted unit tests: `python -m pytest -q tests/test_cli_productized_closeout_aliases.py` and selected alias/legacy tests, which passed.
- Ran full test suite: `python -m pytest -q` with results showing the full suite passing (`1774 passed, 1 skipped, 3 deselected`); `sdetkit repo check --format json --out report.json --force` also succeeded; a local `premium-gate.sh` invocation initially failed due to a dirty working tree (clean-tree check), and after committing the changes the premium-gate full verification completed successfully (with advisory notes about test profiling).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc94aee80833293a082f041a6d046)