### PR TITLE
Handle CLI SystemExit in __main__ and refresh roadmap manifest

### DIFF
--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -12,7 +12,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.acceleration_closeout_43",
         "module_path": "src/sdetkit/acceleration_closeout_43.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 3
       },
       {
         "contract_script_paths": [
@@ -155,6 +155,7 @@
       },
       {
         "contract_script_paths": [
+          "scripts/check_adoption_scorecard_v2_contract.py",
           "scripts/check_case_study_prep2_closeout_contract.py",
           "scripts/check_case_study_prep2_closeout_contract_70.py",
           "scripts/check_case_study_prep4_closeout_contract_72.py",
@@ -168,6 +169,7 @@
           "scripts/check_integration_feedback_closeout_contract_82.py",
           "scripts/check_kpi_audit_contract_27.py",
           "scripts/check_narrative_closeout_contract_52.py",
+          "scripts/check_observability_v2_contract.py",
           "scripts/check_optimization_closeout_contract_42.py",
           "scripts/check_phase1_hardening_contract_29.py",
           "scripts/check_phase2_hardening_closeout_contract.py",
@@ -181,7 +183,7 @@
           "scripts/check_weekly_review_contract_21.py",
           "scripts/check_weekly_review_contract_28.py"
         ],
-        "contract_scripts": 25,
+        "contract_scripts": 27,
         "id": 2,
         "lane": "continuous_upgrade",
         "legacy_anchor_refs_in_module": 0,
@@ -479,7 +481,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.execution_prioritization_closeout_50",
         "module_path": "src/sdetkit/execution_prioritization_closeout_50.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 3
       },
       {
         "contract_script_paths": [
@@ -491,7 +493,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.expansion_closeout_45",
         "module_path": "src/sdetkit/expansion_closeout_45.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 3
       },
       {
         "contract_script_paths": [
@@ -623,7 +625,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.objection_closeout_48",
         "module_path": "src/sdetkit/objection_closeout_48.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 3
       },
       {
         "contract_script_paths": [
@@ -635,7 +637,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.optimization_closeout_42",
         "module_path": "src/sdetkit/optimization_closeout_42.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 3
       },
       {
         "contract_script_paths": [
@@ -647,7 +649,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.optimization_closeout_46",
         "module_path": "src/sdetkit/optimization_closeout_46.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 3
       },
       {
         "contract_script_paths": [
@@ -743,7 +745,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.reliability_closeout_47",
         "module_path": "src/sdetkit/reliability_closeout_47.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 3
       },
       {
         "contract_script_paths": [
@@ -755,7 +757,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.scale_closeout_44",
         "module_path": "src/sdetkit/scale_closeout_44.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 3
       },
       {
         "contract_script_paths": [
@@ -815,7 +817,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.weekly_review_closeout_49",
         "module_path": "src/sdetkit/weekly_review_closeout_49.py",
-        "tests_referencing_module": 3
+        "tests_referencing_module": 4
       },
       {
         "contract_script_paths": [

--- a/src/sdetkit/__main__.py
+++ b/src/sdetkit/__main__.py
@@ -120,7 +120,16 @@ def main() -> int:
 
     from .cli import main as cli_main
 
-    return int(cli_main() or 0)
+    try:
+        return int(cli_main() or 0)
+    except SystemExit as exc:
+        code = exc.code
+        if code is None:
+            return 0
+        if isinstance(code, int):
+            return int(code)
+        sys.stderr.write(f"{code}\n")
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Prevent `SystemExit` raised by delegated CLI code from escaping the package entrypoint and causing CI test failures when non-`cassette-get` commands are executed. 
- Eliminate roadmap manifest drift that caused the premium-gate `clean_tree_check` to fail due to a regenerated `docs/roadmap/manifest.json` in automation lanes. 

### Description
- Update `main()` in `src/sdetkit/__main__.py` to catch `SystemExit` from the delegated `cli.main()` call and normalize it to a deterministic integer return code while preserving the existing `cassette-get` path. 
- Refresh `docs/roadmap/manifest.json` so generated roadmap metadata (added contract script entries and adjusted `tests_referencing_module` / `contract_scripts` counts) matches the repository state and no longer dirties the working tree during quality/premium lanes. 

### Testing
- Ran `python -m pytest -q tests/test_main_cassette_get_extra.py::test_main_delegates_to_cli_main_when_not_cassette_get` and it passed. 
- Ran `python -m pytest -q tests/test_main_cassette_get_extra.py::test_main_delegates_to_cli_main_when_not_cassette_get tests/test_roadmap_manifest_tooling.py` and both tests passed. 
- Ran `python -m sdetkit.roadmap_manifest check` and it passed. 
- Ran full coverage lane with `bash quality.sh cov` and automation reported the coverage suite passed. 
- Ran `python -m sdetkit maintenance --mode full --format json --out .sdetkit/out/maintenance.json` and observed a `clean_tree_check` failure when local uncommitted edits were present (this is expected on a dirty workspace and is resolved by committing the refreshed manifest).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de758090ac833287533998d0574063)