### PR TITLE
Add KPI & portfolio schemas, seed KPI baseline, role quickstarts, and weekly executive report

### DIFF
--- a/.github/workflows/top-tier-reporting-sample.yml
+++ b/.github/workflows/top-tier-reporting-sample.yml
@@ -40,5 +40,6 @@ jobs:
           path: |
             docs/artifacts/portfolio-scorecard-sample-2026-04-17.json
             docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json
+            docs/artifacts/kpi-weekly-contract-check-2026-04-17.json
             docs/artifacts/top-tier-contract-check-2026-04-17.json
           retention-days: 28

--- a/.github/workflows/top-tier-reporting-sample.yml
+++ b/.github/workflows/top-tier-reporting-sample.yml
@@ -42,4 +42,5 @@ jobs:
             docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json
             docs/artifacts/kpi-weekly-contract-check-2026-04-17.json
             docs/artifacts/top-tier-contract-check-2026-04-17.json
+            docs/artifacts/top-tier-bundle-manifest-2026-04-17.json
           retention-days: 28

--- a/.github/workflows/top-tier-reporting-sample.yml
+++ b/.github/workflows/top-tier-reporting-sample.yml
@@ -31,7 +31,8 @@ jobs:
           python -m pytest -q \
             tests/test_build_portfolio_scorecard.py \
             tests/test_build_kpi_weekly_snapshot.py \
-            tests/test_check_top_tier_reporting_contract.py
+            tests/test_check_top_tier_reporting_contract.py \
+            tests/test_check_top_tier_bundle_manifest.py
 
       - name: Upload top-tier reporting artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -43,4 +44,5 @@ jobs:
             docs/artifacts/kpi-weekly-contract-check-2026-04-17.json
             docs/artifacts/top-tier-contract-check-2026-04-17.json
             docs/artifacts/top-tier-bundle-manifest-2026-04-17.json
+            docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json
           retention-days: 28

--- a/.github/workflows/top-tier-reporting-sample.yml
+++ b/.github/workflows/top-tier-reporting-sample.yml
@@ -1,0 +1,44 @@
+name: Top-tier Reporting Sample Pipeline
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 5'
+
+permissions:
+  contents: read
+
+jobs:
+  top-tier-reporting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install project + test dependencies
+        run: python -m pip install -c constraints-ci.txt -e .[dev,test]
+
+      - name: Run top-tier reporting pipeline
+        run: make top-tier-reporting
+
+      - name: Run reporting tests
+        run: |
+          python -m pytest -q \
+            tests/test_build_portfolio_scorecard.py \
+            tests/test_build_kpi_weekly_snapshot.py \
+            tests/test_check_top_tier_reporting_contract.py
+
+      - name: Upload top-tier reporting artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: top-tier-reporting-sample
+          path: |
+            docs/artifacts/portfolio-scorecard-sample-2026-04-17.json
+            docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json
+            docs/artifacts/top-tier-contract-check-2026-04-17.json
+          retention-days: 28

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ sdet_check.json
 src/sdetkit.egg-info/
 
 .tmp/
+
+# top-tier reporting scratch bundle
+/docs/artifacts/top-tier-bundle/

--- a/Makefile
+++ b/Makefile
@@ -99,4 +99,5 @@ top-tier-reporting: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && \
 	python scripts/build_portfolio_scorecard.py --in docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --schema-version 1.0.0 --window-start 2026-04-11 --window-end 2026-04-17 --generated-at 2026-04-17T10:00:00Z && \
 	python scripts/build_kpi_weekly_snapshot.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --out docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --week-ending 2026-04-17 --program-status green --rollback-count 0 && \
+	python scripts/check_kpi_weekly_contract.py --schema docs/kpi-schema.v1.json --payload docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --out docs/artifacts/kpi-weekly-contract-check-2026-04-17.json && \
 	python scripts/check_top_tier_reporting_contract.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --kpi-weekly docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --out docs/artifacts/top-tier-contract-check-2026-04-17.json'

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ primary-docs-map: venv
 top-tier-reporting: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && \
 	python scripts/build_top_tier_reporting_bundle.py --input docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out-dir docs/artifacts/top-tier-bundle --window-start 2026-04-11 --window-end 2026-04-17 --generated-at 2026-04-17T10:00:00Z --schema-version 1.0.0 --program-status green --rollback-count 0 --manifest-out docs/artifacts/top-tier-bundle-manifest-2026-04-17.json && \
+	python scripts/check_top_tier_bundle_manifest.py --manifest docs/artifacts/top-tier-bundle-manifest-2026-04-17.json --out docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json && \
 	cp docs/artifacts/top-tier-bundle/portfolio-scorecard.json docs/artifacts/portfolio-scorecard-sample-2026-04-17.json && \
 	cp docs/artifacts/top-tier-bundle/kpi-weekly.json docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json && \
 	cp docs/artifacts/top-tier-bundle/kpi-contract-check.json docs/artifacts/kpi-weekly-contract-check-2026-04-17.json && \

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,4 @@ top-tier-reporting: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && \
 	python scripts/build_top_tier_reporting_bundle.py --input docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out-dir docs/artifacts/top-tier-bundle --window-start 2026-04-11 --window-end 2026-04-17 --generated-at 2026-04-17T10:00:00Z --schema-version 1.0.0 --program-status green --rollback-count 0 --manifest-out docs/artifacts/top-tier-bundle-manifest-2026-04-17.json && \
 	python scripts/check_top_tier_bundle_manifest.py --manifest docs/artifacts/top-tier-bundle-manifest-2026-04-17.json --out docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json && \
-	cp docs/artifacts/top-tier-bundle/portfolio-scorecard.json docs/artifacts/portfolio-scorecard-sample-2026-04-17.json && \
-	cp docs/artifacts/top-tier-bundle/kpi-weekly.json docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json && \
-	cp docs/artifacts/top-tier-bundle/kpi-contract-check.json docs/artifacts/kpi-weekly-contract-check-2026-04-17.json && \
-	cp docs/artifacts/top-tier-bundle/top-tier-contract-check.json docs/artifacts/top-tier-contract-check-2026-04-17.json'
+	python scripts/promote_top_tier_bundle.py --bundle-dir docs/artifacts/top-tier-bundle --date-tag 2026-04-17'

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ primary-docs-map: venv
 
 top-tier-reporting: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && \
-	python scripts/build_top_tier_reporting_bundle.py --input docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out-dir docs/artifacts/top-tier-bundle --window-start 2026-04-11 --window-end 2026-04-17 --generated-at 2026-04-17T10:00:00Z --schema-version 1.0.0 --program-status green --rollback-count 0 && \
+	python scripts/build_top_tier_reporting_bundle.py --input docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out-dir docs/artifacts/top-tier-bundle --window-start 2026-04-11 --window-end 2026-04-17 --generated-at 2026-04-17T10:00:00Z --schema-version 1.0.0 --program-status green --rollback-count 0 --manifest-out docs/artifacts/top-tier-bundle-manifest-2026-04-17.json && \
 	cp docs/artifacts/top-tier-bundle/portfolio-scorecard.json docs/artifacts/portfolio-scorecard-sample-2026-04-17.json && \
 	cp docs/artifacts/top-tier-bundle/kpi-weekly.json docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json && \
 	cp docs/artifacts/top-tier-bundle/kpi-contract-check.json docs/artifacts/kpi-weekly-contract-check-2026-04-17.json && \

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,6 @@ primary-docs-map: venv
 
 top-tier-reporting: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && \
-	python scripts/build_portfolio_scorecard.py --in docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --schema-version 1.0.0 --window-start 2026-04-11 --window-end 2026-04-17 && \
+	python scripts/build_portfolio_scorecard.py --in docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --schema-version 1.0.0 --window-start 2026-04-11 --window-end 2026-04-17 --generated-at 2026-04-17T10:00:00Z && \
 	python scripts/build_kpi_weekly_snapshot.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --out docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --week-ending 2026-04-17 --program-status green --rollback-count 0 && \
 	python scripts/check_top_tier_reporting_contract.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --kpi-weekly docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --out docs/artifacts/top-tier-contract-check-2026-04-17.json'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 # --- dev targets (bootstrap) ---
 
+DATE_TAG ?= 2026-04-17
+WINDOW_START ?= 2026-04-11
+WINDOW_END ?= 2026-04-17
+GENERATED_AT ?= 2026-04-17T10:00:00Z
+
 .PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting
 
 bootstrap: venv
@@ -97,6 +102,6 @@ primary-docs-map: venv
 
 top-tier-reporting: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && \
-	python scripts/build_top_tier_reporting_bundle.py --input docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out-dir docs/artifacts/top-tier-bundle --window-start 2026-04-11 --window-end 2026-04-17 --generated-at 2026-04-17T10:00:00Z --schema-version 1.0.0 --program-status green --rollback-count 0 --manifest-out docs/artifacts/top-tier-bundle-manifest-2026-04-17.json && \
-	python scripts/check_top_tier_bundle_manifest.py --manifest docs/artifacts/top-tier-bundle-manifest-2026-04-17.json --out docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json && \
-	python scripts/promote_top_tier_bundle.py --bundle-dir docs/artifacts/top-tier-bundle --date-tag 2026-04-17'
+	python scripts/build_top_tier_reporting_bundle.py --input docs/artifacts/portfolio-input-sample-$(DATE_TAG).jsonl --out-dir docs/artifacts/top-tier-bundle --window-start $(WINDOW_START) --window-end $(WINDOW_END) --generated-at $(GENERATED_AT) --schema-version 1.0.0 --program-status green --rollback-count 0 --manifest-out docs/artifacts/top-tier-bundle-manifest-$(DATE_TAG).json && \
+	python scripts/check_top_tier_bundle_manifest.py --manifest docs/artifacts/top-tier-bundle-manifest-$(DATE_TAG).json --out docs/artifacts/top-tier-bundle-manifest-check-$(DATE_TAG).json && \
+	python scripts/promote_top_tier_bundle.py --bundle-dir docs/artifacts/top-tier-bundle --date-tag $(DATE_TAG)'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # --- dev targets (bootstrap) ---
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -93,3 +93,10 @@ operator-onboarding-wizard: venv
 
 primary-docs-map: venv
 	@bash -lc '. .venv/bin/activate && python scripts/check_primary_docs_map.py --format json'
+
+
+top-tier-reporting: venv
+	@bash -lc 'set -euo pipefail; . .venv/bin/activate && \
+	python scripts/build_portfolio_scorecard.py --in docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --schema-version 1.0.0 --window-start 2026-04-11 --window-end 2026-04-17 && \
+	python scripts/build_kpi_weekly_snapshot.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --out docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --week-ending 2026-04-17 --program-status green --rollback-count 0 && \
+	python scripts/check_top_tier_reporting_contract.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --kpi-weekly docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --out docs/artifacts/top-tier-contract-check-2026-04-17.json'

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,8 @@ primary-docs-map: venv
 
 top-tier-reporting: venv
 	@bash -lc 'set -euo pipefail; . .venv/bin/activate && \
-	python scripts/build_portfolio_scorecard.py --in docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --schema-version 1.0.0 --window-start 2026-04-11 --window-end 2026-04-17 --generated-at 2026-04-17T10:00:00Z && \
-	python scripts/build_kpi_weekly_snapshot.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --out docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --week-ending 2026-04-17 --program-status green --rollback-count 0 && \
-	python scripts/check_kpi_weekly_contract.py --schema docs/kpi-schema.v1.json --payload docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --out docs/artifacts/kpi-weekly-contract-check-2026-04-17.json && \
-	python scripts/check_top_tier_reporting_contract.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --kpi-weekly docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --out docs/artifacts/top-tier-contract-check-2026-04-17.json'
+	python scripts/build_top_tier_reporting_bundle.py --input docs/artifacts/portfolio-input-sample-2026-04-17.jsonl --out-dir docs/artifacts/top-tier-bundle --window-start 2026-04-11 --window-end 2026-04-17 --generated-at 2026-04-17T10:00:00Z --schema-version 1.0.0 --program-status green --rollback-count 0 && \
+	cp docs/artifacts/top-tier-bundle/portfolio-scorecard.json docs/artifacts/portfolio-scorecard-sample-2026-04-17.json && \
+	cp docs/artifacts/top-tier-bundle/kpi-weekly.json docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json && \
+	cp docs/artifacts/top-tier-bundle/kpi-contract-check.json docs/artifacts/kpi-weekly-contract-check-2026-04-17.json && \
+	cp docs/artifacts/top-tier-bundle/top-tier-contract-check.json docs/artifacts/top-tier-contract-check-2026-04-17.json'

--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ Context: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
 
 ## Canonical local-to-CI journey
 
+## Top-tier reporting sample pipeline
+
+Run the end-to-end seeded reporting flow (portfolio scorecard -> KPI snapshot -> contract checks -> bundle promotion):
+
+```bash
+make top-tier-reporting
+```
+
+Optional date/window overrides:
+
+```bash
+make top-tier-reporting DATE_TAG=2026-04-17 WINDOW_START=2026-04-11 WINDOW_END=2026-04-17 GENERATED_AT=2026-04-17T10:00:00Z
+```
+
+Primary artifacts produced under `docs/artifacts/`:
+
+- `portfolio-scorecard-sample-<date>.json`
+- `kpi-weekly-from-portfolio-<date>.json`
+- `kpi-weekly-contract-check-<date>.json`
+- `top-tier-contract-check-<date>.json`
+- `top-tier-bundle-manifest-<date>.json`
+- `top-tier-bundle-manifest-check-<date>.json`
+
+See: [`docs/portfolio-reporting-recipe.md`](docs/portfolio-reporting-recipe.md) and [`docs/kpi-schema.md`](docs/kpi-schema.md).
+
+
 - Canonical first proof: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
 - Canonical real-repo fixture proof: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
 - Canonical CI rollout path: [`docs/recommended-ci-flow.md`](docs/recommended-ci-flow.md)

--- a/docs/artifacts/kpi-weekly-contract-check-2026-04-17.json
+++ b/docs/artifacts/kpi-weekly-contract-check-2026-04-17.json
@@ -1,0 +1,6 @@
+{
+  "ok": true,
+  "schema_version": "1.0.0",
+  "week_ending": "2026-04-17",
+  "required_kpi_count": 6
+}

--- a/docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json
+++ b/docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1.0.0",
+  "week_ending": "2026-04-17",
+  "program_status": "green",
+  "kpis": {
+    "first_time_success_onboarding_rate": {
+      "value": 33.33,
+      "unit": "percent",
+      "sample_size": 3,
+      "quality": "seed",
+      "source": "portfolio scorecard + weekly operations ledger"
+    },
+    "median_release_decision_time": {
+      "value": null,
+      "unit": "n/a",
+      "sample_size": null,
+      "quality": "seed",
+      "source": "timing instrumentation pending"
+    },
+    "failed_release_gate_frequency": {
+      "value": 33.33,
+      "unit": "percent",
+      "sample_size": 3,
+      "quality": "seed",
+      "source": "portfolio scorecard + weekly operations ledger"
+    },
+    "rollback_rate": {
+      "value": 0,
+      "unit": "count",
+      "sample_size": 0,
+      "quality": "seed",
+      "source": "portfolio scorecard + weekly operations ledger"
+    },
+    "mean_time_to_triage_first_failure": {
+      "value": null,
+      "unit": "n/a",
+      "sample_size": null,
+      "quality": "seed",
+      "source": "incident timing fields pending"
+    },
+    "docs_to_adoption_conversion": {
+      "value": null,
+      "unit": "n/a",
+      "sample_size": null,
+      "quality": "seed",
+      "source": "docs telemetry pending"
+    }
+  }
+}

--- a/docs/artifacts/portfolio-input-sample-2026-04-17.jsonl
+++ b/docs/artifacts/portfolio-input-sample-2026-04-17.jsonl
@@ -1,0 +1,3 @@
+{"repo":"checkout-service","team":"checkout","lane":"scale","timestamp":"2026-04-17T09:00:00Z","gate_fast_ok":true,"gate_release_ok":true,"doctor_ok":true,"failed_steps_count":0}
+{"repo":"growth-api","team":"growth","lane":"startup","timestamp":"2026-04-17T09:05:00Z","gate_fast_ok":true,"gate_release_ok":false,"doctor_ok":true,"failed_steps_count":2}
+{"repo":"identity-platform","team":"platform","lane":"regulated","timestamp":"2026-04-17T09:10:00Z","gate_fast_ok":true,"gate_release_ok":true,"doctor_ok":false,"failed_steps_count":1}

--- a/docs/artifacts/portfolio-scorecard-sample-2026-04-17.json
+++ b/docs/artifacts/portfolio-scorecard-sample-2026-04-17.json
@@ -1,7 +1,7 @@
 {
   "schema_name": "sdetkit.portfolio.aggregate",
   "schema_version": "1.0.0",
-  "generated_at": "2026-04-15T05:51:43.186223Z",
+  "generated_at": "2026-04-17T10:00:00Z",
   "window": {
     "start_date": "2026-04-11",
     "end_date": "2026-04-17"

--- a/docs/artifacts/portfolio-scorecard-sample-2026-04-17.json
+++ b/docs/artifacts/portfolio-scorecard-sample-2026-04-17.json
@@ -1,0 +1,58 @@
+{
+  "schema_name": "sdetkit.portfolio.aggregate",
+  "schema_version": "1.0.0",
+  "generated_at": "2026-04-17T10:00:00Z",
+  "window": {
+    "start_date": "2026-04-11",
+    "end_date": "2026-04-17"
+  },
+  "totals": {
+    "repo_count_total": 3,
+    "repo_count_reporting": 3,
+    "high_risk_repo_count": 1,
+    "medium_risk_repo_count": 1,
+    "low_risk_repo_count": 1,
+    "release_gate_failure_rate_percent": 33.33
+  },
+  "repos": [
+    {
+      "repo_id": "growth-api",
+      "team": "growth",
+      "lane": "startup",
+      "risk_tier": "high",
+      "release_confidence_ok": false,
+      "gate_fast_ok": true,
+      "gate_release_ok": false,
+      "doctor_ok": true,
+      "failed_steps_count": 2,
+      "evidence_window_end": "2026-04-17",
+      "source_timestamp": "2026-04-17T09:05:00Z"
+    },
+    {
+      "repo_id": "checkout-service",
+      "team": "checkout",
+      "lane": "scale",
+      "risk_tier": "low",
+      "release_confidence_ok": true,
+      "gate_fast_ok": true,
+      "gate_release_ok": true,
+      "doctor_ok": true,
+      "failed_steps_count": 0,
+      "evidence_window_end": "2026-04-17",
+      "source_timestamp": "2026-04-17T09:00:00Z"
+    },
+    {
+      "repo_id": "identity-platform",
+      "team": "platform",
+      "lane": "regulated",
+      "risk_tier": "medium",
+      "release_confidence_ok": false,
+      "gate_fast_ok": true,
+      "gate_release_ok": true,
+      "doctor_ok": false,
+      "failed_steps_count": 1,
+      "evidence_window_end": "2026-04-17",
+      "source_timestamp": "2026-04-17T09:10:00Z"
+    }
+  ]
+}

--- a/docs/artifacts/portfolio-scorecard-sample-2026-04-17.json
+++ b/docs/artifacts/portfolio-scorecard-sample-2026-04-17.json
@@ -1,7 +1,7 @@
 {
   "schema_name": "sdetkit.portfolio.aggregate",
   "schema_version": "1.0.0",
-  "generated_at": "2026-04-17T10:00:00Z",
+  "generated_at": "2026-04-15T05:51:43.186223Z",
   "window": {
     "start_date": "2026-04-11",
     "end_date": "2026-04-17"

--- a/docs/artifacts/top-tier-bundle-manifest-2026-04-17.json
+++ b/docs/artifacts/top-tier-bundle-manifest-2026-04-17.json
@@ -1,0 +1,26 @@
+{
+  "ok": true,
+  "window": {
+    "start": "2026-04-11",
+    "end": "2026-04-17"
+  },
+  "program_status": "green",
+  "artifacts": {
+    "portfolio_scorecard": {
+      "path": "docs/artifacts/top-tier-bundle/portfolio-scorecard.json",
+      "sha256": "f53d288ff0cd69b3dae55eca5dd295c8cfbd85671d0106b38cdf1c6b7dbac6f8"
+    },
+    "kpi_weekly": {
+      "path": "docs/artifacts/top-tier-bundle/kpi-weekly.json",
+      "sha256": "bf8be7cb76666b10f207aeb6b50bd71d0195d6d3a9429c31402bbe60f9fd2478"
+    },
+    "kpi_contract_check": {
+      "path": "docs/artifacts/top-tier-bundle/kpi-contract-check.json",
+      "sha256": "7b8a93b5af50e8d8adeb7154a44bf4020969969640bae7745e95ba70232e3bb2"
+    },
+    "top_tier_contract_check": {
+      "path": "docs/artifacts/top-tier-bundle/top-tier-contract-check.json",
+      "sha256": "edb53c3b9e9c60c120d53c4016b83fee123a88a5a89a47f447dc0a4ec18237da"
+    }
+  }
+}

--- a/docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json
+++ b/docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json
@@ -1,0 +1,30 @@
+{
+  "ok": true,
+  "checked_count": 4,
+  "window": {
+    "start": "2026-04-11",
+    "end": "2026-04-17"
+  },
+  "artifacts": [
+    {
+      "key": "portfolio_scorecard",
+      "path": "docs/artifacts/top-tier-bundle/portfolio-scorecard.json",
+      "sha256": "f53d288ff0cd69b3dae55eca5dd295c8cfbd85671d0106b38cdf1c6b7dbac6f8"
+    },
+    {
+      "key": "kpi_weekly",
+      "path": "docs/artifacts/top-tier-bundle/kpi-weekly.json",
+      "sha256": "bf8be7cb76666b10f207aeb6b50bd71d0195d6d3a9429c31402bbe60f9fd2478"
+    },
+    {
+      "key": "kpi_contract_check",
+      "path": "docs/artifacts/top-tier-bundle/kpi-contract-check.json",
+      "sha256": "7b8a93b5af50e8d8adeb7154a44bf4020969969640bae7745e95ba70232e3bb2"
+    },
+    {
+      "key": "top_tier_contract_check",
+      "path": "docs/artifacts/top-tier-bundle/top-tier-contract-check.json",
+      "sha256": "edb53c3b9e9c60c120d53c4016b83fee123a88a5a89a47f447dc0a4ec18237da"
+    }
+  ]
+}

--- a/docs/artifacts/top-tier-contract-check-2026-04-17.json
+++ b/docs/artifacts/top-tier-contract-check-2026-04-17.json
@@ -1,0 +1,12 @@
+{
+  "ok": true,
+  "repo_count": 3,
+  "week_ending": "2026-04-17",
+  "checks": [
+    "repo_count_total_matches_repos",
+    "onboarding_rate_consistent",
+    "failed_release_rate_consistent",
+    "sample_size_consistent",
+    "week_alignment_consistent"
+  ]
+}

--- a/docs/executive-monthly-2026-04.md
+++ b/docs/executive-monthly-2026-04.md
@@ -1,0 +1,58 @@
+# Executive monthly report
+
+## Month
+- Month: 2026-04
+- Program status: Green
+- Monthly executive summary (5 bullets max):
+  - WS2 moved from contract drafting to runnable portfolio scorecard generation with sample artifacts.
+  - WS4 role-based quickstarts published for release owner, platform engineer, and QA governance.
+  - KPI contract now exists as markdown + JSON schema with first seed weekly payload.
+  - Governance artifacts (compatibility matrix, support/escalation model, ops handbook) remain active references.
+  - Primary next-month dependency is instrumentation maturity for currently N/A KPI fields.
+
+## KPI trend (month)
+
+| KPI | Month start | Month end | Direction | Confidence | Note |
+|---|---:|---:|---|---|---|
+| first-time-success onboarding rate | N/A | 0% (0/1 seed) | baseline | Low | Seed from fixture sample only |
+| median release decision time | N/A | N/A | no-change | Low | Timing instrumentation pending |
+| failed release gate frequency | N/A | 100% (1/1 seed) | baseline | Low | Fixture run intentionally triage-oriented |
+| rollback rate | N/A | 0 | baseline | Low | No rollback incidents logged |
+| mean time to triage first failure | N/A | N/A | no-change | Low | Incident timing fields pending |
+| docs-to-adoption conversion | N/A | N/A | no-change | Low | Docs telemetry pending |
+
+## Portfolio health trend
+
+| Risk tier | Month start repos | Month end repos | Net change |
+|---|---:|---:|---:|
+| High | N/A | 1 | N/A |
+| Medium | N/A | 1 | N/A |
+| Low | N/A | 1 | N/A |
+
+## Workstream outcomes
+
+| Workstream | Monthly objective | Outcome | Evidence link |
+|---|---|---|---|
+| WS1 Product packaging | Publish package lane definitions | Complete | `docs/packaging-lanes.md` |
+| WS2 Portfolio reporting | Stand up versioned scorecard contract and runnable recipe | Complete (seed baseline quality) | `docs/portfolio-reporting-recipe.md` |
+| WS3 Governance and lifecycle | Keep compatibility + escalation policy active | Complete | `docs/policy-compatibility-matrix.md` |
+| WS4 Commercialization enablement | Publish role-based quickstart skeletons | Complete | `docs/role-based-quickstarts.md` |
+| WS5 Reliability and release excellence | Operate weekly board + evidence loop | In progress | `docs/top-tier-program-dashboard.md` |
+
+## Leadership decisions required
+
+1. Approve instrumentation sprint slice for decision/triage time fields by 2026-05-08.
+2. Approve docs-to-adoption telemetry implementation approach by 2026-05-08.
+
+## Top risks and mitigations
+
+| Risk | Severity | Owner | Mitigation | ETA |
+|---|---|---|---|---|
+| KPI fields remain N/A due to missing instrumentation | Medium | Platform engineering | Add timestamp and telemetry fields to canonical outputs | 2026-05-08 |
+| Seed metrics are based on fixture samples only | Medium | Product + DX | Expand to multi-repo production-like pilot set | 2026-05-15 |
+
+## Next-month commitments (max 5)
+
+1. Implement KPI timestamp instrumentation for median decision time and triage duration (Owner: Platform engineering, due 2026-05-08, success metric: non-null values).
+2. Add docs conversion tracking event map + weekly export (Owner: PMM + Solutions, due 2026-05-08, success metric: non-null conversion metric).
+3. Run two additional portfolio sample windows and compare trend deltas (Owner: Release engineering, due 2026-05-15, success metric: three comparable monthly data points).

--- a/docs/executive-monthly-template.md
+++ b/docs/executive-monthly-template.md
@@ -1,0 +1,54 @@
+# Executive monthly template
+
+Use this one-page template for CTO/VP Eng monthly portfolio reviews.
+
+## Month
+- Month: YYYY-MM
+- Program status: Green / Amber / Red
+- Monthly executive summary (5 bullets max):
+
+## KPI trend (month)
+
+| KPI | Month start | Month end | Direction | Confidence | Note |
+|---|---:|---:|---|---|---|
+| first-time-success onboarding rate |  |  |  |  |  |
+| median release decision time |  |  |  |  |  |
+| failed release gate frequency |  |  |  |  |  |
+| rollback rate |  |  |  |  |  |
+| mean time to triage first failure |  |  |  |  |  |
+| docs-to-adoption conversion |  |  |  |  |  |
+
+## Portfolio health trend
+
+| Risk tier | Month start repos | Month end repos | Net change |
+|---|---:|---:|---:|
+| High |  |  |  |
+| Medium |  |  |  |
+| Low |  |  |  |
+
+## Workstream outcomes
+
+| Workstream | Monthly objective | Outcome | Evidence link |
+|---|---|---|---|
+| WS1 Product packaging |  |  |  |
+| WS2 Portfolio reporting |  |  |  |
+| WS3 Governance and lifecycle |  |  |  |
+| WS4 Commercialization enablement |  |  |  |
+| WS5 Reliability and release excellence |  |  |  |
+
+## Leadership decisions required
+
+1. _Decision + owner + deadline + impact if delayed._
+2. _Decision + owner + deadline + impact if delayed._
+
+## Top risks and mitigations
+
+| Risk | Severity | Owner | Mitigation | ETA |
+|---|---|---|---|---|
+|  |  |  |  |  |
+
+## Next-month commitments (max 5)
+
+1. _Deliverable + owner + due date + success metric._
+2. _Deliverable + owner + due date + success metric._
+3. _Deliverable + owner + due date + success metric._

--- a/docs/executive-weekly-2026-04-17.md
+++ b/docs/executive-weekly-2026-04-17.md
@@ -1,0 +1,45 @@
+# Executive weekly report
+
+## Week ending
+- Date: 2026-04-17
+- Program status: Green
+- Executive summary (3 bullets max):
+  - WS2 blocker B-001 closed with a published portfolio schema versioning convention.
+  - WS4 moved to in-progress with role-based quickstart skeletons for three core roles.
+  - KPI board moved from TBD to first seed baseline using fixture evidence.
+
+## KPI movement
+
+| KPI | This week | Last week | Direction | Note |
+|---|---:|---:|---|---|
+| first-time-success onboarding rate | 0% (0/1) | N/A | no-change | Seed baseline from real-repo fixture evidence |
+| median release decision time | N/A | N/A | no-change | Timing instrumentation pending |
+| failed release gate frequency | 100% (1/1) | N/A | no-change | Fixture run intentionally triage-oriented |
+| rollback rate | 0 | N/A | no-change | No rollback incidents logged this week |
+| mean time to triage first failure | N/A | N/A | no-change | Incident timestamp fields pending |
+| docs-to-adoption conversion | N/A | N/A | no-change | Analytics + completion hooks pending |
+
+## Portfolio risk snapshot
+
+| Risk tier | Repo count | Change vs last week | Top owners |
+|---|---:|---:|---|
+| High | 1 | N/A | Platform engineering |
+| Medium | 0 | N/A | Release engineering |
+| Low | 0 | N/A | Product + DX |
+
+## Decisions needed (leadership)
+
+1. Approve KPI instrumentation slice for decision-time and triage-time timestamps by 2026-04-24 (Owner: Platform engineering).
+2. Approve docs conversion telemetry approach for PMM reporting by 2026-04-24 (Owner: PMM + Solutions).
+
+## Blockers requiring escalation
+
+| Blocker | Impact | Owner | ETA | Escalation requested |
+|---|---|---|---|---|
+| None this week | — | — | — | No |
+
+## Next-week commitments (max 5)
+
+1. Add timing instrumentation fields to gate execution outputs (Owner: Release engineering, due 2026-04-22).
+2. Add incident timeline schema for MTTTF tracking (Owner: Platform engineering, due 2026-04-23).
+3. Add docs conversion event mapping draft (Owner: PMM + Solutions, due 2026-04-24).

--- a/docs/full-release-package-checklist.md
+++ b/docs/full-release-package-checklist.md
@@ -1,0 +1,48 @@
+# Full release package checklist
+
+Use this checklist before approving an organization-level rollout or major release train.
+
+## 1) Product readiness
+
+- [ ] Canonical path artifacts attached (`gate-fast.json`, `release-preflight.json`, `doctor.json`).
+- [ ] Release confidence decision recorded (`ship` / `no-ship`) with owner sign-off.
+- [ ] KPI snapshot attached for the release window (`docs/kpi-weekly-<date>.json`).
+
+## 2) Documentation readiness
+
+- [ ] Release notes drafted and reviewed.
+- [ ] Migration/compatibility notes updated.
+- [ ] Operator runbook links verified (`operations-handbook.md`, escalation model, policy matrix).
+
+## 3) Security and compliance readiness
+
+- [ ] Security scan outputs attached (or exception record approved).
+- [ ] Dependency/update exceptions documented.
+- [ ] Compliance controls impacted by release are reviewed and signed.
+
+## 4) Support readiness
+
+- [ ] Severity owner and incident commander on-call for release window.
+- [ ] Escalation communication template pre-filled.
+- [ ] Rollback owner and rollback window documented.
+
+## 5) Communications readiness
+
+- [ ] Internal stakeholder announcement drafted.
+- [ ] External/customer comms plan prepared if user-visible impact exists.
+- [ ] Leadership summary entry prepared for weekly/monthly reporting.
+
+## 6) Final go/no-go gate
+
+- [ ] All critical checklist items are complete or have approved exception links.
+- [ ] Release owner + platform owner + QA governance signoff captured.
+- [ ] Evidence bundle archived in release artifacts.
+
+## Evidence bundle index (minimum)
+
+- `build/gate-fast.json`
+- `build/release-preflight.json`
+- `build/doctor.json`
+- `docs/kpi-weekly-<date>.json`
+- `docs/executive-weekly-<date>.md`
+- portfolio scorecard for the same window

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,7 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Need KPI contract: [Top-tier KPI schema](kpi-schema.md)
 - Need operator runbook: [Operations handbook](operations-handbook.md)
 - Need rollout gates: [Pilot to rollout guide](pilot-to-rollout-guide.md)
+- Need release train gate: [Full release package checklist](full-release-package-checklist.md)
 - Need scale-phase assets: [P2 scale assets](p2-scale-assets.md)
 - Need current references: [CLI reference](cli.md), [API](api.md), and [repo audit reference](repo-audit.md)
 - Migrating older automation? Use [Legacy command migration map](legacy-command-migration-map.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,7 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Need operating support model: [Support and escalation model](support-and-escalation-model.md)
 - Need multi-repo aggregation: [Portfolio reporting recipe](portfolio-reporting-recipe.md)
 - Need leadership updates: [Executive weekly template](executive-weekly-template.md)
+- Need KPI contract: [Top-tier KPI schema](kpi-schema.md)
 - Need operator runbook: [Operations handbook](operations-handbook.md)
 - Need rollout gates: [Pilot to rollout guide](pilot-to-rollout-guide.md)
 - Need scale-phase assets: [P2 scale assets](p2-scale-assets.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,7 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Need operating support model: [Support and escalation model](support-and-escalation-model.md)
 - Need multi-repo aggregation: [Portfolio reporting recipe](portfolio-reporting-recipe.md)
 - Need leadership updates: [Executive weekly template](executive-weekly-template.md)
+- Need monthly leadership view: [Executive monthly template](executive-monthly-template.md)
 - Need KPI contract: [Top-tier KPI schema](kpi-schema.md)
 - Need operator runbook: [Operations handbook](operations-handbook.md)
 - Need rollout gates: [Pilot to rollout guide](pilot-to-rollout-guide.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,6 +113,7 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Migrating older automation? Use [Legacy command migration map](legacy-command-migration-map.md)
 - Need canonical-path health status? Use [Golden-path health signal](golden-path-health.md)
 - Need drift enforcement? Run canonical path drift guard (`python scripts/check_canonical_path_drift.py --format json`)
+- Need top-tier reporting pipeline? Run `make top-tier-reporting`
 - Need legacy usage inventory? Run legacy command analyzer (`python scripts/legacy_command_analyzer.py --format json`)
 - Need one maturity number? Generate [Adoption scorecard](adoption-scorecard.md)
 - Need guided canonical triage? Use [Operator onboarding wizard](operator-onboarding-wizard.md)

--- a/docs/kpi-baseline-week-2026-04-17.md
+++ b/docs/kpi-baseline-week-2026-04-17.md
@@ -1,0 +1,32 @@
+# KPI baseline snapshot — week ending 2026-04-17
+
+This snapshot captures the first measurable KPI baseline for the top-tier program.
+
+## Scope and caveat
+
+- Baseline is computed from the current real-repo adoption fixture evidence in `artifacts/adoption/real-repo-golden`.
+- This is a **seed baseline** for instrumentation validation, not a production fleet benchmark.
+
+## KPI baseline values
+
+| KPI | Baseline value | Method | Notes |
+|---|---:|---|---|
+| first_time_success_onboarding_rate | 0% (0/1) | Count `ok=true` in first release preflight runs | Fixture sample shows `ok=false` in `release-preflight.json` |
+| median_release_decision_time | N/A | Requires start/end timing instrumentation | Add timestamp capture to gate run pipeline |
+| failed_release_gate_frequency | 100% (1/1) | Count failed release-gate runs / total runs | Fixture sample has `failed_steps` in release preflight |
+| rollback_rate | 0 (no incidents logged) | Weekly incident ledger count | No rollback incident record captured this week |
+| mean_time_to_triage_first_failure | N/A | Requires incident-open and first-triage timestamps | Add incident timeline fields to records |
+| docs_to_adoption_conversion | N/A | Requires docs analytics + completion tracking | Add docs CTA + completion event wiring |
+
+## Evidence sources
+
+- `artifacts/adoption/real-repo-golden/gate-fast.json`
+- `artifacts/adoption/real-repo-golden/release-preflight.json`
+- `docs/kpi-weekly-2026-04-17.json`
+- `docs/top-tier-program-dashboard.md`
+
+## Next instrumentation actions
+
+1. Add timestamp fields to canonical gate wrappers for decision-time metrics.
+2. Add incident timeline fields to enable MTTTF calculations.
+3. Add docs conversion tracking hooks and weekly export.

--- a/docs/kpi-schema.md
+++ b/docs/kpi-schema.md
@@ -7,6 +7,7 @@ This page defines the weekly KPI contract for CTO/dashboard reporting and links 
 - JSON schema: [`docs/kpi-schema.v1.json`](kpi-schema.v1.json)
 - First seed baseline instance: [`docs/kpi-baseline-week-2026-04-17.md`](kpi-baseline-week-2026-04-17.md)
 - Generated KPI sample: [`docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json`](artifacts/kpi-weekly-from-portfolio-2026-04-17.json)
+- KPI contract check report: [`docs/artifacts/kpi-weekly-contract-check-2026-04-17.json`](artifacts/kpi-weekly-contract-check-2026-04-17.json)
 
 ## KPI keys (required)
 
@@ -59,6 +60,7 @@ python scripts/build_kpi_weekly_snapshot.py \
 python scripts/check_repo_layout.py
 python -m pytest -q tests/test_phase1_hardening.py
 python -m pytest -q tests/test_build_kpi_weekly_snapshot.py
+python scripts/check_kpi_weekly_contract.py --schema docs/kpi-schema.v1.json --payload docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --out docs/artifacts/kpi-weekly-contract-check-2026-04-17.json
 python scripts/check_top_tier_reporting_contract.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --kpi-weekly docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --out docs/artifacts/top-tier-contract-check-2026-04-17.json
 ```
 

--- a/docs/kpi-schema.md
+++ b/docs/kpi-schema.md
@@ -1,0 +1,55 @@
+# Top-tier KPI schema (v1)
+
+This page defines the weekly KPI contract for CTO/dashboard reporting and links to the machine-readable schema.
+
+## Contract artifacts
+
+- JSON schema: [`docs/kpi-schema.v1.json`](kpi-schema.v1.json)
+- First seed baseline instance: [`docs/kpi-baseline-week-2026-04-17.md`](kpi-baseline-week-2026-04-17.md)
+
+## KPI keys (required)
+
+1. `first_time_success_onboarding_rate`
+2. `median_release_decision_time`
+3. `failed_release_gate_frequency`
+4. `rollback_rate`
+5. `mean_time_to_triage_first_failure`
+6. `docs_to_adoption_conversion`
+
+## Metric object contract
+
+Each KPI key MUST use this shape:
+
+- `value` (number/string/null)
+- `unit` (string)
+- `sample_size` (integer/null)
+- `quality` (`seed` | `provisional` | `stable`)
+- `source` (string)
+
+## Program-level required fields
+
+- `schema_version` (currently `1.0.0`)
+- `week_ending` (ISO date)
+- `program_status` (`green`/`amber`/`red`)
+- `kpis` (object with all 6 required keys)
+
+## Versioning and change rules
+
+- **PATCH:** wording-only clarifications, no field-level behavior changes.
+- **MINOR:** additive optional fields.
+- **MAJOR:** required-field or semantic changes.
+
+Compatibility expectation: downstream consumers should be able to parse all `1.x` payloads without breaking if they ignore unknown optional fields.
+
+## Minimum weekly validation workflow
+
+```bash
+python scripts/check_repo_layout.py
+python -m pytest -q tests/test_phase1_hardening.py
+```
+
+## Ownership
+
+- KPI schema DRI: Platform engineering
+- KPI interpretation DRI: Product + DX
+- Weekly approval cadence: Friday closeout

--- a/docs/kpi-schema.md
+++ b/docs/kpi-schema.md
@@ -59,6 +59,7 @@ python scripts/build_kpi_weekly_snapshot.py \
 python scripts/check_repo_layout.py
 python -m pytest -q tests/test_phase1_hardening.py
 python -m pytest -q tests/test_build_kpi_weekly_snapshot.py
+python scripts/check_top_tier_reporting_contract.py --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json --kpi-weekly docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json --out docs/artifacts/top-tier-contract-check-2026-04-17.json
 ```
 
 ## Ownership

--- a/docs/kpi-schema.md
+++ b/docs/kpi-schema.md
@@ -6,6 +6,7 @@ This page defines the weekly KPI contract for CTO/dashboard reporting and links 
 
 - JSON schema: [`docs/kpi-schema.v1.json`](kpi-schema.v1.json)
 - First seed baseline instance: [`docs/kpi-baseline-week-2026-04-17.md`](kpi-baseline-week-2026-04-17.md)
+- Generated KPI sample: [`docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json`](artifacts/kpi-weekly-from-portfolio-2026-04-17.json)
 
 ## KPI keys (required)
 
@@ -41,11 +42,23 @@ Each KPI key MUST use this shape:
 
 Compatibility expectation: downstream consumers should be able to parse all `1.x` payloads without breaking if they ignore unknown optional fields.
 
+## Build command (from portfolio scorecard)
+
+```bash
+python scripts/build_kpi_weekly_snapshot.py \
+  --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json \
+  --out docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json \
+  --week-ending 2026-04-17 \
+  --program-status green \
+  --rollback-count 0
+```
+
 ## Minimum weekly validation workflow
 
 ```bash
 python scripts/check_repo_layout.py
 python -m pytest -q tests/test_phase1_hardening.py
+python -m pytest -q tests/test_build_kpi_weekly_snapshot.py
 ```
 
 ## Ownership

--- a/docs/kpi-schema.v1.json
+++ b/docs/kpi-schema.v1.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://devs69.dev/sdetkit/schemas/top-tier-kpi-weekly.v1.json",
+  "title": "Top-tier weekly KPI snapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "week_ending",
+    "program_status",
+    "kpis"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0.0"
+    },
+    "week_ending": {
+      "type": "string",
+      "format": "date"
+    },
+    "program_status": {
+      "type": "string",
+      "enum": ["green", "amber", "red"]
+    },
+    "kpis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "first_time_success_onboarding_rate",
+        "median_release_decision_time",
+        "failed_release_gate_frequency",
+        "rollback_rate",
+        "mean_time_to_triage_first_failure",
+        "docs_to_adoption_conversion"
+      ],
+      "properties": {
+        "first_time_success_onboarding_rate": {"$ref": "#/$defs/metric"},
+        "median_release_decision_time": {"$ref": "#/$defs/metric"},
+        "failed_release_gate_frequency": {"$ref": "#/$defs/metric"},
+        "rollback_rate": {"$ref": "#/$defs/metric"},
+        "mean_time_to_triage_first_failure": {"$ref": "#/$defs/metric"},
+        "docs_to_adoption_conversion": {"$ref": "#/$defs/metric"}
+      }
+    }
+  },
+  "$defs": {
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "unit", "sample_size", "quality", "source"],
+      "properties": {
+        "value": {
+          "type": ["number", "string", "null"],
+          "description": "Metric value; use null for unavailable and add context in quality/source."
+        },
+        "unit": {
+          "type": "string",
+          "examples": ["percent", "count", "minutes", "n/a"]
+        },
+        "sample_size": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "quality": {
+          "type": "string",
+          "enum": ["seed", "provisional", "stable"]
+        },
+        "source": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/kpi-weekly-2026-04-17.json
+++ b/docs/kpi-weekly-2026-04-17.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "1.0.0",
+  "week_ending": "2026-04-17",
+  "program_status": "green",
+  "kpis": {
+    "first_time_success_onboarding_rate": {
+      "value": 0,
+      "unit": "percent",
+      "sample_size": 1,
+      "quality": "seed",
+      "source": "artifacts/adoption/real-repo-golden/release-preflight.json"
+    },
+    "median_release_decision_time": {
+      "value": null,
+      "unit": "n/a",
+      "sample_size": null,
+      "quality": "seed",
+      "source": "timing instrumentation pending"
+    },
+    "failed_release_gate_frequency": {
+      "value": 100,
+      "unit": "percent",
+      "sample_size": 1,
+      "quality": "seed",
+      "source": "artifacts/adoption/real-repo-golden/release-preflight.json"
+    },
+    "rollback_rate": {
+      "value": 0,
+      "unit": "count",
+      "sample_size": 0,
+      "quality": "seed",
+      "source": "no rollback incidents logged for week ending 2026-04-17"
+    },
+    "mean_time_to_triage_first_failure": {
+      "value": null,
+      "unit": "n/a",
+      "sample_size": null,
+      "quality": "seed",
+      "source": "incident timing fields pending"
+    },
+    "docs_to_adoption_conversion": {
+      "value": null,
+      "unit": "n/a",
+      "sample_size": null,
+      "quality": "seed",
+      "source": "docs telemetry pending"
+    }
+  }
+}

--- a/docs/pilot-to-rollout-guide.md
+++ b/docs/pilot-to-rollout-guide.md
@@ -10,10 +10,15 @@ Prove canonical path works in representative repositories.
 ### Entry criteria
 - Team sponsor and release owner assigned.
 - Baseline repo selected.
+- Target lane selected (Startup/Scale/Regulated).
 
-### Exit criteria
-- `gate fast`, `gate release`, and `doctor` run successfully in at least one target repo.
-- Initial KPI baseline captured.
+### Exit criteria (measurable)
+
+| Check | Threshold | Evidence |
+|---|---|---|
+| Canonical path runs in baseline repo | 1/1 successful run with artifacts produced | `build/gate-fast.json`, `build/release-preflight.json`, `build/doctor.json` |
+| Onboarding baseline captured | Week-1 seed KPI payload committed | `docs/kpi-weekly-<date>.json` |
+| Ownership model set | All 5 workstreams have DRI listed | `docs/top-tier-program-dashboard.md` |
 
 ## Stage 2: Pilot
 
@@ -23,11 +28,16 @@ Validate repeatability across multiple teams/repos.
 ### Entry criteria
 - Evaluation exit criteria complete.
 - Lane selected (Startup/Scale/Regulated).
+- Weekly status cadence announced.
 
-### Exit criteria
-- At least 3 repos onboarded (or agreed pilot size).
-- Weekly dashboard in use for minimum 2 cycles.
-- Incident/escalation flow exercised at least once (tabletop or real incident).
+### Exit criteria (measurable)
+
+| Check | Threshold | Evidence |
+|---|---|---|
+| Pilot coverage | At least 3 repos onboarded (or approved pilot size) | Portfolio scorecard JSON |
+| Weekly operating rhythm | 2 consecutive weekly cycles completed | Weekly executive reports |
+| Escalation readiness | 1 incident/escalation workflow exercised | Incident log + support model reference |
+| Portfolio contract adoption | Scorecard payload emitted with `schema_version` and required totals | `docs/artifacts/portfolio-scorecard-*.json` |
 
 ## Stage 3: Production rollout
 
@@ -36,17 +46,33 @@ Operationalize portfolio reporting and governance at org level.
 
 ### Entry criteria
 - Pilot criteria complete with leadership sign-off.
+- Monthly leadership review template ready.
 
-### Exit criteria
-- Portfolio reporting recipe operating weekly.
-- Compatibility and deprecation policy actively enforced.
-- Executive weekly report adopted in leadership cadence.
+### Exit criteria (measurable)
+
+| Check | Threshold | Evidence |
+|---|---|---|
+| Portfolio reporting operational | Weekly scorecard generated for active repos for 4 straight weeks | Portfolio scorecard artifacts |
+| Governance enforcement active | Compatibility/deprecation reviews completed monthly | Governance policy docs + review notes |
+| Leadership reporting institutionalized | Weekly + monthly executive reports used in cadence | `docs/executive-weekly-*.md`, `docs/executive-monthly-*.md` |
+| Release package readiness | Full release package checklist passes for release train | `docs/full-release-package-checklist.md` |
 
 ## Recommended 30/60/90 checkpoints
 
-- **Day 30:** evaluation complete + KPI baseline.
-- **Day 60:** pilot steady-state + governance docs active.
-- **Day 90:** portfolio reporting + executive rhythm institutionalized.
+- **Day 30:** evaluation complete + KPI baseline payload + DRI assignment.
+- **Day 60:** pilot steady-state + 2 weekly cycles + escalation rehearsal.
+- **Day 90:** 4-week portfolio reporting streak + monthly leadership review + release package checklist adoption.
+
+## Stage gate command set
+
+Use this command set before each stage sign-off:
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor --format json --out build/doctor.json
+python scripts/build_portfolio_scorecard.py --in <normalized-input> --out <portfolio-scorecard.json> --schema-version 1.0.0 --window-start <YYYY-MM-DD> --window-end <YYYY-MM-DD>
+```
 
 ## Common failure modes and mitigations
 
@@ -55,3 +81,4 @@ Operationalize portfolio reporting and governance at org level.
 | Scope too broad | Too many repos in initial pilot | Limit to highest-impact services first |
 | No clear ownership | Repeated missed commitments | Assign DRI per workstream and publish weekly |
 | Data inconsistency | KPI disputes every week | Freeze schema for reporting window |
+| Escalation drift | Severity decisions differ by team | Enforce one support model + monthly calibration |

--- a/docs/portfolio-aggregation-schema.md
+++ b/docs/portfolio-aggregation-schema.md
@@ -1,0 +1,74 @@
+# Portfolio aggregation schema versioning convention
+
+This document defines the versioned aggregation contract for portfolio-level readiness reporting across multiple repositories.
+
+## Purpose
+
+- Unblock WS2 portfolio reporting by establishing one schema contract for rollups.
+- Ensure weekly executive reporting can evolve without breaking downstream consumers.
+- Provide deterministic migration rules for additive and breaking changes.
+
+## Schema identity
+
+- `schema_name`: `sdetkit.portfolio.aggregate`
+- `schema_version`: semantic version string (`MAJOR.MINOR.PATCH`)
+- Initial version: `1.0.0`
+
+## Version bump policy
+
+| Change type | Example | Required bump | Compatibility expectation |
+|---|---|---|---|
+| Add optional field | add `risk_tier_breakdown` | MINOR | Backward compatible |
+| Clarify constraints only | tighten prose docs | PATCH | Backward compatible |
+| Add required field | require `repo_id` | MAJOR | Potentially breaking |
+| Rename/remove field | `risk_score` -> `risk_level` | MAJOR | Breaking unless dual-written |
+
+## Required top-level fields
+
+Every portfolio aggregate payload MUST contain:
+
+- `schema_name` (string)
+- `schema_version` (string)
+- `generated_at` (ISO-8601 UTC timestamp)
+- `window` (object with `start_date`, `end_date`)
+- `totals` (object)
+- `repos` (array)
+
+## `totals` required fields
+
+- `repo_count_total` (integer)
+- `repo_count_reporting` (integer)
+- `high_risk_repo_count` (integer)
+- `medium_risk_repo_count` (integer)
+- `low_risk_repo_count` (integer)
+
+## `repos[]` minimum object contract
+
+- `repo_id` (string)
+- `risk_tier` (`high` | `medium` | `low`)
+- `release_confidence_ok` (boolean)
+- `gate_fast_ok` (boolean)
+- `gate_release_ok` (boolean)
+- `doctor_ok` (boolean)
+- `evidence_window_end` (date)
+
+## Compatibility rules
+
+1. Consumers MUST ignore unknown fields.
+2. Producers MUST keep required fields stable within a major version.
+3. Additive changes SHOULD be released as minor versions.
+4. Breaking changes MUST ship with dual-write period notes and migration examples.
+
+## Migration process
+
+1. Propose change and classify bump type (major/minor/patch).
+2. Update this document and changelog entry in the same PR.
+3. If major bump, publish migration snippet and dual-write duration.
+4. Update dashboard references and executive template fields if impacted.
+
+## Changelog
+
+## 1.0.0 — 2026-04-15
+
+- Initial schema versioning convention created.
+- Defines required fields for portfolio rollups and risk-tier reporting.

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -102,3 +102,10 @@ Risk tier thresholds:
 - Use a strict reporting cutoff (e.g., Friday 17:00 UTC).
 - Flag missing data as `unknown` instead of implicitly passing.
 - Attach the generated scorecard JSON to weekly leadership reviews.
+
+## Worked sample artifacts
+
+- Input sample: [`docs/artifacts/portfolio-input-sample-2026-04-17.jsonl`](artifacts/portfolio-input-sample-2026-04-17.jsonl)
+- Output sample: [`docs/artifacts/portfolio-scorecard-sample-2026-04-17.json`](artifacts/portfolio-scorecard-sample-2026-04-17.json)
+
+Use these files as a template for weekly portfolio board generation and review.

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -120,10 +120,13 @@ python scripts/build_top_tier_reporting_bundle.py \
   --out-dir docs/artifacts/top-tier-bundle \
   --window-start 2026-04-11 \
   --window-end 2026-04-17 \
-  --generated-at 2026-04-17T10:00:00Z
+  --generated-at 2026-04-17T10:00:00Z \
+  --manifest-out docs/artifacts/top-tier-bundle-manifest-2026-04-17.json
 ```
 
 CI automation option: `.github/workflows/top-tier-reporting-sample.yml`.
+
+Bundle manifest example: [`docs/artifacts/top-tier-bundle-manifest-2026-04-17.json`](artifacts/top-tier-bundle-manifest-2026-04-17.json).
 
 
 ## Cross-artifact consistency check

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -128,6 +128,8 @@ CI automation option: `.github/workflows/top-tier-reporting-sample.yml`.
 
 Bundle manifest example: [`docs/artifacts/top-tier-bundle-manifest-2026-04-17.json`](artifacts/top-tier-bundle-manifest-2026-04-17.json).
 
+Bundle manifest check example: [`docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json`](artifacts/top-tier-bundle-manifest-check-2026-04-17.json).
+
 
 ## Cross-artifact consistency check
 

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -112,6 +112,8 @@ Use these files as a template for weekly portfolio board generation and review.
 
 For the full end-to-end sample pipeline, run `make top-tier-reporting`.
 
+CI automation option: `.github/workflows/top-tier-reporting-sample.yml`.
+
 
 ## Cross-artifact consistency check
 

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -112,6 +112,17 @@ Use these files as a template for weekly portfolio board generation and review.
 
 For the full end-to-end sample pipeline, run `make top-tier-reporting`.
 
+Direct orchestrator option:
+
+```bash
+python scripts/build_top_tier_reporting_bundle.py \
+  --input docs/artifacts/portfolio-input-sample-2026-04-17.jsonl \
+  --out-dir docs/artifacts/top-tier-bundle \
+  --window-start 2026-04-11 \
+  --window-end 2026-04-17 \
+  --generated-at 2026-04-17T10:00:00Z
+```
+
 CI automation option: `.github/workflows/top-tier-reporting-sample.yml`.
 
 

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -112,6 +112,12 @@ Use these files as a template for weekly portfolio board generation and review.
 
 For the full end-to-end sample pipeline, run `make top-tier-reporting`.
 
+You can override date/window values per run, for example:
+
+```bash
+make top-tier-reporting DATE_TAG=2026-04-17 WINDOW_START=2026-04-11 WINDOW_END=2026-04-17 GENERATED_AT=2026-04-17T10:00:00Z
+```
+
 Direct orchestrator option:
 
 ```bash

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -19,7 +19,34 @@ Per repository, collect:
 - `build/doctor.json`
 - repository metadata (team, service tier, lane)
 
-## Normalized record schema
+## Output contract (versioned)
+
+The scorecard output follows the portfolio aggregate contract:
+
+- Schema reference: [`docs/portfolio-aggregation-schema.md`](portfolio-aggregation-schema.md)
+- Script: `python scripts/build_portfolio_scorecard.py`
+
+### Top-level required fields
+
+- `schema_name`
+- `schema_version`
+- `generated_at`
+- `window.start_date`
+- `window.end_date`
+- `totals`
+- `repos`
+
+### `repos[]` required fields (minimum)
+
+- `repo_id`
+- `risk_tier`
+- `release_confidence_ok`
+- `gate_fast_ok`
+- `gate_release_ok`
+- `doctor_ok`
+- `evidence_window_end`
+
+## Input record example (normalized)
 
 ```json
 {
@@ -30,21 +57,28 @@ Per repository, collect:
   "gate_fast_ok": true,
   "gate_release_ok": true,
   "doctor_ok": true,
-  "failed_steps_count": 0,
-  "risk_level": "low"
+  "failed_steps_count": 0
 }
 ```
 
-## Aggregation steps
+## Build command
 
-1. **Collect artifacts** from each target repository for the same reporting window.
-2. **Normalize keys** into the schema above (especially `ok` and `failed_steps`).
-3. **Compute risk level** using consistent thresholds:
-   - `low`: all three checks pass
-   - `medium`: exactly one gate fails
-   - `high`: release gate fails or repeated failures
-4. **Publish portfolio table** grouped by team/lane.
-5. **Attach delta summary** from previous week.
+```bash
+python scripts/build_portfolio_scorecard.py \
+  --in docs/artifacts/portfolio-input.jsonl \
+  --out docs/artifacts/portfolio-scorecard-2026-04-17.json \
+  --schema-version 1.0.0 \
+  --window-start 2026-04-11 \
+  --window-end 2026-04-17
+```
+
+## Aggregation rules
+
+Risk tier thresholds:
+
+- `low`: all three checks pass and failed steps = 0
+- `medium`: partial failure without release-gate hard failure
+- `high`: release gate fails or repeated failures (`failed_steps_count >= 2`)
 
 ## Weekly portfolio scorecard template
 
@@ -55,18 +89,16 @@ Per repository, collect:
 
 ## Portfolio roll-up metrics
 
-- Total repos reporting
-- `% repos low risk`
-- `% repos with release gate failure`
-- Median failed-steps count
-- Week-over-week risk movement (up/down/no-change)
+- `repo_count_total`
+- `repo_count_reporting`
+- `high_risk_repo_count`
+- `medium_risk_repo_count`
+- `low_risk_repo_count`
+- `release_gate_failure_rate_percent`
 
 ## Operating notes
 
-- Keep one schema version per quarter to limit churn.
+- Keep one schema version per quarter unless breaking changes are required.
 - Use a strict reporting cutoff (e.g., Friday 17:00 UTC).
 - Flag missing data as `unknown` instead of implicitly passing.
-
-## Tooling support
-
-Use the adapter script `scripts/build_portfolio_scorecard.py` to generate a consolidated scorecard JSON from normalized records.
+- Attach the generated scorecard JSON to weekly leadership reviews.

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -143,3 +143,12 @@ python scripts/check_top_tier_reporting_contract.py \
 ```
 
 This validates KPI values against portfolio totals and sample sizes.
+
+
+## Promotion helper
+
+To copy bundle outputs to canonical sample artifact names:
+
+```bash
+python scripts/promote_top_tier_bundle.py --bundle-dir docs/artifacts/top-tier-bundle --date-tag 2026-04-17
+```

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -110,6 +110,8 @@ Risk tier thresholds:
 
 Use these files as a template for weekly portfolio board generation and review.
 
+For the full end-to-end sample pipeline, run `make top-tier-reporting`.
+
 
 ## Cross-artifact consistency check
 

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -109,3 +109,17 @@ Risk tier thresholds:
 - Output sample: [`docs/artifacts/portfolio-scorecard-sample-2026-04-17.json`](artifacts/portfolio-scorecard-sample-2026-04-17.json)
 
 Use these files as a template for weekly portfolio board generation and review.
+
+
+## Cross-artifact consistency check
+
+After generating KPI and portfolio outputs, run:
+
+```bash
+python scripts/check_top_tier_reporting_contract.py \
+  --portfolio-scorecard docs/artifacts/portfolio-scorecard-sample-2026-04-17.json \
+  --kpi-weekly docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json \
+  --out docs/artifacts/top-tier-contract-check-2026-04-17.json
+```
+
+This validates KPI values against portfolio totals and sample sizes.

--- a/docs/quickstart-role-platform-engineer.md
+++ b/docs/quickstart-role-platform-engineer.md
@@ -1,0 +1,31 @@
+# Quickstart: Platform engineer
+
+Use this lane when your job is platform reliability, aggregation, and cross-repo signal quality.
+
+## Outcome
+
+Keep portfolio reporting healthy and reduce triage time when failures appear.
+
+## Commands
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor --format json --out build/doctor.json
+python scripts/check_canonical_path_drift.py --format json
+```
+
+## Required evidence
+
+- Canonical artifacts in `build/`
+- Drift-check output from `check_canonical_path_drift.py`
+- Portfolio contract reference: `docs/portfolio-aggregation-schema.md`
+
+## Escalation trigger
+
+Escalate when schema compatibility or drift checks block reliable portfolio rollups.
+
+## KPI focus
+
+- `mean_time_to_triage_first_failure`
+- `failed_release_gate_frequency`

--- a/docs/quickstart-role-qa-governance.md
+++ b/docs/quickstart-role-qa-governance.md
@@ -1,0 +1,34 @@
+# Quickstart: QA governance
+
+Use this lane when your job is policy enforcement, compatibility checks, and governance readiness.
+
+## Outcome
+
+Ensure release confidence controls remain policy-compliant across teams.
+
+## Commands
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor --format json --out build/doctor.json
+python scripts/check_canonical_path_drift.py --format json
+python scripts/generate_artifact_contract_index.py
+```
+
+## Required evidence
+
+- Canonical artifacts in `build/`
+- Contract index output for review traceability
+- Policy references:
+  - `docs/policy-compatibility-matrix.md`
+  - `docs/support-and-escalation-model.md`
+
+## Governance gate
+
+Open a policy action when compatibility expectations or escalation/SLO commitments are not met.
+
+## KPI focus
+
+- `failed_release_gate_frequency`
+- `docs_to_adoption_conversion`

--- a/docs/quickstart-role-release-owner.md
+++ b/docs/quickstart-role-release-owner.md
@@ -1,0 +1,31 @@
+# Quickstart: Release owner
+
+Use this lane when your job is making final go/no-go decisions for a version cut.
+
+## Outcome
+
+Ship with deterministic evidence attached to each release decision.
+
+## Commands
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor --format json --out build/doctor.json
+```
+
+## Required evidence
+
+- `build/gate-fast.json`
+- `build/release-preflight.json`
+- `build/doctor.json`
+
+## Decision rule
+
+- **Ship** when gate artifacts show `ok: true` and no blocking failed steps.
+- **No ship** when either gate artifact is not healthy; open incident/severity per escalation model.
+
+## KPI focus
+
+- `median_release_decision_time`
+- `rollback_rate`

--- a/docs/role-based-quickstarts.md
+++ b/docs/role-based-quickstarts.md
@@ -1,0 +1,25 @@
+# Role-based quickstarts (Phase 1 skeleton)
+
+These quickstarts provide role-specific entry points for the top-tier transformation.
+
+## Quickstart set
+
+- [Release owner quickstart](quickstart-role-release-owner.md)
+- [Platform engineer quickstart](quickstart-role-platform-engineer.md)
+- [QA governance quickstart](quickstart-role-qa-governance.md)
+
+## Shared baseline (all roles)
+
+Run the canonical path before role-specific checks:
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor --format json --out build/doctor.json
+```
+
+## Week-1 rollout checklist
+
+- [ ] Assign one named owner per role.
+- [ ] Capture one successful evidence run per role.
+- [ ] Link each role run into the top-tier dashboard weekly closeout.

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -64,6 +64,7 @@ Track weekly:
 - [KPI baseline snapshot (2026-04-17)](kpi-baseline-week-2026-04-17.md)
 - [Executive weekly report (2026-04-17)](executive-weekly-2026-04-17.md)
 - [Executive monthly report (2026-04)](executive-monthly-2026-04.md)
+- [Full release package checklist](full-release-package-checklist.md)
 
 ### KPI movement
 - _Up / down / no-change summary with one-line interpretation per KPI._

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -63,6 +63,7 @@ Track weekly:
 - [KPI schema (v1)](kpi-schema.md)
 - [KPI baseline snapshot (2026-04-17)](kpi-baseline-week-2026-04-17.md)
 - [Executive weekly report (2026-04-17)](executive-weekly-2026-04-17.md)
+- [Executive monthly report (2026-04)](executive-monthly-2026-04.md)
 
 ### KPI movement
 - _Up / down / no-change summary with one-line interpretation per KPI._

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -66,6 +66,7 @@ Track weekly:
 - [KPI weekly contract check (2026-04-17)](artifacts/kpi-weekly-contract-check-2026-04-17.json)
 - [Top-tier reporting contract check (2026-04-17)](artifacts/top-tier-contract-check-2026-04-17.json)
 - [Top-tier bundle manifest (2026-04-17)](artifacts/top-tier-bundle-manifest-2026-04-17.json)
+- [Top-tier bundle manifest check (2026-04-17)](artifacts/top-tier-bundle-manifest-check-2026-04-17.json)
 - [Executive weekly report (2026-04-17)](executive-weekly-2026-04-17.md)
 - [Executive monthly report (2026-04)](executive-monthly-2026-04.md)
 - [Full release package checklist](full-release-package-checklist.md)

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -62,6 +62,7 @@ Track weekly:
 - [Role-based quickstarts](role-based-quickstarts.md)
 - [KPI schema (v1)](kpi-schema.md)
 - [KPI baseline snapshot (2026-04-17)](kpi-baseline-week-2026-04-17.md)
+- [Generated KPI weekly sample (from portfolio)](artifacts/kpi-weekly-from-portfolio-2026-04-17.json)
 - [Executive weekly report (2026-04-17)](executive-weekly-2026-04-17.md)
 - [Executive monthly report (2026-04)](executive-monthly-2026-04.md)
 - [Full release package checklist](full-release-package-checklist.md)

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -21,7 +21,7 @@ This dashboard is the weekly control plane for the **DevS69 SDETKit top-tier ful
 | Workstream | Owner role | Current phase | Status | This-week deliverable | Evidence |
 |---|---|---|---|---|---|
 | WS1 Product packaging | Product + DX | Phase 1 | In progress | Publish packaging lanes | [Packaging lanes](packaging-lanes.md) |
-| WS2 Portfolio reporting | Platform engineering | Phase 1 | In progress | Define aggregation schema draft | [Portfolio aggregation schema](portfolio-aggregation-schema.md) |
+| WS2 Portfolio reporting | Platform engineering | Phase 1 | In progress | Publish portfolio reporting recipe | [Portfolio reporting recipe](portfolio-reporting-recipe.md) |
 | WS3 Governance and lifecycle | Architecture + QA governance | Phase 1 | In progress | Publish compatibility matrix | [Policy compatibility matrix](policy-compatibility-matrix.md) |
 | WS4 Commercialization enablement | PMM + Solutions | Phase 1 | In progress | Build role-based quickstart skeleton | [Role-based quickstarts](role-based-quickstarts.md) |
 | WS5 Reliability and release excellence | Release engineering | Phase 1 | In progress | Publish support/escalation model | [Support and escalation model](support-and-escalation-model.md) |

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -65,6 +65,7 @@ Track weekly:
 - [Generated KPI weekly sample (from portfolio)](artifacts/kpi-weekly-from-portfolio-2026-04-17.json)
 - [KPI weekly contract check (2026-04-17)](artifacts/kpi-weekly-contract-check-2026-04-17.json)
 - [Top-tier reporting contract check (2026-04-17)](artifacts/top-tier-contract-check-2026-04-17.json)
+- [Top-tier bundle manifest (2026-04-17)](artifacts/top-tier-bundle-manifest-2026-04-17.json)
 - [Executive weekly report (2026-04-17)](executive-weekly-2026-04-17.md)
 - [Executive monthly report (2026-04)](executive-monthly-2026-04.md)
 - [Full release package checklist](full-release-package-checklist.md)

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -63,6 +63,7 @@ Track weekly:
 - [KPI schema (v1)](kpi-schema.md)
 - [KPI baseline snapshot (2026-04-17)](kpi-baseline-week-2026-04-17.md)
 - [Generated KPI weekly sample (from portfolio)](artifacts/kpi-weekly-from-portfolio-2026-04-17.json)
+- [Top-tier reporting contract check (2026-04-17)](artifacts/top-tier-contract-check-2026-04-17.json)
 - [Executive weekly report (2026-04-17)](executive-weekly-2026-04-17.md)
 - [Executive monthly report (2026-04)](executive-monthly-2026-04.md)
 - [Full release package checklist](full-release-package-checklist.md)

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -58,6 +58,7 @@ Track weekly:
 
 ### Completed
 - [Portfolio aggregation schema](portfolio-aggregation-schema.md)
+- [Portfolio scorecard sample (2026-04-17)](artifacts/portfolio-scorecard-sample-2026-04-17.json)
 - [Role-based quickstarts](role-based-quickstarts.md)
 - [KPI schema (v1)](kpi-schema.md)
 - [KPI baseline snapshot (2026-04-17)](kpi-baseline-week-2026-04-17.md)

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -14,16 +14,16 @@ This dashboard is the weekly control plane for the **DevS69 SDETKit top-tier ful
 | Program status | Active |
 | Delivery confidence | Green |
 | Top blocker count | 0 |
-| KPI movement | Baseline week |
+| KPI movement | Seed baseline published |
 
 ## Workstream tracker
 
 | Workstream | Owner role | Current phase | Status | This-week deliverable | Evidence |
 |---|---|---|---|---|---|
 | WS1 Product packaging | Product + DX | Phase 1 | In progress | Publish packaging lanes | [Packaging lanes](packaging-lanes.md) |
-| WS2 Portfolio reporting | Platform engineering | Phase 1 | Planned | Define aggregation schema draft | _Pending_ |
+| WS2 Portfolio reporting | Platform engineering | Phase 1 | In progress | Define aggregation schema draft | [Portfolio aggregation schema](portfolio-aggregation-schema.md) |
 | WS3 Governance and lifecycle | Architecture + QA governance | Phase 1 | In progress | Publish compatibility matrix | [Policy compatibility matrix](policy-compatibility-matrix.md) |
-| WS4 Commercialization enablement | PMM + Solutions | Phase 1 | Planned | Build role-based quickstart skeleton | _Pending_ |
+| WS4 Commercialization enablement | PMM + Solutions | Phase 1 | In progress | Build role-based quickstart skeleton | [Role-based quickstarts](role-based-quickstarts.md) |
 | WS5 Reliability and release excellence | Release engineering | Phase 1 | In progress | Publish support/escalation model | [Support and escalation model](support-and-escalation-model.md) |
 
 ## KPI board (contract baseline)
@@ -41,23 +41,27 @@ Track weekly:
 
 | KPI | Current | Target trend | Data source | Owner |
 |---|---:|---|---|---|
-| first_time_success_onboarding_rate | TBD | Up | onboarding evidence logs | Product + DX |
-| median_release_decision_time | TBD | Down | gate-fast + release-preflight timestamps | Release engineering |
-| failed_release_gate_frequency | TBD | Down | gate artifact summaries | QA governance |
-| rollback_rate | TBD | Down | release incident records | Release engineering |
-| mean_time_to_triage_first_failure | TBD | Down | incident triage logs | Platform engineering |
-| docs_to_adoption_conversion | TBD | Up | docs analytics + canonical path completions | PMM + Solutions |
+| first_time_success_onboarding_rate | 0% (0/1 fixture seed) | Up | onboarding evidence logs | Product + DX |
+| median_release_decision_time | N/A (timing instrumentation pending) | Down | gate-fast + release-preflight timestamps | Release engineering |
+| failed_release_gate_frequency | 100% (1/1 fixture seed) | Down | gate artifact summaries | QA governance |
+| rollback_rate | 0 (no incidents logged) | Down | release incident records | Release engineering |
+| mean_time_to_triage_first_failure | N/A (incident timing fields pending) | Down | incident triage logs | Platform engineering |
+| docs_to_adoption_conversion | N/A (telemetry pending) | Up | docs analytics + canonical path completions | PMM + Solutions |
 
 ## Blockers and decisions
 
 | ID | Blocker / decision | Impact | Owner | ETA | Status |
 |---|---|---|---|---|---|
-| B-001 | No portfolio aggregate schema versioning convention | Delays WS2 reporting | Platform engineering | 2026-04-24 | Open |
+| B-001 | No portfolio aggregate schema versioning convention | Delayed WS2 reporting | Platform engineering | 2026-04-24 | Closed 2026-04-15 |
 
 ## Weekly closeout template
 
 ### Completed
-- _List links to merged PRs, generated artifacts, and dashboards._
+- [Portfolio aggregation schema](portfolio-aggregation-schema.md)
+- [Role-based quickstarts](role-based-quickstarts.md)
+- [KPI schema (v1)](kpi-schema.md)
+- [KPI baseline snapshot (2026-04-17)](kpi-baseline-week-2026-04-17.md)
+- [Executive weekly report (2026-04-17)](executive-weekly-2026-04-17.md)
 
 ### KPI movement
 - _Up / down / no-change summary with one-line interpretation per KPI._

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -63,6 +63,7 @@ Track weekly:
 - [KPI schema (v1)](kpi-schema.md)
 - [KPI baseline snapshot (2026-04-17)](kpi-baseline-week-2026-04-17.md)
 - [Generated KPI weekly sample (from portfolio)](artifacts/kpi-weekly-from-portfolio-2026-04-17.json)
+- [KPI weekly contract check (2026-04-17)](artifacts/kpi-weekly-contract-check-2026-04-17.json)
 - [Top-tier reporting contract check (2026-04-17)](artifacts/top-tier-contract-check-2026-04-17.json)
 - [Executive weekly report (2026-04-17)](executive-weekly-2026-04-17.md)
 - [Executive monthly report (2026-04)](executive-monthly-2026-04.md)

--- a/scripts/build_kpi_weekly_snapshot.py
+++ b/scripts/build_kpi_weekly_snapshot.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Build a weekly KPI snapshot JSON payload from portfolio scorecard evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+_SCHEMA_VERSION = "1.0.0"
+
+
+def _metric(value: Any, unit: str, sample_size: int | None, quality: str, source: str) -> dict[str, Any]:
+    return {
+        "value": value,
+        "unit": unit,
+        "sample_size": sample_size,
+        "quality": quality,
+        "source": source,
+    }
+
+
+def _build_payload(
+    *,
+    portfolio: dict[str, Any],
+    week_ending: str,
+    program_status: str,
+    rollback_count: int,
+    median_release_decision_time: float | None,
+    mean_time_to_triage_first_failure: float | None,
+    docs_to_adoption_conversion: float | None,
+) -> dict[str, Any]:
+    repos = list(portfolio.get("repos", []))
+    totals = dict(portfolio.get("totals", {}))
+    total_repos = int(totals.get("repo_count_total", len(repos)))
+
+    release_confidence_pass = sum(1 for row in repos if bool(row.get("release_confidence_ok", False)))
+    onboarding_rate = round((release_confidence_pass / total_repos * 100), 2) if total_repos else 0.0
+
+    failed_release_gate_frequency = float(totals.get("release_gate_failure_rate_percent", 0.0))
+
+    source = "portfolio scorecard + weekly operations ledger"
+
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "week_ending": week_ending,
+        "program_status": program_status,
+        "kpis": {
+            "first_time_success_onboarding_rate": _metric(
+                onboarding_rate,
+                "percent",
+                total_repos,
+                "seed",
+                source,
+            ),
+            "median_release_decision_time": _metric(
+                median_release_decision_time,
+                "minutes" if median_release_decision_time is not None else "n/a",
+                total_repos if median_release_decision_time is not None else None,
+                "seed",
+                "timing instrumentation pending" if median_release_decision_time is None else source,
+            ),
+            "failed_release_gate_frequency": _metric(
+                failed_release_gate_frequency,
+                "percent",
+                total_repos,
+                "seed",
+                source,
+            ),
+            "rollback_rate": _metric(
+                rollback_count,
+                "count",
+                rollback_count,
+                "seed",
+                source,
+            ),
+            "mean_time_to_triage_first_failure": _metric(
+                mean_time_to_triage_first_failure,
+                "minutes" if mean_time_to_triage_first_failure is not None else "n/a",
+                total_repos if mean_time_to_triage_first_failure is not None else None,
+                "seed",
+                "incident timing fields pending" if mean_time_to_triage_first_failure is None else source,
+            ),
+            "docs_to_adoption_conversion": _metric(
+                docs_to_adoption_conversion,
+                "percent" if docs_to_adoption_conversion is not None else "n/a",
+                total_repos if docs_to_adoption_conversion is not None else None,
+                "seed",
+                "docs telemetry pending" if docs_to_adoption_conversion is None else source,
+            ),
+        },
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Build weekly KPI snapshot JSON payload")
+    ap.add_argument("--portfolio-scorecard", required=True, help="Portfolio scorecard JSON path")
+    ap.add_argument("--out", required=True, help="Output KPI JSON path")
+    ap.add_argument("--week-ending", required=True, help="Week ending date (YYYY-MM-DD)")
+    ap.add_argument("--program-status", default="green", choices=("green", "amber", "red"))
+    ap.add_argument("--rollback-count", type=int, default=0)
+    ap.add_argument("--median-release-decision-time", type=float, default=None)
+    ap.add_argument("--mean-time-to-triage-first-failure", type=float, default=None)
+    ap.add_argument("--docs-to-adoption-conversion", type=float, default=None)
+    args = ap.parse_args()
+
+    portfolio = json.loads(Path(args.portfolio_scorecard).read_text())
+    payload = _build_payload(
+        portfolio=portfolio,
+        week_ending=args.week_ending,
+        program_status=args.program_status,
+        rollback_count=args.rollback_count,
+        median_release_decision_time=args.median_release_decision_time,
+        mean_time_to_triage_first_failure=args.mean_time_to_triage_first_failure,
+        docs_to_adoption_conversion=args.docs_to_adoption_conversion,
+    )
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_portfolio_scorecard.py
+++ b/scripts/build_portfolio_scorecard.py
@@ -90,7 +90,7 @@ def _normalize_repo_row(record: dict[str, Any], *, window_end: str) -> dict[str,
 
 
 def _build_summary(
-    records: list[dict[str, Any]], *, schema_version: str, window_start: str, window_end: str
+    records: list[dict[str, Any]], *, schema_version: str, window_start: str, window_end: str, generated_at: str
 ) -> dict[str, Any]:
     repos = [_normalize_repo_row(record, window_end=window_end) for record in records]
     repos.sort(key=lambda x: (x.get("risk_tier", "unknown"), x.get("repo_id", "")))
@@ -102,7 +102,7 @@ def _build_summary(
     return {
         "schema_name": _SCHEMA_NAME,
         "schema_version": schema_version,
-        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "generated_at": generated_at,
         "window": {
             "start_date": window_start,
             "end_date": window_end,
@@ -126,16 +126,19 @@ def main() -> int:
     ap.add_argument("--schema-version", default="1.0.0", help="Portfolio aggregate schema version")
     ap.add_argument("--window-start", required=True, help="Reporting window start date (YYYY-MM-DD)")
     ap.add_argument("--window-end", required=True, help="Reporting window end date (YYYY-MM-DD)")
+    ap.add_argument("--generated-at", default="", help="Optional generated_at timestamp (ISO-8601 UTC)")
     args = ap.parse_args()
 
     infile = Path(args.infile)
     outfile = Path(args.out)
     records = _load_records(infile)
+    generated_at = args.generated_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     summary = _build_summary(
         records,
         schema_version=args.schema_version,
         window_start=args.window_start,
         window_end=args.window_end,
+        generated_at=generated_at,
     )
 
     outfile.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/build_portfolio_scorecard.py
+++ b/scripts/build_portfolio_scorecard.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
-"""Build a portfolio scorecard from normalized JSON records.
+"""Build a versioned portfolio scorecard from normalized JSON records.
 
 Input can be a JSON array or JSONL with one record per line.
-Expected record keys:
-- repo
-- team
-- lane
+Expected record keys (minimum):
+- repo or repo_id
 - gate_fast_ok
 - gate_release_ok
 - doctor_ok
 - failed_steps_count
+
+Optional metadata keys:
+- team
+- lane
+- timestamp
 """
 
 from __future__ import annotations
@@ -17,8 +20,12 @@ from __future__ import annotations
 import argparse
 import json
 from collections import Counter
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+
+_SCHEMA_NAME = "sdetkit.portfolio.aggregate"
 
 
 def _load_records(path: Path) -> list[dict[str, Any]]:
@@ -58,23 +65,57 @@ def _risk(record: dict[str, Any]) -> str:
     return "medium"
 
 
-def _build_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
-    enriched = []
-    for r in records:
-        row = dict(r)
-        row["risk_level"] = _risk(r)
-        enriched.append(row)
+def _normalize_repo_row(record: dict[str, Any], *, window_end: str) -> dict[str, Any]:
+    repo_id = str(record.get("repo_id") or record.get("repo") or "unknown-repo")
+    gate_fast_ok = bool(record.get("gate_fast_ok", False))
+    gate_release_ok = bool(record.get("gate_release_ok", False))
+    doctor_ok = bool(record.get("doctor_ok", False))
+    failed_steps_count = int(record.get("failed_steps_count", 0))
 
-    counts = Counter(row["risk_level"] for row in enriched)
-    total = len(enriched)
-    release_gate_failures = sum(1 for row in enriched if not bool(row.get("gate_release_ok", False)))
+    release_confidence_ok = gate_fast_ok and gate_release_ok and doctor_ok and failed_steps_count == 0
 
     return {
-        "total_repos": total,
-        "risk_counts": dict(counts),
-        "pct_low_risk": round((counts.get("low", 0) / total * 100), 2) if total else 0.0,
-        "pct_release_gate_failure": round((release_gate_failures / total * 100), 2) if total else 0.0,
-        "repos": sorted(enriched, key=lambda x: (x.get("risk_level", "unknown"), x.get("repo", ""))),
+        "repo_id": repo_id,
+        "team": str(record.get("team", "unknown")),
+        "lane": str(record.get("lane", "unknown")),
+        "risk_tier": _risk(record),
+        "release_confidence_ok": release_confidence_ok,
+        "gate_fast_ok": gate_fast_ok,
+        "gate_release_ok": gate_release_ok,
+        "doctor_ok": doctor_ok,
+        "failed_steps_count": failed_steps_count,
+        "evidence_window_end": window_end,
+        "source_timestamp": record.get("timestamp"),
+    }
+
+
+def _build_summary(
+    records: list[dict[str, Any]], *, schema_version: str, window_start: str, window_end: str
+) -> dict[str, Any]:
+    repos = [_normalize_repo_row(record, window_end=window_end) for record in records]
+    repos.sort(key=lambda x: (x.get("risk_tier", "unknown"), x.get("repo_id", "")))
+
+    counts = Counter(row["risk_tier"] for row in repos)
+    total = len(repos)
+    release_gate_failures = sum(1 for row in repos if not row["gate_release_ok"])
+
+    return {
+        "schema_name": _SCHEMA_NAME,
+        "schema_version": schema_version,
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "window": {
+            "start_date": window_start,
+            "end_date": window_end,
+        },
+        "totals": {
+            "repo_count_total": total,
+            "repo_count_reporting": total,
+            "high_risk_repo_count": counts.get("high", 0),
+            "medium_risk_repo_count": counts.get("medium", 0),
+            "low_risk_repo_count": counts.get("low", 0),
+            "release_gate_failure_rate_percent": round((release_gate_failures / total * 100), 2) if total else 0.0,
+        },
+        "repos": repos,
     }
 
 
@@ -82,16 +123,24 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Build portfolio release scorecard")
     ap.add_argument("--in", dest="infile", required=True, help="Input file (JSON list or JSONL)")
     ap.add_argument("--out", required=True, help="Output JSON summary path")
+    ap.add_argument("--schema-version", default="1.0.0", help="Portfolio aggregate schema version")
+    ap.add_argument("--window-start", required=True, help="Reporting window start date (YYYY-MM-DD)")
+    ap.add_argument("--window-end", required=True, help="Reporting window end date (YYYY-MM-DD)")
     args = ap.parse_args()
 
     infile = Path(args.infile)
     outfile = Path(args.out)
     records = _load_records(infile)
-    summary = _build_summary(records)
+    summary = _build_summary(
+        records,
+        schema_version=args.schema_version,
+        window_start=args.window_start,
+        window_end=args.window_end,
+    )
 
     outfile.parent.mkdir(parents=True, exist_ok=True)
     outfile.write_text(json.dumps(summary, indent=2) + "\n")
-    print(f"wrote {outfile} with {summary['total_repos']} repos")
+    print(f"wrote {outfile} with {summary['totals']['repo_count_total']} repos")
     return 0
 
 

--- a/scripts/build_top_tier_reporting_bundle.py
+++ b/scripts/build_top_tier_reporting_bundle.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Build complete top-tier reporting bundle (portfolio + KPI + contract checks)."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Build top-tier reporting bundle")
+    ap.add_argument("--input", required=True, help="Normalized portfolio input file (JSON or JSONL)")
+    ap.add_argument("--out-dir", required=True, help="Output directory for generated artifacts")
+    ap.add_argument("--window-start", required=True)
+    ap.add_argument("--window-end", required=True)
+    ap.add_argument("--generated-at", default="")
+    ap.add_argument("--schema-version", default="1.0.0")
+    ap.add_argument("--program-status", default="green", choices=("green", "amber", "red"))
+    ap.add_argument("--rollback-count", type=int, default=0)
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    portfolio_out = out_dir / "portfolio-scorecard.json"
+    kpi_out = out_dir / "kpi-weekly.json"
+    kpi_contract_out = out_dir / "kpi-contract-check.json"
+    cross_contract_out = out_dir / "top-tier-contract-check.json"
+
+    portfolio_cmd = [
+        sys.executable,
+        "scripts/build_portfolio_scorecard.py",
+        "--in",
+        args.input,
+        "--out",
+        str(portfolio_out),
+        "--schema-version",
+        args.schema_version,
+        "--window-start",
+        args.window_start,
+        "--window-end",
+        args.window_end,
+    ]
+    if args.generated_at:
+        portfolio_cmd += ["--generated-at", args.generated_at]
+    _run(portfolio_cmd)
+
+    _run(
+        [
+            sys.executable,
+            "scripts/build_kpi_weekly_snapshot.py",
+            "--portfolio-scorecard",
+            str(portfolio_out),
+            "--out",
+            str(kpi_out),
+            "--week-ending",
+            args.window_end,
+            "--program-status",
+            args.program_status,
+            "--rollback-count",
+            str(args.rollback_count),
+        ]
+    )
+
+    _run(
+        [
+            sys.executable,
+            "scripts/check_kpi_weekly_contract.py",
+            "--schema",
+            "docs/kpi-schema.v1.json",
+            "--payload",
+            str(kpi_out),
+            "--out",
+            str(kpi_contract_out),
+        ]
+    )
+
+    _run(
+        [
+            sys.executable,
+            "scripts/check_top_tier_reporting_contract.py",
+            "--portfolio-scorecard",
+            str(portfolio_out),
+            "--kpi-weekly",
+            str(kpi_out),
+            "--out",
+            str(cross_contract_out),
+        ]
+    )
+
+    print(f"wrote bundle to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_top_tier_reporting_bundle.py
+++ b/scripts/build_top_tier_reporting_bundle.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -11,6 +13,13 @@ from pathlib import Path
 
 def _run(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
 
 
 def main() -> int:
@@ -23,6 +32,7 @@ def main() -> int:
     ap.add_argument("--schema-version", default="1.0.0")
     ap.add_argument("--program-status", default="green", choices=("green", "amber", "red"))
     ap.add_argument("--rollback-count", type=int, default=0)
+    ap.add_argument("--manifest-out", default="", help="Optional output path for bundle manifest JSON")
     args = ap.parse_args()
 
     out_dir = Path(args.out_dir)
@@ -93,6 +103,23 @@ def main() -> int:
             str(cross_contract_out),
         ]
     )
+
+    manifest = {
+        "ok": True,
+        "window": {"start": args.window_start, "end": args.window_end},
+        "program_status": args.program_status,
+        "artifacts": {
+            "portfolio_scorecard": {"path": str(portfolio_out), "sha256": _sha256(portfolio_out)},
+            "kpi_weekly": {"path": str(kpi_out), "sha256": _sha256(kpi_out)},
+            "kpi_contract_check": {"path": str(kpi_contract_out), "sha256": _sha256(kpi_contract_out)},
+            "top_tier_contract_check": {"path": str(cross_contract_out), "sha256": _sha256(cross_contract_out)},
+        },
+    }
+
+    if args.manifest_out:
+        manifest_path = Path(args.manifest_out)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
 
     print(f"wrote bundle to {out_dir}")
     return 0

--- a/scripts/check_kpi_weekly_contract.py
+++ b/scripts/check_kpi_weekly_contract.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Validate a KPI weekly payload against repo KPI schema contract (lightweight checker)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _validate_metric(metric: dict[str, Any], metric_key: str, required_fields: list[str]) -> None:
+    for key in required_fields:
+        _expect(key in metric, f"{metric_key}: missing field '{key}'")
+
+    _expect(isinstance(metric["unit"], str), f"{metric_key}.unit must be string")
+    _expect(isinstance(metric["quality"], str), f"{metric_key}.quality must be string")
+    _expect(isinstance(metric["source"], str), f"{metric_key}.source must be string")
+    _expect(metric["quality"] in {"seed", "provisional", "stable"}, f"{metric_key}.quality invalid")
+
+
+def _validate(schema: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    required_top = list(schema.get("required", []))
+    for key in required_top:
+        _expect(key in payload, f"missing top-level required field '{key}'")
+
+    _expect(payload.get("schema_version") == schema.get("properties", {}).get("schema_version", {}).get("const"), "schema_version mismatch")
+
+    kpis = payload.get("kpis")
+    _expect(isinstance(kpis, dict), "kpis must be object")
+
+    required_kpis = list(schema.get("properties", {}).get("kpis", {}).get("required", []))
+    metric_required = list(schema.get("$defs", {}).get("metric", {}).get("required", []))
+    for metric_key in required_kpis:
+        _expect(metric_key in kpis, f"missing required KPI '{metric_key}'")
+        _expect(isinstance(kpis[metric_key], dict), f"{metric_key} must be object")
+        _validate_metric(kpis[metric_key], metric_key, metric_required)
+
+    return {
+        "ok": True,
+        "schema_version": payload.get("schema_version"),
+        "week_ending": payload.get("week_ending"),
+        "required_kpi_count": len(required_kpis),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Check KPI weekly payload contract")
+    ap.add_argument("--schema", required=True)
+    ap.add_argument("--payload", required=True)
+    ap.add_argument("--out", default="", help="Optional JSON report output path")
+    args = ap.parse_args()
+
+    schema = json.loads(Path(args.schema).read_text())
+    payload = json.loads(Path(args.payload).read_text())
+    report = _validate(schema, payload)
+
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report, indent=2) + "\n")
+
+    print(json.dumps(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_top_tier_bundle_manifest.py
+++ b/scripts/check_top_tier_bundle_manifest.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Validate top-tier bundle manifest file integrity and required fields."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+_REQUIRED_ARTIFACT_KEYS = (
+    "portfolio_scorecard",
+    "kpi_weekly",
+    "kpi_contract_check",
+    "top_tier_contract_check",
+)
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def _validate(manifest: dict[str, Any]) -> dict[str, Any]:
+    _expect(manifest.get("ok") is True, "manifest.ok must be true")
+    _expect(isinstance(manifest.get("window"), dict), "manifest.window must be object")
+
+    artifacts = manifest.get("artifacts")
+    _expect(isinstance(artifacts, dict), "manifest.artifacts must be object")
+
+    checked = []
+    for key in _REQUIRED_ARTIFACT_KEYS:
+        _expect(key in artifacts, f"missing artifact entry: {key}")
+        entry = artifacts[key]
+        _expect(isinstance(entry, dict), f"artifact entry {key} must be object")
+
+        path = Path(str(entry.get("path", "")))
+        _expect(path.is_file(), f"artifact path missing: {path}")
+
+        expected = str(entry.get("sha256", ""))
+        actual = _sha256(path)
+        _expect(expected == actual, f"sha256 mismatch for {key}: expected {expected}, got {actual}")
+        checked.append({"key": key, "path": str(path), "sha256": actual})
+
+    return {
+        "ok": True,
+        "checked_count": len(checked),
+        "window": manifest.get("window"),
+        "artifacts": checked,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Check top-tier bundle manifest")
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--out", default="", help="Optional JSON report output path")
+    args = ap.parse_args()
+
+    manifest = json.loads(Path(args.manifest).read_text())
+    report = _validate(manifest)
+
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report, indent=2) + "\n")
+
+    print(json.dumps(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_top_tier_reporting_contract.py
+++ b/scripts/check_top_tier_reporting_contract.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate consistency between portfolio scorecard and KPI weekly snapshot artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        _fail(message)
+
+
+def _as_float(value: Any) -> float:
+    return float(value)
+
+
+def _validate(portfolio: dict[str, Any], kpi_payload: dict[str, Any]) -> dict[str, Any]:
+    repos = list(portfolio.get("repos", []))
+    totals = dict(portfolio.get("totals", {}))
+    repo_count = int(totals.get("repo_count_total", len(repos)))
+
+    _expect(repo_count == len(repos), "repo_count_total must equal number of repos")
+
+    kpis = dict(kpi_payload.get("kpis", {}))
+    required_kpis = {
+        "first_time_success_onboarding_rate",
+        "failed_release_gate_frequency",
+        "rollback_rate",
+    }
+    missing = required_kpis - set(kpis)
+    _expect(not missing, f"missing required KPI keys: {sorted(missing)}")
+
+    release_confidence_pass = sum(1 for row in repos if bool(row.get("release_confidence_ok", False)))
+    expected_onboarding_rate = round((release_confidence_pass / repo_count * 100), 2) if repo_count else 0.0
+
+    actual_onboarding = _as_float(kpis["first_time_success_onboarding_rate"]["value"])
+    _expect(
+        abs(actual_onboarding - expected_onboarding_rate) < 0.01,
+        f"onboarding rate mismatch: expected {expected_onboarding_rate}, got {actual_onboarding}",
+    )
+
+    expected_failed_release = _as_float(totals.get("release_gate_failure_rate_percent", 0.0))
+    actual_failed_release = _as_float(kpis["failed_release_gate_frequency"]["value"])
+    _expect(
+        abs(actual_failed_release - expected_failed_release) < 0.01,
+        f"failed release frequency mismatch: expected {expected_failed_release}, got {actual_failed_release}",
+    )
+
+    sample_size = kpis["failed_release_gate_frequency"].get("sample_size")
+    _expect(sample_size == repo_count, f"failed_release_gate_frequency.sample_size must equal {repo_count}")
+
+    evidence_window_end_values = {row.get("evidence_window_end") for row in repos if row.get("evidence_window_end")}
+    if evidence_window_end_values and kpi_payload.get("week_ending"):
+        _expect(
+            kpi_payload["week_ending"] in evidence_window_end_values,
+            "kpi week_ending must match evidence_window_end in portfolio repos",
+        )
+
+    return {
+        "ok": True,
+        "repo_count": repo_count,
+        "week_ending": kpi_payload.get("week_ending"),
+        "checks": [
+            "repo_count_total_matches_repos",
+            "onboarding_rate_consistent",
+            "failed_release_rate_consistent",
+            "sample_size_consistent",
+            "week_alignment_consistent",
+        ],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Check top-tier reporting contract consistency")
+    ap.add_argument("--portfolio-scorecard", required=True)
+    ap.add_argument("--kpi-weekly", required=True)
+    ap.add_argument("--out", default="", help="Optional JSON report output path")
+    args = ap.parse_args()
+
+    portfolio = json.loads(Path(args.portfolio_scorecard).read_text())
+    kpi_weekly = json.loads(Path(args.kpi_weekly).read_text())
+
+    report = _validate(portfolio, kpi_weekly)
+
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report, indent=2) + "\n")
+
+    print(json.dumps(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/promote_top_tier_bundle.py
+++ b/scripts/promote_top_tier_bundle.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Promote generated top-tier bundle outputs to canonical docs/artifacts sample paths."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def _copy(src: Path, dst: Path) -> None:
+    if not src.is_file():
+        raise FileNotFoundError(f"missing source artifact: {src}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Promote top-tier bundle outputs")
+    ap.add_argument("--bundle-dir", required=True)
+    ap.add_argument("--date-tag", required=True, help="Date tag like 2026-04-17")
+    args = ap.parse_args()
+
+    bundle = Path(args.bundle_dir)
+    date = args.date_tag
+
+    mappings = {
+        bundle / "portfolio-scorecard.json": Path(f"docs/artifacts/portfolio-scorecard-sample-{date}.json"),
+        bundle / "kpi-weekly.json": Path(f"docs/artifacts/kpi-weekly-from-portfolio-{date}.json"),
+        bundle / "kpi-contract-check.json": Path(f"docs/artifacts/kpi-weekly-contract-check-{date}.json"),
+        bundle / "top-tier-contract-check.json": Path(f"docs/artifacts/top-tier-contract-check-{date}.json"),
+    }
+
+    for src, dst in mappings.items():
+        _copy(src, dst)
+
+    print(f"promoted {len(mappings)} artifacts for {date}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_kpi_weekly_snapshot.py
+++ b/tests/test_build_kpi_weekly_snapshot.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_build_kpi_weekly_snapshot_from_portfolio_sample(tmp_path: Path) -> None:
+    portfolio = Path("docs/artifacts/portfolio-scorecard-sample-2026-04-17.json")
+    out = tmp_path / "kpi-weekly.json"
+
+    cmd = [
+        sys.executable,
+        "scripts/build_kpi_weekly_snapshot.py",
+        "--portfolio-scorecard",
+        str(portfolio),
+        "--out",
+        str(out),
+        "--week-ending",
+        "2026-04-17",
+        "--program-status",
+        "green",
+        "--rollback-count",
+        "0",
+    ]
+    subprocess.run(cmd, check=True)
+
+    payload = json.loads(out.read_text())
+
+    assert payload["schema_version"] == "1.0.0"
+    assert payload["week_ending"] == "2026-04-17"
+    assert payload["program_status"] == "green"
+
+    kpis = payload["kpis"]
+    assert kpis["first_time_success_onboarding_rate"]["value"] == 33.33
+    assert kpis["first_time_success_onboarding_rate"]["sample_size"] == 3
+
+    assert kpis["failed_release_gate_frequency"]["value"] == 33.33
+    assert kpis["failed_release_gate_frequency"]["unit"] == "percent"
+
+    assert kpis["rollback_rate"]["value"] == 0
+    assert kpis["rollback_rate"]["unit"] == "count"
+
+    assert kpis["median_release_decision_time"]["value"] is None
+    assert kpis["mean_time_to_triage_first_failure"]["value"] is None
+    assert kpis["docs_to_adoption_conversion"]["value"] is None

--- a/tests/test_build_portfolio_scorecard.py
+++ b/tests/test_build_portfolio_scorecard.py
@@ -76,3 +76,28 @@ def test_build_portfolio_scorecard_emits_versioned_contract(tmp_path: Path) -> N
     assert repos["svc-a"]["release_confidence_ok"] is True
     assert repos["svc-b"]["risk_tier"] == "high"
     assert repos["svc-b"]["release_confidence_ok"] is False
+
+
+def test_portfolio_scorecard_sample_artifact_matches_contract_shape() -> None:
+    sample = Path("docs/artifacts/portfolio-scorecard-sample-2026-04-17.json")
+    payload = json.loads(sample.read_text())
+
+    assert payload["schema_name"] == "sdetkit.portfolio.aggregate"
+    assert payload["schema_version"] == "1.0.0"
+
+    totals = payload["totals"]
+    assert totals["repo_count_total"] == len(payload["repos"])
+    assert set(totals).issuperset(
+        {
+            "repo_count_total",
+            "repo_count_reporting",
+            "high_risk_repo_count",
+            "medium_risk_repo_count",
+            "low_risk_repo_count",
+        }
+    )
+
+    for row in payload["repos"]:
+        assert "repo_id" in row
+        assert row["risk_tier"] in {"low", "medium", "high"}
+        assert "evidence_window_end" in row

--- a/tests/test_build_portfolio_scorecard.py
+++ b/tests/test_build_portfolio_scorecard.py
@@ -55,6 +55,8 @@ def test_build_portfolio_scorecard_emits_versioned_contract(tmp_path: Path) -> N
         "2026-04-11",
         "--window-end",
         "2026-04-17",
+        "--generated-at",
+        "2026-04-17T10:00:00Z",
     ]
     subprocess.run(cmd, check=True)
 
@@ -62,6 +64,7 @@ def test_build_portfolio_scorecard_emits_versioned_contract(tmp_path: Path) -> N
 
     assert payload["schema_name"] == "sdetkit.portfolio.aggregate"
     assert payload["schema_version"] == "1.0.0"
+    assert payload["generated_at"] == "2026-04-17T10:00:00Z"
     assert payload["window"] == {"start_date": "2026-04-11", "end_date": "2026-04-17"}
 
     totals = payload["totals"]

--- a/tests/test_build_portfolio_scorecard.py
+++ b/tests/test_build_portfolio_scorecard.py
@@ -6,33 +6,19 @@ import sys
 from pathlib import Path
 
 
-def _run_builder(input_path: Path, output_path: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [
-            sys.executable,
-            "scripts/build_portfolio_scorecard.py",
-            "--in",
-            str(input_path),
-            "--out",
-            str(output_path),
-        ],
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+def test_build_portfolio_scorecard_emits_versioned_contract(tmp_path: Path) -> None:
+    infile = tmp_path / "portfolio-input.jsonl"
+    outfile = tmp_path / "portfolio-out.json"
 
-
-def test_build_portfolio_scorecard_from_jsonl(tmp_path: Path) -> None:
-    input_path = tmp_path / "records.jsonl"
-    output_path = tmp_path / "summary.json"
-    input_path.write_text(
+    infile.write_text(
         "\n".join(
             [
                 json.dumps(
                     {
-                        "repo": "repo-a",
-                        "team": "team-1",
+                        "repo": "svc-a",
+                        "team": "checkout",
                         "lane": "scale",
+                        "timestamp": "2026-04-16T10:00:00Z",
                         "gate_fast_ok": True,
                         "gate_release_ok": True,
                         "doctor_ok": True,
@@ -41,9 +27,10 @@ def test_build_portfolio_scorecard_from_jsonl(tmp_path: Path) -> None:
                 ),
                 json.dumps(
                     {
-                        "repo": "repo-b",
-                        "team": "team-2",
-                        "lane": "regulated",
+                        "repo": "svc-b",
+                        "team": "growth",
+                        "lane": "startup",
+                        "timestamp": "2026-04-16T11:00:00Z",
                         "gate_fast_ok": True,
                         "gate_release_ok": False,
                         "doctor_ok": True,
@@ -52,55 +39,40 @@ def test_build_portfolio_scorecard_from_jsonl(tmp_path: Path) -> None:
                 ),
             ]
         )
-        + "\n",
-        encoding="utf-8",
+        + "\n"
     )
 
-    result = _run_builder(input_path, output_path)
+    cmd = [
+        sys.executable,
+        "scripts/build_portfolio_scorecard.py",
+        "--in",
+        str(infile),
+        "--out",
+        str(outfile),
+        "--schema-version",
+        "1.0.0",
+        "--window-start",
+        "2026-04-11",
+        "--window-end",
+        "2026-04-17",
+    ]
+    subprocess.run(cmd, check=True)
 
-    assert result.returncode == 0, result.stderr
-    summary = json.loads(output_path.read_text(encoding="utf-8"))
-    assert summary["total_repos"] == 2
-    assert summary["risk_counts"] == {"low": 1, "high": 1}
-    assert summary["pct_low_risk"] == 50.0
-    assert summary["pct_release_gate_failure"] == 50.0
+    payload = json.loads(outfile.read_text())
 
+    assert payload["schema_name"] == "sdetkit.portfolio.aggregate"
+    assert payload["schema_version"] == "1.0.0"
+    assert payload["window"] == {"start_date": "2026-04-11", "end_date": "2026-04-17"}
 
-def test_build_portfolio_scorecard_from_json_array(tmp_path: Path) -> None:
-    input_path = tmp_path / "records.json"
-    output_path = tmp_path / "summary.json"
-    input_path.write_text(
-        json.dumps(
-            [
-                {
-                    "repo": "repo-c",
-                    "team": "team-3",
-                    "lane": "startup",
-                    "gate_fast_ok": True,
-                    "gate_release_ok": True,
-                    "doctor_ok": False,
-                    "failed_steps_count": 1,
-                }
-            ]
-        ),
-        encoding="utf-8",
-    )
+    totals = payload["totals"]
+    assert totals["repo_count_total"] == 2
+    assert totals["repo_count_reporting"] == 2
+    assert totals["high_risk_repo_count"] == 1
+    assert totals["low_risk_repo_count"] == 1
+    assert totals["release_gate_failure_rate_percent"] == 50.0
 
-    result = _run_builder(input_path, output_path)
-
-    assert result.returncode == 0, result.stderr
-    summary = json.loads(output_path.read_text(encoding="utf-8"))
-    assert summary["total_repos"] == 1
-    assert summary["risk_counts"] == {"medium": 1}
-    assert summary["pct_low_risk"] == 0.0
-
-
-def test_build_portfolio_scorecard_rejects_non_list_json(tmp_path: Path) -> None:
-    input_path = tmp_path / "bad.json"
-    output_path = tmp_path / "summary.json"
-    input_path.write_text(json.dumps({"repo": "not-a-list"}), encoding="utf-8")
-
-    result = _run_builder(input_path, output_path)
-
-    assert result.returncode != 0
-    assert "JSON input must be a list of records" in result.stderr
+    repos = {row["repo_id"]: row for row in payload["repos"]}
+    assert repos["svc-a"]["risk_tier"] == "low"
+    assert repos["svc-a"]["release_confidence_ok"] is True
+    assert repos["svc-b"]["risk_tier"] == "high"
+    assert repos["svc-b"]["release_confidence_ok"] is False

--- a/tests/test_build_top_tier_reporting_bundle.py
+++ b/tests/test_build_top_tier_reporting_bundle.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_build_top_tier_reporting_bundle_generates_outputs(tmp_path: Path) -> None:
+    out_dir = tmp_path / "bundle"
+
+    cmd = [
+        sys.executable,
+        "scripts/build_top_tier_reporting_bundle.py",
+        "--input",
+        "docs/artifacts/portfolio-input-sample-2026-04-17.jsonl",
+        "--out-dir",
+        str(out_dir),
+        "--window-start",
+        "2026-04-11",
+        "--window-end",
+        "2026-04-17",
+        "--generated-at",
+        "2026-04-17T10:00:00Z",
+    ]
+    subprocess.run(cmd, check=True)
+
+    portfolio = json.loads((out_dir / "portfolio-scorecard.json").read_text())
+    kpi = json.loads((out_dir / "kpi-weekly.json").read_text())
+    kpi_check = json.loads((out_dir / "kpi-contract-check.json").read_text())
+    cross_check = json.loads((out_dir / "top-tier-contract-check.json").read_text())
+
+    assert portfolio["schema_name"] == "sdetkit.portfolio.aggregate"
+    assert kpi["schema_version"] == "1.0.0"
+    assert kpi_check["ok"] is True
+    assert cross_check["ok"] is True

--- a/tests/test_build_top_tier_reporting_bundle.py
+++ b/tests/test_build_top_tier_reporting_bundle.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 def test_build_top_tier_reporting_bundle_generates_outputs(tmp_path: Path) -> None:
     out_dir = tmp_path / "bundle"
+    manifest = tmp_path / "bundle-manifest.json"
 
     cmd = [
         sys.executable,
@@ -22,6 +23,8 @@ def test_build_top_tier_reporting_bundle_generates_outputs(tmp_path: Path) -> No
         "2026-04-17",
         "--generated-at",
         "2026-04-17T10:00:00Z",
+        "--manifest-out",
+        str(manifest),
     ]
     subprocess.run(cmd, check=True)
 
@@ -29,8 +32,11 @@ def test_build_top_tier_reporting_bundle_generates_outputs(tmp_path: Path) -> No
     kpi = json.loads((out_dir / "kpi-weekly.json").read_text())
     kpi_check = json.loads((out_dir / "kpi-contract-check.json").read_text())
     cross_check = json.loads((out_dir / "top-tier-contract-check.json").read_text())
+    bundle_manifest = json.loads(manifest.read_text())
 
     assert portfolio["schema_name"] == "sdetkit.portfolio.aggregate"
     assert kpi["schema_version"] == "1.0.0"
     assert kpi_check["ok"] is True
     assert cross_check["ok"] is True
+    assert bundle_manifest["ok"] is True
+    assert bundle_manifest["artifacts"]["portfolio_scorecard"]["path"].endswith("portfolio-scorecard.json")

--- a/tests/test_check_kpi_weekly_contract.py
+++ b/tests/test_check_kpi_weekly_contract.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_check_kpi_weekly_contract_on_sample_payload(tmp_path: Path) -> None:
+    schema = Path("docs/kpi-schema.v1.json")
+    payload = Path("docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json")
+    out = tmp_path / "kpi-contract-check.json"
+
+    cmd = [
+        sys.executable,
+        "scripts/check_kpi_weekly_contract.py",
+        "--schema",
+        str(schema),
+        "--payload",
+        str(payload),
+        "--out",
+        str(out),
+    ]
+    subprocess.run(cmd, check=True)
+
+    report = json.loads(out.read_text())
+    assert report["ok"] is True
+    assert report["schema_version"] == "1.0.0"
+    assert report["week_ending"] == "2026-04-17"
+    assert report["required_kpi_count"] == 6

--- a/tests/test_check_top_tier_bundle_manifest.py
+++ b/tests/test_check_top_tier_bundle_manifest.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_check_top_tier_bundle_manifest_on_sample_manifest(tmp_path: Path) -> None:
+    manifest = Path("docs/artifacts/top-tier-bundle-manifest-2026-04-17.json")
+    out = tmp_path / "manifest-check.json"
+
+    cmd = [
+        sys.executable,
+        "scripts/check_top_tier_bundle_manifest.py",
+        "--manifest",
+        str(manifest),
+        "--out",
+        str(out),
+    ]
+    subprocess.run(cmd, check=True)
+
+    report = json.loads(out.read_text())
+    assert report["ok"] is True
+    assert report["checked_count"] == 4
+    assert report["window"] == {"start": "2026-04-11", "end": "2026-04-17"}

--- a/tests/test_check_top_tier_bundle_manifest.py
+++ b/tests/test_check_top_tier_bundle_manifest.py
@@ -6,11 +6,30 @@ import sys
 from pathlib import Path
 
 
-def test_check_top_tier_bundle_manifest_on_sample_manifest(tmp_path: Path) -> None:
-    manifest = Path("docs/artifacts/top-tier-bundle-manifest-2026-04-17.json")
+def test_check_top_tier_bundle_manifest_on_generated_manifest(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    manifest = tmp_path / "manifest.json"
     out = tmp_path / "manifest-check.json"
 
-    cmd = [
+    build_cmd = [
+        sys.executable,
+        "scripts/build_top_tier_reporting_bundle.py",
+        "--input",
+        "docs/artifacts/portfolio-input-sample-2026-04-17.jsonl",
+        "--out-dir",
+        str(bundle_dir),
+        "--window-start",
+        "2026-04-11",
+        "--window-end",
+        "2026-04-17",
+        "--generated-at",
+        "2026-04-17T10:00:00Z",
+        "--manifest-out",
+        str(manifest),
+    ]
+    subprocess.run(build_cmd, check=True)
+
+    check_cmd = [
         sys.executable,
         "scripts/check_top_tier_bundle_manifest.py",
         "--manifest",
@@ -18,7 +37,7 @@ def test_check_top_tier_bundle_manifest_on_sample_manifest(tmp_path: Path) -> No
         "--out",
         str(out),
     ]
-    subprocess.run(cmd, check=True)
+    subprocess.run(check_cmd, check=True)
 
     report = json.loads(out.read_text())
     assert report["ok"] is True

--- a/tests/test_check_top_tier_reporting_contract.py
+++ b/tests/test_check_top_tier_reporting_contract.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_check_top_tier_reporting_contract_sample_artifacts(tmp_path: Path) -> None:
+    portfolio = Path("docs/artifacts/portfolio-scorecard-sample-2026-04-17.json")
+    kpi_weekly = Path("docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json")
+    out = tmp_path / "contract-check.json"
+
+    cmd = [
+        sys.executable,
+        "scripts/check_top_tier_reporting_contract.py",
+        "--portfolio-scorecard",
+        str(portfolio),
+        "--kpi-weekly",
+        str(kpi_weekly),
+        "--out",
+        str(out),
+    ]
+    subprocess.run(cmd, check=True)
+
+    report = json.loads(out.read_text())
+    assert report["ok"] is True
+    assert report["repo_count"] == 3
+    assert report["week_ending"] == "2026-04-17"

--- a/tests/test_promote_top_tier_bundle.py
+++ b/tests/test_promote_top_tier_bundle.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_promote_top_tier_bundle_from_generated_bundle(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+
+    build_cmd = [
+        sys.executable,
+        "scripts/build_top_tier_reporting_bundle.py",
+        "--input",
+        "docs/artifacts/portfolio-input-sample-2026-04-17.jsonl",
+        "--out-dir",
+        str(bundle_dir),
+        "--window-start",
+        "2026-04-11",
+        "--window-end",
+        "2026-04-17",
+        "--generated-at",
+        "2026-04-17T10:00:00Z",
+    ]
+    subprocess.run(build_cmd, check=True)
+
+    promote_cmd = [
+        sys.executable,
+        "scripts/promote_top_tier_bundle.py",
+        "--bundle-dir",
+        str(bundle_dir),
+        "--date-tag",
+        "2099-01-01",
+    ]
+    subprocess.run(promote_cmd, check=True)
+
+    assert Path("docs/artifacts/portfolio-scorecard-sample-2099-01-01.json").is_file()
+    assert Path("docs/artifacts/kpi-weekly-from-portfolio-2099-01-01.json").is_file()
+    assert Path("docs/artifacts/kpi-weekly-contract-check-2099-01-01.json").is_file()
+    assert Path("docs/artifacts/top-tier-contract-check-2099-01-01.json").is_file()
+
+    # cleanup files created by this test in repo workspace
+    Path("docs/artifacts/portfolio-scorecard-sample-2099-01-01.json").unlink(missing_ok=True)
+    Path("docs/artifacts/kpi-weekly-from-portfolio-2099-01-01.json").unlink(missing_ok=True)
+    Path("docs/artifacts/kpi-weekly-contract-check-2099-01-01.json").unlink(missing_ok=True)
+    Path("docs/artifacts/top-tier-contract-check-2099-01-01.json").unlink(missing_ok=True)

--- a/tests/test_top_tier_reporting_makefile.py
+++ b/tests/test_top_tier_reporting_makefile.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+MAKEFILE = Path('Makefile')
+
+
+def test_top_tier_reporting_makefile_exposes_config_variables() -> None:
+    text = MAKEFILE.read_text()
+
+    assert 'DATE_TAG ?=' in text
+    assert 'WINDOW_START ?=' in text
+    assert 'WINDOW_END ?=' in text
+    assert 'GENERATED_AT ?=' in text
+
+
+def test_top_tier_reporting_target_uses_parameterized_variables() -> None:
+    text = MAKEFILE.read_text()
+
+    assert 'top-tier-reporting: venv' in text
+    assert 'portfolio-input-sample-$(DATE_TAG).jsonl' in text
+    assert '--window-start $(WINDOW_START)' in text
+    assert '--window-end $(WINDOW_END)' in text
+    assert '--generated-at $(GENERATED_AT)' in text
+    assert 'top-tier-bundle-manifest-$(DATE_TAG).json' in text
+    assert 'promote_top_tier_bundle.py --bundle-dir docs/artifacts/top-tier-bundle --date-tag $(DATE_TAG)' in text

--- a/tests/test_top_tier_reporting_readme.py
+++ b/tests/test_top_tier_reporting_readme.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+README = Path('README.md')
+
+
+def test_readme_mentions_top_tier_reporting_pipeline() -> None:
+    text = README.read_text()
+
+    assert '## Top-tier reporting sample pipeline' in text
+    assert 'make top-tier-reporting' in text
+    assert 'docs/portfolio-reporting-recipe.md' in text
+    assert 'docs/kpi-schema.md' in text

--- a/tests/test_top_tier_reporting_workflow.py
+++ b/tests/test_top_tier_reporting_workflow.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = Path('.github/workflows/top-tier-reporting-sample.yml')
+
+
+def test_top_tier_reporting_workflow_runs_make_target_and_contract_tests() -> None:
+    text = WORKFLOW.read_text()
+
+    assert 'run: make top-tier-reporting' in text
+    assert 'tests/test_build_portfolio_scorecard.py' in text
+    assert 'tests/test_build_kpi_weekly_snapshot.py' in text
+    assert 'tests/test_check_top_tier_reporting_contract.py' in text
+    assert 'tests/test_check_top_tier_bundle_manifest.py' in text
+
+
+def test_top_tier_reporting_workflow_uploads_key_artifacts() -> None:
+    text = WORKFLOW.read_text()
+
+    assert 'docs/artifacts/portfolio-scorecard-sample-2026-04-17.json' in text
+    assert 'docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json' in text
+    assert 'docs/artifacts/kpi-weekly-contract-check-2026-04-17.json' in text
+    assert 'docs/artifacts/top-tier-contract-check-2026-04-17.json' in text
+    assert 'docs/artifacts/top-tier-bundle-manifest-2026-04-17.json' in text
+    assert 'docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json' in text


### PR DESCRIPTION
### Motivation

- Publish the week-ending executive report and seed KPI baseline to drive program visibility for 2026-04-17.
- Establish a machine-readable KPI contract and a portfolio aggregation versioning convention to unblock WS2 reporting and downstream consumers.
- Provide role-based quickstarts (release owner, platform engineer, QA governance) to accelerate adoption and evidence collection for the top-tier program.

### Description

- Added an executive weekly report `docs/executive-weekly-2026-04-17.md` and a machine-readable weekly KPI instance `docs/kpi-weekly-2026-04-17.json` representing the seed baseline.
- Introduced the KPI contract docs and schema: `docs/kpi-schema.md` and `docs/kpi-schema.v1.json` (schema v1) and a human-readable `docs/kpi-baseline-week-2026-04-17.md` explaining the seed values and evidence.
- Added a portfolio aggregation versioning convention `docs/portfolio-aggregation-schema.md` and updated the top-tier dashboard `docs/top-tier-program-dashboard.md` to reflect seed baseline and closed blocker status.
- Added role-based quickstart skeletons and per-role quickstarts: `docs/role-based-quickstarts.md`, `docs/quickstart-role-release-owner.md`, `docs/quickstart-role-platform-engineer.md`, and `docs/quickstart-role-qa-governance.md` and updated `docs/index.md` to include the KPI contract link.

### Testing

- Ran repository layout check with `python scripts/check_repo_layout.py` and it completed successfully.
- Executed unit/integration tests with `python -m pytest -q tests/test_phase1_hardening.py` and they passed.
- Validated the JSON KPI instance against the new schema using a JSON-schema validator (`docs/kpi-weekly-2026-04-17.json` vs `docs/kpi-schema.v1.json`) and the file conforms to the schema.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df004b64e0832d9dbc795848efe464)