### PR TITLE
Add enterprise reliability profile, focused reruns, and next-pass handoff to `doctor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - add GHAS alert SLA + metrics export bots, wire them into maintenance coverage checks, and refresh GHAS automation docs.
 - add Name 86 launch readiness closeout lane command, docs, checks, and tests (`name86-launch-readiness-closeout`).
 - upgrade audit: parse modern `pyproject.toml` `[dependency-groups]` declarations, including `{include-group = "..."}` expansions.
+- doctor enterprise workflow: add `--enterprise`, `--enterprise-rerun-failed`, `--enterprise-rerun-high`, and `--enterprise-next-pass-only` modes with enterprise insights/remediation bundles in JSON+markdown output and workspace-driven focused reruns.
 
 # Changelog
 ## [1.0.2]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,46 @@ Use this exact sequence first:
 
 This is the primary product path for first-time adoption and release-confidence proof. If a new visitor remembers only one thing, it should be this exact path.
 
+## Enterprise reliability workflow (step-by-step)
+
+After the canonical path succeeds, use the enterprise doctor profile for stricter release governance and focused remediation loops:
+
+1. Full enterprise scan:
+   - `python -m sdetkit doctor --enterprise --format md`
+2. Focused failed-check rerun from workspace history:
+   - `python -m sdetkit doctor --enterprise-rerun-failed --json`
+   - optional scope cap: `--enterprise-rerun-top <N>`
+3. Focused high-severity rerun from workspace history:
+   - `python -m sdetkit doctor --enterprise-rerun-high --json`
+   - optional scope cap: `--enterprise-rerun-top <N>`
+4. Repeat rerun/fix cycles until blockers are cleared and score stabilizes.
+5. Automation handoff (emit only suggested next-pass command):
+   - `python -m sdetkit doctor --enterprise-next-pass-only`
+   - CI-friendly status mode: `python -m sdetkit doctor --enterprise-next-pass-only --enterprise-next-pass-exit-code`
+     (returns exit code `2` when a follow-up pass is recommended, else `0`)
+   - plain output emits three lines: command/no-op, `reason: ...`, `alternates: ...`
+   - markdown-friendly output: `python -m sdetkit doctor --enterprise-next-pass-only --format md`
+   - when no follow-up is needed in markdown mode, output is `_no follow-up pass required_`
+   - markdown mode also emits a second line reason hint: `` `reason: <reason>` ``
+   - markdown mode also emits a third line alternates hint: `` `alternates: <cmds|none>` ``
+   - JSON handoff payload includes `schema_version=sdetkit.doctor.next_pass.v1`
+   - JSON handoff payload includes `has_next_pass` boolean for direct pipeline branching
+   - JSON handoff payload includes `next_pass_reason` (`none|blockers_present|failed_checks_present`)
+   - JSON handoff payload includes `alternate_commands` for fallback lane selection
+   - JSON handoff payload includes `exit_code_hint` (`0` no follow-up, `2` follow-up recommended)
+   - note: this handoff mode is standalone and cannot be combined with rerun flags.
+   - note: `--enterprise-next-pass-exit-code` only works with `--enterprise-next-pass-only`.
+
+If historical workspace payloads do not include per-check severity metadata, `--enterprise-rerun-high` falls back to rerunning recorded failed checks.
+
+Expected enterprise outputs include:
+
+- profile markers (`profile=enterprise`, `profile_mode=full_scan|rerun_failed|rerun_high`)
+- rerun scope metadata (`rerun_top`) when `--enterprise-rerun-top` is used
+- enterprise execution insights (maturity tier, blockers, optimization queue, next-pass reason)
+- next-pass command hint (`next_pass_command`) for the recommended focused rerun step
+- remediation bundle items for rapid operator follow-up
+
 ## Stability-aware command discovery
 
 After the canonical path is working, expand deliberately:

--- a/docs/final-enterprise-reliability-plan.md
+++ b/docs/final-enterprise-reliability-plan.md
@@ -1,0 +1,140 @@
+# Final Enterprise Reliability Execution Plan
+
+## Objective
+Turn `sdetkit` into a company-grade, highly reliable automation platform with deterministic quality gates, resilient integrations, and measurable operational trust.
+
+Execution tracker: `plans/enterprise-reliability-execution-tracker.json`.
+
+## Success Criteria (Exit Gates)
+- Doctor enterprise profile is adoption-ready with actionable insights and evidence outputs for CI/release governance.
+- All critical reliability paths have deterministic tests and contract checks.
+- Upgrade, release, and incident-response loops are codified with runbooks and automation.
+- KPI dashboards report trend, risk, and remediation latency.
+
+---
+
+## Phase 1 — Baseline Lockdown (Week 1)
+### 1.1 Establish hard baseline
+- Freeze current quality baseline (`doctor`, `gate`, `security`, `repo` outputs).
+- Capture golden snapshots for enterprise-mode JSON and markdown outputs.
+- Record baseline scorecards in `.sdetkit/workspace` and docs.
+
+### 1.2 Harden policy defaults
+- Promote a default enterprise policy template (`sdetkit.policy.toml`) with fail-on thresholds by environment (`dev`, `ci`, `release`).
+- Require strict policy for protected branches.
+
+### 1.3 Close discoverability gaps
+- Update user-facing docs (`docs/cli.md`, `docs/release-readiness.md`) with enterprise-mode examples.
+- Add troubleshooting matrix for common failure signatures.
+
+**Deliverables**
+- Baseline snapshot artifacts
+- Policy template + docs update
+- Enterprise quickstart section
+
+---
+
+## Phase 2 — Reliability Deepening (Weeks 2–3)
+### 2.1 Double-analysis workflow
+Implement a repeatable two-pass enterprise workflow:
+1. **Pass A (Broad scan)**: full checks with upgrade intelligence.
+2. **Pass B (Focused validation)**: rerun only high-risk/failed checks with strict gating and evidence bundling.
+
+### 2.2 Action prioritization engine
+- Rank blockers by severity + blast radius + evidence density.
+- Add remediation bundles with:
+  - top 3 commands,
+  - expected validation checks,
+  - rollback notes.
+
+### 2.3 Evidence quality improvements
+- Standardize evidence schema fields (run id, scope, policy version, timestamp, commit SHA).
+- Ensure markdown and JSON evidence are cross-linked.
+
+**Deliverables**
+- Two-pass execution command set
+- Prioritized remediation bundles
+- Evidence schema revision doc
+
+---
+
+## Phase 3 — Toolchain Optimization (Weeks 3–4)
+### 3.1 Performance and determinism
+- Profile slow checks and add caching where safe.
+- Bound network-sensitive checks with timeout/retry policy.
+- Add deterministic offline mode guidance for CI.
+
+### 3.2 Upgrade governance
+- Expand upgrade-audit lanes with policy ownership and SLA tags.
+- Auto-generate dependency remediation roadmap by impact area.
+
+### 3.3 CI integration blueprint
+- Add reusable CI templates for:
+  - PR validation,
+  - release candidate gates,
+  - nightly deep reliability scan.
+
+**Deliverables**
+- Check runtime optimization report
+- Dependency governance matrix
+- CI blueprint examples
+- `templates/automations/enterprise-next-pass-handoff.yaml` for contract-driven follow-up branching
+
+---
+
+## Phase 4 — Enterprise Operations Readiness (Weeks 5–6)
+### 4.1 Incident and rollback readiness
+- Add incident response runbook for failed enterprise gates.
+- Add rollback criteria and safe bypass protocol with audit trail.
+
+### 4.2 SLO/KPI instrumentation
+Track:
+- gate pass rate,
+- mean time to remediate,
+- high-severity blocker recurrence,
+- dependency risk backlog burn-down,
+- release gate stability trend.
+
+### 4.3 Adoption package
+- Create role-based playbooks (platform, QA, security, release managers).
+- Provide migration checklist for existing repos.
+
+**Deliverables**
+- Incident runbook
+- KPI/SLO dashboard spec
+- Adoption playbook pack
+
+---
+
+## Phase 5 — Production Rollout and Continuous Improvement (Ongoing)
+### 5.1 Rollout model
+- Pilot in 1–2 internal repos.
+- Expand to tier-1 production repos.
+- Make enterprise profile default for release pipelines after stability criteria are met.
+
+### 5.2 Governance cadence
+- Weekly reliability review.
+- Monthly dependency risk review.
+- Quarterly policy and control revision.
+
+### 5.3 Continuous validation
+- Track escaped defects and post-release incidents.
+- Feed outcomes back into doctor checks, policy defaults, and evidence templates.
+
+**Deliverables**
+- Rollout completion report
+- Governance cadence calendar
+- Continuous-improvement backlog
+
+---
+
+## Step-by-Step Start (Immediate Next Actions)
+1. Run baseline capture and save artifacts.
+2. Publish enterprise policy template and wire CI fail-on thresholds.
+3. Add two-pass enterprise command examples to docs.
+4. Implement focused rerun mode for failed/high checks.
+5. Ship remediation bundle output in enterprise JSON.
+6. Pilot on one repo and review KPI deltas after one week.
+
+## Definition of Done
+- Enterprise mode is deterministic, documented, measurable, and operationalized in CI/release paths with clear ownership and incident playbooks.

--- a/plans/enterprise-reliability-execution-tracker.json
+++ b/plans/enterprise-reliability-execution-tracker.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "sdetkit.enterprise.execution-tracker.v1",
+  "objective": "Operationalize enterprise doctor workflow across remediation, CI handoff, and governance lanes.",
+  "updated_for": "2026-Q2",
+  "phases": [
+    {
+      "id": "phase-1-baseline",
+      "name": "Baseline Lockdown",
+      "status": "in_progress",
+      "success_metric": "Enterprise doctor run artifacts are generated and reviewed weekly.",
+      "tasks": [
+        {
+          "id": "baseline-capture",
+          "status": "in_progress",
+          "owner": "repo-ops",
+          "deliverable": "Initial enterprise baseline snapshots and scorecard"
+        },
+        {
+          "id": "policy-template",
+          "status": "pending",
+          "owner": "quality-governance",
+          "deliverable": "Versioned enterprise policy defaults"
+        }
+      ]
+    },
+    {
+      "id": "phase-2-remediation-loop",
+      "name": "Focused Remediation Loops",
+      "status": "in_progress",
+      "success_metric": "Rerun loops close high-severity blockers within one iteration window.",
+      "tasks": [
+        {
+          "id": "rerun-high-lane",
+          "status": "completed",
+          "owner": "repo-ops",
+          "deliverable": "--enterprise-rerun-high workflow"
+        },
+        {
+          "id": "next-pass-contract",
+          "status": "completed",
+          "owner": "automation-platform",
+          "deliverable": "next-pass JSON/markdown/plain contracts"
+        },
+        {
+          "id": "rerun-top-controls",
+          "status": "completed",
+          "owner": "repo-ops",
+          "deliverable": "--enterprise-rerun-top scoped reruns"
+        }
+      ]
+    },
+    {
+      "id": "phase-3-ci-governance",
+      "name": "CI Governance & Rollout",
+      "status": "pending",
+      "success_metric": "Pipelines branch on next-pass contract and report SLA trends.",
+      "tasks": [
+        {
+          "id": "pipeline-branching",
+          "status": "pending",
+          "owner": "automation-platform",
+          "deliverable": "Use has_next_pass/exit_code_hint in CI workflows"
+        },
+        {
+          "id": "slo-reporting",
+          "status": "pending",
+          "owner": "quality-governance",
+          "deliverable": "Monthly blocker recurrence and remediation latency report"
+        }
+      ]
+    }
+  ]
+}

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -44,8 +44,11 @@ EXIT_OK = 0
 EXIT_FAILED = 2
 EVIDENCE_SCHEMA_VERSION = "sdetkit.doctor.evidence.v2"
 EVIDENCE_MANIFEST_SCHEMA_VERSION = "sdetkit.doctor.evidence.manifest.v1"
+NEXT_PASS_SCHEMA_VERSION = "sdetkit.doctor.next_pass.v1"
 EVIDENCE_PROFILES = ("ci", "release", "full")
 EVIDENCE_INCLUDES = ("failed", "actionable", "all")
+ENTERPRISE_RERUN_FAILED_COMMAND = "python -m sdetkit doctor --enterprise-rerun-failed --json"
+ENTERPRISE_RERUN_HIGH_COMMAND = "python -m sdetkit doctor --enterprise-rerun-high --json"
 
 SUPPORTED_POLICY_CHECKS = {
     "ascii",
@@ -490,6 +493,38 @@ def _parse_check_csv(value: str | None) -> list[str]:
         if s:
             out.append(s)
     return out
+
+
+def _resolve_rerun_failed_checks(
+    *, workspace_root: Path, scope: str, severity: str | None = None
+) -> list[str]:
+    previous_payload, _ = load_latest_previous_payload(
+        workspace_root=workspace_root,
+        workflow="doctor",
+        scope=scope,
+    )
+    if not isinstance(previous_payload, dict):
+        return []
+    failed: list[str] = []
+    next_actions = previous_payload.get("next_actions", [])
+    if isinstance(next_actions, list):
+        for item in next_actions:
+            if not isinstance(item, dict):
+                continue
+            check_id = str(item.get("id", "")).strip()
+            item_severity = str(item.get("severity", "")).strip().lower()
+            if severity and item_severity != severity:
+                continue
+            if check_id in CHECK_ORDER:
+                failed.append(check_id)
+    if not failed:
+        failed_checks = previous_payload.get("failed_checks", [])
+        if isinstance(failed_checks, list):
+            for check_id in failed_checks:
+                cid = str(check_id).strip()
+                if cid in CHECK_ORDER:
+                    failed.append(cid)
+    return sorted(set(failed), key=CHECK_ORDER.index)
 
 
 def _baseline_snapshot_path(root: Path) -> Path:
@@ -1481,6 +1516,45 @@ def _format_doctor_markdown(data: dict[str, Any]) -> str:
             lines.append(f"- {hint}")
     else:
         lines.append("- None")
+    enterprise = data.get("enterprise", {})
+    if isinstance(enterprise, dict):
+        lines.append("")
+        lines.append("#### Enterprise execution")
+        profile_mode = str(data.get("profile_mode", "")).strip()
+        if profile_mode:
+            lines.append(f"- profile mode: `{profile_mode}`")
+        lines.append(f"- maturity tier: `{enterprise.get('maturity_tier', 'unknown')}`")
+        lines.append(f"- blocker count: {enterprise.get('blocker_count', 0)}")
+        next_pass = str(enterprise.get("next_pass_command", "")).strip()
+        next_pass_reason = str(enterprise.get("next_pass_reason", "none")).strip() or "none"
+        lines.append(f"- next pass reason: `{next_pass_reason}`")
+        if next_pass:
+            lines.append(f"- next pass command: `{next_pass}`")
+        blockers = enterprise.get("blockers", [])
+        if isinstance(blockers, list) and blockers:
+            lines.append("- blockers:")
+            for blocker in blockers[:3]:
+                if not isinstance(blocker, dict):
+                    continue
+                lines.append(
+                    f"  - `{blocker.get('id', '')}`: {blocker.get('summary', '')}"
+                )
+        queue = enterprise.get("optimization_queue", [])
+        if isinstance(queue, list) and queue:
+            lines.append("- optimization queue:")
+            for item in queue[:3]:
+                if not isinstance(item, dict):
+                    continue
+                lines.append(
+                    f"  - `{item.get('check_id', '')}` ({item.get('severity', 'medium')}): {item.get('summary', '')}"
+                )
+        bundle = enterprise.get("remediation_bundle", [])
+        if isinstance(bundle, list) and bundle:
+            lines.append("- remediation bundle:")
+            for row in bundle[:3]:
+                if not isinstance(row, dict):
+                    continue
+                lines.append(f"  - `{row.get('check_id', '')}`: {row.get('action', '')}")
     return "\n".join(lines) + "\n"
 
 
@@ -1578,6 +1652,112 @@ def _structured_recommendations(data: dict[str, Any]) -> list[dict[str, Any]]:
                 continue
             rec["related_evidence_refs"] = sorted(str(ref) for ref in refs if str(ref).strip())[:5]
     return recs
+
+
+def _build_enterprise_insights(data: dict[str, Any]) -> dict[str, Any]:
+    checks = data.get("checks", {})
+    next_actions = data.get("next_actions", [])
+    if not isinstance(next_actions, list):
+        next_actions = []
+
+    blockers: list[dict[str, Any]] = []
+    optimization_queue: list[dict[str, Any]] = []
+    for item in next_actions:
+        if not isinstance(item, dict):
+            continue
+        check_id = str(item.get("id", "")).strip()
+        severity = str(item.get("severity", "medium")).strip() or "medium"
+        summary = str(item.get("summary", "")).strip()
+        fix = item.get("fix", [])
+        fix_list = [str(fix_item).strip() for fix_item in fix if str(fix_item).strip()]
+        if severity == "high":
+            blockers.append({"id": check_id, "summary": summary})
+        priority = SEVERITY_ORDER.get(severity, SEVERITY_ORDER["medium"]) * 100
+        check_item = checks.get(check_id, {})
+        if isinstance(check_item, dict):
+            evidence = check_item.get("evidence", [])
+            priority += len(evidence) if isinstance(evidence, list) else 0
+            priority += 5 if fix_list else 0
+        optimization_queue.append(
+            {
+                "check_id": check_id,
+                "severity": severity,
+                "priority": priority,
+                "summary": summary,
+                "first_fix": fix_list[0] if fix_list else "",
+            }
+        )
+
+    optimization_queue.sort(key=lambda row: (-int(row["priority"]), str(row["check_id"])))
+    upgrade_meta = (
+        data.get("checks", {}).get("upgrade_audit", {}).get("meta", {})
+        if isinstance(data.get("checks", {}), dict)
+        else {}
+    )
+    validation_commands: list[str] = []
+    if isinstance(upgrade_meta, dict):
+        validation_summary = upgrade_meta.get("validation_summary", [])
+        if isinstance(validation_summary, list):
+            for item in validation_summary:
+                if not isinstance(item, dict):
+                    continue
+                command = str(item.get("command", "")).strip()
+                if command and command not in validation_commands:
+                    validation_commands.append(command)
+
+    remediation_bundle: list[dict[str, Any]] = []
+    checks_map = data.get("checks", {})
+    for item in optimization_queue[:3]:
+        check_id = str(item.get("check_id", "")).strip()
+        check_row = checks_map.get(check_id, {}) if isinstance(checks_map, dict) else {}
+        fix_items = check_row.get("fix", []) if isinstance(check_row, dict) else []
+        fix_list = [str(fix).strip() for fix in fix_items if str(fix).strip()]
+        if not fix_list:
+            continue
+        remediation_bundle.append(
+            {
+                "check_id": check_id,
+                "severity": str(item.get("severity", "medium")),
+                "action": fix_list[0],
+                "validation": validation_commands[0] if validation_commands else "",
+                "owner_hint": "repo-ops",
+            }
+        )
+
+    score = int(data.get("score", 0))
+    if blockers:
+        maturity_tier = "at_risk"
+    elif score >= 95:
+        maturity_tier = "production_hardened"
+    elif score >= 80:
+        maturity_tier = "hardening"
+    else:
+        maturity_tier = "stabilizing"
+
+    next_pass_command = ""
+    next_pass_reason = "none"
+    alternate_commands: list[str] = []
+    if blockers:
+        next_pass_command = ENTERPRISE_RERUN_HIGH_COMMAND
+        next_pass_reason = "blockers_present"
+        alternate_commands = [ENTERPRISE_RERUN_HIGH_COMMAND, ENTERPRISE_RERUN_FAILED_COMMAND]
+    elif next_actions:
+        next_pass_command = ENTERPRISE_RERUN_FAILED_COMMAND
+        next_pass_reason = "failed_checks_present"
+        alternate_commands = [ENTERPRISE_RERUN_FAILED_COMMAND]
+
+    return {
+        "maturity_tier": maturity_tier,
+        "blocker_count": len(blockers),
+        "blockers": blockers[:5],
+        "optimization_queue": optimization_queue[:8],
+        "remediation_bundle": remediation_bundle,
+        "execution_commands": _evidence_next_commands(data),
+        "next_pass_command": next_pass_command,
+        "next_pass_reason": next_pass_reason,
+        "alternate_commands": alternate_commands,
+        "focus": "Resolve blockers first, then execute the optimization queue in priority order.",
+    }
 
 
 def _select_evidence_rows(
@@ -2264,11 +2444,54 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--pyproject", action="store_true")
     parser.add_argument("--pr", action="store_true", help="print a PR-ready markdown summary")
     parser.add_argument("--all", action="store_true")
+    parser.add_argument(
+        "--enterprise",
+        action="store_true",
+        help=(
+            "Run the enterprise reliability profile (full checks + strict policy + "
+            "upgrade-audit optimization defaults)."
+        ),
+    )
     parser.add_argument("--release", action="store_true")
     parser.add_argument("--release-full", dest="release_full", action="store_true")
     parser.add_argument("--policy")
     parser.add_argument("--fail-on", choices=["low", "medium", "high"])
     parser.add_argument("--strict", action="store_true")
+    parser.add_argument(
+        "--enterprise-rerun-failed",
+        action="store_true",
+        help="Rerun only failed checks from the latest doctor workspace run (implies --enterprise).",
+    )
+    parser.add_argument(
+        "--enterprise-rerun-high",
+        action="store_true",
+        help=(
+            "Rerun only high-severity failed checks from the latest doctor workspace run "
+            "(implies --enterprise)."
+        ),
+    )
+    parser.add_argument(
+        "--enterprise-rerun-top",
+        type=int,
+        default=None,
+        help="Limit enterprise rerun modes to top N selected checks (after severity/failure filtering).",
+    )
+    parser.add_argument(
+        "--enterprise-next-pass-only",
+        action="store_true",
+        help=(
+            "Print only the enterprise next-pass command hint for automation handoff "
+            "(implies --enterprise)."
+        ),
+    )
+    parser.add_argument(
+        "--enterprise-next-pass-exit-code",
+        action="store_true",
+        help=(
+            "When used with --enterprise-next-pass-only, return 2 if a follow-up pass is "
+            "recommended, else 0."
+        ),
+    )
     parser.add_argument("--out", default=None)
     parser.add_argument("--treat", action="store_true")
     parser.add_argument("--treat-only", dest="treat_only", action="store_true")
@@ -2330,6 +2553,58 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("unknown check id(s): " + ", ".join(unknown))
     only_set = set(only_raw)
     skip_set = set(skip_raw)
+    if ns.enterprise_rerun_failed and ns.enterprise_rerun_high:
+        parser.error("use only one of --enterprise-rerun-failed or --enterprise-rerun-high")
+    if ns.enterprise_next_pass_only and (ns.enterprise_rerun_failed or ns.enterprise_rerun_high):
+        parser.error(
+            "--enterprise-next-pass-only cannot be combined with rerun mode flags."
+        )
+    if ns.enterprise_next_pass_exit_code and not ns.enterprise_next_pass_only:
+        parser.error("--enterprise-next-pass-exit-code requires --enterprise-next-pass-only.")
+    if ns.enterprise_rerun_top is not None and not (ns.enterprise_rerun_failed or ns.enterprise_rerun_high):
+        parser.error("--enterprise-rerun-top requires --enterprise-rerun-failed or --enterprise-rerun-high.")
+    if ns.enterprise_rerun_top is not None and ns.enterprise_rerun_top <= 0:
+        parser.error("--enterprise-rerun-top must be >= 1.")
+    if ns.enterprise_rerun_failed or ns.enterprise_rerun_high:
+        if ns.no_workspace:
+            parser.error(
+                "enterprise rerun modes require workspace history (omit --no-workspace)."
+            )
+        scope_name = root.name or "repo"
+        rerun_severity = "high" if ns.enterprise_rerun_high else None
+        failed_only = _resolve_rerun_failed_checks(
+            workspace_root=Path(ns.workspace_root),
+            scope=scope_name,
+            severity=rerun_severity,
+        )
+        if not failed_only:
+            if ns.enterprise_rerun_high:
+                parser.error(
+                    "--enterprise-rerun-high found no high-severity failed checks in latest workspace doctor run."
+                )
+            parser.error("--enterprise-rerun-failed found no failed checks in latest workspace doctor run.")
+        if ns.enterprise_rerun_top is not None:
+            failed_only = failed_only[: ns.enterprise_rerun_top]
+        only_set = set(failed_only)
+        skip_set = set()
+        ns.enterprise = True
+    if ns.enterprise_next_pass_only:
+        ns.enterprise = True
+
+    if ns.enterprise:
+        ns.all = True
+        ns.release = True
+        ns.release_full = True
+        ns.dev = True
+        ns.repo_readiness = True
+        ns.pyproject = True
+        ns.strict = True
+        if ns.fail_on is None:
+            ns.fail_on = "medium"
+        if ns.upgrade_audit_top is None:
+            ns.upgrade_audit_top = 15
+        ns.upgrade_audit_used_in_repo_only = True
+        ns.upgrade_audit_outdated_only = True
 
     if only_set:
         ns.ascii = False
@@ -2458,6 +2733,14 @@ def main(argv: list[str] | None = None) -> int:
         "package": _package_info(),
         "checks": _baseline_checks(),
     }
+    if ns.enterprise:
+        data["profile"] = "enterprise"
+        data["profile_mode"] = "full_scan"
+        data["rerun_top"] = int(ns.enterprise_rerun_top) if ns.enterprise_rerun_top is not None else None
+        if ns.enterprise_rerun_failed:
+            data["profile_mode"] = "rerun_failed"
+        elif ns.enterprise_rerun_high:
+            data["profile_mode"] = "rerun_high"
     if ns.treat:
         data["treatments"] = treat_steps
         data["treatments_ok"] = data_treat_ok
@@ -2803,6 +3086,8 @@ def main(argv: list[str] | None = None) -> int:
         selected_checks=data["selected_checks"],
         hints=data["hints"],
     )
+    if ns.enterprise:
+        data["enterprise"] = _build_enterprise_insights(data)
 
     scope_name = root.name or "repo"
     previous_payload = None
@@ -2878,6 +3163,55 @@ def main(argv: list[str] | None = None) -> int:
     if getattr(ns, "explain", False):
         data["explain"] = _build_explain_payload(data)
 
+    if ns.enterprise_next_pass_only:
+        enterprise_raw = data.get("enterprise", {})
+        enterprise = enterprise_raw if isinstance(enterprise_raw, dict) else {}
+        next_pass = str(enterprise.get("next_pass_command", "")).strip()
+        next_pass_reason = str(enterprise.get("next_pass_reason", "none")).strip()
+        alternate_commands = enterprise.get("alternate_commands", [])
+        if not isinstance(alternate_commands, list):
+            alternate_commands = []
+        alternate_commands = [
+            str(command).strip() for command in alternate_commands if str(command).strip()
+        ]
+        if ns.format == "json" or ns.json:
+            payload = {
+                "schema_version": NEXT_PASS_SCHEMA_VERSION,
+                "workflow": "doctor",
+                "profile": "enterprise",
+                "profile_mode": str(data.get("profile_mode", "")),
+                "selected_checks": list(data.get("selected_checks", [])),
+                "next_pass_command": next_pass,
+                "next_pass_reason": next_pass_reason or "none",
+                "alternate_commands": alternate_commands,
+                "has_next_pass": bool(next_pass),
+                "exit_code_hint": 2 if next_pass else 0,
+                "message": "no follow-up pass required" if not next_pass else "next pass available",
+            }
+            output = json.dumps(payload, sort_keys=True) + "\n"
+            is_json = True
+        elif ns.format == "md":
+            first_line = f"`{next_pass}`" if next_pass else "_no follow-up pass required_"
+            alt_line = (
+                "`alternates: " + " | ".join(alternate_commands) + "`"
+                if alternate_commands
+                else "`alternates: none`"
+            )
+            output = first_line + "\n" + f"`reason: {next_pass_reason or 'none'}`" + "\n" + alt_line + "\n"
+            is_json = False
+        else:
+            first_line = next_pass or "no follow-up pass required"
+            alt_line = "alternates: " + (" | ".join(alternate_commands) if alternate_commands else "none")
+            output = first_line + "\n" + f"reason: {next_pass_reason or 'none'}" + "\n" + alt_line + "\n"
+            is_json = False
+        if ns.out:
+            Path(ns.out).write_text(output, encoding="utf-8")
+        else:
+            sys.stdout.write(output)
+        if ns.enterprise_next_pass_exit_code and next_pass:
+            return 2
+        return 0
+
     if ns.format == "json" or ns.json:
         output = json.dumps(data, sort_keys=True) + "\n"
         is_json = True
@@ -2911,6 +3245,45 @@ def main(argv: list[str] | None = None) -> int:
             lines.append("hints:")
             for hint in hints:
                 lines.append(f"- {hint}")
+        enterprise = data.get("enterprise", {})
+        if isinstance(enterprise, dict):
+            lines.append("enterprise:")
+            profile_mode = str(data.get("profile_mode", "")).strip()
+            if profile_mode:
+                lines.append(f"- profile_mode: {profile_mode}")
+            lines.append(f"- maturity_tier: {enterprise.get('maturity_tier')}")
+            lines.append(f"- blocker_count: {enterprise.get('blocker_count', 0)}")
+            next_pass = str(enterprise.get("next_pass_command", "")).strip()
+            next_pass_reason = str(enterprise.get("next_pass_reason", "none")).strip() or "none"
+            lines.append(f"- next_pass_reason: {next_pass_reason}")
+            if next_pass:
+                lines.append(f"- next_pass_command: {next_pass}")
+            blockers = enterprise.get("blockers", [])
+            if isinstance(blockers, list):
+                for blocker in blockers[:3]:
+                    if not isinstance(blocker, dict):
+                        continue
+                    lines.append(
+                        f"- blocker {blocker.get('id')}: {blocker.get('summary', '')}"
+                    )
+            queue = enterprise.get("optimization_queue", [])
+            if isinstance(queue, list) and queue:
+                lines.append("- optimization_queue:")
+                for item in queue[:3]:
+                    if not isinstance(item, dict):
+                        continue
+                    lines.append(
+                        f"  - {item.get('check_id')} ({item.get('severity')}): {item.get('summary', '')}"
+                    )
+            bundle = enterprise.get("remediation_bundle", [])
+            if isinstance(bundle, list) and bundle:
+                lines.append("- remediation_bundle:")
+                for row in bundle[:3]:
+                    if not isinstance(row, dict):
+                        continue
+                    lines.append(
+                        f"  - {row.get('check_id')}: {row.get('action', '')}"
+                    )
         if getattr(ns, "explain", False):
             explain = data.get("explain", {})
             if isinstance(explain, dict):

--- a/templates/automations/enterprise-next-pass-handoff.yaml
+++ b/templates/automations/enterprise-next-pass-handoff.yaml
@@ -1,0 +1,68 @@
+name: Enterprise Next-Pass Handoff
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  enterprise-doctor:
+    runs-on: ubuntu-latest
+    outputs:
+      has_next_pass: ${{ steps.parse.outputs.has_next_pass }}
+      next_pass_command: ${{ steps.parse.outputs.next_pass_command }}
+      next_pass_reason: ${{ steps.parse.outputs.next_pass_reason }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install sdetkit
+        run: pip install .
+      - name: Generate next-pass payload
+        run: python -m sdetkit doctor --enterprise-next-pass-only --json --out next-pass.json
+      - name: Parse payload
+        id: parse
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import uuid
+          from pathlib import Path
+
+          payload = json.loads(Path('next-pass.json').read_text(encoding='utf-8'))
+          out = Path(os.environ['GITHUB_OUTPUT'])
+
+          def write_output(handle, key: str, value: object) -> None:
+              text = str(value)
+              if '\n' in text:
+                  marker = f"SDETKIT_{uuid.uuid4().hex}"
+                  while marker in text:
+                      marker = f"SDETKIT_{uuid.uuid4().hex}"
+                  handle.write(f"{key}<<{marker}\n")
+                  handle.write(text)
+                  handle.write("\n")
+                  handle.write(f"{marker}\n")
+                  return
+              handle.write(f"{key}={text}\n")
+
+          with out.open('a', encoding='utf-8') as handle:
+              write_output(handle, "has_next_pass", str(payload.get('has_next_pass', False)).lower())
+              write_output(handle, "next_pass_command", payload.get('next_pass_command', ''))
+              write_output(handle, "next_pass_reason", payload.get('next_pass_reason', 'none'))
+          PY
+
+  enterprise-follow-up:
+    needs: enterprise-doctor
+    if: needs.enterprise-doctor.outputs.has_next_pass == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install sdetkit
+        run: pip install .
+      - name: Execute recommended follow-up pass
+        run: ${{ needs.enterprise-doctor.outputs.next_pass_command }}

--- a/tests/doctor_test_support.py
+++ b/tests/doctor_test_support.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from sdetkit import doctor
+
+
+def stub_enterprise_env(monkeypatch, *, clean_tree_ok: bool = True) -> None:
+    monkeypatch.setattr(doctor, "find_stdlib_shadowing", lambda _root: [])
+    monkeypatch.setattr(doctor, "_in_virtualenv", lambda: True)
+    monkeypatch.setattr(doctor, "_check_tools", lambda: (["git", "python3"], []))
+    monkeypatch.setattr(doctor, "_check_pyproject_toml", lambda _root: (True, "ok"))
+    monkeypatch.setattr(doctor, "_check_release_meta", lambda _root: (True, "ok", [], [], {}))
+    monkeypatch.setattr(doctor, "_scan_non_ascii", lambda _root: ([], []))
+    monkeypatch.setattr(doctor, "_check_ci_workflows", lambda _root: ([], []))
+    monkeypatch.setattr(doctor, "_check_security_files", lambda _root: ([], []))
+    monkeypatch.setattr(doctor, "_check_pre_commit", lambda _root: True)
+    monkeypatch.setattr(doctor, "_check_deps", lambda _root: True)
+    monkeypatch.setattr(doctor, "_check_clean_tree", lambda _root: clean_tree_ok)
+    monkeypatch.setattr(doctor, "_check_repo_readiness", lambda _root: ([], []))
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )

--- a/tests/test_doctor_enterprise_profile.py
+++ b/tests/test_doctor_enterprise_profile.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit import doctor
+
+
+def _stubbed_doctor_environment(monkeypatch):
+    monkeypatch.setattr(doctor, "find_stdlib_shadowing", lambda _root: [])
+    monkeypatch.setattr(doctor, "_in_virtualenv", lambda: True)
+    monkeypatch.setattr(doctor, "_check_tools", lambda: (["git", "python3"], []))
+    monkeypatch.setattr(
+        doctor, "_check_pyproject_toml", lambda _root: (True, "pyproject.toml is valid TOML")
+    )
+    monkeypatch.setattr(doctor, "_check_release_meta", lambda _root: (True, "ok", [], [], {}))
+    monkeypatch.setattr(doctor, "_scan_non_ascii", lambda _root: ([], []))
+    monkeypatch.setattr(doctor, "_check_ci_workflows", lambda _root: ([], []))
+    monkeypatch.setattr(doctor, "_check_security_files", lambda _root: ([], []))
+    monkeypatch.setattr(doctor, "_check_pre_commit", lambda _root: True)
+    monkeypatch.setattr(doctor, "_check_deps", lambda _root: True)
+    monkeypatch.setattr(doctor, "_check_clean_tree", lambda _root: True)
+    monkeypatch.setattr(doctor, "_check_repo_readiness", lambda _root: ([], []))
+
+
+def test_doctor_enterprise_profile_applies_reliability_defaults(
+    tmp_path: Path, monkeypatch, capsys
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    def fake_upgrade(_root, **kwargs):
+        captured.update(kwargs)
+        return True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(doctor, "_check_upgrade_audit", fake_upgrade)
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise", "--json", "--no-workspace"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert data["profile"] == "enterprise"
+    assert data["profile_mode"] == "full_scan"
+    assert data["policy"]["strict"] is True
+    assert data["policy"]["fail_on"] == "medium"
+    assert captured["used_in_repo_only"] is True
+    assert captured["outdated_only"] is True
+    assert captured["top"] == 15
+    assert data["enterprise"]["maturity_tier"] == "production_hardened"
+    assert data["enterprise"]["blocker_count"] == 0
+    assert data["enterprise"]["remediation_bundle"] == []
+    assert data["enterprise"]["next_pass_command"] == ""
+    assert data["enterprise"]["next_pass_reason"] == "none"
+    assert data["enterprise"]["alternate_commands"] == []
+
+
+def test_doctor_enterprise_profile_respects_explicit_fail_on(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise", "--fail-on", "high", "--json", "--no-workspace"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert data["policy"]["fail_on"] == "high"
+
+
+def test_doctor_enterprise_profile_surfaces_blockers(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(doctor, "_check_clean_tree", lambda _root: False)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise", "--json", "--no-workspace"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert data["enterprise"]["maturity_tier"] == "at_risk"
+    assert data["enterprise"]["blocker_count"] >= 1
+    assert any(item["id"] == "clean_tree" for item in data["enterprise"]["blockers"])
+    assert data["enterprise"]["remediation_bundle"]
+    assert data["enterprise"]["remediation_bundle"][0]["check_id"] == "clean_tree"
+    assert data["enterprise"]["next_pass_command"] == doctor.ENTERPRISE_RERUN_HIGH_COMMAND
+    assert data["enterprise"]["next_pass_reason"] == "blockers_present"
+    assert data["enterprise"]["alternate_commands"][0] == doctor.ENTERPRISE_RERUN_HIGH_COMMAND
+
+
+def test_doctor_enterprise_rerun_failed_selects_only_failed_checks(
+    tmp_path: Path, monkeypatch, capsys
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "_resolve_rerun_failed_checks",
+        lambda **_kwargs: ["clean_tree", "repo_readiness"],
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-rerun-failed", "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert data["profile"] == "enterprise"
+    assert data["profile_mode"] == "rerun_failed"
+    assert data["selected_checks"] == ["clean_tree", "repo_readiness"]
+
+
+def test_doctor_enterprise_rerun_failed_requires_workspace(tmp_path: Path, monkeypatch):
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+
+    with pytest.raises(SystemExit):
+        doctor.main(["--enterprise-rerun-failed", "--no-workspace"])
+
+
+def test_doctor_enterprise_markdown_includes_execution_section(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(doctor, "_check_clean_tree", lambda _root: False)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise", "--format", "md", "--no-workspace"])
+    out = capsys.readouterr().out
+
+    assert rc == 2
+    assert "#### Enterprise execution" in out
+    assert "- blocker count:" in out
+    assert "- next pass reason: `blockers_present`" in out
+    assert "- remediation bundle:" in out
+    assert f"- next pass command: `{doctor.ENTERPRISE_RERUN_HIGH_COMMAND}`" in out
+
+
+def test_doctor_help_includes_enterprise_rerun_flag(capsys):
+    with pytest.raises(SystemExit):
+        doctor.main(["--help"])
+    out = capsys.readouterr().out
+    assert "--enterprise-rerun-failed" in out
+    assert "--enterprise-rerun-high" in out
+    assert "--enterprise-rerun-top" in out
+    assert "--enterprise-next-pass-only" in out
+    assert "--enterprise-next-pass-exit-code" in out
+
+
+def test_resolve_rerun_failed_checks_uses_failed_checks_fallback(monkeypatch):
+    monkeypatch.setattr(
+        doctor,
+        "load_latest_previous_payload",
+        lambda **_kwargs: ({"failed_checks": ["repo_readiness", "clean_tree"]}, {}),
+    )
+
+    selected = doctor._resolve_rerun_failed_checks(workspace_root=Path("."), scope="repo")
+
+    assert selected == ["clean_tree", "repo_readiness"]
+
+
+def test_resolve_rerun_failed_checks_returns_empty_when_no_payload(monkeypatch):
+    monkeypatch.setattr(doctor, "load_latest_previous_payload", lambda **_kwargs: (None, {}))
+
+    selected = doctor._resolve_rerun_failed_checks(workspace_root=Path("."), scope="repo")
+
+    assert selected == []
+
+
+def test_resolve_rerun_failed_checks_filters_by_severity(monkeypatch):
+    monkeypatch.setattr(
+        doctor,
+        "load_latest_previous_payload",
+        lambda **_kwargs: (
+            {
+                "next_actions": [
+                    {"id": "clean_tree", "severity": "high"},
+                    {"id": "repo_readiness", "severity": "high"},
+                    {"id": "deps", "severity": "medium"},
+                ]
+            },
+            {},
+        ),
+    )
+
+    selected = doctor._resolve_rerun_failed_checks(
+        workspace_root=Path("."), scope="repo", severity="high"
+    )
+
+    assert selected == ["clean_tree", "repo_readiness"]
+
+
+def test_resolve_rerun_failed_checks_high_severity_uses_failed_checks_fallback(monkeypatch):
+    monkeypatch.setattr(
+        doctor,
+        "load_latest_previous_payload",
+        lambda **_kwargs: ({"failed_checks": ["repo_readiness", "clean_tree"]}, {}),
+    )
+
+    selected = doctor._resolve_rerun_failed_checks(
+        workspace_root=Path("."), scope="repo", severity="high"
+    )
+
+    assert selected == ["clean_tree", "repo_readiness"]
+
+
+def test_doctor_enterprise_rerun_high_selects_high_only(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "_resolve_rerun_failed_checks",
+        lambda **_kwargs: ["clean_tree"],
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-rerun-high", "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert data["profile"] == "enterprise"
+    assert data["profile_mode"] == "rerun_high"
+    assert data["selected_checks"] == ["clean_tree"]
+
+
+def test_doctor_enterprise_rerun_modes_are_mutually_exclusive(tmp_path: Path, monkeypatch):
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+
+    with pytest.raises(SystemExit):
+        doctor.main(["--enterprise-rerun-failed", "--enterprise-rerun-high"])
+
+
+def test_doctor_enterprise_rerun_top_limits_selected_checks(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "_resolve_rerun_failed_checks",
+        lambda **_kwargs: ["clean_tree", "repo_readiness"],
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-rerun-failed", "--enterprise-rerun-top", "1", "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert data["rerun_top"] == 1
+    assert data["selected_checks"] == ["clean_tree"]
+
+
+def test_doctor_enterprise_rerun_top_requires_rerun_mode(tmp_path: Path, monkeypatch):
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+
+    with pytest.raises(SystemExit):
+        doctor.main(["--enterprise-rerun-top", "1"])
+
+
+def test_doctor_enterprise_rerun_top_requires_positive_value(tmp_path: Path, monkeypatch):
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+
+    with pytest.raises(SystemExit):
+        doctor.main(["--enterprise-rerun-failed", "--enterprise-rerun-top", "0"])
+
+
+def test_doctor_enterprise_markdown_includes_profile_mode_for_rerun_high(
+    tmp_path: Path, monkeypatch, capsys
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.setattr(doctor, "_resolve_rerun_failed_checks", lambda **_kwargs: ["clean_tree"])
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-rerun-high", "--format", "md"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "- profile mode: `rerun_high`" in out
+
+
+def test_doctor_enterprise_next_pass_only_prints_command(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(doctor, "_check_clean_tree", lambda _root: False)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    lines = out.strip().splitlines()
+    assert lines[0] == doctor.ENTERPRISE_RERUN_HIGH_COMMAND
+    assert lines[1] == "reason: blockers_present"
+    assert lines[2] == (
+        f"alternates: {doctor.ENTERPRISE_RERUN_HIGH_COMMAND} | {doctor.ENTERPRISE_RERUN_FAILED_COMMAND}"
+    )
+
+
+def test_doctor_enterprise_next_pass_only_reports_no_follow_up(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert data["schema_version"] == doctor.NEXT_PASS_SCHEMA_VERSION
+    assert data["workflow"] == "doctor"
+    assert data["profile"] == "enterprise"
+    assert data["profile_mode"] == "full_scan"
+    assert "selected_checks" in data
+    assert data["next_pass_command"] == ""
+    assert data["next_pass_reason"] == "none"
+    assert data["alternate_commands"] == []
+    assert data["has_next_pass"] is False
+    assert data["exit_code_hint"] == 0
+    assert data["message"] == "no follow-up pass required"
+
+
+def test_doctor_enterprise_next_pass_only_tolerates_non_dict_enterprise_payload(
+    tmp_path: Path, monkeypatch, capsys
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(doctor, "_build_enterprise_insights", lambda _data: ["not-a-dict"])
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert data["next_pass_command"] == ""
+    assert data["next_pass_reason"] == "none"
+    assert data["alternate_commands"] == []
+    assert data["has_next_pass"] is False
+
+
+def test_doctor_enterprise_next_pass_only_json_reports_available_pass(
+    tmp_path: Path, monkeypatch, capsys
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(doctor, "_check_clean_tree", lambda _root: False)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert data["next_pass_command"] == doctor.ENTERPRISE_RERUN_HIGH_COMMAND
+    assert data["next_pass_reason"] == "blockers_present"
+    assert data["alternate_commands"][:2] == [
+        doctor.ENTERPRISE_RERUN_HIGH_COMMAND,
+        doctor.ENTERPRISE_RERUN_FAILED_COMMAND,
+    ]
+    assert data["has_next_pass"] is True
+    assert data["exit_code_hint"] == 2
+    assert data["message"] == "next pass available"
+
+
+def test_doctor_enterprise_next_pass_only_plain_no_follow_up_message(
+    tmp_path: Path, monkeypatch, capsys
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only"])
+    lines = capsys.readouterr().out.strip().splitlines()
+
+    assert rc == 0
+    assert lines[0] == "no follow-up pass required"
+    assert lines[1] == "reason: none"
+    assert lines[2] == "alternates: none"
+
+
+def test_doctor_enterprise_next_pass_only_is_mutually_exclusive_with_rerun_flags(
+    tmp_path: Path, monkeypatch
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+
+    with pytest.raises(SystemExit):
+        doctor.main(["--enterprise-next-pass-only", "--enterprise-rerun-failed"])
+
+    with pytest.raises(SystemExit):
+        doctor.main(["--enterprise-next-pass-only", "--enterprise-rerun-high"])
+
+
+def test_doctor_enterprise_next_pass_exit_code_requires_next_pass_only(tmp_path: Path, monkeypatch):
+    root = tmp_path / "repo"
+    root.mkdir()
+    monkeypatch.chdir(root)
+
+    with pytest.raises(SystemExit):
+        doctor.main(["--enterprise-next-pass-exit-code"])
+
+
+def test_doctor_enterprise_next_pass_only_writes_out_file(tmp_path: Path, monkeypatch):
+    root = tmp_path / "repo"
+    root.mkdir()
+    out_file = root / "next-pass.txt"
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(doctor, "_check_clean_tree", lambda _root: False)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--out", str(out_file)])
+
+    assert rc == 0
+    lines = out_file.read_text(encoding="utf-8").strip().splitlines()
+    assert lines[0] == doctor.ENTERPRISE_RERUN_HIGH_COMMAND
+    assert lines[1] == "reason: blockers_present"
+    assert lines[2] == (
+        f"alternates: {doctor.ENTERPRISE_RERUN_HIGH_COMMAND} | {doctor.ENTERPRISE_RERUN_FAILED_COMMAND}"
+    )
+
+
+def test_doctor_enterprise_next_pass_only_markdown_wraps_command(
+    tmp_path: Path, monkeypatch, capsys
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(doctor, "_check_clean_tree", lambda _root: False)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--format", "md"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    lines = out.strip().splitlines()
+    assert lines[0] == f"`{doctor.ENTERPRISE_RERUN_HIGH_COMMAND}`"
+    assert lines[1] == "`reason: blockers_present`"
+    assert lines[2] == (
+        f"`alternates: {doctor.ENTERPRISE_RERUN_HIGH_COMMAND} | {doctor.ENTERPRISE_RERUN_FAILED_COMMAND}`"
+    )
+
+
+def test_doctor_enterprise_next_pass_only_markdown_no_follow_up_message(
+    tmp_path: Path, monkeypatch, capsys
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--format", "md"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    lines = out.strip().splitlines()
+    assert lines[0] == "_no follow-up pass required_"
+    assert lines[1] == "`reason: none`"
+    assert lines[2] == "`alternates: none`"
+
+
+def test_doctor_enterprise_next_pass_only_can_return_exit_code_hint(
+    tmp_path: Path, monkeypatch, capsys
+):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+
+    _stubbed_doctor_environment(monkeypatch)
+    monkeypatch.setattr(doctor, "_check_clean_tree", lambda _root: False)
+    monkeypatch.setattr(
+        doctor,
+        "_check_upgrade_audit",
+        lambda _root, **_kwargs: (True, "ok", [], [], {"packages_audited": 0, "actionable_packages": 0}),
+    )
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--enterprise-next-pass-exit-code"])
+    lines = capsys.readouterr().out.strip().splitlines()
+
+    assert rc == 2
+    assert lines[0] == doctor.ENTERPRISE_RERUN_HIGH_COMMAND

--- a/tests/test_doctor_next_pass_contract.py
+++ b/tests/test_doctor_next_pass_contract.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import doctor
+
+from tests.doctor_test_support import stub_enterprise_env
+
+
+def test_next_pass_json_contract_no_follow_up(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+    stub_enterprise_env(monkeypatch)
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["schema_version"] == doctor.NEXT_PASS_SCHEMA_VERSION
+    assert payload["workflow"] == "doctor"
+    assert payload["profile"] == "enterprise"
+    assert payload["profile_mode"] == "full_scan"
+    assert payload["next_pass_reason"] == "none"
+    assert payload["alternate_commands"] == []
+    assert payload["has_next_pass"] is False
+    assert payload["exit_code_hint"] == 0
+
+
+def test_next_pass_json_contract_with_follow_up(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+    stub_enterprise_env(monkeypatch, clean_tree_ok=False)
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["profile_mode"] == "full_scan"
+    assert payload["next_pass_reason"] == "blockers_present"
+    assert payload["alternate_commands"][:2] == [
+        doctor.ENTERPRISE_RERUN_HIGH_COMMAND,
+        doctor.ENTERPRISE_RERUN_FAILED_COMMAND,
+    ]
+    assert payload["has_next_pass"] is True
+    assert payload["exit_code_hint"] == 2
+    assert payload["next_pass_command"] == doctor.ENTERPRISE_RERUN_HIGH_COMMAND
+
+
+def test_next_pass_exit_code_flag_returns_zero_without_follow_up(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+    stub_enterprise_env(monkeypatch)
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--enterprise-next-pass-exit-code"])
+    payload = capsys.readouterr().out.strip().splitlines()
+
+    assert rc == 0
+    assert payload[0] == "no follow-up pass required"

--- a/tests/test_doctor_next_pass_markdown_contract.py
+++ b/tests/test_doctor_next_pass_markdown_contract.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit import doctor
+
+from tests.doctor_test_support import stub_enterprise_env
+
+
+def test_next_pass_markdown_contract_no_follow_up(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+    stub_enterprise_env(monkeypatch)
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--format", "md"])
+    lines = capsys.readouterr().out.strip().splitlines()
+
+    assert rc == 0
+    assert lines[0] == "_no follow-up pass required_"
+    assert lines[1] == "`reason: none`"
+    assert lines[2] == "`alternates: none`"
+
+
+def test_next_pass_markdown_contract_with_follow_up(tmp_path: Path, monkeypatch, capsys):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\nversion='0.1.0'\n", encoding="utf-8")
+    stub_enterprise_env(monkeypatch, clean_tree_ok=False)
+    monkeypatch.chdir(root)
+
+    rc = doctor.main(["--enterprise-next-pass-only", "--format", "md"])
+    lines = capsys.readouterr().out.strip().splitlines()
+
+    assert rc == 0
+    assert lines[0] == f"`{doctor.ENTERPRISE_RERUN_HIGH_COMMAND}`"
+    assert lines[1] == "`reason: blockers_present`"
+    assert lines[2] == (
+        f"`alternates: {doctor.ENTERPRISE_RERUN_HIGH_COMMAND} | {doctor.ENTERPRISE_RERUN_FAILED_COMMAND}`"
+    )

--- a/tests/test_enterprise_execution_tracker_plan.py
+++ b/tests/test_enterprise_execution_tracker_plan.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_enterprise_execution_tracker_has_required_shape():
+    path = Path("plans/enterprise-reliability-execution-tracker.json")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == "sdetkit.enterprise.execution-tracker.v1"
+    assert isinstance(payload.get("phases"), list)
+    assert payload["phases"]
+
+    valid_status = {"pending", "in_progress", "completed"}
+    for phase in payload["phases"]:
+        assert phase["status"] in valid_status
+        tasks = phase.get("tasks", [])
+        assert isinstance(tasks, list) and tasks
+        for task in tasks:
+            assert task["status"] in valid_status
+            assert task.get("owner")
+            assert task.get("deliverable")

--- a/tests/test_enterprise_next_pass_template.py
+++ b/tests/test_enterprise_next_pass_template.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_enterprise_next_pass_template_contains_required_contract_steps():
+    path = Path("templates/automations/enterprise-next-pass-handoff.yaml")
+    text = path.read_text(encoding="utf-8")
+
+    assert "python -m sdetkit doctor --enterprise-next-pass-only --json --out next-pass.json" in text
+    assert "os.environ['GITHUB_OUTPUT']" in text
+    assert "def write_output" in text
+    assert "<<" in text
+    assert "while marker in text" in text
+    assert "has_next_pass" in text
+    assert "next_pass_command" in text
+    assert "next_pass_reason" in text
+    assert "needs.enterprise-doctor.outputs.has_next_pass == 'true'" in text


### PR DESCRIPTION
### Motivation

- Provide an enterprise-grade reliability workflow for `sdetkit doctor` that supports focused remediation loops, deterministic CI handoff, and operator-friendly remediation bundles.
- Enable automation-friendly next-pass signaling so pipelines can branch or trigger focused reruns based on evidence produced by the doctor run.

### Description

- Add new CLI flags: `--enterprise`, `--enterprise-rerun-failed`, `--enterprise-rerun-high`, `--enterprise-rerun-top`, `--enterprise-next-pass-only`, and `--enterprise-next-pass-exit-code`, and wire them into `main` argument parsing and validation.
- Implement rerun resolution via `_resolve_rerun_failed_checks` to pick failed or high-severity checks from the latest workspace payload and limit scope with `--enterprise-rerun-top`.
- Build enterprise insights with `_build_enterprise_insights` (maturity tier, blockers, optimization queue, remediation bundle, `next_pass_command`, `next_pass_reason`, and `alternate_commands`) and expose them in JSON/plain/markdown outputs and the human-readable summary rendering.
- Add a next-pass contract JSON schema string `NEXT_PASS_SCHEMA_VERSION` and a `--enterprise-next-pass-only` mode that emits a lightweight contract payload (or plain/markdown hint) for CI handoff and optionally returns an exit code hint.
- Add documentation and artifacts: update `docs/cli.md` with a step-by-step enterprise workflow, add `docs/final-enterprise-reliability-plan.md`, add `plans/enterprise-reliability-execution-tracker.json`, and add a GitHub Actions template `templates/automations/enterprise-next-pass-handoff.yaml` to demonstrate how to consume the next-pass payload. Also update `CHANGELOG.md`.
- Add unit test support and tests covering the enterprise profile, rerun modes, next-pass JSON/markdown contracts, template presence, and the execution tracker plan (`tests/*.py` and `tests/doctor_test_support.py`).

### Testing

- Added comprehensive unit tests under `tests/` (including `test_doctor_enterprise_profile.py`, `test_doctor_next_pass_contract.py`, `test_doctor_next_pass_markdown_contract.py`, `test_enterprise_next_pass_template.py`, and `test_enterprise_execution_tracker_plan.py`).
- Ran the test suite with `pytest -q` (executing the new enterprise-focused test modules); all new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e01838aa08832d8e4314bb5f0fd47f)