### PR TITLE
Add production readiness scorecard and integrate into review/adaptive pipeline; add optional httpx loader and release-readiness contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,38 @@ Primary artifacts produced under `docs/artifacts/`:
 
 See: [`docs/portfolio-reporting-recipe.md`](docs/portfolio-reporting-recipe.md) and [`docs/kpi-schema.md`](docs/kpi-schema.md).
 
+## Production-readiness snapshot (investor/leadership brief)
+
+Generate a deterministic readiness scorecard that summarizes governance, CI, quality, and release evidence surfaces.
+The scorecard is content-aware (checks policy keywords and CI steps), so it is useful for real production triage:
+
+```bash
+python -m sdetkit readiness . --format text
+python -m sdetkit readiness . --format json
+```
+
+Use this output in due-diligence decks, internal operating reviews, or go-to-production checkpoint meetings.
+For repo targets, `sdetkit review` also publishes this snapshot into the review adaptive database (`adaptive_database.readiness_snapshot`).
+Readiness output includes pass/miss scorecards and achievement tiers so reviewers can track quality progression over time.
+Remediation recommendations are adaptive from scan evidence (lane/priority/rationale), not fixed static text.
+The readiness snapshot also tracks test scenario capacity against a 250-scenario target for scale readiness planning.
+For top-tier decisions, use `top_tier_ready` and `operational_tier` from readiness JSON.
+Review adaptive database also includes large-scale analytics blocks (`quality_matrix`, `findings_analytics`, `action_analytics`, `scalability_posture`) to power richer dashboards.
+For near-term launch operations, use `adaptive_database.release_readiness_contract` (`gate_decision`, blockers, next_24h_actions, next_72h_actions).
+`sdetkit review` now also emits a standalone `adaptive-database.json` artifact for direct dashboard ingestion.
+It also emits `release-readiness.json` and `release-readiness.md` for final launch call workflows.
+Release readiness contract now includes `contract_id`, `generated_at_utc`, and `next_review_due_at_utc` for traceable handoffs.
+It also includes a `trend` block so each run can compare decision/blocker movement vs the previous review.
+`release_readiness_contract` now includes `risk_score`, `risk_band`, and `sla_review_hours` for release-room prioritization.
+It also includes `blocker_catalog` for structured blocker triage (id/kind/severity/priority/next_action).
+Blocker catalog now includes `owner_team` and per-blocker `response_sla_hours` for clear routing.
+`release_readiness_contract.owner_summary` aggregates blocker workload by team for standup planning.
+`release_readiness_contract.recommendation_engine` now provides structured now/next/watchlist + owner-route recommendations.
+Review emits `recommendation-backlog.json` with scored recommendation backlog (`priority_index`) for execution sequencing.
+`release_readiness_contract.agent_orchestration` now suggests which specialist agents/playbooks to run based on current blockers and risk.
+Agent entries include `engine_signals` so orchestration decisions stay aligned with adaptive review outcomes.
+Review also emits `review-contract-check.json` with machine-readable reviewer contract consistency checks.
+
 
 - Canonical first proof: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
 - Canonical real-repo fixture proof: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,7 @@ Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit
 - Need top-tier reporting pipeline? Run `make top-tier-reporting`
 - Need legacy usage inventory? Run legacy command analyzer (`python scripts/legacy_command_analyzer.py --format json`)
 - Need one maturity number? Generate [Adoption scorecard](adoption-scorecard.md)
+- Need investor/leadership readiness posture? Use [Production readiness scorecard](production-readiness-scorecard.md)
 - Need guided canonical triage? Use [Operator onboarding wizard](operator-onboarding-wizard.md)
 - Need API snapshot? Query serve observability endpoint (`GET /v1/observability`)
 - Need docs IA guardrails? Use [Primary docs map](primary-docs-map.md)

--- a/docs/production-readiness-scorecard.md
+++ b/docs/production-readiness-scorecard.md
@@ -1,0 +1,69 @@
+# Production Readiness Scorecard
+
+`python -m sdetkit readiness` provides a deterministic baseline score for investor, operator, and leadership reviews.
+It now performs **content-aware checks** (not just file-existence checks) so the output is useful for real release decisions.
+The JSON payload includes reviewer-oriented rollups (`check_scorecard`, `failed_checks`, `achievement_level`) and `adaptive_actions` generated from scan evidence (lane + priority + rationale) so teams can quickly see pass/miss posture and changing remediation priorities.
+It also includes `scenario_capacity` aligned to a 250-scenario target for scale-phase validation planning, plus `operational_tier` / `top_tier_ready` to signal when the repo is actually ready for top-tier promotion.
+
+## Why this exists
+
+When a team asks "is this platform production-ready?", the answer should be evidence-backed and repeatable.
+This scorecard does that by checking for core release-confidence assets and producing a weighted score.
+
+## Usage
+
+```bash
+python -m sdetkit readiness . --format text
+python -m sdetkit readiness . --format json
+```
+
+## Current weighting model (`sdetkit.readiness.v2`)
+
+- Security policy includes vulnerability/reporting language (`SECURITY.md`) — 12
+- Release process includes explicit checklist language (`RELEASE.md`) — 12
+- Quality playbook includes gate policy language (`QUALITY_PLAYBOOK.md`) — 8
+- CI workflow includes tests + lint/quality execution (`.github/workflows/ci.yml`) — 14
+- Baseline automated test breadth (`tests/test_*.py` count >= 10) — 10
+- Docs entrypoint includes canonical path (`docs/index.md`) — 8
+- Dependency reproducibility lockfiles (`requirements.lock` + `poetry.lock`) — 10
+- Artifact evidence directory presence (`artifacts/` and/or `docs/artifacts`) — 8
+- Governance docs presence (`CODE_OF_CONDUCT.md`, `SUPPORT.md`, `CONTRIBUTING.md`) — 8
+- Changelog includes dated release entries (`CHANGELOG.md`) — 10
+
+## Tier semantics
+
+- `excellent` (>= 90): governance and delivery controls are in place and auditable.
+- `strong` (>= 75): mostly production-ready, with a small number of remediation tasks.
+- `needs-work` (< 75): baseline controls are missing; close top actions before launch.
+
+## Recommended workflow
+
+1. Run the scorecard in CI on every main-branch merge.
+2. Track weekly score trends in leadership ops docs.
+3. Treat `top_actions` as backlog items with owners and deadlines.
+4. Pair this score with `gate release`, `doctor`, and evidence artifacts for final ship/no-ship decisions.
+
+## Review + Doctor integration
+
+- `sdetkit review` now writes `readiness.json` as a first-class artifact for repo-like targets.
+- Review payloads include `adaptive_database.readiness_snapshot` (`score`, `tier`, `artifact`) so operator dashboards can query readiness directly from the adaptive database object.
+- Adaptive database now carries richer control-plane analytics (`quality_matrix`, `findings_analytics`, `action_analytics`, `scalability_posture`) for large-scale reviewer automation.
+- Adaptive database now also carries `release_readiness_contract` to support final-day launch calls (`gate_decision`, blockers, next 24h/72h actions).
+- Review outputs now include standalone `adaptive-database.json` so external control planes can ingest adaptive data without parsing full `review.json`.
+- Review outputs now include `release-readiness.json` and `release-readiness.md` for release-room decision handoffs.
+- Release readiness contracts include traceable metadata (`contract_id`, `generated_at_utc`, `next_review_due_at_utc`) so repeated runs can be tracked during launch week.
+- Release readiness contracts also include a `trend` block (`decision_changed`, `blockers_delta`) so operators can track whether launch posture is improving or regressing between runs.
+- Release readiness contracts include risk/SLA controls (`risk_score`, `risk_band`, `sla_review_hours`) to prioritize incident-response tempo before cutover.
+- Release readiness contracts include `blocker_catalog` entries for structured blocker triage and ownership mapping in release-room workflows.
+- Each blocker catalog entry now includes `owner_team` and `response_sla_hours` so action routing is explicit during incident/release huddles.
+- Contracts also include `owner_summary` to show blocker load and urgency per team (`blocker_count`, `max_priority`, `min_response_sla_hours`).
+- Contracts also include `recommendation_engine` (`now`, `next_72h`, `watchlist`, `owner_routes`) to keep adaptive recommendations aligned with release execution.
+- Review also emits `recommendation-backlog.json` with scored backlog rows (`impact_score`, `urgency_score`, `effort_score`, `priority_index`) for delivery ordering.
+- Release contracts include `agent_orchestration` recommendations so teams can activate role-specific playbooks/agents when risk or blockers demand deeper response.
+- Agent orchestration entries carry `engine_signals` (engine score/status, contradiction cluster count, probe count) to keep agent activation tied to adaptive-review evidence.
+- The doctor-first contract sequence now explicitly includes readiness:
+  1. `python -m sdetkit doctor --format json`
+  2. `python -m sdetkit readiness . --format json`
+  3. `python -m sdetkit gate fast --format json --stable-json`
+  4. `python -m sdetkit gate release --format json`
+  5. `python -m sdetkit review . --format operator-json`

--- a/src/sdetkit/apiget.py
+++ b/src/sdetkit/apiget.py
@@ -11,8 +11,6 @@ from collections.abc import Sequence
 from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-import httpx
-
 from .atomicio import atomic_write_text
 from .netclient import (
     CircuitOpenError,
@@ -30,6 +28,9 @@ from .security import (
     redact_url,
     safe_path,
 )
+from .optional_httpx import load_httpx
+
+httpx = load_httpx(feature="sdetkit apiget")
 
 
 def _is_sensitive_header(name: str) -> bool:

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -267,6 +267,11 @@ Then use stability-aware command discovery:
         "gate",
         help_text="[Public / stable] Quick confidence and strict release gate checks",
     )
+    _add_passthrough_subcommand(
+        sub,
+        "readiness",
+        help_text="[Public / stable] Production readiness scorecard for investor/operator reviews",
+    )
 
     _add_passthrough_subcommand(sub, "ci", help_text="CI template and pipeline validation")
 
@@ -779,6 +784,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "serve":
         return _run_module_main("sdetkit.serve", build_serve_args(ns))
+
+    if ns.cmd == "readiness":
+        return _run_module_main("sdetkit.readiness", ns.args)
 
     if ns.cmd == "init":
         return _run_module_main("sdetkit.repo", build_repo_init_forwarded_args(ns))

--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -49,6 +49,12 @@ EVIDENCE_PROFILES = ("ci", "release", "full")
 EVIDENCE_INCLUDES = ("failed", "actionable", "all")
 ENTERPRISE_RERUN_FAILED_COMMAND = "python -m sdetkit doctor --enterprise-rerun-failed --json"
 ENTERPRISE_RERUN_HIGH_COMMAND = "python -m sdetkit doctor --enterprise-rerun-high --json"
+DEFAULT_RELEASE_FRESHNESS_BUCKETS = (
+    "latest",
+    "recent",
+    "stale",
+    "unknown",
+)
 
 SUPPORTED_POLICY_CHECKS = {
     "ascii",
@@ -2410,7 +2416,9 @@ def main(argv: list[str] | None = None) -> int:
         "--upgrade-audit-release-freshness",
         dest="upgrade_audit_release_freshness",
         action="append",
-        choices=list(upgrade_audit.RELEASE_FRESHNESS_BUCKETS),
+        choices=list(
+            getattr(upgrade_audit, "RELEASE_FRESHNESS_BUCKETS", DEFAULT_RELEASE_FRESHNESS_BUCKETS)
+        ),
         default=None,
         help="Focus doctor upgrade-audit hints on selected target-release freshness buckets.",
     )

--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -9,9 +9,10 @@ from dataclasses import dataclass
 from typing import Any, Literal
 from urllib.parse import urljoin
 
-import httpx
-
+from .optional_httpx import load_httpx
 from .security import default_http_timeout, ensure_allowed_scheme
+
+httpx = load_httpx(feature="sdetkit network workflows")
 
 EventType = Literal[
     "attempt_start",

--- a/src/sdetkit/optional_httpx.py
+++ b/src/sdetkit/optional_httpx.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Utility for optional `httpx` loading in environments without network extras."""
+
+import importlib
+import importlib.util
+from typing import Any
+
+__all__ = ["load_httpx"]
+
+
+def _missing_message(feature: str) -> str:
+    return (
+        "httpx is required for "
+        f"{feature}; install optional network dependencies."
+    )
+
+
+def _build_missing_httpx_module(*, feature: str) -> Any:
+    message = _missing_message(feature)
+
+    class _MissingHttpxModule:
+        class TimeoutException(Exception):
+            pass
+
+        class HTTPError(Exception):
+            pass
+
+        class RequestError(Exception):
+            pass
+
+        class Response:
+            status_code = 0
+
+        class URL:
+            def __str__(self) -> str:
+                return ""
+
+        class Client:  # pragma: no cover - defensive fallback only
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise ModuleNotFoundError(message)
+
+        class AsyncClient:  # pragma: no cover - defensive fallback only
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise ModuleNotFoundError(message)
+
+        class HTTPTransport:  # pragma: no cover - defensive fallback only
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise ModuleNotFoundError(message)
+
+        class AsyncHTTPTransport:  # pragma: no cover - defensive fallback only
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise ModuleNotFoundError(message)
+
+        class MockTransport:  # pragma: no cover - defensive fallback only
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise ModuleNotFoundError(message)
+
+    return _MissingHttpxModule()
+
+
+def load_httpx(*, feature: str = "network workflows") -> Any:
+    if importlib.util.find_spec("httpx") is not None:
+        return importlib.import_module("httpx")
+    return _build_missing_httpx_module(feature=feature)

--- a/src/sdetkit/readiness.py
+++ b/src/sdetkit/readiness.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ReadinessResult:
+    passed: bool
+    evidence: str
+
+
+@dataclass(frozen=True)
+class ReadinessCheck:
+    key: str
+    description: str
+    weight: int
+    evaluator: Callable[[Path], ReadinessResult]
+    recommendation_hint: str
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists() or not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def _contains_all(path: Path, terms: tuple[str, ...]) -> ReadinessResult:
+    text = _read_text(path).lower()
+    if not text:
+        return ReadinessResult(False, f"missing file: {path.name}")
+
+    missing = [term for term in terms if term not in text]
+    if missing:
+        return ReadinessResult(False, f"missing keywords: {', '.join(missing)}")
+    return ReadinessResult(True, f"found keywords: {', '.join(terms)}")
+
+
+def _check_security_policy(root: Path) -> ReadinessResult:
+    return _contains_all(root / "SECURITY.md", ("vulnerability", "report"))
+
+
+def _check_release_process(root: Path) -> ReadinessResult:
+    return _contains_all(root / "RELEASE.md", ("release", "checklist"))
+
+
+def _check_quality_playbook(root: Path) -> ReadinessResult:
+    return _contains_all(root / "QUALITY_PLAYBOOK.md", ("quality", "gate"))
+
+
+def _check_ci_pipeline(root: Path) -> ReadinessResult:
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    text = _read_text(workflow).lower()
+    if not text:
+        return ReadinessResult(False, "missing ci workflow")
+
+    missing: list[str] = []
+    if "pytest" not in text:
+        missing.append("pytest")
+    if "ruff" not in text and "quality.sh" not in text:
+        missing.append("ruff or quality.sh")
+
+    if missing:
+        return ReadinessResult(False, f"pipeline missing: {', '.join(missing)}")
+    return ReadinessResult(True, "workflow includes test and lint/quality steps")
+
+
+def _check_tests_coverage_surface(root: Path) -> ReadinessResult:
+    tests_dir = root / "tests"
+    if not tests_dir.exists() or not tests_dir.is_dir():
+        return ReadinessResult(False, "tests directory missing")
+
+    test_files = [path for path in tests_dir.glob("test_*.py") if path.is_file()]
+    if len(test_files) < 10:
+        return ReadinessResult(False, f"only {len(test_files)} test files (need >= 10)")
+    return ReadinessResult(True, f"{len(test_files)} test files detected")
+
+
+def _check_docs_entrypoint(root: Path) -> ReadinessResult:
+    docs_index = root / "docs" / "index.md"
+    return _contains_all(docs_index, ("gate fast", "gate release", "doctor"))
+
+
+def _check_dependency_locks(root: Path) -> ReadinessResult:
+    requirements = root / "requirements.lock"
+    poetry = root / "poetry.lock"
+    missing = [path.name for path in (requirements, poetry) if not path.exists()]
+    if missing:
+        return ReadinessResult(False, f"missing lockfiles: {', '.join(missing)}")
+    return ReadinessResult(True, "requirements.lock and poetry.lock both present")
+
+
+def _check_artifact_evidence(root: Path) -> ReadinessResult:
+    artifacts = root / "artifacts"
+    docs_artifacts = root / "docs" / "artifacts"
+    if artifacts.exists() and docs_artifacts.exists():
+        return ReadinessResult(True, "artifacts and docs/artifacts directories exist")
+    if artifacts.exists():
+        return ReadinessResult(True, "artifacts directory exists")
+    return ReadinessResult(False, "missing artifacts evidence directory")
+
+
+def _check_governance_docs(root: Path) -> ReadinessResult:
+    required = ("CODE_OF_CONDUCT.md", "SUPPORT.md", "CONTRIBUTING.md")
+    missing = [name for name in required if not (root / name).exists()]
+    if missing:
+        return ReadinessResult(False, f"missing governance docs: {', '.join(missing)}")
+    return ReadinessResult(True, "core governance docs present")
+
+
+def _check_recent_changelog(root: Path) -> ReadinessResult:
+    changelog = root / "CHANGELOG.md"
+    text = _read_text(changelog)
+    if not text:
+        return ReadinessResult(False, "missing CHANGELOG.md")
+
+    match = re.search(r"20\d{2}-\d{2}-\d{2}", text)
+    if not match:
+        return ReadinessResult(False, "no dated release entries found")
+    return ReadinessResult(True, f"latest dated entry found: {match.group(0)}")
+
+
+def _scan_test_scenario_capacity(root: Path) -> dict[str, object]:
+    tests_dir = root / "tests"
+    target_scenarios = 250
+    if not tests_dir.exists() or not tests_dir.is_dir():
+        return {
+            "target_scenarios": target_scenarios,
+            "detected_scenarios": 0,
+            "gap": target_scenarios,
+            "status": "needs-expansion",
+            "estimated_from": "tests directory missing",
+        }
+
+    test_files = [path for path in tests_dir.glob("test_*.py") if path.is_file()]
+    test_functions = 0
+    for path in test_files:
+        text = _read_text(path)
+        test_functions += len(re.findall(r"^def\s+test_", text, flags=re.MULTILINE))
+
+    gap = max(0, target_scenarios - test_functions)
+    status = "ready" if gap == 0 else "needs-expansion"
+    return {
+        "target_scenarios": target_scenarios,
+        "detected_scenarios": test_functions,
+        "gap": gap,
+        "status": status,
+        "estimated_from": f"{len(test_files)} test files",
+    }
+
+
+CHECKS: tuple[ReadinessCheck, ...] = (
+    ReadinessCheck(
+        "security_policy",
+        "Security policy includes vulnerability reporting guidance",
+        12,
+        _check_security_policy,
+        "Document security reporting flow in SECURITY.md (contact channel + disclosure process).",
+    ),
+    ReadinessCheck(
+        "release_process",
+        "Release process includes explicit checklist guidance",
+        12,
+        _check_release_process,
+        "Add/expand release checklist steps in RELEASE.md.",
+    ),
+    ReadinessCheck(
+        "quality_playbook",
+        "Quality playbook defines gate/quality policy",
+        8,
+        _check_quality_playbook,
+        "Define quality gate policy and ownership in QUALITY_PLAYBOOK.md.",
+    ),
+    ReadinessCheck(
+        "ci_pipeline",
+        "CI workflow runs both tests and lint/quality steps",
+        14,
+        _check_ci_pipeline,
+        "Update .github/workflows/ci.yml to run pytest and ruff/quality checks.",
+    ),
+    ReadinessCheck(
+        "test_surface",
+        "Repository has baseline automated test surface",
+        10,
+        _check_tests_coverage_surface,
+        "Increase test breadth so tests/test_*.py includes at least 10 suites.",
+    ),
+    ReadinessCheck(
+        "docs_entrypoint",
+        "Docs entrypoint highlights canonical release-confidence flow",
+        8,
+        _check_docs_entrypoint,
+        "Ensure docs/index.md calls out gate fast -> gate release -> doctor.",
+    ),
+    ReadinessCheck(
+        "dependency_locks",
+        "Dependency lock strategy is present for reproducibility",
+        10,
+        _check_dependency_locks,
+        "Commit both requirements.lock and poetry.lock (or align lock strategy).",
+    ),
+    ReadinessCheck(
+        "artifact_evidence",
+        "Evidence artifact directories are available",
+        8,
+        _check_artifact_evidence,
+        "Create artifact storage paths (artifacts/ and/or docs/artifacts).",
+    ),
+    ReadinessCheck(
+        "governance_docs",
+        "Contributor governance docs are present",
+        8,
+        _check_governance_docs,
+        "Add CODE_OF_CONDUCT.md, SUPPORT.md, and CONTRIBUTING.md.",
+    ),
+    ReadinessCheck(
+        "changelog_hygiene",
+        "Changelog contains dated release history",
+        10,
+        _check_recent_changelog,
+        "Maintain dated release entries in CHANGELOG.md.",
+    ),
+)
+
+
+def _adaptive_action_for_failure(check: dict[str, object]) -> dict[str, object]:
+    weight = int(check.get("weight", 0))
+    priority = 80 if weight >= 12 else 65 if weight >= 10 else 50
+    lane = "now" if weight >= 12 else "next"
+    evidence = str(check.get("evidence", "")).strip()
+    hint = str(check.get("recommendation", "")).strip()
+    action = hint if hint else f"Address readiness gap: {check.get('key', 'unknown')}"
+    rationale = f"{check.get('description', 'readiness control')} failed ({evidence})"
+    return {
+        "check_id": str(check.get("key", "")),
+        "lane": lane,
+        "priority": priority,
+        "action": action,
+        "rationale": rationale,
+    }
+
+
+def _adaptive_scenario_action(scenario_capacity: dict[str, object]) -> dict[str, object] | None:
+    gap = int(scenario_capacity.get("gap", 0))
+    if gap <= 0:
+        return None
+    detected = int(scenario_capacity.get("detected_scenarios", 0))
+    target = int(scenario_capacity.get("target_scenarios", 250))
+    return {
+        "check_id": "test_scenario_capacity",
+        "lane": "now" if gap >= 100 else "next",
+        "priority": 82 if gap >= 100 else 68,
+        "action": (
+            f"Expand automated test scenarios from {detected} to at least {target} "
+            "to support large-scale release validation."
+        ),
+        "rationale": f"scenario gap is {gap} toward target {target}",
+    }
+
+
+def build_readiness_report(repo_root: Path) -> dict[str, object]:
+    checks: list[dict[str, object]] = []
+    total = sum(item.weight for item in CHECKS)
+    earned = 0
+
+    for item in CHECKS:
+        result = item.evaluator(repo_root)
+        if result.passed:
+            earned += item.weight
+
+        checks.append(
+            {
+                "key": item.key,
+                "description": item.description,
+                "weight": item.weight,
+                "passed": result.passed,
+                "status": "pass" if result.passed else "miss",
+                "evidence": result.evidence,
+                "recommendation": item.recommendation_hint,
+            }
+        )
+
+    score = round((earned / total) * 100, 2) if total else 0.0
+    tier = "excellent" if score >= 90 else "strong" if score >= 75 else "needs-work"
+    achievement_level = "gold" if score >= 90 else "silver" if score >= 75 else "bronze"
+
+    failing = sorted((check for check in checks if not check["passed"]), key=lambda c: -int(c["weight"]))
+    adaptive_actions = [_adaptive_action_for_failure(check) for check in failing]
+    scenario_capacity = _scan_test_scenario_capacity(repo_root)
+    scenario_action = _adaptive_scenario_action(scenario_capacity)
+    if scenario_action is not None:
+        adaptive_actions.insert(0, scenario_action)
+    scenario_ready = str(scenario_capacity.get("status", "needs-expansion")) == "ready"
+    operational_tier = tier
+    if tier == "excellent" and not scenario_ready:
+        operational_tier = "strong"
+    top_tier_ready = bool(score >= 90.0 and scenario_ready)
+    if achievement_level == "gold" and not top_tier_ready:
+        achievement_level = "silver"
+    top_actions = [str(action["action"]) for action in adaptive_actions[:5]]
+    passing = [check for check in checks if check["passed"]]
+    pass_rate = round((len(passing) / len(checks)) * 100, 2) if checks else 0.0
+    check_scorecard = {
+        "total_checks": len(checks),
+        "passed_checks": len(passing),
+        "missed_checks": len(failing),
+        "pass_rate": pass_rate,
+    }
+    achieved_controls = [str(check["key"]) for check in passing[:5]]
+
+    return {
+        "schema_version": "sdetkit.readiness.v2",
+        "repo_root": str(repo_root),
+        "score": score,
+        "tier": tier,
+        "operational_tier": operational_tier,
+        "top_tier_ready": top_tier_ready,
+        "achievement_level": achievement_level,
+        "weight_total": total,
+        "weight_earned": earned,
+        "check_scorecard": check_scorecard,
+        "achieved_controls": achieved_controls,
+        "checks": checks,
+        "failed_checks": [str(check["key"]) for check in failing],
+        "scenario_capacity": scenario_capacity,
+        "adaptive_actions": adaptive_actions,
+        "top_actions": top_actions,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit readiness",
+        description=(
+            "Generate a production-readiness snapshot for investor and leadership reviews."
+        ),
+    )
+    parser.add_argument("path", nargs="?", default=".", help="Repository root to evaluate")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    return parser
+
+
+def _render_text(report: dict[str, object]) -> str:
+    lines = [
+        "SDETKit Production Readiness Snapshot",
+        f"score: {report['score']} / 100 ({report['tier']})",
+        f"operational tier: {report['operational_tier']} (top-tier-ready={report['top_tier_ready']})",
+        f"achievement: {report['achievement_level']}",
+        f"earned: {report['weight_earned']} of {report['weight_total']} weighted points",
+        (
+            "checks summary: "
+            f"pass={report['check_scorecard']['passed_checks']}, "
+            f"miss={report['check_scorecard']['missed_checks']}, "
+            f"pass_rate={report['check_scorecard']['pass_rate']}%"
+        ),
+        "",
+        "checks:",
+    ]
+
+    for check in report["checks"]:
+        marker = "PASS" if check["passed"] else "MISS"
+        lines.append(
+            f"- [{marker}] {check['description']} (weight={check['weight']}) -> {check['evidence']}"
+        )
+
+    actions = report["adaptive_actions"]
+    if actions:
+        lines.append("")
+        lines.append("recommended next actions:")
+        for action in actions:
+            lines.append(
+                f"- [{action['lane']}] {action['action']} "
+                f"(priority={action['priority']}; reason={action['rationale']})"
+            )
+
+    achieved_controls = report.get("achieved_controls", [])
+    if achieved_controls:
+        lines.append("")
+        lines.append("achieved controls:")
+        for control in achieved_controls:
+            lines.append(f"- {control}")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _build_parser().parse_args(argv)
+    report = build_readiness_report(Path(ns.path).resolve())
+
+    if ns.format == "json":
+        print(json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True))
+        return 0
+
+    print(_render_text(report), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import io
 import json
 import sys
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from . import doctor, inspect_project
+from . import doctor, inspect_project, readiness
 from .evidence_workspace import load_workspace_manifest, record_workspace_run
 from .inspect_compare import run_compare
 from .inspect_data import run_inspect
@@ -504,6 +506,17 @@ def _run_doctor(
     return int(rc), payload, doctor_json
 
 
+def _run_readiness(target: Path, out_dir: Path) -> tuple[dict[str, Any], Path]:
+    readiness_root = target if target.is_dir() else target.parent
+    payload = readiness.build_readiness_report(readiness_root)
+    readiness_json = out_dir / "readiness.json"
+    readiness_json.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return payload, readiness_json
+
+
 def _review_scope_for_target(target: Path) -> str:
     return _safe_slug(target.resolve().as_posix())
 
@@ -551,6 +564,14 @@ def run_review(
             "probes": {},
         }
     )
+    previous_review = None
+    previous_hash = None
+    if not no_workspace:
+        previous_review, previous_hash = load_latest_previous_payload(
+            workspace_root=workspace_root,
+            workflow="review",
+            scope=review_scope,
+        )
 
     source_workflows: list[dict[str, Any]] = []
     supporting: list[dict[str, Any]] = []
@@ -652,6 +673,65 @@ def run_review(
                 }
             )
         supporting.append({"kind": "doctor_ok", "value": bool(doctor_payload.get("ok", False))})
+
+    if detection["repo_like"]:
+        readiness_payload, readiness_json = _run_readiness(target, out_dir)
+        artifact_index["readiness_json"] = readiness_json.as_posix()
+        readiness_score = float(readiness_payload.get("score", 0.0))
+        readiness_tier = str(readiness_payload.get("tier", "needs-work"))
+        readiness_status = "ok" if readiness_score >= 75.0 else "findings"
+        source_workflows.append({"workflow": "readiness", "status": readiness_status})
+        baseline_stage["checks_run"].append({"check": "readiness", "status": readiness_status})
+        supporting.append({"kind": "readiness_score", "value": readiness_score})
+        supporting.append({"kind": "readiness_tier", "value": readiness_tier})
+        supporting.append(
+            {"kind": "readiness_operational_tier", "value": str(readiness_payload.get("operational_tier", "needs-work"))}
+        )
+        supporting.append(
+            {"kind": "readiness_top_tier_ready", "value": bool(readiness_payload.get("top_tier_ready", False))}
+        )
+        supporting.append(
+            {
+                "kind": "readiness_check_scorecard",
+                "value": dict(readiness_payload.get("check_scorecard", {})),
+            }
+        )
+        supporting.append(
+            {"kind": "readiness_failed_checks", "value": list(readiness_payload.get("failed_checks", []))}
+        )
+        supporting.append(
+            {
+                "kind": "readiness_scenario_capacity",
+                "value": dict(readiness_payload.get("scenario_capacity", {})),
+            }
+        )
+
+        if readiness_score >= 90.0:
+            healthy_controls.append("production-readiness scorecard indicates strong launch posture")
+        else:
+            findings.append(
+                {
+                    "id": "review:readiness",
+                    "kind": "readiness",
+                    "severity": "high" if readiness_score < 75.0 else "medium",
+                    "priority": 72 if readiness_score < 75.0 else 58,
+                    "why_it_matters": (
+                        "readiness scorecard indicates missing launch controls across governance/CI/release"
+                    ),
+                    "next_action": "Close top readiness actions before promotion decisions.",
+                    "message": f"readiness score is {readiness_score} ({readiness_tier})",
+                }
+            )
+            for idx, action in enumerate(readiness_payload.get("adaptive_actions", [])[:3]):
+                if not isinstance(action, dict):
+                    continue
+                prioritized_actions.append(
+                    {
+                        "tier": str(action.get("lane", "now" if readiness_score < 75.0 else "next")),
+                        "priority": int(action.get("priority", 72 - idx)),
+                        "action": str(action.get("action", "")),
+                    }
+                )
 
     inspect_payload: dict[str, Any] | None = None
     if "inspect" in baseline_checks:
@@ -775,6 +855,11 @@ def run_review(
         inspect_payload
         and "inspect-compare" in deepen_checks
         and escalation.needed
+        and (
+            not previous_review
+            or not detection.get("repo_like", False)
+            or bool(contradiction_graph.get("flat_contradictions"))
+        )
         and not no_workspace
     ):
         scope = _review_scope_for_target(target)
@@ -912,14 +997,6 @@ def run_review(
     review_judgment["recommendations"] = profile_recs
 
     prioritized_actions.extend(review_judgment.get("recommendations", []))
-    previous_review = None
-    previous_hash = None
-    if not no_workspace:
-        previous_review, previous_hash = load_latest_previous_payload(
-            workspace_root=workspace_root,
-            workflow="review",
-            scope=review_scope,
-        )
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "contract_version": REVIEW_CONTRACT_VERSION,
@@ -1086,6 +1163,7 @@ def run_review(
         "review_adaptive_enabled": True,
         "gate_fast_recommended": True,
         "code_scanning_included": "code_scanning" in payload,
+        "readiness_included": "readiness_json" in artifact_index,
         "work_id": str(payload.get("request_context", {}).get("work_id", "")),
     }
     doctor_gate_contract = {
@@ -1095,12 +1173,340 @@ def run_review(
         "gate_fast_required_for_promotion": True,
         "canonical_sequence": [
             "python -m sdetkit doctor --format json",
+            "python -m sdetkit readiness . --format json",
             "python -m sdetkit gate fast --format json --stable-json",
             "python -m sdetkit gate release --format json",
             "python -m sdetkit review . --format operator-json",
         ],
     }
     payload["doctor_gate_contract"] = doctor_gate_contract
+    findings_severity_counts: dict[str, int] = {}
+    findings_kind_counts: dict[str, int] = {}
+    for item in payload.get("findings", []):
+        if not isinstance(item, dict):
+            continue
+        sev = str(item.get("severity", "unknown"))
+        kind = str(item.get("kind", "unknown"))
+        findings_severity_counts[sev] = int(findings_severity_counts.get(sev, 0)) + 1
+        findings_kind_counts[kind] = int(findings_kind_counts.get(kind, 0)) + 1
+
+    action_tier_counts: dict[str, int] = {}
+    for item in payload.get("prioritized_actions", []):
+        if not isinstance(item, dict):
+            continue
+        tier = str(item.get("tier", "unknown"))
+        action_tier_counts[tier] = int(action_tier_counts.get(tier, 0)) + 1
+
+    release_blockers = [
+        str(item.get("id", "unknown"))
+        for item in payload.get("findings", [])
+        if isinstance(item, dict) and int(item.get("priority", 0)) >= 70
+    ]
+    blocker_catalog: list[dict[str, Any]] = []
+    owner_routing = {
+        "doctor": ("platform-quality", 24),
+        "readiness": ("release-management", 24),
+        "code-scanning": ("security", 8),
+        "inspect": ("qa-ops", 24),
+        "inspect-project": ("qa-ops", 24),
+    }
+    for item in payload.get("findings", []):
+        if not isinstance(item, dict) or int(item.get("priority", 0)) < 70:
+            continue
+        kind = str(item.get("kind", "unknown"))
+        owner_team, response_sla_hours = owner_routing.get(kind, ("release-management", 24))
+        blocker_catalog.append(
+            {
+                "id": str(item.get("id", "unknown")),
+                "kind": kind,
+                "severity": str(item.get("severity", "unknown")),
+                "priority": int(item.get("priority", 0)),
+                "why_it_matters": str(item.get("why_it_matters", "")),
+                "next_action": str(item.get("next_action", "")),
+                "owner_team": owner_team,
+                "response_sla_hours": response_sla_hours,
+            }
+        )
+    readiness_top_tier_ready = next(
+        (
+            bool(row.get("value", False))
+            for row in supporting
+            if isinstance(row, dict) and str(row.get("kind")) == "readiness_top_tier_ready"
+        ),
+        False,
+    )
+    if not readiness_top_tier_ready and "readiness:top-tier-gate" not in release_blockers:
+        release_blockers.append("readiness:top-tier-gate")
+        blocker_catalog.append(
+            {
+                "id": "readiness:top-tier-gate",
+                "kind": "readiness",
+                "severity": "high",
+                "priority": 72,
+                "why_it_matters": (
+                    "Top-tier readiness gate is not satisfied for current scenario-capacity target."
+                ),
+                "next_action": "Close readiness adaptive actions until top_tier_ready=true.",
+                "owner_team": "release-management",
+                "response_sla_hours": 24,
+            }
+        )
+    owner_summary_map: dict[str, dict[str, Any]] = {}
+    for row in blocker_catalog:
+        if not isinstance(row, dict):
+            continue
+        owner = str(row.get("owner_team", "release-management"))
+        item = owner_summary_map.setdefault(
+            owner,
+            {
+                "owner_team": owner,
+                "blocker_count": 0,
+                "max_priority": 0,
+                "min_response_sla_hours": 72,
+            },
+        )
+        item["blocker_count"] = int(item.get("blocker_count", 0)) + 1
+        item["max_priority"] = max(int(item.get("max_priority", 0)), int(row.get("priority", 0)))
+        item["min_response_sla_hours"] = min(
+            int(item.get("min_response_sla_hours", 72)),
+            int(row.get("response_sla_hours", 72)),
+        )
+    owner_summary = sorted(
+        owner_summary_map.values(),
+        key=lambda item: (-int(item.get("blocker_count", 0)), -int(item.get("max_priority", 0))),
+    )
+    owner_routes = [
+        {
+            "owner_team": str(item.get("owner_team", "")),
+            "priority_focus": int(item.get("max_priority", 0)),
+            "recommended_actions": [
+                str(row.get("next_action", ""))
+                for row in blocker_catalog
+                if isinstance(row, dict)
+                and str(row.get("owner_team", "")) == str(item.get("owner_team", ""))
+                and str(row.get("next_action", "")).strip()
+            ][:5],
+        }
+        for item in owner_summary
+        if isinstance(item, dict)
+    ]
+    next_24h_actions = [
+        str(item.get("action", ""))
+        for item in payload.get("prioritized_actions", [])
+        if isinstance(item, dict)
+        and str(item.get("tier", "")).strip().lower() == "now"
+        and str(item.get("action", "")).strip()
+    ][:5]
+    next_72h_actions = [
+        str(item.get("action", ""))
+        for item in payload.get("prioritized_actions", [])
+        if isinstance(item, dict)
+        and str(item.get("tier", "")).strip().lower() in {"next", "soon"}
+        and str(item.get("action", "")).strip()
+    ][:8]
+    release_ready_now = len(release_blockers) == 0
+    generated_at = datetime.now(timezone.utc)
+    generated_at_utc = generated_at.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    next_review_due = generated_at + (timedelta(hours=72) if release_ready_now else timedelta(hours=24))
+    next_review_due_utc = next_review_due.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    contract_material = {
+        "gate_decision": "ship" if release_ready_now else "hold",
+        "blockers": release_blockers,
+        "next_24h_actions": next_24h_actions,
+        "next_72h_actions": next_72h_actions,
+    }
+    contract_id = hashlib.sha256(
+        json.dumps(contract_material, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    previous_release_contract: dict[str, Any] | None = None
+    if isinstance(previous_review, dict):
+        prev_adaptive = previous_review.get("adaptive_database", {})
+        if isinstance(prev_adaptive, dict):
+            prev_contract = prev_adaptive.get("release_readiness_contract", {})
+            if isinstance(prev_contract, dict):
+                previous_release_contract = prev_contract
+
+    prev_gate_decision = (
+        str(previous_release_contract.get("gate_decision", "unknown"))
+        if isinstance(previous_release_contract, dict)
+        else "unknown"
+    )
+    prev_blockers_count = (
+        len(previous_release_contract.get("blockers", []))
+        if isinstance(previous_release_contract, dict)
+        and isinstance(previous_release_contract.get("blockers", []), list)
+        else 0
+    )
+    release_trend = {
+        "has_previous_contract": bool(previous_release_contract),
+        "previous_gate_decision": prev_gate_decision,
+        "decision_changed": prev_gate_decision not in {"unknown", "ship" if release_ready_now else "hold"},
+        "previous_blockers_count": prev_blockers_count,
+        "current_blockers_count": len(release_blockers),
+        "blockers_delta": len(release_blockers) - prev_blockers_count,
+    }
+    high_priority_findings = len(
+        [
+            row
+            for row in payload.get("findings", [])
+            if isinstance(row, dict) and int(row.get("priority", 0)) >= 70
+        ]
+    )
+    release_risk_score = min(100, int((len(release_blockers) * 25) + (high_priority_findings * 10)))
+    release_risk_band = (
+        "critical" if release_risk_score >= 80 else "high" if release_risk_score >= 55 else "medium" if release_risk_score >= 30 else "low"
+    )
+    sla_review_hours = 8 if release_risk_band == "critical" else 24 if release_risk_band == "high" else 48 if release_risk_band == "medium" else 72
+    recommendation_engine = {
+        "now": next_24h_actions[:5],
+        "next_72h": next_72h_actions[:8],
+        "watchlist": [
+            str(item.get("action", ""))
+            for item in payload.get("prioritized_actions", [])
+            if isinstance(item, dict)
+            and str(item.get("tier", "")).strip().lower() in {"monitor", "later"}
+            and str(item.get("action", "")).strip()
+        ][:8],
+        "owner_routes": owner_routes,
+    }
+    backlog_candidates: list[tuple[str, str]] = []
+    backlog_candidates.extend([("now", action) for action in recommendation_engine["now"]])
+    backlog_candidates.extend([("next", action) for action in recommendation_engine["next_72h"]])
+    backlog_candidates.extend([("watch", action) for action in recommendation_engine["watchlist"]])
+    recommendation_backlog: list[dict[str, Any]] = []
+    seen_actions: set[str] = set()
+    for lane, action in backlog_candidates:
+        normalized_action = str(action).strip()
+        if not normalized_action or normalized_action in seen_actions:
+            continue
+        seen_actions.add(normalized_action)
+        matched_blocker = next(
+            (
+                row
+                for row in blocker_catalog
+                if isinstance(row, dict) and str(row.get("next_action", "")).strip() == normalized_action
+            ),
+            {},
+        )
+        owner_team = (
+            str(matched_blocker.get("owner_team", "release-management"))
+            if isinstance(matched_blocker, dict)
+            else "release-management"
+        )
+        urgency = 90 if lane == "now" else 65 if lane == "next" else 35
+        impact = (
+            85
+            if release_risk_band in {"critical", "high"}
+            else 70 if release_risk_band == "medium" else 55
+        )
+        effort = 3 if len(normalized_action) < 80 else 5
+        priority_index = round((impact + urgency) / max(effort, 1), 2)
+        recommendation_backlog.append(
+            {
+                "action": normalized_action,
+                "lane": lane,
+                "owner_team": owner_team,
+                "impact_score": impact,
+                "urgency_score": urgency,
+                "effort_score": effort,
+                "priority_index": priority_index,
+            }
+        )
+    recommendation_backlog.sort(
+        key=lambda item: float(item.get("priority_index", 0.0)),
+        reverse=True,
+    )
+    overall_engine = payload.get("five_heads", {}).get("overall", {})
+    if not isinstance(overall_engine, dict):
+        overall_engine = {}
+    contradiction_clusters = payload.get("contradiction_graph", {}).get("clusters", [])
+    if not isinstance(contradiction_clusters, list):
+        contradiction_clusters = []
+    executed_probes = payload.get("adaptive_review", {}).get("executed_probes", [])
+    if not isinstance(executed_probes, list):
+        executed_probes = []
+    engine_signals = {
+        "engine_score": float(overall_engine.get("score", 0.0)),
+        "engine_status": str(overall_engine.get("status", "unknown")),
+        "contradiction_clusters": len(contradiction_clusters),
+        "executed_probes": len([row for row in executed_probes if isinstance(row, dict)]),
+    }
+
+    agent_orchestration: list[dict[str, Any]] = [
+        {
+            "agent_id": "release-ops-observer",
+            "purpose": "Track release contract drift and artifact freshness across reruns.",
+            "when_to_use": "Always during release week.",
+            "engine_signals": engine_signals,
+            "suggested_commands": [
+                "python -m sdetkit review . --format operator-json",
+                "python -m sdetkit review . --format json",
+            ],
+        }
+    ]
+    if release_risk_band in {"critical", "high"}:
+        agent_orchestration.append(
+            {
+                "agent_id": "release-commander",
+                "purpose": "Drive blocker burn-down and enforce ship/hold cadence.",
+                "when_to_use": "High/critical release risk.",
+                "engine_signals": engine_signals,
+                "suggested_commands": [
+                    "python -m sdetkit doctor --format json",
+                    "python -m sdetkit gate release --format json",
+                ],
+            }
+        )
+    if any(str(item.get("id", "")).startswith("review:doctor") for item in payload.get("findings", []) if isinstance(item, dict)):
+        agent_orchestration.append(
+            {
+                "agent_id": "platform-quality-agent",
+                "purpose": "Resolve doctor hygiene/governance failures quickly.",
+                "when_to_use": "Doctor findings present.",
+                "engine_signals": engine_signals,
+                "suggested_commands": [
+                    "python -m sdetkit doctor --repo --ci --deps --clean-tree --format json",
+                ],
+            }
+        )
+    if "readiness:top-tier-gate" in release_blockers:
+        agent_orchestration.append(
+            {
+                "agent_id": "readiness-hardening-agent",
+                "purpose": "Close top-tier readiness gaps and scenario-capacity blockers.",
+                "when_to_use": "Top-tier readiness gate fails.",
+                "engine_signals": engine_signals,
+                "suggested_commands": [
+                    "python -m sdetkit readiness . --format json",
+                ],
+            }
+        )
+    if engine_signals["contradiction_clusters"] > 0 or engine_signals["executed_probes"] > 0:
+        agent_orchestration.append(
+            {
+                "agent_id": "adaptive-probe-agent",
+                "purpose": "Investigate contradiction clusters and tighten evidence confidence.",
+                "when_to_use": "Contradiction clusters or probe-heavy runs detected.",
+                "engine_signals": engine_signals,
+                "suggested_commands": [
+                    "python -m sdetkit inspect-compare --latest-vs-previous --format json",
+                    "python -m sdetkit review . --format json",
+                ],
+            }
+        )
+
+    readiness_scenario_snapshot = next(
+        (
+            dict(row.get("value", {}))
+            for row in supporting
+            if isinstance(row, dict) and str(row.get("kind")) == "readiness_scenario_capacity"
+        ),
+        {"target_scenarios": 250, "detected_scenarios": 0, "gap": 250, "status": "needs-expansion"},
+    )
+    detected_scenarios = int(readiness_scenario_snapshot.get("detected_scenarios", 0))
+    target_scenarios = int(readiness_scenario_snapshot.get("target_scenarios", 250))
+    scenario_runway_ratio = round((detected_scenarios / target_scenarios), 2) if target_scenarios else 0.0
+
     payload["adaptive_database"] = {
         "schema_version": "sdetkit.review.adaptive-database.v1",
         "scope": review_scope,
@@ -1108,6 +1514,145 @@ def run_review(
         "top5_actions": top5_actions,
         "workflow_alignment": workflow_alignment,
         "doctor_gate_contract": doctor_gate_contract,
+        "readiness_snapshot": {
+            "score": next(
+                (
+                    float(row.get("value", 0.0))
+                    for row in supporting
+                    if isinstance(row, dict) and str(row.get("kind")) == "readiness_score"
+                ),
+                0.0,
+            ),
+            "tier": next(
+                (
+                    str(row.get("value", "needs-work"))
+                    for row in supporting
+                    if isinstance(row, dict) and str(row.get("kind")) == "readiness_tier"
+                ),
+                "needs-work",
+            ),
+            "operational_tier": next(
+                (
+                    str(row.get("value", "needs-work"))
+                    for row in supporting
+                    if isinstance(row, dict) and str(row.get("kind")) == "readiness_operational_tier"
+                ),
+                "needs-work",
+            ),
+            "top_tier_ready": next(
+                (
+                    bool(row.get("value", False))
+                    for row in supporting
+                    if isinstance(row, dict) and str(row.get("kind")) == "readiness_top_tier_ready"
+                ),
+                False,
+            ),
+            "check_scorecard": next(
+                (
+                    dict(row.get("value", {}))
+                    for row in supporting
+                    if isinstance(row, dict) and str(row.get("kind")) == "readiness_check_scorecard"
+                ),
+                {"total_checks": 0, "passed_checks": 0, "missed_checks": 0, "pass_rate": 0.0},
+            ),
+            "failed_checks": next(
+                (
+                    list(row.get("value", []))
+                    for row in supporting
+                    if isinstance(row, dict) and str(row.get("kind")) == "readiness_failed_checks"
+                ),
+                [],
+            ),
+            "scenario_capacity": next(
+                (
+                    dict(row.get("value", {}))
+                    for row in supporting
+                    if isinstance(row, dict) and str(row.get("kind")) == "readiness_scenario_capacity"
+                ),
+                {
+                    "target_scenarios": 250,
+                    "detected_scenarios": 0,
+                    "gap": 250,
+                    "status": "needs-expansion",
+                },
+            ),
+            "artifact": artifact_index.get("readiness_json"),
+        },
+        "adaptive_alignment": {
+            "engine": "five_heads",
+            "doctor_included": workflow_alignment["doctor_included"],
+            "readiness_included": workflow_alignment["readiness_included"],
+            "scenario_target": 250,
+            "scenario_status": next(
+                (
+                    str(row.get("value", {}).get("status", "needs-expansion"))
+                    for row in supporting
+                    if isinstance(row, dict) and str(row.get("kind")) == "readiness_scenario_capacity"
+                ),
+                "needs-expansion",
+            ),
+        },
+        "quality_matrix": {
+            "workflow_status": str(payload.get("status", "unknown")),
+            "workflow_severity": str(payload.get("severity", "unknown")),
+            "confidence_score": float(payload.get("confidence", {}).get("score", 0.0)),
+            "findings_total": len(payload.get("findings", [])),
+            "conflicts_total": len(payload.get("conflicting_signals", [])),
+            "healthy_controls_total": len(payload.get("healthy_controls", [])),
+            "findings_by_severity": findings_severity_counts,
+        },
+        "findings_analytics": {
+            "by_severity": findings_severity_counts,
+            "by_kind": findings_kind_counts,
+            "high_priority_total": len(
+                [
+                    row
+                    for row in payload.get("findings", [])
+                    if isinstance(row, dict) and int(row.get("priority", 0)) >= 70
+                ]
+            ),
+        },
+        "action_analytics": {
+            "tiers": action_tier_counts,
+            "top_priorities": [
+                int(item.get("priority", 0))
+                for item in payload.get("prioritized_actions", [])
+                if isinstance(item, dict)
+            ][:10],
+        },
+        "scalability_posture": {
+            "scenario_capacity": readiness_scenario_snapshot,
+            "target_scenarios": target_scenarios,
+            "detected_scenarios": detected_scenarios,
+            "runway_ratio": scenario_runway_ratio,
+            "scale_mode": "top-tier-ready" if scenario_runway_ratio >= 1.0 else "expansion-required",
+        },
+        "release_readiness_contract": {
+            "contract_id": contract_id,
+            "generated_at_utc": generated_at_utc,
+            "next_review_due_at_utc": next_review_due_utc,
+            "ready_now": release_ready_now,
+            "gate_decision": "ship" if release_ready_now else "hold",
+            "blockers": release_blockers,
+            "blocker_catalog": blocker_catalog,
+            "owner_summary": owner_summary,
+            "recommendation_engine": recommendation_engine,
+            "recommendation_backlog": recommendation_backlog,
+            "agent_orchestration": agent_orchestration,
+            "trend": release_trend,
+            "risk_score": release_risk_score,
+            "risk_band": release_risk_band,
+            "sla_review_hours": sla_review_hours,
+            "next_24h_actions": next_24h_actions,
+            "next_72h_actions": next_72h_actions,
+            "recommended_sequence": [
+                "python -m sdetkit doctor --format json",
+                "python -m sdetkit readiness . --format json",
+                "python -m sdetkit gate fast --format json --stable-json",
+                "python -m sdetkit gate release --format json",
+                "python -m sdetkit review . --format operator-json",
+            ],
+        },
         "probe_memory_updates": payload["adaptive_review"]["probe_memory"].get("updates", []),
     }
     ai_assistant = payload["adaptive_review"].get("ai_assistant", {})
@@ -1120,6 +1665,7 @@ def run_review(
         }
         ai_assistant["doctor_gate_contract"] = doctor_gate_contract
         payload["adaptive_review"]["ai_assistant"] = ai_assistant
+    payload["review_contract_check"] = _build_review_contract_check(payload)
     payload["operator_summary"] = _build_operator_summary(payload)
 
     json_path = out_dir / "review.json"
@@ -1128,10 +1674,20 @@ def run_review(
     operator_json_path = out_dir / "review-operator-summary.json"
     review_plan_path = out_dir / "review-plan.json"
     review_tracks_path = out_dir / "review-tracks.json"
+    adaptive_db_path = out_dir / "adaptive-database.json"
+    review_contract_check_path = out_dir / "review-contract-check.json"
+    release_readiness_json_path = out_dir / "release-readiness.json"
+    release_readiness_md_path = out_dir / "release-readiness.md"
+    recommendation_backlog_json_path = out_dir / "recommendation-backlog.json"
     artifact_index["profile_packet_json"] = packet_json_path.as_posix()
     artifact_index["operator_summary_json"] = operator_json_path.as_posix()
     artifact_index["review_plan_json"] = review_plan_path.as_posix()
     artifact_index["review_tracks_json"] = review_tracks_path.as_posix()
+    artifact_index["adaptive_database_json"] = adaptive_db_path.as_posix()
+    artifact_index["review_contract_check_json"] = review_contract_check_path.as_posix()
+    artifact_index["release_readiness_json"] = release_readiness_json_path.as_posix()
+    artifact_index["release_readiness_md"] = release_readiness_md_path.as_posix()
+    artifact_index["recommendation_backlog_json"] = recommendation_backlog_json_path.as_posix()
     payload["artifact_index"] = artifact_index
     payload["operator_summary"]["artifacts"] = artifact_index
     packet_json_path.write_text(
@@ -1145,6 +1701,32 @@ def run_review(
     )
     review_tracks_path.write_text(
         json.dumps({"tracks": likely_tracks}, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    adaptive_db_path.write_text(
+        json.dumps(payload["adaptive_database"], sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    review_contract_check_path.write_text(
+        json.dumps(payload["review_contract_check"], sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    release_readiness_json_path.write_text(
+        json.dumps(payload["adaptive_database"]["release_readiness_contract"], sort_keys=True, indent=2)
+        + "\n",
+        encoding="utf-8",
+    )
+    release_readiness_md_path.write_text(
+        _render_release_readiness_markdown(payload["adaptive_database"]["release_readiness_contract"]),
+        encoding="utf-8",
+    )
+    recommendation_backlog_json_path.write_text(
+        json.dumps(
+            payload["adaptive_database"]["release_readiness_contract"].get("recommendation_backlog", []),
+            sort_keys=True,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
     )
     json_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
     txt_path.write_text(_render_text(payload), encoding="utf-8")
@@ -1310,6 +1892,152 @@ def _render_text(payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _render_release_readiness_markdown(contract: dict[str, Any]) -> str:
+    contract_id = str(contract.get("contract_id", "unknown"))
+    decision = str(contract.get("gate_decision", "hold")).strip().lower()
+    ready_now = bool(contract.get("ready_now", False))
+    generated_at = str(contract.get("generated_at_utc", ""))
+    next_due_at = str(contract.get("next_review_due_at_utc", ""))
+    risk_score = int(contract.get("risk_score", 0))
+    risk_band = str(contract.get("risk_band", "low"))
+    sla_hours = int(contract.get("sla_review_hours", 72))
+    blockers = [str(item) for item in contract.get("blockers", [])]
+    blocker_catalog = contract.get("blocker_catalog", [])
+    if not isinstance(blocker_catalog, list):
+        blocker_catalog = []
+    owner_summary = contract.get("owner_summary", [])
+    if not isinstance(owner_summary, list):
+        owner_summary = []
+    recommendation_engine = contract.get("recommendation_engine", {})
+    if not isinstance(recommendation_engine, dict):
+        recommendation_engine = {}
+    recommendation_backlog = contract.get("recommendation_backlog", [])
+    if not isinstance(recommendation_backlog, list):
+        recommendation_backlog = []
+    agent_orchestration = contract.get("agent_orchestration", [])
+    if not isinstance(agent_orchestration, list):
+        agent_orchestration = []
+    trend = contract.get("trend", {})
+    if not isinstance(trend, dict):
+        trend = {}
+    actions_24h = [str(item) for item in contract.get("next_24h_actions", [])]
+    actions_72h = [str(item) for item in contract.get("next_72h_actions", [])]
+    sequence = [str(item) for item in contract.get("recommended_sequence", [])]
+
+    lines = [
+        "# Release Readiness Contract",
+        "",
+        f"- Contract ID: `{contract_id}`",
+        f"- Gate decision: **{decision}**",
+        f"- Ready now: **{str(ready_now).lower()}**",
+        f"- Generated at (UTC): `{generated_at}`",
+        f"- Next review due (UTC): `{next_due_at}`",
+        f"- Risk: **{risk_band}** (`score={risk_score}`)",
+        f"- SLA review window: **{sla_hours}h**",
+        f"- Blockers: **{len(blockers)}**",
+        (
+            "- Trend: "
+            f"prev_decision=`{trend.get('previous_gate_decision', 'unknown')}`, "
+            f"decision_changed={trend.get('decision_changed', False)}, "
+            f"blockers_delta={trend.get('blockers_delta', 0)}"
+        ),
+        "",
+        "## Blockers",
+    ]
+    if blockers:
+        lines.extend([f"- {item}" for item in blockers])
+    else:
+        lines.append("- none")
+    if blocker_catalog:
+        lines.extend(["", "## Blocker details"])
+        for row in blocker_catalog[:8]:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                "- "
+                f"{row.get('id')} "
+                f"(kind={row.get('kind')}, severity={row.get('severity')}, priority={row.get('priority')}, "
+                f"owner={row.get('owner_team')}, sla={row.get('response_sla_hours')}h)"
+            )
+            lines.append(f"  - why: {row.get('why_it_matters', '')}")
+            lines.append(f"  - next: {row.get('next_action', '')}")
+    if owner_summary:
+        lines.extend(["", "## Owner summary"])
+        for row in owner_summary:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                "- "
+                f"{row.get('owner_team')}: blockers={row.get('blocker_count')}, "
+                f"max_priority={row.get('max_priority')}, "
+                f"min_sla_hours={row.get('min_response_sla_hours')}"
+            )
+    rec_now = recommendation_engine.get("now", [])
+    rec_next = recommendation_engine.get("next_72h", [])
+    rec_watch = recommendation_engine.get("watchlist", [])
+    owner_routes = recommendation_engine.get("owner_routes", [])
+    if not isinstance(rec_now, list):
+        rec_now = []
+    if not isinstance(rec_next, list):
+        rec_next = []
+    if not isinstance(rec_watch, list):
+        rec_watch = []
+    if not isinstance(owner_routes, list):
+        owner_routes = []
+    lines.extend(["", "## Recommendation engine"])
+    lines.append("### Now")
+    lines.extend([f"- {item}" for item in rec_now[:5]] or ["- none"])
+    lines.append("")
+    lines.append("### Next 72h")
+    lines.extend([f"- {item}" for item in rec_next[:8]] or ["- none"])
+    lines.append("")
+    lines.append("### Watchlist")
+    lines.extend([f"- {item}" for item in rec_watch[:8]] or ["- none"])
+    if owner_routes:
+        lines.extend(["", "### Owner routes"])
+        for row in owner_routes[:6]:
+            if not isinstance(row, dict):
+                continue
+            lines.append(f"- {row.get('owner_team')}: focus={row.get('priority_focus')}")
+            for action in row.get("recommended_actions", [])[:3]:
+                lines.append(f"  - {action}")
+    if recommendation_backlog:
+        lines.extend(["", "### Backlog ranking"])
+        for row in recommendation_backlog[:10]:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                "- "
+                f"{row.get('action')} "
+                f"(lane={row.get('lane')}, owner={row.get('owner_team')}, "
+                f"priority_index={row.get('priority_index')})"
+            )
+    if agent_orchestration:
+        lines.extend(["", "## Agent playbook"])
+        for row in agent_orchestration:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                f"- {row.get('agent_id')}: {row.get('purpose')} (when: {row.get('when_to_use')})"
+            )
+            for cmd in row.get("suggested_commands", [])[:3]:
+                lines.append(f"  - {cmd}")
+    lines.extend(["", "## Next 24h actions"])
+    if actions_24h:
+        lines.extend([f"- {item}" for item in actions_24h])
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Next 72h actions"])
+    if actions_72h:
+        lines.extend([f"- {item}" for item in actions_72h])
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Recommended execution sequence"])
+    lines.extend([f"{idx + 1}. {item}" for idx, item in enumerate(sequence)])
+    lines.append("")
+    return "\n".join(lines)
+
+
 def _build_operator_summary(payload: dict[str, Any]) -> dict[str, Any]:
     tracks = [row for row in payload.get("likely_issue_tracks", []) if isinstance(row, dict)]
     conflicts = [row for row in payload.get("conflicting_evidence", []) if isinstance(row, dict)]
@@ -1383,8 +2111,64 @@ def _build_operator_summary(payload: dict[str, Any]) -> dict[str, Any]:
         },
         "code_scanning": payload.get("code_scanning", {}),
         "adaptive_database": payload.get("adaptive_database", {}),
+        "review_contract_check": payload.get("review_contract_check", {}),
         "doctor_gate_contract": payload.get("doctor_gate_contract", {}),
         "artifacts": payload.get("artifact_index", {}),
+    }
+
+
+def _build_review_contract_check(payload: dict[str, Any]) -> dict[str, Any]:
+    release_contract = payload.get("adaptive_database", {}).get("release_readiness_contract", {})
+    if not isinstance(release_contract, dict):
+        release_contract = {}
+    recommendation_backlog = release_contract.get("recommendation_backlog", [])
+    if not isinstance(recommendation_backlog, list):
+        recommendation_backlog = []
+    blocker_catalog = release_contract.get("blocker_catalog", [])
+    if not isinstance(blocker_catalog, list):
+        blocker_catalog = []
+    owner_summary = release_contract.get("owner_summary", [])
+    if not isinstance(owner_summary, list):
+        owner_summary = []
+    agent_orchestration = release_contract.get("agent_orchestration", [])
+    if not isinstance(agent_orchestration, list):
+        agent_orchestration = []
+
+    gate_decision = str(release_contract.get("gate_decision", "hold"))
+    blockers = [str(item) for item in release_contract.get("blockers", [])]
+    issues: list[str] = []
+
+    if gate_decision == "ship" and blockers:
+        issues.append("gate_decision is ship but blockers are still present")
+    if gate_decision == "hold" and not blockers:
+        issues.append("gate_decision is hold but blockers list is empty")
+    if blockers and not blocker_catalog:
+        issues.append("blockers present but blocker_catalog is empty")
+    if blocker_catalog and not owner_summary:
+        issues.append("blocker_catalog present but owner_summary is empty")
+    if recommendation_backlog and not agent_orchestration:
+        issues.append("recommendation_backlog present but agent_orchestration is empty")
+
+    return {
+        "schema_version": "sdetkit.review.contract-check.v1",
+        "status": "pass" if not issues else "fail",
+        "checks": {
+            "gate_matches_blockers": not (gate_decision == "ship" and blockers)
+            and not (gate_decision == "hold" and not blockers),
+            "blocker_catalog_present_when_blocked": not blockers or bool(blocker_catalog),
+            "owner_summary_present_when_catalog_exists": not blocker_catalog or bool(owner_summary),
+            "agent_orchestration_present_when_backlog_exists": not recommendation_backlog
+            or bool(agent_orchestration),
+        },
+        "issues": issues,
+        "signals": {
+            "gate_decision": gate_decision,
+            "blockers_count": len(blockers),
+            "blocker_catalog_count": len(blocker_catalog),
+            "owner_summary_count": len(owner_summary),
+            "recommendation_backlog_count": len(recommendation_backlog),
+            "agent_orchestration_count": len(agent_orchestration),
+        },
     }
 
 

--- a/src/sdetkit/review_engine.py
+++ b/src/sdetkit/review_engine.py
@@ -331,6 +331,15 @@ def build_contradiction_graph(
     has_doctor_failure = any(str(f.get("kind", "")) == doctor_kind for f in findings)
     has_inspect_failure = any(str(f.get("kind", "")) == inspect_kind for f in findings)
     repo_like = bool((detection or {}).get("repo_like", False))
+    data_like = bool((detection or {}).get("data_like", False))
+    if repo_like and data_like and not has_doctor_failure and not has_inspect_failure:
+        graph.append(
+            {
+                "id": "review:conflict:repo-and-data-coexist",
+                "kind": "cross_surface_disagreement",
+                "message": "Repo and data surfaces coexist and require explicit cross-surface verification.",
+            }
+        )
     if has_doctor_failure and not has_inspect_failure:
         graph.append(
             {

--- a/tests/test_doctor_upgrade_audit_fallback.py
+++ b/tests/test_doctor_upgrade_audit_fallback.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from sdetkit import doctor
+
+
+def test_doctor_help_works_without_upgrade_audit_release_freshness_buckets(monkeypatch) -> None:
+    if hasattr(doctor.upgrade_audit, "RELEASE_FRESHNESS_BUCKETS"):
+        monkeypatch.delattr(doctor.upgrade_audit, "RELEASE_FRESHNESS_BUCKETS", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        doctor.main(["--help"])
+
+    assert int(exc.value.code) == 0

--- a/tests/test_optional_httpx.py
+++ b/tests/test_optional_httpx.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import types
+
+from sdetkit import optional_httpx
+
+
+def test_load_httpx_returns_fallback_when_module_missing(monkeypatch) -> None:
+    monkeypatch.setattr(optional_httpx.importlib.util, "find_spec", lambda _name: None)
+
+    module = optional_httpx.load_httpx(feature="sdetkit apiget")
+    assert hasattr(module, "Client")
+    assert hasattr(module, "HTTPTransport")
+    try:
+        module.Client()
+        raise AssertionError("expected fallback Client() to raise ModuleNotFoundError")
+    except ModuleNotFoundError as exc:
+        assert "sdetkit apiget" in str(exc)
+
+    try:
+        module.HTTPTransport()
+        raise AssertionError("expected fallback HTTPTransport() to raise ModuleNotFoundError")
+    except ModuleNotFoundError as exc:
+        assert "optional network dependencies" in str(exc)
+
+
+def test_load_httpx_imports_module_when_available(monkeypatch) -> None:
+    expected = types.SimpleNamespace(__name__="httpx")
+    monkeypatch.setattr(optional_httpx.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.setattr(optional_httpx.importlib, "import_module", lambda _name: expected)
+
+    loaded = optional_httpx.load_httpx(feature="sdetkit apiget")
+    assert loaded is expected

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+
+from sdetkit import readiness
+
+
+def _seed_repo(tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "artifacts").mkdir()
+
+    (tmp_path / "SECURITY.md").write_text("How to report a vulnerability\nReport via email\n")
+    (tmp_path / "RELEASE.md").write_text("Release checklist\n")
+    (tmp_path / "QUALITY_PLAYBOOK.md").write_text("quality gate policy\n")
+    (tmp_path / "docs" / "index.md").write_text("gate fast -> gate release -> doctor\n")
+    (tmp_path / "requirements.lock").write_text("pkg==1.0\n")
+    (tmp_path / "poetry.lock").write_text("[[package]]\n")
+    (tmp_path / "CODE_OF_CONDUCT.md").write_text("be kind\n")
+    (tmp_path / "SUPPORT.md").write_text("support policy\n")
+    (tmp_path / "CONTRIBUTING.md").write_text("contributing flow\n")
+    (tmp_path / "CHANGELOG.md").write_text("## 2026-04-16\n- release\n")
+    (tmp_path / ".github" / "workflows" / "ci.yml").write_text(
+        "steps:\n  - run: pytest -q\n  - run: ruff check .\n"
+    )
+
+    for index in range(10):
+        (tmp_path / "tests" / f"test_sample_{index}.py").write_text("def test_ok():\n    assert True\n")
+
+
+def _seed_scenario_capacity(tmp_path, count: int):
+    test_lines = ["from __future__ import annotations", ""]
+    for index in range(count):
+        test_lines.append(f"def test_case_{index}():")
+        test_lines.append("    assert True")
+        test_lines.append("")
+    (tmp_path / "tests" / "test_capacity.py").write_text("\n".join(test_lines), encoding="utf-8")
+
+
+def test_build_readiness_report_missing_files(tmp_path):
+    report = readiness.build_readiness_report(tmp_path)
+
+    assert report["schema_version"] == "sdetkit.readiness.v2"
+    assert report["score"] == 0.0
+    assert report["tier"] == "needs-work"
+    assert report["operational_tier"] == "needs-work"
+    assert report["top_tier_ready"] is False
+    assert report["achievement_level"] == "bronze"
+    assert report["top_actions"]
+    assert report["adaptive_actions"]
+    assert all("priority" in action for action in report["adaptive_actions"])
+    assert report["scenario_capacity"]["target_scenarios"] == 250
+    assert report["scenario_capacity"]["status"] == "needs-expansion"
+    assert report["check_scorecard"]["passed_checks"] == 0
+    assert report["check_scorecard"]["missed_checks"] == report["check_scorecard"]["total_checks"]
+    assert all("recommendation" in check for check in report["checks"])
+    assert all(check["status"] == "miss" for check in report["checks"])
+
+
+def test_build_readiness_report_seeded_repo_scores_excellent(tmp_path):
+    _seed_repo(tmp_path)
+
+    report = readiness.build_readiness_report(tmp_path)
+
+    assert report["schema_version"] == "sdetkit.readiness.v2"
+    assert report["score"] == 100.0
+    assert report["tier"] == "excellent"
+    assert report["operational_tier"] == "strong"
+    assert report["top_tier_ready"] is False
+    assert report["achievement_level"] == "silver"
+    assert report["adaptive_actions"]
+    assert report["scenario_capacity"]["target_scenarios"] == 250
+    assert report["scenario_capacity"]["detected_scenarios"] == 10
+    assert report["scenario_capacity"]["status"] == "needs-expansion"
+    assert report["failed_checks"] == []
+    assert report["check_scorecard"]["missed_checks"] == 0
+    assert all(check["passed"] for check in report["checks"])
+
+
+def test_build_readiness_report_top_tier_ready_when_scenarios_hit_target(tmp_path):
+    _seed_repo(tmp_path)
+    _seed_scenario_capacity(tmp_path, 250)
+
+    report = readiness.build_readiness_report(tmp_path)
+
+    assert report["score"] == 100.0
+    assert report["tier"] == "excellent"
+    assert report["operational_tier"] == "excellent"
+    assert report["top_tier_ready"] is True
+    assert report["achievement_level"] == "gold"
+    assert report["scenario_capacity"]["status"] == "ready"
+    assert report["scenario_capacity"]["detected_scenarios"] >= 250
+
+
+def test_cli_readiness_json_output(capsys):
+    rc = readiness.main([".", "--format", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+
+    payload = json.loads(out)
+    assert payload["schema_version"] == "sdetkit.readiness.v2"
+    assert "checks" in payload

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -59,6 +59,7 @@ def test_review_repo_plus_data_surfaces_cross_surface_conflict(tmp_path: Path) -
         target=repo,
         out_dir=tmp_path / "out",
         workspace_root=tmp_path / "workspace",
+        profile="forensics",
         no_workspace=True,
     )
 
@@ -337,7 +338,55 @@ def test_review_operator_summary_artifact_written(tmp_path: Path) -> None:
     assert operator_payload["adaptive_database"]["schema_version"] == (
         "sdetkit.review.adaptive-database.v1"
     )
+    assert operator_payload["review_contract_check"]["schema_version"] == (
+        "sdetkit.review.contract-check.v1"
+    )
     assert operator_payload["doctor_gate_contract"]["enforced_each_run"] is True
+    adaptive_db_artifact = Path(payload["artifact_index"]["adaptive_database_json"])
+    contract_check_artifact = Path(payload["artifact_index"]["review_contract_check_json"])
+    assert adaptive_db_artifact.exists()
+    assert contract_check_artifact.exists()
+    adaptive_db_payload = json.loads(adaptive_db_artifact.read_text(encoding="utf-8"))
+    contract_check_payload = json.loads(contract_check_artifact.read_text(encoding="utf-8"))
+    assert adaptive_db_payload["schema_version"] == "sdetkit.review.adaptive-database.v1"
+    assert contract_check_payload["status"] == "pass"
+    assert contract_check_payload["checks"]["gate_matches_blockers"] is True
+    release_readiness_json = Path(payload["artifact_index"]["release_readiness_json"])
+    release_readiness_md = Path(payload["artifact_index"]["release_readiness_md"])
+    recommendation_backlog_json = Path(payload["artifact_index"]["recommendation_backlog_json"])
+    assert release_readiness_json.exists()
+    assert release_readiness_md.exists()
+    assert recommendation_backlog_json.exists()
+    release_payload = json.loads(release_readiness_json.read_text(encoding="utf-8"))
+    assert release_payload["contract_id"]
+    assert release_payload["generated_at_utc"].endswith("Z")
+    assert release_payload["next_review_due_at_utc"].endswith("Z")
+    assert release_payload["gate_decision"] in {"ship", "hold"}
+    assert release_payload["risk_band"] in {"low", "medium", "high", "critical"}
+    assert isinstance(release_payload["risk_score"], int)
+    assert isinstance(release_payload["sla_review_hours"], int)
+    assert isinstance(release_payload["blocker_catalog"], list)
+    assert isinstance(release_payload["owner_summary"], list)
+    assert isinstance(release_payload["recommendation_engine"], dict)
+    assert isinstance(release_payload["recommendation_backlog"], list)
+    assert isinstance(release_payload["agent_orchestration"], list)
+    assert any(row.get("agent_id") == "release-ops-observer" for row in release_payload["agent_orchestration"] if isinstance(row, dict))
+    assert all("engine_signals" in row for row in release_payload["agent_orchestration"] if isinstance(row, dict))
+    if release_payload["blocker_catalog"]:
+        first_blocker = release_payload["blocker_catalog"][0]
+        assert "owner_team" in first_blocker
+        assert "response_sla_hours" in first_blocker
+    assert "trend" in release_payload
+    assert "blockers_delta" in release_payload["trend"]
+    assert "Release Readiness Contract" in release_readiness_md.read_text(encoding="utf-8")
+    assert "Contract ID" in release_readiness_md.read_text(encoding="utf-8")
+    assert "Trend:" in release_readiness_md.read_text(encoding="utf-8")
+    assert "Risk:" in release_readiness_md.read_text(encoding="utf-8")
+    assert "Blocker details" in release_readiness_md.read_text(encoding="utf-8")
+    assert "Owner summary" in release_readiness_md.read_text(encoding="utf-8")
+    assert "Recommendation engine" in release_readiness_md.read_text(encoding="utf-8")
+    assert "Backlog ranking" in release_readiness_md.read_text(encoding="utf-8")
+    assert "Agent playbook" in release_readiness_md.read_text(encoding="utf-8")
 
 
 def test_cli_review_interactive_navigator_outputs_selected_section(tmp_path: Path) -> None:
@@ -522,11 +571,73 @@ def test_review_adaptive_database_and_ai_handoff_contract(tmp_path: Path) -> Non
     assert rc == 2
     assert payload["adaptive_database"]["schema_version"] == "sdetkit.review.adaptive-database.v1"
     assert len(payload["adaptive_database"]["top5_actions"]) <= 5
+    assert "quality_matrix" in payload["adaptive_database"]
+    assert "findings_analytics" in payload["adaptive_database"]
+    assert "action_analytics" in payload["adaptive_database"]
+    assert "scalability_posture" in payload["adaptive_database"]
+    assert "release_readiness_contract" in payload["adaptive_database"]
+    assert payload["review_contract_check"]["status"] == "pass"
+    assert payload["adaptive_database"]["release_readiness_contract"]["gate_decision"] in {
+        "ship",
+        "hold",
+    }
     ai_packet = payload["adaptive_review"]["ai_assistant"]
     assert ai_packet["workflow_alignment"]["review_adaptive_enabled"] is True
     assert ai_packet["reviewer_engine_contract"]["five_heads_required"] is True
     assert ai_packet["doctor_gate_contract"]["doctor_first"] is True
     assert payload["doctor_gate_contract"]["gate_fast_required_for_promotion"] is True
+
+
+def test_review_includes_readiness_snapshot_for_repo_targets(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n",
+        encoding="utf-8",
+    )
+    (repo / "docs").mkdir()
+    (repo / "docs" / "index.md").write_text("gate fast -> gate release -> doctor\n", encoding="utf-8")
+    (repo / "tests").mkdir()
+    for index in range(10):
+        (repo / "tests" / f"test_seed_{index}.py").write_text("def test_ok():\n    assert True\n")
+    (repo / "SECURITY.md").write_text("report a vulnerability here\n", encoding="utf-8")
+    (repo / "RELEASE.md").write_text("release checklist\n", encoding="utf-8")
+    (repo / "QUALITY_PLAYBOOK.md").write_text("quality gate\n", encoding="utf-8")
+    (repo / "requirements.lock").write_text("pkg==1.0\n", encoding="utf-8")
+    (repo / "poetry.lock").write_text("[[package]]\n", encoding="utf-8")
+    (repo / "CODE_OF_CONDUCT.md").write_text("be respectful\n", encoding="utf-8")
+    (repo / "SUPPORT.md").write_text("support policy\n", encoding="utf-8")
+    (repo / "CONTRIBUTING.md").write_text("contribution rules\n", encoding="utf-8")
+    (repo / "CHANGELOG.md").write_text("## 2026-04-16\n- initial\n", encoding="utf-8")
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / ".github" / "workflows" / "ci.yml").write_text(
+        "steps:\n  - run: pytest -q\n  - run: ruff check .\n",
+        encoding="utf-8",
+    )
+    (repo / "artifacts").mkdir()
+
+    rc, payload, _, _ = review.run_review(
+        target=repo,
+        out_dir=tmp_path / "out",
+        workspace_root=tmp_path / "workspace",
+        profile="forensics",
+        no_workspace=True,
+    )
+
+    assert rc in {0, 2}
+    assert "readiness_json" in payload["artifact_index"]
+    snapshot = payload["adaptive_database"]["readiness_snapshot"]
+    assert snapshot["score"] >= 0.0
+    assert snapshot["artifact"] == payload["artifact_index"]["readiness_json"]
+    assert "operational_tier" in snapshot
+    assert "top_tier_ready" in snapshot
+    assert "check_scorecard" in snapshot
+    assert "failed_checks" in snapshot
+    assert "scenario_capacity" in snapshot
+    assert payload["adaptive_database"]["workflow_alignment"]["readiness_included"] is True
+    assert payload["adaptive_database"]["adaptive_alignment"]["engine"] == "five_heads"
+    assert payload["adaptive_database"]["scalability_posture"]["target_scenarios"] == 250
+    assert "next_24h_actions" in payload["adaptive_database"]["release_readiness_contract"]
 
 
 def test_probe_memory_artifact_written_and_exposed(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Provide a deterministic, content-aware production-readiness snapshot for investor/operator/leadership reviews and enforce a repeatable release gate.
- Make `httpx` optional in environments without network extras while keeping deterministic behavior for HTTP helpers.
- Surface release-readiness artifacts and structured contract material into the adaptive review database so downstream dashboards and agents can act on gate decisions.

### Description

- Add a new `sdetkit.readiness` CLI and module that computes a weighted, content-aware readiness scorecard with checks, `scenario_capacity`, `adaptive_actions`, tiers, and `top_tier_ready` logic, and expose both `text` and `json` outputs via `python -m sdetkit readiness` and programmatic `build_readiness_report()`.
- Integrate readiness into `sdetkit.review`: run readiness for repo-like targets, write `readiness.json` artifact, include readiness values in `supporting`, and persist rich adaptive database entries including `adaptive-database.json`, `release-readiness.json`, `release-readiness.md`, `recommendation-backlog.json`, and `review-contract-check.json` alongside existing review artifacts.
- Generate a structured `release_readiness_contract` in the adaptive database that contains `contract_id`, `generated_at_utc`, `next_review_due_at_utc`, `risk_score`, `risk_band`, `sla_review_hours`, `blocker_catalog` (with `owner_team` and `response_sla_hours`), `owner_summary`, `recommendation_engine`, and `agent_orchestration` entries; add a review contract consistency check (`review_contract_check`).
- Add an `optional_httpx` loader that conditionally imports `httpx` and otherwise returns a defensive fallback that raises clear `ModuleNotFoundError` messages; switch `apiget` and `netclient` to use the loader so the package can be used without the network extra.
- Add a small defensive fallback for `doctor` upgrade-audit freshness choices via `DEFAULT_RELEASE_FRESHNESS_BUCKETS` when `upgrade_audit.RELEASE_FRESHNESS_BUCKETS` is unavailable.
- Extend review engine contradiction graph to detect cross-surface disagreement when both `repo_like` and `data_like` are present without doctor/inspect failures.
- CLI surface: register `readiness` subcommand and wire `sdetkit review` to call the `readiness` step and include readiness in the canonical doctor-first sequence.

### Testing

- Added unit tests and ran the test suite with `pytest`; new tests include `tests/test_readiness.py`, `tests/test_optional_httpx.py`, and `tests/test_doctor_upgrade_audit_fallback.py`, and updated `tests/test_review.py` assertions that exercise the new artifacts and adaptive-database contents, and all tests passed.
- Exercised CLI flows in tests by invoking `readiness.main([...])` and `review.run_review(...)` to verify artifacts (`readiness.json`, `adaptive-database.json`, `release-readiness.json`, `release-readiness.md`, `recommendation-backlog.json`, `review-contract-check.json`) are produced and schema fields (e.g. `schema_version`, `contract_id`, `generated_at_utc`, `risk_band`) are present.
- Verified optional `httpx` loader behavior by simulating missing and present `httpx` imports in `tests/test_optional_httpx.py` and confirmed the fallback raises helpful `ModuleNotFoundError` messages when used without the network extra.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e058e2d4d4832da70a22b7cfb44cb8)