### PR TITLE
Enhance production-readiness reporting: categories, aspects, boost plan, and adaptive review integration

### DIFF
--- a/src/sdetkit/production_readiness.py
+++ b/src/sdetkit/production_readiness.py
@@ -42,6 +42,60 @@ def _first_existing(root: Path, candidates: tuple[str, ...]) -> str | None:
     return None
 
 
+def _category_progress(checks: list[ReadinessCheck]) -> list[dict[str, Any]]:
+    category_map: dict[str, tuple[str, ...]] = {
+        "governance": ("governance_core_docs",),
+        "engineering": ("engineering_baseline_files", "src_package_present", "lockfiles_present"),
+        "quality_and_ci": ("ci_workflows_present", "tests_folder_present"),
+        "docs_and_ops": ("docs_operating_surface", "phase_boost_blueprint_present"),
+    }
+    check_by_id = {check.check_id: check for check in checks}
+    categories: list[dict[str, Any]] = []
+    for category, check_ids in category_map.items():
+        scoped = [check_by_id[cid] for cid in check_ids if cid in check_by_id]
+        total_weight = sum(check.weight for check in scoped)
+        earned_weight = sum(check.weight for check in scoped if check.passed)
+        percent = int(round((earned_weight / total_weight) * 100)) if total_weight else 0
+        categories.append(
+            {
+                "category": category,
+                "score": percent,
+                "weight_total": total_weight,
+                "weight_earned": earned_weight,
+                "passed_checks": sum(1 for check in scoped if check.passed),
+                "total_checks": len(scoped),
+            }
+        )
+    return categories
+
+
+def _main_aspect_readiness(checks: list[ReadinessCheck]) -> list[dict[str, Any]]:
+    aspect_map: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("governance_and_security", ("governance_core_docs",)),
+        ("engineering_baseline", ("engineering_baseline_files", "lockfiles_present")),
+        ("quality_execution", ("ci_workflows_present", "tests_folder_present")),
+        ("documentation_ops", ("docs_operating_surface", "phase_boost_blueprint_present")),
+        ("package_entrypoints", ("src_package_present",)),
+    )
+    check_by_id = {check.check_id: check for check in checks}
+    aspects: list[dict[str, Any]] = []
+    for aspect, check_ids in aspect_map:
+        scoped = [check_by_id[cid] for cid in check_ids if cid in check_by_id]
+        total_weight = sum(check.weight for check in scoped)
+        earned_weight = sum(check.weight for check in scoped if check.passed)
+        score = int(round((earned_weight / total_weight) * 100)) if total_weight else 0
+        aspects.append(
+            {
+                "aspect": aspect,
+                "ready": all(check.passed for check in scoped) and bool(scoped),
+                "score": score,
+                "passed_checks": sum(1 for check in scoped if check.passed),
+                "total_checks": len(scoped),
+            }
+        )
+    return aspects
+
+
 def build_production_readiness_summary(root: Path) -> dict[str, Any]:
     phase_boost_path = _first_existing(root, _PHASE_BOOST_BLUEPRINT_FILES)
     required_files = [
@@ -138,18 +192,44 @@ def build_production_readiness_summary(root: Path) -> dict[str, Any]:
     earned = sum(c.weight for c in checks if c.passed)
     score = int(round((earned / total_weight) * 100)) if total_weight else 0
     missing_items = [c.check_id for c in checks if not c.passed]
+    stage = (
+        "production-ready"
+        if score >= 90
+        else "stabilizing" if score >= 75 else "foundation-building"
+    )
+    category_breakdown = _category_progress(checks)
+    main_aspects = _main_aspect_readiness(checks)
+    main_aspects_ready = sum(1 for aspect in main_aspects if aspect["ready"])
+    accomplishment_percent = round((earned / total_weight) * 100, 2) if total_weight else 0.0
+    boost_plan = [
+        {
+            "check_id": check.check_id,
+            "impact": check.weight,
+            "action": check.remediation,
+        }
+        for check in sorted((c for c in checks if not c.passed), key=lambda c: -c.weight)
+    ]
 
     return {
         "summary": {
             "score": score,
+            "accomplishment_percent": accomplishment_percent,
+            "stage": stage,
             "total_checks": len(checks),
             "passed_checks": sum(1 for c in checks if c.passed),
             "strict_pass": score >= 90 and not missing_items,
+            "production_ready": score >= 90 and not missing_items,
+            "job_done_ready": main_aspects_ready == len(main_aspects) and not missing_items,
+            "main_aspects_ready_count": main_aspects_ready,
+            "main_aspects_total": len(main_aspects),
             "required_files_count": len(required_files),
             "required_workflows_count": len(required_workflows),
         },
+        "main_aspects": main_aspects,
+        "category_breakdown": category_breakdown,
         "checks": [c.to_dict() for c in checks],
         "missing": missing_items,
+        "boost_plan": boost_plan,
     }
 
 
@@ -158,12 +238,23 @@ def _render_text(payload: dict[str, Any]) -> str:
     lines = [
         "production-readiness",
         f"score: {s['score']}",
+        f"accomplished: {s['accomplishment_percent']}%",
+        f"stage: {s['stage']}",
         f"checks: {s['passed_checks']}/{s['total_checks']}",
+        f"main_aspects_ready: {s['main_aspects_ready_count']}/{s['main_aspects_total']}",
+        f"job_done_ready: {s['job_done_ready']}",
         f"strict_pass: {s['strict_pass']}",
     ]
     for c in payload["checks"]:
         status = "PASS" if c["passed"] else "FAIL"
         lines.append(f"- [{status}] {c['check_id']} ({c['weight']}): {c['evidence']}")
+    lines.append("")
+    lines.append("main aspects:")
+    for aspect in payload.get("main_aspects", []):
+        marker = "READY" if aspect["ready"] else "GAP"
+        lines.append(
+            f"- [{marker}] {aspect['aspect']} ({aspect['passed_checks']}/{aspect['total_checks']}; score={aspect['score']}%)"
+        )
     return "\n".join(lines) + "\n"
 
 
@@ -173,7 +264,11 @@ def _render_markdown(payload: dict[str, Any]) -> str:
         "# Production readiness report",
         "",
         f"- **Score:** {s['score']}",
+        f"- **Accomplished:** {s['accomplishment_percent']}%",
+        f"- **Stage:** `{s['stage']}`",
         f"- **Checks passed:** {s['passed_checks']}/{s['total_checks']}",
+        f"- **Main aspects ready:** {s['main_aspects_ready_count']}/{s['main_aspects_total']}",
+        f"- **Job done ready:** `{s['job_done_ready']}`",
         f"- **Strict pass:** `{s['strict_pass']}`",
         "",
         "## Check breakdown",
@@ -185,11 +280,32 @@ def _render_markdown(payload: dict[str, Any]) -> str:
         status = "\u2705 pass" if c["passed"] else "\u274c fail"
         lines.append(f"| `{c['check_id']}` | {status} | {c['weight']} | {c['evidence']} |")
 
+    lines.extend(["", "## Category progress", "", "| Category | Score | Passed | Weight |", "|---|---:|---:|---:|"])
+    for category in payload.get("category_breakdown", []):
+        lines.append(
+            "| `{}` | {}% | {}/{} | {}/{} |".format(
+                category["category"],
+                category["score"],
+                category["passed_checks"],
+                category["total_checks"],
+                category["weight_earned"],
+                category["weight_total"],
+            )
+        )
+
+    lines.extend(["", "## Main aspects readiness", "", "| Main aspect | Ready | Score | Passed checks |", "|---|---|---:|---:|"])
+    for aspect in payload.get("main_aspects", []):
+        ready = "\u2705 ready" if aspect["ready"] else "\u274c gap"
+        lines.append(
+            f"| `{aspect['aspect']}` | {ready} | {aspect['score']}% | {aspect['passed_checks']}/{aspect['total_checks']} |"
+        )
+
     if payload["missing"]:
         lines.extend(["", "## Remediation priorities", ""])
-        for c in payload["checks"]:
-            if not c["passed"]:
-                lines.append(f"- `{c['check_id']}`: {c['remediation']}")
+        for action in payload.get("boost_plan", []):
+            lines.append(
+                f"- `{action['check_id']}` (impact={action['impact']}): {action['action']}"
+            )
     return "\n".join(lines) + "\n"
 
 

--- a/src/sdetkit/review.py
+++ b/src/sdetkit/review.py
@@ -1506,12 +1506,191 @@ def run_review(
     detected_scenarios = int(readiness_scenario_snapshot.get("detected_scenarios", 0))
     target_scenarios = int(readiness_scenario_snapshot.get("target_scenarios", 250))
     scenario_runway_ratio = round((detected_scenarios / target_scenarios), 2) if target_scenarios else 0.0
+    readiness_failed_checks = next(
+        (
+            list(row.get("value", []))
+            for row in supporting
+            if isinstance(row, dict) and str(row.get("kind")) == "readiness_failed_checks"
+        ),
+        [],
+    )
+    canonical_aspects: tuple[str, ...] = (
+        "governance_policy",
+        "security_posture",
+        "ci_quality",
+        "test_capacity",
+        "docs_operations",
+        "dependency_hygiene",
+        "release_management",
+        "doctor_hygiene",
+        "adaptive_reviewer_confidence",
+        "scalability_readiness",
+    )
+    encountered_sources: dict[str, set[str]] = {aspect: set() for aspect in canonical_aspects}
+    findings = [row for row in payload.get("findings", []) if isinstance(row, dict)]
+    for finding in findings:
+        kind = str(finding.get("kind", "")).lower()
+        if "doctor" in kind:
+            encountered_sources["doctor_hygiene"].add("finding.kind")
+        if "security" in kind:
+            encountered_sources["security_posture"].add("finding.kind")
+        if "ci" in kind or "lint" in kind:
+            encountered_sources["ci_quality"].add("finding.kind")
+        if "release" in kind or "gate" in kind:
+            encountered_sources["release_management"].add("finding.kind")
+        if "readiness" in kind:
+            encountered_sources["adaptive_reviewer_confidence"].add("finding.kind")
+    for check_id in readiness_failed_checks:
+        cid = str(check_id)
+        if "security" in cid:
+            encountered_sources["security_posture"].add("readiness.failed_check")
+        if "release" in cid or "changelog" in cid:
+            encountered_sources["release_management"].add("readiness.failed_check")
+        if "dependency" in cid:
+            encountered_sources["dependency_hygiene"].add("readiness.failed_check")
+        if "test" in cid or "scenario" in cid:
+            encountered_sources["test_capacity"].add("readiness.failed_check")
+        if "docs" in cid:
+            encountered_sources["docs_operations"].add("readiness.failed_check")
+        if "governance" in cid:
+            encountered_sources["governance_policy"].add("readiness.failed_check")
+    if workflow_alignment["doctor_included"]:
+        encountered_sources["doctor_hygiene"].add("workflow_alignment")
+    if workflow_alignment["readiness_included"]:
+        encountered_sources["adaptive_reviewer_confidence"].add("workflow_alignment")
+        encountered_sources["governance_policy"].add("workflow_alignment")
+    if scenario_runway_ratio < 1.0:
+        encountered_sources["scalability_readiness"].add("scenario_capacity")
+    else:
+        encountered_sources["scalability_readiness"].add("scenario_capacity_ready")
+    aspect_database = [
+        {
+            "aspect": aspect,
+            "encountered": bool(encountered_sources[aspect]),
+            "sources": sorted(encountered_sources[aspect]),
+            "priority": (
+                "now"
+                if aspect in {"doctor_hygiene", "security_posture", "release_management"}
+                else "next"
+            ),
+        }
+        for aspect in canonical_aspects
+    ]
+    next_5_prompts_plan = [
+        {
+            "prompt_index": 1,
+            "focus": "doctor baseline hardening",
+            "goal": "Stabilize doctor lane and remove high-severity hygiene blockers.",
+            "recommended_command": "python -m sdetkit doctor --repo --ci --deps --upgrade-audit --format json",
+            "final_prompt": (
+                "Run the doctor hardening pass now. Analyze all failed checks, rank blockers by risk, "
+                "and produce a step-by-step fix list with exact commands and expected outputs."
+            ),
+        },
+        {
+            "prompt_index": 2,
+            "focus": "adaptive reviewer evidence refresh",
+            "goal": "Re-run adaptive review and inspect contradiction clusters/probe confidence.",
+            "recommended_command": "python -m sdetkit review . --format json",
+            "final_prompt": (
+                "Re-run adaptive review and explain contradictions. Tell me which signals conflict, "
+                "what evidence is missing, and which probe should run next to increase confidence."
+            ),
+        },
+        {
+            "prompt_index": 3,
+            "focus": "readiness depth and scenario runway",
+            "goal": "Close readiness misses and expand automated scenario capacity toward target.",
+            "recommended_command": "python -m sdetkit readiness . --format json",
+            "final_prompt": (
+                "Use readiness output to build an execution backlog: top 5 actions, owners, ETA, "
+                "and measurable completion criteria to close production gaps."
+            ),
+        },
+        {
+            "prompt_index": 4,
+            "focus": "gate confidence rehearsal",
+            "goal": "Rehearse ship/no-ship evidence through canonical gate fast/release outputs.",
+            "recommended_command": "python -m sdetkit gate fast --format json --stable-json && python -m sdetkit gate release --format json",
+            "final_prompt": (
+                "Run gate fast and gate release and summarize go/no-go. Highlight failing steps, "
+                "root causes, and the shortest path to a passing release contract."
+            ),
+        },
+        {
+            "prompt_index": 5,
+            "focus": "release-room final review",
+            "goal": "Produce operator summary and confirm final gate decision with updated adaptive DB.",
+            "recommended_command": "python -m sdetkit review . --format operator-json",
+            "final_prompt": (
+                "Prepare the final release-room decision brief from operator-json: gate decision, "
+                "blockers, risk band, next 24h actions, and owner routing."
+            ),
+        },
+    ]
+    gate_fast_artifact_present = bool(artifact_index.get("gate_fast_json"))
+    gate_release_artifact_present = bool(artifact_index.get("gate_release_json"))
+    step_statuses = {
+        1: "done" if workflow_alignment["doctor_included"] else "pending",
+        2: "done",
+        3: "done" if workflow_alignment["readiness_included"] else "pending",
+        4: "done" if gate_fast_artifact_present and gate_release_artifact_present else "pending",
+        5: "in_progress",
+    }
+    for step in next_5_prompts_plan:
+        prompt_index = int(step.get("prompt_index", 0))
+        step["implementation_status"] = step_statuses.get(prompt_index, "pending")
+    implementation_summary = {
+        "completed_steps": sum(1 for step in next_5_prompts_plan if step["implementation_status"] == "done"),
+        "in_progress_steps": sum(
+            1 for step in next_5_prompts_plan if step["implementation_status"] == "in_progress"
+        ),
+        "pending_steps": sum(1 for step in next_5_prompts_plan if step["implementation_status"] == "pending"),
+        "total_steps": len(next_5_prompts_plan),
+    }
+    next_step = next(
+        (
+            {
+                "prompt_index": int(step.get("prompt_index", 0)),
+                "focus": str(step.get("focus", "")),
+                "recommended_command": str(step.get("recommended_command", "")),
+                "final_prompt": str(step.get("final_prompt", "")),
+                "status": str(step.get("implementation_status", "pending")),
+            }
+            for step in next_5_prompts_plan
+            if str(step.get("implementation_status")) in {"in_progress", "pending"}
+        ),
+        {
+            "prompt_index": 0,
+            "focus": "all_done",
+            "recommended_command": "",
+            "final_prompt": "All boost-plan prompts are completed.",
+            "status": "done",
+        },
+    )
+    autostart_lane = [
+        str(step.get("recommended_command", ""))
+        for step in next_5_prompts_plan
+        if str(step.get("implementation_status")) in {"in_progress", "pending"}
+    ]
 
     payload["adaptive_database"] = {
         "schema_version": "sdetkit.review.adaptive-database.v1",
         "scope": review_scope,
         "five_heads_overview": payload["five_heads"].get("overall", {}),
         "top5_actions": top5_actions,
+        "aspect_database": {
+            "catalog": aspect_database,
+            "encountered_total": sum(1 for row in aspect_database if row["encountered"]),
+            "total_aspects": len(aspect_database),
+        },
+        "execution_boost_plan": {
+            "next_5_prompts_plan": next_5_prompts_plan,
+            "copy_ready_prompts": [str(step.get("final_prompt", "")) for step in next_5_prompts_plan],
+            "implementation_summary": implementation_summary,
+            "next_step": next_step,
+            "autostart_lane": autostart_lane,
+        },
         "workflow_alignment": workflow_alignment,
         "doctor_gate_contract": doctor_gate_contract,
         "readiness_snapshot": {

--- a/tests/test_production_readiness.py
+++ b/tests/test_production_readiness.py
@@ -9,7 +9,14 @@ def test_production_readiness_summary_for_repo_has_high_score():
     payload = build_production_readiness_summary(Path("."))
 
     assert payload["summary"]["score"] >= 90
+    assert payload["summary"]["accomplishment_percent"] >= 90
+    assert payload["summary"]["stage"] == "production-ready"
+    assert payload["summary"]["production_ready"] is True
+    assert payload["summary"]["job_done_ready"] is True
+    assert payload["summary"]["main_aspects_ready_count"] == payload["summary"]["main_aspects_total"]
     assert payload["summary"]["total_checks"] >= 8
+    assert payload["main_aspects"]
+    assert payload["category_breakdown"]
 
 
 def test_production_readiness_cli_emit_pack(tmp_path: Path, capsys):

--- a/tests/test_production_readiness_extra.py
+++ b/tests/test_production_readiness_extra.py
@@ -30,7 +30,12 @@ def test_render_text_includes_check_status_lines(tmp_path: Path) -> None:
     text = pr._render_text(payload)
 
     assert text.startswith("production-readiness\n")
+    assert "accomplished:" in text
+    assert "stage:" in text
     assert "checks:" in text
+    assert "main_aspects_ready:" in text
+    assert "job_done_ready:" in text
+    assert "main aspects:" in text
     assert "- [FAIL] governance_core_docs" in text
 
 
@@ -40,6 +45,8 @@ def test_main_markdown_and_text_output_modes(tmp_path: Path, capsys) -> None:
 
     assert markdown_rc == 0
     assert markdown_out.startswith("# Production readiness report")
+    assert "Category progress" in markdown_out
+    assert "Main aspects readiness" in markdown_out
 
     text_rc = pr.main(["--root", str(tmp_path), "--format", "text"])
     text_out = capsys.readouterr().out

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -576,6 +576,30 @@ def test_review_adaptive_database_and_ai_handoff_contract(tmp_path: Path) -> Non
     assert "action_analytics" in payload["adaptive_database"]
     assert "scalability_posture" in payload["adaptive_database"]
     assert "release_readiness_contract" in payload["adaptive_database"]
+    assert "aspect_database" in payload["adaptive_database"]
+    assert payload["adaptive_database"]["aspect_database"]["total_aspects"] >= 10
+    assert "execution_boost_plan" in payload["adaptive_database"]
+    assert len(payload["adaptive_database"]["execution_boost_plan"]["next_5_prompts_plan"]) == 5
+    assert len(payload["adaptive_database"]["execution_boost_plan"]["copy_ready_prompts"]) == 5
+    assert all(
+        row.get("final_prompt")
+        for row in payload["adaptive_database"]["execution_boost_plan"]["next_5_prompts_plan"]
+    )
+    statuses = {
+        row.get("implementation_status")
+        for row in payload["adaptive_database"]["execution_boost_plan"]["next_5_prompts_plan"]
+    }
+    assert statuses.issubset({"done", "in_progress", "pending"})
+    assert payload["adaptive_database"]["execution_boost_plan"]["implementation_summary"][
+        "total_steps"
+    ] == 5
+    assert "next_step" in payload["adaptive_database"]["execution_boost_plan"]
+    assert payload["adaptive_database"]["execution_boost_plan"]["next_step"]["status"] in {
+        "done",
+        "in_progress",
+        "pending",
+    }
+    assert isinstance(payload["adaptive_database"]["execution_boost_plan"]["autostart_lane"], list)
     assert payload["review_contract_check"]["status"] == "pass"
     assert payload["adaptive_database"]["release_readiness_contract"]["gate_decision"] in {
         "ship",
@@ -638,6 +662,16 @@ def test_review_includes_readiness_snapshot_for_repo_targets(tmp_path: Path) -> 
     assert payload["adaptive_database"]["adaptive_alignment"]["engine"] == "five_heads"
     assert payload["adaptive_database"]["scalability_posture"]["target_scenarios"] == 250
     assert "next_24h_actions" in payload["adaptive_database"]["release_readiness_contract"]
+    assert payload["adaptive_database"]["execution_boost_plan"]["next_5_prompts_plan"][0][
+        "prompt_index"
+    ] == 1
+    assert payload["adaptive_database"]["execution_boost_plan"]["next_5_prompts_plan"][4][
+        "prompt_index"
+    ] == 5
+    assert payload["adaptive_database"]["execution_boost_plan"]["implementation_summary"][
+        "total_steps"
+    ] == 5
+    assert payload["adaptive_database"]["execution_boost_plan"]["next_step"]["prompt_index"] >= 0
 
 
 def test_probe_memory_artifact_written_and_exposed(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Provide richer production-readiness output with categorical and aspect-based progress so teams can prioritize remediation work. 
- Surface an actionable boost plan with prioritized remediation actions and a simple stage/percent view of overall progress. 
- Expose readiness signals into the adaptive review database to drive follow-up prompts and automated next steps. 

### Description

- Added `_category_progress` and `_main_aspect_readiness` helpers and extended `build_production_readiness_summary` to compute `stage`, `accomplishment_percent`, `category_breakdown`, `main_aspects`, `boost_plan`, `production_ready`, and `job_done_ready` fields. 
- Enhanced textual and markdown renderers to include accomplishment percent, stage, main aspects, and category progress tables. 
- Extended the review flow to synthesize an `aspect_database` and an `execution_boost_plan` containing `next_5_prompts_plan`, `implementation_summary`, `next_step`, and an `autostart_lane`, and fed readiness failed checks and findings into aspect detection. 
- Updated and added unit tests to assert the new summary fields and adaptive-database keys and to verify markdown/text output contains the new sections. 

### Testing

- Ran the updated unit tests including `tests/test_production_readiness.py`, `tests/test_production_readiness_extra.py`, and `tests/test_review.py` against the changes. 
- All modified and added assertions for `accomplishment_percent`, `stage`, `main_aspects`, `category_breakdown`, and `execution_boost_plan` passed under the test run. 
- Verified CLI emission via `cli.main([

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e15f364d8c832da489f49b90b71d78)