### PR TITLE
adaptive_postcheck: robust subprocess parsing, PYTHONPATH handling, and tests

### DIFF
--- a/scripts/adaptive_postcheck.py
+++ b/scripts/adaptive_postcheck.py
@@ -25,9 +25,7 @@ def _local_python_env(repo_root: str) -> dict[str, str]:
     existing = env.get("PYTHONPATH", "").strip()
     candidate_root = Path(repo_root).resolve()
     src_path = str((candidate_root / "src").resolve())
-    env["PYTHONPATH"] = (
-        src_path if not existing else f"{src_path}{os.pathsep}{existing}"
-    )
+    env["PYTHONPATH"] = src_path if not existing else f"{src_path}{os.pathsep}{existing}"
     return env
 
 
@@ -100,8 +98,6 @@ def _load_scenario(name: str) -> dict[str, Any]:
     return selected
 
 
-
-
 def _latest_artifact(prefix: str) -> Path | None:
     candidates = sorted((ROOT / "docs/artifacts").glob(f"{prefix}*.json"))
     return candidates[-1] if candidates else None
@@ -136,11 +132,15 @@ def _doctor_summary(repo_root: str) -> dict[str, Any] | None:
     }
 
 
-def _bool_check(name: str, passed: bool, details: str, severity: str = "required") -> dict[str, Any]:
+def _bool_check(
+    name: str, passed: bool, details: str, severity: str = "required"
+) -> dict[str, Any]:
     return {"check": name, "passed": passed, "details": details, "severity": severity}
 
 
-def _run_alignment_checks(payload: dict[str, Any], scenario: dict[str, Any], first_run_triage: dict[str, Any]) -> list[dict[str, Any]]:
+def _run_alignment_checks(
+    payload: dict[str, Any], scenario: dict[str, Any], first_run_triage: dict[str, Any]
+) -> list[dict[str, Any]]:
     checks: list[dict[str, Any]] = []
     enabled = set(scenario.get("enabled_checks", []))
     warn_checks = set(scenario.get("warn_only_checks", []))
@@ -248,11 +248,19 @@ def _run_alignment_checks(payload: dict[str, Any], scenario: dict[str, Any], fir
     return checks
 
 
-
-
-def _build_first_run_triage(payload: dict[str, Any], doctor: dict[str, Any] | None) -> dict[str, Any]:
-    adaptive = payload.get("adaptive_database", {}) if isinstance(payload.get("adaptive_database"), dict) else {}
-    contract = adaptive.get("release_readiness_contract", {}) if isinstance(adaptive.get("release_readiness_contract"), dict) else {}
+def _build_first_run_triage(
+    payload: dict[str, Any], doctor: dict[str, Any] | None
+) -> dict[str, Any]:
+    adaptive = (
+        payload.get("adaptive_database", {})
+        if isinstance(payload.get("adaptive_database"), dict)
+        else {}
+    )
+    contract = (
+        adaptive.get("release_readiness_contract", {})
+        if isinstance(adaptive.get("release_readiness_contract"), dict)
+        else {}
+    )
 
     doctor_failed = []
     if isinstance(doctor, dict):
@@ -304,6 +312,7 @@ def _build_first_run_triage(payload: dict[str, Any], doctor: dict[str, Any] | No
         "hint_count": len(fix_hints),
     }
 
+
 def _default_out_path() -> str:
     date_tag = datetime.now(UTC).date().isoformat()
     return f"docs/artifacts/adaptive-postcheck-{date_tag}.json"
@@ -313,7 +322,11 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("repo", nargs="?", default=".")
     ap.add_argument("--input-json", default=None, help="Path to existing review JSON payload")
-    ap.add_argument("--scenario", default="balanced", help="Scenario name from adaptive-postcheck-scenarios contract")
+    ap.add_argument(
+        "--scenario",
+        default="balanced",
+        help="Scenario name from adaptive-postcheck-scenarios contract",
+    )
     ap.add_argument(
         "--out",
         default=None,
@@ -327,7 +340,9 @@ def main() -> int:
     first_run_triage = _build_first_run_triage(payload, doctor)
     checks = _run_alignment_checks(payload, scenario, first_run_triage)
     passed = sum(1 for c in checks if c.get("passed"))
-    failed_required = sum(1 for c in checks if (not c.get("passed")) and c.get("severity") != "warn")
+    failed_required = sum(
+        1 for c in checks if (not c.get("passed")) and c.get("severity") != "warn"
+    )
     failed_warn = sum(1 for c in checks if (not c.get("passed")) and c.get("severity") == "warn")
 
     out_payload = {

--- a/scripts/adaptive_postcheck.py
+++ b/scripts/adaptive_postcheck.py
@@ -8,16 +8,53 @@ changes, making automation adaptive rather than fixed-date/fixed-rule.
 from __future__ import annotations
 
 import argparse
-from datetime import datetime, timezone
 import json
-from pathlib import Path
+import os
 import subprocess
 import sys
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
-
 
 ROOT = Path(__file__).resolve().parent.parent
 SCENARIO_PATH = ROOT / "docs/contracts/adaptive-postcheck-scenarios.v1.json"
+
+
+def _local_python_env(repo_root: str) -> dict[str, str]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "").strip()
+    candidate_root = Path(repo_root).resolve()
+    src_path = str((candidate_root / "src").resolve())
+    env["PYTHONPATH"] = (
+        src_path if not existing else f"{src_path}{os.pathsep}{existing}"
+    )
+    return env
+
+
+def _parse_json_stdout(text: str) -> dict[str, Any] | None:
+    raw = text.strip()
+    if not raw:
+        return None
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError:
+        loaded = None
+    if isinstance(loaded, dict):
+        return loaded
+
+    for line in reversed(raw.splitlines()):
+        candidate = line.strip()
+        if not candidate:
+            continue
+        if not (candidate.startswith("{") and candidate.endswith("}")):
+            continue
+        try:
+            loaded = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(loaded, dict):
+            return loaded
+    return None
 
 
 def _load_review_payload(repo_root: str, input_json: str | None) -> dict[str, Any]:
@@ -34,15 +71,20 @@ def _load_review_payload(repo_root: str, input_json: str | None) -> dict[str, An
         "--format",
         "json",
     ]
-    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
-    if result.stdout.strip():
-        try:
-            return json.loads(result.stdout)
-        except json.JSONDecodeError:
-            pass
+    result = subprocess.run(
+        cmd,
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        env=_local_python_env(repo_root),
+    )
+    parsed = _parse_json_stdout(result.stdout)
+    if isinstance(parsed, dict):
+        return parsed
     raise RuntimeError(
         "failed to load review payload from command; "
-        f"exit={result.returncode}, stderr={result.stderr.strip()!r}"
+        f"exit={result.returncode}, stdout={result.stdout.strip()[:200]!r}, stderr={result.stderr.strip()!r}"
     )
 
 
@@ -75,13 +117,15 @@ def _load_latest_scenario_database() -> dict[str, Any] | None:
 
 def _doctor_summary(repo_root: str) -> dict[str, Any] | None:
     cmd = [sys.executable, "-m", "sdetkit", "doctor", "--format", "json"]
-    result = subprocess.run(cmd, check=False, capture_output=True, text=True, cwd=repo_root)
-    if not result.stdout.strip():
-        return None
-    try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return None
+    result = subprocess.run(
+        cmd,
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        env=_local_python_env(repo_root),
+    )
+    payload = _parse_json_stdout(result.stdout)
     if not isinstance(payload, dict):
         return None
     return {
@@ -261,7 +305,7 @@ def _build_first_run_triage(payload: dict[str, Any], doctor: dict[str, Any] | No
     }
 
 def _default_out_path() -> str:
-    date_tag = datetime.now(timezone.utc).date().isoformat()
+    date_tag = datetime.now(UTC).date().isoformat()
     return f"docs/artifacts/adaptive-postcheck-{date_tag}.json"
 
 

--- a/tests/test_adaptive_postcheck.py
+++ b/tests/test_adaptive_postcheck.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "adaptive_postcheck.py"
+_SPEC = importlib.util.spec_from_file_location("adaptive_postcheck_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+adaptive_postcheck = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(adaptive_postcheck)
+
+
+def test_parse_json_stdout_accepts_clean_json_object() -> None:
+    payload = adaptive_postcheck._parse_json_stdout('{"ok": true, "score": 95}')
+    assert payload == {"ok": True, "score": 95}
+
+
+def test_parse_json_stdout_recovers_json_after_log_lines() -> None:
+    payload = adaptive_postcheck._parse_json_stdout(
+        "warning: bootstrapping lane\ninfo: continuing\n{\"ok\": false, \"failed_required\": 1}\n"
+    )
+    assert payload == {"ok": False, "failed_required": 1}
+
+
+def test_local_python_env_targets_repo_root_src(monkeypatch) -> None:
+    monkeypatch.setenv("PYTHONPATH", "existing-path")
+    env = adaptive_postcheck._local_python_env("/tmp/demo-repo")
+    assert env["PYTHONPATH"].startswith(str(Path("/tmp/demo-repo/src").resolve()))
+    assert env["PYTHONPATH"].endswith("existing-path")
+
+
+def test_load_review_payload_parses_noisy_subprocess_stdout(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    captured: dict[str, object] = {}
+
+    def _fake_run(*_args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            returncode=2,
+            stdout="boot log\n{\"status\":\"watch\",\"findings_count\":3}\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(adaptive_postcheck.subprocess, "run", _fake_run)
+    payload = adaptive_postcheck._load_review_payload(str(repo_root), None)
+    assert payload == {"status": "watch", "findings_count": 3}
+    assert captured["cwd"] == str(repo_root)
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert str((repo_root / "src").resolve()) in str(env.get("PYTHONPATH", ""))
+
+
+def test_doctor_summary_parses_noisy_subprocess_stdout(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    captured: dict[str, object] = {}
+
+    def _fake_run(*_args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            returncode=2,
+            stdout=(
+                "doctor preface\n"
+                '{"ok": false, "score": 70, "quality": {"failed_checks": 2, "failed_check_ids": ["deps", "ci"]}}\n'
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(adaptive_postcheck.subprocess, "run", _fake_run)
+    payload = adaptive_postcheck._doctor_summary(str(repo_root))
+    assert payload == {
+        "ok": False,
+        "score": 70,
+        "failed_checks": 2,
+        "failed_check_ids": ["deps", "ci"],
+    }
+    assert captured["cwd"] == str(repo_root)
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert str((repo_root / "src").resolve()) in str(env.get("PYTHONPATH", ""))
+
+
+def test_load_review_payload_raises_with_stdout_and_stderr_context(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    def _fake_run(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="not-json-output",
+            stderr="module import failure",
+        )
+
+    monkeypatch.setattr(adaptive_postcheck.subprocess, "run", _fake_run)
+    with pytest.raises(RuntimeError) as excinfo:
+        adaptive_postcheck._load_review_payload(str(repo_root), None)
+    message = str(excinfo.value)
+    assert "stdout='not-json-output'" in message
+    assert "stderr='module import failure'" in message
+
+
+def test_main_writes_output_artifact_for_mocked_inputs(monkeypatch, tmp_path: Path) -> None:
+    out_path = tmp_path / "adaptive-postcheck.json"
+    payload = {"adaptive_database": {"release_readiness_contract": {}}}
+    scenario = {
+        "enabled_checks": ["adaptive_database_present"],
+        "warn_only_checks": [],
+    }
+
+    monkeypatch.setattr(adaptive_postcheck, "_load_review_payload", lambda *_args, **_kwargs: payload)
+    monkeypatch.setattr(adaptive_postcheck, "_load_scenario", lambda *_args, **_kwargs: scenario)
+    monkeypatch.setattr(adaptive_postcheck, "_doctor_summary", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        adaptive_postcheck.sys,
+        "argv",
+        ["adaptive_postcheck.py", ".", "--scenario", "fast", "--out", str(out_path)],
+    )
+
+    rc = adaptive_postcheck.main()
+    assert rc == 0
+    written = json.loads(out_path.read_text(encoding="utf-8"))
+    assert written["summary"]["ok"] is True
+    assert written["summary"]["failed_required"] == 0

--- a/tests/test_adaptive_postcheck.py
+++ b/tests/test_adaptive_postcheck.py
@@ -21,7 +21,7 @@ def test_parse_json_stdout_accepts_clean_json_object() -> None:
 
 def test_parse_json_stdout_recovers_json_after_log_lines() -> None:
     payload = adaptive_postcheck._parse_json_stdout(
-        "warning: bootstrapping lane\ninfo: continuing\n{\"ok\": false, \"failed_required\": 1}\n"
+        'warning: bootstrapping lane\ninfo: continuing\n{"ok": false, "failed_required": 1}\n'
     )
     assert payload == {"ok": False, "failed_required": 1}
 
@@ -43,7 +43,7 @@ def test_load_review_payload_parses_noisy_subprocess_stdout(monkeypatch, tmp_pat
         captured.update(kwargs)
         return SimpleNamespace(
             returncode=2,
-            stdout="boot log\n{\"status\":\"watch\",\"findings_count\":3}\n",
+            stdout='boot log\n{"status":"watch","findings_count":3}\n',
             stderr="",
         )
 
@@ -137,7 +137,9 @@ def test_main_writes_output_artifact_for_mocked_inputs(monkeypatch, tmp_path: Pa
         "warn_only_checks": [],
     }
 
-    monkeypatch.setattr(adaptive_postcheck, "_load_review_payload", lambda *_args, **_kwargs: payload)
+    monkeypatch.setattr(
+        adaptive_postcheck, "_load_review_payload", lambda *_args, **_kwargs: payload
+    )
     monkeypatch.setattr(adaptive_postcheck, "_load_scenario", lambda *_args, **_kwargs: scenario)
     monkeypatch.setattr(adaptive_postcheck, "_doctor_summary", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(

--- a/tests/test_adaptive_postcheck.py
+++ b/tests/test_adaptive_postcheck.py
@@ -108,6 +108,27 @@ def test_load_review_payload_raises_with_stdout_and_stderr_context(
     assert "stderr='module import failure'" in message
 
 
+def test_load_review_payload_truncates_stdout_snippet_in_error(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    very_long_stdout = "x" * 400
+
+    def _fake_run(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout=very_long_stdout,
+            stderr="boom",
+        )
+
+    monkeypatch.setattr(adaptive_postcheck.subprocess, "run", _fake_run)
+    with pytest.raises(RuntimeError) as excinfo:
+        adaptive_postcheck._load_review_payload(str(repo_root), None)
+
+    message = str(excinfo.value)
+    assert ("stdout='" + ("x" * 200) + "'") in message
+    assert ("stdout='" + ("x" * 201)) not in message
+
+
 def test_main_writes_output_artifact_for_mocked_inputs(monkeypatch, tmp_path: Path) -> None:
     out_path = tmp_path / "adaptive-postcheck.json"
     payload = {"adaptive_database": {"release_readiness_contract": {}}}


### PR DESCRIPTION
### Motivation

- Make the adaptive post-check script more robust when external tooling prints non-JSON log lines before or after JSON payloads. 
- Ensure subprocesses executed for review/doctor commands run with the repository `src` directory on `PYTHONPATH` and in the repository working directory. 
- Add unit tests to verify the new parsing and environment behavior and to prevent regressions.

### Description

- Add `_local_python_env(repo_root)` to inject `repo_root/src` into `PYTHONPATH` and pass that `env` and `cwd` into `subprocess.run` calls for `sdetkit review` and `sdetkit doctor`. 
- Introduce `_parse_json_stdout(text)` which extracts the last JSON object from possibly noisy stdout and use it in `_load_review_payload` and `_doctor_summary`, and improve the runtime error message to include truncated `stdout` and `stderr` context. 
- Replace use of `timezone` with `UTC` for `datetime.now(UTC)` and add a comprehensive test module `tests/test_adaptive_postcheck.py` that covers parsing, env injection, subprocess stdout recovery, error message content, and `main` output behavior under mocked inputs. 

### Testing

- Added `tests/test_adaptive_postcheck.py` which contains unit tests for `_parse_json_stdout`, `_local_python_env`, `_load_review_payload` handling noisy stdout, `_doctor_summary` handling noisy stdout, error message content on failure, and `main` producing an output artifact with mocked inputs. 
- Ran the test suite with `pytest` against the new tests and they all passed. 
- The tests exercise subprocess `run` interception via `monkeypatch` and validate that `cwd` and `env` are set and that noisy stdout is recovered into proper JSON payloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e2bfe80490832d82a2d6f2ceefcc7a)