### PR TITLE
Docs: reorganize README, add team-facing guide, and update mkdocs nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,42 @@ DevS69 SDETKit is a release-confidence CLI: it gives engineering teams determini
 
 **Primary outcome:** know if a change is ready to ship.
 
-**Canonical first path:** `python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`.
+## What this product is
 
-## Product promise (30-second view)
+SDETKit is a deterministic release-confidence layer for software teams that want one clear shipping decision (`ship` / `no-ship`) backed by JSON artifacts.
 
-SDETKit's primary user outcome is **shipping readiness confidence**: a team can decide go/no-go from explicit JSON evidence instead of ad hoc interpretation.
+Instead of stitching together separate scripts and tools for every repo, teams run one canonical path and get machine-readable evidence they can use in pull requests, release reviews, and CI gates.
 
-In plain terms: one clear product identity, one primary outcome, one canonical first path.
+## Who it is for
 
-The primary path is always:
+**Best fit**
+- Teams that want deterministic release decisions instead of ad hoc interpretation.
+- Engineers who need machine-readable evidence for PR/release review.
+- Repos standardizing the same release checks in local and CI runs.
 
-`python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`
+**Probably not a fit (yet)**
+- Very low-risk repos that do not need structured release evidence.
+- Teams that only want raw tool invocations with fully custom orchestration.
 
-Everything else (umbrella kits, utilities, historical/transition-era lanes) stays available, but is intentionally secondary to first-time adoption.
+## Canonical first path (run this first)
 
-## Canonical first proof lane (start here)
-
-Run this exact command path first in a brand-new repository (not this repo):
+Install the released package:
 
 ```bash
-mkdir my-repo && cd my-repo
-git init
 python -m pip install sdetkit==1.0.3
-python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
-python -m sdetkit gate release --format json --out build/release-preflight.json
+```
+
+Then run the canonical path:
+
+```bash
+python -m sdetkit gate fast
+python -m sdetkit gate release
 python -m sdetkit doctor
 ```
 
-Expected first artifacts:
+## What artifacts appear
+
+After the first path, expect:
 
 ```text
 build/
@@ -39,105 +47,34 @@ build/
 └── release-preflight.json
 ```
 
-Inspect order:
+Inspect in this order:
 1. `build/release-preflight.json` (`ok`, `failed_steps`, `profile`)
-2. If `failed_steps` includes `gate_fast`, open `build/gate-fast.json` (`ok`, `failed_steps`, `profile`)
+2. If `failed_steps` includes `gate_fast`, inspect `build/gate-fast.json`
 3. Use raw logs only after artifact triage
 
-What success means:
-- `release-preflight.json` has `ok: true`
-- `gate-fast.json` has `ok: true`
+Decision rule:
+- `ok: true` in both artifacts = ready to advance.
+- `ok: false` and/or non-empty `failed_steps` = first deterministic remediation target.
 
-What failure means:
-- `ok: false` and/or non-empty `failed_steps` gives the first deterministic remediation target.
-- A non-zero exit code with JSON artifacts present is still a trustworthy first run: inspect `failed_steps` instead of treating it as a hidden crash.
+## Where to go next
 
-External first-run contract proof (automated):
+- Start here in docs: [`docs/start-here-5-minutes.md`](docs/start-here-5-minutes.md)
+- Buyer-facing team overview: [`docs/why-sdetkit-for-teams.md`](docs/why-sdetkit-for-teams.md)
+- Blank repo proof in 60 seconds: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
+- CI rollout path: [`docs/recommended-ci-flow.md`](docs/recommended-ci-flow.md)
+- Artifact decoder: [`docs/ci-artifact-walkthrough.md`](docs/ci-artifact-walkthrough.md)
+
+## Canonical local-to-CI journey
+
+The same first-path commands should run locally and in CI so teams make release decisions from consistent evidence contracts.
+
+For a reproducible first-run acceptance proof in a fresh repo:
 
 ```bash
 python -m pytest -q tests/test_external_first_run_contract.py
 ```
 
-This acceptance test creates a truly fresh temporary repo, installs SDETKit into a clean virtual environment, executes the canonical commands, and verifies artifact contracts.
-
-```text
-$ cd examples/adoption/real-repo
-$ python -m sdetkit gate fast
-exit 2  -> build/gate-fast.json: ok=false (fixture triage)
-$ python -m sdetkit gate release
-exit 2  -> build/release-preflight.json: ok=false (fixture triage)
-$ python -m sdetkit doctor
-exit 0  -> build/doctor.json: ok=true
-```
-
-Real fixture-oriented canonical flow; any failing gate result shown here is expected triage for the adoption fixture, not a product failure.
-
 Context: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
-
-## Canonical local-to-CI journey
-
-## Top-tier reporting sample pipeline
-
-Run the end-to-end seeded reporting flow (portfolio scorecard -> KPI snapshot -> contract checks -> bundle promotion):
-
-```bash
-make top-tier-reporting
-```
-
-Optional date/window overrides:
-
-```bash
-make top-tier-reporting DATE_TAG=2026-04-17 WINDOW_START=2026-04-11 WINDOW_END=2026-04-17 GENERATED_AT=2026-04-17T10:00:00Z
-```
-
-Primary artifacts produced under `docs/artifacts/`:
-
-- `portfolio-scorecard-sample-<date>.json`
-- `kpi-weekly-from-portfolio-<date>.json`
-- `kpi-weekly-contract-check-<date>.json`
-- `top-tier-contract-check-<date>.json`
-- `top-tier-bundle-manifest-<date>.json`
-- `top-tier-bundle-manifest-check-<date>.json`
-
-See: [`docs/portfolio-reporting-recipe.md`](docs/portfolio-reporting-recipe.md) and [`docs/kpi-schema.md`](docs/kpi-schema.md).
-
-## Production-readiness snapshot (investor/leadership brief)
-
-Generate a deterministic readiness scorecard that summarizes governance, CI, quality, and release evidence surfaces.
-The scorecard is content-aware (checks policy keywords and CI steps), so it is useful for real production triage:
-
-```bash
-python -m sdetkit readiness . --format text
-python -m sdetkit readiness . --format json
-```
-
-Use this output in due-diligence decks, internal operating reviews, or go-to-production checkpoint meetings.
-For repo targets, `sdetkit review` also publishes this snapshot into the review adaptive database (`adaptive_database.readiness_snapshot`).
-Readiness output includes pass/miss scorecards and achievement tiers so reviewers can track quality progression over time.
-Remediation recommendations are adaptive from scan evidence (lane/priority/rationale), not fixed static text.
-The readiness snapshot also tracks test scenario capacity against a 250-scenario target for scale readiness planning.
-For top-tier decisions, use `top_tier_ready` and `operational_tier` from readiness JSON.
-Review adaptive database also includes large-scale analytics blocks (`quality_matrix`, `findings_analytics`, `action_analytics`, `scalability_posture`) to power richer dashboards.
-For near-term launch operations, use `adaptive_database.release_readiness_contract` (`gate_decision`, blockers, next_24h_actions, next_72h_actions).
-`sdetkit review` now also emits a standalone `adaptive-database.json` artifact for direct dashboard ingestion.
-It also emits `release-readiness.json` and `release-readiness.md` for final launch call workflows.
-Release readiness contract now includes `contract_id`, `generated_at_utc`, and `next_review_due_at_utc` for traceable handoffs.
-It also includes a `trend` block so each run can compare decision/blocker movement vs the previous review.
-`release_readiness_contract` now includes `risk_score`, `risk_band`, and `sla_review_hours` for release-room prioritization.
-It also includes `blocker_catalog` for structured blocker triage (id/kind/severity/priority/next_action).
-Blocker catalog now includes `owner_team` and per-blocker `response_sla_hours` for clear routing.
-`release_readiness_contract.owner_summary` aggregates blocker workload by team for standup planning.
-`release_readiness_contract.recommendation_engine` now provides structured now/next/watchlist + owner-route recommendations.
-Review emits `recommendation-backlog.json` with scored recommendation backlog (`priority_index`) for execution sequencing.
-`release_readiness_contract.agent_orchestration` now suggests which specialist agents/playbooks to run based on current blockers and risk.
-Agent entries include `engine_signals` so orchestration decisions stay aligned with adaptive review outcomes.
-Review also emits `review-contract-check.json` with machine-readable reviewer contract consistency checks.
-
-
-- Canonical first proof: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
-- Canonical real-repo fixture proof: [`docs/real-repo-adoption.md`](docs/real-repo-adoption.md)
-- Canonical CI rollout path: [`docs/recommended-ci-flow.md`](docs/recommended-ci-flow.md)
-- Canonical artifact decoder: [`docs/ci-artifact-walkthrough.md`](docs/ci-artifact-walkthrough.md)
 
 ## Review command format quick guide (operator adoption)
 
@@ -163,30 +100,6 @@ python -m sdetkit review . --no-workspace --format json | jq '{status, severity,
 # Stable operator contract: gate on operator-facing situation/actions fields
 python -m sdetkit review . --no-workspace --format operator-json | jq '{status: .situation.status, severity: .situation.severity, now_actions: (.actions.now | length)}'
 ```
-
-## Who this is for / not for
-
-**Best fit**
-- Teams that want deterministic release decisions instead of ad hoc interpretation.
-- Engineers who need machine-readable evidence for PR/release review.
-- Repos standardizing the same release checks in local and CI runs.
-
-**Probably not a fit (yet)**
-- Very low-risk repos that do not need structured release evidence.
-- Teams that only want raw tool invocations with fully custom orchestration.
-
-## Start here (canonical first path)
-
-- Install (canonical): [`docs/install.md`](docs/install.md)
-- Container runtime adoption: [`docs/container-runtime.md`](docs/container-runtime.md)
-- Blank repo proof in 60 seconds (recommended first run): [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
-- Guided run (same canonical path): [`docs/ready-to-use.md`](docs/ready-to-use.md)
-- Release-confidence model (why this product exists): [`docs/release-confidence.md`](docs/release-confidence.md)
-- Root CLI grouping and canonical path view: `python -m sdetkit --help`
-- Machine-readable public command contract: [`src/sdetkit/public_command_surface.json`](src/sdetkit/public_command_surface.json)
-- Stability levels (policy boundary): [`docs/stability-levels.md`](docs/stability-levels.md) — understand what is stable vs advanced vs experimental
-- Before/after evidence behavior: [`docs/before-after-evidence-example.md`](docs/before-after-evidence-example.md)
-- Real evidence artifacts from this repo: [`docs/evidence-showcase.md`](docs/evidence-showcase.md)
 
 ## Secondary surfaces (after canonical confidence path)
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ python -m pip install sdetkit==1.0.3
 Then run the canonical path:
 
 ```bash
-python -m sdetkit gate fast
-python -m sdetkit gate release
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor
 ```
 

--- a/docs/why-sdetkit-for-teams.md
+++ b/docs/why-sdetkit-for-teams.md
@@ -1,0 +1,68 @@
+# Why SDETKit for teams
+
+SDETKit exists to answer one expensive question with less ambiguity:
+
+**"Is this change safe to ship right now?"**
+
+For many teams, that decision is spread across shell scripts, CI snippets, raw logs, and human interpretation. That works until release pressure increases and teams need repeatable evidence they can trust.
+
+SDETKit provides a deterministic release-confidence path that turns this into a consistent contract:
+
+- one repeatable local-to-CI command flow
+- machine-readable evidence artifacts
+- explicit `ship` / `no-ship` decision inputs
+
+## What problem SDETKit solves
+
+Without a common release-confidence path, teams often face:
+
+- inconsistent checks between local runs and CI
+- slow triage through logs instead of clear artifacts
+- go/no-go decisions based on tribal knowledge
+- hard-to-audit release decisions
+
+SDETKit standardizes that decision surface so teams can review release readiness from stable JSON artifacts, not scattered tooling output.
+
+## Why not just separate tools and scripts?
+
+Separate tools are still valuable, but orchestration usually becomes the fragile part:
+
+- each repository wires tools differently
+- output formats vary and drift over time
+- CI and local commands diverge
+- evidence is harder to compare from run to run
+
+SDETKit is the thin confidence layer above those checks. It focuses on deterministic outcome contracts and artifact-driven triage, so teams can make consistent release calls under time pressure.
+
+## Why deterministic, artifact-driven decisions help teams
+
+Deterministic artifacts improve release operations because they make decisions:
+
+- **repeatable**: same path, same evidence contract
+- **reviewable**: machine-readable output for PRs and release reviews
+- **automatable**: CI systems can gate on structured fields
+- **auditable**: teams can trace why a release was blocked or approved
+
+## Who it is for / not for
+
+**Best fit**
+- Teams that want explicit ship/no-ship evidence.
+- Engineering orgs that need one path from local runs to CI gates.
+- Repositories that want stable machine-readable release artifacts.
+
+**Probably not a fit (yet)**
+- Teams that only need lightweight ad hoc checks.
+- Repos where release governance and evidence contracts are unnecessary.
+
+## How to start (canonical path)
+
+Install and run the canonical path:
+
+```bash
+python -m pip install sdetkit==1.0.3
+python -m sdetkit gate fast
+python -m sdetkit gate release
+python -m sdetkit doctor
+```
+
+Then inspect `build/release-preflight.json` first, and use `failed_steps` to find the first deterministic remediation target.

--- a/docs/why-sdetkit-for-teams.md
+++ b/docs/why-sdetkit-for-teams.md
@@ -60,8 +60,8 @@ Install and run the canonical path:
 
 ```bash
 python -m pip install sdetkit==1.0.3
-python -m sdetkit gate fast
-python -m sdetkit gate release
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,64 +82,52 @@ extra_javascript:
   - javascripts/mermaid-init.js
 
 nav:
-  - Start here: index.md
-  - Canonical first-proof path (primary):
-      - Homepage: index.md
-      - Start Here in 5 Minutes (fast path): start-here-5-minutes.md
-      - Install (canonical): install.md
+  - Start here:
+      - Overview: index.md
+      - Why SDETKit for teams: why-sdetkit-for-teams.md
+      - Start Here in 5 Minutes: start-here-5-minutes.md
+      - Release confidence model: release-confidence.md
+      - Decision guide: decision-guide.md
+  - Getting started:
+      - Install: install.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
-      - First run quickstart (guided canonical path): ready-to-use.md
-      - Release confidence (canonical explainer): release-confidence.md
-      - Decision guide (is SDETKit a fit?): decision-guide.md
-      - Choose your path (30-second router): choose-your-path.md
+      - Guided first run: ready-to-use.md
+      - Adopt in your repository: adoption.md
+      - Team rollout scenario: team-rollout-scenario.md
+      - Container runtime: container-runtime.md
+      - Recommended CI flow: recommended-ci-flow.md
+  - Release confidence:
+      - CI artifact walkthrough: ci-artifact-walkthrough.md
+      - CI contract: ci-contract.md
       - Before/after evidence example: before-after-evidence-example.md
       - Evidence showcase: evidence-showcase.md
-  - Team adoption and CI rollout (primary):
-      - Adopt in your repository (canonical): adoption.md
-      - Team rollout scenario: team-rollout-scenario.md
-      - Example adoption flow: example-adoption-flow.md
-      - Adoption examples: adoption-examples.md
-      - Adoption troubleshooting: adoption-troubleshooting.md
-      - Recommended CI flow (canonical): recommended-ci-flow.md
-      - CI artifact walkthrough (canonical evidence decode): ci-artifact-walkthrough.md
-      - CI contract (reference): ci-contract.md
-      - Remediation cookbook: remediation-cookbook.md
       - Reporting and trends: reporting-and-trends.md
       - Release confidence KPI pack: release-confidence-kpi-pack.md
-      - Sample outputs (exploratory, non-canonical): sample-outputs.md
-  - Current reference and discoverability (secondary):
-      - Docs map (compact): docs-map.md
+      - Remediation cookbook: remediation-cookbook.md
+      - Determinism checklist: determinism-checklist.md
+      - Determinism contract: determinism-contract.md
+  - Reference:
       - CLI reference: cli.md
       - API: api.md
       - Doctor checks: doctor.md
       - Repo audit: repo-audit.md
-      - Security:
-          - Security gate: security-gate.md
-          - Security model: security-model.md
-          - Security hardening: security.md
-          - Policy-as-Code: policy.md
+      - Security gate: security-gate.md
+      - Security model: security-model.md
+      - Security hardening: security.md
+      - Policy-as-Code: policy.md
       - Feature registry: feature-registry.md
-      - Release confidence architecture note: architecture/umbrella-kits.md
       - Command surface inventory: command-surface.md
       - Capability map and command taxonomy: command-taxonomy.md
       - Legacy command migration map: legacy-command-migration-map.md
-      - Golden-path health signal: golden-path-health.md
-      - Adoption scorecard: adoption-scorecard.md
-      - Legacy burn-down program: legacy-burndown.md
-      - Operational maturity v2 rollout: operational-maturity-v2-rollout.md
-      - Operator onboarding wizard: operator-onboarding-wizard.md
-      - Primary docs map: primary-docs-map.md
-      - Docs nav cleanup progress: docs-nav-cleanup-progress.md
-      - Determinism checklist: determinism-checklist.md
-      - Determinism contract: determinism-contract.md
-      - Stability levels (current policy): stability-levels.md
-      - Versioning and support posture (current policy): versioning-and-support.md
-      - Integrations and extension boundary (current policy): integrations-and-extension-boundary.md
+      - Stability levels: stability-levels.md
+      - Versioning and support posture: versioning-and-support.md
+      - Integrations and extension boundary: integrations-and-extension-boundary.md
       - Release verification records: release-verification.md
+      - Docs map: docs-map.md
       - Roadmap: roadmap.md
       - Changelog: changelog.md
       - License: license.md
-  - Advanced (secondary):
+  - Advanced:
       - Contributing and maintenance:
           - Repo tour: repo-tour.md
           - First contribution quickstart: first-contribution-quickstart.md
@@ -150,7 +138,7 @@ nav:
           - PR automation for audit auto-fixes: pr-automation.md
           - Automation bots and maintenance control loop: automation-bots.md
           - n8n integration (PR webhook automation): n8n.md
-      - Kits (secondary umbrella):
+      - Kits:
           - Release Confidence Kit: kits/release-confidence.md
           - Test Intelligence Kit: kits/test-intelligence.md
           - Integration Assurance Kit: kits/integration-assurance.md
@@ -168,8 +156,8 @@ nav:
           - Plugins: plugins.md
           - Plugins, rule packs, and fix-audit: plugins-and-fix.md
       - Product and governance:
-          - Why not just separate tools? (system value): why-not-just-tools.md
-          - Product strategy (release confidence): product-strategy.md
+          - Why not just separate tools?: why-not-just-tools.md
+          - Product strategy: product-strategy.md
           - Productization map: productization-map.md
           - Design notes: design.md
           - Governance and org packs: governance-and-org-packs.md
@@ -182,10 +170,9 @@ nav:
           - 🔄 DevS69 Diff-to-Decision — Live Detail View: diff-flow-live.md
           - 🗺️ DevS69 Repo Map — Live Detail View: repo-map-live.md
           - DevS69 Visual HUD Showcase: hud-showcase.md
-  - Historical archive (non-primary):
+  - Archive:
       - Archive overview: archive/index.md
       - Transition-era material map: archive/transition-era-material.md
-
 exclude_docs: |
   artifacts/**
   roadmap/reports/**


### PR DESCRIPTION
### Motivation
- Clarify the product positioning and provide a concise, operator-focused onboarding path so teams can run one canonical local-to-CI flow and inspect deterministic artifacts. 
- Make the docs navigation more discoverable and surface team-oriented guidance and start-up paths first. 
- Provide a short, standalone explanation of why teams would adopt SDETKit to aid buy-in and onboarding.

### Description
- Rewrote `README.md` to focus on product purpose, canonical first path, artifact decoding, decision rules, and links to starter docs. 
- Added a new team-facing doc `docs/why-sdetkit-for-teams.md` that explains problem, value, fit, and the canonical start commands. 
- Reworked `mkdocs.yml` navigation to surface the overview, "Why SDETKit for teams", getting-started pages, and reorganized reference/advanced sections for clearer discovery. 
- Removed and simplified several legacy/secondary README sections to keep the canonical onboarding flow prominent.

### Testing
- Executed the external first-run acceptance test via `python -m pytest -q tests/test_external_first_run_contract.py`, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e323d00e24832dab0b266704ef2101)