### PR TITLE
Add team-facing docs (use cases, adoption examples, release ROI) and update README/nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Decision rule:
 - Blank repo proof in 60 seconds: [`docs/blank-repo-to-value-60-seconds.md`](docs/blank-repo-to-value-60-seconds.md)
 - CI rollout path: [`docs/recommended-ci-flow.md`](docs/recommended-ci-flow.md)
 - Artifact decoder: [`docs/ci-artifact-walkthrough.md`](docs/ci-artifact-walkthrough.md)
+- Team use cases: [`docs/use-cases.md`](docs/use-cases.md)
+- Release confidence ROI: [`docs/release-confidence-roi.md`](docs/release-confidence-roi.md)
+- Adoption-proof examples: [`docs/adoption-proof-examples.md`](docs/adoption-proof-examples.md)
 
 ## Canonical local-to-CI journey
 

--- a/docs/adoption-proof-examples.md
+++ b/docs/adoption-proof-examples.md
@@ -1,0 +1,61 @@
+# Adoption-proof examples
+
+These examples show realistic, artifact-first usage that maps to day-to-day PR and release review flow.
+
+Canonical artifact-producing run:
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor
+```
+
+## Example 1: Team runs `gate fast`, `gate release`, `doctor`
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor
+```
+
+Why this sequence works:
+- `gate fast` gives immediate pre-merge signal.
+- `gate release` gives release-level aggregate decision input.
+- `doctor` validates runtime/setup assumptions that can explain unexpected failures.
+
+## Example 2: Artifact-first triage path
+
+Use this deterministic order:
+1. Read `build/release-preflight.json`.
+2. If `failed_steps` includes `gate_fast`, read `build/gate-fast.json`.
+3. Only then inspect raw logs for low-level details.
+
+This keeps triage focused on explicit machine-readable decision points.
+
+## Example 3: What blocked
+
+A practical blocked state looks like:
+- `release-preflight.json` has `ok: false`
+- `failed_steps` is non-empty
+- failure points to the next deterministic remediation target
+
+At this stage, the team has enough structure to decide “not ready yet” without narrative guesswork.
+
+## Example 4: What to fix next
+
+Teams can choose the next action from the first failing artifact field instead of broad, unfocused investigation.
+
+Typical next-step pattern:
+- fix the earliest failing gate condition
+- re-run `gate fast`
+- re-run `gate release`
+- keep `doctor` clean before final review
+
+## Example 5: How this helps real review/release flow
+
+In practical review operations:
+- engineers attach artifact outputs in PR context
+- reviewers validate `ok` / `failed_steps` quickly
+- release owners use the same outputs for go/no-go calls
+
+This creates a single evidence thread from implementation review through release decision, without changing core repo workflows.

--- a/docs/release-confidence-roi.md
+++ b/docs/release-confidence-roi.md
@@ -1,0 +1,44 @@
+# Release confidence ROI (without invented metrics)
+
+This page describes practical value teams can capture from SDETKit without using fabricated percentages or synthetic customer claims.
+
+## What value looks like in practice
+
+## 1) Fewer ad hoc release decisions
+
+Teams use a declared command path (`gate fast` → `gate release` → `doctor`) and consistent artifact fields (`ok`, `failed_steps`) to decide whether to advance a change.
+
+That reduces “it depends who reviewed it” decision patterns and creates a shared decision language.
+
+## 2) Less time spent reading raw logs
+
+Instead of starting with full log streams, teams begin with structured artifacts:
+
+- `build/release-preflight.json` for top-level go/no-go context
+- `build/gate-fast.json` for focused failure breakdown
+
+Raw logs are still available, but they become a second-step drill-down, not the first triage surface.
+
+## 3) One repeatable local-to-CI path
+
+The same commands can run on a laptop and in CI, with the same artifact contract. That reduces friction when reproducing issues between local development, PR validation, and release checks.
+
+## 4) Machine-readable evidence for repeatable reviews
+
+JSON outputs allow deterministic review workflows:
+- reviewers can inspect the same fields every time
+- automation can parse artifacts without brittle text scraping
+- release records can store evidence in a stable structure
+
+## 5) Better handoff across roles
+
+SDETKit artifacts support cleaner handoff between:
+- engineers preparing a change
+- reviewers validating readiness
+- release owners making advancement calls
+
+Each role sees the same structured decision inputs, which lowers ambiguity in review and sign-off conversations.
+
+## Adoption note
+
+ROI should be validated by each team against its own baseline (current review time, release friction, and defect escape profile). SDETKit provides a repeatable evidence path; teams should measure the impact in their own delivery context.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,80 @@
+# Team use cases
+
+This page shows practical ways teams use SDETKit in day-to-day delivery work, using the current public command surface (`gate fast`, `gate release`, `doctor`) and artifact-first triage.
+
+Canonical artifact-producing run:
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor
+```
+
+## 1) PR gate / pre-merge confidence
+
+**When:** before merge on pull requests.
+
+**What teams run:**
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+```
+
+**How teams use it:**
+- Treat `build/gate-fast.json` as the first decision artifact.
+- Check `ok` and `failed_steps` first, before reading raw logs.
+- Keep the same command locally and in CI so a PR decision does not depend on who ran it.
+
+**Outcome:** a deterministic pre-merge pass/fail signal with structured evidence for reviewers.
+
+## 2) Release go/no-go
+
+**When:** during release preflight and sign-off.
+
+**What teams run:**
+
+```bash
+python -m sdetkit gate release --format json --out build/release-preflight.json
+```
+
+**How teams use it:**
+- Use `build/release-preflight.json` as the top-level release decision input.
+- Interpret `ok: true` as ready to advance and `ok: false` as no-go until remediated.
+- Use `failed_steps` to identify the first deterministic remediation target.
+
+**Outcome:** release decisions are based on one declared contract instead of ad hoc interpretation.
+
+## 3) Repo onboarding / first triage
+
+**When:** a new engineer or reviewer needs a fast understanding of repo readiness.
+
+**What teams run:**
+
+```bash
+python -m sdetkit doctor
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+```
+
+**How teams use it:**
+- `doctor` confirms environment and setup assumptions.
+- `gate fast` gives quick readiness signals.
+- `gate release` provides the release-oriented aggregate view.
+
+**Outcome:** first triage is consistent across maintainers, newcomers, and CI.
+
+## 4) Audit / evidence handoff
+
+**When:** handing release readiness evidence between engineers, reviewers, and release owners.
+
+**What teams hand off:**
+- `build/gate-fast.json`
+- `build/release-preflight.json`
+- command invocation context from CI/local run logs
+
+**How teams use it:**
+- Reviewers validate decisions from machine-readable artifacts.
+- Release owners can re-check the same fields without reconstructing ad hoc narratives.
+- Teams store artifacts as evidence in PR/release records.
+
+**Outcome:** handoff quality improves because decision inputs are explicit, repeatable, and parseable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
   - Start here:
       - Overview: index.md
       - Why SDETKit for teams: why-sdetkit-for-teams.md
+      - Team use cases: use-cases.md
       - Start Here in 5 Minutes: start-here-5-minutes.md
       - Release confidence model: release-confidence.md
       - Decision guide: decision-guide.md
@@ -102,6 +103,8 @@ nav:
       - Before/after evidence example: before-after-evidence-example.md
       - Evidence showcase: evidence-showcase.md
       - Reporting and trends: reporting-and-trends.md
+      - Release confidence ROI: release-confidence-roi.md
+      - Adoption proof examples: adoption-proof-examples.md
       - Release confidence KPI pack: release-confidence-kpi-pack.md
       - Remediation cookbook: remediation-cookbook.md
       - Determinism checklist: determinism-checklist.md


### PR DESCRIPTION
### Motivation

- Provide concrete, team-focused guidance for adopting the artifact-first workflow and how SDETKit fits into PR/release review processes. 
- Surface practical examples and ROI thinking so teams can validate and communicate value without synthetic metrics. 
- Make the new pages discoverable from the project README and site navigation so adopters can find them quickly.

### Description

- Add `docs/use-cases.md` with practical team workflows for `gate fast`, `gate release`, and `doctor` usage. 
- Add `docs/adoption-proof-examples.md` containing deterministic artifact-first triage and example sequences. 
- Add `docs/release-confidence-roi.md` describing pragmatic ROI topics and adoption notes. 
- Update `README.md` and `mkdocs.yml` to link the new pages and include them in the site navigation.

### Testing

- No automated tests were modified in this change because it is documentation-only. 
- No CI test runs were required to validate these documentation updates. 
- Consumers can validate local site build with `mkdocs build` when needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e32b12112c832d94f468b75aae0b21)