### PR TITLE
docs: align runtime, install, and canonical path guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ Instead of stitching together separate scripts and tools for every repo, teams r
 
 ## Canonical first path (run this first)
 
-Install the released package:
+Install the released package in an isolated environment (Python 3.11+):
 
 ```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
 python -m pip install sdetkit==1.0.3
 ```
+
+If you prefer an isolated global CLI install instead of a project venv, use `pipx install sdetkit==1.0.3`.
 
 Then run the canonical path:
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -16,7 +16,10 @@ Move from local confidence checks to repeatable team gates with machine-readable
 Use [Install](install.md), then verify:
 
 ```bash
-python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
+python -m pip install sdetkit==1.0.3
 python -m sdetkit --help
 python -m sdetkit gate --help
 ```

--- a/docs/blank-repo-to-value-60-seconds.md
+++ b/docs/blank-repo-to-value-60-seconds.md
@@ -9,7 +9,10 @@ If you want the same path with more guidance, use [First run quickstart](ready-t
 ```bash
 mkdir my-repo && cd my-repo
 git init
-python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
+python -m pip install sdetkit==1.0.3
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
 python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,7 +29,7 @@ Use this page as a concise handoff, then follow the detailed path in [`CONTRIBUT
 ```bash
 python -m pre_commit run -a
 bash quality.sh cov
-mkdocs build
+NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q
 ```
 
 ## Feature registry governance (for command-surface changes)

--- a/docs/example-adoption-flow.md
+++ b/docs/example-adoption-flow.md
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+      - run: python -m pip install sdetkit==1.0.3
       - name: Fast confidence gate
         run: python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
       - name: Strict release checks

--- a/docs/first-contribution-quickstart.md
+++ b/docs/first-contribution-quickstart.md
@@ -60,7 +60,7 @@ For docs-only changes:
 
 ```bash
 python -m pre_commit run -a
-mkdocs build
+NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q
 ```
 
 ## 4) Open your PR

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,25 +2,29 @@
 
 Use this page for canonical installation paths before running release-confidence commands.
 
+Python 3.11+ is required.
+
 After install, continue with:
 - Ultra-fast proof: [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
 - Guided run: [First run quickstart (canonical)](ready-to-use.md)
 
 ## Recommended install path (first-time and external users)
 
-Install directly from GitHub, then verify CLI wiring:
+Create a virtual environment first, then install from PyPI and verify CLI wiring:
 
 ```bash
-python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
+python -m pip install sdetkit==1.0.3
 python -m sdetkit --help
 ```
 
 Why this is the recommended path now:
 
-- Works in any repository without cloning this project first.
-- Uses the same public source every team can access.
-- Does not rely on this repository's helper scripts.
-- Public PyPI install is not yet verified in this repository's release records.
+- Avoids system Python `externally-managed-environment` failures on Ubuntu/WSL.
+- Uses the public release surface directly.
+- Works consistently for local first runs and CI smoke checks.
 
 ## Alternative install paths
 
@@ -29,20 +33,23 @@ Use these only if they better fit your environment.
 ### `pipx` (isolated CLI install)
 
 ```bash
-pipx install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+pipx install sdetkit==1.0.3
 pipx run sdetkit --help
 ```
 
 ### `uv tool install` (isolated tool install)
 
 ```bash
-uv tool install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+uv tool install sdetkit==1.0.3
 uv tool run sdetkit --help
 ```
 
 ### Local source install (contributors in this repo)
 
 ```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
 python -m pip install .
 python -m sdetkit --help
 ```
@@ -94,7 +101,7 @@ This setup is for contributors/maintainers, not required for external adoption.
 
 SDETKit has release automation for build, wheel validation, optional PyPI publish, and provenance attestation in `.github/workflows/release.yml`.
 
-Until a release is publicly published and externally verified, the install recommendation remains GitHub URL install.
+For end users, prefer PyPI (venv or `pipx`) and use GitHub-source installs only when you explicitly need unreleased changes.
 
 - Maintainer release process summary: [Releasing sdetkit](releasing.md)
 - Public verification log: [release-verification.md](release-verification.md)

--- a/docs/premium-quality-gate.md
+++ b/docs/premium-quality-gate.md
@@ -21,7 +21,7 @@ python -m pre_commit run -a
 bash quality.sh cov
 python -m build
 python -m twine check dist/*
-mkdocs build
+NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q
 ```
 
 ## Coverage expectations

--- a/docs/ready-to-use.md
+++ b/docs/ready-to-use.md
@@ -6,11 +6,16 @@ If you only want the fastest proof with minimal text, use [Blank repo to value i
 
 ## Guided run (5 minutes)
 
-0. Install in the target external repo (skip only if already installed):
+0. Install in the target external repo with Python 3.11+ (skip only if already installed):
 
 ```bash
-python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
+python -m pip install sdetkit==1.0.3
 ```
+
+Alternative for an isolated global CLI: `pipx install sdetkit==1.0.3`.
 
 1. (Optional) Verify CLI wiring:
 

--- a/docs/recommended-ci-flow.md
+++ b/docs/recommended-ci-flow.md
@@ -61,7 +61,7 @@ jobs:
           python -m pre_commit run -a
           bash quality.sh registry
           bash quality.sh cov
-          NO_MKDOCS_2_WARNING=1 python -m mkdocs build
+          NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q
 
       - name: Upload CI diagnostics
         if: always()

--- a/docs/release-confidence.md
+++ b/docs/release-confidence.md
@@ -9,7 +9,10 @@ Release confidence means a repository can answer **"Is this ready to ship?"** wi
 ## Canonical command path (primary)
 
 ```bash
-python -m pip install "git+https://github.com/sherif69-sa/DevS69-sdetkit.git"
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
+python -m pip install sdetkit==1.0.3
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
 python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,7 +21,7 @@ Current baseline release: **v1.0.2**.
    bash quality.sh cov
    python -m build
    python -m twine check dist/*
-   mkdocs build
+   NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q
    ```
 
 4. Commit changes and open/merge a PR.

--- a/docs/why-sdetkit-for-teams.md
+++ b/docs/why-sdetkit-for-teams.md
@@ -56,9 +56,12 @@ Deterministic artifacts improve release operations because they make decisions:
 
 ## How to start (canonical path)
 
-Install and run the canonical path:
+Install and run the canonical path (Python 3.11+, isolated env):
 
 ```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
 python -m pip install sdetkit==1.0.3
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
 python -m sdetkit gate release --format json --out build/release-preflight.json


### PR DESCRIPTION
### Motivation
- Remove stale/misleading install and runtime guidance so docs match the repository's current Python/runtime expectations and artifact-producing path. 
- Make local contributor guidance explicit about using an isolated environment (`venv`) or `pipx` and avoid recommending bare system `pip` installs that can fail on Ubuntu/WSL. 
- Normalize local docs build instructions to a reproducible command that suppresses MkDocs v2 warnings when used in automation. 

### Description
- Replaced bare `python -m pip install sdetkit==1.0.3` and `git+https://...` GitHub-source install examples with isolated-install guidance using a `venv` plus PyPI (`python -m venv .venv` → `python -m pip install sdetkit==1.0.3`) and a `pipx` alternative, and added an explicit `Python 3.11+` requirement. 
- Standardized the canonical artifact-producing command examples to the canonical path (`python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`, `python -m sdetkit gate release --format json --out build/release-preflight.json`, `python -m sdetkit doctor`). 
- Normalized local docs build guidance from `mkdocs build` to `NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q` in contributor/release-facing docs and CI examples. 
- Updated documentation files (13 files): `README.md`, `docs/install.md`, `docs/ready-to-use.md`, `docs/release-confidence.md`, `docs/adoption.md`, `docs/blank-repo-to-value-60-seconds.md`, `docs/why-sdetkit-for-teams.md`, `docs/contributing.md`, `docs/first-contribution-quickstart.md`, `docs/premium-quality-gate.md`, `docs/releasing.md`, `docs/recommended-ci-flow.md`, and `docs/example-adoption-flow.md`. 

### Testing
- Ran the docs build validation command `NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q`; the first attempt using the repository default interpreter failed with `/root/.pyenv/versions/3.10.19/bin/python: No module named mkdocs`. 
- Re-ran the docs build inside a Python 3.11 venv (`PYENV_VERSION=3.11.14` / `python -m venv .venv && source .venv/bin/activate && python -m pip install -q mkdocs mkdocs-material`) and `NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q` completed successfully with exit code 0 and no output. 
- Performed repository-wide searches to confirm removed/updated stale references and inspected the diff stats to verify only documentation files were changed (13 files, 51 insertions, 22 deletions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e33168d338832d8ee8fa34ce443a36)