### PR TITLE
Docs: Simplify homepage and emphasize canonical local→CI path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,54 +1,10 @@
 # Start here: deterministic release confidence
 
-DevS69 SDETKit is a release-confidence CLI: it gives engineering teams deterministic ship/no-ship decisions with machine-readable evidence, using one repeatable command path from local to CI.
+DevS69 SDETKit is a release-confidence CLI for deterministic ship/no-ship decisions with machine-readable evidence.
 
-**Primary outcome:** know if a change is ready to ship.
+**Primary outcome:** move from local proof to CI using one repeatable path.
 
-**Canonical first path:** `python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`.
-
-Need the fastest onboarding path? Start with [Start Here in 5 Minutes](start-here-5-minutes.md).
-
-## What this is
-
-SDETKit is a productized release-confidence path for engineering teams that need clear ship/no-ship decisions backed by structured artifacts.
-
-Everything else is intentionally secondary until this canonical first-proof lane is trusted.
-
-## How to use this docs site
-
-Use the navigation in this order to reduce decision fatigue:
-
-1. **Start Here (primary)** for first-run success on the canonical path.
-2. **Team Rollout / CI (primary)** when moving from local proof to team adoption.
-3. **Reference (secondary)** for command/options lookup and policy details.
-4. **Advanced (secondary)** for maintainer, platform, and extension workflows.
-5. **Archive / Historical (non-primary)** only when you need transition-era traceability.
-
-## Why trust it
-
-- The core flow is explicit and repeatable: `python -m sdetkit gate fast` → `python -m sdetkit gate release` → `python -m sdetkit doctor`.
-- Outputs are machine-readable JSON artifacts, not only terminal logs.
-- Evidence examples in this repo use representative real output shapes (no fabricated customer claims or synthetic benchmarks).
-
-```text
-$ cd examples/adoption/real-repo
-$ python -m sdetkit gate fast
-exit 2  -> build/gate-fast.json: ok=false (fixture triage)
-$ python -m sdetkit gate release
-exit 2  -> build/release-preflight.json: ok=false (fixture triage)
-$ python -m sdetkit doctor
-exit 0  -> build/doctor.json: ok=true
-```
-
-Real fixture-oriented canonical flow; any failing gate result shown here is expected triage for the adoption fixture, not a product failure.
-
-Context: [real-repo adoption fixture + golden artifacts](real-repo-adoption.md)
-
-## What to run first
-
-### Fast start
-
-Canonical first-proof commands (same as README and first-run guides):
+## Canonical first run (local -> CI)
 
 ```bash
 python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
@@ -56,106 +12,35 @@ python -m sdetkit gate release --format json --out build/release-preflight.json
 python -m sdetkit doctor
 ```
 
-1. [Install (canonical)](install.md)
-2. [Start Here in 5 Minutes](start-here-5-minutes.md)
-3. [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
-4. [Release confidence explainer](release-confidence.md)
-
-If you want a guided run instead of the ultra-fast proof lane, use [First run quickstart](ready-to-use.md).
-For CLI-first orientation, run `python -m sdetkit --help` to see the same canonical path plus stability-tier grouping.
-Need compatibility-lane expectations? See [Versioning and support posture](versioning-and-support.md#canonical-path-vs-compatibility-lanes-visibility-policy).
-
-## What artifacts appear
-
-Core first-run artifacts:
+## What you get
 
 ```text
-build/
-├── gate-fast.json
-└── release-preflight.json
+build/gate-fast.json
+build/release-preflight.json
 ```
 
-Inspect these keys first:
-- `ok`
-- `failed_steps`
-- `profile`
+## Try it quickly
 
-For side-by-side behavior and deeper examples:
-- [Before/after evidence example](before-after-evidence-example.md)
-- [Evidence showcase](evidence-showcase.md)
+- [Start Here in 5 Minutes](start-here-5-minutes.md)
+- [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
+- [First run quickstart](ready-to-use.md)
 
-## Decide fit quickly
+## Team rollout / CI
 
-Use [Decision guide](decision-guide.md) to confirm whether SDETKit is a good fit before broader rollout.
+- [Adopt in your repository](adoption.md)
+- [Recommended CI flow](recommended-ci-flow.md)
+- [CI artifact walkthrough](ci-artifact-walkthrough.md)
 
-## Where to go next
+## Reference / advanced
 
-- Need lane routing: [Choose your path](choose-your-path.md)
-- Need team rollout: [Adopt in your repository](adoption.md)
-- Need CI rollout: [Recommended CI flow](recommended-ci-flow.md)
-- Need fast troubleshooting: [First failure triage](first-failure-triage.md), [Adoption troubleshooting](adoption-troubleshooting.md), [Remediation cookbook](remediation-cookbook.md)
-- Need compact navigation: [Docs map (compact)](docs-map.md)
-- Need leadership packaging guidance: [CTO full-package review](cto-full-package-review.md)
-- Need two-pass release hardening assessment: [Repo double-analysis (April 2026)](repo-double-analysis-2026-04.md)
-- Need execution tracker input: `plans/top-tier-repo-execution-plan-2026-q2.json` (repo plan artifact)
-- Need weekly control plane: [Top-tier program dashboard](top-tier-program-dashboard.md)
-- Need point-by-point CTO execution lane? Use [CTO execution workflow (6-point)](cto-execution-workflow.md)
-- Need post-completion operating plan? Use [CTO Phase 2 launch plan](cto-phase2-launch-plan.md)
-- Need package lane definitions: [Packaging lanes](packaging-lanes.md)
-- Need governance policy table: [Policy compatibility matrix](policy-compatibility-matrix.md)
-- Need operating support model: [Support and escalation model](support-and-escalation-model.md)
-- Need multi-repo aggregation: [Portfolio reporting recipe](portfolio-reporting-recipe.md)
-- Need leadership updates: [Executive weekly template](executive-weekly-template.md)
-- Need monthly leadership view: [Executive monthly template](executive-monthly-template.md)
-- Need KPI contract: [Top-tier KPI schema](kpi-schema.md)
-- Need operator runbook: [Operations handbook](operations-handbook.md)
-- Need rollout gates: [Pilot to rollout guide](pilot-to-rollout-guide.md)
-- Need release train gate: [Full release package checklist](full-release-package-checklist.md)
-- Need scale-phase assets: [P2 scale assets](p2-scale-assets.md)
-- Need current references: [CLI reference](cli.md), [API](api.md), and [repo audit reference](repo-audit.md)
-- Migrating older automation? Use [Legacy command migration map](legacy-command-migration-map.md)
-- Need canonical-path health status? Use [Golden-path health signal](golden-path-health.md)
-- Need drift enforcement? Run canonical path drift guard (`python scripts/check_canonical_path_drift.py --format json`)
-- Need top-tier reporting pipeline? Run `make top-tier-reporting`
-- Need legacy usage inventory? Run legacy command analyzer (`python scripts/legacy_command_analyzer.py --format json`)
-- Need one maturity number? Generate [Adoption scorecard](adoption-scorecard.md)
-- Need investor/leadership readiness posture? Use [Production readiness scorecard](production-readiness-scorecard.md)
-- Need company-grade boost roadmap from current repo state? Use [Enterprise assessment](enterprise-assessment.md)
-- Need one-command go/no-go release contract? Use [Ship readiness](ship-readiness.md)
-- Need multi-repo risk ranking and executive triage view? Use [Portfolio readiness](portfolio-readiness.md)
-- Need guided canonical triage? Use [Operator onboarding wizard](operator-onboarding-wizard.md)
-- Need API snapshot? Query serve observability endpoint (`GET /v1/observability`)
-- Need docs IA guardrails? Use [Primary docs map](primary-docs-map.md)
-- Need artifact contract inventory: [Artifact contract index](artifact-contract-index.json) (refresh with `python scripts/generate_artifact_contract_index.py`).
-- Need contributor workflow: [Contributing](contributing.md)
-- Need boundary guidance: [Stability levels](stability-levels.md) for adopters and contributors
+- [CLI reference](cli.md)
+- [Doctor checks](doctor.md)
+- [Why SDETKit for teams](why-sdetkit-for-teams.md)
+- [Use cases](use-cases.md)
+- [Release confidence ROI](release-confidence-roi.md)
 
-## Secondary references (current)
+## Install and runtime notes
 
-This page is a product homepage/router, not a historical archive. Deep references and advanced material remain available and are intentionally secondary to first-time adoption.
-
-If you need context after the canonical first-proof path is working:
-- New contributor? Start with the safe-first lane in [Contributing](contributing.md#first-trustworthy-contribution-safe-first-lane).
-- [SDETKit vs ad hoc tooling](sdetkit-vs-ad-hoc.md)
-- [Repo cleanup plan](repo-cleanup-plan.md)
-- [Repo health dashboard](repo-health-dashboard.md)
-
-## Historical archive (non-primary)
-
-Historical and transition-era documentation is preserved for traceability, but intentionally demoted in primary navigation.
-
-- [Archive index](archive/index.md)
-
-<div class="quick-jump" markdown>
-
-[⚡ Fast start](#fast-start) · [🧭 Repo tour](repo-tour.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-reports)
-
-</div>
-
-## Legacy reports
-
-### Top journeys
-
-- Run first command in under 60 seconds
-- Validate docs links and anchors before publishing
-- Ship a first contribution with deterministic quality gates
+- Python 3.11+
+- Prefer isolated environments
+- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q`


### PR DESCRIPTION
### Motivation

- Reduce noise on the docs landing page and make the canonical local→CI onboarding path more discoverable and actionable.
- Shorten and reorganize content to direct users quickly to first-run commands, team rollout, and reference material. 
- Surface minimal install/runtime notes and build command for predictable documentation builds.

### Description

- Rewrote `docs/index.md` to condense the homepage into focused sections: "Canonical first run (local -> CI)", "What you get", "Try it quickly", "Team rollout / CI", "Reference / advanced", and "Install and runtime notes". 
- Replaced a long narrative and examples with a compact canonical command snippet and simplified artifact listing (`build/gate-fast.json`, `build/release-preflight.json`).
- Removed many secondary/legacy link lists and archival noise, moving primary quick-start links into prominent quick-jump areas.
- Added runtime guidance including `Python 3.11+`, preference for isolated environments, and the recommended build invocation `NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q`.

### Testing

- Ran the documentation build with `NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e33382dce0832da2d0fc8a85ddec18)