### PR TITLE
Add SUPPORT.md and expand versioning/support documentation; update README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ artifacts/     # generated evidence packs
 - Docs hub: [`docs/index.md`](docs/index.md)
 - Architecture quick map for contributors: [`ARCHITECTURE.md`](ARCHITECTURE.md)
 - Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Support and issue routing: [`SUPPORT.md`](SUPPORT.md)
 - Release process: [`RELEASE.md`](RELEASE.md)
 - Git workflow (branch tracking + ahead/behind): [`docs/git-workflow.md`](docs/git-workflow.md)
 - Enterprise readiness audit: [`docs/enterprise-readiness-audit-2026-04.md`](docs/enterprise-readiness-audit-2026-04.md)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,14 +1,68 @@
 # Support
 
-This repository is provided as-is.
+This project is maintained in public and provided without a contractual SLA.
+Support is best-effort through the public issue tracker and project docs.
 
-For questions, licensing inquiries, or feature requests, please open an issue with:
-- what you tried
-- expected behavior
-- actual behavior
-- minimal repro steps
+## Before opening an issue
 
-## Contact
+1. Use an isolated environment (recommended): virtualenv or `pipx`.
+2. Confirm your runtime is **Python 3.11+**.
+3. Re-run the canonical release-confidence path:
+   - `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`
+   - `python -m sdetkit gate release --format json --out build/release-preflight.json`
+   - `python -m sdetkit doctor`
+
+If the problem persists, open an issue with the artifacts below.
+
+## Where to get help
+
+- **Install/runtime problems:** open a GitHub issue and label it as install/runtime.
+- **Docs problems:** open a GitHub issue and label it as documentation.
+- **Release-confidence / gate interpretation questions:** open a GitHub issue and include the gate artifacts so maintainers can interpret the same evidence.
+- **Bug reports vs feature requests:**
+  - Use **Bug report** when behavior is incorrect or inconsistent with docs.
+  - Use **Feature request** when behavior is working as documented but you want new capability.
+
+Project issue tracker:
+- https://github.com/sherif69-sa/DevS69-sdetkit/issues
+
+## What to include in every support issue
+
+Please include:
+
+- What you tried.
+- Expected behavior.
+- Actual behavior.
+- Minimal reproduction steps.
+
+### Attach these artifacts
+
+When possible, attach these files/outputs directly to the issue:
+
+- `build/gate-fast.json`
+- `build/release-preflight.json`
+- output of `python -m sdetkit doctor`
+- environment details:
+  - Python version (`python --version`)
+  - OS + version
+  - install method (for example `pip install ...` in venv, or `pipx install ...`)
+
+These details make support triage significantly faster and reduce back-and-forth.
+
+## Stability and support boundaries
+
+Support expectations follow documented surface tiers:
+
+- **Public / stable:** strongest compatibility and support expectations; safest dependency targets for adopters.
+- **Advanced but supported:** supported in production, but ergonomics/docs/integration edges may iterate faster.
+- **Experimental / incubator:** opt-in, best-effort continuity; validate in your own repository/CI before depending on it.
+
+See also:
+- `docs/versioning-and-support.md`
+- `docs/stability-levels.md`
+- `docs/command-surface.md`
+
+## Private contact
 
 For private inquiries (including commercial licensing permissions), use one of the channels below:
 - LinkedIn: https://www.linkedin.com/in/sherif-atef-b1077a124/

--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -10,6 +10,13 @@ Canonical first path: `python -m sdetkit gate fast` -> `python -m sdetkit gate r
 This page is the operational policy for versioning, compatibility, support, and
 deprecation. It intentionally avoids guarantees we do not operationally enforce.
 
+## Quick support snapshot
+
+- **Supported Python floor:** **3.11+**
+- **Preferred install mode:** isolated environments (`venv` or `pipx`)
+- **First dependency target for adopters:** canonical command path artifacts and decision flow
+- **Support model:** best-effort public support (no contractual SLA stated in project policy)
+
 ## Scope and intent
 
 - This is a **current policy** for maintainers and adopters.
@@ -26,17 +33,48 @@ deprecation. It intentionally avoids guarantees we do not operationally enforce.
   - `MAJOR` for deliberate breaking changes.
 - Treat this as practical project policy, not a legal compatibility SLA.
 
-## Compatibility and support posture by tier
+## What adopters should depend on first
 
-- **Public / stable:** primary compatibility target and strongest change-control
-  expectation for release-confidence flows.
-- **Advanced but supported:** supported for production use, but docs/ergonomics
-  and integration-facing edges may iterate faster.
-- **Experimental / incubator:** opt-in and best-effort continuity; validate in
-  your own repo/CI before treating as a hard dependency.
+For release-confidence decisions, depend on this order first:
 
-This posture does not mean every command has the same change velocity.
-Compatibility expectations are intentionally tier-aware.
+1. Canonical commands and flow:
+   - `python -m sdetkit gate fast`
+   - `python -m sdetkit gate release`
+   - `python -m sdetkit doctor`
+2. Canonical artifact outputs used for triage and CI evidence:
+   - `build/gate-fast.json`
+   - `build/release-preflight.json`
+3. Public documentation for tier boundaries and command-surface intent.
+
+This ordering keeps integrations aligned with the most stable, adopter-facing contract.
+
+## Stability and support boundaries
+
+### Public / stable
+
+Intended as the strongest compatibility target and safest dependency surface for production adoption.
+
+You can generally treat these as the first surfaces to automate against:
+- canonical release-confidence flow
+- core evidence and decision lane behavior
+- user-facing docs describing canonical usage
+
+### Advanced but supported
+
+Supported for real production use, but expected to iterate faster than public/stable surfaces.
+
+Typical changes here may include:
+- docs/UX refinements
+- integration ergonomics
+- broader operational and rollout helpers
+
+Adopters can depend on this tier, but should expect more frequent incremental adjustments.
+
+### Experimental / incubator
+
+Opt-in and best-effort continuity only.
+
+Treat this tier as subject to faster change and require explicit local/CI validation before making it a hard dependency in organizational workflows.
 
 ## Canonical path vs compatibility lanes (visibility policy)
 
@@ -53,6 +91,17 @@ availability preserves transition continuity and advanced workflows, but does
 
 This section is guidance visibility only. It is **not** a new deprecation wave,
 removal announcement, or command-behavior change.
+
+## Best-effort / subject-to-change areas
+
+Without changing documented tier policy, adopters should treat the following as
+higher-iteration or best-effort compared with canonical public/stable paths:
+
+- experimental/incubator and transition-era lanes
+- hidden/legacy-oriented command families
+- secondary/advanced docs and rollout playbooks used after first-proof adoption
+
+When in doubt, anchor automations to canonical command flow + documented artifacts first.
 
 ## Deprecation approach (current)
 
@@ -77,6 +126,7 @@ path, or integration-facing interfaces), release notes should:
 
 ## Related references
 
+- [support.md](../SUPPORT.md)
 - [stability-levels.md](stability-levels.md)
 - [integrations-and-extension-boundary.md](integrations-and-extension-boundary.md)
 - [release-confidence.md](release-confidence.md)


### PR DESCRIPTION
### Motivation

- Provide a clear, single place for support and issue-routing guidance and to make triage faster by standardizing required artifacts and runtime expectations. 
- Surface the recommended canonical command path and artifact-first triage order used for release-confidence evidence. 
- Ensure repository landing docs reference support guidance directly from the README. 

### Description

- Add `SUPPORT.md` with sections for pre-issue troubleshooting, where to get help, what to include in issues, artifact attachments, stability/support boundaries, and private contact details. 
- Add canonical troubleshooting commands and artifact examples in `SUPPORT.md`, for example `python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json`, `python -m sdetkit gate release --format json --out build/release-preflight.json`, and `python -m sdetkit doctor`. 
- Update `README.md` to link the new `SUPPORT.md`. 
- Update `docs/versioning-and-support.md` to include a quick support snapshot, explicit recommended dependency/order-of-trust for canonical commands and artifacts, clearer tier descriptions, and a link to `SUPPORT.md`. 

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e33785e940832da7a16567136a87fe)