### PR TITLE
Add release confidence flow doc and navigation entry

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ build/release-preflight.json
 - [Adopt in your repository](adoption.md)
 - [Recommended CI flow](recommended-ci-flow.md)
 - [CI artifact walkthrough](ci-artifact-walkthrough.md)
+- [Release confidence flow](release-confidence-flow.md)
 
 ## Reference / advanced
 

--- a/docs/release-confidence-flow.md
+++ b/docs/release-confidence-flow.md
@@ -1,0 +1,45 @@
+# Release confidence flow
+
+This page gives first-time readers a visual map of the release-confidence path in SDETKit.
+Primary outcome: consistent ship/no-ship decisions from local runs to CI using artifact-first triage.
+
+```mermaid
+flowchart LR
+    A[Install / first run] --> B[gate fast]
+    B --> C[build/gate-fast.json]
+    C --> D[gate release]
+    D --> E[build/release-preflight.json]
+    E --> F[doctor]
+    F --> G[Local to CI continuity]
+
+    G --> H[Engineer]
+    G --> I[Reviewer]
+    G --> J[Release owner]
+
+    subgraph Triage order
+      T1[1) build/release-preflight.json]
+      T2[2) build/gate-fast.json]
+      T3[3) Raw logs after artifact triage]
+      T1 --> T2 --> T3
+    end
+
+    E -.inspect first.-> T1
+    C -.then inspect.-> T2
+```
+
+## How to read this flow
+
+```bash
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor
+```
+
+Inspect `build/release-preflight.json` first, then `build/gate-fast.json`, and only read raw logs after artifact triage. “Blocked” means one or more release checks did not meet policy, so treat the run as not ready to ship, fix the failing checks, and rerun the same commands.
+
+## Why this helps teams
+
+- Repeatable release decisions.
+- Machine-readable evidence.
+- Less ad hoc interpretation.
+- Smoother handoff across roles.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
       - Container runtime: container-runtime.md
       - Recommended CI flow: recommended-ci-flow.md
   - Release confidence:
+      - Release confidence flow: release-confidence-flow.md
       - CI artifact walkthrough: ci-artifact-walkthrough.md
       - CI contract: ci-contract.md
       - Before/after evidence example: before-after-evidence-example.md


### PR DESCRIPTION
### Motivation

- Provide a concise visual map of the release-confidence path so readers can follow the artifact-first triage flow from local runs to CI. 
- Make the flow discoverable from the main docs to improve team onboarding and reduce ad hoc interpretation during releases. 
- Improve handoff guidance for engineers, reviewers, and release owners by documenting triage order and recommended commands.

### Description

- Add `docs/release-confidence-flow.md` containing a Mermaid flowchart, example commands, triage ordering guidance, and short rationale. 
- Add a link to the new page in `docs/index.md` under the Team rollout / CI section. 
- Update `mkdocs.yml` navigation to include `release-confidence-flow.md` under the Release confidence section.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e33957ca28832da393a42cc46fd296)