### PR TITLE
Docs: add quickstart copy-paste and team adoption checklist; clarify install guidance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,10 +24,12 @@ build/release-preflight.json
 - [Start Here in 5 Minutes](start-here-5-minutes.md)
 - [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
 - [First run quickstart](ready-to-use.md)
+- [Quickstart (copy-paste)](quickstart-copy-paste.md)
 
 ## Team rollout / CI
 
 - [Adopt in your repository](adoption.md)
+- [Team adoption checklist](team-adoption-checklist.md)
 - [Recommended CI flow](recommended-ci-flow.md)
 - [CI artifact walkthrough](ci-artifact-walkthrough.md)
 - [Release confidence flow](release-confidence-flow.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,53 +1,44 @@
 # Install SDETKit
 
-Use this page for canonical installation paths before running release-confidence commands.
+Use this page to choose an install mode quickly before your first run.
 
 Python 3.11+ is required.
 
 After install, continue with:
-- Ultra-fast proof: [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
+- Fast onboarding: [Quickstart (copy-paste)](quickstart-copy-paste.md)
 - Guided run: [First run quickstart (canonical)](ready-to-use.md)
 
-## Recommended install path (first-time and external users)
+## Choose an install mode
 
-Create a virtual environment first, then install from PyPI and verify CLI wiring:
+| If you need... | Use this mode |
+| --- | --- |
+| Project-local, repeatable setup (recommended for most users/teams) | `venv` |
+| Isolated global CLI-style install | `pipx` |
+| Local development of this repository | Local source install |
+
+Do **not** rely on bare system `pip install ...` on Ubuntu/WSL; it may fail with an externally-managed-environment error. Use `venv` or `pipx` instead.
+
+## Recommended: `venv` (project-local, first-time friendly)
 
 ```bash
-python -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
 python -m pip install -U pip
 python -m pip install sdetkit==1.0.3
 python -m sdetkit --help
 ```
 
-Why this is the recommended path now:
-
-- Avoids system Python `externally-managed-environment` failures on Ubuntu/WSL.
-- Uses the public release surface directly.
-- Works consistently for local first runs and CI smoke checks.
-
-## Alternative install paths
-
-Use these only if they better fit your environment.
-
-### `pipx` (isolated CLI install)
+## `pipx` (isolated app-style install)
 
 ```bash
 pipx install sdetkit==1.0.3
 pipx run sdetkit --help
 ```
 
-### `uv tool install` (isolated tool install)
+## Local source install (contributors in this repo)
 
 ```bash
-uv tool install sdetkit==1.0.3
-uv tool run sdetkit --help
-```
-
-### Local source install (contributors in this repo)
-
-```bash
-python -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
 python -m pip install -U pip
 python -m pip install .
@@ -56,19 +47,11 @@ python -m sdetkit --help
 
 ## Runtime contract check (adopters and CI)
 
-Use the adopter-focused runtime contract command to discover stable install/run surfaces:
+Use the runtime contract command to confirm stable install/run surfaces:
 
 ```bash
 python -m sdetkit contract runtime --format json
 ```
-
-This prints:
-- `runtime_contract_version` (versioned install/run contract identifier)
-- canonical first path commands
-- stable machine output contract details for `review --format operator-json`
-- container runtime invocation examples
-
-Use this as a first CI/script check before running gates.
 
 ## External repository usage (canonical handoff)
 
@@ -81,7 +64,7 @@ python -m sdetkit doctor
 ```
 
 Then continue with:
-- [Blank repo to value in 60 seconds](blank-repo-to-value-60-seconds.md)
+- [Quickstart (copy-paste)](quickstart-copy-paste.md)
 - [First run quickstart](ready-to-use.md)
 - [Release confidence explainer](release-confidence.md)
 
@@ -95,13 +78,4 @@ source .venv/bin/activate
 python -m pip install -e .[dev,test,docs]
 ```
 
-This setup is for contributors/maintainers, not required for external adoption.
-
-## PyPI/public distribution posture
-
-SDETKit has release automation for build, wheel validation, optional PyPI publish, and provenance attestation in `.github/workflows/release.yml`.
-
-For end users, prefer PyPI (venv or `pipx`) and use GitHub-source installs only when you explicitly need unreleased changes.
-
-- Maintainer release process summary: [Releasing sdetkit](releasing.md)
-- Public verification log: [release-verification.md](release-verification.md)
+This setup is for contributors/maintainers and is not required for external adoption.

--- a/docs/quickstart-copy-paste.md
+++ b/docs/quickstart-copy-paste.md
@@ -1,0 +1,21 @@
+# Quickstart (copy-paste)
+
+Run from your target repository root.
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
+python -m pip install sdetkit==1.0.3
+
+mkdir -p build
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor
+```
+
+## Artifact triage order
+
+1. `build/release-preflight.json`
+2. `build/gate-fast.json`
+3. raw logs only after artifact triage

--- a/docs/team-adoption-checklist.md
+++ b/docs/team-adoption-checklist.md
@@ -1,0 +1,39 @@
+# Team adoption checklist
+
+Use this as a short rollout checklist for first-time team adoption.
+
+## Runtime baseline
+
+- [ ] Python 3.11+ confirmed on developer machines and CI runners
+- [ ] Team can create and activate isolated Python environments
+
+## Install approach
+
+- [ ] Isolated install mode chosen (`venv` for project-local, or `pipx` for app-style)
+- [ ] Team avoids bare system `pip install` on Ubuntu/WSL (externally-managed risk)
+- [ ] Install commands are documented in team onboarding notes
+
+## First-run proof
+
+- [ ] Canonical commands run locally in a clean repository checkout
+- [ ] `build/release-preflight.json` is generated
+- [ ] `build/gate-fast.json` is generated
+- [ ] `python -m sdetkit doctor` completes
+
+## CI adoption
+
+- [ ] CI path chosen (start with one lane, then expand)
+- [ ] CI stores JSON artifacts for review
+- [ ] CI output matches local command path as closely as possible
+
+## Artifact review expectations
+
+- [ ] Review order is agreed: `release-preflight.json` → `gate-fast.json` → logs
+- [ ] Team has a clear owner for artifact triage on failures
+- [ ] PR/release decisions reference artifacts, not only console snippets
+
+## Support and escalation hygiene
+
+- [ ] Team knows what to include in a support issue (OS, Python version, commands, artifacts)
+- [ ] Team uses a consistent issue template for install/runtime failures
+- [ ] Escalation path is documented for blocked releases

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,8 +91,10 @@ nav:
       - Decision guide: decision-guide.md
   - Getting started:
       - Install: install.md
+      - Quickstart (copy-paste): quickstart-copy-paste.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
       - Guided first run: ready-to-use.md
+      - Team adoption checklist: team-adoption-checklist.md
       - Adopt in your repository: adoption.md
       - Team rollout scenario: team-rollout-scenario.md
       - Container runtime: container-runtime.md


### PR DESCRIPTION
### Motivation

- Provide a minimal, copy-paste quickstart for fast onboarding and make it easy to generate the canonical JSON artifacts. 
- Clarify and standardize recommended install modes to avoid common Ubuntu/WSL `externally-managed-environment` problems. 
- Add a concise team adoption checklist to streamline first-time rollout and CI handoff.

### Description

- Add `docs/quickstart-copy-paste.md` with a one-shot sequence to create a `venv`, install `sdetkit==1.0.3`, and generate `build/gate-fast.json` and `build/release-preflight.json` artifacts. 
- Add `docs/team-adoption-checklist.md` capturing runtime baseline, install approach, first-run proof, CI adoption, artifact review expectations, and support hygiene. 
- Revise `docs/install.md` to present a compact install-mode table, prefer `python3.11 -m venv .venv` in examples, document `pipx` and local source install flows, and remove older detailed release/maintainer sections. 
- Update `docs/index.md` to surface the new quickstart and checklist links. 
- Update `mkdocs.yml` navigation to include the two new pages so they appear under "Getting started".

### Testing

- Built the documentation site with `python -m mkdocs build -q` to validate Markdown and navigation, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e33b265530832d82586bc3cbc81510)