### PR TITLE
Add one-by-one Phase 1 execution tooling, dashboards, reports, Makefile targets and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-telemetry phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -177,6 +177,9 @@ phase1-control-loop: venv
 
 phase1-run-all: venv
 	@bash -lc '. .venv/bin/activate && python scripts/phase1_run_all.py --format json'
+
+phase1-artifact-set: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_phase1_artifact_set.py --format json'
 
 phase1-telemetry: venv
 	@bash -lc '. .venv/bin/activate && python scripts/phase1_telemetry_history.py --format json'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-do-it phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-do-it phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -185,7 +185,10 @@ phase1-telemetry: venv
 	@bash -lc '. .venv/bin/activate && python scripts/phase1_telemetry_history.py --format json'
 
 phase1-finish-signal: venv
-	@bash -lc '. .venv/bin/activate && python scripts/phase1_finish_signal.py --format json'
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_finish_signal.py --format json > build/phase1-baseline/phase1-finish-signal.json'
+
+phase1-next-pass: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_next_pass_card.py --format json'
 
 phase1-do-it: phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal
 	@bash -lc 'echo phase1-do-it: pipeline completed'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-gate-phase2 phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -195,6 +195,9 @@ phase1-blocker-register: venv
 
 phase1-do-it: phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal
 	@bash -lc 'echo phase1-do-it: pipeline completed'
+
+phase1-gate-phase2: venv
+	@bash -lc ' . .venv/bin/activate && python scripts/phase1_gate_phase2.py --format json'
 
 phase1-retire-plan: venv
 	@bash -lc ' . .venv/bin/activate && python scripts/phase1_retire_plan_into_flow.py --format json'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-gate-phase2 phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -197,7 +197,10 @@ phase1-do-it: phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-
 	@bash -lc 'echo phase1-do-it: pipeline completed'
 
 phase1-gate-phase2: venv
-	@bash -lc ' . .venv/bin/activate && python scripts/phase1_gate_phase2.py --format json'
+	@bash -lc ' . .venv/bin/activate && python scripts/phase1_gate_phase2.py --format json > build/phase1-baseline/phase1-gate-phase2.json'
+
+phase1-executive-report: venv
+	@bash -lc ' . .venv/bin/activate && python scripts/phase1_executive_report.py --format json'
 
 phase1-retire-plan: venv
 	@bash -lc ' . .venv/bin/activate && python scripts/phase1_retire_plan_into_flow.py --format json'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-do-it phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -189,6 +189,9 @@ phase1-finish-signal: venv
 
 phase1-next-pass: venv
 	@bash -lc '. .venv/bin/activate && python scripts/phase1_next_pass_card.py --format json'
+
+phase1-blocker-register: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_blocker_register.py --format json'
 
 phase1-do-it: phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal
 	@bash -lc 'echo phase1-do-it: pipeline completed'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -195,6 +195,9 @@ phase1-blocker-register: venv
 
 phase1-do-it: phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal
 	@bash -lc 'echo phase1-do-it: pipeline completed'
+
+phase1-retire-plan: venv
+	@bash -lc ' . .venv/bin/activate && python scripts/phase1_retire_plan_into_flow.py --format json'
 
 phase1-complete: install
 	@bash -lc '. .venv/bin/activate && bash scripts/phase1_baseline_lane.sh && python scripts/check_phase1_baseline_summary_contract.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json --require-logs && python scripts/phase1_completion_gate.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -196,6 +196,9 @@ phase1-blocker-register: venv
 phase1-do-it: phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal
 	@bash -lc 'echo phase1-do-it: pipeline completed'
 
+phase1-flow-contract: venv
+	@bash -lc ' . .venv/bin/activate && python scripts/check_phase1_flow_contract.py --format json'
+
 phase1-gate-phase2: venv
 	@bash -lc ' . .venv/bin/activate && python scripts/phase1_gate_phase2.py --format json > build/phase1-baseline/phase1-gate-phase2.json'
 
@@ -204,6 +207,9 @@ phase1-executive-report: venv
 
 phase1-retire-plan: venv
 	@bash -lc ' . .venv/bin/activate && python scripts/phase1_retire_plan_into_flow.py --format json'
+
+phase1-closeout: venv
+	@bash -lc ' . .venv/bin/activate && python scripts/phase1_closeout_and_prune_plan.py --format json'
 
 phase1-complete: install
 	@bash -lc '. .venv/bin/activate && bash scripts/phase1_baseline_lane.sh && python scripts/check_phase1_baseline_summary_contract.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json --require-logs && python scripts/phase1_completion_gate.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-do-it phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -186,6 +186,9 @@ phase1-telemetry: venv
 
 phase1-finish-signal: venv
 	@bash -lc '. .venv/bin/activate && python scripts/phase1_finish_signal.py --format json'
+
+phase1-do-it: phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal
+	@bash -lc 'echo phase1-do-it: pipeline completed'
 
 phase1-complete: install
 	@bash -lc '. .venv/bin/activate && bash scripts/phase1_baseline_lane.sh && python scripts/check_phase1_baseline_summary_contract.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json --require-logs && python scripts/phase1_completion_gate.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-complete phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -161,10 +161,31 @@ phase1-status: venv
 	@bash -lc '. .venv/bin/activate && python scripts/phase1_status_report.py --format json --out build/phase1-baseline/phase1-status.json'
 
 phase1-next: venv
-	@bash -lc '. .venv/bin/activate && python scripts/phase1_next_actions.py --status-json build/phase1-baseline/phase1-status.json --format json'
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_next_actions.py --status-json build/phase1-baseline/phase1-status.json --format json --out build/phase1-baseline/phase1-next-actions.json'
+
+phase1-ops-snapshot: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_build_ops_snapshot.py --format json'
+
+phase1-dashboard: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_completion_dashboard.py --format json'
+
+phase1-weekly-pack: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_weekly_report_pack.py --format json'
+
+phase1-control-loop: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_control_loop_report.py --format json'
+
+phase1-run-all: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_run_all.py --format json'
 
 phase1-complete: install
 	@bash -lc '. .venv/bin/activate && bash scripts/phase1_baseline_lane.sh && python scripts/check_phase1_baseline_summary_contract.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json --require-logs && python scripts/phase1_completion_gate.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json'
+
+phase-current: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase_sequential_executor.py --format text'
+
+phase-current-json: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase_sequential_executor.py --format json'
 
 phase2-surface-clarity: venv
 	@bash -lc '. .venv/bin/activate && python scripts/check_operator_essentials_contract.py --format json'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-telemetry phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -177,6 +177,9 @@ phase1-control-loop: venv
 
 phase1-run-all: venv
 	@bash -lc '. .venv/bin/activate && python scripts/phase1_run_all.py --format json'
+
+phase1-telemetry: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_telemetry_history.py --format json'
 
 phase1-complete: install
 	@bash -lc '. .venv/bin/activate && bash scripts/phase1_baseline_lane.sh && python scripts/check_phase1_baseline_summary_contract.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json --require-logs && python scripts/phase1_completion_gate.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-complete phase1-closeout phase-current phase-current-json phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -183,6 +183,9 @@ phase1-artifact-set: venv
 
 phase1-telemetry: venv
 	@bash -lc '. .venv/bin/activate && python scripts/phase1_telemetry_history.py --format json'
+
+phase1-finish-signal: venv
+	@bash -lc '. .venv/bin/activate && python scripts/phase1_finish_signal.py --format json'
 
 phase1-complete: install
 	@bash -lc '. .venv/bin/activate && bash scripts/phase1_baseline_lane.sh && python scripts/check_phase1_baseline_summary_contract.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json --require-logs && python scripts/phase1_completion_gate.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json'

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ build/release-preflight.json
 - [Release confidence flow](release-confidence-flow.md)
 - [First failure triage](first-failure-triage.md)
 - [Phase-by-phase execution plan](phase-by-phase-execution-plan.md)
+- [One-by-one phase execution](phase-execution-one-by-one.md)
 
 ## Reference / advanced
 

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -24,6 +24,7 @@ make phase1-run-all
 make phase1-artifact-set
 make phase1-telemetry
 make phase1-finish-signal
+make phase1-do-it
 make phase1-complete
 make phase1-closeout
 ```
@@ -86,3 +87,6 @@ Use `make phase1-artifact-set` to enforce that all Phase 1 JSON/Markdown artifac
 
 
 Use `make phase1-finish-signal` to answer if Phase 1 is early / in_progress / near_finish / complete.
+
+
+If you want to run the full evidence pipeline now, use `make phase1-do-it`.

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -27,6 +27,7 @@ make phase1-finish-signal
 make phase1-next-pass
 make phase1-blocker-register
 make phase1-do-it
+make phase1-flow-contract
 make phase1-gate-phase2
 make phase1-executive-report
 make phase1-retire-plan
@@ -110,3 +111,6 @@ Use `make phase1-gate-phase2` to decide if Phase 2 can start, based on finish si
 
 
 Use `make phase1-executive-report` to produce a one-page status for leadership handoff and phase decision meetings.
+
+
+Use `make phase1-flow-contract` to ensure the documented command path and Makefile targets stay in sync.

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -21,6 +21,7 @@ make phase1-dashboard
 make phase1-weekly-pack
 make phase1-control-loop
 make phase1-run-all
+make phase1-artifact-set
 make phase1-telemetry
 make phase1-complete
 make phase1-closeout
@@ -78,3 +79,6 @@ For one-command orchestration, run `make phase1-run-all` (or `python scripts/pha
 
 
 Use `make phase1-telemetry` after `phase1-run-all` to track run timing drift, pass-rate, and blocker categories over time.
+
+
+Use `make phase1-artifact-set` to enforce that all Phase 1 JSON/Markdown artifacts exist before closeout.

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -28,6 +28,7 @@ make phase1-next-pass
 make phase1-blocker-register
 make phase1-do-it
 make phase1-gate-phase2
+make phase1-executive-report
 make phase1-retire-plan
 make phase1-complete
 make phase1-closeout
@@ -106,3 +107,6 @@ After Phase 1 is truly complete, run `make phase1-retire-plan` to archive Phase 
 
 
 Use `make phase1-gate-phase2` to decide if Phase 2 can start, based on finish signal + artifact contract.
+
+
+Use `make phase1-executive-report` to produce a one-page status for leadership handoff and phase decision meetings.

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -27,6 +27,7 @@ make phase1-finish-signal
 make phase1-next-pass
 make phase1-blocker-register
 make phase1-do-it
+make phase1-gate-phase2
 make phase1-retire-plan
 make phase1-complete
 make phase1-closeout
@@ -102,3 +103,6 @@ Use `make phase1-blocker-register` to produce a prioritized JSON/CSV blocker lis
 
 
 After Phase 1 is truly complete, run `make phase1-retire-plan` to archive Phase 1 planning state and keep flow-first operations as the repo default.
+
+
+Use `make phase1-gate-phase2` to decide if Phase 2 can start, based on finish signal + artifact contract.

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -1,0 +1,76 @@
+# One-by-one phase execution (operator guide)
+
+If you already completed planning for all 6 phases, execute only one phase at a time with this rule:
+
+1. Finish current phase exit criteria.
+2. Publish evidence artifacts.
+3. Freeze phase status.
+4. Start next phase kickoff.
+
+## Current focus: Phase 1
+
+Use this exact sequence for Phase 1 operations:
+
+```bash
+make phase-current
+make phase1-baseline
+make phase1-status
+make phase1-next
+make phase1-ops-snapshot
+make phase1-dashboard
+make phase1-weekly-pack
+make phase1-control-loop
+make phase1-run-all
+make phase1-complete
+make phase1-closeout
+```
+
+If you want machine-readable output for automation:
+
+```bash
+make phase-current-json
+```
+
+## Phase completion contract
+
+Before promoting a phase from active to complete:
+
+- Canonical truth lane artifacts exist and are readable.
+- Exit criteria are all explicitly marked pass.
+- Remaining work is moved to either:
+  - the next phase backlog, or
+  - an expansion options backlog.
+
+## Weekly operating cadence (recommended)
+
+- **Monday:** Plan (scope, KPI, risks)
+- **Wednesday:** Build + validate checkpoint
+- **Friday:** Operationalize + expand backlog + phase status update
+
+## Phase gate decision record template
+
+For each phase closeout, record:
+
+- Phase id and name
+- Date
+- Exit criteria pass/fail status
+- Blocking risks
+- Canonical artifacts produced
+- Go/No-go decision for next phase
+
+Keeping this format constant makes trend reporting and investor review easier.
+
+
+## After Phase 1 is completed
+
+Run `make phase1-closeout` to archive the previous strategic plan snapshot and remove Phase 1 from the active phase queue, then advance `current_phase` to Phase 2.
+
+Use `make phase1-ops-snapshot` each week to publish:
+
+- progress percent (accomplished vs remaining),
+- hard blockers,
+- ranked quality debt register,
+- recommended next actions.
+
+
+For one-command orchestration, run `make phase1-run-all` (or `python scripts/phase1_run_all.py --include-closeout`).

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -25,6 +25,7 @@ make phase1-artifact-set
 make phase1-telemetry
 make phase1-finish-signal
 make phase1-next-pass
+make phase1-blocker-register
 make phase1-do-it
 make phase1-complete
 make phase1-closeout
@@ -94,3 +95,6 @@ If you want to run the full evidence pipeline now, use `make phase1-do-it`.
 
 
 Use `make phase1-next-pass` to generate a concise remediation card for the immediate next pass.
+
+
+Use `make phase1-blocker-register` to produce a prioritized JSON/CSV blocker list for assignment tracking.

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -23,6 +23,7 @@ make phase1-control-loop
 make phase1-run-all
 make phase1-artifact-set
 make phase1-telemetry
+make phase1-finish-signal
 make phase1-complete
 make phase1-closeout
 ```
@@ -82,3 +83,6 @@ Use `make phase1-telemetry` after `phase1-run-all` to track run timing drift, pa
 
 
 Use `make phase1-artifact-set` to enforce that all Phase 1 JSON/Markdown artifacts exist before closeout.
+
+
+Use `make phase1-finish-signal` to answer if Phase 1 is early / in_progress / near_finish / complete.

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -24,6 +24,7 @@ make phase1-run-all
 make phase1-artifact-set
 make phase1-telemetry
 make phase1-finish-signal
+make phase1-next-pass
 make phase1-do-it
 make phase1-complete
 make phase1-closeout
@@ -90,3 +91,6 @@ Use `make phase1-finish-signal` to answer if Phase 1 is early / in_progress / ne
 
 
 If you want to run the full evidence pipeline now, use `make phase1-do-it`.
+
+
+Use `make phase1-next-pass` to generate a concise remediation card for the immediate next pass.

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -27,6 +27,7 @@ make phase1-finish-signal
 make phase1-next-pass
 make phase1-blocker-register
 make phase1-do-it
+make phase1-retire-plan
 make phase1-complete
 make phase1-closeout
 ```
@@ -98,3 +99,6 @@ Use `make phase1-next-pass` to generate a concise remediation card for the immed
 
 
 Use `make phase1-blocker-register` to produce a prioritized JSON/CSV blocker list for assignment tracking.
+
+
+After Phase 1 is truly complete, run `make phase1-retire-plan` to archive Phase 1 planning state and keep flow-first operations as the repo default.

--- a/docs/phase-execution-one-by-one.md
+++ b/docs/phase-execution-one-by-one.md
@@ -21,6 +21,7 @@ make phase1-dashboard
 make phase1-weekly-pack
 make phase1-control-loop
 make phase1-run-all
+make phase1-telemetry
 make phase1-complete
 make phase1-closeout
 ```
@@ -74,3 +75,6 @@ Use `make phase1-ops-snapshot` each week to publish:
 
 
 For one-command orchestration, run `make phase1-run-all` (or `python scripts/phase1_run_all.py --include-closeout`).
+
+
+Use `make phase1-telemetry` after `phase1-run-all` to track run timing drift, pass-rate, and blocker categories over time.

--- a/docs/phase1-execution-checklist.md
+++ b/docs/phase1-execution-checklist.md
@@ -7,8 +7,12 @@ Use this checklist to execute and close Phase 1 before moving to later phases.
 1. `make phase1-baseline`
 2. `python scripts/phase1_status_report.py --format json --out build/phase1-baseline/phase1-status.json`
 3. `make phase1-next`
-4. `python scripts/check_phase1_baseline_summary_contract.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json --require-logs`
-5. `python scripts/phase1_completion_gate.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json`
+4. `make phase1-ops-snapshot`
+5. `make phase1-dashboard`
+6. `make phase1-weekly-pack`
+7. `make phase1-control-loop`
+8. `python scripts/check_phase1_baseline_summary_contract.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json --require-logs`
+9. `python scripts/phase1_completion_gate.py --summary build/phase1-baseline/phase1-baseline-summary.json --format json`
 
 Or run the full closeout path in one command:
 

--- a/plans/strategic-execution-model-2026.json
+++ b/plans/strategic-execution-model-2026.json
@@ -1,0 +1,104 @@
+{
+  "plan_id": "strategic-execution-model-2026",
+  "date": "2026-04-18",
+  "status": "active",
+  "program_objective": "Execute major upgrades one-by-one while preserving deterministic release confidence via the canonical path: gate fast -> gate release -> doctor.",
+  "current_phase": {
+    "id": 1,
+    "name": "Foundation Hardening & Truth Baseline",
+    "window": "Weeks 1-3",
+    "objective": "Create a trusted baseline so future upgrades are measurable, reproducible, and investor-defensible."
+  },
+  "control_loop": [
+    "Plan (scope + KPI + risks)",
+    "Build (deliverables + integration)",
+    "Validate (truth-lane + policy checks)",
+    "Operationalize (docs + automation + ownership)",
+    "Expand (open-option backlog to next phase)"
+  ],
+  "phase_sequence": [
+    {
+      "id": 1,
+      "name": "Foundation Hardening & Truth Baseline",
+      "objective": "Trusted operational baseline",
+      "deliverables": [
+        "Baseline Runbook v1",
+        "Environment Contract v1",
+        "Quality Debt Register",
+        "Ops Snapshot"
+      ],
+      "exit_criteria": [
+        "Stable baseline lane on standardized environment",
+        "Lint/test debt is not increasing",
+        "Artifact history supports trend interpretation"
+      ],
+      "now_actions": [
+        "Run make phase1-baseline",
+        "Run make phase1-status",
+        "Run make phase1-next",
+        "Run make phase1-complete once blockers are triaged"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Product Surface Simplification & Clarity",
+      "objective": "Instantly understandable product surface",
+      "deliverables": [
+        "Product Surface Map v2",
+        "Operator Essentials Guide",
+        "Migration Corridor Map",
+        "Docs Navigation Model v2"
+      ],
+      "exit_criteria": [
+        "New user reaches first success in one linear path",
+        "Reduced onboarding command confusion",
+        "Clear stable vs advanced boundaries"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "Deterministic Quality Engine Expansion",
+      "objective": "Adaptive quality decision engine",
+      "deliverables": [
+        "Quality Engine Spec v2",
+        "Artifact Contract v2",
+        "Adaptive Profile Playbooks",
+        "Forensics Correlation Report"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "Enterprise Trust, Governance, and Auditability",
+      "objective": "Enterprise buying confidence",
+      "deliverables": [
+        "Enterprise Assurance Bundle",
+        "Governance Contract Suite",
+        "Audit Trail Export",
+        "Support Operations Playbook"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "Ecosystem & Integration Platformization",
+      "objective": "Low-friction integration platform",
+      "deliverables": [
+        "Plugin API Contract v1",
+        "Integration Accelerator Kits",
+        "Extension Certification Program",
+        "Partner Integration Guide"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "Commercialization, Metrics, and Continuous Scale",
+      "objective": "Evidence-backed business outcomes",
+      "deliverables": [
+        "Commercial Readiness Dashboard",
+        "Value Proof Reports",
+        "Offering Architecture Map",
+        "Quarterly Strategic Plan"
+      ]
+    }
+  ],
+  "phase_handoff_rule": "Do not begin a new phase until the current phase exit criteria are met and validated with canonical artifacts."
+}

--- a/scripts/check_phase1_artifact_set.py
+++ b/scripts/check_phase1_artifact_set.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Validate that required Phase 1 artifact set exists and is readable JSON/Markdown."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+REQUIRED_JSON = [
+    "build/phase1-baseline/phase1-status.json",
+    "build/phase1-baseline/phase1-next-actions.json",
+    "build/phase1-baseline/phase1-ops-snapshot.json",
+    "build/phase1-baseline/phase1-completion-dashboard.json",
+    "build/phase1-baseline/weekly-pack/phase1-weekly-pack.json",
+    "build/phase1-baseline/phase1-control-loop-report.json",
+    "build/phase1-baseline/phase1-run-all.json",
+    "build/phase1-baseline/phase1-telemetry-summary.json",
+]
+
+REQUIRED_MD = [
+    "build/phase1-baseline/phase1-ops-snapshot.md",
+    "build/phase1-baseline/phase1-completion-dashboard.md",
+    "build/phase1-baseline/weekly-pack/phase1-weekly-pack.md",
+    "build/phase1-baseline/phase1-control-loop-report.md",
+    "build/phase1-baseline/phase1-run-all.md",
+]
+
+
+def _validate_json(path: Path) -> bool:
+    try:
+        json.loads(path.read_text(encoding="utf-8"))
+        return True
+    except Exception:
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Phase 1 artifact set.")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    rows = []
+    for rel in REQUIRED_JSON:
+        p = Path(rel)
+        rows.append(
+            {
+                "path": rel,
+                "kind": "json",
+                "exists": p.is_file(),
+                "valid": p.is_file() and _validate_json(p),
+            }
+        )
+    for rel in REQUIRED_MD:
+        p = Path(rel)
+        rows.append(
+            {
+                "path": rel,
+                "kind": "markdown",
+                "exists": p.is_file(),
+                "valid": p.is_file(),
+            }
+        )
+
+    missing = [row["path"] for row in rows if not row["exists"]]
+    invalid = [row["path"] for row in rows if row["exists"] and not row["valid"]]
+    ok = not missing and not invalid
+
+    payload = {
+        "ok": ok,
+        "schema_version": "sdetkit.phase1_artifact_set_contract.v1",
+        "missing": missing,
+        "invalid": invalid,
+        "checks": rows,
+    }
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("phase1-artifact-set: OK" if ok else "phase1-artifact-set: FAIL")
+        for item in missing:
+            print(f"- missing: {item}")
+        for item in invalid:
+            print(f"- invalid: {item}")
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_phase1_flow_contract.py
+++ b/scripts/check_phase1_flow_contract.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate that documented Phase 1 flow commands map to Makefile targets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DOC_PATH = Path("docs/phase-execution-one-by-one.md")
+MAKEFILE_PATH = Path("Makefile")
+
+
+def _extract_doc_targets(doc_text: str) -> list[str]:
+    in_block = False
+    targets: list[str] = []
+    for line in doc_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```bash"):
+            in_block = True
+            continue
+        if in_block and stripped.startswith("```"):
+            break
+        if in_block and stripped.startswith("make "):
+            parts = stripped.split()
+            if len(parts) >= 2:
+                targets.append(parts[1])
+    return targets
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check Phase 1 flow contract between docs and Makefile.")
+    parser.add_argument("--doc", default=str(DOC_PATH))
+    parser.add_argument("--makefile", default=str(MAKEFILE_PATH))
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    doc_path = Path(args.doc)
+    make_path = Path(args.makefile)
+
+    if not doc_path.is_file() or not make_path.is_file():
+        payload = {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_flow_contract.v1",
+            "reason": "missing doc or makefile",
+        }
+        if args.format == "json":
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"phase1-flow-contract: FAIL ({payload['reason']})")
+        return 1
+
+    doc_targets = _extract_doc_targets(doc_path.read_text(encoding="utf-8"))
+    make_text = make_path.read_text(encoding="utf-8")
+
+    missing = [target for target in doc_targets if f"{target}:" not in make_text]
+    ok = not missing
+    payload = {
+        "ok": ok,
+        "schema_version": "sdetkit.phase1_flow_contract.v1",
+        "doc": str(doc_path),
+        "makefile": str(make_path),
+        "doc_targets": doc_targets,
+        "missing_makefile_targets": missing,
+    }
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("phase1-flow-contract: OK" if ok else "phase1-flow-contract: FAIL")
+        for target in missing:
+            print(f"- missing target: {target}")
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_blocker_register.py
+++ b/scripts/phase1_blocker_register.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Build a prioritized blocker register for the next Phase 1 pass."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+RISK_PRIORITY = {
+    "doctor": 100,
+    "enterprise_contracts": 95,
+    "primary_docs_map": 90,
+    "build": 85,
+    "validate": 80,
+    "operationalize": 70,
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_blocker_register(next_pass: dict[str, Any], control_loop: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+
+    checks = next_pass.get("blocking_required_checks", [])
+    if isinstance(checks, list):
+        for check in checks:
+            cid = str(check)
+            rows.append(
+                {
+                    "blocker": cid,
+                    "category": "required_check",
+                    "priority": RISK_PRIORITY.get(cid, 60),
+                    "recommended_action": f"Resolve {cid} and rerun make phase1-dashboard",
+                }
+            )
+
+    stages = next_pass.get("missing_control_loop_stages", [])
+    if isinstance(stages, list):
+        for stage in stages:
+            sid = str(stage)
+            rows.append(
+                {
+                    "blocker": sid,
+                    "category": "control_loop_stage",
+                    "priority": RISK_PRIORITY.get(sid, 55),
+                    "recommended_action": f"Complete {sid} stage before closeout",
+                }
+            )
+
+    if not rows:
+        # fallback: infer from control-loop rows if card had no blockers list
+        for row in control_loop.get("stages", []):
+            if isinstance(row, dict) and not bool(row.get("ok", False)):
+                sid = str(row.get("stage", "unknown"))
+                rows.append(
+                    {
+                        "blocker": sid,
+                        "category": "control_loop_stage",
+                        "priority": RISK_PRIORITY.get(sid, 50),
+                        "recommended_action": str(row.get("action_if_missing", "Run next phase1 action")),
+                    }
+                )
+
+    rows.sort(key=lambda item: (-int(item["priority"]), item["blocker"]))
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Phase 1 blocker register.")
+    parser.add_argument("--next-pass", default="build/phase1-baseline/phase1-next-pass-card.json")
+    parser.add_argument("--control-loop", default="build/phase1-baseline/phase1-control-loop-report.json")
+    parser.add_argument("--out-json", default="build/phase1-baseline/phase1-blocker-register.json")
+    parser.add_argument("--out-csv", default="build/phase1-baseline/phase1-blocker-register.csv")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    next_pass = _load_json(Path(args.next_pass))
+    control_loop = _load_json(Path(args.control_loop))
+
+    if not next_pass and not control_loop:
+        payload = {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_blocker_register.v1",
+            "reason": "missing next-pass and control-loop artifacts",
+        }
+        if args.format == "json":
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"phase1-blocker-register: FAIL ({payload['reason']})")
+        return 1
+
+    rows = build_blocker_register(next_pass, control_loop)
+    payload = {
+        "ok": True,
+        "schema_version": "sdetkit.phase1_blocker_register.v1",
+        "count": len(rows),
+        "rows": rows,
+    }
+
+    out_json = Path(args.out_json)
+    out_csv = Path(args.out_csv)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with out_csv.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["blocker", "category", "priority", "recommended_action"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("phase1-blocker-register: OK")
+        print(f"- blockers: {len(rows)}")
+        print(f"- json: {out_json}")
+        print(f"- csv: {out_csv}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_build_ops_snapshot.py
+++ b/scripts/phase1_build_ops_snapshot.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Build Phase 1 weekly ops snapshot + quality debt register from baseline artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+RISK_WEIGHTS = {
+    "doctor": 100,
+    "enterprise_contracts": 95,
+    "primary_docs_map": 80,
+    "gate_release": 75,
+    "gate_fast": 70,
+    "ruff": 50,
+    "pytest": 60,
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
+
+
+def _debt_register(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    checks = summary.get("checks", []) if isinstance(summary, dict) else []
+    if not isinstance(checks, list):
+        checks = []
+
+    rows: list[dict[str, Any]] = []
+    for row in checks:
+        if not isinstance(row, dict):
+            continue
+        check_id = str(row.get("id", "")).strip()
+        ok = bool(row.get("ok", False))
+        if not check_id or ok:
+            continue
+        score = RISK_WEIGHTS.get(check_id, 40)
+        impact = "high" if score >= 80 else "medium" if score >= 60 else "low"
+        rows.append(
+            {
+                "check_id": check_id,
+                "risk_score": score,
+                "impact": impact,
+                "owner_hint": "platform-engineering" if score >= 70 else "repo-maintainers",
+                "recommendation": f"Address failing check '{check_id}' and rerun make phase1-baseline",
+            }
+        )
+
+    rows.sort(key=lambda item: (-int(item["risk_score"]), item["check_id"]))
+    return rows
+
+
+def build_ops_snapshot(summary: dict[str, Any], status: dict[str, Any], next_actions: dict[str, Any]) -> dict[str, Any]:
+    debt = _debt_register(summary)
+    accomplished = status.get("accomplished", []) if isinstance(status, dict) else []
+    not_yet = status.get("not_yet", []) if isinstance(status, dict) else []
+    if not isinstance(accomplished, list):
+        accomplished = []
+    if not isinstance(not_yet, list):
+        not_yet = []
+    total = len(accomplished) + len(not_yet)
+    progress = round((len(accomplished) / total) * 100, 1) if total else 0
+
+    return {
+        "schema_version": "sdetkit.phase1_ops_snapshot.v1",
+        "generated_at": _utc_now(),
+        "phase": "phase1",
+        "progress_percent": progress,
+        "completed_items": len(accomplished),
+        "remaining_items": len(not_yet),
+        "hard_blockers": status.get("hard_blockers", []),
+        "recommended_next_actions": next_actions.get("next_actions", []),
+        "quality_debt_register": debt,
+        "top_risk_item": debt[0] if debt else None,
+    }
+
+
+def _to_markdown(snapshot: dict[str, Any]) -> str:
+    lines = [
+        "# Phase 1 weekly ops snapshot",
+        "",
+        f"- Generated at: {snapshot.get('generated_at', '')}",
+        f"- Progress: {snapshot.get('progress_percent', 0)}%",
+        f"- Completed items: {snapshot.get('completed_items', 0)}",
+        f"- Remaining items: {snapshot.get('remaining_items', 0)}",
+        "",
+        "## Hard blockers",
+    ]
+
+    hard_blockers = snapshot.get("hard_blockers", [])
+    if isinstance(hard_blockers, list) and hard_blockers:
+        lines.extend(f"- {item}" for item in hard_blockers)
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Recommended next actions"])
+    actions = snapshot.get("recommended_next_actions", [])
+    if isinstance(actions, list) and actions:
+        lines.extend(f"- {item}" for item in actions)
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Quality debt register (ranked)"])
+    debt = snapshot.get("quality_debt_register", [])
+    if isinstance(debt, list) and debt:
+        for item in debt:
+            lines.append(
+                f"- {item.get('check_id')}: risk={item.get('risk_score')} impact={item.get('impact')} "
+                f"owner={item.get('owner_hint')}"
+            )
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Phase 1 ops snapshot from baseline artifacts.")
+    parser.add_argument("--summary", default="build/phase1-baseline/phase1-baseline-summary.json")
+    parser.add_argument("--status", default="build/phase1-baseline/phase1-status.json")
+    parser.add_argument("--next-actions", default="build/phase1-baseline/phase1-next-actions.json")
+    parser.add_argument("--out-json", default="build/phase1-baseline/phase1-ops-snapshot.json")
+    parser.add_argument("--out-md", default="build/phase1-baseline/phase1-ops-snapshot.md")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    summary = _load_json(Path(args.summary))
+    status = _load_json(Path(args.status))
+    next_actions = _load_json(Path(args.next_actions))
+
+    snapshot = build_ops_snapshot(summary, status, next_actions)
+
+    out_json = Path(args.out_json)
+    out_md = Path(args.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md.write_text(_to_markdown(snapshot), encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(snapshot, indent=2, sort_keys=True))
+    else:
+        print("phase1-ops-snapshot: OK")
+        print(f"- json: {out_json}")
+        print(f"- markdown: {out_md}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_closeout_and_prune_plan.py
+++ b/scripts/phase1_closeout_and_prune_plan.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Close out Phase 1 and prune it from the active strategic plan when complete."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _find_phase(sequence: list[dict[str, Any]], phase_id: int) -> dict[str, Any] | None:
+    for phase in sequence:
+        if phase.get("id") == phase_id:
+            return phase
+    return None
+
+
+def closeout_phase1(status_path: Path, plan_path: Path, archive_dir: Path) -> dict[str, Any]:
+    if not status_path.is_file():
+        return {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_closeout.v1",
+            "reason": f"missing status file: {status_path}",
+        }
+
+    status_payload = _load_json(status_path)
+    if not bool(status_payload.get("ok", False)):
+        return {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_closeout.v1",
+            "reason": "phase1 status is incomplete; complete phase1 before closeout",
+            "hard_blockers": status_payload.get("hard_blockers", []),
+        }
+
+    if not plan_path.is_file():
+        return {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_closeout.v1",
+            "reason": f"missing plan file: {plan_path}",
+        }
+
+    plan_payload = _load_json(plan_path)
+    phase_sequence = plan_payload.get("phase_sequence", [])
+    if not isinstance(phase_sequence, list):
+        phase_sequence = []
+
+    phase1 = _find_phase(phase_sequence, 1)
+    phase2 = _find_phase(phase_sequence, 2)
+    if phase1 is None:
+        return {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_closeout.v1",
+            "reason": "phase 1 is not present in active phase_sequence",
+        }
+    if phase2 is None:
+        return {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_closeout.v1",
+            "reason": "phase 2 is missing; cannot advance current phase",
+        }
+
+    timestamp = _utc_now()
+    archive_path = archive_dir / f"phase1-closeout-plan-snapshot-{timestamp[:10]}.json"
+    _write_json(archive_path, plan_payload)
+
+    new_sequence = [phase for phase in phase_sequence if phase.get("id") != 1]
+    completed = list(plan_payload.get("completed_phases", []))
+    completed.append(
+        {
+            "id": 1,
+            "name": phase1.get("name"),
+            "completed_at": timestamp,
+            "status_source": str(status_path),
+        }
+    )
+
+    plan_payload["phase_sequence"] = new_sequence
+    plan_payload["completed_phases"] = completed
+    plan_payload["current_phase"] = {
+        "id": phase2.get("id"),
+        "name": phase2.get("name"),
+        "objective": phase2.get("objective", ""),
+        "window": phase2.get("window", "Weeks 3-6"),
+    }
+    plan_payload["updated_at"] = timestamp
+
+    _write_json(plan_path, plan_payload)
+
+    return {
+        "ok": True,
+        "schema_version": "sdetkit.phase1_closeout.v1",
+        "closed_phase": 1,
+        "new_current_phase": plan_payload["current_phase"],
+        "archived_plan": str(archive_path),
+        "plan": str(plan_path),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Close Phase 1 and prune it from active plan.")
+    parser.add_argument("--status-json", default="build/phase1-baseline/phase1-status.json")
+    parser.add_argument("--plan", default="plans/strategic-execution-model-2026.json")
+    parser.add_argument("--archive-dir", default="plans/archive")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    result = closeout_phase1(
+        status_path=Path(args.status_json),
+        plan_path=Path(args.plan),
+        archive_dir=Path(args.archive_dir),
+    )
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        if result.get("ok", False):
+            print("phase1-closeout: COMPLETE")
+            print(f"- archived plan: {result['archived_plan']}")
+            nxt = result.get("new_current_phase", {})
+            print(f"- next active phase: {nxt.get('id')} ({nxt.get('name')})")
+        else:
+            print(f"phase1-closeout: FAIL ({result.get('reason', 'unknown error')})")
+
+    return 0 if result.get("ok", False) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_completion_dashboard.py
+++ b/scripts/phase1_completion_dashboard.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Build a single readiness dashboard for Phase 1 completion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REQUIRED_CHECKS = ["doctor", "enterprise_contracts", "primary_docs_map"]
+ALLOW_FAIL = {"ruff", "pytest", "gate_fast", "gate_release"}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sequential_summary(plan_path: Path, status_path: Path) -> dict[str, Any]:
+    plan = _load_json(plan_path)
+    status = _load_json(status_path)
+    current = plan.get("current_phase", {}) if isinstance(plan, dict) else {}
+    progress = {
+        "available": bool(status),
+        "status_file": str(status_path),
+        "phase1_ok": bool(status.get("ok", False)) if isinstance(status, dict) else False,
+        "accomplished_count": len(status.get("accomplished", []))
+        if isinstance(status.get("accomplished", []), list)
+        else 0,
+        "remaining_count": len(status.get("not_yet", []))
+        if isinstance(status.get("not_yet", []), list)
+        else 0,
+        "hard_blockers": status.get("hard_blockers", []) if isinstance(status, dict) else [],
+    }
+    total = progress["accomplished_count"] + progress["remaining_count"]
+    progress["progress_percent"] = round((progress["accomplished_count"] / total) * 100, 1) if total else 0
+    return {
+        "ok": bool(plan),
+        "schema_version": "sdetkit.phase_sequential_executor.v1",
+        "plan_id": plan.get("plan_id"),
+        "current_phase": current,
+        "control_loop": plan.get("control_loop", []),
+        "phase_handoff_rule": plan.get("phase_handoff_rule", ""),
+        "next_commands": current.get("now_actions", []) if isinstance(current, dict) else [],
+        "progress": progress,
+    }
+
+
+def _completion_gate(summary: dict[str, Any]) -> dict[str, Any]:
+    rows = summary.get("checks", []) if isinstance(summary, dict) else []
+    if not isinstance(rows, list):
+        rows = []
+
+    by_id: dict[str, bool] = {}
+    for row in rows:
+        if isinstance(row, dict):
+            cid = str(row.get("id", "")).strip()
+            if cid:
+                by_id[cid] = bool(row.get("ok", False))
+
+    failing_required = [cid for cid in REQUIRED_CHECKS if not by_id.get(cid, False)]
+    missing_required = [cid for cid in REQUIRED_CHECKS if cid not in by_id]
+    blocked_nonrequired = [
+        cid
+        for cid, ok in by_id.items()
+        if not ok and cid not in REQUIRED_CHECKS and cid not in ALLOW_FAIL
+    ]
+
+    ok = not failing_required and not missing_required and not blocked_nonrequired
+    return {
+        "ok": ok,
+        "required_checks": REQUIRED_CHECKS,
+        "allow_fail": sorted(ALLOW_FAIL),
+        "failing_required_checks": failing_required,
+        "missing_required_checks": missing_required,
+        "blocked_nonrequired_checks": sorted(blocked_nonrequired),
+    }
+
+
+def build_dashboard(
+    plan_path: Path,
+    status_path: Path,
+    summary_path: Path,
+    snapshot_path: Path,
+) -> dict[str, Any]:
+    sequential = _sequential_summary(plan_path=plan_path, status_path=status_path)
+    status = _load_json(status_path)
+    summary = _load_json(summary_path)
+    snapshot = _load_json(snapshot_path)
+    gate = _completion_gate(summary)
+
+    hard_blockers = status.get("hard_blockers", []) if isinstance(status, dict) else []
+    if not isinstance(hard_blockers, list):
+        hard_blockers = []
+
+    remaining = status.get("not_yet", []) if isinstance(status, dict) else []
+    if not isinstance(remaining, list):
+        remaining = []
+
+    ready = bool(gate.get("ok", False)) and len(hard_blockers) == 0
+
+    return {
+        "schema_version": "sdetkit.phase1_completion_dashboard.v1",
+        "generated_at": _utc_now(),
+        "phase": "phase1",
+        "ready_to_close": ready,
+        "sequential": sequential,
+        "status": {
+            "ok": bool(status.get("ok", False)),
+            "accomplished": status.get("accomplished", []),
+            "not_yet": remaining,
+            "hard_blockers": hard_blockers,
+        },
+        "completion_gate": gate,
+        "ops_snapshot": {
+            "progress_percent": snapshot.get("progress_percent", 0),
+            "top_risk_item": snapshot.get("top_risk_item"),
+            "recommended_next_actions": snapshot.get("recommended_next_actions", []),
+        },
+        "next_step": "make phase1-closeout" if ready else "make phase1-next && make phase1-ops-snapshot",
+    }
+
+
+def _to_markdown(payload: dict[str, Any]) -> str:
+    status = payload.get("status", {})
+    gate = payload.get("completion_gate", {})
+    ops = payload.get("ops_snapshot", {})
+
+    lines = [
+        "# Phase 1 completion dashboard",
+        "",
+        f"- Generated at: {payload.get('generated_at', '')}",
+        f"- Ready to close: {payload.get('ready_to_close', False)}",
+        f"- Progress: {ops.get('progress_percent', 0)}%",
+        f"- Next step: {payload.get('next_step', '')}",
+        "",
+        "## Hard blockers",
+    ]
+
+    blockers = status.get("hard_blockers", [])
+    if isinstance(blockers, list) and blockers:
+        lines.extend(f"- {item}" for item in blockers)
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Completion gate"])
+    lines.append(f"- gate_ok: {gate.get('ok', False)}")
+    for key in ("failing_required_checks", "missing_required_checks", "blocked_nonrequired_checks"):
+        vals = gate.get(key, [])
+        if isinstance(vals, list) and vals:
+            lines.append(f"- {key}: {', '.join(vals)}")
+        else:
+            lines.append(f"- {key}: none")
+
+    lines.extend(["", "## Top risk item"])
+    top_risk = ops.get("top_risk_item")
+    if isinstance(top_risk, dict) and top_risk:
+        lines.append(
+            f"- {top_risk.get('check_id')}: risk={top_risk.get('risk_score')} impact={top_risk.get('impact')}"
+        )
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Phase 1 completion dashboard.")
+    parser.add_argument("--plan", default="plans/strategic-execution-model-2026.json")
+    parser.add_argument("--status", default="build/phase1-baseline/phase1-status.json")
+    parser.add_argument("--summary", default="build/phase1-baseline/phase1-baseline-summary.json")
+    parser.add_argument("--snapshot", default="build/phase1-baseline/phase1-ops-snapshot.json")
+    parser.add_argument("--out-json", default="build/phase1-baseline/phase1-completion-dashboard.json")
+    parser.add_argument("--out-md", default="build/phase1-baseline/phase1-completion-dashboard.md")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    payload = build_dashboard(
+        plan_path=Path(args.plan),
+        status_path=Path(args.status),
+        summary_path=Path(args.summary),
+        snapshot_path=Path(args.snapshot),
+    )
+
+    out_json = Path(args.out_json)
+    out_md = Path(args.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md.write_text(_to_markdown(payload), encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("phase1-completion-dashboard: OK")
+        print(f"- ready_to_close: {payload.get('ready_to_close', False)}")
+        print(f"- json: {out_json}")
+        print(f"- markdown: {out_md}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_control_loop_report.py
+++ b/scripts/phase1_control_loop_report.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Summarize Phase 1 progress by control-loop stage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_control_loop_report(
+    plan: dict[str, Any],
+    baseline_summary: dict[str, Any],
+    dashboard: dict[str, Any],
+    weekly_pack: dict[str, Any],
+) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+
+    plan_ok = bool(plan.get("current_phase", {}).get("id") == 1)
+    checks.append(
+        {
+            "stage": "plan",
+            "ok": plan_ok,
+            "evidence": "current_phase.id == 1",
+            "action_if_missing": "Run make phase-current-json and verify phase lock",
+        }
+    )
+
+    build_ok = bool(baseline_summary)
+    checks.append(
+        {
+            "stage": "build",
+            "ok": build_ok,
+            "evidence": "phase1-baseline-summary exists",
+            "action_if_missing": "Run make phase1-baseline",
+        }
+    )
+
+    validate_ok = bool(dashboard)
+    checks.append(
+        {
+            "stage": "validate",
+            "ok": validate_ok,
+            "evidence": "phase1-completion-dashboard exists",
+            "action_if_missing": "Run make phase1-dashboard",
+        }
+    )
+
+    operationalize_ok = bool(weekly_pack)
+    checks.append(
+        {
+            "stage": "operationalize",
+            "ok": operationalize_ok,
+            "evidence": "phase1-weekly-pack exists",
+            "action_if_missing": "Run make phase1-weekly-pack",
+        }
+    )
+
+    expand_ok = bool(dashboard.get("next_step"))
+    checks.append(
+        {
+            "stage": "expand",
+            "ok": expand_ok,
+            "evidence": "next_step computed",
+            "action_if_missing": "Run make phase1-next",
+        }
+    )
+
+    passed = sum(1 for row in checks if row["ok"])
+    next_actions = [row["action_if_missing"] for row in checks if not row["ok"]]
+
+    return {
+        "schema_version": "sdetkit.phase1_control_loop_report.v1",
+        "generated_at": _utc_now(),
+        "phase": "phase1",
+        "stages": checks,
+        "passed_stages": passed,
+        "total_stages": len(checks),
+        "completion_percent": round((passed / len(checks)) * 100, 1) if checks else 0,
+        "ready_for_closeout": bool(dashboard.get("ready_to_close", False)),
+        "next_actions": next_actions,
+    }
+
+
+def _to_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Phase 1 control loop report",
+        "",
+        f"- Generated at: {payload.get('generated_at', '')}",
+        f"- Completion: {payload.get('completion_percent', 0)}%",
+        f"- Ready for closeout: {payload.get('ready_for_closeout', False)}",
+        "",
+        "## Stage checks",
+    ]
+    stages = payload.get("stages", [])
+    if isinstance(stages, list):
+        for row in stages:
+            if isinstance(row, dict):
+                lines.append(f"- {row.get('stage')}: ok={row.get('ok')} ({row.get('evidence')})")
+
+    lines.extend(["", "## Next actions"])
+    actions = payload.get("next_actions", [])
+    if isinstance(actions, list) and actions:
+        lines.extend(f"- {item}" for item in actions)
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Phase 1 control loop report.")
+    parser.add_argument("--plan", default="plans/strategic-execution-model-2026.json")
+    parser.add_argument("--baseline-summary", default="build/phase1-baseline/phase1-baseline-summary.json")
+    parser.add_argument("--dashboard", default="build/phase1-baseline/phase1-completion-dashboard.json")
+    parser.add_argument("--weekly-pack", default="build/phase1-baseline/weekly-pack/phase1-weekly-pack.json")
+    parser.add_argument("--out-json", default="build/phase1-baseline/phase1-control-loop-report.json")
+    parser.add_argument("--out-md", default="build/phase1-baseline/phase1-control-loop-report.md")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    payload = build_control_loop_report(
+        plan=_load_json(Path(args.plan)),
+        baseline_summary=_load_json(Path(args.baseline_summary)),
+        dashboard=_load_json(Path(args.dashboard)),
+        weekly_pack=_load_json(Path(args.weekly_pack)),
+    )
+
+    out_json = Path(args.out_json)
+    out_md = Path(args.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md.write_text(_to_markdown(payload), encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("phase1-control-loop-report: OK")
+        print(f"- completion_percent: {payload.get('completion_percent', 0)}")
+        print(f"- json: {out_json}")
+        print(f"- markdown: {out_md}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_executive_report.py
+++ b/scripts/phase1_executive_report.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Build a concise executive report for current Phase 1 status."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_report(finish: dict[str, Any], gate: dict[str, Any], blockers: dict[str, Any], telemetry: dict[str, Any]) -> dict[str, Any]:
+    rows = blockers.get("rows", []) if isinstance(blockers, dict) else []
+    if not isinstance(rows, list):
+        rows = []
+
+    top_blockers = rows[:3]
+    return {
+        "schema_version": "sdetkit.phase1_executive_report.v1",
+        "generated_at": _utc_now(),
+        "status": finish.get("status", "unknown"),
+        "ready_for_phase2": bool(gate.get("ready_for_phase2", False)),
+        "completion_percent": float(finish.get("completion_percent", 0) or 0),
+        "gate_next_step": gate.get("next_step", "make phase1-next"),
+        "blocker_count": int(blockers.get("count", len(rows) if rows else 0) or 0),
+        "top_blockers": top_blockers,
+        "telemetry": {
+            "runs": telemetry.get("runs", 0),
+            "pass_rate": telemetry.get("pass_rate", 0),
+            "avg_duration_ms": telemetry.get("avg_duration_ms", 0),
+            "duration_drift_ms": telemetry.get("duration_drift_ms", 0),
+        },
+    }
+
+
+def _to_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Phase 1 executive report",
+        "",
+        f"- Generated at: {payload.get('generated_at', '')}",
+        f"- Status: {payload.get('status', 'unknown')}",
+        f"- Completion: {payload.get('completion_percent', 0)}%",
+        f"- Ready for Phase 2: {payload.get('ready_for_phase2', False)}",
+        f"- Next step: {payload.get('gate_next_step', '')}",
+        "",
+        "## Telemetry",
+    ]
+
+    tele = payload.get("telemetry", {})
+    lines.append(f"- runs: {tele.get('runs', 0)}")
+    lines.append(f"- pass_rate: {tele.get('pass_rate', 0)}%")
+    lines.append(f"- avg_duration_ms: {tele.get('avg_duration_ms', 0)}")
+    lines.append(f"- duration_drift_ms: {tele.get('duration_drift_ms', 0)}")
+
+    lines.extend(["", "## Top blockers"])
+    blockers = payload.get("top_blockers", [])
+    if isinstance(blockers, list) and blockers:
+        for row in blockers:
+            if isinstance(row, dict):
+                lines.append(
+                    f"- {row.get('blocker')}: priority={row.get('priority')} action={row.get('recommended_action')}"
+                )
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Phase 1 executive report.")
+    parser.add_argument("--finish", default="build/phase1-baseline/phase1-finish-signal.json")
+    parser.add_argument("--gate", default="build/phase1-baseline/phase1-gate-phase2.json")
+    parser.add_argument("--blockers", default="build/phase1-baseline/phase1-blocker-register.json")
+    parser.add_argument("--telemetry", default="build/phase1-baseline/phase1-telemetry-summary.json")
+    parser.add_argument("--out-json", default="build/phase1-baseline/phase1-executive-report.json")
+    parser.add_argument("--out-md", default="build/phase1-baseline/phase1-executive-report.md")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    finish = _load_json(Path(args.finish))
+    gate = _load_json(Path(args.gate))
+    blockers = _load_json(Path(args.blockers))
+    telemetry = _load_json(Path(args.telemetry))
+
+    if not finish or not gate:
+        payload = {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_executive_report.v1",
+            "reason": "missing finish or gate payload",
+        }
+        if args.format == "json":
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"phase1-executive-report: FAIL ({payload['reason']})")
+        return 1
+
+    report = build_report(finish, gate, blockers, telemetry)
+    report["ok"] = True
+
+    out_json = Path(args.out_json)
+    out_md = Path(args.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md.write_text(_to_markdown(report), encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"phase1-executive-report: {report.get('status', 'unknown')}")
+        print(f"- ready_for_phase2: {report.get('ready_for_phase2', False)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_finish_signal.py
+++ b/scripts/phase1_finish_signal.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Compute a simple finish signal for Phase 1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_finish_signal(control_loop: dict[str, Any], dashboard: dict[str, Any]) -> dict[str, Any]:
+    completion = float(control_loop.get("completion_percent", 0) or 0)
+    ready = bool(dashboard.get("ready_to_close", False))
+    gate_ok = bool(dashboard.get("completion_gate", {}).get("ok", False))
+
+    if ready and gate_ok:
+        status = "complete"
+    elif completion >= 80:
+        status = "near_finish"
+    elif completion >= 50:
+        status = "in_progress"
+    else:
+        status = "early"
+
+    blockers = dashboard.get("completion_gate", {}).get("failing_required_checks", [])
+    if not isinstance(blockers, list):
+        blockers = []
+
+    return {
+        "schema_version": "sdetkit.phase1_finish_signal.v1",
+        "status": status,
+        "completion_percent": completion,
+        "ready_to_close": ready,
+        "gate_ok": gate_ok,
+        "blocking_required_checks": blockers,
+        "next_step": dashboard.get("next_step", "make phase1-next"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compute Phase 1 finish signal.")
+    parser.add_argument("--control-loop", default="build/phase1-baseline/phase1-control-loop-report.json")
+    parser.add_argument("--dashboard", default="build/phase1-baseline/phase1-completion-dashboard.json")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    control = _load_json(Path(args.control_loop))
+    dashboard = _load_json(Path(args.dashboard))
+
+    if not control or not dashboard:
+        payload = {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_finish_signal.v1",
+            "reason": "missing control-loop or dashboard artifact",
+        }
+        if args.format == "json":
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"phase1-finish-signal: FAIL ({payload['reason']})")
+        return 1
+
+    payload = build_finish_signal(control, dashboard)
+    payload["ok"] = True
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"phase1-finish-signal: {payload['status']}")
+        print(f"- completion_percent: {payload['completion_percent']}")
+        print(f"- next_step: {payload['next_step']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_gate_phase2.py
+++ b/scripts/phase1_gate_phase2.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Gate Phase 2 entry based on Phase 1 completion artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_gate_result(finish_signal: dict[str, Any], artifact_set: dict[str, Any]) -> dict[str, Any]:
+    complete = finish_signal.get("status") == "complete"
+    artifacts_ok = bool(artifact_set.get("ok", False))
+    ready = bool(complete and artifacts_ok)
+
+    return {
+        "schema_version": "sdetkit.phase1_gate_phase2.v1",
+        "ready_for_phase2": ready,
+        "finish_status": finish_signal.get("status", "unknown"),
+        "finish_gate_ok": bool(finish_signal.get("gate_ok", False)),
+        "artifacts_ok": artifacts_ok,
+        "blocking_required_checks": finish_signal.get("blocking_required_checks", []),
+        "missing_artifacts": artifact_set.get("missing", []),
+        "next_step": "make phase1-retire-plan" if ready else "make phase1-next-pass && make phase1-blocker-register",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Evaluate gate to Phase 2.")
+    parser.add_argument("--finish-signal", default="build/phase1-baseline/phase1-finish-signal.json")
+    parser.add_argument("--artifact-set", default="build/phase1-baseline/phase1-artifact-set.json")
+    parser.add_argument("--auto-retire", action="store_true")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    finish = _load_json(Path(args.finish_signal))
+    artifacts = _load_json(Path(args.artifact_set))
+
+    if not finish or not artifacts:
+        payload = {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_gate_phase2.v1",
+            "reason": "missing finish-signal or artifact-set payload",
+        }
+        if args.format == "json":
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"phase1-gate-phase2: FAIL ({payload['reason']})")
+        return 1
+
+    gate = build_gate_result(finish, artifacts)
+    gate["ok"] = True
+
+    if args.auto_retire and gate["ready_for_phase2"]:
+        proc = subprocess.run(["make", "phase1-retire-plan"], capture_output=True, text=True)
+        gate["auto_retire"] = {
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+
+    if args.format == "json":
+        print(json.dumps(gate, indent=2, sort_keys=True))
+    else:
+        print("phase1-gate-phase2: READY" if gate["ready_for_phase2"] else "phase1-gate-phase2: BLOCKED")
+        print(f"- finish_status: {gate['finish_status']}")
+        print(f"- artifacts_ok: {gate['artifacts_ok']}")
+        print(f"- next_step: {gate['next_step']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_next_actions.py
+++ b/scripts/phase1_next_actions.py
@@ -11,6 +11,7 @@ from pathlib import Path
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--status-json", required=True)
+    ap.add_argument("--out", default=None, help="Optional output path for next-actions JSON payload.")
     ap.add_argument("--format", choices=["text", "json"], default="text")
     ns = ap.parse_args()
 
@@ -70,6 +71,11 @@ def main() -> int:
         "actions_are_advisory": ok and len(deduped) > 0,
         "next_actions": deduped,
     }
+
+    if ns.out:
+        out_path = Path(ns.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     if ns.format == "json":
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/phase1_next_pass_card.py
+++ b/scripts/phase1_next_pass_card.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Generate a concise next-pass card for Phase 1 remediation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_next_pass_card(finish_signal: dict[str, Any], next_actions: dict[str, Any], control_loop: dict[str, Any]) -> dict[str, Any]:
+    status = finish_signal.get("status", "unknown")
+    blockers = finish_signal.get("blocking_required_checks", [])
+    if not isinstance(blockers, list):
+        blockers = []
+
+    missing_stages = [
+        row.get("stage")
+        for row in control_loop.get("stages", [])
+        if isinstance(row, dict) and not bool(row.get("ok", False))
+    ]
+
+    actions = next_actions.get("next_actions", []) if isinstance(next_actions, dict) else []
+    if not isinstance(actions, list):
+        actions = []
+
+    if not actions:
+        actions = [finish_signal.get("next_step", "make phase1-next")]
+
+    return {
+        "schema_version": "sdetkit.phase1_next_pass_card.v1",
+        "status": status,
+        "ready_to_close": bool(finish_signal.get("ready_to_close", False)),
+        "completion_percent": float(finish_signal.get("completion_percent", 0) or 0),
+        "blocking_required_checks": blockers,
+        "missing_control_loop_stages": missing_stages,
+        "next_actions": actions,
+    }
+
+
+def _to_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Phase 1 next-pass card",
+        "",
+        f"- Status: {payload.get('status', 'unknown')}",
+        f"- Completion: {payload.get('completion_percent', 0)}%",
+        f"- Ready to close: {payload.get('ready_to_close', False)}",
+        "",
+        "## Blocking required checks",
+    ]
+
+    blockers = payload.get("blocking_required_checks", [])
+    if isinstance(blockers, list) and blockers:
+        lines.extend(f"- {item}" for item in blockers)
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Missing control-loop stages"])
+    stages = payload.get("missing_control_loop_stages", [])
+    if isinstance(stages, list) and stages:
+        lines.extend(f"- {item}" for item in stages)
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Next actions"])
+    actions = payload.get("next_actions", [])
+    if isinstance(actions, list) and actions:
+        lines.extend(f"- {item}" for item in actions)
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Phase 1 next-pass remediation card.")
+    parser.add_argument("--finish-signal", default="build/phase1-baseline/phase1-finish-signal.json")
+    parser.add_argument("--next-actions", default="build/phase1-baseline/phase1-next-actions.json")
+    parser.add_argument("--control-loop", default="build/phase1-baseline/phase1-control-loop-report.json")
+    parser.add_argument("--out-json", default="build/phase1-baseline/phase1-next-pass-card.json")
+    parser.add_argument("--out-md", default="build/phase1-baseline/phase1-next-pass-card.md")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    finish_signal = _load_json(Path(args.finish_signal))
+    control_loop = _load_json(Path(args.control_loop))
+    next_actions = _load_json(Path(args.next_actions))
+
+    if not finish_signal or not control_loop:
+        payload = {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_next_pass_card.v1",
+            "reason": "missing finish-signal or control-loop artifact",
+        }
+        if args.format == "json":
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"phase1-next-pass-card: FAIL ({payload['reason']})")
+        return 1
+
+    card = build_next_pass_card(finish_signal, next_actions, control_loop)
+    card["ok"] = True
+
+    out_json = Path(args.out_json)
+    out_md = Path(args.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(card, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md.write_text(_to_markdown(card), encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(card, indent=2, sort_keys=True))
+    else:
+        print(f"phase1-next-pass-card: {card.get('status', 'unknown')}")
+        print(f"- json: {out_json}")
+        print(f"- markdown: {out_md}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_retire_plan_into_flow.py
+++ b/scripts/phase1_retire_plan_into_flow.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Retire Phase 1 planning state and persist flow-first manifest after closeout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.phase1_closeout_and_prune_plan import closeout_phase1
+
+FLOW_COMMANDS = [
+    "make phase-current",
+    "make phase1-baseline",
+    "make phase1-status",
+    "make phase1-next",
+    "make phase1-ops-snapshot",
+    "make phase1-dashboard",
+    "make phase1-weekly-pack",
+    "make phase1-control-loop",
+    "make phase1-run-all",
+    "make phase1-artifact-set",
+    "make phase1-telemetry",
+    "make phase1-finish-signal",
+    "make phase1-next-pass",
+    "make phase1-blocker-register",
+]
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def retire_phase1_plan(status_json: Path, plan_json: Path, archive_dir: Path, flow_manifest: Path) -> dict[str, Any]:
+    closeout = closeout_phase1(status_json, plan_json, archive_dir)
+    if not closeout.get("ok", False):
+        return {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_retire_plan.v1",
+            "reason": closeout.get("reason", "closeout failed"),
+            "closeout": closeout,
+        }
+
+    manifest = {
+        "schema_version": "sdetkit.phase1_flow_manifest.v1",
+        "phase1_plan_retired": True,
+        "status_source": str(status_json),
+        "archived_plan": closeout.get("archived_plan"),
+        "active_plan": closeout.get("plan"),
+        "flow_commands": FLOW_COMMANDS,
+        "next_phase": closeout.get("new_current_phase", {}),
+    }
+    _write_json(flow_manifest, manifest)
+
+    return {
+        "ok": True,
+        "schema_version": "sdetkit.phase1_retire_plan.v1",
+        "flow_manifest": str(flow_manifest),
+        "closeout": closeout,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Retire Phase 1 plan into a flow-first manifest.")
+    parser.add_argument("--status-json", default="build/phase1-baseline/phase1-status.json")
+    parser.add_argument("--plan", default="plans/strategic-execution-model-2026.json")
+    parser.add_argument("--archive-dir", default="plans/archive")
+    parser.add_argument("--flow-manifest", default="plans/phase1-flow-manifest.json")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    result = retire_phase1_plan(
+        status_json=Path(args.status_json),
+        plan_json=Path(args.plan),
+        archive_dir=Path(args.archive_dir),
+        flow_manifest=Path(args.flow_manifest),
+    )
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        if result.get("ok", False):
+            print("phase1-retire-plan: COMPLETE")
+            print(f"- flow_manifest: {result['flow_manifest']}")
+        else:
+            print(f"phase1-retire-plan: FAIL ({result.get('reason', 'unknown error')})")
+
+    return 0 if result.get("ok", False) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_run_all.py
+++ b/scripts/phase1_run_all.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Run the full Phase 1 operational sequence and persist execution evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def build_command_plan(include_closeout: bool = False) -> list[list[str]]:
+    commands = [
+        ["make", "phase1-baseline"],
+        ["make", "phase1-status"],
+        ["make", "phase1-next"],
+        ["make", "phase1-ops-snapshot"],
+        ["make", "phase1-dashboard"],
+        ["make", "phase1-weekly-pack"],
+        ["make", "phase1-control-loop"],
+    ]
+    if include_closeout:
+        commands.append(["make", "phase1-closeout"])
+    return commands
+
+
+def run_plan(commands: list[list[str]]) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    overall_ok = True
+
+    for cmd in commands:
+        started = time.time()
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        duration_ms = int((time.time() - started) * 1000)
+        ok = proc.returncode == 0
+        rows.append(
+            {
+                "command": " ".join(cmd),
+                "ok": ok,
+                "returncode": proc.returncode,
+                "duration_ms": duration_ms,
+                "stdout": proc.stdout.strip(),
+                "stderr": proc.stderr.strip(),
+            }
+        )
+        if not ok:
+            overall_ok = False
+            break
+
+    return {
+        "ok": overall_ok,
+        "steps": rows,
+    }
+
+
+def _to_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Phase 1 run-all execution report",
+        "",
+        f"- Generated at: {payload.get('generated_at', '')}",
+        f"- Overall ok: {payload.get('ok', False)}",
+        "",
+        "## Steps",
+    ]
+    for step in payload.get("steps", []):
+        lines.append(
+            f"- `{step.get('command')}` -> ok={step.get('ok')} rc={step.get('returncode')} duration_ms={step.get('duration_ms')}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run full Phase 1 sequence.")
+    parser.add_argument("--include-closeout", action="store_true")
+    parser.add_argument("--out-json", default="build/phase1-baseline/phase1-run-all.json")
+    parser.add_argument("--out-md", default="build/phase1-baseline/phase1-run-all.md")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    commands = build_command_plan(include_closeout=args.include_closeout)
+    executed = run_plan(commands)
+
+    payload = {
+        "schema_version": "sdetkit.phase1_run_all.v1",
+        "generated_at": _utc_now(),
+        "ok": executed["ok"],
+        "steps": executed["steps"],
+    }
+
+    out_json = Path(args.out_json)
+    out_md = Path(args.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md.write_text(_to_markdown(payload), encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("phase1-run-all: OK" if payload["ok"] else "phase1-run-all: FAIL")
+        print(f"- json: {out_json}")
+        print(f"- markdown: {out_md}")
+
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_telemetry_history.py
+++ b/scripts/phase1_telemetry_history.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Append Phase 1 run telemetry and compute drift metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if not path.is_file():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _duration_total_ms(run_payload: dict[str, Any]) -> int:
+    total = 0
+    for row in run_payload.get("steps", []):
+        if isinstance(row, dict):
+            total += int(row.get("duration_ms", 0) or 0)
+    return total
+
+
+def build_history_entry(run_payload: dict[str, Any]) -> dict[str, Any]:
+    steps = run_payload.get("steps", []) if isinstance(run_payload, dict) else []
+    if not isinstance(steps, list):
+        steps = []
+    failed = [row for row in steps if isinstance(row, dict) and not bool(row.get("ok", False))]
+    blocker_categories = []
+    for row in failed:
+        cmd = str(row.get("command", ""))
+        if "baseline" in cmd:
+            blocker_categories.append("build")
+        elif "dashboard" in cmd or "control-loop" in cmd:
+            blocker_categories.append("validate")
+        else:
+            blocker_categories.append("other")
+
+    return {
+        "recorded_at": _utc_now(),
+        "ok": bool(run_payload.get("ok", False)),
+        "duration_ms": _duration_total_ms(run_payload),
+        "steps_total": len(steps),
+        "steps_failed": len(failed),
+        "blocker_categories": sorted(set(blocker_categories)),
+    }
+
+
+def summarize(history: list[dict[str, Any]]) -> dict[str, Any]:
+    if not history:
+        return {
+            "runs": 0,
+            "pass_rate": 0,
+            "avg_duration_ms": 0,
+            "last_duration_ms": 0,
+            "duration_drift_ms": 0,
+            "blocker_category_counts": {},
+        }
+
+    runs = len(history)
+    pass_count = sum(1 for row in history if bool(row.get("ok", False)))
+    avg_duration = int(sum(int(row.get("duration_ms", 0)) for row in history) / runs)
+    last_duration = int(history[-1].get("duration_ms", 0))
+    previous = int(history[-2].get("duration_ms", 0)) if runs > 1 else last_duration
+    drift = last_duration - previous
+
+    counts: dict[str, int] = {}
+    for row in history:
+        for cat in row.get("blocker_categories", []):
+            counts[cat] = counts.get(cat, 0) + 1
+
+    return {
+        "runs": runs,
+        "pass_rate": round((pass_count / runs) * 100, 1),
+        "avg_duration_ms": avg_duration,
+        "last_duration_ms": last_duration,
+        "duration_drift_ms": drift,
+        "blocker_category_counts": counts,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Update Phase 1 telemetry history.")
+    parser.add_argument("--run-json", default="build/phase1-baseline/phase1-run-all.json")
+    parser.add_argument("--history-json", default="build/phase1-baseline/phase1-telemetry-history.json")
+    parser.add_argument("--summary-json", default="build/phase1-baseline/phase1-telemetry-summary.json")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    run_payload = _load_json(Path(args.run_json), {})
+    if not run_payload:
+        result = {
+            "ok": False,
+            "schema_version": "sdetkit.phase1_telemetry_history.v1",
+            "reason": f"missing run payload: {args.run_json}",
+        }
+        if args.format == "json":
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print(f"phase1-telemetry-history: FAIL ({result['reason']})")
+        return 1
+
+    history_path = Path(args.history_json)
+    history = _load_json(history_path, [])
+    if not isinstance(history, list):
+        history = []
+
+    history.append(build_history_entry(run_payload))
+    summary = summarize(history)
+
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    history_path.write_text(json.dumps(history, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    summary_payload = {
+        "schema_version": "sdetkit.phase1_telemetry_summary.v1",
+        "generated_at": _utc_now(),
+        **summary,
+    }
+    summary_path = Path(args.summary_json)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(summary_payload, indent=2, sort_keys=True))
+    else:
+        print("phase1-telemetry-history: OK")
+        print(f"- runs: {summary_payload['runs']}")
+        print(f"- pass_rate: {summary_payload['pass_rate']}%")
+        print(f"- avg_duration_ms: {summary_payload['avg_duration_ms']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase1_weekly_report_pack.py
+++ b/scripts/phase1_weekly_report_pack.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Build a single weekly Phase 1 report pack from generated artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ARTIFACT_INPUTS = {
+    "status": "build/phase1-baseline/phase1-status.json",
+    "next_actions": "build/phase1-baseline/phase1-next-actions.json",
+    "ops_snapshot": "build/phase1-baseline/phase1-ops-snapshot.json",
+    "completion_dashboard": "build/phase1-baseline/phase1-completion-dashboard.json",
+    "baseline_summary": "build/phase1-baseline/phase1-baseline-summary.json",
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_pack_payload(inputs: dict[str, Path]) -> dict[str, Any]:
+    loaded = {name: _load_json(path) for name, path in inputs.items()}
+    ready = bool(loaded.get("completion_dashboard", {}).get("ready_to_close", False))
+    hard_blockers = loaded.get("status", {}).get("hard_blockers", [])
+    if not isinstance(hard_blockers, list):
+        hard_blockers = []
+
+    return {
+        "schema_version": "sdetkit.phase1_weekly_report_pack.v1",
+        "generated_at": _utc_now(),
+        "phase": "phase1",
+        "ready_to_close": ready,
+        "hard_blocker_count": len(hard_blockers),
+        "artifact_inventory": {
+            name: {
+                "path": str(path),
+                "exists": path.is_file(),
+            }
+            for name, path in inputs.items()
+        },
+        "top_risk_item": loaded.get("ops_snapshot", {}).get("top_risk_item"),
+        "next_step": loaded.get("completion_dashboard", {}).get("next_step", "make phase1-next"),
+        "hard_blockers": hard_blockers,
+    }
+
+
+def _to_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Phase 1 weekly report pack",
+        "",
+        f"- Generated at: {payload.get('generated_at', '')}",
+        f"- Ready to close: {payload.get('ready_to_close', False)}",
+        f"- Hard blocker count: {payload.get('hard_blocker_count', 0)}",
+        f"- Next step: {payload.get('next_step', '')}",
+        "",
+        "## Artifact inventory",
+    ]
+
+    inventory = payload.get("artifact_inventory", {})
+    if isinstance(inventory, dict):
+        for name, meta in inventory.items():
+            if isinstance(meta, dict):
+                lines.append(f"- {name}: exists={meta.get('exists', False)} path={meta.get('path', '')}")
+
+    lines.extend(["", "## Hard blockers"])
+    blockers = payload.get("hard_blockers", [])
+    if isinstance(blockers, list) and blockers:
+        lines.extend(f"- {item}" for item in blockers)
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Phase 1 weekly report pack.")
+    parser.add_argument("--out-dir", default="build/phase1-baseline/weekly-pack")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    inputs = {name: Path(path) for name, path in ARTIFACT_INPUTS.items()}
+    payload = build_pack_payload(inputs)
+
+    out_json = out_dir / "phase1-weekly-pack.json"
+    out_md = out_dir / "phase1-weekly-pack.md"
+    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md.write_text(_to_markdown(payload), encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("phase1-weekly-pack: OK")
+        print(f"- json: {out_json}")
+        print(f"- markdown: {out_md}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase_sequential_executor.py
+++ b/scripts/phase_sequential_executor.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Print one-phase-at-a-time execution guidance from the strategic plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_PLAN = Path("plans/strategic-execution-model-2026.json")
+DEFAULT_STATUS = Path("build/phase1-baseline/phase1-status.json")
+
+
+def _load_plan(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "ok": False,
+            "error": f"missing plan file: {path}",
+            "schema_version": "sdetkit.phase_sequential_executor.v1",
+        }
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "ok": True,
+        "plan": data,
+        "schema_version": "sdetkit.phase_sequential_executor.v1",
+    }
+
+
+def _phase_from_plan(plan: dict[str, Any], phase_id: int | None) -> dict[str, Any] | None:
+    phase_sequence = plan.get("phase_sequence", [])
+    if phase_id is None:
+        current_phase = plan.get("current_phase", {})
+        phase_id = current_phase.get("id")
+    if phase_id is None:
+        return None
+    for item in phase_sequence:
+        if item.get("id") == phase_id:
+            return item
+    return None
+
+
+def _status_progress(status_path: Path) -> dict[str, Any]:
+    if not status_path.is_file():
+        return {
+            "status_file": str(status_path),
+            "available": False,
+            "progress_percent": 0,
+            "accomplished_count": 0,
+            "remaining_count": 0,
+        }
+    payload = json.loads(status_path.read_text(encoding="utf-8"))
+    accomplished = payload.get("accomplished", []) if isinstance(payload, dict) else []
+    not_yet = payload.get("not_yet", []) if isinstance(payload, dict) else []
+    if not isinstance(accomplished, list):
+        accomplished = []
+    if not isinstance(not_yet, list):
+        not_yet = []
+    total = len(accomplished) + len(not_yet)
+    percent = round((len(accomplished) / total) * 100, 1) if total else 0
+    return {
+        "status_file": str(status_path),
+        "available": True,
+        "phase1_ok": bool(payload.get("ok", False)),
+        "progress_percent": percent,
+        "accomplished_count": len(accomplished),
+        "remaining_count": len(not_yet),
+        "hard_blockers": payload.get("hard_blockers", []),
+    }
+
+
+def build_payload(
+    plan_path: Path,
+    phase_id: int | None = None,
+    status_path: Path = DEFAULT_STATUS,
+) -> dict[str, Any]:
+    loaded = _load_plan(plan_path)
+    if not loaded["ok"]:
+        return loaded
+
+    plan = loaded["plan"]
+    phase = _phase_from_plan(plan, phase_id)
+    if phase is None:
+        return {
+            "ok": False,
+            "schema_version": "sdetkit.phase_sequential_executor.v1",
+            "error": "phase not found in plan",
+            "requested_phase": phase_id,
+            "available_phases": [item.get("id") for item in plan.get("phase_sequence", [])],
+        }
+
+    return {
+        "ok": True,
+        "schema_version": "sdetkit.phase_sequential_executor.v1",
+        "plan_id": plan.get("plan_id"),
+        "current_phase": phase,
+        "control_loop": plan.get("control_loop", []),
+        "phase_handoff_rule": plan.get("phase_handoff_rule", ""),
+        "next_commands": phase.get("now_actions", []),
+        "progress": _status_progress(status_path),
+    }
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    if not payload.get("ok", False):
+        return f"phase-sequential: FAIL ({payload.get('error', 'unknown error')})"
+
+    phase = payload.get("current_phase", {})
+    lines = [
+        "phase-sequential: READY",
+        f"phase: {phase.get('id')} - {phase.get('name', 'unknown')}",
+        "control loop:",
+    ]
+    for item in payload.get("control_loop", []):
+        lines.append(f"- {item}")
+
+    commands = payload.get("next_commands", [])
+    if commands:
+        lines.append("next commands:")
+        for cmd in commands:
+            lines.append(f"- {cmd}")
+
+    handoff = payload.get("phase_handoff_rule")
+    if handoff:
+        lines.append(f"handoff rule: {handoff}")
+    progress = payload.get("progress", {})
+    if isinstance(progress, dict) and progress.get("available"):
+        lines.append(
+            "progress: "
+            f"{progress.get('progress_percent', 0)}% "
+            f"({progress.get('accomplished_count', 0)} done / {progress.get('remaining_count', 0)} remaining)"
+        )
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Execute strategic phases one-by-one.")
+    parser.add_argument("--plan", default=str(DEFAULT_PLAN))
+    parser.add_argument("--status-json", default=str(DEFAULT_STATUS))
+    parser.add_argument("--phase", type=int)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+
+    payload = build_payload(Path(args.plan), phase_id=args.phase, status_path=Path(args.status_json))
+    ok = bool(payload.get("ok", False))
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_render_text(payload))
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_phase1_artifact_set.py
+++ b/tests/test_check_phase1_artifact_set.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import check_phase1_artifact_set as contract
+
+
+def test_contract_fails_when_missing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = contract.main(["--format", "json"])
+    assert rc == 1
+
+
+def test_contract_passes_when_artifacts_present(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    for rel in contract.REQUIRED_JSON:
+        p = Path(rel)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"ok": True}) + "\n", encoding="utf-8")
+
+    for rel in contract.REQUIRED_MD:
+        p = Path(rel)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# ok\n", encoding="utf-8")
+
+    rc = contract.main(["--format", "json"])
+    assert rc == 0

--- a/tests/test_check_phase1_flow_contract.py
+++ b/tests/test_check_phase1_flow_contract.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import check_phase1_flow_contract as contract
+
+
+def test_extract_doc_targets() -> None:
+    text = """\n```bash\nmake a\nmake b\n```\n"""
+    assert contract._extract_doc_targets(text) == ["a", "b"]
+
+
+def test_main_ok_with_repo_files() -> None:
+    rc = contract.main(["--format", "json"])
+    assert rc == 0
+
+
+def test_main_missing_inputs(tmp_path: Path) -> None:
+    rc = contract.main(["--doc", str(tmp_path / "missing.md"), "--makefile", str(tmp_path / "M"), "--format", "json"])
+    assert rc == 1

--- a/tests/test_phase1_blocker_register.py
+++ b/tests/test_phase1_blocker_register.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_blocker_register as reg
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_blocker_register_prioritizes_required() -> None:
+    rows = reg.build_blocker_register(
+        {"blocking_required_checks": ["doctor"], "missing_control_loop_stages": ["build"]},
+        {"stages": []},
+    )
+    assert rows[0]["blocker"] == "doctor"
+
+
+def test_main_writes_outputs(tmp_path: Path) -> None:
+    next_pass = tmp_path / "next-pass.json"
+    loop = tmp_path / "control-loop.json"
+    out_json = tmp_path / "out" / "register.json"
+    out_csv = tmp_path / "out" / "register.csv"
+
+    _write(next_pass, {"blocking_required_checks": ["doctor"], "missing_control_loop_stages": ["build"]})
+    _write(loop, {"stages": []})
+
+    rc = reg.main([
+        "--next-pass", str(next_pass),
+        "--control-loop", str(loop),
+        "--out-json", str(out_json),
+        "--out-csv", str(out_csv),
+        "--format", "json",
+    ])
+    assert rc == 0
+    assert out_json.exists()
+    assert out_csv.exists()

--- a/tests/test_phase1_build_ops_snapshot.py
+++ b/tests/test_phase1_build_ops_snapshot.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_build_ops_snapshot as snap
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_ops_snapshot_ranks_debt() -> None:
+    summary = {
+        "checks": [
+            {"id": "ruff", "ok": False},
+            {"id": "doctor", "ok": False},
+            {"id": "pytest", "ok": True},
+        ]
+    }
+    status = {"accomplished": ["a", "b"], "not_yet": ["c"], "hard_blockers": ["c"]}
+    next_actions = {"next_actions": ["fix doctor"]}
+
+    out = snap.build_ops_snapshot(summary, status, next_actions)
+    assert out["progress_percent"] == 66.7
+    assert out["quality_debt_register"][0]["check_id"] == "doctor"
+
+
+def test_main_writes_outputs(tmp_path: Path) -> None:
+    summary = tmp_path / "summary.json"
+    status = tmp_path / "status.json"
+    next_actions = tmp_path / "next.json"
+    out_json = tmp_path / "out" / "snapshot.json"
+    out_md = tmp_path / "out" / "snapshot.md"
+
+    _write(summary, {"checks": [{"id": "doctor", "ok": True}]})
+    _write(status, {"accomplished": ["x"], "not_yet": [], "hard_blockers": []})
+    _write(next_actions, {"next_actions": ["none"]})
+
+    rc = snap.main(
+        [
+            "--summary",
+            str(summary),
+            "--status",
+            str(status),
+            "--next-actions",
+            str(next_actions),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    assert out_json.exists()
+    assert out_md.exists()

--- a/tests/test_phase1_closeout_and_prune_plan.py
+++ b/tests/test_phase1_closeout_and_prune_plan.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_closeout_and_prune_plan as closeout
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_closeout_prunes_phase1_and_advances(tmp_path: Path) -> None:
+    status = tmp_path / "phase1-status.json"
+    plan = tmp_path / "plan.json"
+    archive = tmp_path / "archive"
+
+    _write(status, {"ok": True, "hard_blockers": []})
+    _write(
+        plan,
+        {
+            "plan_id": "x",
+            "current_phase": {"id": 1, "name": "P1"},
+            "phase_sequence": [
+                {"id": 1, "name": "P1", "objective": "a"},
+                {"id": 2, "name": "P2", "objective": "b", "window": "Weeks 3-6"},
+            ],
+        },
+    )
+
+    result = closeout.closeout_phase1(status, plan, archive)
+    assert result["ok"] is True
+
+    updated = json.loads(plan.read_text(encoding="utf-8"))
+    ids = [row["id"] for row in updated["phase_sequence"]]
+    assert 1 not in ids
+    assert updated["current_phase"]["id"] == 2
+    assert updated["completed_phases"][0]["id"] == 1
+
+    archived = list(archive.glob("phase1-closeout-plan-snapshot-*.json"))
+    assert archived
+
+
+def test_closeout_fails_when_status_incomplete(tmp_path: Path) -> None:
+    status = tmp_path / "phase1-status.json"
+    plan = tmp_path / "plan.json"
+    archive = tmp_path / "archive"
+
+    _write(status, {"ok": False, "hard_blockers": ["required_check_ok::doctor"]})
+    _write(plan, {"phase_sequence": [{"id": 1}, {"id": 2}]})
+
+    result = closeout.closeout_phase1(status, plan, archive)
+    assert result["ok"] is False
+    assert "incomplete" in result["reason"]

--- a/tests/test_phase1_completion_dashboard.py
+++ b/tests/test_phase1_completion_dashboard.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_completion_dashboard as dash
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_dashboard_ready_true(tmp_path: Path) -> None:
+    plan = tmp_path / "plan.json"
+    status = tmp_path / "status.json"
+    summary = tmp_path / "summary.json"
+    snapshot = tmp_path / "snapshot.json"
+
+    _write(
+        plan,
+        {
+            "plan_id": "p",
+            "current_phase": {"id": 1, "name": "P1"},
+            "phase_sequence": [{"id": 1, "name": "P1", "now_actions": ["x"]}],
+            "control_loop": ["Plan"],
+            "phase_handoff_rule": "rule",
+        },
+    )
+    _write(status, {"ok": True, "accomplished": ["a"], "not_yet": [], "hard_blockers": []})
+    _write(
+        summary,
+        {
+            "checks": [
+                {"id": "doctor", "ok": True},
+                {"id": "enterprise_contracts", "ok": True},
+                {"id": "primary_docs_map", "ok": True},
+            ]
+        },
+    )
+    _write(snapshot, {"progress_percent": 100, "top_risk_item": None, "recommended_next_actions": []})
+
+    out = dash.build_dashboard(plan, status, summary, snapshot)
+    assert out["ready_to_close"] is True
+    assert out["next_step"] == "make phase1-closeout"
+
+
+def test_main_writes_outputs(tmp_path: Path) -> None:
+    plan = tmp_path / "plan.json"
+    status = tmp_path / "status.json"
+    summary = tmp_path / "summary.json"
+    snapshot = tmp_path / "snapshot.json"
+    out_json = tmp_path / "out" / "dashboard.json"
+    out_md = tmp_path / "out" / "dashboard.md"
+
+    _write(
+        plan,
+        {
+            "plan_id": "p",
+            "current_phase": {"id": 1, "name": "P1"},
+            "phase_sequence": [{"id": 1, "name": "P1", "now_actions": ["x"]}],
+            "control_loop": ["Plan"],
+            "phase_handoff_rule": "rule",
+        },
+    )
+    _write(status, {"ok": False, "accomplished": [], "not_yet": ["x"], "hard_blockers": ["x"]})
+    _write(summary, {"checks": []})
+    _write(snapshot, {"progress_percent": 0, "recommended_next_actions": ["x"]})
+
+    rc = dash.main(
+        [
+            "--plan",
+            str(plan),
+            "--status",
+            str(status),
+            "--summary",
+            str(summary),
+            "--snapshot",
+            str(snapshot),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    assert out_json.exists()
+    assert out_md.exists()

--- a/tests/test_phase1_control_loop_report.py
+++ b/tests/test_phase1_control_loop_report.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_control_loop_report as report
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_control_loop_report_partial() -> None:
+    payload = report.build_control_loop_report(
+        plan={"current_phase": {"id": 1}},
+        baseline_summary={},
+        dashboard={},
+        weekly_pack={},
+    )
+    assert payload["completion_percent"] == 20.0
+    assert payload["passed_stages"] == 1
+
+
+def test_main_writes_outputs(tmp_path: Path) -> None:
+    plan = tmp_path / "plan.json"
+    baseline = tmp_path / "baseline.json"
+    dashboard = tmp_path / "dashboard.json"
+    weekly = tmp_path / "weekly.json"
+    out_json = tmp_path / "out" / "loop.json"
+    out_md = tmp_path / "out" / "loop.md"
+
+    _write(plan, {"current_phase": {"id": 1}})
+    _write(baseline, {"checks": []})
+    _write(dashboard, {"ready_to_close": False, "next_step": "make phase1-next"})
+    _write(weekly, {"artifact_inventory": {}})
+
+    rc = report.main(
+        [
+            "--plan",
+            str(plan),
+            "--baseline-summary",
+            str(baseline),
+            "--dashboard",
+            str(dashboard),
+            "--weekly-pack",
+            str(weekly),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    assert out_json.exists()
+    assert out_md.exists()

--- a/tests/test_phase1_do_it_makefile_target.py
+++ b/tests/test_phase1_do_it_makefile_target.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_makefile_has_phase1_do_it_target() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "Makefile").read_text(encoding="utf-8")
+    assert "phase1-do-it: phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal" in text

--- a/tests/test_phase1_executive_report.py
+++ b/tests/test_phase1_executive_report.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_executive_report as report
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_report() -> None:
+    out = report.build_report(
+        {"status": "near_finish", "completion_percent": 80},
+        {"ready_for_phase2": False, "next_step": "make phase1-next-pass"},
+        {"count": 1, "rows": [{"blocker": "doctor", "priority": 100, "recommended_action": "fix"}]},
+        {"runs": 2, "pass_rate": 50.0, "avg_duration_ms": 200, "duration_drift_ms": 10},
+    )
+    assert out["status"] == "near_finish"
+    assert out["blocker_count"] == 1
+
+
+def test_main_missing_required_inputs(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = report.main(["--format", "json"])
+    assert rc == 1
+
+
+def test_main_writes_outputs(tmp_path: Path) -> None:
+    finish = tmp_path / "finish.json"
+    gate = tmp_path / "gate.json"
+    blockers = tmp_path / "blockers.json"
+    telemetry = tmp_path / "telemetry.json"
+    out_json = tmp_path / "out" / "exec.json"
+    out_md = tmp_path / "out" / "exec.md"
+
+    _write(finish, {"status": "early", "completion_percent": 0})
+    _write(gate, {"ready_for_phase2": False, "next_step": "make phase1-next"})
+    _write(blockers, {"count": 0, "rows": []})
+    _write(telemetry, {"runs": 1, "pass_rate": 100.0, "avg_duration_ms": 100, "duration_drift_ms": 0})
+
+    rc = report.main([
+        "--finish", str(finish),
+        "--gate", str(gate),
+        "--blockers", str(blockers),
+        "--telemetry", str(telemetry),
+        "--out-json", str(out_json),
+        "--out-md", str(out_md),
+        "--format", "json",
+    ])
+    assert rc == 0
+    assert out_json.exists()
+    assert out_md.exists()

--- a/tests/test_phase1_finish_signal.py
+++ b/tests/test_phase1_finish_signal.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from scripts import phase1_finish_signal as signal
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_finish_signal_near_finish() -> None:
+    out = signal.build_finish_signal(
+        {"completion_percent": 80},
+        {"ready_to_close": False, "completion_gate": {"ok": False, "failing_required_checks": ["doctor"]}},
+    )
+    assert out["status"] == "near_finish"
+
+
+def test_main_missing_files(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = signal.main(["--format", "json"])
+    assert rc == 1
+
+
+def test_main_success(tmp_path: Path) -> None:
+    control = tmp_path / "control.json"
+    dash = tmp_path / "dash.json"
+    _write(control, {"completion_percent": 100})
+    _write(dash, {"ready_to_close": True, "completion_gate": {"ok": True}, "next_step": "make phase1-closeout"})
+    rc = signal.main(["--control-loop", str(control), "--dashboard", str(dash), "--format", "json"])
+    assert rc == 0

--- a/tests/test_phase1_gate_phase2.py
+++ b/tests/test_phase1_gate_phase2.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_gate_phase2 as gate
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_gate_result_ready() -> None:
+    payload = gate.build_gate_result(
+        {"status": "complete", "gate_ok": True, "blocking_required_checks": []},
+        {"ok": True, "missing": []},
+    )
+    assert payload["ready_for_phase2"] is True
+
+
+def test_main_missing_inputs(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = gate.main(["--format", "json"])
+    assert rc == 1
+
+
+def test_main_success(tmp_path: Path) -> None:
+    finish = tmp_path / "finish.json"
+    artifacts = tmp_path / "artifacts.json"
+    _write(finish, {"status": "complete", "gate_ok": True, "blocking_required_checks": []})
+    _write(artifacts, {"ok": True, "missing": []})
+
+    rc = gate.main(["--finish-signal", str(finish), "--artifact-set", str(artifacts), "--format", "json"])
+    assert rc == 0

--- a/tests/test_phase1_next_pass_card.py
+++ b/tests/test_phase1_next_pass_card.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_next_pass_card as card
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_next_pass_card() -> None:
+    out = card.build_next_pass_card(
+        {"status": "near_finish", "completion_percent": 80, "blocking_required_checks": ["doctor"], "next_step": "make x"},
+        {"next_actions": ["fix doctor"]},
+        {"stages": [{"stage": "build", "ok": False}]},
+    )
+    assert out["status"] == "near_finish"
+    assert out["missing_control_loop_stages"] == ["build"]
+
+
+def test_main_missing_inputs(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    rc = card.main(["--format", "json"])
+    assert rc == 1
+
+
+def test_main_writes_outputs(tmp_path: Path) -> None:
+    finish = tmp_path / "finish.json"
+    nxt = tmp_path / "next.json"
+    loop = tmp_path / "loop.json"
+    out_json = tmp_path / "out" / "card.json"
+    out_md = tmp_path / "out" / "card.md"
+
+    _write(finish, {"status": "early", "completion_percent": 0, "blocking_required_checks": [], "next_step": "make phase1-next"})
+    _write(nxt, {"next_actions": ["make phase1-next"]})
+    _write(loop, {"stages": [{"stage": "build", "ok": False}]})
+
+    rc = card.main([
+        "--finish-signal", str(finish),
+        "--next-actions", str(nxt),
+        "--control-loop", str(loop),
+        "--out-json", str(out_json),
+        "--out-md", str(out_md),
+        "--format", "json",
+    ])
+    assert rc == 0
+    assert out_json.exists()
+    assert out_md.exists()

--- a/tests/test_phase1_retire_plan_into_flow.py
+++ b/tests/test_phase1_retire_plan_into_flow.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_retire_plan_into_flow as retire
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_retire_plan_success(tmp_path: Path) -> None:
+    status = tmp_path / "status.json"
+    plan = tmp_path / "plan.json"
+    archive = tmp_path / "archive"
+    manifest = tmp_path / "flow.json"
+
+    _write(status, {"ok": True, "hard_blockers": []})
+    _write(
+        plan,
+        {
+            "plan_id": "x",
+            "current_phase": {"id": 1, "name": "P1"},
+            "phase_sequence": [
+                {"id": 1, "name": "P1", "objective": "a"},
+                {"id": 2, "name": "P2", "objective": "b"},
+            ],
+        },
+    )
+
+    out = retire.retire_phase1_plan(status, plan, archive, manifest)
+    assert out["ok"] is True
+    assert manifest.exists()
+
+
+def test_retire_plan_fails_when_status_not_done(tmp_path: Path) -> None:
+    status = tmp_path / "status.json"
+    plan = tmp_path / "plan.json"
+    archive = tmp_path / "archive"
+    manifest = tmp_path / "flow.json"
+
+    _write(status, {"ok": False, "hard_blockers": ["x"]})
+    _write(plan, {"phase_sequence": [{"id": 1}, {"id": 2}]})
+
+    out = retire.retire_phase1_plan(status, plan, archive, manifest)
+    assert out["ok"] is False
+    assert not manifest.exists()

--- a/tests/test_phase1_run_all.py
+++ b/tests/test_phase1_run_all.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import phase1_run_all as run_all
+
+
+def test_build_command_plan_default() -> None:
+    cmds = run_all.build_command_plan(include_closeout=False)
+    assert cmds[0] == ["make", "phase1-baseline"]
+    assert all(cmd != ["make", "phase1-closeout"] for cmd in cmds)
+
+
+def test_build_command_plan_with_closeout() -> None:
+    cmds = run_all.build_command_plan(include_closeout=True)
+    assert cmds[-1] == ["make", "phase1-closeout"]
+
+
+def test_main_writes_outputs(tmp_path: Path) -> None:
+    # Run only a safe command set by monkeypatching command plan.
+    original = run_all.build_command_plan
+    run_all.build_command_plan = lambda include_closeout=False: [["python", "-c", "print('ok')"]]
+    try:
+        rc = run_all.main(
+            [
+                "--out-json",
+                str(tmp_path / "run.json"),
+                "--out-md",
+                str(tmp_path / "run.md"),
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 0
+        assert (tmp_path / "run.json").exists()
+        assert (tmp_path / "run.md").exists()
+    finally:
+        run_all.build_command_plan = original

--- a/tests/test_phase1_telemetry_history.py
+++ b/tests/test_phase1_telemetry_history.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_telemetry_history as telemetry
+
+
+def _write(path: Path, payload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_history_entry() -> None:
+    entry = telemetry.build_history_entry(
+        {
+            "ok": False,
+            "steps": [
+                {"command": "make phase1-baseline", "ok": False, "duration_ms": 12},
+                {"command": "make phase1-status", "ok": True, "duration_ms": 8},
+            ],
+        }
+    )
+    assert entry["duration_ms"] == 20
+    assert entry["blocker_categories"] == ["build"]
+
+
+def test_main_updates_history(tmp_path: Path) -> None:
+    run = tmp_path / "run.json"
+    history = tmp_path / "history.json"
+    summary = tmp_path / "summary.json"
+
+    _write(run, {"ok": True, "steps": [{"command": "make x", "ok": True, "duration_ms": 10}]})
+
+    rc = telemetry.main(
+        [
+            "--run-json",
+            str(run),
+            "--history-json",
+            str(history),
+            "--summary-json",
+            str(summary),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    assert history.exists()
+    assert summary.exists()

--- a/tests/test_phase1_weekly_report_pack.py
+++ b/tests/test_phase1_weekly_report_pack.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase1_weekly_report_pack as pack
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_pack_payload(tmp_path: Path) -> None:
+    status = tmp_path / "status.json"
+    dashboard = tmp_path / "dashboard.json"
+    _write(status, {"hard_blockers": ["a", "b"]})
+    _write(dashboard, {"ready_to_close": False, "next_step": "make phase1-next"})
+
+    inputs = {
+        "status": status,
+        "next_actions": tmp_path / "missing-next.json",
+        "ops_snapshot": tmp_path / "missing-snapshot.json",
+        "completion_dashboard": dashboard,
+        "baseline_summary": tmp_path / "missing-summary.json",
+    }
+    payload = pack.build_pack_payload(inputs)
+    assert payload["hard_blocker_count"] == 2
+    assert payload["ready_to_close"] is False
+
+
+def test_main_writes_outputs(tmp_path: Path) -> None:
+    rc = pack.main(["--out-dir", str(tmp_path / "pack"), "--format", "json"])
+    assert rc == 0
+    assert (tmp_path / "pack" / "phase1-weekly-pack.json").exists()
+    assert (tmp_path / "pack" / "phase1-weekly-pack.md").exists()

--- a/tests/test_phase_sequential_executor.py
+++ b/tests/test_phase_sequential_executor.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import phase_sequential_executor as pse
+
+
+def test_build_payload_uses_current_phase() -> None:
+    payload = pse.build_payload(Path("plans/strategic-execution-model-2026.json"))
+    assert payload["ok"] is True
+    assert payload["current_phase"]["id"] == 1
+    assert payload["next_commands"]
+    assert "progress" in payload
+
+
+def test_main_json_output(capsys) -> None:
+    rc = pse.main(["--format", "json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["schema_version"] == "sdetkit.phase_sequential_executor.v1"
+
+
+def test_missing_plan_returns_error(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    payload = pse.build_payload(missing)
+    assert payload["ok"] is False
+
+
+def test_progress_from_status_file(tmp_path: Path) -> None:
+    status = tmp_path / "phase1-status.json"
+    status.write_text(
+        json.dumps(
+            {
+                "ok": False,
+                "accomplished": ["a", "b", "c"],
+                "not_yet": ["d"],
+                "hard_blockers": ["d"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    payload = pse.build_payload(
+        Path("plans/strategic-execution-model-2026.json"),
+        status_path=status,
+    )
+    assert payload["progress"]["available"] is True
+    assert payload["progress"]["progress_percent"] == 75.0


### PR DESCRIPTION
### Motivation
- Introduce a one-by-one phase execution model to support deterministic, operator-driven Phase 1 operations and safe handoff into later phases.
- Provide machine-readable artifacts and lightweight tooling to produce weekly ops snapshots, completion dashboards, control-loop reports, and an automated run-all orchestrator for repeatable evidence collection.
- Ensure the repository has CLI hooks and Makefile targets so teams can run the new Phase 1 workflows with consistent commands.

### Description
- Added multiple new scripts under `scripts/` implementing Phase 1 workflows: `phase1_build_ops_snapshot.py`, `phase1_completion_dashboard.py`, `phase1_control_loop_report.py`, `phase1_weekly_report_pack.py`, `phase1_run_all.py`, `phase1_closeout_and_prune_plan.py`, and `phase_sequential_executor.py` along with a small enhancement to `phase1_next_actions.py` to optionally write next-actions JSON via `--out`.
- Extended `Makefile` with new targets for phase operations (for example `phase1-ops-snapshot`, `phase1-dashboard`, `phase1-weekly-pack`, `phase1-control-loop`, `phase1-run-all`, `phase-current`, `phase-current-json`, and several phase orchestration targets) and updated `phase1-next` to emit `--out` JSON path by default.
- Added operator-facing documentation `docs/phase-execution-one-by-one.md` and updated `docs/index.md` to link the new guide, and included a strategic plan `plans/strategic-execution-model-2026.json` used by the executor and dashboards.
- Added comprehensive unit tests under `tests/` for each new script and core behaviors, including `test_phase1_build_ops_snapshot.py`, `test_phase1_completion_dashboard.py`, `test_phase1_control_loop_report.py`, `test_phase1_weekly_report_pack.py`, `test_phase1_run_all.py`, `test_phase1_closeout_and_prune_plan.py`, and `test_phase_sequential_executor.py`.

### Testing
- Ran the new unit test suite via `pytest -q` against the added `tests/` and `scripts/` modules and observed that all tests completed successfully.
- Exercised the CLI entrypoints in tests by invoking `main()` for each script and asserting written JSON/MD outputs exist and content shape expectations are met.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d74bd7e8833283518c59ca3558a7)