### PR TITLE
Add Phase 4 governance contract generation, workflow, configs, and tests

### DIFF
--- a/.github/workflows/phase4-governance-contract.yml
+++ b/.github/workflows/phase4-governance-contract.yml
@@ -1,0 +1,75 @@
+name: phase4-governance-contract
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'scripts/check_phase4_governance_contract.py'
+      - 'config/phase4_drift_scoring.json'
+      - 'docs/**'
+      - 'Makefile'
+      - '.github/workflows/phase4-governance-contract.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'scripts/check_phase4_governance_contract.py'
+      - 'config/phase4_drift_scoring.json'
+      - 'docs/**'
+      - 'Makefile'
+      - '.github/workflows/phase4-governance-contract.yml'
+jobs:
+  phase4-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install -e .
+      - name: Run phase4 contract
+        run: |
+          . .venv/bin/activate
+          make phase4-governance-contract
+      - name: Validate exact artifact set
+        run: |
+          python - <<'PYCODE'
+          from pathlib import Path
+          expected = {
+              "phase4-governance-contract.json",
+              "phase4-release-evidence.json",
+              "phase4-release-evidence.md",
+              "phase4-governance-adherence.json",
+              "phase4-compliance-overlay-pack.json",
+              "phase4-policy-as-code-template.json",
+              "phase4-governance-drift-alerts.json",
+              "phase4-governance-drift-alerts.md",
+              "phase4-compliance-overlay-security.json",
+              "phase4-compliance-overlay-privacy.json",
+              "phase4-compliance-overlay-regulated.json",
+          }
+          actual = {p.name for p in Path("build/phase4-governance").glob("*") if p.is_file()}
+          missing = sorted(expected - actual)
+          extra = sorted(actual - expected)
+          if missing or extra:
+              raise SystemExit(f"artifact-set mismatch missing={missing} extra={extra}")
+          PYCODE
+      - name: Upload phase4 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase4-governance-artifacts
+          path: |
+            build/phase4-governance/phase4-governance-contract.json
+            build/phase4-governance/phase4-release-evidence.json
+            build/phase4-governance/phase4-release-evidence.md
+            build/phase4-governance/phase4-governance-adherence.json
+            build/phase4-governance/phase4-compliance-overlay-pack.json
+            build/phase4-governance/phase4-policy-as-code-template.json
+            build/phase4-governance/phase4-governance-drift-alerts.json
+            build/phase4-governance/phase4-governance-drift-alerts.md
+            build/phase4-governance/phase4-compliance-overlay-security.json
+            build/phase4-governance/phase4-compliance-overlay-privacy.json
+            build/phase4-governance/phase4-compliance-overlay-regulated.json

--- a/config/phase4_drift_scoring.json
+++ b/config/phase4_drift_scoring.json
@@ -1,0 +1,5 @@
+{
+  "governance_check_failures": 2,
+  "release_missing_artifacts": 2,
+  "adherence_status": 1
+}

--- a/scripts/check_phase4_governance_contract.py
+++ b/scripts/check_phase4_governance_contract.py
@@ -1,11 +1,53 @@
 #!/usr/bin/env python3
-"""Validate Phase 4 governance docs and execution contract."""
+"""Validate and emit Phase 4 governance payload contracts."""
 
 from __future__ import annotations
 
 import argparse
 import json
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.phase4_governance_contract.v2"
+LEGACY_SCHEMA_VERSION = "sdetkit.phase4_governance_contract.v1"
+RELEASE_EVIDENCE_SCHEMA_VERSION = "sdetkit.phase4_release_evidence.v1"
+ADHERENCE_SCHEMA_VERSION = "sdetkit.phase4_governance_adherence.v1"
+
+ALLOWED_CHECK_STATUSES = ("pass", "warn", "fail")
+ALLOWED_POLICY_DOMAINS = (
+    "contract",
+    "compatibility",
+    "release_evidence",
+    "retention",
+    "review_cadence",
+)
+ALLOWED_DECISION_DISPOSITIONS = ("accepted", "rejected", "deferred")
+ALLOWED_IMPACT_TIERS = ("now", "next", "monitor")
+ALLOWED_EVIDENCE_STATUSES = ("complete", "incomplete")
+ALLOWED_ADHERENCE_STATUSES = ("on_track", "due", "overdue", "unknown")
+ALLOWED_DRIFT_STATUSES = ("healthy", "drift")
+DRIFT_THRESHOLD = 2
+DEFAULT_DRIFT_SCORE_BY_SIGNAL = {
+    "governance_check_failures": 2,
+    "release_missing_artifacts": 2,
+    "adherence_status": 1,
+}
+COMPLIANCE_OVERLAY_DOMAINS = ("security", "privacy", "regulated")
+
+REASON_CODES = (
+    "contract_satisfied",
+    "missing_required_reference",
+    "retention_policy_missing",
+    "compatibility_boundary_missing",
+    "review_signal_missing",
+)
+RATIONALE_CODES = (
+    "risk_mitigation",
+    "compatibility_commitment",
+    "audit_readiness",
+    "operational_focus",
+)
 
 REQUIRED_INDEX_LINKS = [
     "- [Versioning and support posture](versioning-and-support.md)",
@@ -22,54 +64,660 @@ REQUIRED_OPERATOR_LINES = [
 ]
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--docs-index", default="docs/index.md")
-    ap.add_argument("--operator-essentials", default="docs/operator-essentials.md")
-    ap.add_argument("--format", choices=["text", "json"], default="text")
-    ns = ap.parse_args()
+def _now_utc() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
-    checks: list[dict[str, object]] = []
-    failures: list[str] = []
 
+def _sorted_unique(rows: list[str]) -> list[str]:
+    return sorted({row for row in rows if row})
+
+
+def _load_drift_scoring_config(path: Path) -> dict[str, int]:
+    if not path.is_file():
+        return dict(DEFAULT_DRIFT_SCORE_BY_SIGNAL)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return dict(DEFAULT_DRIFT_SCORE_BY_SIGNAL)
+    if not isinstance(payload, dict):
+        return dict(DEFAULT_DRIFT_SCORE_BY_SIGNAL)
+
+    scores = dict(DEFAULT_DRIFT_SCORE_BY_SIGNAL)
+    for key in list(scores):
+        value = payload.get(key)
+        if isinstance(value, int) and value >= 0:
+            scores[key] = value
+    return scores
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _check_row(*, check_id: str, ok: bool, evidence_refs: list[str], policy_domain: str) -> dict[str, Any]:
+    return {
+        "check_id": check_id,
+        "status": "pass" if ok else "fail",
+        "reason_code": "contract_satisfied" if ok else "missing_required_reference",
+        "evidence_refs": _sorted_unique(evidence_refs) or ["missing:evidence"],
+        "owner_hint": "governance-ops",
+        "policy_domain": policy_domain,
+    }
+
+
+def _build_governance_payload(ns: argparse.Namespace) -> dict[str, Any]:
     docs_index = Path(ns.docs_index)
-    index_exists = docs_index.is_file()
-    checks.append({"id": "docs_index_exists", "ok": index_exists, "path": str(docs_index)})
-    index_text = docs_index.read_text(encoding="utf-8") if index_exists else ""
-    if not index_exists:
-        failures.append("missing docs/index.md")
+    operator = Path(ns.operator_essentials)
 
+    docs_index_text = docs_index.read_text(encoding="utf-8") if docs_index.is_file() else ""
+    operator_text = operator.read_text(encoding="utf-8") if operator.is_file() else ""
+
+    checks: list[dict[str, Any]] = []
+    checks.append(
+        _check_row(
+            check_id="docs_index_exists",
+            ok=docs_index.is_file(),
+            evidence_refs=[str(docs_index)],
+            policy_domain="contract",
+        )
+    )
     for link in REQUIRED_INDEX_LINKS:
-        present = link in index_text
-        checks.append({"id": f"index_has::{link}", "ok": present})
-        if not present:
-            failures.append(f"docs/index.md missing governance link: {link}")
+        checks.append(
+            _check_row(
+                check_id=f"docs_index_link::{link}",
+                ok=link in docs_index_text,
+                evidence_refs=[str(docs_index), link],
+                policy_domain="contract",
+            )
+        )
 
     for path_text in REQUIRED_GOV_DOCS:
         p = Path(path_text)
-        exists = p.is_file()
-        checks.append({"id": f"gov_doc_exists::{path_text}", "ok": exists})
-        if not exists:
-            failures.append(f"missing governance doc: {path_text}")
+        checks.append(
+            _check_row(
+                check_id=f"gov_doc_exists::{path_text}",
+                ok=p.is_file(),
+                evidence_refs=[path_text],
+                policy_domain="compatibility",
+            )
+        )
 
-    operator_doc = Path(ns.operator_essentials)
-    operator_exists = operator_doc.is_file()
-    checks.append({"id": "operator_essentials_exists", "ok": operator_exists, "path": str(operator_doc)})
-    operator_text = operator_doc.read_text(encoding="utf-8") if operator_exists else ""
-    if not operator_exists:
-        failures.append("missing docs/operator-essentials.md")
-
+    checks.append(
+        _check_row(
+            check_id="operator_essentials_exists",
+            ok=operator.is_file(),
+            evidence_refs=[str(operator)],
+            policy_domain="review_cadence",
+        )
+    )
     for line in REQUIRED_OPERATOR_LINES:
-        present = line in operator_text
-        checks.append({"id": f"operator_has::{line}", "ok": present})
-        if not present:
-            failures.append(f"operator essentials missing governance line: {line}")
+        checks.append(
+            _check_row(
+                check_id=f"operator_line::{line}",
+                ok=line in operator_text,
+                evidence_refs=[str(operator), line],
+                policy_domain="review_cadence",
+            )
+        )
+
+    checks.sort(key=lambda row: str(row["check_id"]))
+
+    policy_decisions = [
+        {
+            "decision_id": "phase4.compatibility.boundary.v1",
+            "policy_id": "compatibility-boundary",
+            "disposition": "accepted",
+            "rationale_code": "compatibility_commitment",
+            "impact_tier": "now",
+        },
+        {
+            "decision_id": "phase4.release.evidence.retention.v1",
+            "policy_id": "release-evidence-retention",
+            "disposition": "accepted",
+            "rationale_code": "audit_readiness",
+            "impact_tier": "next",
+        },
+    ]
+    policy_decisions.sort(key=lambda row: str(row["decision_id"]))
+
+    compatibility_contract = {
+        "supported_tiers": ["tier0", "tier1", "tier2"],
+        "deprecation_boundaries": [
+            "No tier removal without one release-cycle notice.",
+            "Public CLI aliases remain available for one major cycle.",
+        ],
+        "compatibility_guards": [
+            "make phase3-quality-contract",
+            "make phase4-governance-contract",
+        ],
+    }
+    compatibility_contract["supported_tiers"] = _sorted_unique(compatibility_contract["supported_tiers"])
+    compatibility_contract["deprecation_boundaries"] = _sorted_unique(
+        compatibility_contract["deprecation_boundaries"]
+    )
+    compatibility_contract["compatibility_guards"] = _sorted_unique(
+        compatibility_contract["compatibility_guards"]
+    )
+
+    release_evidence_contract = {
+        "required_artifacts": _sorted_unique(
+            [
+                *REQUIRED_GOV_DOCS,
+                str(operator),
+                str(docs_index),
+            ]
+        ),
+        "retention_window_days": 90,
+        "auditability_status": "pass",
+    }
+
+    failures = _validate_policy_and_compatibility(
+        governance_checks=checks,
+        policy_decisions=policy_decisions,
+        compatibility_contract=compatibility_contract,
+        release_evidence_contract=release_evidence_contract,
+    )
+
+    legacy_checks = [
+        {
+            "id": row["check_id"],
+            "ok": row["status"] == "pass",
+            "reason_code": row["reason_code"],
+        }
+        for row in checks
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "legacy_schema_version": LEGACY_SCHEMA_VERSION,
+        "migration_note": "v2 adds governance_checks/policy_decisions and dual-writes legacy checks.",
+        "governance_checks": checks,
+        "policy_decisions": policy_decisions,
+        "compatibility_contract": compatibility_contract,
+        "release_evidence_contract": release_evidence_contract,
+        "generated_at": _now_utc(),
+        # one-cycle legacy bridge
+        "ok": not failures,
+        "checks": legacy_checks,
+        "failures": failures,
+    }
+
+
+def _render_release_evidence_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Phase 4 release evidence",
+        "",
+        f"- schema_version: `{payload.get('schema_version', '')}`",
+        f"- evidence_status: `{payload.get('evidence_status', '')}`",
+        f"- retention_window_days: `{payload.get('retention_window_days', '')}`",
+        "",
+        "## Required artifacts",
+    ]
+    for item in payload.get("required_artifacts", []):
+        lines.append(f"- `{item}`")
+    lines.append("")
+    lines.append("## Missing artifacts")
+    missing = payload.get("missing_artifacts", [])
+    if missing:
+        for item in missing:
+            lines.append(f"- `{item}`")
+    else:
+        lines.append("- none")
+    lines.append("")
+    lines.append(f"- generated_at: `{payload.get('generated_at', '')}`")
+    return "\n".join(lines) + "\n"
+
+
+def _build_release_evidence(governance_payload: dict[str, Any]) -> dict[str, Any]:
+    contract = governance_payload.get("release_evidence_contract", {})
+    required = _sorted_unique(list(contract.get("required_artifacts", [])))
+    discovered = _sorted_unique([path for path in required if Path(path).is_file()])
+    missing = _sorted_unique(sorted(set(required) - set(discovered)))
+    evidence_status = "complete" if not missing else "incomplete"
+    return {
+        "schema_version": RELEASE_EVIDENCE_SCHEMA_VERSION,
+        "required_artifacts": required,
+        "discovered_artifacts": discovered,
+        "missing_artifacts": missing,
+        "retention_window_days": int(contract.get("retention_window_days", 0) or 0),
+        "evidence_status": evidence_status,
+        "generated_at": _now_utc(),
+    }
+
+
+def _build_adherence_payload(ns: argparse.Namespace) -> tuple[dict[str, Any], list[str]]:
+    blockers: list[str] = []
+    recommendations: list[str] = []
+    adherence_failures: list[str] = []
+    review_cadence_days = int(ns.review_cadence_days)
+    last_review_at = str(ns.last_review_at or "").strip()
+    next_due = ""
+    adherence_status = "unknown"
+
+    if not last_review_at:
+        blockers.append("last_review_at_missing")
+        recommendations.append("Set --last-review-at (YYYY-MM-DD) to enable schedule tracking.")
+        recommendations.append("Run governance review and update adherence artifact in CI.")
+    else:
+        try:
+            review_date = date.fromisoformat(last_review_at)
+        except ValueError:
+            blockers.append("last_review_at_invalid")
+            adherence_failures.append("last_review_at must use YYYY-MM-DD")
+            recommendations.append("Fix --last-review-at format to YYYY-MM-DD.")
+        else:
+            next_due_date = review_date + timedelta(days=review_cadence_days)
+            next_due = next_due_date.isoformat()
+            today = datetime.now(UTC).date()
+            delta = (next_due_date - today).days
+            if delta > 0:
+                adherence_status = "on_track"
+            elif delta == 0:
+                adherence_status = "due"
+                recommendations.append("Complete governance review today.")
+            else:
+                adherence_status = "overdue"
+                blockers.append("review_cadence_breached")
+                recommendations.append("Run governance review immediately and record signoff.")
+
+    return {
+        "schema_version": ADHERENCE_SCHEMA_VERSION,
+        "review_cadence_days": review_cadence_days,
+        "last_review_at": last_review_at,
+        "next_review_due_at": next_due,
+        "adherence_status": adherence_status,
+        "blockers": _sorted_unique(blockers),
+        "recommended_actions": _sorted_unique(recommendations),
+    }, _sorted_unique(adherence_failures)
+
+
+def _validate_policy_and_compatibility(
+    *,
+    governance_checks: list[dict[str, Any]],
+    policy_decisions: list[dict[str, Any]],
+    compatibility_contract: dict[str, Any],
+    release_evidence_contract: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+
+    for row in governance_checks:
+        if str(row.get("status", "")) not in ALLOWED_CHECK_STATUSES:
+            failures.append(f"invalid governance_checks.status: {row.get('status')}")
+        if str(row.get("reason_code", "")) not in REASON_CODES:
+            failures.append(f"invalid governance_checks.reason_code: {row.get('reason_code')}")
+        evidence = row.get("evidence_refs", [])
+        if not isinstance(evidence, list) or not evidence:
+            failures.append(f"missing governance_checks.evidence_refs for {row.get('check_id')}")
+        if str(row.get("policy_domain", "")) not in ALLOWED_POLICY_DOMAINS:
+            failures.append(f"invalid governance_checks.policy_domain: {row.get('policy_domain')}")
+
+    for row in policy_decisions:
+        if str(row.get("disposition", "")) not in ALLOWED_DECISION_DISPOSITIONS:
+            failures.append(f"invalid policy_decisions.disposition: {row.get('decision_id')}")
+        if str(row.get("rationale_code", "")) not in RATIONALE_CODES:
+            failures.append(f"missing/invalid policy_decisions.rationale_code: {row.get('decision_id')}")
+        if str(row.get("impact_tier", "")) not in ALLOWED_IMPACT_TIERS:
+            failures.append(f"missing/invalid policy_decisions.impact_tier: {row.get('decision_id')}")
+
+    if not compatibility_contract.get("deprecation_boundaries"):
+        failures.append("compatibility_contract.deprecation_boundaries missing/empty")
+    if not compatibility_contract.get("compatibility_guards"):
+        failures.append("compatibility_contract.compatibility_guards missing/empty")
+
+    artifacts = release_evidence_contract.get("required_artifacts", [])
+    if not isinstance(artifacts, list) or not artifacts:
+        failures.append("release_evidence_contract.required_artifacts missing/empty")
+    if int(release_evidence_contract.get("retention_window_days", 0) or 0) <= 0:
+        failures.append("release_evidence_contract.retention_window_days missing/invalid")
+
+    return _sorted_unique(failures)
+
+
+def _validate_deterministic_dict_list(payload: dict[str, Any], key: str, sort_key: str) -> list[str]:
+    rows = payload.get(key)
+    if not isinstance(rows, list):
+        return [f"{key} must be a list"]
+    if not all(isinstance(row, dict) for row in rows):
+        return [f"{key} rows must be objects"]
+    expected = sorted(rows, key=lambda row: str(row.get(sort_key, "")))
+    if rows != expected:
+        return [f"{key} not deterministically sorted"]
+    return []
+
+
+def _validate_output_contracts(
+    governance_payload: dict[str, Any],
+    release_payload: dict[str, Any],
+    adherence_payload: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+
+    for key in (
+        "schema_version",
+        "governance_checks",
+        "policy_decisions",
+        "compatibility_contract",
+        "release_evidence_contract",
+        "generated_at",
+    ):
+        if key not in governance_payload:
+            failures.append(f"governance payload missing key: {key}")
+
+    governance_checks = governance_payload.get("governance_checks", [])
+    policy_decisions = governance_payload.get("policy_decisions", [])
+    compatibility_contract = governance_payload.get("compatibility_contract", {})
+    release_evidence_contract = governance_payload.get("release_evidence_contract", {})
+
+    if not isinstance(compatibility_contract, dict):
+        failures.append("compatibility_contract must be an object")
+    if not isinstance(release_evidence_contract, dict):
+        failures.append("release_evidence_contract must be an object")
+
+    if isinstance(governance_checks, list) and isinstance(policy_decisions, list):
+        failures.extend(
+            _validate_policy_and_compatibility(
+                governance_checks=list(governance_checks),
+                policy_decisions=list(policy_decisions),
+                compatibility_contract=(
+                    dict(compatibility_contract) if isinstance(compatibility_contract, dict) else {}
+                ),
+                release_evidence_contract=(
+                    dict(release_evidence_contract) if isinstance(release_evidence_contract, dict) else {}
+                ),
+            )
+        )
+
+    failures.extend(_validate_deterministic_dict_list(governance_payload, "governance_checks", "check_id"))
+    failures.extend(_validate_deterministic_dict_list(governance_payload, "policy_decisions", "decision_id"))
+
+    for key in (
+        "schema_version",
+        "required_artifacts",
+        "discovered_artifacts",
+        "missing_artifacts",
+        "retention_window_days",
+        "evidence_status",
+        "generated_at",
+    ):
+        if key not in release_payload:
+            failures.append(f"release evidence missing key: {key}")
+    for list_key in ("required_artifacts", "discovered_artifacts", "missing_artifacts"):
+        rows = release_payload.get(list_key, [])
+        if not isinstance(rows, list) or rows != sorted(rows):
+            failures.append(f"release evidence {list_key} must be sorted list")
+    if str(release_payload.get("evidence_status", "")) not in ALLOWED_EVIDENCE_STATUSES:
+        failures.append(f"invalid release evidence status: {release_payload.get('evidence_status')}")
+
+    for key in (
+        "schema_version",
+        "review_cadence_days",
+        "last_review_at",
+        "next_review_due_at",
+        "adherence_status",
+        "blockers",
+        "recommended_actions",
+    ):
+        if key not in adherence_payload:
+            failures.append(f"adherence payload missing key: {key}")
+    for list_key in ("blockers", "recommended_actions"):
+        rows = adherence_payload.get(list_key, [])
+        if not isinstance(rows, list) or rows != sorted(rows):
+            failures.append(f"adherence {list_key} must be sorted list")
+    if str(adherence_payload.get("adherence_status", "")) not in ALLOWED_ADHERENCE_STATUSES:
+        failures.append(f"invalid adherence status: {adherence_payload.get('adherence_status')}")
+    if not adherence_payload.get("last_review_at") and adherence_payload.get("adherence_status") != "unknown":
+        failures.append("missing last_review_at must produce unknown adherence_status")
+    if not adherence_payload.get("last_review_at") and not adherence_payload.get("recommended_actions"):
+        failures.append("missing last_review_at must provide actionable recommendations")
+
+    return _sorted_unique(failures)
+
+
+def _build_compliance_overlay_pack() -> dict[str, Any]:
+    overlays = [
+        {
+            "domain": domain,
+            "controls": [
+                f"{domain}.evidence_retention",
+                f"{domain}.compatibility_boundary",
+                f"{domain}.review_cadence",
+            ],
+            "owner_hint": "governance-ops",
+        }
+        for domain in COMPLIANCE_OVERLAY_DOMAINS
+    ]
+    overlays.sort(key=lambda row: str(row["domain"]))
+    return {
+        "schema_version": "sdetkit.phase4_compliance_overlay_pack.v1",
+        "overlays": overlays,
+        "generated_at": _now_utc(),
+    }
+
+
+def _emit_domain_overlay_files(out_dir: Path, compliance_overlay: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+    for row in compliance_overlay.get("overlays", []):
+        if not isinstance(row, dict):
+            continue
+        domain = str(row.get("domain", "")).strip()
+        if not domain:
+            continue
+        path = out_dir / f"phase4-compliance-overlay-{domain}.json"
+        _write_json(
+            path,
+            {
+                "schema_version": "sdetkit.phase4_compliance_overlay.v1",
+                "domain": domain,
+                "controls": sorted(str(item) for item in row.get("controls", [])),
+                "owner_hint": str(row.get("owner_hint", "governance-ops")),
+                "generated_at": _now_utc(),
+            },
+        )
+        paths.append(str(path))
+    return sorted(paths)
+
+
+def _build_policy_as_code_template() -> dict[str, Any]:
+    rules = [
+        {"rule_id": "compatibility.boundary", "enforcement": "required", "severity": "high"},
+        {"rule_id": "release.evidence.retention", "enforcement": "required", "severity": "high"},
+        {"rule_id": "review.cadence", "enforcement": "warn", "severity": "medium"},
+    ]
+    rules.sort(key=lambda row: str(row["rule_id"]))
+    return {
+        "schema_version": "sdetkit.phase4_policy_as_code_template.v1",
+        "target": "partner-repo",
+        "rules": rules,
+        "generated_at": _now_utc(),
+    }
+
+
+def _build_governance_drift_alerts(
+    governance_payload: dict[str, Any],
+    release_payload: dict[str, Any],
+    adherence_payload: dict[str, Any],
+    *,
+    score_by_signal: dict[str, int] | None = None,
+    drift_threshold: int = DRIFT_THRESHOLD,
+) -> dict[str, Any]:
+    alerts: list[str] = []
+    drift_score = 0
+    scores = score_by_signal or DEFAULT_DRIFT_SCORE_BY_SIGNAL
+
+    failed_checks = [
+        str(row.get("check_id", ""))
+        for row in governance_payload.get("governance_checks", [])
+        if isinstance(row, dict) and str(row.get("status", "")) != "pass"
+    ]
+    if failed_checks:
+        alerts.append(f"governance_check_failures:{','.join(sorted(failed_checks))}")
+        drift_score += int(scores.get("governance_check_failures", 0))
+
+    missing_artifacts = release_payload.get("missing_artifacts", [])
+    if isinstance(missing_artifacts, list) and missing_artifacts:
+        alerts.append(f"release_missing_artifacts:{','.join(sorted(str(x) for x in missing_artifacts))}")
+        drift_score += int(scores.get("release_missing_artifacts", 0))
+
+    adherence_status = str(adherence_payload.get("adherence_status", ""))
+    if adherence_status in {"due", "overdue", "unknown"}:
+        alerts.append(f"adherence_status:{adherence_status}")
+        drift_score += int(scores.get("adherence_status", 0))
+
+    drift_status = "drift" if drift_score >= int(drift_threshold) else "healthy"
+    return {
+        "schema_version": "sdetkit.phase4_governance_drift_alerts.v1",
+        "drift_status": drift_status,
+        "alerts": sorted(alerts),
+        "drift_score": drift_score,
+        "drift_threshold": int(drift_threshold),
+        "generated_at": _now_utc(),
+    }
+
+
+def _render_drift_alerts_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Phase 4 governance drift alerts",
+        "",
+        f"- drift_status: `{payload.get('drift_status', '')}`",
+        f"- drift_score: `{payload.get('drift_score', '')}`",
+        f"- drift_threshold: `{payload.get('drift_threshold', '')}`",
+        "",
+        "## Alerts",
+    ]
+    alerts = payload.get("alerts", [])
+    if isinstance(alerts, list) and alerts:
+        for alert in alerts:
+            lines.append(f"- `{alert}`")
+    else:
+        lines.append("- none")
+    lines.append("")
+    lines.append(f"- generated_at: `{payload.get('generated_at', '')}`")
+    return "\n".join(lines) + "\n"
+
+
+def _validate_drift_alerts(payload: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    for key in ("schema_version", "drift_status", "alerts", "drift_score", "drift_threshold", "generated_at"):
+        if key not in payload:
+            failures.append(f"drift alerts missing key: {key}")
+    alerts = payload.get("alerts", [])
+    if not isinstance(alerts, list) or alerts != sorted(alerts):
+        failures.append("drift alerts list must be sorted")
+    if str(payload.get("drift_status", "")) not in ALLOWED_DRIFT_STATUSES:
+        failures.append(f"invalid drift_status: {payload.get('drift_status')}")
+    if not isinstance(payload.get("drift_score"), int):
+        failures.append("drift_score must be int")
+    threshold_value = payload.get("drift_threshold", -1)
+    if not isinstance(threshold_value, int) or threshold_value < 0:
+        failures.append("drift_threshold must be non-negative int")
+    return _sorted_unique(failures)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--docs-index", default="docs/index.md")
+    ap.add_argument("--operator-essentials", default="docs/operator-essentials.md")
+    ap.add_argument("--out-dir", default="build/phase4-governance")
+    ap.add_argument("--review-cadence-days", type=int, default=30)
+    ap.add_argument("--last-review-at", default="")
+    ap.add_argument("--format", choices=["text", "json"], default="text")
+    ap.add_argument("--no-md", action="store_true", help="Skip phase4-release-evidence.md emission")
+    ap.add_argument("--drift-scoring-config", default="config/phase4_drift_scoring.json")
+    ap.add_argument("--drift-threshold", type=int, default=DRIFT_THRESHOLD)
+    ns = ap.parse_args(argv)
+
+    out_dir = Path(ns.out_dir)
+    governance_payload = _build_governance_payload(ns)
+    release_payload = _build_release_evidence(governance_payload)
+    adherence_payload, adherence_failures = _build_adherence_payload(ns)
+    compliance_overlay = _build_compliance_overlay_pack()
+    policy_template = _build_policy_as_code_template()
+    drift_scores = _load_drift_scoring_config(Path(ns.drift_scoring_config))
+    drift_alerts = _build_governance_drift_alerts(
+        governance_payload,
+        release_payload,
+        adherence_payload,
+        score_by_signal=drift_scores,
+        drift_threshold=max(0, int(ns.drift_threshold)),
+    )
+
+    _write_json(out_dir / "phase4-governance-contract.json", governance_payload)
+    _write_json(out_dir / "phase4-release-evidence.json", release_payload)
+    release_md_path = out_dir / "phase4-release-evidence.md"
+    if not ns.no_md:
+        release_md_path.write_text(_render_release_evidence_markdown(release_payload), encoding="utf-8")
+    _write_json(out_dir / "phase4-governance-adherence.json", adherence_payload)
+    _write_json(out_dir / "phase4-compliance-overlay-pack.json", compliance_overlay)
+    domain_overlay_paths = _emit_domain_overlay_files(out_dir, compliance_overlay)
+    _write_json(out_dir / "phase4-policy-as-code-template.json", policy_template)
+    _write_json(out_dir / "phase4-governance-drift-alerts.json", drift_alerts)
+    (out_dir / "phase4-governance-drift-alerts.md").write_text(
+        _render_drift_alerts_markdown(drift_alerts), encoding="utf-8"
+    )
+
+    failures = _validate_output_contracts(governance_payload, release_payload, adherence_payload)
+    failures.extend(_validate_drift_alerts(drift_alerts))
+    failures.extend(adherence_failures)
+    failures.extend(_sorted_unique([str(item) for item in governance_payload.get("failures", [])]))
+    check_failures = [
+        f"governance check failed: {row.get('check_id', '')}"
+        for row in governance_payload.get("governance_checks", [])
+        if isinstance(row, dict) and row.get("status") != "pass"
+    ]
+    failures.extend(_sorted_unique(check_failures))
+    failures = _sorted_unique(failures)
+
+    checks = [
+        {"id": "schema_completeness", "ok": not any("missing key" in msg for msg in failures)},
+        {
+            "id": "policy_compatibility_enforcement",
+            "ok": not any(
+                "compatibility_contract" in msg
+                or "release_evidence_contract" in msg
+                or "governance_checks" in msg
+                or "policy_decisions" in msg
+                for msg in failures
+            ),
+        },
+        {
+            "id": "release_evidence_presence_schema",
+            "ok": not any(msg.startswith("release evidence") for msg in failures),
+        },
+        {
+            "id": "adherence_presence_schema",
+            "ok": not any(msg.startswith("adherence") for msg in failures),
+        },
+        {
+            "id": "deterministic_ordering",
+            "ok": not any("sorted" in msg for msg in failures),
+        },
+        {
+            "id": "reason_rationale_vocabulary_enforced",
+            "ok": not any("reason_code" in msg or "rationale_code" in msg for msg in failures),
+        },
+        {
+            "id": "drift_alerts_schema",
+            "ok": not any(msg.startswith("drift alerts") or "drift_status" in msg for msg in failures),
+        },
+    ]
 
     payload = {
         "ok": not failures,
-        "schema_version": "sdetkit.phase4_governance_contract.v1",
+        "schema_version": SCHEMA_VERSION,
         "checks": checks,
         "failures": failures,
+        "artifacts": {
+            "governance_contract": str(out_dir / "phase4-governance-contract.json"),
+            "release_evidence": str(out_dir / "phase4-release-evidence.json"),
+            "release_evidence_markdown": str(release_md_path) if not ns.no_md else "",
+            "governance_adherence": str(out_dir / "phase4-governance-adherence.json"),
+            "compliance_overlay_pack": str(out_dir / "phase4-compliance-overlay-pack.json"),
+            "policy_as_code_template": str(out_dir / "phase4-policy-as-code-template.json"),
+            "governance_drift_alerts": str(out_dir / "phase4-governance-drift-alerts.json"),
+            "governance_drift_alerts_markdown": str(out_dir / "phase4-governance-drift-alerts.md"),
+            "compliance_overlay_domain_artifacts": domain_overlay_paths,
+        },
     }
 
     if ns.format == "json":
@@ -78,9 +726,8 @@ def main() -> int:
         print("phase4-governance-contract: OK" if payload["ok"] else "phase4-governance-contract: FAIL")
         for check in checks:
             print(f"[{'OK' if check['ok'] else 'FAIL'}] {check['id']}")
-        if failures:
-            for failure in failures:
-                print(f"- {failure}")
+        for failure in failures:
+            print(f"- {failure}")
 
     return 0 if payload["ok"] else 1
 

--- a/scripts/phase2_seed_prerequisites.py
+++ b/scripts/phase2_seed_prerequisites.py
@@ -25,6 +25,25 @@ def _write_board(path: Path, title: str) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+
+
+def _phase1_baseline_seed() -> dict:
+    return {
+        "schema_version": "sdetkit.phase1_baseline.v1",
+        "generated_at_utc": "2026-04-19T00:00:00Z",
+        "out_dir": "build/phase1-baseline",
+        "ok": True,
+        "checks": [
+            {
+                "id": "seed_baseline",
+                "ok": True,
+                "rc": 0,
+                "stdout_log": "build/phase1-baseline/seed.stdout.log",
+                "stderr_log": "build/phase1-baseline/seed.stderr.log",
+            }
+        ],
+    }
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Seed minimal prerequisites for phase2 workflows.")
     parser.add_argument("--root", default=".")
@@ -58,11 +77,13 @@ def main(argv: list[str] | None = None) -> int:
         "Phase3 preplan board",
     )
 
+    _write_json(root / "build/phase1-baseline/phase1-baseline-summary.json", _phase1_baseline_seed())
+
     print(
         json.dumps(
             {
                 "ok": True,
-                "schema_version": "sdetkit.phase2_seed_prerequisites.v1",
+                "schema_version": "sdetkit.phase2_seed_prerequisites.v2",
                 "root": str(root),
             },
             indent=2,

--- a/scripts/phase3_quality_engine.py
+++ b/scripts/phase3_quality_engine.py
@@ -58,7 +58,10 @@ REMEDIATION_ACTION_KEYS = (
 def load_json(path: Path) -> dict[str, Any]:
     if not path.is_file():
         return {}
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
     return payload if isinstance(payload, dict) else {}
 
 

--- a/tests/test_phase2_seed_prerequisites.py
+++ b/tests/test_phase2_seed_prerequisites.py
@@ -18,3 +18,15 @@ def test_seed_prerequisites_writes_required_inputs(tmp_path: Path) -> None:
     assert (
         tmp_path / "docs/artifacts/phase3-preplan-closeout-pack/phase3-preplan-closeout-summary.json"
     ).exists()
+
+
+def test_seed_prerequisites_writes_phase1_baseline_summary_for_phase3_contract(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("", encoding="utf-8")
+    rc = phase2_seed_prerequisites.main(["--root", str(tmp_path)])
+    assert rc == 0
+    summary = tmp_path / "build/phase1-baseline/phase1-baseline-summary.json"
+    assert summary.exists()
+
+    payload = __import__("json").loads(summary.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.phase1_baseline.v1"
+    assert isinstance(payload["checks"], list) and payload["checks"]

--- a/tests/test_phase3_quality_contract.py
+++ b/tests/test_phase3_quality_contract.py
@@ -373,3 +373,22 @@ def test_phase3_quality_contract_module_invocation_strict_mismatch_fails(tmp_pat
     assert completed.returncode == 1
     assert payload["decision"] == "fail"
     assert "doctor handoff alignment mismatch" in payload["failures"]
+
+
+def test_phase3_quality_contract_ignores_malformed_history_previous_summary(tmp_path: Path, capsys) -> None:
+    summary = _write_summary(
+        tmp_path / "phase1-baseline-summary.json",
+        [{"id": "doctor", "ok": True, "rc": 0, "stdout_log": "a", "stderr_log": "b"}],
+    )
+    bad_history = tmp_path / "history" / "phase1-baseline-summary-latest.json"
+    bad_history.parent.mkdir(parents=True, exist_ok=True)
+    bad_history.write_text("{not-json", encoding="utf-8")
+
+    out_dir = tmp_path / "phase3"
+    rc = contract.main(["--summary", str(summary), "--out-dir", str(out_dir), "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+    trend = json.loads((out_dir / "phase3-trend-delta.json").read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert payload["ok"] is True
+    assert trend["status"] == "bootstrap"

--- a/tests/test_phase4_governance_adherence.py
+++ b/tests/test_phase4_governance_adherence.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import argparse
+
+from scripts import check_phase4_governance_contract as contract
+
+
+def test_adherence_missing_review_timestamp_is_unknown_with_actions() -> None:
+    payload, failures = contract._build_adherence_payload(
+        argparse.Namespace(review_cadence_days=30, last_review_at="")
+    )
+    assert payload["adherence_status"] == "unknown"
+    assert failures == []
+    assert payload["recommended_actions"]
+
+
+def test_adherence_sorted_lists_and_due_state() -> None:
+    payload, failures = contract._build_adherence_payload(
+        argparse.Namespace(review_cadence_days=30, last_review_at="2026-04-19")
+    )
+    assert failures == []
+    assert payload["blockers"] == sorted(payload["blockers"])
+    assert payload["recommended_actions"] == sorted(payload["recommended_actions"])
+    assert payload["adherence_status"] in {"on_track", "due", "overdue"}
+
+
+def test_adherence_invalid_review_timestamp_flags_failure() -> None:
+    payload, failures = contract._build_adherence_payload(
+        argparse.Namespace(review_cadence_days=30, last_review_at="04/19/2026")
+    )
+    assert payload["adherence_status"] == "unknown"
+    assert "last_review_at must use YYYY-MM-DD" in failures

--- a/tests/test_phase4_governance_contract.py
+++ b/tests/test_phase4_governance_contract.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import check_phase4_governance_contract as contract
+
+
+def _write_baseline_docs(root: Path) -> None:
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "\n".join(
+            [
+                "# index",
+                "- [Versioning and support posture](versioning-and-support.md)",
+                "- [Stability levels](stability-levels.md)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "docs/operator-essentials.md").write_text(
+        "\n".join(
+            [
+                "make phase4-governance-contract",
+                "python scripts/validate_enterprise_contracts.py",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    for name in (
+        "versioning-and-support.md",
+        "stability-levels.md",
+        "integrations-and-extension-boundary.md",
+    ):
+        (root / "docs" / name).write_text("ok\n", encoding="utf-8")
+
+
+def test_phase4_governance_contract_positive_path(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    rc = contract.main(["--format", "json", "--last-review-at", "2026-04-01"])
+    assert rc == 0
+
+    payload = json.loads((tmp_path / "build/phase4-governance/phase4-governance-contract.json").read_text())
+    assert payload["schema_version"] == "sdetkit.phase4_governance_contract.v2"
+    assert payload["legacy_schema_version"] == "sdetkit.phase4_governance_contract.v1"
+    assert payload["governance_checks"] == sorted(payload["governance_checks"], key=lambda r: r["check_id"])
+    assert payload["policy_decisions"] == sorted(payload["policy_decisions"], key=lambda r: r["decision_id"])
+
+
+def test_phase4_governance_contract_missing_docs_fails(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    (tmp_path / "docs/stability-levels.md").unlink()
+    monkeypatch.chdir(tmp_path)
+
+    rc = contract.main(["--format", "json", "--last-review-at", "2026-04-01"])
+    assert rc == 1
+
+
+def test_phase4_governance_contract_invalid_last_review_date_fails(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    rc = contract.main(["--format", "json", "--last-review-at", "04/01/2026"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert "last_review_at must use YYYY-MM-DD" in payload["failures"]
+
+
+def test_phase4_validate_output_contracts_handles_invalid_row_types() -> None:
+    failures = contract._validate_output_contracts(
+        governance_payload={
+            "schema_version": "sdetkit.phase4_governance_contract.v2",
+            "governance_checks": ["not-an-object"],
+            "policy_decisions": "not-a-list",
+            "compatibility_contract": {},
+            "release_evidence_contract": {},
+            "generated_at": "2026-04-19T00:00:00Z",
+        },
+        release_payload={
+            "schema_version": "sdetkit.phase4_release_evidence.v1",
+            "required_artifacts": [],
+            "discovered_artifacts": [],
+            "missing_artifacts": [],
+            "retention_window_days": 90,
+            "evidence_status": "complete",
+            "generated_at": "2026-04-19T00:00:00Z",
+        },
+        adherence_payload={
+            "schema_version": "sdetkit.phase4_governance_adherence.v1",
+            "review_cadence_days": 30,
+            "last_review_at": "",
+            "next_review_due_at": "",
+            "adherence_status": "unknown",
+            "blockers": [],
+            "recommended_actions": ["set review"],
+        },
+    )
+
+    assert "governance_checks rows must be objects" in failures
+    assert "policy_decisions must be a list" in failures
+
+
+def test_phase4_validate_output_contracts_flags_unsorted_policy_decisions() -> None:
+    failures = contract._validate_output_contracts(
+        governance_payload={
+            "schema_version": "sdetkit.phase4_governance_contract.v2",
+            "governance_checks": [],
+            "policy_decisions": [
+                {"decision_id": "z", "disposition": "accepted", "rationale_code": "audit_readiness", "impact_tier": "now"},
+                {"decision_id": "a", "disposition": "accepted", "rationale_code": "audit_readiness", "impact_tier": "now"},
+            ],
+            "compatibility_contract": {"deprecation_boundaries": ["x"], "compatibility_guards": ["y"]},
+            "release_evidence_contract": {"required_artifacts": ["docs/index.md"], "retention_window_days": 10},
+            "generated_at": "2026-04-19T00:00:00Z",
+        },
+        release_payload={
+            "schema_version": "sdetkit.phase4_release_evidence.v1",
+            "required_artifacts": ["docs/index.md"],
+            "discovered_artifacts": [],
+            "missing_artifacts": ["docs/index.md"],
+            "retention_window_days": 10,
+            "evidence_status": "incomplete",
+            "generated_at": "2026-04-19T00:00:00Z",
+        },
+        adherence_payload={
+            "schema_version": "sdetkit.phase4_governance_adherence.v1",
+            "review_cadence_days": 30,
+            "last_review_at": "",
+            "next_review_due_at": "",
+            "adherence_status": "unknown",
+            "blockers": [],
+            "recommended_actions": ["set review"],
+        },
+    )
+
+    assert "policy_decisions not deterministically sorted" in failures
+
+
+def test_phase4_validate_output_contracts_flags_release_contract_type() -> None:
+    failures = contract._validate_output_contracts(
+        governance_payload={
+            "schema_version": "sdetkit.phase4_governance_contract.v2",
+            "governance_checks": [],
+            "policy_decisions": [],
+            "compatibility_contract": {},
+            "release_evidence_contract": "not-an-object",
+            "generated_at": "2026-04-19T00:00:00Z",
+        },
+        release_payload={
+            "schema_version": "sdetkit.phase4_release_evidence.v1",
+            "required_artifacts": [],
+            "discovered_artifacts": [],
+            "missing_artifacts": [],
+            "retention_window_days": 90,
+            "evidence_status": "complete",
+            "generated_at": "2026-04-19T00:00:00Z",
+        },
+        adherence_payload={
+            "schema_version": "sdetkit.phase4_governance_adherence.v1",
+            "review_cadence_days": 30,
+            "last_review_at": "",
+            "next_review_due_at": "",
+            "adherence_status": "unknown",
+            "blockers": [],
+            "recommended_actions": ["set review"],
+        },
+    )
+
+    assert "release_evidence_contract must be an object" in failures
+
+
+def test_phase4_validate_output_contracts_flags_compatibility_contract_type() -> None:
+    failures = contract._validate_output_contracts(
+        governance_payload={
+            "schema_version": "sdetkit.phase4_governance_contract.v2",
+            "governance_checks": [],
+            "policy_decisions": [],
+            "compatibility_contract": "not-an-object",
+            "release_evidence_contract": {},
+            "generated_at": "2026-04-19T00:00:00Z",
+        },
+        release_payload={
+            "schema_version": "sdetkit.phase4_release_evidence.v1",
+            "required_artifacts": [],
+            "discovered_artifacts": [],
+            "missing_artifacts": [],
+            "retention_window_days": 90,
+            "evidence_status": "complete",
+            "generated_at": "2026-04-19T00:00:00Z",
+        },
+        adherence_payload={
+            "schema_version": "sdetkit.phase4_governance_adherence.v1",
+            "review_cadence_days": 30,
+            "last_review_at": "",
+            "next_review_due_at": "",
+            "adherence_status": "unknown",
+            "blockers": [],
+            "recommended_actions": ["set review"],
+        },
+    )
+
+    assert "compatibility_contract must be an object" in failures
+
+
+def test_phase4_main_reports_malformed_governance_check_rows(tmp_path: Path, monkeypatch, capsys) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def _bad_payload(_ns):
+        return {
+            "schema_version": "sdetkit.phase4_governance_contract.v2",
+            "governance_checks": [
+                {
+                    "check_id": "broken",
+                    "status": "pass",
+                    "reason_code": "",
+                    "evidence_refs": [],
+                    "owner_hint": "ops",
+                    "policy_domain": "contract",
+                }
+            ],
+            "policy_decisions": [
+                {
+                    "decision_id": "d1",
+                    "policy_id": "p1",
+                    "disposition": "accepted",
+                    "rationale_code": "audit_readiness",
+                    "impact_tier": "now",
+                }
+            ],
+            "compatibility_contract": {
+                "supported_tiers": ["tier0"],
+                "deprecation_boundaries": ["notice"],
+                "compatibility_guards": ["make phase4-governance-contract"],
+            },
+            "release_evidence_contract": {"required_artifacts": ["docs/index.md"], "retention_window_days": 90},
+            "generated_at": "2026-04-19T00:00:00Z",
+            "ok": True,
+            "checks": [],
+            "failures": [],
+        }
+
+    monkeypatch.setattr(contract, "_build_governance_payload", _bad_payload)
+    rc = contract.main(["--format", "json", "--last-review-at", "2026-04-01"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert any("governance_checks.reason_code" in failure for failure in payload["failures"])
+    assert any("governance_checks.evidence_refs" in failure for failure in payload["failures"])
+
+
+def test_phase4_corrupt_emitted_contract_reports_schema_errors(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert contract.main(["--format", "json", "--last-review-at", "2026-04-01"]) == 0
+
+    out_dir = tmp_path / "build/phase4-governance"
+    governance = json.loads((out_dir / "phase4-governance-contract.json").read_text(encoding="utf-8"))
+    release = json.loads((out_dir / "phase4-release-evidence.json").read_text(encoding="utf-8"))
+    adherence = json.loads((out_dir / "phase4-governance-adherence.json").read_text(encoding="utf-8"))
+
+    governance.pop("generated_at", None)
+    governance["policy_decisions"] = "invalid"
+
+    failures = contract._validate_output_contracts(governance, release, adherence)
+    assert "governance payload missing key: generated_at" in failures
+    assert "policy_decisions must be a list" in failures
+
+
+def test_phase4_governance_emits_overlay_template_and_drift_artifacts(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    rc = contract.main(["--format", "json", "--last-review-at", "2026-04-01"])
+    assert rc == 0
+
+    out_dir = tmp_path / "build/phase4-governance"
+    overlay = json.loads((out_dir / "phase4-compliance-overlay-pack.json").read_text(encoding="utf-8"))
+    template = json.loads((out_dir / "phase4-policy-as-code-template.json").read_text(encoding="utf-8"))
+    drift = json.loads((out_dir / "phase4-governance-drift-alerts.json").read_text(encoding="utf-8"))
+
+    assert overlay["schema_version"] == "sdetkit.phase4_compliance_overlay_pack.v1"
+    assert [row["domain"] for row in overlay["overlays"]] == sorted([row["domain"] for row in overlay["overlays"]])
+    assert template["schema_version"] == "sdetkit.phase4_policy_as_code_template.v1"
+    assert [row["rule_id"] for row in template["rules"]] == sorted([row["rule_id"] for row in template["rules"]])
+    assert drift["schema_version"] == "sdetkit.phase4_governance_drift_alerts.v1"
+    assert drift["alerts"] == sorted(drift["alerts"])
+
+
+def test_phase4_drift_alerts_detect_release_missing_artifacts() -> None:
+    drift = contract._build_governance_drift_alerts(
+        governance_payload={"governance_checks": []},
+        release_payload={"missing_artifacts": ["b", "a"]},
+        adherence_payload={"adherence_status": "on_track"},
+    )
+    assert drift["drift_status"] == "drift"
+    assert drift["drift_score"] == 2
+    assert drift["alerts"] == ["release_missing_artifacts:a,b"]
+
+
+def test_phase4_drift_threshold_treats_due_only_as_healthy() -> None:
+    drift = contract._build_governance_drift_alerts(
+        governance_payload={"governance_checks": []},
+        release_payload={"missing_artifacts": []},
+        adherence_payload={"adherence_status": "due"},
+    )
+    assert drift["drift_score"] == 1
+    assert drift["drift_status"] == "healthy"
+
+
+def test_phase4_end_to_end_artifacts_are_non_empty_json_objects(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert contract.main(["--format", "json", "--last-review-at", "2026-04-01"]) == 0
+
+    out_dir = tmp_path / "build/phase4-governance"
+    artifact_names = [
+        "phase4-governance-contract.json",
+        "phase4-release-evidence.json",
+        "phase4-governance-adherence.json",
+        "phase4-compliance-overlay-pack.json",
+        "phase4-policy-as-code-template.json",
+        "phase4-governance-drift-alerts.json",
+        "phase4-compliance-overlay-privacy.json",
+        "phase4-compliance-overlay-regulated.json",
+        "phase4-compliance-overlay-security.json",
+    ]
+    for name in artifact_names:
+        payload = json.loads((out_dir / name).read_text(encoding="utf-8"))
+        assert isinstance(payload, dict)
+        assert payload
+
+
+def test_phase4_drift_alerts_markdown_emitted(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert contract.main(["--format", "json", "--last-review-at", "2026-04-01"]) == 0
+
+    md_path = tmp_path / "build/phase4-governance/phase4-governance-drift-alerts.md"
+    assert md_path.exists()
+    text = md_path.read_text(encoding="utf-8")
+    assert "# Phase 4 governance drift alerts" in text
+    assert "drift_threshold" in text
+
+
+def test_phase4_drift_score_mapping_constant_is_applied() -> None:
+    assert contract.DEFAULT_DRIFT_SCORE_BY_SIGNAL["adherence_status"] == 1
+    drift = contract._build_governance_drift_alerts(
+        governance_payload={"governance_checks": []},
+        release_payload={"missing_artifacts": []},
+        adherence_payload={"adherence_status": "overdue"},
+    )
+    assert drift["drift_score"] == 1
+
+
+def test_phase4_drift_markdown_parity_with_json(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert contract.main(["--format", "json", "--last-review-at", "2026-04-01"]) == 0
+
+    out_dir = tmp_path / "build/phase4-governance"
+    drift = json.loads((out_dir / "phase4-governance-drift-alerts.json").read_text(encoding="utf-8"))
+    md = (out_dir / "phase4-governance-drift-alerts.md").read_text(encoding="utf-8")
+
+    assert f"`{drift['drift_status']}`" in md
+    assert f"`{drift['drift_score']}`" in md
+    for alert in drift["alerts"]:
+        assert f"`{alert}`" in md
+
+
+def test_phase4_loads_external_drift_scoring_config(tmp_path: Path) -> None:
+    cfg = tmp_path / "drift.json"
+    cfg.write_text('{"adherence_status": 3}', encoding="utf-8")
+    loaded = contract._load_drift_scoring_config(cfg)
+    assert loaded["adherence_status"] == 3
+    assert loaded["governance_check_failures"] == 2
+
+
+def test_phase4_malformed_drift_config_falls_back_to_defaults(tmp_path: Path) -> None:
+    cfg = tmp_path / "bad.json"
+    cfg.write_text('{"adherence_status":"oops"}', encoding="utf-8")
+    loaded = contract._load_drift_scoring_config(cfg)
+    assert loaded == contract.DEFAULT_DRIFT_SCORE_BY_SIGNAL
+
+
+def test_phase4_drift_threshold_cli_override(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    rc = contract.main(["--format", "json", "--drift-threshold", "1", "--last-review-at", "2026-04-01"])
+    assert rc == 0
+
+    drift = json.loads((tmp_path / "build/phase4-governance/phase4-governance-drift-alerts.json").read_text(encoding="utf-8"))
+    assert drift["drift_threshold"] == 1
+
+
+def test_phase4_negative_drift_threshold_is_clamped_to_zero(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert contract.main(["--format", "json", "--drift-threshold", "-1", "--last-review-at", "2026-04-01"]) == 0
+
+    drift = json.loads((tmp_path / "build/phase4-governance/phase4-governance-drift-alerts.json").read_text(encoding="utf-8"))
+    assert drift["drift_threshold"] == 0
+
+
+def test_phase4_validate_drift_alerts_rejects_malformed_schema() -> None:
+    failures = contract._validate_drift_alerts(
+        {
+            "schema_version": "sdetkit.phase4_governance_drift_alerts.v1",
+            "drift_status": "bad",
+            "alerts": "not-a-list",
+            "drift_score": "x",
+            "drift_threshold": -1,
+            "generated_at": "2026-04-20T00:00:00Z",
+        }
+    )
+    assert "invalid drift_status: bad" in failures
+    assert "drift alerts list must be sorted" in failures
+    assert "drift_score must be int" in failures
+    assert "drift_threshold must be non-negative int" in failures

--- a/tests/test_phase4_governance_workflow.py
+++ b/tests/test_phase4_governance_workflow.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_phase4_governance_workflow_uploads_expected_artifacts() -> None:
+    workflow = Path('.github/workflows/phase4-governance-contract.yml')
+    text = workflow.read_text(encoding='utf-8')
+    assert 'name: phase4-governance-contract' in text
+    assert 'make phase4-governance-contract' in text
+    assert 'actions/upload-artifact@v4' in text
+    assert 'build/phase4-governance/phase4-governance-contract.json' in text
+    assert 'build/phase4-governance/phase4-release-evidence.json' in text
+    assert 'build/phase4-governance/phase4-release-evidence.md' in text
+    assert 'build/phase4-governance/phase4-governance-adherence.json' in text
+    assert 'build/phase4-governance/phase4-compliance-overlay-pack.json' in text
+    assert 'build/phase4-governance/phase4-policy-as-code-template.json' in text
+    assert 'build/phase4-governance/phase4-governance-drift-alerts.json' in text
+    assert 'build/phase4-governance/phase4-compliance-overlay-security.json' in text
+    assert 'build/phase4-governance/phase4-compliance-overlay-privacy.json' in text
+    assert 'build/phase4-governance/phase4-compliance-overlay-regulated.json' in text
+    assert 'Validate exact artifact set' in text
+    assert 'phase4-governance-drift-alerts.md' in text
+    assert 'expected = {' in text
+    assert 'artifact-set mismatch' in text
+
+
+def test_phase4_workflow_artifact_entries_are_unique() -> None:
+    text = Path('.github/workflows/phase4-governance-contract.yml').read_text(encoding='utf-8')
+    upload_section = text.split('path: |', 1)[1]
+    expected = [
+        'phase4-governance-contract.json',
+        'phase4-release-evidence.json',
+        'phase4-release-evidence.md',
+        'phase4-governance-adherence.json',
+        'phase4-compliance-overlay-pack.json',
+        'phase4-policy-as-code-template.json',
+        'phase4-governance-drift-alerts.json',
+        'phase4-governance-drift-alerts.md',
+        'phase4-compliance-overlay-security.json',
+        'phase4-compliance-overlay-privacy.json',
+        'phase4-compliance-overlay-regulated.json',
+    ]
+    for name in expected:
+        assert upload_section.count(name) == 1
+
+
+def test_phase4_workflow_is_repo_ci_only() -> None:
+    text = Path('.github/workflows/phase4-governance-contract.yml').read_text(encoding='utf-8')
+    assert 'workflow_dispatch' not in text
+    assert 'pull_request:' in text
+    assert 'branches: [ main ]' in text
+    assert "config/phase4_drift_scoring.json" in text

--- a/tests/test_phase4_policy_compatibility.py
+++ b/tests/test_phase4_policy_compatibility.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from scripts import check_phase4_governance_contract as contract
+
+
+def test_policy_compatibility_validation_rejects_missing_required_fields() -> None:
+    failures = contract._validate_policy_and_compatibility(
+        governance_checks=[
+            {
+                "check_id": "c1",
+                "status": "pass",
+                "reason_code": "",
+                "evidence_refs": [],
+                "owner_hint": "ops",
+                "policy_domain": "contract",
+            }
+        ],
+        policy_decisions=[
+            {
+                "decision_id": "d1",
+                "policy_id": "p1",
+                "disposition": "accepted",
+                "rationale_code": "",
+                "impact_tier": "",
+            }
+        ],
+        compatibility_contract={
+            "supported_tiers": ["tier0"],
+            "deprecation_boundaries": [],
+            "compatibility_guards": [],
+        },
+        release_evidence_contract={"required_artifacts": [], "retention_window_days": 0},
+    )
+
+    assert any("reason_code" in failure for failure in failures)
+    assert any("rationale_code" in failure for failure in failures)
+    assert any("impact_tier" in failure for failure in failures)
+    assert any("deprecation_boundaries" in failure for failure in failures)
+    assert any("required_artifacts" in failure for failure in failures)
+    assert any("retention_window_days" in failure for failure in failures)
+
+
+def test_policy_compatibility_validation_accepts_valid_payload() -> None:
+    failures = contract._validate_policy_and_compatibility(
+        governance_checks=[
+            {
+                "check_id": "c1",
+                "status": "pass",
+                "reason_code": "contract_satisfied",
+                "evidence_refs": ["docs/index.md"],
+                "owner_hint": "ops",
+                "policy_domain": "contract",
+            }
+        ],
+        policy_decisions=[
+            {
+                "decision_id": "d1",
+                "policy_id": "p1",
+                "disposition": "accepted",
+                "rationale_code": "audit_readiness",
+                "impact_tier": "now",
+            }
+        ],
+        compatibility_contract={
+            "supported_tiers": ["tier0"],
+            "deprecation_boundaries": ["notice"],
+            "compatibility_guards": ["make phase4-governance-contract"],
+        },
+        release_evidence_contract={"required_artifacts": ["docs/index.md"], "retention_window_days": 30},
+    )
+    assert failures == []

--- a/tests/test_phase4_release_evidence.py
+++ b/tests/test_phase4_release_evidence.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import check_phase4_governance_contract as contract
+
+
+def _write_baseline_docs(root: Path) -> None:
+    (root / "docs").mkdir(parents=True, exist_ok=True)
+    (root / "docs/index.md").write_text(
+        "\n".join([
+            "# index",
+            "- [Versioning and support posture](versioning-and-support.md)",
+            "- [Stability levels](stability-levels.md)",
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "docs/operator-essentials.md").write_text(
+        "make phase4-governance-contract\npython scripts/validate_enterprise_contracts.py\n",
+        encoding="utf-8",
+    )
+    for name in ("versioning-and-support.md", "stability-levels.md", "integrations-and-extension-boundary.md"):
+        (root / "docs" / name).write_text("ok\n", encoding="utf-8")
+
+
+def test_release_evidence_complete_and_sorted(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert contract.main(["--format", "json", "--last-review-at", "2026-04-01"]) == 0
+
+    payload = json.loads((tmp_path / "build/phase4-governance/phase4-release-evidence.json").read_text())
+    assert payload["required_artifacts"] == sorted(payload["required_artifacts"])
+    assert payload["discovered_artifacts"] == sorted(payload["discovered_artifacts"])
+    assert payload["missing_artifacts"] == sorted(payload["missing_artifacts"])
+    assert payload["evidence_status"] == "complete"
+
+
+def test_release_evidence_incomplete_when_required_missing(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    (tmp_path / "docs/versioning-and-support.md").unlink()
+    monkeypatch.chdir(tmp_path)
+    contract.main(["--format", "json", "--last-review-at", "2026-04-01"])
+
+    payload = json.loads((tmp_path / "build/phase4-governance/phase4-release-evidence.json").read_text())
+    assert payload["evidence_status"] == "incomplete"
+    assert "docs/versioning-and-support.md" in payload["missing_artifacts"]
+
+
+def test_release_evidence_markdown_emitted(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert contract.main(["--format", "json", "--last-review-at", "2026-04-01"]) == 0
+
+    md_path = tmp_path / "build/phase4-governance/phase4-release-evidence.md"
+    assert md_path.exists()
+    text = md_path.read_text(encoding="utf-8")
+    assert "# Phase 4 release evidence" in text
+    assert "evidence_status" in text
+
+
+def test_release_evidence_markdown_ordering_snapshot(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert contract.main(["--format", "json", "--last-review-at", "2026-04-01"]) == 0
+
+    md_path = tmp_path / "build/phase4-governance/phase4-release-evidence.md"
+    text = md_path.read_text(encoding="utf-8")
+    expected_sequence = [
+        "# Phase 4 release evidence",
+        "## Required artifacts",
+        "`docs/index.md`",
+        "`docs/integrations-and-extension-boundary.md`",
+        "`docs/operator-essentials.md`",
+        "`docs/stability-levels.md`",
+        "`docs/versioning-and-support.md`",
+        "## Missing artifacts",
+        "- none",
+        "- generated_at:",
+    ]
+    cursor = 0
+    for token in expected_sequence:
+        pos = text.find(token, cursor)
+        assert pos >= 0
+        cursor = pos + len(token)
+
+
+def test_release_evidence_markdown_can_be_skipped(tmp_path: Path, monkeypatch) -> None:
+    _write_baseline_docs(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert contract.main(["--format", "json", "--no-md", "--last-review-at", "2026-04-01"]) == 0
+
+    md_path = tmp_path / "build/phase4-governance/phase4-release-evidence.md"
+    assert not md_path.exists()


### PR DESCRIPTION
### Motivation

- Introduce a Phase 4 governance contract generator and CI workflow to standardize governance artifacts, emission, and drift detection. 
- Improve robustness and schema completeness for release evidence, adherence, policy compatibility, and drift alerts.

### Description

- Add a new GitHub Actions workflow ` .github/workflows/phase4-governance-contract.yml` that runs `make phase4-governance-contract`, validates the emitted artifact set, and uploads artifacts via `actions/upload-artifact@v4`.
- Implement a full Phase 4 generator in `scripts/check_phase4_governance_contract.py` with a v2 schema (`sdetkit.phase4_governance_contract.v2`), deterministic ordering, production of multiple artifacts (governance contract, release evidence + optional markdown, adherence, compliance overlay pack + per-domain overlays, policy-as-code template, drift alerts + markdown), drift scoring configurable via `config/phase4_drift_scoring.json`, and validation helpers (`_validate_policy_and_compatibility`, `_validate_output_contracts`, `_validate_drift_alerts`).
- Add `config/phase4_drift_scoring.json` defaults and clampable CLI drift threshold support, plus improved JSON reading/writing helpers and deterministic sorting utilities.
- Update `scripts/phase2_seed_prerequisites.py` to emit a phase1 baseline seed file and bump its `schema_version` to v2 via `sdetkit.phase2_seed_prerequisites.v2`.
- Hardening: make JSON loads resilient to malformed files in `scripts/phase3_quality_engine.py` by catching `JSONDecodeError`/`OSError`.
- Add a comprehensive set of unit tests for Phase 4 functionality and workflow expectations under `tests/` (new `test_phase4_*` suites), plus adjustments to existing tests in `tests/test_phase2_seed_prerequisites.py` and `tests/test_phase3_quality_contract.py` to cover new behavior.

### Testing

- Ran the unit test suite with `pytest -q`, including new Phase 4 tests `tests/test_phase4_*.py` and updated tests `tests/test_phase2_seed_prerequisites.py` and `tests/test_phase3_quality_contract.py`. All tests passed.
- Exercised CLI flows by invoking `scripts/check_phase4_governance_contract.py` via the test harness to verify artifact emission, JSON/MD output parity, drift scoring behavior, and schema validation.
- Workflow file inspection tests validate the workflow contains the expected `make` invocation, artifact upload entries, artifact-set validation snippet, and repository-only triggers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54bc34ce483328e2f5525091731dd)