### PR TITLE
Add repo-alignment check target, make adaptive_postcheck testable, and pin upload-artifact to v4

### DIFF
--- a/.github/workflows/phase4-governance-contract.yml
+++ b/.github/workflows/phase4-governance-contract.yml
@@ -58,7 +58,7 @@ jobs:
               raise SystemExit(f"artifact-set mismatch missing={missing} extra={extra}")
           PYCODE
       - name: Upload phase4 artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: phase4-governance-artifacts
           path: |

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-premerge adaptive-ops-bundle test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-workflow phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-start phase2-workflow phase2-status phase2-start-contract phase2-seed phase2-complete phase2-progress phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-premerge adaptive-ops-bundle repo-alignment-check test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-workflow phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-start phase2-workflow phase2-status phase2-start-contract phase2-seed phase2-complete phase2-progress phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -157,6 +157,11 @@ adaptive-scenario-db: venv
 
 adaptive-ops-bundle: adaptive-postcheck enterprise-contracts-check
 	@bash -lc '. .venv/bin/activate && python scripts/build_adaptive_ops_summary.py --out-md docs/artifacts/adaptive-ops-summary-$(DATE_TAG).md --out-json docs/artifacts/adaptive-ops-summary-$(DATE_TAG).json'
+
+repo-alignment-check: venv
+	@bash -lc '. .venv/bin/activate && PYTHONPATH=src python scripts/adaptive_postcheck.py . --scenario strict --out build/repo-alignment/adaptive-postcheck.json --out-md build/repo-alignment/adaptive-postcheck.md --history-json build/repo-alignment/adaptive-history.json'
+	@bash -lc '. .venv/bin/activate && python scripts/validate_enterprise_contracts.py'
+	@bash -lc '. .venv/bin/activate && pytest -q'
 
 phase1-baseline: install
 	@bash -lc '. .venv/bin/activate && bash scripts/phase1_baseline_lane.sh'

--- a/scripts/adaptive_postcheck.py
+++ b/scripts/adaptive_postcheck.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import subprocess
+import subprocess as _subprocess
 import sys
 import tempfile
 from datetime import UTC, datetime
@@ -20,6 +20,15 @@ from typing import Any
 ROOT = Path(__file__).resolve().parent.parent
 SCENARIO_PATH = ROOT / "docs/contracts/adaptive-postcheck-scenarios.v1.json"
 SCENARIO_DB_SCRIPT = ROOT / "scripts/build_adaptive_scenario_database.py"
+
+
+class _SubprocessFacade:
+    """Local subprocess facade so tests can monkeypatch run() without global side effects."""
+
+    run = staticmethod(_subprocess.run)
+
+
+subprocess = _SubprocessFacade()
 
 
 def _local_python_env(repo_root: str) -> dict[str, str]:
@@ -148,7 +157,11 @@ def _build_fresh_scenario_database(
 
 
 def _resolve_scenario_database(
-    *, minimum: int, minimum_matrix_rows: int, refresh_when_stale: bool, persist_refresh_artifact: bool
+    *,
+    minimum: int,
+    minimum_matrix_rows: int,
+    refresh_when_stale: bool,
+    persist_refresh_artifact: bool,
 ) -> tuple[dict[str, Any] | None, str]:
     scenario_db = _load_latest_scenario_database()
     source = "latest-artifact"
@@ -259,6 +272,7 @@ def _run_alignment_checks(
         )
 
     if "agent_entries_include_engine_signals" in enabled:
+
         def _has_signals(row: Any) -> bool:
             if not isinstance(row, dict):
                 return False
@@ -352,7 +366,10 @@ def _run_alignment_checks(
 
 
 def _build_follow_up_enhancements(
-    *, checks: list[dict[str, Any]], scenario_db: dict[str, Any] | None, plan_payload: dict[str, Any] | None
+    *,
+    checks: list[dict[str, Any]],
+    scenario_db: dict[str, Any] | None,
+    plan_payload: dict[str, Any] | None,
 ) -> list[dict[str, str]]:
     by_name = {str(row.get("check", "")): row for row in checks if isinstance(row, dict)}
     summary = (scenario_db or {}).get("summary", {})
@@ -727,7 +744,9 @@ def main() -> int:
     confidence_guidance = _confidence_band(confidence_score)
     confidence_trend = "insufficient-history"
     if args.history_json:
-        history = _update_confidence_history(history_path=Path(args.history_json), score=confidence_score)
+        history = _update_confidence_history(
+            history_path=Path(args.history_json), score=confidence_score
+        )
         confidence_trend = str(history.get("trend", "insufficient-history"))
     next_plan = _next_follow_up_plan(
         confidence_band=confidence_guidance["band"],
@@ -763,9 +782,9 @@ def main() -> int:
         "scenario_database": {
             "source": scenario_db_source,
             "total_scenarios": int(
-                ((scenario_db or {}).get("summary", {}) if isinstance(scenario_db, dict) else {}).get(
-                    "total_scenarios", 0
-                )
+                (
+                    (scenario_db or {}).get("summary", {}) if isinstance(scenario_db, dict) else {}
+                ).get("total_scenarios", 0)
             ),
             "domain_confidence": domain_confidence,
         },


### PR DESCRIPTION
### Motivation
- Add a reusable repository alignment check target to the Makefile and improve testability of the adaptive postcheck script for easier automated testing and CI integration.
- Ensure the workflow uses a known `actions/upload-artifact` version to avoid unexpected behavior across runner environments.

### Description
- Added `repo-alignment-check` target to the `Makefile` and added it to the `.PHONY` list, which runs `scripts/adaptive_postcheck.py`, `scripts/validate_enterprise_contracts.py`, and `pytest -q` to produce alignment artifacts and run tests.
- Introduced a `_SubprocessFacade` in `scripts/adaptive_postcheck.py` and replaced direct `subprocess.run` usage with `subprocess.run` on the facade to allow tests to monkeypatch subprocess behavior without global side effects.
- Applied minor refactors and formatting/type-annotation tweaks in `scripts/adaptive_postcheck.py` (argument formatting, return type annotations, small expression parenthesis adjustments) with no intended change to runtime logic.
- Updated the GitHub Actions workflow `phase4-governance-contract.yml` to use `actions/upload-artifact@v4` instead of `@v7`.

### Testing
- Executed the new `repo-alignment-check` flow which runs `pytest -q` as part of its steps, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c11809e08332bfdded5ef4b88e1e)