### PR TITLE
Add unit tests for sdetkit.__main__ entrypoint behavior

### DIFF
--- a/tests/test_main_entrypoint_coverage.py
+++ b/tests/test_main_entrypoint_coverage.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import sdetkit.__main__ as entry
+
+
+def test_main_routes_cassette_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(entry.sys, "argv", ["sdetkit", "cassette-get", "demo"])
+    monkeypatch.setattr(entry, "_cassette_get", lambda argv: 7)
+
+    assert entry.main() == 7
+
+
+def test_main_cassette_get_exception_writes_stderr(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(entry.sys, "argv", ["sdetkit", "cassette-get"])
+
+    def _boom(_: list[str]) -> int:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(entry, "_cassette_get", _boom)
+
+    assert entry.main() == 2
+    assert capsys.readouterr().err == "boom\n"
+
+
+def test_main_cli_none_becomes_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(entry.sys, "argv", ["sdetkit"])
+    monkeypatch.setitem(entry.sys.modules, "sdetkit.cli", types.SimpleNamespace(main=lambda: None))
+
+    assert entry.main() == 0
+
+
+def test_main_system_exit_none_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(entry.sys, "argv", ["sdetkit"])
+
+    def _raise_none() -> int:
+        raise SystemExit(None)
+
+    monkeypatch.setitem(entry.sys.modules, "sdetkit.cli", types.SimpleNamespace(main=_raise_none))
+
+    assert entry.main() == 0
+
+
+def test_main_system_exit_int_returns_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(entry.sys, "argv", ["sdetkit"])
+
+    def _raise_int() -> int:
+        raise SystemExit(3)
+
+    monkeypatch.setitem(entry.sys.modules, "sdetkit.cli", types.SimpleNamespace(main=_raise_int))
+
+    assert entry.main() == 3
+
+
+def test_main_system_exit_text_returns_one_and_prints(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(entry.sys, "argv", ["sdetkit"])
+
+    def _raise_text() -> int:
+        raise SystemExit("bye")
+
+    monkeypatch.setitem(entry.sys.modules, "sdetkit.cli", types.SimpleNamespace(main=_raise_text))
+
+    assert entry.main() == 1
+    assert capsys.readouterr().err == "bye\n"


### PR DESCRIPTION
### Motivation
- Add coverage for the CLI entrypoint to verify routing and exit-code semantics of `sdetkit.__main__`.
- Ensure exceptions and `SystemExit` outcomes produce the expected exit codes and stderr output.

### Description
- Add new test file `tests/test_main_entrypoint_coverage.py` that uses `monkeypatch` and `capsys` to exercise `entry.main()` behavior.
- Verify that the `cassette-get` route delegates to `_cassette_get` and returns its value.
- Verify that exceptions from routed handlers result in an exit code of `2` and the exception message is written to stderr.
- Verify CLI `main` return and `SystemExit` cases produce expected numeric return codes and stderr printing for text exits.

### Testing
- Ran `pytest tests/test_main_entrypoint_coverage.py` and all added tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c7c096d08332a254bb895e07d0d5)