### PR TITLE
Improve maintenance bot issue generation and make worker artifact paths relative

### DIFF
--- a/.github/workflows/ghas-campaign-bot.yml
+++ b/.github/workflows/ghas-campaign-bot.yml
@@ -124,10 +124,20 @@ jobs:
             const configuration = await fetchRepoSecurityConfiguration();
 
             const title = `🧭 GHAS campaign planner (${weekOf})`;
-            const mapToLines = (map, label) => {
+            const mapToLines = (map, label, preferredOrder = []) => {
               if (!map || map.size === 0) return [`- ${label}: none`];
-              return [...map.entries()].sort((a, b) => String(a[0]).localeCompare(String(b[0]))).map(([key, value]) => `- ${label} ${key}: **${value}**`);
+              const rank = new Map(preferredOrder.map((name, index) => [name, index]));
+              return [...map.entries()]
+                .sort((a, b) => {
+                  const left = rank.has(a[0]) ? rank.get(a[0]) : Number.MAX_SAFE_INTEGER;
+                  const right = rank.has(b[0]) ? rank.get(b[0]) : Number.MAX_SAFE_INTEGER;
+                  if (left !== right) return left - right;
+                  return String(a[0]).localeCompare(String(b[0]));
+                })
+                .map(([key, value]) => `- ${label} ${key}: **${value}**`);
             };
+            const severityOrder = ['critical', 'high', 'medium', 'low', 'warning', 'note', 'unknown'];
+            const ageOrder = ['0-6d', '7-13d', '14-29d', '30+d', 'unknown'];
 
             const body = [
               'This issue is auto-generated to turn open GHAS alerts into actionable remediation campaigns.',
@@ -144,13 +154,13 @@ jobs:
               `- Push-protection bypassed secret alerts: **${secretSummary.bypassed}**`,
               '',
               '### Code scanning by severity',
-              ...mapToLines(codeSummary.severityCounts, 'severity'),
+              ...mapToLines(codeSummary.severityCounts, 'severity', severityOrder),
               '',
               '### Code scanning by age',
-              ...mapToLines(codeSummary.ageCounts, 'age'),
+              ...mapToLines(codeSummary.ageCounts, 'age', ageOrder),
               '',
               '### Secret scanning by age',
-              ...mapToLines(secretSummary.ageCounts, 'age'),
+              ...mapToLines(secretSummary.ageCounts, 'age', ageOrder),
               '',
               '## Security configuration context',
               configuration
@@ -164,7 +174,7 @@ jobs:
                 : '- Secret protection status: unavailable from API response.',
               '',
               '## Suggested weekly execution lane',
-              '- [ ] Create or refresh a security campaign for any 14+  code scanning backlog.',
+              '- [ ] Create or refresh a security campaign for any 14+ day code scanning backlog.',
               '- [ ] Use Copilot Autofix suggestions where available, then validate fixes in CI before merge.',
               '- [ ] Group push-protection bypass secret alerts into a focused follow-up campaign and record owner/disposition.',
               '- [ ] Link the resulting issue or PR back to this planner for traceability.',

--- a/.github/workflows/ghas-codeql-hotspots-bot.yml
+++ b/.github/workflows/ghas-codeql-hotspots-bot.yml
@@ -113,7 +113,13 @@ jobs:
 
             const topRules = [...ruleCounts.values()].sort((a, b) => b.count - a.count || b.oldest_age_days - a.oldest_age_days).slice(0, 10);
             const topFiles = [...fileCounts.values()].sort((a, b) => b.count - a.count).slice(0, 10);
-            const severitySummary = [...severityCounts.values()].sort((a, b) => b.count - a.count);
+            const severityOrder = new Map(['critical', 'high', 'medium', 'low', 'warning', 'note', 'unknown'].map((name, index) => [name, index]));
+            const severitySummary = [...severityCounts.values()].sort((a, b) => {
+              const left = severityOrder.has(a.severity) ? severityOrder.get(a.severity) : Number.MAX_SAFE_INTEGER;
+              const right = severityOrder.has(b.severity) ? severityOrder.get(b.severity) : Number.MAX_SAFE_INTEGER;
+              if (left !== right) return left - right;
+              return b.count - a.count;
+            });
             const snapshot = {
               generated_at: new Date().toISOString(),
               repository: `${owner}/${repo}`,
@@ -141,7 +147,7 @@ jobs:
               '',
               '## Top rules to batch-fix',
               ...(topRules.length
-                ? topRules.map((item) => `- **${item.rule_name}** (\`${item.key}\`, ${item.tool}) — ${item.count} open alert(s), oldest ${item.oldest_age_days} (s)`)
+                ? topRules.map((item) => `- **${item.rule_name}** (\`${item.key}\`, ${item.tool}) — ${item.count} open alert(s), oldest ${item.oldest_age_days} day(s)`)
                 : ['- No open code scanning alerts were returned.']),
               '',
               '## Top files / paths',
@@ -156,7 +162,7 @@ jobs:
               '',
               '## Suggested follow-up',
               '- [ ] Batch the top rule into one remediation PR or issue cluster.',
-              '- [ ] Start with any 14+  hotspot that touches a hot-path file.',
+              '- [ ] Start with any 14+ day hotspot that touches a hot-path file.',
               '- [ ] Re-run the GHAS campaign planner after closing the top hotspot to verify backlog reduction.',
               '',
               '## Artifact',

--- a/.github/workflows/ghas-metrics-export-bot.yml
+++ b/.github/workflows/ghas-metrics-export-bot.yml
@@ -51,6 +51,15 @@ jobs:
             };
             const notes = [];
             const dayMs = 24 * 60 * 60 * 1000;
+            const staleWorkflowDays = 14;
+
+            function ageInDays(isoAt) {
+              const at = new Date(isoAt || '').getTime();
+              if (!Number.isFinite(at)) {
+                return null;
+              }
+              return Math.max(0, Math.floor((Date.now() - at) / dayMs));
+            }
 
             async function fetchAlerts(path, label) {
               try {
@@ -122,10 +131,13 @@ jobs:
                   per_page: 1,
                 });
                 const latest = runs.data.workflow_runs?.[0];
+                const updatedAgeDays = ageInDays(latest?.updated_at);
                 workflowFreshness.push({
                   workflow: workflowFile,
                   latest_result: latest ? (latest.conclusion || latest.status || 'unknown') : 'no-runs',
                   updated_at: latest?.updated_at || null,
+                  updated_age_days: updatedAgeDays,
+                  stale_14d: updatedAgeDays !== null ? updatedAgeDays >= staleWorkflowDays : null,
                   url: latest?.html_url || `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
               } catch (error) {
@@ -134,6 +146,8 @@ jobs:
                   workflow: workflowFile,
                   latest_result: 'inspection-failed',
                   updated_at: null,
+                  updated_age_days: null,
+                  stale_14d: null,
                   url: `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
               }
@@ -193,9 +207,9 @@ jobs:
               `- Secret scanning: \`${JSON.stringify(snapshot.alerts.secret_scanning.age_buckets)}\``,
               '',
               '## Workflow freshness',
-              '| Workflow | Latest result | Updated at | Link |',
-              '| --- | --- | --- | --- |',
-              ...workflowFreshness.map((row) => `| ${row.workflow} | ${row.latest_result} | ${row.updated_at || 'n/a'} | [open](${row.url}) |`),
+              '| Workflow | Latest result | Updated at | Age (days) | 14d stale | Link |',
+              '| --- | --- | --- | --- | --- | --- |',
+              ...workflowFreshness.map((row) => `| ${row.workflow} | ${row.latest_result} | ${row.updated_at || 'n/a'} | ${row.updated_age_days ?? 'n/a'} | ${row.stale_14d === null ? 'n/a' : (row.stale_14d ? 'yes' : 'no')} | [open](${row.url}) |`),
               '',
               '## Artifact',
               '- Action artifact: `ghas-metrics-snapshot` (`build/ghas-metrics.json`)',

--- a/.github/workflows/secret-protection-review-bot.yml
+++ b/.github/workflows/secret-protection-review-bot.yml
@@ -124,6 +124,19 @@ jobs:
                 : null;
               return `- ${label}: **${raw ?? 'unavailable'}**`;
             });
+            const delegatedBypassReviewersLine = configuration && Array.isArray(configuration.secret_scanning_delegated_bypass_options?.reviewers)
+              ? `- Delegated bypass reviewers: **${configuration.secret_scanning_delegated_bypass_options.reviewers.length}**`
+              : '- Delegated bypass reviewers: unavailable.';
+            const configSection = configuration
+              ? [
+                `- Attached configuration: **${configuration.name || 'attached'}**`,
+                ...configRows,
+                delegatedBypassReviewersLine,
+              ]
+              : [
+                '- Repository code security configuration was not visible via API for this run.',
+                '- Configuration detail rows are omitted until code-security configuration access is available.',
+              ];
 
             const title = `🔑 Secret protection review (${weekOf})`;
             const body = [
@@ -140,13 +153,7 @@ jobs:
                 : ['- No open secret alerts were returned for this repository.']),
               '',
               '## Repository secret protection configuration',
-              configuration
-                ? `- Attached configuration: **${configuration.name || 'attached'}**`
-                : '- Repository code security configuration was not visible via API for this run.',
-              ...configRows,
-              configuration && Array.isArray(configuration.secret_scanning_delegated_bypass_options?.reviewers)
-                ? `- Delegated bypass reviewers: **${configuration.secret_scanning_delegated_bypass_options.reviewers.length}**`
-                : '- Delegated bypass reviewers: unavailable.',
+              ...configSection,
               '',
               '## Suggested weekly follow-up',
               '- [ ] Review every push-protection bypass alert the same week it appears and record disposition/owner.',

--- a/.github/workflows/security-maintenance-bot.yml
+++ b/.github/workflows/security-maintenance-bot.yml
@@ -99,6 +99,51 @@ jobs:
               }
             }
 
+            const openIssues = (await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            })).filter((issue) => !issue.pull_request);
+            const recentIssues = [];
+            let recentIssuePages = 0;
+            for await (const response of github.paginate.iterator(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'all',
+              per_page: 100,
+            })) {
+              recentIssues.push(...response.data.filter((issue) => !issue.pull_request));
+              recentIssuePages += 1;
+              if (recentIssuePages >= 3) {
+                break;
+              }
+            }
+            const hasLabel = (issue, label) => issue.labels?.some((entry) => {
+              if (typeof entry === 'string') {
+                return entry === label;
+              }
+              return entry?.name === label;
+            });
+            const findIssueByPrefix = (prefix) => recentIssues.find((issue) => issue.title.startsWith(prefix));
+            const relatedIssueLinks = [
+              ['GHAS digest', '🛡️ GHAS weekly digest'],
+              ['GHAS campaign planner', '🧭 GHAS campaign planner'],
+              ['GHAS alert SLA tracker', '⏱️ GHAS alert SLA tracker'],
+              ['GHAS metrics snapshot', '📊 GHAS metrics snapshot'],
+              ['GHAS CodeQL hotspots', '🧪 GHAS CodeQL hotspots'],
+              ['GHAS configuration audit', '🧱 GHAS configuration audit'],
+              ['Workflow governance audit', '🧾 Workflow governance audit'],
+              ['Secret protection review', '🔑 Secret protection review'],
+              ['Repo optimization control loop', '🧠 Repo optimization control loop'],
+              ['Dependency radar', '📡 Dependency radar + runtime watchlist'],
+            ]
+              .map(([label, prefix]) => {
+                const issue = findIssueByPrefix(prefix);
+                return issue ? `- ${label}: ${issue.html_url}` : null;
+              })
+              .filter(Boolean);
+
             const mainTitle = `🔐 Weekly security + maintenance checklist (${weekOf})`;
             const mainBody = [
               'This issue is auto-generated to keep the repository secure and continuously updated.',
@@ -109,7 +154,7 @@ jobs:
               '- [ ] Review GitHub code scanning, Dependabot, and secret-scanning alerts and close/resolution as needed.',
               '- [ ] Review the weekly GHAS digest issue and assign owners to any open high-severity findings.',
               '- [ ] Review the GHAS campaign planner issue for Copilot Autofix opportunities, alert-age slices, and push-protection bypass follow-up.',
-              '- [ ] Review the GHAS alert SLA tracker and convert every 14+  breach into an owned issue or PR.',
+              '- [ ] Review the GHAS alert SLA tracker and convert every 14+ day breach into an owned issue or PR.',
               '- [ ] Review the GHAS metrics snapshot artifact before weekly reporting or roadmap updates.',
               '- [ ] Review the GHAS CodeQL hotspots issue and batch the top rule or file into one remediation lane.',
               '- [ ] Review the latest workflow governance audit for permissions/pinning drift.',
@@ -123,21 +168,17 @@ jobs:
               '- [ ] Link roadmap updates in `docs/roadmap.md`.',
               '- [ ] Review the dependency radar issue and select at least one validation-linked upgrade candidate.',
               '',
+              '## Related weekly issue links',
+              ...(relatedIssueLinks.length ? relatedIssueLinks : ['- No related weekly issues are currently open.']),
+              '',
               '## Quick links',
               `- Code scanning: https://github.com/${owner}/${repo}/security/code-scanning`,
               `- Dependabot: https://github.com/${owner}/${repo}/security/dependabot`,
               `- Actions: https://github.com/${owner}/${repo}/actions`,
             ].join('\n');
 
-            const maintenanceIssues = await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              labels: maintenanceLabel,
-              per_page: 100,
-            });
-
-            const previousMaintenance = maintenanceIssues.data.filter((i) => i.title.startsWith('🔐 Weekly security + maintenance checklist'));
+            const maintenanceIssues = openIssues.filter((issue) => hasLabel(issue, maintenanceLabel));
+            const previousMaintenance = maintenanceIssues.filter((i) => i.title.startsWith('🔐 Weekly security + maintenance checklist'));
             for (const oldIssue of previousMaintenance) {
               if (oldIssue.title !== mainTitle) {
                 await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
@@ -170,14 +211,8 @@ jobs:
               '- Link the final implementation PR back to this issue.',
             ].join('\n');
 
-            const enhancementIssues = await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              labels: enhancementLabel,
-              per_page: 100,
-            });
-            const existingEnhancement = enhancementIssues.data.find((i) => i.title === enhancementTitle);
+            const enhancementIssues = openIssues.filter((issue) => hasLabel(issue, enhancementLabel));
+            const existingEnhancement = enhancementIssues.find((i) => i.title === enhancementTitle);
             if (!existingEnhancement) {
               await github.rest.issues.create({
                 owner,
@@ -239,7 +274,12 @@ jobs:
                   });
                 }
 
-                const conclusion = latest.conclusion || latest.status || 'unknown';
+                const status = latest.status || 'unknown';
+                if (status !== 'completed') {
+                  continue;
+                }
+
+                const conclusion = latest.conclusion || 'unknown';
                 if (!['success', 'neutral', 'skipped'].includes(conclusion)) {
                   weakSpots.push({
                     area: `Workflow health: ${workflowFile}`,
@@ -256,14 +296,8 @@ jobs:
               }
             }
 
-            const staleOpenIssues = (await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              labels: maintenanceLabel,
-              per_page: 100,
-            })).data.filter((issue) => {
-              if (issue.pull_request) return false;
+            const staleOpenIssues = openIssues.filter((issue) => {
+              if (!hasLabel(issue, maintenanceLabel)) return false;
               const updatedAt = new Date(issue.updated_at).getTime();
               return Number.isFinite(updatedAt) && now - updatedAt > staleMs;
             });
@@ -271,7 +305,7 @@ jobs:
             if (staleOpenIssues.length > 0) {
               weakSpots.push({
                 area: 'Maintenance issue hygiene',
-                observation: `${staleOpenIssues.length} maintenance issue(s) have been open with no recent updates for 14+ names.`,
+                observation: `${staleOpenIssues.length} maintenance issue(s) have been open with no recent updates for 14+ days.`,
                 suggestion: 'Close outdated trackers or convert them into actionable implementation issues with owners.',
               });
             }
@@ -294,13 +328,11 @@ jobs:
               '- [ ] Link implemented fixes back to this report and `docs/roadmap.md`.',
             ].join('\n');
 
-            const weakOpen = (await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              labels: `${maintenanceLabel},${weakSpotLabel}`,
-              per_page: 100,
-            })).data.filter((i) => i.title.startsWith('🛠️ Weekly maintenance weak-spot report'));
+            const weakOpen = openIssues.filter(
+              (issue) => hasLabel(issue, maintenanceLabel)
+                && hasLabel(issue, weakSpotLabel)
+                && issue.title.startsWith('🛠️ Weekly maintenance weak-spot report'),
+            );
 
             for (const oldIssue of weakOpen) {
               if (oldIssue.title !== weakTitle) {

--- a/.github/workflows/worker-alignment-bot.yml
+++ b/.github/workflows/worker-alignment-bot.yml
@@ -45,6 +45,7 @@ jobs:
           from pathlib import Path
 
           build = Path("build")
+          repo_root = Path.cwd()
           runs = {
               "adapter-smoke-worker": json.loads((build / "adapter-smoke-worker-run.json").read_text(encoding="utf-8")),
               "dependency-radar-worker": json.loads((build / "dependency-radar-worker-run.json").read_text(encoding="utf-8")),
@@ -63,13 +64,20 @@ jobs:
               "## Worker run status",
           ]
 
+          def display_path(raw_artifact: str) -> str:
+              artifact = Path(raw_artifact)
+              try:
+                  return str(artifact.resolve().relative_to(repo_root))
+              except ValueError:
+                  return raw_artifact
+
           for worker_id, payload in runs.items():
               artifacts = payload.get("artifacts", [])
               lines.append(
                   f"- **{worker_id}** · status `{payload.get('status', 'unknown')}` · artifacts `{len(artifacts)}`"
               )
               if artifacts:
-                  lines.append(f"  - First artifact: `{artifacts[0]}`")
+                  lines.append(f"  - First artifact: `{display_path(artifacts[0])}`")
 
           lines.extend(
               [


### PR DESCRIPTION
### Motivation
- Reduce redundant API calls and make weekly maintenance/weak-spot issue generation more accurate and informative.
- Surface related weekly issue links in the maintenance checklist and correct wording around "14+ day" staleness.
- Avoid false positive workflow failures by only evaluating completed workflow runs for conclusions.
- Make artifact paths in the worker alignment report human-readable by resolving them relative to the repository root.

### Description
- Replace multiple `issues.listForRepo` calls with paginated collection using `github.paginate` to build `openIssues` and a limited `recentIssues` set, and add helpers `hasLabel` and `findIssueByPrefix` to filter and match issues.
- Add `related weekly issue links` to the main maintenance issue body, correct typos to "14+ day(s)", and update logic to close/replace prior maintenance and weak-spot issues based on title comparisons.
- Ensure workflow health checks skip non-`completed` runs by checking `latest.status` before using `latest.conclusion`, and compute stale maintenance issues by filtering `openIssues` with `hasLabel`.
- In `worker-alignment-bot.yml` add `repo_root` and a `display_path` function that resolves artifact paths relative to the repo root and use it when reporting the first artifact.

### Testing
- No automated unit tests were added or modified as part of this change.
- These edits are to GitHub Actions workflow files and will be validated/executed by CI when the workflows run; no CI run results are included in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6f06f6ae08332811cfd57b3537330)