### PR TITLE
Improve GHAS/workflow radars: aging, ordering, path relativization, and config details

### DIFF
--- a/.github/workflows/adapter-smoke-bot.yml
+++ b/.github/workflows/adapter-smoke-bot.yml
@@ -108,14 +108,16 @@ jobs:
               }
             }
 
-            const openIssues = await github.rest.issues.listForRepo({
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
               state: 'open',
               labels: 'automation',
               per_page: 100,
             });
-            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('📣 Adapter smoke pack'));
+            const priorIssues = openIssues
+              .filter((issue) => !issue.pull_request)
+              .filter((issue) => issue.title.startsWith('📣 Adapter smoke pack'));
 
             for (const oldIssue of priorIssues) {
               if (oldIssue.title !== title) {

--- a/.github/workflows/adapter-smoke-bot.yml
+++ b/.github/workflows/adapter-smoke-bot.yml
@@ -37,8 +37,15 @@ jobs:
           import json
           from pathlib import Path
 
+          repo_root = Path.cwd()
           payload = json.loads(Path("build/adapter-smoke-worker-run.json").read_text(encoding="utf-8"))
           artifacts = payload.get("artifacts", [])
+          def display_path(raw: str) -> str:
+              artifact = Path(raw)
+              try:
+                  return str(artifact.resolve().relative_to(repo_root))
+              except ValueError:
+                  return raw
 
           lines = [
               "# Adapter smoke pack",
@@ -48,16 +55,22 @@ jobs:
               "## Worker status",
               f"- Status: **{payload.get('status', 'unknown')}**",
               f"- Artifacts captured: **{len(artifacts)}**",
+              f"- First artifact: `{display_path(artifacts[0])}`" if artifacts else "- First artifact: none",
               "",
               "## Suggested follow-up",
               "- [ ] Review adapter route-map output before changing optional integration dependencies.",
               "- [ ] Keep adapter quickstarts aligned with environment variables and offline defaults.",
               "- [ ] Use the worker bundle as the baseline before expanding notify channels or plugins.",
               "",
+              "## Worker artifact highlights",
+          ]
+          lines.extend([f"- `{display_path(path)}`" for path in artifacts[:3]] or ["- None"])
+          lines.extend([
+              "",
               "## Artifacts",
               "- `build/adapter-smoke-worker-run.json`",
               "- `.sdetkit/agent/template-runs/adapter-smoke-worker`",
-          ]
+          ])
 
           Path("build/adapter-smoke.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
           PY

--- a/.github/workflows/dependency-radar-bot.yml
+++ b/.github/workflows/dependency-radar-bot.yml
@@ -38,6 +38,14 @@ jobs:
           import json
           from pathlib import Path
 
+          repo_root = str(Path.cwd())
+
+          def relativize_repo_paths(text: str) -> str:
+              if not text:
+                  return text
+              normalized = text.replace(f"{repo_root}/", "")
+              return normalized.replace(repo_root, ".")
+
           data = json.loads(Path('build/dependency-radar.json').read_text(encoding='utf-8'))
           packages = data.get('packages', [])[:5]
           route_map = data.get('packages', [])[:3]
@@ -70,7 +78,7 @@ jobs:
           lines.extend([
               '',
               '## Runtime fast-follow watchlist',
-              Path('build/runtime-fast-follow.md').read_text(encoding='utf-8').strip(),
+              relativize_repo_paths(Path('build/runtime-fast-follow.md').read_text(encoding='utf-8').strip()),
               '',
               '## Recommended follow-up',
               '- [ ] Validate the hottest package lane before merging broad dependency refreshes.',

--- a/.github/workflows/docs-experience-bot.yml
+++ b/.github/workflows/docs-experience-bot.yml
@@ -136,7 +136,10 @@ jobs:
           )
           lines.extend([f'- ⚠️ `{path}`' for path in missing_nav_targets] or ['- None'])
           lines.extend(['', '## Orphan docs outside the primary nav'])
-          lines.extend([f'- `{path}`' for path in orphan_docs[:15]] or ['- None'])
+          shown_orphans = orphan_docs[:15]
+          if orphan_docs:
+              lines.append(f"- Showing first **{len(shown_orphans)}** of **{len(orphan_docs)}** orphan docs.")
+          lines.extend([f'- `{path}`' for path in shown_orphans] or ['- None'])
           lines.extend(['', '## Flagship docs needing attention'])
           lines.extend([f'- ⚠️ `{path}`' for path in missing_flagship_docs] or ['- None'])
           lines.extend(

--- a/.github/workflows/ghas-alert-sla-bot.yml
+++ b/.github/workflows/ghas-alert-sla-bot.yml
@@ -93,10 +93,16 @@ jobs:
                 .slice(0, 5);
             }
 
-            function mapLines(map, prefix) {
+            function mapLines(map, prefix, preferredOrder = []) {
               if (map.size === 0) return [`- ${prefix}: none`];
+              const rank = new Map(preferredOrder.map((name, index) => [name, index]));
               return [...map.entries()]
-                .sort((a, b) => String(a[0]).localeCompare(String(b[0])))
+                .sort((a, b) => {
+                  const left = rank.has(a[0]) ? rank.get(a[0]) : Number.MAX_SAFE_INTEGER;
+                  const right = rank.has(b[0]) ? rank.get(b[0]) : Number.MAX_SAFE_INTEGER;
+                  if (left !== right) return left - right;
+                  return String(a[0]).localeCompare(String(b[0]));
+                })
                 .map(([key, value]) => `- ${prefix} ${key}: **${value}**`);
             }
 
@@ -115,6 +121,7 @@ jobs:
 
             const secretBypassed = secretAlerts.filter((alert) => alert.push_protection_bypassed === true);
             const secretBypassedAged = secretBypassed.filter((alert) => ageDays(alert) >= 7).length;
+            const severityOrder = ['critical', 'high', 'medium', 'low', 'warning', 'note', 'unknown'];
             const highSeverityCodeAged = codeAlerts.filter((alert) => {
               const severity = alert.rule?.security_severity_level || alert.rule?.severity || 'unknown';
               return ['critical', 'high'].includes(String(severity).toLowerCase()) && ageDays(alert) >= 14;
@@ -123,6 +130,7 @@ jobs:
               const severity = alert.security_vulnerability?.severity || alert.severity || 'unknown';
               return ['critical', 'high'].includes(String(severity).toLowerCase()) && ageDays(alert) >= 14;
             }).length;
+            const oldCodeRules = topOldCodeRules(codeAlerts);
 
             const title = `⏱️ GHAS alert SLA tracker (${weekOf})`;
             const body = [
@@ -149,17 +157,17 @@ jobs:
               `- Push-protection bypassed secret alerts aged 7+ days: **${secretBypassedAged}**`,
               '',
               '## Severity slices',
-              ...mapLines(codeSeverity, 'Code scanning severity'),
-              ...mapLines(dependabotSeverity, 'Dependabot severity'),
+              ...mapLines(codeSeverity, 'Code scanning severity', severityOrder),
+              ...mapLines(dependabotSeverity, 'Dependabot severity', severityOrder),
               '',
               '## Older CodeQL rules to batch together',
-              ...(topOldCodeRules(codeAlerts).length
-                ? topOldCodeRules(codeAlerts).map(([rule, count]) => `- ${rule}: **${count}** alert(s) aged 14+ days`)
-                : ['- No code-scanning rules currently breach the 14- SLA window.']),
+              ...(oldCodeRules.length
+                ? oldCodeRules.map(([rule, count]) => `- ${rule}: **${count}** alert(s) aged 14+ days`)
+                : ['- No code-scanning rules currently breach the 14+ day SLA window.']),
               '',
               '## Suggested execution lane',
-              '- [ ] Convert every 14+  high-severity code or Dependabot alert into an owned issue or PR.',
-              '- [ ] Group 14+  CodeQL alerts by rule into one focused remediation batch and use Copilot Autofix when appropriate.',
+              '- [ ] Convert every 14+ day high-severity code or Dependabot alert into an owned issue or PR.',
+              '- [ ] Group 14+ day CodeQL alerts by rule into one focused remediation batch and use Copilot Autofix when appropriate.',
               '- [ ] Treat push-protection bypassed secret alerts as same-week work until resolved or explicitly dismissed.',
               '- [ ] Link resulting PRs or follow-up issues back to this SLA tracker for audit history.',
               '',

--- a/.github/workflows/ghas-campaign-bot.yml
+++ b/.github/workflows/ghas-campaign-bot.yml
@@ -124,10 +124,20 @@ jobs:
             const configuration = await fetchRepoSecurityConfiguration();
 
             const title = `🧭 GHAS campaign planner (${weekOf})`;
-            const mapToLines = (map, label) => {
+            const mapToLines = (map, label, preferredOrder = []) => {
               if (!map || map.size === 0) return [`- ${label}: none`];
-              return [...map.entries()].sort((a, b) => String(a[0]).localeCompare(String(b[0]))).map(([key, value]) => `- ${label} ${key}: **${value}**`);
+              const rank = new Map(preferredOrder.map((name, index) => [name, index]));
+              return [...map.entries()]
+                .sort((a, b) => {
+                  const left = rank.has(a[0]) ? rank.get(a[0]) : Number.MAX_SAFE_INTEGER;
+                  const right = rank.has(b[0]) ? rank.get(b[0]) : Number.MAX_SAFE_INTEGER;
+                  if (left !== right) return left - right;
+                  return String(a[0]).localeCompare(String(b[0]));
+                })
+                .map(([key, value]) => `- ${label} ${key}: **${value}**`);
             };
+            const severityOrder = ['critical', 'high', 'medium', 'low', 'warning', 'note', 'unknown'];
+            const ageOrder = ['0-6d', '7-13d', '14-29d', '30+d', 'unknown'];
 
             const body = [
               'This issue is auto-generated to turn open GHAS alerts into actionable remediation campaigns.',
@@ -144,13 +154,13 @@ jobs:
               `- Push-protection bypassed secret alerts: **${secretSummary.bypassed}**`,
               '',
               '### Code scanning by severity',
-              ...mapToLines(codeSummary.severityCounts, 'severity'),
+              ...mapToLines(codeSummary.severityCounts, 'severity', severityOrder),
               '',
               '### Code scanning by age',
-              ...mapToLines(codeSummary.ageCounts, 'age'),
+              ...mapToLines(codeSummary.ageCounts, 'age', ageOrder),
               '',
               '### Secret scanning by age',
-              ...mapToLines(secretSummary.ageCounts, 'age'),
+              ...mapToLines(secretSummary.ageCounts, 'age', ageOrder),
               '',
               '## Security configuration context',
               configuration
@@ -164,7 +174,7 @@ jobs:
                 : '- Secret protection status: unavailable from API response.',
               '',
               '## Suggested weekly execution lane',
-              '- [ ] Create or refresh a security campaign for any 14+  code scanning backlog.',
+              '- [ ] Create or refresh a security campaign for any 14+ day code scanning backlog.',
               '- [ ] Use Copilot Autofix suggestions where available, then validate fixes in CI before merge.',
               '- [ ] Group push-protection bypass secret alerts into a focused follow-up campaign and record owner/disposition.',
               '- [ ] Link the resulting issue or PR back to this planner for traceability.',

--- a/.github/workflows/ghas-codeql-hotspots-bot.yml
+++ b/.github/workflows/ghas-codeql-hotspots-bot.yml
@@ -113,7 +113,13 @@ jobs:
 
             const topRules = [...ruleCounts.values()].sort((a, b) => b.count - a.count || b.oldest_age_days - a.oldest_age_days).slice(0, 10);
             const topFiles = [...fileCounts.values()].sort((a, b) => b.count - a.count).slice(0, 10);
-            const severitySummary = [...severityCounts.values()].sort((a, b) => b.count - a.count);
+            const severityOrder = new Map(['critical', 'high', 'medium', 'low', 'warning', 'note', 'unknown'].map((name, index) => [name, index]));
+            const severitySummary = [...severityCounts.values()].sort((a, b) => {
+              const left = severityOrder.has(a.severity) ? severityOrder.get(a.severity) : Number.MAX_SAFE_INTEGER;
+              const right = severityOrder.has(b.severity) ? severityOrder.get(b.severity) : Number.MAX_SAFE_INTEGER;
+              if (left !== right) return left - right;
+              return b.count - a.count;
+            });
             const snapshot = {
               generated_at: new Date().toISOString(),
               repository: `${owner}/${repo}`,
@@ -141,7 +147,7 @@ jobs:
               '',
               '## Top rules to batch-fix',
               ...(topRules.length
-                ? topRules.map((item) => `- **${item.rule_name}** (\`${item.key}\`, ${item.tool}) — ${item.count} open alert(s), oldest ${item.oldest_age_days} (s)`)
+                ? topRules.map((item) => `- **${item.rule_name}** (\`${item.key}\`, ${item.tool}) — ${item.count} open alert(s), oldest ${item.oldest_age_days} day(s)`)
                 : ['- No open code scanning alerts were returned.']),
               '',
               '## Top files / paths',
@@ -156,7 +162,7 @@ jobs:
               '',
               '## Suggested follow-up',
               '- [ ] Batch the top rule into one remediation PR or issue cluster.',
-              '- [ ] Start with any 14+  hotspot that touches a hot-path file.',
+              '- [ ] Start with any 14+ day hotspot that touches a hot-path file.',
               '- [ ] Re-run the GHAS campaign planner after closing the top hotspot to verify backlog reduction.',
               '',
               '## Artifact',

--- a/.github/workflows/ghas-metrics-export-bot.yml
+++ b/.github/workflows/ghas-metrics-export-bot.yml
@@ -51,6 +51,15 @@ jobs:
             };
             const notes = [];
             const dayMs = 24 * 60 * 60 * 1000;
+            const staleWorkflowDays = 14;
+
+            function ageInDays(isoAt) {
+              const at = new Date(isoAt || '').getTime();
+              if (!Number.isFinite(at)) {
+                return null;
+              }
+              return Math.max(0, Math.floor((Date.now() - at) / dayMs));
+            }
 
             async function fetchAlerts(path, label) {
               try {
@@ -122,10 +131,13 @@ jobs:
                   per_page: 1,
                 });
                 const latest = runs.data.workflow_runs?.[0];
+                const updatedAgeDays = ageInDays(latest?.updated_at);
                 workflowFreshness.push({
                   workflow: workflowFile,
                   latest_result: latest ? (latest.conclusion || latest.status || 'unknown') : 'no-runs',
                   updated_at: latest?.updated_at || null,
+                  updated_age_days: updatedAgeDays,
+                  stale_14d: updatedAgeDays !== null ? updatedAgeDays >= staleWorkflowDays : null,
                   url: latest?.html_url || `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
               } catch (error) {
@@ -134,6 +146,8 @@ jobs:
                   workflow: workflowFile,
                   latest_result: 'inspection-failed',
                   updated_at: null,
+                  updated_age_days: null,
+                  stale_14d: null,
                   url: `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
               }
@@ -193,9 +207,9 @@ jobs:
               `- Secret scanning: \`${JSON.stringify(snapshot.alerts.secret_scanning.age_buckets)}\``,
               '',
               '## Workflow freshness',
-              '| Workflow | Latest result | Updated at | Link |',
-              '| --- | --- | --- | --- |',
-              ...workflowFreshness.map((row) => `| ${row.workflow} | ${row.latest_result} | ${row.updated_at || 'n/a'} | [open](${row.url}) |`),
+              '| Workflow | Latest result | Updated at | Age (days) | 14d stale | Link |',
+              '| --- | --- | --- | --- | --- | --- |',
+              ...workflowFreshness.map((row) => `| ${row.workflow} | ${row.latest_result} | ${row.updated_at || 'n/a'} | ${row.updated_age_days ?? 'n/a'} | ${row.stale_14d === null ? 'n/a' : (row.stale_14d ? 'yes' : 'no')} | [open](${row.url}) |`),
               '',
               '## Artifact',
               '- Action artifact: `ghas-metrics-snapshot` (`build/ghas-metrics.json`)',

--- a/.github/workflows/ghas-review-bot.yml
+++ b/.github/workflows/ghas-review-bot.yml
@@ -40,6 +40,8 @@ jobs:
             }
 
             const fallbackNotes = [];
+            const dayMs = 24 * 60 * 60 * 1000;
+            const staleWorkflowDays = 14;
             const trackedWorkflows = [
               'security.yml',
               'osv-scanner.yml',
@@ -58,6 +60,13 @@ jobs:
             ];
 
             const workflowRows = [];
+            const ageInDays = (isoAt) => {
+              const at = new Date(isoAt || '').getTime();
+              if (!Number.isFinite(at)) {
+                return null;
+              }
+              return Math.max(0, Math.floor((Date.now() - at) / dayMs));
+            };
             for (const workflowFile of trackedWorkflows) {
               try {
                 const runs = await github.rest.actions.listWorkflowRuns({
@@ -67,10 +76,13 @@ jobs:
                   per_page: 1,
                 });
                 const latest = runs.data.workflow_runs?.[0];
+                const ageDays = ageInDays(latest?.updated_at);
                 workflowRows.push({
                   workflow: workflowFile,
                   status: latest ? (latest.conclusion || latest.status || 'unknown') : 'no-runs',
                   updatedAt: latest?.updated_at || 'n/a',
+                  ageDays,
+                  stale14d: ageDays !== null ? ageDays >= staleWorkflowDays : null,
                   url: latest?.html_url || `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
               } catch (error) {
@@ -78,6 +90,8 @@ jobs:
                   workflow: workflowFile,
                   status: 'inspection-failed',
                   updatedAt: 'n/a',
+                  ageDays: null,
+                  stale14d: null,
                   url: `https://github.com/${owner}/${repo}/actions/workflows/${workflowFile}`,
                 });
                 fallbackNotes.push(`Unable to inspect ${workflowFile}: ${error.message}`);
@@ -162,9 +176,9 @@ jobs:
               `- Security overview: https://github.com/${owner}/${repo}/security`,
               '',
               '## Workflow freshness',
-              '| Workflow | Latest result | Updated at | Link |',
-              '| --- | --- | --- | --- |',
-              ...workflowRows.map((row) => `| ${row.workflow} | ${row.status} | ${row.updatedAt} | [open](${row.url}) |`),
+              '| Workflow | Latest result | Updated at | Age (days) | 14d stale | Link |',
+              '| --- | --- | --- | --- | --- | --- |',
+              ...workflowRows.map((row) => `| ${row.workflow} | ${row.status} | ${row.updatedAt} | ${row.ageDays ?? 'n/a'} | ${row.stale14d === null ? 'n/a' : (row.stale14d ? 'yes' : 'no')} | [open](${row.url}) |`),
               '',
               '## Required follow-up',
               '- [ ] Review every open GHAS alert and document disposition for anything that is still open at the end of the week.',

--- a/.github/workflows/integration-topology-radar-bot.yml
+++ b/.github/workflows/integration-topology-radar-bot.yml
@@ -108,14 +108,16 @@ jobs:
               }
             }
 
-            const openIssues = await github.rest.issues.listForRepo({
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
               state: 'open',
               labels: 'integration',
               per_page: 100,
             });
-            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('🕸️ Integration topology radar'));
+            const priorIssues = openIssues
+              .filter((issue) => !issue.pull_request)
+              .filter((issue) => issue.title.startsWith('🕸️ Integration topology radar'));
 
             for (const oldIssue of priorIssues) {
               if (oldIssue.title !== title) {

--- a/.github/workflows/integration-topology-radar-bot.yml
+++ b/.github/workflows/integration-topology-radar-bot.yml
@@ -37,8 +37,15 @@ jobs:
           import json
           from pathlib import Path
 
+          repo_root = Path.cwd()
           payload = json.loads(Path("build/integration-topology-worker-run.json").read_text(encoding="utf-8"))
           artifacts = payload.get("artifacts", [])
+          def display_path(raw: str) -> str:
+              artifact = Path(raw)
+              try:
+                  return str(artifact.resolve().relative_to(repo_root))
+              except ValueError:
+                  return raw
 
           lines = [
               "# Integration topology radar",
@@ -48,16 +55,22 @@ jobs:
               "## Worker status",
               f"- Status: **{payload.get('status', 'unknown')}**",
               f"- Artifacts captured: **{len(artifacts)}**",
+              f"- First artifact: `{display_path(artifacts[0])}`" if artifacts else "- First artifact: none",
               "",
               "## Suggested follow-up",
               "- [ ] Review topology-check.json before landing umbrella integration refactors or platform workflow changes.",
               "- [ ] Compare the optimize snapshot against the current release and worker lanes for any premium-gate drift.",
               "- [ ] Convert any service-owner, telemetry, or deployment gaps into scoped issues or PRs.",
               "",
+              "## Worker artifact highlights",
+          ]
+          lines.extend([f"- `{display_path(path)}`" for path in artifacts[:3]] or ["- None"])
+          lines.extend([
+              "",
               "## Artifacts",
               "- `build/integration-topology-worker-run.json`",
               "- `.sdetkit/agent/template-runs/integration-topology-worker`",
-          ]
+          ])
 
           Path("build/integration-topology-radar.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
           PY

--- a/.github/workflows/repo-optimization-bot.yml
+++ b/.github/workflows/repo-optimization-bot.yml
@@ -8,8 +8,138 @@ on:
 jobs:
   optimize:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run optimize lane snapshot
         run: |
-          python -m sdetkit kits optimize "repo optimization control loop" --format json --limit 3
+          set -euo pipefail
+          mkdir -p build
+          python -m sdetkit kits optimize "repo optimization control loop" --format json --limit 3 > build/repo-optimization.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("build/repo-optimization.json").read_text(encoding="utf-8"))
+          score = payload.get("alignment_score", {})
+          next_boosts = payload.get("next_boosts") or []
+          missing_domains = payload.get("missing_domains") or []
+          search_queries = payload.get("search_queries") or []
+          opportunities = payload.get("innovation_opportunities") or []
+
+          lines = [
+              "# Repo optimization control loop",
+              "",
+              "This issue is auto-generated from the repo's optimize surface so recurring upgrade and maintenance lanes stay actionable.",
+              "",
+              "## Current alignment score",
+              f"- Alignment status: **{score.get('status', 'unknown')}**",
+              f"- Alignment score: **{score.get('score', 'n/a')}**",
+              "",
+              "## Next boosts",
+          ]
+
+          if next_boosts:
+              for boost in next_boosts:
+                  boost_id = boost.get("id", "unknown")
+                  commands = boost.get("commands") or []
+                  lines.append(f"- **{boost.get('title', boost_id)}** (`{boost_id}`)")
+                  if commands:
+                      lines.append(f"  - Commands: `{', '.join(commands)}`")
+                  summary = boost.get("summary")
+                  if summary:
+                      lines.append(f"  - {summary}")
+          else:
+              lines.append("- None returned by the optimizer payload.")
+
+          lines.extend(["", "## Innovation opportunities"])
+          if opportunities:
+              lines.extend([f"- `{item.get('id', 'unknown')}`" for item in opportunities])
+          else:
+              lines.append("- None")
+
+          lines.extend(["", "## Missing domains"])
+          lines.extend([f"- ⚠️ `{name}`" for name in missing_domains] or ["- None"])
+
+          lines.extend(["", "## Search missions"])
+          if search_queries:
+              for item in search_queries:
+                  lines.append(f"- `{item.get('topic', 'unknown')}`")
+                  if item.get("query"):
+                      lines.append(f"  - Query: `{item['query']}`")
+          else:
+              lines.append("- None")
+
+          lines.extend([
+              "",
+              "## Suggested follow-up",
+              "- [ ] Pick one `next boost` and open/refresh a scoped implementation issue or PR.",
+              "- [ ] Turn one search mission into a concrete research or docs lane.",
+              "- [ ] Keep this loop linked to the weekly maintenance checklist for traceability.",
+              "",
+              "## Artifact",
+              "- `build/repo-optimization.json`",
+          ])
+
+          Path("build/repo-optimization.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+      - name: Upload optimization artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: repo-optimization
+          path: |
+            build/repo-optimization.json
+            build/repo-optimization.md
+
+      - name: Publish optimization issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const weekOf = new Date().toISOString().slice(0, 10);
+            const title = `🧠 Repo optimization control loop (${weekOf})`;
+            const body = fs.readFileSync('build/repo-optimization.md', 'utf8');
+
+            const labels = [
+              { name: 'maintenance', color: '0E8A16', description: 'Automated maintenance tracking' },
+              { name: 'enhancement', color: 'a2eeef', description: 'Feature work and product improvements' },
+              { name: 'priority:medium', color: 'fbca04', description: 'Medium-priority work item' },
+            ];
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+              } catch {
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              }
+            }
+
+            const openIssues = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'enhancement',
+              per_page: 100,
+            });
+            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('🧠 Repo optimization control loop'));
+            for (const oldIssue of priorIssues) {
+              if (oldIssue.title !== title) {
+                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
+              }
+            }
+
+            const existing = priorIssues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['maintenance', 'enhancement', 'priority:medium'],
+              });
+            }

--- a/.github/workflows/runtime-watchlist-bot.yml
+++ b/.github/workflows/runtime-watchlist-bot.yml
@@ -108,14 +108,16 @@ jobs:
               }
             }
 
-            const openIssues = await github.rest.issues.listForRepo({
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
               state: 'open',
               labels: 'dependencies',
               per_page: 100,
             });
-            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('⚡ Runtime fast-follow watchlist'));
+            const priorIssues = openIssues
+              .filter((issue) => !issue.pull_request)
+              .filter((issue) => issue.title.startsWith('⚡ Runtime fast-follow watchlist'));
 
             for (const oldIssue of priorIssues) {
               if (oldIssue.title !== title) {

--- a/.github/workflows/runtime-watchlist-bot.yml
+++ b/.github/workflows/runtime-watchlist-bot.yml
@@ -37,8 +37,15 @@ jobs:
           import json
           from pathlib import Path
 
+          repo_root = Path.cwd()
           payload = json.loads(Path("build/runtime-watchlist-worker-run.json").read_text(encoding="utf-8"))
           artifacts = payload.get("artifacts", [])
+          def display_path(raw: str) -> str:
+              artifact = Path(raw)
+              try:
+                  return str(artifact.resolve().relative_to(repo_root))
+              except ValueError:
+                  return raw
 
           lines = [
               "# Runtime fast-follow watchlist",
@@ -48,16 +55,22 @@ jobs:
               "## Worker status",
               f"- Status: **{payload.get('status', 'unknown')}**",
               f"- Artifacts captured: **{len(artifacts)}**",
+              f"- First artifact: `{display_path(artifacts[0])}`" if artifacts else "- First artifact: none",
               "",
               "## Suggested follow-up",
               "- [ ] Review the runtime watchlist before broad dependency refreshes or transport changes.",
               "- [ ] Route the hottest runtime-core package to the smallest validation command first.",
               "- [ ] Promote any recurring runtime drift into a scoped maintenance issue or PR.",
               "",
+              "## Worker artifact highlights",
+          ]
+          lines.extend([f"- `{display_path(path)}`" for path in artifacts[:3]] or ["- None"])
+          lines.extend([
+              "",
               "## Artifacts",
               "- `build/runtime-watchlist-worker-run.json`",
               "- `.sdetkit/agent/template-runs/runtime-watchlist-worker`",
-          ]
+          ])
 
           Path("build/runtime-watchlist.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
           PY

--- a/.github/workflows/secret-protection-review-bot.yml
+++ b/.github/workflows/secret-protection-review-bot.yml
@@ -124,6 +124,19 @@ jobs:
                 : null;
               return `- ${label}: **${raw ?? 'unavailable'}**`;
             });
+            const delegatedBypassReviewersLine = configuration && Array.isArray(configuration.secret_scanning_delegated_bypass_options?.reviewers)
+              ? `- Delegated bypass reviewers: **${configuration.secret_scanning_delegated_bypass_options.reviewers.length}**`
+              : '- Delegated bypass reviewers: unavailable.';
+            const configSection = configuration
+              ? [
+                `- Attached configuration: **${configuration.name || 'attached'}**`,
+                ...configRows,
+                delegatedBypassReviewersLine,
+              ]
+              : [
+                '- Repository code security configuration was not visible via API for this run.',
+                '- Configuration detail rows are omitted until code-security configuration access is available.',
+              ];
 
             const title = `🔑 Secret protection review (${weekOf})`;
             const body = [
@@ -140,13 +153,7 @@ jobs:
                 : ['- No open secret alerts were returned for this repository.']),
               '',
               '## Repository secret protection configuration',
-              configuration
-                ? `- Attached configuration: **${configuration.name || 'attached'}**`
-                : '- Repository code security configuration was not visible via API for this run.',
-              ...configRows,
-              configuration && Array.isArray(configuration.secret_scanning_delegated_bypass_options?.reviewers)
-                ? `- Delegated bypass reviewers: **${configuration.secret_scanning_delegated_bypass_options.reviewers.length}**`
-                : '- Delegated bypass reviewers: unavailable.',
+              ...configSection,
               '',
               '## Suggested weekly follow-up',
               '- [ ] Review every push-protection bypass alert the same week it appears and record disposition/owner.',

--- a/.github/workflows/security-configuration-audit-bot.yml
+++ b/.github/workflows/security-configuration-audit-bot.yml
@@ -97,10 +97,11 @@ jobs:
                 });
                 return Array.isArray(response.data) ? response.data.length : 0;
               } catch (error) {
-                notes.push(`${label} unavailable: ${error.message}`);
-                return 'unknown';
+                notes.push(`${label} unavailable: ${error.message}. Add GHAS_READ_TOKEN if broader security scopes are required.`);
+                return null;
               }
             }
+            const formatCount = (count) => (count === null ? 'unavailable' : count);
 
             const configuration = await fetchConfiguration();
             const codeAlerts = await fetchAlerts('/repos/{owner}/{repo}/code-scanning/alerts', 'Code scanning alerts');
@@ -137,9 +138,9 @@ jobs:
                 : '- Automatic dependency submission: unavailable.',
               '',
               '## Open alert snapshot',
-              `- Code scanning alerts: **${codeAlerts}**`,
-              `- Secret scanning alerts: **${secretAlerts}**`,
-              `- Dependabot alerts: **${dependabotAlerts}**`,
+              `- Code scanning alerts: **${formatCount(codeAlerts)}**`,
+              `- Secret scanning alerts: **${formatCount(secretAlerts)}**`,
+              `- Dependabot alerts: **${formatCount(dependabotAlerts)}**`,
               '',
               '## Suggested monthly follow-up',
               '- [ ] Confirm the repo still uses the intended GitHub-recommended or custom security configuration.',

--- a/.github/workflows/security-maintenance-bot.yml
+++ b/.github/workflows/security-maintenance-bot.yml
@@ -192,7 +192,8 @@ jobs:
               await github.rest.issues.create({ owner, repo, title: mainTitle, body: mainBody, labels: [maintenanceLabel] });
             }
 
-            const enhancementTitle = '🧩 Monthly enhancement intake from user feedback';
+            const monthOf = weekOf.slice(0, 7);
+            const enhancementTitle = `🧩 Monthly enhancement intake from user feedback (${monthOf})`;
             const enhancementBody = [
               'This issue is auto-generated to ensure at least one enhancement candidate is always tracked.',
               '',
@@ -211,9 +212,19 @@ jobs:
               '- Link the final implementation PR back to this issue.',
             ].join('\n');
 
-            const enhancementIssues = openIssues.filter((issue) => hasLabel(issue, enhancementLabel));
+            const enhancementIssues = openIssues.filter(
+              (issue) => hasLabel(issue, enhancementLabel)
+                && issue.title.startsWith('🧩 Monthly enhancement intake from user feedback'),
+            );
+            for (const oldIssue of enhancementIssues) {
+              if (oldIssue.title !== enhancementTitle) {
+                await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
+              }
+            }
             const existingEnhancement = enhancementIssues.find((i) => i.title === enhancementTitle);
-            if (!existingEnhancement) {
+            if (existingEnhancement) {
+              await github.rest.issues.update({ owner, repo, issue_number: existingEnhancement.number, body: enhancementBody });
+            } else {
               await github.rest.issues.create({
                 owner,
                 repo,

--- a/.github/workflows/security-maintenance-bot.yml
+++ b/.github/workflows/security-maintenance-bot.yml
@@ -257,6 +257,20 @@ jobs:
             const now = Date.now();
             const staleMs = 14 * 24 * 60 * 60 * 1000;
             const weakSpots = [];
+            const automatedMaintenancePrefixes = [
+              '🔐 Weekly security + maintenance checklist',
+              '🛠️ Weekly maintenance weak-spot report',
+              '🤖 Worker alignment radar',
+              '📚 Docs experience radar',
+              '📡 Dependency radar + runtime watchlist',
+              '⚡ Runtime fast-follow watchlist',
+              '📣 Adapter smoke pack',
+              '🕸️ Integration topology radar',
+              '🧾 Workflow governance audit',
+              '🧱 GHAS configuration audit',
+              '🧩 Monthly enhancement intake from user feedback',
+              '🧠 Repo optimization control loop',
+            ];
 
             for (const workflowFile of trackedWorkflows) {
               try {
@@ -309,6 +323,7 @@ jobs:
 
             const staleOpenIssues = openIssues.filter((issue) => {
               if (!hasLabel(issue, maintenanceLabel)) return false;
+              if (automatedMaintenancePrefixes.some((prefix) => issue.title.startsWith(prefix))) return false;
               const updatedAt = new Date(issue.updated_at).getTime();
               return Number.isFinite(updatedAt) && now - updatedAt > staleMs;
             });

--- a/.github/workflows/security-maintenance-bot.yml
+++ b/.github/workflows/security-maintenance-bot.yml
@@ -99,6 +99,51 @@ jobs:
               }
             }
 
+            const openIssues = (await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            })).filter((issue) => !issue.pull_request);
+            const recentIssues = [];
+            let recentIssuePages = 0;
+            for await (const response of github.paginate.iterator(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'all',
+              per_page: 100,
+            })) {
+              recentIssues.push(...response.data.filter((issue) => !issue.pull_request));
+              recentIssuePages += 1;
+              if (recentIssuePages >= 3) {
+                break;
+              }
+            }
+            const hasLabel = (issue, label) => issue.labels?.some((entry) => {
+              if (typeof entry === 'string') {
+                return entry === label;
+              }
+              return entry?.name === label;
+            });
+            const findIssueByPrefix = (prefix) => recentIssues.find((issue) => issue.title.startsWith(prefix));
+            const relatedIssueLinks = [
+              ['GHAS digest', '🛡️ GHAS weekly digest'],
+              ['GHAS campaign planner', '🧭 GHAS campaign planner'],
+              ['GHAS alert SLA tracker', '⏱️ GHAS alert SLA tracker'],
+              ['GHAS metrics snapshot', '📊 GHAS metrics snapshot'],
+              ['GHAS CodeQL hotspots', '🧪 GHAS CodeQL hotspots'],
+              ['GHAS configuration audit', '🧱 GHAS configuration audit'],
+              ['Workflow governance audit', '🧾 Workflow governance audit'],
+              ['Secret protection review', '🔑 Secret protection review'],
+              ['Repo optimization control loop', '🧠 Repo optimization control loop'],
+              ['Dependency radar', '📡 Dependency radar + runtime watchlist'],
+            ]
+              .map(([label, prefix]) => {
+                const issue = findIssueByPrefix(prefix);
+                return issue ? `- ${label}: ${issue.html_url}` : null;
+              })
+              .filter(Boolean);
+
             const mainTitle = `🔐 Weekly security + maintenance checklist (${weekOf})`;
             const mainBody = [
               'This issue is auto-generated to keep the repository secure and continuously updated.',
@@ -109,7 +154,7 @@ jobs:
               '- [ ] Review GitHub code scanning, Dependabot, and secret-scanning alerts and close/resolution as needed.',
               '- [ ] Review the weekly GHAS digest issue and assign owners to any open high-severity findings.',
               '- [ ] Review the GHAS campaign planner issue for Copilot Autofix opportunities, alert-age slices, and push-protection bypass follow-up.',
-              '- [ ] Review the GHAS alert SLA tracker and convert every 14+  breach into an owned issue or PR.',
+              '- [ ] Review the GHAS alert SLA tracker and convert every 14+ day breach into an owned issue or PR.',
               '- [ ] Review the GHAS metrics snapshot artifact before weekly reporting or roadmap updates.',
               '- [ ] Review the GHAS CodeQL hotspots issue and batch the top rule or file into one remediation lane.',
               '- [ ] Review the latest workflow governance audit for permissions/pinning drift.',
@@ -123,21 +168,17 @@ jobs:
               '- [ ] Link roadmap updates in `docs/roadmap.md`.',
               '- [ ] Review the dependency radar issue and select at least one validation-linked upgrade candidate.',
               '',
+              '## Related weekly issue links',
+              ...(relatedIssueLinks.length ? relatedIssueLinks : ['- No related weekly issues are currently open.']),
+              '',
               '## Quick links',
               `- Code scanning: https://github.com/${owner}/${repo}/security/code-scanning`,
               `- Dependabot: https://github.com/${owner}/${repo}/security/dependabot`,
               `- Actions: https://github.com/${owner}/${repo}/actions`,
             ].join('\n');
 
-            const maintenanceIssues = await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              labels: maintenanceLabel,
-              per_page: 100,
-            });
-
-            const previousMaintenance = maintenanceIssues.data.filter((i) => i.title.startsWith('🔐 Weekly security + maintenance checklist'));
+            const maintenanceIssues = openIssues.filter((issue) => hasLabel(issue, maintenanceLabel));
+            const previousMaintenance = maintenanceIssues.filter((i) => i.title.startsWith('🔐 Weekly security + maintenance checklist'));
             for (const oldIssue of previousMaintenance) {
               if (oldIssue.title !== mainTitle) {
                 await github.rest.issues.update({ owner, repo, issue_number: oldIssue.number, state: 'closed' });
@@ -170,14 +211,8 @@ jobs:
               '- Link the final implementation PR back to this issue.',
             ].join('\n');
 
-            const enhancementIssues = await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              labels: enhancementLabel,
-              per_page: 100,
-            });
-            const existingEnhancement = enhancementIssues.data.find((i) => i.title === enhancementTitle);
+            const enhancementIssues = openIssues.filter((issue) => hasLabel(issue, enhancementLabel));
+            const existingEnhancement = enhancementIssues.find((i) => i.title === enhancementTitle);
             if (!existingEnhancement) {
               await github.rest.issues.create({
                 owner,
@@ -239,7 +274,12 @@ jobs:
                   });
                 }
 
-                const conclusion = latest.conclusion || latest.status || 'unknown';
+                const status = latest.status || 'unknown';
+                if (status !== 'completed') {
+                  continue;
+                }
+
+                const conclusion = latest.conclusion || 'unknown';
                 if (!['success', 'neutral', 'skipped'].includes(conclusion)) {
                   weakSpots.push({
                     area: `Workflow health: ${workflowFile}`,
@@ -256,14 +296,8 @@ jobs:
               }
             }
 
-            const staleOpenIssues = (await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              labels: maintenanceLabel,
-              per_page: 100,
-            })).data.filter((issue) => {
-              if (issue.pull_request) return false;
+            const staleOpenIssues = openIssues.filter((issue) => {
+              if (!hasLabel(issue, maintenanceLabel)) return false;
               const updatedAt = new Date(issue.updated_at).getTime();
               return Number.isFinite(updatedAt) && now - updatedAt > staleMs;
             });
@@ -271,7 +305,7 @@ jobs:
             if (staleOpenIssues.length > 0) {
               weakSpots.push({
                 area: 'Maintenance issue hygiene',
-                observation: `${staleOpenIssues.length} maintenance issue(s) have been open with no recent updates for 14+ names.`,
+                observation: `${staleOpenIssues.length} maintenance issue(s) have been open with no recent updates for 14+ days.`,
                 suggestion: 'Close outdated trackers or convert them into actionable implementation issues with owners.',
               });
             }
@@ -294,13 +328,11 @@ jobs:
               '- [ ] Link implemented fixes back to this report and `docs/roadmap.md`.',
             ].join('\n');
 
-            const weakOpen = (await github.rest.issues.listForRepo({
-              owner,
-              repo,
-              state: 'open',
-              labels: `${maintenanceLabel},${weakSpotLabel}`,
-              per_page: 100,
-            })).data.filter((i) => i.title.startsWith('🛠️ Weekly maintenance weak-spot report'));
+            const weakOpen = openIssues.filter(
+              (issue) => hasLabel(issue, maintenanceLabel)
+                && hasLabel(issue, weakSpotLabel)
+                && issue.title.startsWith('🛠️ Weekly maintenance weak-spot report'),
+            );
 
             for (const oldIssue of weakOpen) {
               if (oldIssue.title !== weakTitle) {

--- a/.github/workflows/worker-alignment-bot.yml
+++ b/.github/workflows/worker-alignment-bot.yml
@@ -149,14 +149,16 @@ jobs:
               }
             }
 
-            const openIssues = await github.rest.issues.listForRepo({
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
               state: 'open',
               labels: 'automation',
               per_page: 100,
             });
-            const priorIssues = openIssues.data.filter((issue) => issue.title.startsWith('🤖 Worker alignment radar'));
+            const priorIssues = openIssues
+              .filter((issue) => !issue.pull_request)
+              .filter((issue) => issue.title.startsWith('🤖 Worker alignment radar'));
 
             for (const oldIssue of priorIssues) {
               if (oldIssue.title !== title) {

--- a/.github/workflows/worker-alignment-bot.yml
+++ b/.github/workflows/worker-alignment-bot.yml
@@ -45,6 +45,7 @@ jobs:
           from pathlib import Path
 
           build = Path("build")
+          repo_root = Path.cwd()
           runs = {
               "adapter-smoke-worker": json.loads((build / "adapter-smoke-worker-run.json").read_text(encoding="utf-8")),
               "dependency-radar-worker": json.loads((build / "dependency-radar-worker-run.json").read_text(encoding="utf-8")),
@@ -63,13 +64,20 @@ jobs:
               "## Worker run status",
           ]
 
+          def display_path(raw_artifact: str) -> str:
+              artifact = Path(raw_artifact)
+              try:
+                  return str(artifact.resolve().relative_to(repo_root))
+              except ValueError:
+                  return raw_artifact
+
           for worker_id, payload in runs.items():
               artifacts = payload.get("artifacts", [])
               lines.append(
                   f"- **{worker_id}** · status `{payload.get('status', 'unknown')}` · artifacts `{len(artifacts)}`"
               )
               if artifacts:
-                  lines.append(f"  - First artifact: `{artifacts[0]}`")
+                  lines.append(f"  - First artifact: `{display_path(artifacts[0])}`")
 
           lines.extend(
               [

--- a/.github/workflows/workflow-governance-bot.yml
+++ b/.github/workflows/workflow-governance-bot.yml
@@ -27,6 +27,9 @@ jobs:
           files = sorted(workflow_dir.glob('*.yml'))
           sha_pin = re.compile(r'@[0-9a-f]{40}(?:\s|$)', re.IGNORECASE)
           uses_re = re.compile(r'^\s*-?\s*uses:\s*(\S+)', re.MULTILINE)
+          schedule_event_re = re.compile(r'^\s*schedule:\s*$', re.MULTILINE)
+          dispatch_event_re = re.compile(r'^\s*workflow_dispatch:\s*$', re.MULTILINE)
+          pr_target_event_re = re.compile(r'^\s*pull_request_target:\s*$', re.MULTILINE)
 
           findings = []
           summary = {
@@ -49,7 +52,7 @@ jobs:
                       'message': 'Workflow does not declare a top-level permissions block.',
                   })
 
-              if 'schedule:' in text and 'workflow_dispatch:' not in text:
+              if schedule_event_re.search(text) and not dispatch_event_re.search(text):
                   summary['missing_dispatch'].append(path.name)
                   findings.append({
                       'type': 'missing_dispatch',
@@ -57,7 +60,7 @@ jobs:
                       'message': 'Scheduled workflow should also expose workflow_dispatch for manual recovery.',
                   })
 
-              if 'pull_request_target:' in text:
+              if pr_target_event_re.search(text):
                   summary['pr_target'].append(path.name)
                   findings.append({
                       'type': 'pr_target',


### PR DESCRIPTION
### Motivation

- Improve clarity and actionability of auto-generated security/maintenance radars by surfacing ages, staleness, and preferred severity ordering. 
- Make produced artifact content friendlier to readers by relativizing repo paths and showing counts/preview hints for long lists. 
- Surface additional repository configuration details (delegated bypass reviewers) and related weekly issue links for traceability. 
- Standardize wording around SLA/age references to explicitly use "14+ day" phrasing.

### Description

- Added a `relativize_repo_paths` helper and used it when embedding the runtime fast-follow markdown to convert absolute repo paths into relative paths in `dependency-radar-bot.yml`. 
- Show a preview/count line for orphan docs and limit the displayed items in `docs-experience-bot.yml`. 
- Introduced preferred ordering for severity/age buckets and updated mapping helpers (`mapLines`/`mapToLines`) with `severityOrder`/`ageOrder` in several GHAS scripts (`ghas-alert-sla-bot.yml`, `ghas-campaign-bot.yml`, `ghas-codeql-hotspots-bot.yml`) to produce predictable ordering in reports. 
- Refined CodeQL hotspot summaries to sort severity using an explicit order and normalized wording for day counts. 
- Added workflow run age computation, `stale_14d` flags, and extra table columns (Age (days) and 14d stale) to GHAS metrics/digest exporters (`ghas-metrics-export-bot.yml`, `ghas-review-bot.yml`) and included `updated_age_days` in the metrics snapshot. 
- Enhanced secret-protection report to include delegated bypass reviewers and to conditionally present a configuration section when API access is available (`secret-protection-review-bot.yml`). 
- Reworked the weekly security/maintenance flow (`security-maintenance-bot.yml`) to page recent issues, provide helper functions `hasLabel`/`findIssueByPrefix`, link related weekly issues, reuse fetched open issues for label-based lookups, treat workflow runs that aren't `completed` as non-actionable, and improve stale issue/workflow messaging. 
- Made artifact path display relative in the worker-alignment radar by resolving and relativizing artifact paths (`worker-alignment-bot.yml`). 
- Minor wording and consistency fixes across multiple workflows to clarify "14+ day" phrasing and other messages.

### Testing

- No new unit tests were added to the repository. 
- Performed local smoke runs of the affected generation scripts to verify `build/*.json` and `build/*.md` artifacts are produced and that new fields/columns appear as expected. 
- Ran basic YAML/JS/JSON sanity checks and linters over the modified workflow scripts and they passed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6f06f6ae08332811cfd57b3537330)