### PR TITLE
Validate phase-boost start-date; fix onboarding test alias; clarify security-model allowlist

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -36,12 +36,13 @@ AgentOS deny-by-default controls:
 - obvious path traversal / unsafe writes
 - secret leakage patterns
 - network calls without timeouts
-- debug prints in `src/`
+- debug prints in `src/` (except for an explicit allowlist of operational CLI modules)
 
 Allowlists:
 
 - inline: `# sdetkit: allow-security <RULE_ID>`
 - repo file: `tools/security_allowlist.json`
+- module-level debug print exceptions: `PRINT_ALLOWED_MODULE_SUFFIXES` in `src/sdetkit/security_gate.py`
 
 Baseline regression gate:
 

--- a/src/sdetkit/phase_boost.py
+++ b/src/sdetkit/phase_boost.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from datetime import date
 from pathlib import Path
 
@@ -36,8 +37,23 @@ def _parser() -> argparse.ArgumentParser:
     return p
 
 
+def _is_valid_iso_date(value: str) -> bool:
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        return False
+    return parsed.isoformat() == value
+
+
 def main(argv: list[str] | None = None) -> int:
     ns = _parser().parse_args(argv)
+    if not _is_valid_iso_date(ns.start_date):
+        print(
+            "error: --start-date must be a valid ISO date in YYYY-MM-DD format.",
+            file=sys.stderr,
+        )
+        return 2
+
     payload = build_phase_boost_payload(ns.repo_name, ns.start_date)
     md = _render_markdown(payload)
     print(md, end="")

--- a/tests/test_onboarding_optimization.py
+++ b/tests/test_onboarding_optimization.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from sdetkit import cli
-from sdetkit import onboarding_optimization as otu
+from sdetkit import onboarding_optimization as onboarding_opt
 
 
 def _write_fixture(root: Path) -> None:
@@ -20,7 +20,7 @@ def _write_fixture(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/onboarding-optimization.md").write_text(
-        otu._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
+        onboarding_opt._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
     (root / "src/sdetkit").mkdir(parents=True, exist_ok=True)
     (root / "src/sdetkit/onboarding.py").write_text(
@@ -31,7 +31,7 @@ def _write_fixture(root: Path) -> None:
 def test_onboarding_json(tmp_path: Path, capsys) -> None:
     _write_fixture(tmp_path)
 
-    rc = otu.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    rc = onboarding_opt.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 0
 
     out = json.loads(capsys.readouterr().out)
@@ -42,7 +42,7 @@ def test_onboarding_json(tmp_path: Path, capsys) -> None:
 def test_onboarding_emit_pack_and_execute(tmp_path: Path) -> None:
     _write_fixture(tmp_path)
 
-    rc = otu.main(
+    rc = onboarding_opt.main(
         [
             "--root",
             str(tmp_path),
@@ -85,7 +85,7 @@ def test_onboarding_strict_fails_when_sections_missing(tmp_path: Path) -> None:
         "# Onboarding optimization\n", encoding="utf-8"
     )
 
-    rc = otu.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    rc = onboarding_opt.main(["--root", str(tmp_path), "--format", "json", "--strict"])
     assert rc == 1
 
 

--- a/tests/test_phase_boost.py
+++ b/tests/test_phase_boost.py
@@ -46,3 +46,42 @@ def test_phase_boost_parser_defaults_start_date_to_today_iso():
     args = phase_boost._parser().parse_args([])
 
     assert args.start_date == phase_boost.date.today().isoformat()
+
+
+def test_phase_boost_rejects_invalid_start_date(capsys) -> None:
+    rc = phase_boost.main(["--repo-name", "repo-prod", "--start-date", "not-a-date"])
+
+    captured = capsys.readouterr()
+    assert rc != 0
+    assert "--start-date must be a valid ISO date" in captured.err
+
+
+def test_phase_boost_main_valid_start_date_emits_markdown(capsys) -> None:
+    rc = phase_boost.main(["--repo-name", "repo-prod", "--start-date", "2026-03-01"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "# Phase boost plan for repo-prod" in captured.out
+    assert "- Phase 1 - Baseline hardening (30 days)" in captured.out
+
+
+def test_phase_boost_main_json_output_contract(tmp_path: Path) -> None:
+    out_json = tmp_path / "phase-boost.json"
+
+    rc = phase_boost.main(
+        [
+            "--repo-name",
+            "repo-prod",
+            "--start-date",
+            "2026-03-01",
+            "--json-output",
+            str(out_json),
+        ]
+    )
+
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert payload["repository"] == "repo-prod"
+    assert payload["start_date"] == "2026-03-01"
+    assert payload["goal"] == "S-class production readiness"
+    assert isinstance(payload["phases"], list)

--- a/tests/test_security_gate_helpers_extra.py
+++ b/tests/test_security_gate_helpers_extra.py
@@ -214,3 +214,23 @@ def test_security_gate_iter_files_skips_generated_dirs(tmp_path: Path) -> None:
     assert all(not item.startswith(".venv/") for item in files)
     assert all(not item.startswith("site/") for item in files)
     assert all(not item.startswith("docs/artifacts/") for item in files)
+
+
+def test_security_gate_allows_debug_print_in_allowlisted_src_modules(tmp_path: Path) -> None:
+    module = tmp_path / "src" / "sdetkit" / "onboarding.py"
+    module.parent.mkdir(parents=True)
+    module.write_text("print('debug')\n", encoding="utf-8")
+
+    findings = sg.scan_repo(tmp_path)
+
+    assert not any(f.rule_id == "SEC_DEBUG_PRINT" for f in findings)
+
+
+def test_security_gate_flags_debug_print_outside_allowlisted_src_modules(tmp_path: Path) -> None:
+    module = tmp_path / "src" / "sdetkit" / "non_allowlisted_module.py"
+    module.parent.mkdir(parents=True)
+    module.write_text("print('debug')\n", encoding="utf-8")
+
+    findings = sg.scan_repo(tmp_path)
+
+    assert any(f.rule_id == "SEC_DEBUG_PRINT" for f in findings)


### PR DESCRIPTION
### Motivation

- Fix an unclear test alias in `tests/test_onboarding_optimization.py` to improve readability and maintainability.
- Prevent `phase-boost` from silently accepting malformed `--start-date` values so invalid pipeline input fails fast.
- Reconcile the security-model documentation with the implemented allowlist behavior for debug `print(...)` checks.

### Description

- Add strict ISO date validation to `phase_boost` by introducing `_is_valid_iso_date()` and returning non-zero with an error on stderr for invalid `--start-date`, and add `import sys` (file: `src/sdetkit/phase_boost.py`).
- Add focused CLI tests for `phase-boost` covering invalid date rejection, valid markdown output, and JSON output contract (file: `tests/test_phase_boost.py`).
- Replace the ambiguous `otu` alias with `onboarding_opt` in `tests/test_onboarding_optimization.py` to clarify module references (file: `tests/test_onboarding_optimization.py`).
- Update `docs/security-model.md` to explicitly document the `PRINT_ALLOWED_MODULE_SUFFIXES` allowlist behavior used by the security gate (file: `docs/security-model.md`).
- Add tests asserting `SEC_DEBUG_PRINT` is suppressed for allowlisted modules and flagged for non-allowlisted modules via `scan_repo` (file: `tests/test_security_gate_helpers_extra.py`).

### Testing

- Ran `pytest -q tests/test_onboarding_optimization.py tests/test_phase_boost.py tests/test_security_gate_helpers_extra.py tests/test_security_info_default.py` and all tests passed (27 passed).
- The new `phase-boost` negative and positive CLI tests exercise the added validation and JSON output contract and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74264a090833294f79c726b9a1af8)