### PR TITLE
Introduce DuplicateKeyError and improve kv parsing, duplicate handling, and CLI arg validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ src/sdetkit.egg-info/
 
 # top-tier reporting scratch bundle
 /docs/artifacts/top-tier-bundle/
+
+# enterprise assessment scratch bundle
+/docs/artifacts/enterprise-assessment-pack/

--- a/src/sdetkit/kvcli.py
+++ b/src/sdetkit/kvcli.py
@@ -1,10 +1,11 @@
+import inspect
 import json
 import sys
 from collections.abc import Callable
 from typing import NoReturn
 
 from .bools import coerce_bool
-from .textutil import parse_kv_line
+from .textutil import DuplicateKeyError, parse_kv_line
 
 
 def _die(msg: str) -> NoReturn:
@@ -17,18 +18,28 @@ def _build_comment_aware_parser(
     *,
     duplicate_policy: str = "last",
 ) -> Callable[[str], dict[str, str]]:
+    supports_allow_comments = False
+    supports_duplicate_policy = False
+    try:
+        sig = inspect.signature(parser)
+        params = sig.parameters
+        supports_allow_comments = "allow_comments" in params
+        supports_duplicate_policy = "duplicate_policy" in params
+        if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+            supports_allow_comments = True
+            supports_duplicate_policy = True
+    except (TypeError, ValueError):
+        pass
+
     def _wrapped(line: str) -> dict[str, str]:
-        try:
-            return parser(
-                line,
-                allow_comments=True,
-                duplicate_policy=duplicate_policy,
-            )
-        except TypeError:
-            try:
-                return parser(line, allow_comments=True)
-            except TypeError:
-                return parser(line)
+        kwargs: dict[str, object] = {}
+        if supports_allow_comments:
+            kwargs["allow_comments"] = True
+        if supports_duplicate_policy:
+            kwargs["duplicate_policy"] = duplicate_policy
+        if kwargs:
+            return parser(line, **kwargs)
+        return parser(line)
 
     return _wrapped
 
@@ -45,13 +56,20 @@ def _process(raw: str, *, strict: bool, duplicates: str) -> int:
     for line_no, line in enumerate(raw.splitlines(), start=1):
         try:
             chunk = parse_line(line)
+        except DuplicateKeyError as exc:
+            _die(f"{exc} at line {line_no}")
         except ValueError:
             invalid_lines += 1
             if strict:
                 _die(f"invalid input at line {line_no}")
             continue
         if chunk:
-            data.update(chunk)
+            for key, value in chunk.items():
+                if duplicates == "error" and key in data:
+                    _die(f"duplicate key: {key} at line {line_no}")
+                if duplicates == "first" and key in data:
+                    continue
+                data[key] = value
 
     if raw.strip() != "" and (not data or (strict and invalid_lines > 0)):
         _die("invalid input")
@@ -103,6 +121,9 @@ def _parse_fast(argv: list[str]) -> dict[str, object]:
                 sys.stderr.write(_usage())
                 _die(f"argument {arg}: expected one argument")
             value = argv[i + 1]
+            if value.startswith("--"):
+                sys.stderr.write(_usage())
+                _die(f"argument {arg}: expected one argument")
             if arg == "--text":
                 text = value
             elif arg == "--path":

--- a/src/sdetkit/textutil.py
+++ b/src/sdetkit/textutil.py
@@ -3,6 +3,10 @@ import shlex
 _DUPLICATE_POLICIES = {"last", "first", "error"}
 
 
+class DuplicateKeyError(ValueError):
+    """Raised when duplicate keys are disallowed by parser policy."""
+
+
 def normalize_line(line: str) -> str:
     return line.strip()
 
@@ -38,7 +42,7 @@ def parse_kv_line(
             raise ValueError("bad kv")
 
         if duplicate_policy == "error" and k in out:
-            raise ValueError(f"duplicate key: {k}")
+            raise DuplicateKeyError(f"duplicate key: {k}")
         if duplicate_policy == "first" and k in out:
             continue
 

--- a/tests/test_kvcli.py
+++ b/tests/test_kvcli.py
@@ -97,6 +97,20 @@ def test_kvcli_path_missing_exit_2(tmp_path):
     assert "traceback" not in p.stderr.lower()
 
 
+def test_kvcli_text_missing_value_reports_expected_one_argument():
+    p = run_kvcli("--text", "--path", "some.txt")
+    assert p.returncode == 2
+    assert p.stdout == ""
+    assert "argument --text: expected one argument" in p.stderr.lower()
+
+
+def test_kvcli_duplicates_missing_value_reports_expected_one_argument():
+    p = run_kvcli("--duplicates", "--strict")
+    assert p.returncode == 2
+    assert p.stdout == ""
+    assert "argument --duplicates: expected one argument" in p.stderr.lower()
+
+
 def test_kvcli_multiline_ignores_bad_lines_and_merges_last_wins():
     p = run_kvcli(input_text="a=1\nbadline\nb=2 a=3\n")
     assert p.returncode == 0
@@ -188,6 +202,22 @@ def test_build_comment_aware_parser_passes_duplicate_policy_for_modern_parser():
     assert parser("a=1 a=2") == {"a": "1"}
 
 
+def test_build_comment_aware_parser_does_not_mask_parser_typeerror():
+    import sdetkit.kvcli as kvcli
+
+    def broken_parser(
+        _line: str,
+        *,
+        allow_comments: bool = False,
+        duplicate_policy: str = "last",
+    ) -> dict[str, str]:
+        raise TypeError("boom")
+
+    parser = kvcli._build_comment_aware_parser(broken_parser)
+    with pytest.raises(TypeError, match="boom"):
+        parser("a=1")
+
+
 def test_kvcli_runner_supports_timeout(tmp_path):
     # Give subprocess startup enough headroom for highly parallel CI workers.
     p = run_kvcli("--text", "a=1", timeout=2.0)
@@ -205,7 +235,28 @@ def test_kvcli_duplicates_error_fails_on_duplicate_key():
     p = run_kvcli("--duplicates", "error", "--text", "a=1 a=2")
     assert p.returncode == 2
     assert p.stdout == ""
-    assert "invalid input" in p.stderr.lower()
+    assert "duplicate key" in p.stderr.lower()
+
+
+def test_kvcli_duplicates_first_preserves_first_value_across_lines():
+    p = run_kvcli("--duplicates", "first", input_text="a=1\na=2\n")
+    assert p.returncode == 0
+    assert p.stderr == ""
+    assert json.loads(p.stdout) == {"a": "1"}
+
+
+def test_kvcli_duplicates_error_fails_on_duplicate_key_across_lines():
+    p = run_kvcli("--duplicates", "error", input_text="a=1\na=2\n")
+    assert p.returncode == 2
+    assert p.stdout == ""
+    assert "duplicate key" in p.stderr.lower()
+
+
+def test_kvcli_duplicates_error_fails_even_when_other_lines_are_valid():
+    p = run_kvcli("--duplicates", "error", input_text="a=1\nb=2 b=3\nc=4\n")
+    assert p.returncode == 2
+    assert p.stdout == ""
+    assert "duplicate key" in p.stderr.lower()
 
 
 def test_kvcli_main_text_ok(capsys):

--- a/tests/test_textutil.py
+++ b/tests/test_textutil.py
@@ -4,7 +4,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from sdetkit.textutil import normalize_line, parse_kv_line
+from sdetkit.textutil import DuplicateKeyError, normalize_line, parse_kv_line
 
 
 @pytest.mark.parametrize(
@@ -76,7 +76,7 @@ def test_parse_kv_line_duplicate_policy_first_keeps_first_value():
 
 
 def test_parse_kv_line_duplicate_policy_error_raises():
-    with pytest.raises(ValueError, match="duplicate key: a"):
+    with pytest.raises(DuplicateKeyError, match="duplicate key: a"):
         parse_kv_line("a=1 a=2", duplicate_policy="error")
 
 


### PR DESCRIPTION
### Motivation

- Make duplicate-key failures distinct and actionable by introducing a dedicated exception for the parser. 
- Ensure the comment-aware parser wrapper adapts to different parser signatures without masking real `TypeError` failures. 
- Improve CLI argument validation for missing option values that look like flags and enforce consistent duplicate-key behavior across multi-line input.

### Description

- Add a new `DuplicateKeyError` exception in `src/sdetkit/textutil.py` and raise it from `parse_kv_line` when `duplicate_policy == "error"` instead of raising a generic `ValueError`.
- Update `parse_kv_line` to keep the same duplicate policies and behavior but emit the new `DuplicateKeyError` for the error policy.
- Make `_build_comment_aware_parser` in `src/sdetkit/kvcli.py` detect parser parameters via `inspect.signature` and only pass `allow_comments` and `duplicate_policy` when supported, and avoid masking parser `TypeError` exceptions.
- In `_process`, handle `DuplicateKeyError` to emit a clear error with the offending line number and iterate chunk items to correctly apply `duplicates` policies (`last`, `first`, `error`) across multiple input lines.
- Improve `_parse_fast` argument parsing to treat values starting with `--` as missing arguments and report the expected-argument error for options like `--text` and `--duplicates`.
- Add and adjust tests to cover the new exception, duplicate behavior across lines, missing-value detection when values look like flags, and to ensure the wrapper does not hide parser `TypeError` errors (tests updated in `tests/test_kvcli.py` and `tests/test_textutil.py`).

### Testing

- Ran the test suite with `pytest` including updated tests in `tests/test_kvcli.py` and `tests/test_textutil.py`, and all tests passed. 
- New tests added verify `DuplicateKeyError` is raised by `parse_kv_line` when `duplicate_policy="error"` and that CLI reports duplicate-key errors with line numbers. 
- Tests were added to verify missing option values that start with `--` produce an "expected one argument" error, and that a parser `TypeError` is propagated rather than being masked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e743892a9c83329a3d9d19d96e9608)