### PR TITLE
Skip ignored directories when computing repo fingerprint and add tests

### DIFF
--- a/src/sdetkit/checks/cache.py
+++ b/src/sdetkit/checks/cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from dataclasses import asdict
 from pathlib import Path
 
@@ -98,20 +99,53 @@ class CheckCache:
     def _entry_path(self, key: str) -> Path:
         return self._base_dir / f"{key}.json"
 
+    def _is_ignored_path(self, repo_root: Path, path: Path) -> bool:
+        try:
+            parts = set(path.relative_to(repo_root).parts)
+        except ValueError:
+            return True
+        if parts & _IGNORED_PARTS:
+            return True
+        if ".sdetkit" in parts and "out" in parts:
+            return True
+        return False
+
+    def _iter_tree_files(self, root: Path):
+        for dirpath, dirnames, filenames in os.walk(root):
+            current = Path(dirpath)
+            rel_parts = current.relative_to(root).parts
+            if set(rel_parts) & _IGNORED_PARTS:
+                dirnames[:] = []
+                continue
+            if ".sdetkit" in rel_parts and "out" in rel_parts:
+                dirnames[:] = []
+                continue
+            if current.name == ".sdetkit":
+                dirnames[:] = [name for name in dirnames if name != "out"]
+            dirnames[:] = [name for name in dirnames if name not in _IGNORED_PARTS]
+            for filename in filenames:
+                yield current / filename
+
     def _iter_paths(self, repo_root: Path, changed_paths: tuple[str, ...]):
         if changed_paths:
+            seen: set[Path] = set()
             for rel in changed_paths:
                 path = repo_root / rel
                 if path.is_file():
-                    yield path
+                    seen.add(path)
+                    continue
+                if path.is_dir():
+                    if self._is_ignored_path(repo_root, path):
+                        continue
+                    for child in self._iter_tree_files(path):
+                        seen.add(child)
+            for path in sorted(seen):
+                if self._is_ignored_path(repo_root, path):
+                    continue
+                yield path
             return
 
-        for path in sorted(repo_root.rglob("*")):
-            if not path.is_file():
-                continue
-            parts = set(path.relative_to(repo_root).parts)
-            if parts & _IGNORED_PARTS:
-                continue
-            if ".sdetkit" in parts and "out" in parts:
+        for path in sorted(self._iter_tree_files(repo_root)):
+            if self._is_ignored_path(repo_root, path):
                 continue
             yield path

--- a/tests/test_checks_cache.py
+++ b/tests/test_checks_cache.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit.checks.cache import CheckCache
+
+
+def test_compute_repo_fingerprint_tracks_directory_targets(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    pkg = repo_root / "src" / "pkg"
+    pkg.mkdir(parents=True)
+    target = pkg / "module.py"
+    target.write_text("value = 1\n", encoding="utf-8")
+
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    before = cache.compute_repo_fingerprint(repo_root, ("src/pkg",))
+
+    target.write_text("value = 2\n", encoding="utf-8")
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    after = cache.compute_repo_fingerprint(repo_root, ("src/pkg",))
+
+    assert before != after
+
+
+def test_compute_repo_fingerprint_ignores_tooling_cache_with_directory_targets(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    out_dir = repo_root / ".sdetkit" / "out"
+    out_dir.mkdir(parents=True)
+    noisy = out_dir / "run.json"
+    noisy.write_text('{"v": 1}\n', encoding="utf-8")
+
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    before = cache.compute_repo_fingerprint(repo_root, (".sdetkit",))
+
+    noisy.write_text('{"v": 2}\n', encoding="utf-8")
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    after = cache.compute_repo_fingerprint(repo_root, (".sdetkit",))
+
+    assert before == after
+
+
+def test_compute_repo_fingerprint_ignores_venv_directory_targets(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    venv_dir = repo_root / ".venv"
+    venv_dir.mkdir(parents=True)
+    noisy = venv_dir / "state.txt"
+    noisy.write_text("v1\n", encoding="utf-8")
+
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    before = cache.compute_repo_fingerprint(repo_root, (".venv",))
+
+    noisy.write_text("v2\n", encoding="utf-8")
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    after = cache.compute_repo_fingerprint(repo_root, (".venv",))
+
+    assert before == after
+
+
+def test_compute_repo_fingerprint_ignores_outside_repo_hint_paths(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "tracked.txt").write_text("ok\n", encoding="utf-8")
+
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    inside_only = cache.compute_repo_fingerprint(repo_root, ("tracked.txt",))
+
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    with_outside_hint = cache.compute_repo_fingerprint(repo_root, ("../outside", "tracked.txt"))
+
+    assert inside_only == with_outside_hint


### PR DESCRIPTION
### Motivation

- Ensure repository fingerprinting and cache lookups do not consider transient or tooling-generated files like `.sdetkit/out`, virtualenvs, or VCS metadata directories.
- Make path traversal more robust for both explicit changed-path hints and full-repo scans to avoid noisy updates to cache fingerprints.

### Description

- Add `_is_ignored_path` helper to centralize logic for ignoring `.git`, `.venv`, `.sdetkit/out`, and other listed parts. 
- Implement `_iter_tree_files` using `os.walk` with directory pruning to efficiently enumerate files while skipping ignored directories. 
- Update `_iter_paths` to collect file paths for provided `changed_paths` (tracking seen files, expanding directory targets, and filtering ignored paths) and to reuse `_iter_tree_files` for the full-repo case. 
- Add `tests/test_checks_cache.py` with tests that assert directory targets are tracked and that `.sdetkit/out`, `.venv`, and outside-repo hint paths are ignored when computing fingerprints.

### Testing

- Added unit tests in `tests/test_checks_cache.py` that exercise directory-target behavior and ignored-path handling. 
- Ran `pytest tests/test_checks_cache.py -q` and all tests passed. 
- No other automated test failures were observed when running the new tests locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74a530b048332ac1ef972069b8d92)