### PR TITLE
Add compatibility shim modules for relocated sdetkit modules

### DIFF
--- a/src/sdetkit/_legacy_lane.py
+++ b/src/sdetkit/_legacy_lane.py
@@ -1,0 +1,3 @@
+"""Backward-compatible legacy lane helper re-export."""
+
+from sdetkit.core._legacy_lane import *  # noqa: F403

--- a/src/sdetkit/_toml.py
+++ b/src/sdetkit/_toml.py
@@ -1,0 +1,21 @@
+"""Backward-compatible TOML helpers.
+
+Preserves monkeypatchable symbols expected by existing tests/importers.
+"""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from types import ModuleType
+
+
+def _load_toml_module() -> ModuleType:
+    module_name = "tomllib" if sys.version_info >= (3, 11) else "tomli"
+    return import_module(module_name)
+
+
+_toml = _load_toml_module()
+loads = _toml.loads
+
+__all__ = ["_load_toml_module", "loads", "import_module"]

--- a/src/sdetkit/apiget_dispatch.py
+++ b/src/sdetkit/apiget_dispatch.py
@@ -1,0 +1,3 @@
+"""Backward-compatible apiget_dispatch re-export."""
+
+from sdetkit.core.apiget_dispatch import *  # noqa: F403

--- a/src/sdetkit/argv_flags.py
+++ b/src/sdetkit/argv_flags.py
@@ -1,0 +1,3 @@
+"""Backward-compatible argv flags helper re-export."""
+
+from sdetkit.core.argv_flags import *  # noqa: F403

--- a/src/sdetkit/atomicio.py
+++ b/src/sdetkit/atomicio.py
@@ -1,0 +1,3 @@
+"""Backward-compatible atomic I/O utilities re-export."""
+
+from sdetkit.utils.atomicio import *  # noqa: F403

--- a/src/sdetkit/baseline_dispatch.py
+++ b/src/sdetkit/baseline_dispatch.py
@@ -1,0 +1,3 @@
+"""Backward-compatible baseline_dispatch re-export."""
+
+from sdetkit.core.baseline_dispatch import *  # noqa: F403

--- a/src/sdetkit/bools.py
+++ b/src/sdetkit/bools.py
@@ -1,0 +1,7 @@
+"""Backward-compatible bool utilities re-export.
+
+This module preserves legacy import paths after the bool helpers were
+moved under ``sdetkit.utils``.
+"""
+
+from sdetkit.utils.bools import *  # noqa: F403

--- a/src/sdetkit/cli_shortcuts.py
+++ b/src/sdetkit/cli_shortcuts.py
@@ -1,0 +1,3 @@
+"""Backward-compatible cli_shortcuts re-export."""
+
+from sdetkit.cli.cli_shortcuts import *  # noqa: F403

--- a/src/sdetkit/cli_timing.py
+++ b/src/sdetkit/cli_timing.py
@@ -1,0 +1,3 @@
+"""Backward-compatible cli_timing re-export."""
+
+from sdetkit.cli.cli_timing import *  # noqa: F403

--- a/src/sdetkit/core_preparse_dispatch.py
+++ b/src/sdetkit/core_preparse_dispatch.py
@@ -1,0 +1,3 @@
+"""Backward-compatible core_preparse_dispatch re-export."""
+
+from sdetkit.core.core_preparse_dispatch import *  # noqa: F403

--- a/src/sdetkit/parser_helpers.py
+++ b/src/sdetkit/parser_helpers.py
@@ -1,0 +1,3 @@
+"""Backward-compatible parser_helpers re-export."""
+
+from sdetkit.core.parser_helpers import *  # noqa: F403

--- a/src/sdetkit/playbook_aliases.py
+++ b/src/sdetkit/playbook_aliases.py
@@ -1,0 +1,3 @@
+"""Backward-compatible playbook_aliases re-export."""
+
+from sdetkit.cli.playbook_aliases import *  # noqa: F403

--- a/src/sdetkit/release_dispatch.py
+++ b/src/sdetkit/release_dispatch.py
@@ -1,0 +1,3 @@
+"""Backward-compatible release_dispatch re-export."""
+
+from sdetkit.core.release_dispatch import *  # noqa: F403

--- a/src/sdetkit/review_forwarding.py
+++ b/src/sdetkit/review_forwarding.py
@@ -1,0 +1,3 @@
+"""Backward-compatible review_forwarding re-export."""
+
+from sdetkit.intelligence.review_forwarding import *  # noqa: F403

--- a/src/sdetkit/serve_forwarding.py
+++ b/src/sdetkit/serve_forwarding.py
@@ -1,0 +1,3 @@
+"""Backward-compatible serve_forwarding re-export."""
+
+from sdetkit.cli.serve_forwarding import *  # noqa: F403

--- a/src/sdetkit/textutil.py
+++ b/src/sdetkit/textutil.py
@@ -1,0 +1,3 @@
+"""Backward-compatible text utility re-export."""
+
+from sdetkit.utils.textutil import *  # noqa: F403


### PR DESCRIPTION
### Motivation
- A package reorganization moved several helpers into subpackages and broke legacy top-level imports, causing test collection to fail with `ModuleNotFoundError` errors.
- Restore backward-compatible import paths so existing code, tests, and downstream integrations can continue to import modules like `sdetkit.atomicio`, `sdetkit.bools`, and CLI helpers.

### Description
- Add simple re-export shim modules under `src/sdetkit/` that import and re-export symbols from `sdetkit.utils`, `sdetkit.core`, `sdetkit.cli`, and `sdetkit.intelligence` (e.g. `atomicio`, `textutil`, `bools`, `argv_flags`, `_legacy_lane`, `apiget_dispatch`, `baseline_dispatch`, `core_preparse_dispatch`, `parser_helpers`, `release_dispatch`, `cli_shortcuts`, `cli_timing`, `playbook_aliases`, `serve_forwarding`, `review_forwarding`).
- Implement a compatibility-safe `sdetkit._toml` shim that provides `import_module`, `_load_toml_module`, and `loads` so tests and downstream code can monkeypatch or call the same symbols as before.
- The shims are minimal and delegate directly to the relocated modules to avoid duplicating logic and to preserve runtime behavior.

### Testing
- Before the changes a full `pytest -q` run failed during collection with many `ModuleNotFoundError` import errors caused by missing top-level modules.
- After adding the shims I ran `pytest -q tests/test_atomicio.py tests/test_textutil.py tests/test_toml_compat.py tests/test_argv_flags.py tests/test_upgrade_audit_script.py` and the suite completed successfully with `72 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76b5cd0188332b33028c04aff8731)