### PR TITLE
Fix CLI subprocess entrypoints and package-relative imports

### DIFF
--- a/src/sdetkit/cli/__init__.py
+++ b/src/sdetkit/cli/__init__.py
@@ -1,0 +1,23 @@
+"""CLI package compatibility wrappers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Sequence
+
+
+def _load_legacy_cli_module() -> ModuleType:
+    module_path = Path(__file__).resolve().parent.parent / "cli.py"
+    spec = importlib.util.spec_from_file_location("sdetkit._legacy_cli_module", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load CLI module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    module = _load_legacy_cli_module()
+    return int(module.main(argv))

--- a/src/sdetkit/cli/__main__.py
+++ b/src/sdetkit/cli/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sdetkit.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli/_legacy_lane.py
+++ b/src/sdetkit/cli/_legacy_lane.py
@@ -1,0 +1,3 @@
+"""Backward-compatible _legacy_lane re-export."""
+
+from sdetkit._legacy_lane import *  # noqa: F403

--- a/src/sdetkit/cli/legacy_cli.py
+++ b/src/sdetkit/cli/legacy_cli.py
@@ -1,0 +1,3 @@
+"""Backward-compatible legacy_cli re-export."""
+
+from sdetkit.legacy_cli import *  # noqa: F403

--- a/src/sdetkit/cli/legacy_commands.py
+++ b/src/sdetkit/cli/legacy_commands.py
@@ -1,0 +1,3 @@
+"""Backward-compatible legacy_commands re-export."""
+
+from sdetkit.legacy_commands import *  # noqa: F403

--- a/src/sdetkit/cli/security.py
+++ b/src/sdetkit/cli/security.py
@@ -1,0 +1,3 @@
+"""Backward-compatible security re-export."""
+
+from sdetkit.security import *  # noqa: F403

--- a/src/sdetkit/cli/serve.py
+++ b/src/sdetkit/cli/serve.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from . import review
-from .security import SecurityError, safe_path
+from ..security import SecurityError, safe_path
 
 SERVE_CONTRACT_VERSION = "sdetkit.serve.contract.v1"
 _MAX_BODY_BYTES = 1_048_576

--- a/src/sdetkit/evidence/evidence_workspace.py
+++ b/src/sdetkit/evidence/evidence_workspace.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from .security import SecurityError, safe_path
+from ..security import SecurityError, safe_path
 
 WORKSPACE_SCHEMA_VERSION = "sdetkit.evidence.workspace.v1"
 

--- a/src/sdetkit/evidence_workspace.py
+++ b/src/sdetkit/evidence_workspace.py
@@ -1,0 +1,3 @@
+"""Backward-compatible evidence_workspace re-export."""
+
+from sdetkit.evidence.evidence_workspace import *  # noqa: F403

--- a/src/sdetkit/intelligence/review.py
+++ b/src/sdetkit/intelligence/review.py
@@ -33,7 +33,7 @@ from .review_engine import (
     rank_likely_issue_tracks,
     summarize_history_delta,
 )
-from .security import SecurityError, safe_path
+from ..security import SecurityError, safe_path
 
 SCHEMA_VERSION = "sdetkit.review.v3"
 REVIEW_CONTRACT_VERSION = "sdetkit.review.contract.v1"

--- a/src/sdetkit/judgment.py
+++ b/src/sdetkit/judgment.py
@@ -1,0 +1,3 @@
+"""Backward-compatible judgment re-export."""
+
+from sdetkit.intelligence.judgment import *  # noqa: F403

--- a/src/sdetkit/ops/ops.py
+++ b/src/sdetkit/ops/ops.py
@@ -19,14 +19,14 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 
-from . import _toml
-from .atomicio import atomic_write_text
-from .bools import coerce_bool
-from .doctor import _scan_non_ascii
-from .repo import run_repo_audit
-from .report import build_run_record
-from .security import safe_path
-from .security_gate import scan_repo
+from .. import _toml
+from ..atomicio import atomic_write_text
+from ..bools import coerce_bool
+from ..doctor import _scan_non_ascii
+from ..repo import run_repo_audit
+from ..report import build_run_record
+from ..security import safe_path
+from ..security_gate import scan_repo
 
 _UTC = getattr(dt, "UTC", dt.timezone.utc)  # noqa: UP017
 _VAR_RE = re.compile(r"\$\{([^}]+)\}")

--- a/src/sdetkit/ops/ops_control.py
+++ b/src/sdetkit/ops/ops_control.py
@@ -11,9 +11,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from . import _toml
-from .atomicio import atomic_write_text
-from .plugin_system import discover
+from .. import _toml
+from ..atomicio import atomic_write_text
+from ..plugin_system import discover
 
 
 @dataclass(frozen=True)

--- a/src/sdetkit/ops_control.py
+++ b/src/sdetkit/ops_control.py
@@ -1,0 +1,3 @@
+"""Backward-compatible ops_control re-export."""
+
+from sdetkit.ops.ops_control import *  # noqa: F403


### PR DESCRIPTION
### Motivation
- Subprocess/e2e CLI invocations (e.g. `python -m sdetkit.cli` and `python -m sdetkit.doctor`) were failing due to missing module entrypoints and stale package-relative imports after a package refactor, breaking critical CLI workflows and tests.

### Description
- Added a package-level CLI loader `src/sdetkit/cli/__init__.py` and module entrypoint `src/sdetkit/cli/__main__.py` so `python -m sdetkit.cli ...` resolves and invokes the legacy `cli.py` main implementation.
- Added small backward-compatible re-export shim modules: `src/sdetkit/evidence_workspace.py`, `src/sdetkit/judgment.py`, `src/sdetkit/ops_control.py` and `src/sdetkit/cli/{legacy_cli,legacy_commands,_legacy_lane,security}.py` to restore moved public interfaces expected by older import paths.
- Fixed incorrect relative imports that caused import-time failures by updating nested modules to import from the package parent, including `src/sdetkit/evidence/evidence_workspace.py`, `src/sdetkit/intelligence/review.py`, `src/sdetkit/cli/serve.py`, `src/sdetkit/ops/ops.py`, and `src/sdetkit/ops/ops_control.py`.

### Testing
- Ran the end-to-end CLI tests with `pytest -q tests/test_cli_e2e_subprocess.py tests/test_apiget_dispatch.py`. 
- All targeted tests passed: `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76cc2a01883328ce2cf6b2e95aa02)