### PR TITLE
Handle `Retry-After` HTTP-date values in API/HTTP clients

### DIFF
--- a/src/sdetkit/apiclient.py
+++ b/src/sdetkit/apiclient.py
@@ -5,6 +5,8 @@ import random
 import time
 import uuid
 from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any
 from urllib.parse import urljoin
 
@@ -28,10 +30,20 @@ def _retry_after_seconds(headers: Any) -> float | None:
         v = None
     if not v:
         return None
+    raw = str(v).strip()
     try:
-        return float(int(str(v).strip()))
+        delay = float(int(raw))
+        return max(0.0, delay)
     except Exception:
+        pass
+    try:
+        parsed = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
         return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    delay = (parsed - datetime.now(timezone.utc)).total_seconds()
+    return max(0.0, delay)
 
 
 def _merge_headers(

--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -6,6 +6,8 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any, Literal
 from urllib.parse import urljoin
 
@@ -115,10 +117,20 @@ def _retry_after_seconds(headers: Any) -> float | None:
         v = None
     if not v:
         return None
+    raw = str(v).strip()
     try:
-        return float(int(str(v).strip()))
+        delay = float(int(raw))
+        return max(0.0, delay)
     except Exception:
+        pass
+    try:
+        parsed = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
         return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    delay = (parsed - datetime.now(timezone.utc)).total_seconds()
+    return max(0.0, delay)
 
 
 def _normalized_timeout(timeout: float | httpx.Timeout | None) -> float | httpx.Timeout | None:

--- a/tests/test_apiclient_retry_helpers_extra.py
+++ b/tests/test_apiclient_retry_helpers_extra.py
@@ -12,6 +12,8 @@ class _BadHeaders:
 
 def test_retry_after_seconds_defensive_paths() -> None:
     assert apiclient._retry_after_seconds({"Retry-After": "12"}) == 12.0
+    assert apiclient._retry_after_seconds({"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"}) > 0.0
+    assert apiclient._retry_after_seconds({"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"}) == 0.0
     assert apiclient._retry_after_seconds({"Retry-After": "oops"}) is None
     assert apiclient._retry_after_seconds(_BadHeaders()) is None
 

--- a/tests/test_netclient_retry_after_http_date.py
+++ b/tests/test_netclient_retry_after_http_date.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from sdetkit import netclient
+
+
+def test_retry_after_seconds_supports_http_date_values() -> None:
+    assert netclient._retry_after_seconds({"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"}) > 0.0
+    assert netclient._retry_after_seconds({"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"}) == 0.0


### PR DESCRIPTION
### Motivation
- Some servers return `Retry-After` as an HTTP-date (RFC 7231) instead of delta-seconds, and the prior helpers only accepted integer seconds which caused these headers to be ignored.
- Ignoring HTTP-date values can lead to immediate retries against a rate-limited endpoint and amplify throttling.
- Expired HTTP-date values previously could compute negative delays, which should be normalized to `0.0`.

### Description
- Parse `Retry-After` header values using `email.utils.parsedate_to_datetime` (and `datetime`/`timezone`) in both `src/sdetkit/apiclient.py` and `src/sdetkit/netclient.py` to support HTTP-date strings.
- Preserve support for delta-seconds and clamp computed delays with `max(0.0, delay)` so negative results become `0.0`.
- Update `tests/test_apiclient_retry_helpers_extra.py` to assert HTTP-date handling and add `tests/test_netclient_retry_after_http_date.py` to cover `netclient` behavior.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_apiclient_retry_helpers_extra.py tests/test_netclient_retry_after_http_date.py` and all tests passed (`3 passed`).
- A broader run that included `tests/test_coverage_boost_targets.py` failed during collection due to an unrelated import error (`ImportError: cannot import name 'gate' from 'sdetkit'`), so the focused test set above was used for validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76deac9008332a75693922497098d)