### PR TITLE
Fix Ruff Fast CI failures in unit tests

### DIFF
--- a/tests/test_main_alias_entrypoint_unit.py
+++ b/tests/test_main_alias_entrypoint_unit.py
@@ -70,8 +70,11 @@ def test_main_alias_cassette_get_helper_wires_module_globals(
 ) -> None:
     import sdetkit.cassette_get as mod
 
-    marker_write = lambda *_a, **_k: None
-    marker_safe = lambda p: p
+    def marker_write(*_a, **_k) -> None:
+        return None
+
+    def marker_safe(path):
+        return path
 
     class MarkerError(Exception):
         pass

--- a/tests/test_package_lazy_imports_unit.py
+++ b/tests/test_package_lazy_imports_unit.py
@@ -41,8 +41,8 @@ def test_package_getattr_caches_loaded_module_for_future_attribute_access(monkey
     monkeypatch.delattr(sdetkit, "playbooks_cli", raising=False)
     monkeypatch.setattr(sdetkit.importlib, "import_module", _fake_import)
 
-    loaded = getattr(sdetkit, "playbooks_cli")
-    cached = getattr(sdetkit, "playbooks_cli")
+    loaded = sdetkit.playbooks_cli
+    cached = sdetkit.playbooks_cli
 
     assert loaded is marker
     assert cached is marker


### PR DESCRIPTION
### Motivation
- Fast CI on Python 3.11/3.12 reported Ruff lint failures (`E731` and `B009`) in unit tests which caused the CI job to fail.

### Description
- Replaced assigned `lambda` expressions in `tests/test_main_alias_entrypoint_unit.py` with named helper functions `marker_write` and `marker_safe` to satisfy Ruff `E731` while preserving test behavior.
- Replaced `getattr(sdetkit, "playbooks_cli")` calls with direct attribute access `sdetkit.playbooks_cli` in `tests/test_package_lazy_imports_unit.py` to address Ruff `B009`.
- Changes are test-only and do not modify production code or test semantics.

### Testing
- Ran `python -m ruff check src tests` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95960131c8332a1a67c3bb64de23c)