### PR TITLE
Add repo visual snapshot generator, artifacts, README badges and theme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,24 @@ Canonical first path:
 
 ![DevS69 SDETKit hero](docs/assets/devs69-hero.svg)
 
-[![Pages](https://img.shields.io/website?url=https%3A%2F%2Fsherif69-sa.github.io%2FDevS69-sdetkit%2F&up_message=live&down_message=down&label=Pages)](https://sherif69-sa.github.io/DevS69-sdetkit/)
-[![CI](https://img.shields.io/github/actions/workflow/status/sherif69-sa/DevS69-sdetkit/ci.yml?branch=main&label=CI)](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml)
-[![Last commit](https://img.shields.io/github/last-commit/sherif69-sa/DevS69-sdetkit/main?label=Last%20commit)](https://github.com/sherif69-sa/DevS69-sdetkit/commits/main)
-[![Latest release](https://img.shields.io/github/v/release/sherif69-sa/DevS69-sdetkit?label=Latest%20release)](https://github.com/sherif69-sa/DevS69-sdetkit/releases)
-[![Open issues](https://img.shields.io/github/issues/sherif69-sa/DevS69-sdetkit?label=Open%20issues)](https://github.com/sherif69-sa/DevS69-sdetkit/issues)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+| Signal | Live status |
+|---|---|
+| Pages | [![Pages](https://img.shields.io/website?url=https%3A%2F%2Fsherif69-sa.github.io%2FDevS69-sdetkit%2F&up_message=live&down_message=down&label=Pages)](https://sherif69-sa.github.io/DevS69-sdetkit/) |
+| CI | [![CI](https://img.shields.io/github/actions/workflow/status/sherif69-sa/DevS69-sdetkit/ci.yml?branch=main&label=CI)](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml) |
+| Docs link check | [![Docs link check](https://img.shields.io/github/actions/workflow/status/sherif69-sa/DevS69-sdetkit/docs-link-check.yml?branch=main&label=Docs%20links)](https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/docs-link-check.yml) |
+| Last commit | [![Last commit](https://img.shields.io/github/last-commit/sherif69-sa/DevS69-sdetkit/main?label=Last%20commit)](https://github.com/sherif69-sa/DevS69-sdetkit/commits/main) |
+| Latest release | [![Latest release](https://img.shields.io/github/v/release/sherif69-sa/DevS69-sdetkit?label=Latest%20release)](https://github.com/sherif69-sa/DevS69-sdetkit/releases) |
+| Open issues | [![Open issues](https://img.shields.io/github/issues/sherif69-sa/DevS69-sdetkit?label=Open%20issues)](https://github.com/sherif69-sa/DevS69-sdetkit/issues) |
+| Community | [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md) |
+
 
 DevS69 SDETKit is a release-confidence CLI: it gives engineering teams deterministic ship/no-ship decisions with machine-readable evidence, using one repeatable command path from local to CI.
 
 **Primary outcome:** know in minutes if a change is ready to ship.
 
 **Fast path:** [Live HUD](https://sherif69-sa.github.io/DevS69-sdetkit/command-hud-live/) · [Quickstart](#quickstart) · [CI rollout](docs/recommended-ci-flow.md)
+
+**Current stable release:** `1.0.3` (released on **April 18, 2026**).
 
 ## Live product visualization
 
@@ -45,6 +51,12 @@ These pull directly from GitHub and auto-update whenever workflows, releases, or
 - ✅ One clear release decision: **ship / no-ship**
 - ✅ Same commands locally and in CI
 - ✅ JSON artifacts that make triage faster
+
+## Honest product stance
+
+We welcome all feedback, including low-star reviews. The goal is to respond with better clarity, better UX, and stronger reliability evidence—not defensiveness.
+
+If you felt friction, open an issue with the exact step where confidence dropped and we will treat it as a product input signal.
 
 ## Quickstart
 
@@ -84,6 +96,18 @@ Decision:
 - Open the live HUD: <https://sherif69-sa.github.io/DevS69-sdetkit/command-hud-live/>
 - Try the quickstart above
 - If it helps, ⭐ star the repo
+
+## Repo visual snapshot tool
+
+Need a cleaner way to *see* repo presentation quality in one place? Run:
+
+```bash
+python scripts/render_repo_visual_snapshot.py
+# optional private screenshot capture (local only):
+python scripts/render_repo_visual_snapshot.py --capture-screenshot
+```
+
+This generates `docs/artifacts/repo-visual-snapshot.md` and `docs/artifacts/repo-visual-snapshot.html`. If you pass `--capture-screenshot`, it also writes a **private local screenshot** at `.sdetkit/out/repo-visual-snapshot.png` (git-ignored) for a high-contrast dashboard preview that is not publicly committed.
 
 ## Proof of value (live log)
 

--- a/docs/artifacts/case-snippet-closeout-pack/proof-map.csv
+++ b/docs/artifacts/case-snippet-closeout-pack/proof-map.csv
@@ -1,2 +1,3 @@
-stream,owner,backup,review_window,docs_cta,command_cta,kpi_target,risk_flag
-case-snippet-floor,qa-lead,docs-owner,2026-03-19T10:00:00Z,docs/integrations-case-snippet-closeout.md,python -m sdetkit case-snippet-closeout --format json --strict,failed-checks:0,narrative-drift
+stream_id,stream,owner,backup,review_window,docs_cta,command_cta,kpi_target,risk_flag,status
+case-snippet-floor,Case Snippet Closeout,qa-lead,docs-owner,2026-03-19T10:00:00Z,docs/integrations-case-snippet-closeout.md,python -m sdetkit case-snippet-closeout --format json --strict,failed-checks:0,narrative-drift,active
+case-snippet-proof,Case Snippet Proof Log,qa-lead,release-manager,2026-03-19T14:00:00Z,docs/proof-log.md,python -m sdetkit gate release --format json --out build/release-preflight.json,release-ok:true,evidence-lag,active

--- a/docs/artifacts/repo-visual-snapshot.html
+++ b/docs/artifacts/repo-visual-snapshot.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8' />
+  <meta name='viewport' content='width=device-width, initial-scale=1' />
+  <title>Repo Visual Snapshot</title>
+  <style>
+    body { font-family: Inter, Segoe UI, system-ui, sans-serif; margin: 0; background: #0b1020; color: #e6e9f4; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 24px; }
+    .hero { background: linear-gradient(135deg, #5b4bff, #0ea5a4); padding: 20px; border-radius: 14px; }
+    .hero h1 { margin: 0 0 8px 0; }
+    .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-top: 16px; }
+    .kpi { background: #131b33; border: 1px solid #273458; border-radius: 12px; padding: 12px; }
+    .progress { height: 10px; background: #1f2b4d; border-radius: 999px; overflow: hidden; margin-top: 8px; }
+    .bar { height: 100%; width: 90%; background: linear-gradient(90deg, #10b981, #22d3ee); }
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-top: 20px; }
+    .card { background: #121a30; border: 1px solid #283659; border-radius: 12px; padding: 12px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 14px; background: #121a30; border-radius: 12px; overflow: hidden; }
+    th, td { border-bottom: 1px solid #243256; text-align: left; padding: 10px; }
+    th { background: #192548; }
+    .chip { background: #243256; border-radius: 999px; padding: 2px 8px; }
+    a { color: #7dd3fc; }
+  </style>
+</head>
+<body>
+  <div class='wrap'>
+    <section class='hero'>
+      <h1>Repo Visual Snapshot</h1>
+      <p>A high-contrast dashboard for README signals, docs theme palette, and proof-map readability.</p>
+      <div class='progress'><div class='bar'></div></div>
+      <p>Readability score: <strong>18</strong>/20 · Grade <strong>A</strong></p>
+    </section>
+
+    <section class='kpis'>
+      <div class='kpi'><strong>Signal rows</strong><br />7</div>
+      <div class='kpi'><strong>Badge links</strong><br />7</div>
+      <div class='kpi'><strong>Palettes</strong><br />2</div>
+      <div class='kpi'><strong>Active streams</strong><br />2</div>
+    </section>
+
+    <h2>Signal cards</h2>
+    <section class='cards'>
+      <div class='card'><h3>Pages</h3><p>Status: ✅ linked badge</p><p><a href='https://sherif69-sa.github.io/DevS69-sdetkit/'>https://sherif69-sa.github.io/DevS69-sdetkit/</a></p></div>
+<div class='card'><h3>CI</h3><p>Status: ✅ linked badge</p><p><a href='https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml'>https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml</a></p></div>
+<div class='card'><h3>Docs link check</h3><p>Status: ✅ linked badge</p><p><a href='https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/docs-link-check.yml'>https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/docs-link-check.yml</a></p></div>
+<div class='card'><h3>Last commit</h3><p>Status: ✅ linked badge</p><p><a href='https://github.com/sherif69-sa/DevS69-sdetkit/commits/main'>https://github.com/sherif69-sa/DevS69-sdetkit/commits/main</a></p></div>
+<div class='card'><h3>Latest release</h3><p>Status: ✅ linked badge</p><p><a href='https://github.com/sherif69-sa/DevS69-sdetkit/releases'>https://github.com/sherif69-sa/DevS69-sdetkit/releases</a></p></div>
+<div class='card'><h3>Open issues</h3><p>Status: ✅ linked badge</p><p><a href='https://github.com/sherif69-sa/DevS69-sdetkit/issues'>https://github.com/sherif69-sa/DevS69-sdetkit/issues</a></p></div>
+<div class='card'><h3>Community</h3><p>Status: ✅ linked badge</p><p><a href='CONTRIBUTING.md'>CONTRIBUTING.md</a></p></div>
+    </section>
+
+    <h2>Docs theme palette</h2>
+    <table>
+      <thead><tr><th>Media</th><th>Scheme</th><th>Primary</th><th>Accent</th></tr></thead>
+      <tbody><tr><td>(prefers-color-scheme: light)</td><td>default</td><td><span class='chip'>deep purple</span></td><td><span class='chip'>teal</span></td></tr>
+<tr><td>(prefers-color-scheme: dark)</td><td>slate</td><td><span class='chip'>deep purple</span></td><td><span class='chip'>lime</span></td></tr></tbody>
+    </table>
+
+    <h2>Proof stream table</h2>
+    <table>
+      <thead><tr><th>Stream</th><th>Owner</th><th>KPI</th><th>Risk</th><th>Status</th></tr></thead>
+      <tbody><tr><td>Case Snippet Closeout</td><td>qa-lead</td><td>failed-checks:0</td><td>narrative-drift</td><td>active</td></tr>
+<tr><td>Case Snippet Proof Log</td><td>qa-lead</td><td>release-ok:true</td><td>evidence-lag</td><td>active</td></tr></tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/docs/artifacts/repo-visual-snapshot.md
+++ b/docs/artifacts/repo-visual-snapshot.md
@@ -1,0 +1,48 @@
+# Repo visual snapshot
+
+This artifact summarizes README live signals, docs palette settings, and proof map readability.
+
+## Scorecard
+
+- Composite readability score: **18**
+- Grade: **A**
+- Signal rows found: **7**
+- Active proof streams: **2**
+
+## README live-signal coverage
+
+| Signal | Badge/Link present | Badge image URL found |
+|---|---|---|
+| Pages | ✅ | ✅ |
+| CI | ✅ | ✅ |
+| Docs link check | ✅ | ✅ |
+| Last commit | ✅ | ✅ |
+| Latest release | ✅ | ✅ |
+| Open issues | ✅ | ✅ |
+| Community | ✅ | ✅ |
+
+## Docs theme palette
+
+| Media query | Scheme | Primary | Accent |
+|---|---|---|---|
+| (prefers-color-scheme: light) | `default` | `deep purple` | `teal` |
+| (prefers-color-scheme: dark) | `slate` | `deep purple` | `lime` |
+
+## Proof map CSV view
+
+| Stream | Owner | KPI target | Risk | Status |
+|---|---|---|---|---|
+| Case Snippet Closeout | qa-lead | failed-checks:0 | narrative-drift | active |
+| Case Snippet Proof Log | qa-lead | release-ok:true | evidence-lag | active |
+
+## Signal targets
+
+| Signal | Target URL |
+|---|---|
+| Pages | https://sherif69-sa.github.io/DevS69-sdetkit/ |
+| CI | https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml |
+| Docs link check | https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/docs-link-check.yml |
+| Last commit | https://github.com/sherif69-sa/DevS69-sdetkit/commits/main |
+| Latest release | https://github.com/sherif69-sa/DevS69-sdetkit/releases |
+| Open issues | https://github.com/sherif69-sa/DevS69-sdetkit/issues |
+| Community | CONTRIBUTING.md |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,15 +29,15 @@ theme:
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: cyan
+      primary: deep purple
+      accent: teal
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: indigo
-      accent: cyan
+      primary: deep purple
+      accent: lime
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
@@ -69,6 +69,8 @@ markdown_extensions:
       custom_checkbox: true
 
 extra:
+  status:
+    new: Recently updated
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/sherif69-sa/DevS69-sdetkit

--- a/scripts/render_repo_visual_snapshot.py
+++ b/scripts/render_repo_visual_snapshot.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SignalRow:
+    name: str
+    markdown_cell: str
+
+    @property
+    def has_badge_link(self) -> bool:
+        return "![" in self.markdown_cell and "](" in self.markdown_cell
+
+    @property
+    def badge_image_url(self) -> str | None:
+        match = re.search(r"!\[[^\]]*\]\(([^)]+)\)", self.markdown_cell)
+        return match.group(1) if match else None
+
+    @property
+    def target_url(self) -> str | None:
+        match = re.search(r"\]\(([^)]+)\)$", self.markdown_cell.strip())
+        return match.group(1) if match else None
+
+
+@dataclass(frozen=True)
+class PaletteRow:
+    media: str
+    scheme: str
+    primary: str
+    accent: str
+
+
+@dataclass(frozen=True)
+class SnapshotData:
+    signals: list[SignalRow]
+    palettes: list[PaletteRow]
+    proof_rows: list[dict[str, str]]
+
+
+def _extract_signal_rows(readme_text: str) -> list[SignalRow]:
+    rows: list[SignalRow] = []
+    in_table = False
+    for line in readme_text.splitlines():
+        if line.strip() == "| Signal | Live status |":
+            in_table = True
+            continue
+        if in_table and line.strip() == "|---|---|":
+            continue
+        if in_table:
+            if not line.startswith("|"):
+                break
+            parts = [p.strip() for p in line.strip().strip("|").split("|")]
+            if len(parts) >= 2:
+                rows.append(SignalRow(name=parts[0], markdown_cell=parts[1]))
+    return rows
+
+
+def _extract_palette(mkdocs_text: str) -> list[PaletteRow]:
+    entries: list[PaletteRow] = []
+    media_blocks = re.split(r"\n\s*- media:", mkdocs_text)
+    for block in media_blocks[1:]:
+        media_line = block.splitlines()[0].strip().strip('"')
+        primary = re.search(r"^\s*primary:\s*(.+)$", block, flags=re.MULTILINE)
+        accent = re.search(r"^\s*accent:\s*(.+)$", block, flags=re.MULTILINE)
+        scheme = re.search(r"^\s*scheme:\s*(.+)$", block, flags=re.MULTILINE)
+        entries.append(
+            PaletteRow(
+                media=media_line,
+                scheme=scheme.group(1).strip() if scheme else "unknown",
+                primary=primary.group(1).strip() if primary else "unknown",
+                accent=accent.group(1).strip() if accent else "unknown",
+            )
+        )
+    return entries
+
+
+def _load_csv_rows(csv_path: Path) -> list[dict[str, str]]:
+    with csv_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        return [dict(row) for row in reader]
+
+
+def _build_data(readme: Path, mkdocs: Path, proof_csv: Path) -> SnapshotData:
+    return SnapshotData(
+        signals=_extract_signal_rows(readme.read_text(encoding="utf-8")),
+        palettes=_extract_palette(mkdocs.read_text(encoding="utf-8")),
+        proof_rows=_load_csv_rows(proof_csv),
+    )
+
+
+def _readability_score(data: SnapshotData) -> int:
+    badge_quality = sum(1 for s in data.signals if s.has_badge_link)
+    active_streams = sum(1 for row in data.proof_rows if row.get("status") == "active")
+    palette_rows = len(data.palettes)
+    return badge_quality * 2 + active_streams + palette_rows
+
+
+def _score_grade(score: int) -> str:
+    if score >= 16:
+        return "A"
+    if score >= 12:
+        return "B"
+    if score >= 8:
+        return "C"
+    return "D"
+
+
+def build_snapshot_markdown(data: SnapshotData) -> str:
+    score = _readability_score(data)
+    grade = _score_grade(score)
+    lines = [
+        "# Repo visual snapshot",
+        "",
+        "This artifact summarizes README live signals, docs palette settings, and proof map readability.",
+        "",
+        "## Scorecard",
+        "",
+        f"- Composite readability score: **{score}**",
+        f"- Grade: **{grade}**",
+        f"- Signal rows found: **{len(data.signals)}**",
+        f"- Active proof streams: **{sum(1 for row in data.proof_rows if row.get('status') == 'active')}**",
+        "",
+        "## README live-signal coverage",
+        "",
+        "| Signal | Badge/Link present | Badge image URL found |",
+        "|---|---|---|",
+    ]
+    for signal in data.signals:
+        lines.append(
+            f"| {signal.name} | {'✅' if signal.has_badge_link else '❌'} | {'✅' if signal.badge_image_url else '❌'} |"
+        )
+
+    lines.extend(
+        ["", "## Docs theme palette", "", "| Media query | Scheme | Primary | Accent |", "|---|---|---|---|"]
+    )
+    for entry in data.palettes:
+        lines.append(f"| {entry.media} | `{entry.scheme}` | `{entry.primary}` | `{entry.accent}` |")
+
+    lines.extend(
+        ["", "## Proof map CSV view", "", "| Stream | Owner | KPI target | Risk | Status |", "|---|---|---|---|---|"]
+    )
+    for row in data.proof_rows:
+        lines.append(
+            "| "
+            f"{row.get('stream', 'n/a')} | "
+            f"{row.get('owner', 'n/a')} | "
+            f"{row.get('kpi_target', 'n/a')} | "
+            f"{row.get('risk_flag', 'n/a')} | "
+            f"{row.get('status', 'n/a')} |"
+        )
+
+    lines.extend(["", "## Signal targets", "", "| Signal | Target URL |", "|---|---|"])
+    for signal in data.signals:
+        lines.append(f"| {signal.name} | {signal.target_url or 'n/a'} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def build_snapshot_html(data: SnapshotData) -> str:
+    score = _readability_score(data)
+    grade = _score_grade(score)
+    active_streams = sum(1 for row in data.proof_rows if row.get("status") == "active")
+    max_score = 20
+    progress = min(100, int((score / max_score) * 100))
+
+    signal_cards = "\n".join(
+        (
+            "<div class='card'>"
+            f"<h3>{html.escape(signal.name)}</h3>"
+            f"<p>Status: {'✅ linked badge' if signal.has_badge_link else '❌ missing badge link'}</p>"
+            f"<p><a href='{html.escape(signal.target_url or '#')}'>{html.escape(signal.target_url or 'n/a')}</a></p>"
+            "</div>"
+        )
+        for signal in data.signals
+    )
+
+    palette_rows = "\n".join(
+        (
+            "<tr>"
+            f"<td>{html.escape(entry.media)}</td>"
+            f"<td>{html.escape(entry.scheme)}</td>"
+            f"<td><span class='chip'>{html.escape(entry.primary)}</span></td>"
+            f"<td><span class='chip'>{html.escape(entry.accent)}</span></td>"
+            "</tr>"
+        )
+        for entry in data.palettes
+    )
+
+    proof_rows = "\n".join(
+        (
+            "<tr>"
+            f"<td>{html.escape(row.get('stream', 'n/a'))}</td>"
+            f"<td>{html.escape(row.get('owner', 'n/a'))}</td>"
+            f"<td>{html.escape(row.get('kpi_target', 'n/a'))}</td>"
+            f"<td>{html.escape(row.get('risk_flag', 'n/a'))}</td>"
+            f"<td>{html.escape(row.get('status', 'n/a'))}</td>"
+            "</tr>"
+        )
+        for row in data.proof_rows
+    )
+
+    return f"""<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8' />
+  <meta name='viewport' content='width=device-width, initial-scale=1' />
+  <title>Repo Visual Snapshot</title>
+  <style>
+    body {{ font-family: Inter, Segoe UI, system-ui, sans-serif; margin: 0; background: #0b1020; color: #e6e9f4; }}
+    .wrap {{ max-width: 1100px; margin: 0 auto; padding: 24px; }}
+    .hero {{ background: linear-gradient(135deg, #5b4bff, #0ea5a4); padding: 20px; border-radius: 14px; }}
+    .hero h1 {{ margin: 0 0 8px 0; }}
+    .kpis {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-top: 16px; }}
+    .kpi {{ background: #131b33; border: 1px solid #273458; border-radius: 12px; padding: 12px; }}
+    .progress {{ height: 10px; background: #1f2b4d; border-radius: 999px; overflow: hidden; margin-top: 8px; }}
+    .bar {{ height: 100%; width: {progress}%; background: linear-gradient(90deg, #10b981, #22d3ee); }}
+    .cards {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-top: 20px; }}
+    .card {{ background: #121a30; border: 1px solid #283659; border-radius: 12px; padding: 12px; }}
+    table {{ width: 100%; border-collapse: collapse; margin-top: 14px; background: #121a30; border-radius: 12px; overflow: hidden; }}
+    th, td {{ border-bottom: 1px solid #243256; text-align: left; padding: 10px; }}
+    th {{ background: #192548; }}
+    .chip {{ background: #243256; border-radius: 999px; padding: 2px 8px; }}
+    a {{ color: #7dd3fc; }}
+  </style>
+</head>
+<body>
+  <div class='wrap'>
+    <section class='hero'>
+      <h1>Repo Visual Snapshot</h1>
+      <p>A high-contrast dashboard for README signals, docs theme palette, and proof-map readability.</p>
+      <div class='progress'><div class='bar'></div></div>
+      <p>Readability score: <strong>{score}</strong>/20 · Grade <strong>{grade}</strong></p>
+    </section>
+
+    <section class='kpis'>
+      <div class='kpi'><strong>Signal rows</strong><br />{len(data.signals)}</div>
+      <div class='kpi'><strong>Badge links</strong><br />{sum(1 for s in data.signals if s.has_badge_link)}</div>
+      <div class='kpi'><strong>Palettes</strong><br />{len(data.palettes)}</div>
+      <div class='kpi'><strong>Active streams</strong><br />{active_streams}</div>
+    </section>
+
+    <h2>Signal cards</h2>
+    <section class='cards'>
+      {signal_cards}
+    </section>
+
+    <h2>Docs theme palette</h2>
+    <table>
+      <thead><tr><th>Media</th><th>Scheme</th><th>Primary</th><th>Accent</th></tr></thead>
+      <tbody>{palette_rows}</tbody>
+    </table>
+
+    <h2>Proof stream table</h2>
+    <table>
+      <thead><tr><th>Stream</th><th>Owner</th><th>KPI</th><th>Risk</th><th>Status</th></tr></thead>
+      <tbody>{proof_rows}</tbody>
+    </table>
+  </div>
+</body>
+</html>
+"""
+
+
+def capture_private_screenshot(html_report: str, screenshot_path: Path) -> None:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise RuntimeError(
+            "playwright is required for screenshots. "
+            "Install with: python -m pip install playwright && python -m playwright install chromium"
+        ) from exc
+
+    screenshot_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", suffix=".html", encoding="utf-8", delete=False) as handle:
+        handle.write(html_report)
+        temp_html = Path(handle.name)
+
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch()
+            page = browser.new_page(viewport={"width": 1366, "height": 2200})
+            page.goto(temp_html.as_uri(), wait_until="networkidle")
+            page.screenshot(path=str(screenshot_path), full_page=True)
+            browser.close()
+    finally:
+        temp_html.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render visual snapshot reports for repo presentation assets.")
+    parser.add_argument("--readme", type=Path, default=Path("README.md"))
+    parser.add_argument("--mkdocs", type=Path, default=Path("mkdocs.yml"))
+    parser.add_argument(
+        "--proof-csv",
+        type=Path,
+        default=Path("docs/artifacts/case-snippet-closeout-pack/proof-map.csv"),
+    )
+    parser.add_argument("--out-md", type=Path, default=Path("docs/artifacts/repo-visual-snapshot.md"))
+    parser.add_argument("--out-html", type=Path, default=Path("docs/artifacts/repo-visual-snapshot.html"))
+    parser.add_argument(
+        "--private-screenshot",
+        type=Path,
+        default=Path(".sdetkit/out/repo-visual-snapshot.png"),
+        help="Private screenshot path (ignored by git by default).",
+    )
+    parser.add_argument(
+        "--capture-screenshot",
+        action="store_true",
+        help="Capture a private local screenshot with Playwright.",
+    )
+    args = parser.parse_args(argv)
+
+    data = _build_data(args.readme, args.mkdocs, args.proof_csv)
+    markdown = build_snapshot_markdown(data)
+    html_report = build_snapshot_html(data)
+
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_html.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.write_text(markdown, encoding="utf-8")
+    args.out_html.write_text(html_report, encoding="utf-8")
+    print(f"wrote {args.out_md}")
+    print(f"wrote {args.out_html}")
+    if args.capture_screenshot:
+        capture_private_screenshot(html_report, args.private_screenshot)
+        print(f"wrote private screenshot {args.private_screenshot}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_render_repo_visual_snapshot.py
+++ b/tests/test_render_repo_visual_snapshot.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "render_repo_visual_snapshot.py"
+
+
+def _load_snapshot_module():
+    spec = importlib.util.spec_from_file_location("render_repo_visual_snapshot", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_snapshot_markdown_contains_scorecard() -> None:
+    module = _load_snapshot_module()
+    data = module._build_data(
+        REPO_ROOT / "README.md",
+        REPO_ROOT / "mkdocs.yml",
+        REPO_ROOT / "docs/artifacts/case-snippet-closeout-pack/proof-map.csv",
+    )
+
+    markdown = module.build_snapshot_markdown(data)
+
+    assert "## Scorecard" in markdown
+    assert "Composite readability score" in markdown
+    assert "## Signal targets" in markdown
+
+
+def test_cli_writes_markdown_and_html_without_screenshot(tmp_path: Path) -> None:
+    out_md = tmp_path / "snapshot.md"
+    out_html = tmp_path / "snapshot.html"
+
+    cmd = [
+        sys.executable,
+        str(SCRIPT_PATH),
+        "--out-md",
+        str(out_md),
+        "--out-html",
+        str(out_html),
+    ]
+
+    completed = subprocess.run(cmd, cwd=REPO_ROOT, check=False, capture_output=True, text=True)
+
+    assert completed.returncode == 0, completed.stderr
+    assert out_md.exists()
+    assert out_html.exists()
+    assert "Repo visual snapshot" in out_md.read_text(encoding="utf-8")
+    assert "<html lang='en'>" in out_html.read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation

- Provide a lightweight tool to surface README live signals, docs theme palette, and proof-map readability as human- and machine-friendly artifacts. 
- Improve README signal presentation and document the current stable release and product stance for clarity. 
- Capture proof-stream data and visual presentation so maintainers can quickly see presentation quality and active streams.

### Description

- Adds a new CLI script `scripts/render_repo_visual_snapshot.py` that parses `README.md`, `mkdocs.yml`, and a proof CSV to emit `docs/artifacts/repo-visual-snapshot.md` and `docs/artifacts/repo-visual-snapshot.html`, and optionally capture a private screenshot via Playwright. 
- Commits generated artifacts `docs/artifacts/repo-visual-snapshot.md` and `docs/artifacts/repo-visual-snapshot.html` and updates `docs/artifacts/case-snippet-closeout-pack/proof-map.csv` to include new headers/rows and `status` field. 
- Updates `README.md` to present live badges as a signals table, adds `Current stable release` and an "Honest product stance" section, and documents the new repo snapshot tool in the quickstart; updates `mkdocs.yml` theme palette primary/accent colors and adds `extra.status` metadata.
- Adds unit tests `tests/test_render_repo_visual_snapshot.py` that load the script, validate the generated markdown scorecard, and run the CLI to ensure it writes both markdown and HTML outputs.

### Testing

- Ran `pytest tests/test_render_repo_visual_snapshot.py` which loads the script and asserts the produced markdown contains the scorecard and that the CLI invocation writes `--out-md` and `--out-html` files; the tests passed. 
- The CLI was executed in a test to verify it exits `0` and produces both the markdown and HTML artifacts, which succeeded. 
- Static inspection of generated HTML/MD artifacts was performed by the tests to confirm presence of `Repo visual snapshot` and `<html lang='en'>`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95b5b92448332a4e28100790964b7)