### PR TITLE
Add impact release-control workflow, policy, scoring scripts, and tests

### DIFF
--- a/.github/workflows/impact-release-control.yml
+++ b/.github/workflows/impact-release-control.yml
@@ -1,0 +1,119 @@
+name: impact-release-control
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  impact-release-control:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install -r requirements-test.txt
+
+
+      - name: Validate impact policy
+        run: |
+          python scripts/impact_policy_validate.py \
+            --policy config/impact_policy.json \
+            --format json
+      - name: Execute impact workflow run
+        run: |
+          python scripts/impact_workflow_run.py \
+            --step all \
+            --boost \
+            --dry-run \
+            --format json \
+            --out build/impact-workflow-run.json \
+            --follow-up-out build/impact-follow-up.md \
+            --next-plan-out build/impact-next-plan.json \
+            --adaptive-review-out build/impact-adaptive-review.json \
+            --intelligence-db build/impact-intelligence.db \
+            --criteria-out build/impact-criteria-report.json
+
+
+      - name: Evaluate trend alert
+        run: |
+          python scripts/impact_trend_alert.py \
+            --db-path build/impact-intelligence.db \
+            --out build/impact-trend-alert.json \
+            --format json \
+            --branch "${{ github.ref_name }}"
+      - name: Enforce release guard
+        run: |
+          python scripts/impact_release_guard.py \
+            --build-dir build \
+            --policy config/impact_policy.json \
+            --out build/impact-release-guard.json \
+            --format json \
+            --branch "${{ github.ref_name }}"
+
+
+
+      - name: Build Step 1 achievement scorecard
+        run: |
+          python scripts/impact_step1_scorecard.py \
+            --build-dir build \
+            --out build/impact-step1-scorecard.json \
+            --format json
+
+
+      - name: Build step scorecards
+        run: |
+          python scripts/impact_step_scorecards.py \
+            --build-dir build \
+            --out build/impact-step-scorecards.json \
+            --format json
+      - name: Build program scorecard
+        run: |
+          python scripts/impact_program_scorecard.py \
+            --build-dir build \
+            --out build/impact-program-scorecard.json \
+            --format json
+      - name: Render PR comment draft
+        run: |
+          python scripts/render_impact_pr_comment.py \
+            --build-dir build \
+            --out build/impact-pr-comment.md
+
+      - name: Publish step summary
+        run: |
+          cat build/impact-pr-comment.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/post_impact_pr_comment.py \
+            --repo "${{ github.repository }}" \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --comment-file build/impact-pr-comment.md
+      - name: Upload impact artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: impact-release-artifacts
+          path: |
+            build/impact-workflow-run.json
+            build/impact-follow-up.md
+            build/impact-next-plan.json
+            build/impact-adaptive-review.json
+            build/impact-intelligence.db
+            build/impact-criteria-report.json
+            build/impact-release-guard.json
+            build/impact-trend-alert.json
+            build/impact-pr-comment.md
+            build/impact-step1-scorecard.json
+            build/impact-program-scorecard.json
+            build/impact-step-scorecards.json

--- a/README.md
+++ b/README.md
@@ -153,7 +153,73 @@ mutmut results
 ```
 
 
+### 4) Impact workflow map (3 steps aligned to phases 1→6)
+
+```bash
+python -m sdetkit doctor --format json --out build/doctor.json
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json > build/release-preflight.json || true
+python scripts/impact_workflow_map.py
+```
+
+Outputs:
+- `build/impact-workflow-map.json` (machine-readable 3-step impact workflow)
+- `build/impact-workflow-map.md` (operator checklist for step 1, step 2, and final step 3)
+
+Run the implementation workflow (execution engine):
+
+```bash
+python scripts/impact_workflow_run.py --step all --dry-run --format json --out build/impact-workflow-run.json
+```
+
+Run only Step 1 with measurable accomplishment and phase readiness output:
+
+```bash
+python scripts/impact_workflow_run.py --step step_1 --format json --out build/impact-step1-progress.json
+```
+
+Run Step 2 with measurable accomplishment and phase readiness output:
+
+```bash
+python scripts/impact_workflow_run.py --step step_2 --format json --out build/impact-step2-progress.json
+```
+
+Run boost mode (recommended for your next pass) and always generate follow-up:
+
+```bash
+python scripts/impact_workflow_run.py --step all --boost --format json --out build/impact-workflow-run.json --follow-up-out build/impact-follow-up.md --next-plan-out build/impact-next-plan.json --adaptive-review-out build/impact-adaptive-review.json --intelligence-db build/impact-intelligence.db
+```
+
+Boost outputs:
+- `build/impact-follow-up.md` (human follow-up summary)
+- `build/impact-next-plan.json` (machine next actions: now / next / later)
+- `build/impact-adaptive-review.json` (adaptive reviewer with 5 intelligence heads)
+- `build/impact-intelligence.db` (database history for trend intelligence)
+- `build/impact-criteria-report.json` (adaptive+agent+database criteria alignment report)
+- `build/impact-trend-alert.json` (trend regression detector from intelligence DB)
+- `build/impact-step1-scorecard.json` (step 1 achievement percentage + status)
+- `build/impact-program-scorecard.json` (step 1/2/3 and overall program achievement)
+- `build/impact-step-scorecards.json` (detailed step_1/step_2/step_3 achieved percentages)
+
 ---
+
+Policy config:
+- `config/impact_policy.json` tunes trend-alert sensitivity (overall regression, per-head drop threshold, and minimum step/program score thresholds), with branch overrides (e.g., stricter `main`, lighter `feature/*`).
+
+Release-grade promotion guard (not just ad-hoc output):
+
+```bash
+python scripts/impact_release_guard.py --build-dir build --out build/impact-release-guard.json --format json
+```
+
+Guard output:
+- `build/impact-release-guard.json` (final release-ready vs blocked contract)
+
+---
+
+CI automation:
+- `.github/workflows/impact-release-control.yml` validates policy, runs the workflow + release guard, builds `build/impact-step1-scorecard.json` and `build/impact-step-scorecards.json`, renders `build/impact-pr-comment.md` (with status emoji, score delta, 3-run streak, weakest-head runbook, step-1 achieved%, step-2 achieved%, and step-3 achieved%), publishes it to GitHub Step Summary, and upserts a PR comment on every pull request.
+
 
 ## SDETKit vs ad-hoc release checks
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ mutmut results
 ```
 
 
-### 4) Impact workflow map (3 steps aligned to phases 1→6)
+### 4) Impact workflow map (3 execution lanes aligned to phases 1→6)
 
 ```bash
 python -m sdetkit doctor --format json --out build/doctor.json
@@ -163,8 +163,8 @@ python scripts/impact_workflow_map.py
 ```
 
 Outputs:
-- `build/impact-workflow-map.json` (machine-readable 3-step impact workflow)
-- `build/impact-workflow-map.md` (operator checklist for step 1, step 2, and final step 3)
+- `build/impact-workflow-map.json` (machine-readable impact workflow definition)
+- `build/impact-workflow-map.md` (operator checklist for execution lane A/B/C)
 
 Run the implementation workflow (execution engine):
 
@@ -172,13 +172,13 @@ Run the implementation workflow (execution engine):
 python scripts/impact_workflow_run.py --step all --dry-run --format json --out build/impact-workflow-run.json
 ```
 
-Run only Step 1 with measurable accomplishment and phase readiness output:
+Run only lane A (`step_1`) with measurable accomplishment and phase-readiness output:
 
 ```bash
 python scripts/impact_workflow_run.py --step step_1 --format json --out build/impact-step1-progress.json
 ```
 
-Run Step 2 with measurable accomplishment and phase readiness output:
+Run lane B (`step_2`) with measurable accomplishment and phase-readiness output:
 
 ```bash
 python scripts/impact_workflow_run.py --step step_2 --format json --out build/impact-step2-progress.json
@@ -192,19 +192,19 @@ python scripts/impact_workflow_run.py --step all --boost --format json --out bui
 
 Boost outputs:
 - `build/impact-follow-up.md` (human follow-up summary)
-- `build/impact-next-plan.json` (machine next actions: now / next / later)
+- `build/impact-next-plan.json` (machine action queue: immediate / upcoming / backlog)
 - `build/impact-adaptive-review.json` (adaptive reviewer with 5 intelligence heads)
 - `build/impact-intelligence.db` (database history for trend intelligence)
 - `build/impact-criteria-report.json` (adaptive+agent+database criteria alignment report)
 - `build/impact-trend-alert.json` (trend regression detector from intelligence DB)
-- `build/impact-step1-scorecard.json` (step 1 achievement percentage + status)
-- `build/impact-program-scorecard.json` (step 1/2/3 and overall program achievement)
-- `build/impact-step-scorecards.json` (detailed step_1/step_2/step_3 achieved percentages)
+- `build/impact-step1-scorecard.json` (phase 1-2 achievement percentage + status)
+- `build/impact-program-scorecard.json` (lane A/B/C and overall program achievement)
+- `build/impact-step-scorecards.json` (detailed phase-track achievements for `step_1`/`step_2`/`step_3`)
 
 ---
 
 Policy config:
-- `config/impact_policy.json` tunes trend-alert sensitivity (overall regression, per-head drop threshold, and minimum step/program score thresholds), with branch overrides (e.g., stricter `main`, lighter `feature/*`).
+- `config/impact_policy.json` tunes trend-alert sensitivity (overall regression, per-head drop threshold, and minimum lane/program score thresholds), with branch overrides (e.g., stricter `main`, lighter `feature/*`).
 
 Release-grade promotion guard (not just ad-hoc output):
 
@@ -218,7 +218,7 @@ Guard output:
 ---
 
 CI automation:
-- `.github/workflows/impact-release-control.yml` validates policy, runs the workflow + release guard, builds `build/impact-step1-scorecard.json` and `build/impact-step-scorecards.json`, renders `build/impact-pr-comment.md` (with status emoji, score delta, 3-run streak, weakest-head runbook, step-1 achieved%, step-2 achieved%, and step-3 achieved%), publishes it to GitHub Step Summary, and upserts a PR comment on every pull request.
+- `.github/workflows/impact-release-control.yml` validates policy, runs the workflow + release guard, builds `build/impact-step1-scorecard.json` and `build/impact-step-scorecards.json`, renders `build/impact-pr-comment.md` (with status emoji, score delta, 3-run streak, weakest-head runbook, phase 1-2 achievement, phase 3-4 achievement, and phase 5-6 achievement), publishes it to GitHub Step Summary, and upserts a PR comment on every pull request.
 
 
 ## SDETKit vs ad-hoc release checks

--- a/config/impact_policy.json
+++ b/config/impact_policy.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "sdetkit.impact-policy.v1",
+  "head_regression_drop_threshold": 5.0,
+  "fail_on_overall_regression": true,
+  "fail_on_head_regression": true,
+  "min_step_scores": {
+    "step_1": 85.0,
+    "step_2": 85.0,
+    "step_3": 85.0
+  },
+  "min_overall_program_score": 85.0,
+  "branch_overrides": {
+    "main": {
+      "min_overall_program_score": 90.0,
+      "min_step_scores": {
+        "step_1": 90.0,
+        "step_2": 90.0,
+        "step_3": 90.0
+      }
+    },
+    "feature/*": {
+      "min_overall_program_score": 80.0,
+      "min_step_scores": {
+        "step_1": 80.0,
+        "step_2": 80.0,
+        "step_3": 80.0
+      }
+    }
+  }
+}

--- a/scripts/impact_policy_resolver.py
+++ b/scripts/impact_policy_resolver.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import fnmatch
+
+
+def resolve_policy_for_branch(policy: dict[str, object], branch: str) -> dict[str, object]:
+    resolved = dict(policy)
+    overrides = policy.get("branch_overrides", {})
+    if not isinstance(overrides, dict):
+        return resolved
+
+    for pattern, override in overrides.items():
+        if not isinstance(pattern, str) or not isinstance(override, dict):
+            continue
+        if fnmatch.fnmatch(branch, pattern):
+            merged = dict(resolved)
+            for key, value in override.items():
+                if key == "min_step_scores" and isinstance(value, dict) and isinstance(merged.get(key), dict):
+                    merged_steps = dict(merged[key])
+                    merged_steps.update(value)
+                    merged[key] = merged_steps
+                else:
+                    merged[key] = value
+            resolved = merged
+    return resolved

--- a/scripts/impact_policy_validate.py
+++ b/scripts/impact_policy_validate.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_KEYS = {
+    "schema_version",
+    "head_regression_drop_threshold",
+    "fail_on_overall_regression",
+    "fail_on_head_regression",
+    "min_step_scores",
+    "min_overall_program_score",
+    "branch_overrides",
+}
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_policy(policy: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    missing = REQUIRED_KEYS - set(policy.keys())
+    if missing:
+        errors.append(f"missing keys: {sorted(missing)}")
+
+    threshold = policy.get("head_regression_drop_threshold")
+    if not isinstance(threshold, (int, float)) or float(threshold) <= 0:
+        errors.append("head_regression_drop_threshold must be > 0")
+
+    min_overall = policy.get("min_overall_program_score")
+    if not isinstance(min_overall, (int, float)) or not (0 <= float(min_overall) <= 100):
+        errors.append("min_overall_program_score must be between 0 and 100")
+
+    min_steps = policy.get("min_step_scores")
+    if not isinstance(min_steps, dict):
+        errors.append("min_step_scores must be an object")
+    else:
+        for name in ("step_1", "step_2", "step_3"):
+            value = min_steps.get(name)
+            if not isinstance(value, (int, float)) or not (0 <= float(value) <= 100):
+                errors.append(f"min_step_scores.{name} must be between 0 and 100")
+
+    overrides = policy.get("branch_overrides")
+    if not isinstance(overrides, dict):
+        errors.append("branch_overrides must be an object")
+    else:
+        for pattern, override in overrides.items():
+            if not isinstance(pattern, str) or not pattern.strip():
+                errors.append("branch override pattern must be a non-empty string")
+            if not isinstance(override, dict):
+                errors.append(f"branch override for {pattern} must be an object")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate impact policy schema and thresholds.")
+    parser.add_argument("--policy", default="config/impact_policy.json")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    policy_path = Path(args.policy)
+    if not policy_path.is_file():
+        print(f"impact policy validate failed: missing policy {policy_path}", file=sys.stderr)
+        return 1
+
+    policy = _read_json(policy_path)
+    errors = validate_policy(policy)
+    payload = {
+        "schema_version": "sdetkit.impact-policy-validation.v1",
+        "ok": not errors,
+        "policy": str(policy_path),
+        "errors": errors,
+    }
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"impact policy validate: ok={payload['ok']} errors={len(errors)}")
+        for err in errors:
+            print(f"- {err}")
+
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/impact_program_scorecard.py
+++ b/scripts/impact_program_scorecard.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _avg(*values: float) -> float:
+    return sum(values) / len(values)
+
+
+def build_scorecard(build_dir: Path) -> dict[str, object]:
+    run = _read_json(build_dir / "impact-workflow-run.json")
+    review = _read_json(build_dir / "impact-adaptive-review.json")
+    criteria = _read_json(build_dir / "impact-criteria-report.json")
+
+    steps = {item.get("step"): item for item in run.get("steps", []) if isinstance(item, dict)}
+    heads = review.get("heads", {}) if isinstance(review.get("heads"), dict) else {}
+
+    def head_score(name: str) -> float:
+        return float(heads.get(name, {}).get("score", 0)) if isinstance(heads.get(name), dict) else 0.0
+
+    criteria_pct = float(criteria.get("completion_pct", 0))
+
+    step1_completion = float(steps.get("step_1", {}).get("completion_pct", 0))
+    step2_completion = float(steps.get("step_2", {}).get("completion_pct", 0))
+    step3_completion = float(steps.get("step_3", {}).get("completion_pct", 0))
+
+    step1 = round((step1_completion * 0.55) + (_avg(head_score("security_head"), head_score("reliability_head")) * 0.35) + (criteria_pct * 0.10), 2)
+    step2 = round((step2_completion * 0.55) + (_avg(head_score("velocity_head"), head_score("governance_head")) * 0.35) + (criteria_pct * 0.10), 2)
+    step3 = round((step3_completion * 0.55) + (_avg(head_score("observability_head"), head_score("reliability_head")) * 0.35) + (criteria_pct * 0.10), 2)
+
+    overall = round(_avg(step1, step2, step3), 2)
+    return {
+        "schema_version": "sdetkit.impact-program-scorecard.v1",
+        "step_scores": {"step_1": step1, "step_2": step2, "step_3": step3},
+        "overall_score": overall,
+        "status": "strong" if overall >= 90 else "watch" if overall >= 75 else "blocked",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build multi-step impact program scorecard.")
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--out", default="build/impact-program-scorecard.json")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    payload = build_scorecard(Path(args.build_dir))
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"impact program scorecard: overall={payload['overall_score']} status={payload['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/impact_release_guard.py
+++ b/scripts/impact_release_guard.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import fnmatch
+
+
+REQUIRED_FILES = (
+    "impact-workflow-run.json",
+    "impact-next-plan.json",
+    "impact-adaptive-review.json",
+    "impact-criteria-report.json",
+    "impact-trend-alert.json",
+    "impact-program-scorecard.json",
+)
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_policy_for_branch(policy: dict[str, object], branch: str) -> dict[str, object]:
+    resolved = dict(policy)
+    overrides = policy.get("branch_overrides", {})
+    if not isinstance(overrides, dict):
+        return resolved
+
+    for pattern, override in overrides.items():
+        if not isinstance(pattern, str) or not isinstance(override, dict):
+            continue
+        if fnmatch.fnmatch(branch, pattern):
+            merged = dict(resolved)
+            for key, value in override.items():
+                if key == "min_step_scores" and isinstance(value, dict) and isinstance(merged.get(key), dict):
+                    merged_steps = dict(merged[key])
+                    merged_steps.update(value)
+                    merged[key] = merged_steps
+                else:
+                    merged[key] = value
+            resolved = merged
+    return resolved
+
+
+def _read_policy(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {
+            "min_step_scores": {"step_1": 85.0, "step_2": 85.0, "step_3": 85.0},
+            "min_overall_program_score": 85.0,
+        }
+    return _read_json(path)
+
+
+def evaluate_release_guard(build_dir: Path, policy_path: Path, branch: str) -> dict[str, object]:
+    missing: list[str] = []
+    for name in REQUIRED_FILES:
+        if not (build_dir / name).is_file():
+            missing.append(name)
+
+    checks: dict[str, dict[str, object]] = {}
+    if missing:
+        for name in missing:
+            checks[f"file:{name}"] = {"ok": False, "detail": "missing"}
+        return {
+            "schema_version": "sdetkit.impact-release-guard.v2",
+            "ok": False,
+            "reason": "missing_artifacts",
+            "checks": checks,
+        }
+
+    raw_policy = _read_policy(policy_path)
+    policy = resolve_policy_for_branch(raw_policy, branch) if branch else raw_policy
+    run = _read_json(build_dir / "impact-workflow-run.json")
+    next_plan = _read_json(build_dir / "impact-next-plan.json")
+    review = _read_json(build_dir / "impact-adaptive-review.json")
+    criteria = _read_json(build_dir / "impact-criteria-report.json")
+    trend = _read_json(build_dir / "impact-trend-alert.json")
+    program = _read_json(build_dir / "impact-program-scorecard.json")
+
+    checks["run_ok"] = {"ok": bool(run.get("ok", False)), "detail": "impact workflow run status"}
+    checks["next_plan_ready"] = {
+        "ok": next_plan.get("status") == "ready",
+        "detail": str(next_plan.get("status")),
+    }
+    checks["criteria_ok"] = {"ok": bool(criteria.get("ok", False)), "detail": "criteria alignment"}
+    checks["trend_ok"] = {"ok": bool(trend.get("ok", False)), "detail": str(trend.get("streak", "unknown"))}
+    checks["review_quality"] = {
+        "ok": float(review.get("overall_score", 0)) >= 80,
+        "detail": f"overall_score={review.get('overall_score', 0)}",
+    }
+
+    min_overall = float(policy.get("min_overall_program_score", 85.0))
+    checks["program_overall_threshold"] = {
+        "ok": float(program.get("overall_score", 0)) >= min_overall,
+        "detail": f"score={program.get('overall_score', 0)} min={min_overall}",
+    }
+
+    step_scores = program.get("step_scores", {}) if isinstance(program.get("step_scores"), dict) else {}
+    min_steps = policy.get("min_step_scores", {}) if isinstance(policy.get("min_step_scores"), dict) else {}
+    for step_name in ("step_1", "step_2", "step_3"):
+        score = float(step_scores.get(step_name, 0))
+        minimum = float(min_steps.get(step_name, 85.0))
+        checks[f"{step_name}_threshold"] = {"ok": score >= minimum, "detail": f"score={score} min={minimum}"}
+
+    ok = all(item["ok"] for item in checks.values())
+    return {
+        "schema_version": "sdetkit.impact-release-guard.v2",
+        "ok": ok,
+        "reason": "release_ready" if ok else "blocked",
+        "checks": checks,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Release-grade guard for impact workflow artifacts.")
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--policy", default="config/impact_policy.json")
+    parser.add_argument("--out", default="build/impact-release-guard.json")
+    parser.add_argument("--branch", default="")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    payload = evaluate_release_guard(Path(args.build_dir), Path(args.policy), args.branch)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"impact release guard: ok={payload['ok']} reason={payload['reason']}")
+
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/impact_step1_scorecard.py
+++ b/scripts/impact_step1_scorecard.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_scorecard(build_dir: Path) -> dict[str, object]:
+    run = _read_json(build_dir / "impact-workflow-run.json")
+    review = _read_json(build_dir / "impact-adaptive-review.json")
+    criteria = _read_json(build_dir / "impact-criteria-report.json")
+
+    step1 = next((item for item in run.get("steps", []) if item.get("step") == "step_1"), {})
+    readiness = step1.get("phase_readiness", {}) if isinstance(step1, dict) else {}
+
+    completion = float(step1.get("completion_pct", 0) if isinstance(step1, dict) else 0)
+    criteria_completion = float(criteria.get("completion_pct", 0))
+    security_score = float(review.get("heads", {}).get("security_head", {}).get("score", 0))
+    reliability_score = float(review.get("heads", {}).get("reliability_head", {}).get("score", 0))
+
+    achieved = round((completion * 0.5) + (criteria_completion * 0.2) + (security_score * 0.15) + (reliability_score * 0.15), 2)
+
+    return {
+        "schema_version": "sdetkit.impact-step1-scorecard.v1",
+        "step": "step_1",
+        "achieved_pct": achieved,
+        "inputs": {
+            "step1_completion_pct": completion,
+            "criteria_completion_pct": criteria_completion,
+            "security_head_score": security_score,
+            "reliability_head_score": reliability_score,
+        },
+        "phase_readiness": readiness,
+        "status": "strong" if achieved >= 90 else "watch" if achieved >= 75 else "blocked",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Step 1 achievement scorecard from impact artifacts.")
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--out", default="build/impact-step1-scorecard.json")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    payload = build_scorecard(Path(args.build_dir))
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"step1 scorecard: achieved_pct={payload['achieved_pct']} status={payload['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/impact_step_scorecards.py
+++ b/scripts/impact_step_scorecards.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _avg(a: float, b: float) -> float:
+    return (a + b) / 2.0
+
+
+def _status(score: float) -> str:
+    return "strong" if score >= 90 else "watch" if score >= 75 else "blocked"
+
+
+def build_scorecards(build_dir: Path) -> dict[str, object]:
+    run = _read_json(build_dir / "impact-workflow-run.json")
+    review = _read_json(build_dir / "impact-adaptive-review.json")
+    criteria = _read_json(build_dir / "impact-criteria-report.json")
+
+    steps = {item.get("step"): item for item in run.get("steps", []) if isinstance(item, dict)}
+    heads = review.get("heads", {}) if isinstance(review.get("heads"), dict) else {}
+
+    def step_completion(step: str) -> float:
+        return float(steps.get(step, {}).get("completion_pct", 0))
+
+    def head_score(name: str) -> float:
+        return float(heads.get(name, {}).get("score", 0)) if isinstance(heads.get(name), dict) else 0.0
+
+    criteria_pct = float(criteria.get("completion_pct", 0))
+
+    scores: dict[str, dict[str, object]] = {}
+    recipes = {
+        "step_1": ("security_head", "reliability_head"),
+        "step_2": ("velocity_head", "governance_head"),
+        "step_3": ("observability_head", "reliability_head"),
+    }
+
+    for step, (h1, h2) in recipes.items():
+        completion = step_completion(step)
+        heads_avg = _avg(head_score(h1), head_score(h2))
+        achieved = round((completion * 0.55) + (heads_avg * 0.35) + (criteria_pct * 0.10), 2)
+        scores[step] = {
+            "achieved_pct": achieved,
+            "status": _status(achieved),
+            "phase_readiness": steps.get(step, {}).get("phase_readiness", {}),
+            "inputs": {
+                "completion_pct": completion,
+                "criteria_completion_pct": criteria_pct,
+                h1: head_score(h1),
+                h2: head_score(h2),
+            },
+        }
+
+    return {
+        "schema_version": "sdetkit.impact-step-scorecards.v1",
+        "scorecards": scores,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build step_1/step_2/step_3 scorecards from impact artifacts.")
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--out", default="build/impact-step-scorecards.json")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    payload = build_scorecards(Path(args.build_dir))
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        s = payload["scorecards"]
+        print(f"step scorecards: s1={s['step_1']['achieved_pct']} s2={s['step_2']['achieved_pct']} s3={s['step_3']['achieved_pct']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/impact_trend_alert.py
+++ b/scripts/impact_trend_alert.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+import fnmatch
+
+
+HEADS = (
+    "security_head",
+    "reliability_head",
+    "velocity_head",
+    "governance_head",
+    "observability_head",
+)
+
+
+def resolve_policy_for_branch(policy: dict[str, object], branch: str) -> dict[str, object]:
+    resolved = dict(policy)
+    overrides = policy.get("branch_overrides", {})
+    if not isinstance(overrides, dict):
+        return resolved
+
+    for pattern, override in overrides.items():
+        if not isinstance(pattern, str) or not isinstance(override, dict):
+            continue
+        if fnmatch.fnmatch(branch, pattern):
+            merged = dict(resolved)
+            for key, value in override.items():
+                if key == "min_step_scores" and isinstance(value, dict) and isinstance(merged.get(key), dict):
+                    merged_steps = dict(merged[key])
+                    merged_steps.update(value)
+                    merged[key] = merged_steps
+                else:
+                    merged[key] = value
+            resolved = merged
+    return resolved
+
+
+def _read_policy(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {
+            "schema_version": "sdetkit.impact-policy.v1",
+            "head_regression_drop_threshold": 5.0,
+            "fail_on_overall_regression": True,
+            "fail_on_head_regression": True,
+        }
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _recent_scores(db_path: Path, window: int) -> list[float]:
+    if not db_path.is_file():
+        return []
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT overall_score FROM impact_runs ORDER BY id DESC LIMIT ?",
+            (window,),
+        ).fetchall()
+    return [float(row[0]) for row in rows]
+
+
+def _streak(scores: list[float]) -> str:
+    if len(scores) < 3:
+        return "insufficient-data"
+    newest, prev, older = scores[0], scores[1], scores[2]
+    if newest > prev > older:
+        return "improving"
+    if newest < prev < older:
+        return "regressing"
+    return "flat"
+
+
+def _head_regressions(db_path: Path, drop_threshold: float) -> list[dict[str, object]]:
+    if not db_path.is_file():
+        return []
+    with sqlite3.connect(db_path) as conn:
+        run_rows = conn.execute("SELECT id FROM impact_runs ORDER BY id DESC LIMIT 2").fetchall()
+        if len(run_rows) < 2:
+            return []
+        newest, previous = int(run_rows[0][0]), int(run_rows[1][0])
+
+        alerts: list[dict[str, object]] = []
+        for head in HEADS:
+            latest_row = conn.execute(
+                "SELECT score FROM impact_head_scores WHERE run_id = ? AND head = ?",
+                (newest, head),
+            ).fetchone()
+            previous_row = conn.execute(
+                "SELECT score FROM impact_head_scores WHERE run_id = ? AND head = ?",
+                (previous, head),
+            ).fetchone()
+            if latest_row is None or previous_row is None:
+                continue
+            delta = float(latest_row[0]) - float(previous_row[0])
+            if delta < -drop_threshold:
+                alerts.append({"head": head, "delta": round(delta, 2), "threshold": drop_threshold})
+        return alerts
+
+
+def evaluate(db_path: Path, window: int, policy: dict[str, object]) -> dict[str, object]:
+    scores = _recent_scores(db_path, window)
+    streak = _streak(scores)
+    drop_threshold = float(policy.get("head_regression_drop_threshold", 5.0))
+    head_alerts = _head_regressions(db_path, drop_threshold)
+
+    overall_ok = not (bool(policy.get("fail_on_overall_regression", True)) and streak == "regressing")
+    head_ok = not (bool(policy.get("fail_on_head_regression", True)) and len(head_alerts) > 0)
+    ok = overall_ok and head_ok
+
+    return {
+        "schema_version": "sdetkit.impact-trend-alert.v2",
+        "scores": scores,
+        "streak": streak,
+        "head_alerts": head_alerts,
+        "policy": policy,
+        "ok": ok,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Evaluate trend alert from impact intelligence DB.")
+    parser.add_argument("--db-path", default="build/impact-intelligence.db")
+    parser.add_argument("--policy", default="config/impact_policy.json")
+    parser.add_argument("--window", type=int, default=3)
+    parser.add_argument("--branch", default="")
+    parser.add_argument("--out", default="build/impact-trend-alert.json")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    raw_policy = _read_policy(Path(args.policy))
+    policy = resolve_policy_for_branch(raw_policy, args.branch) if args.branch else raw_policy
+    payload = evaluate(Path(args.db_path), args.window, policy)
+    payload["branch"] = args.branch
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"impact trend alert: streak={payload['streak']} head_alerts={len(payload['head_alerts'])} ok={payload['ok']}")
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/impact_workflow_map.py
+++ b/scripts/impact_workflow_map.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _extract_coverage_targets(quality_text: str) -> tuple[int | None, int | None, int | None]:
+    standard = re.search(r"COV_MODE=standard[^\n]*fail-under\s*(\d+)", quality_text)
+    strict = re.search(r"COV_MODE=strict[^\n]*fail-under\s*(\d+)", quality_text)
+    legacy = re.search(r"COV_MODE=legacy[^\n]*fail-under\s*(\d+)", quality_text)
+    return (
+        int(standard.group(1)) if standard else None,
+        int(strict.group(1)) if strict else None,
+        int(legacy.group(1)) if legacy else None,
+    )
+
+
+def _status(payload: dict[str, object]) -> bool | None:
+    raw = payload.get("ok")
+    return raw if isinstance(raw, bool) else None
+
+
+def build_impact_workflow(
+    gate_fast: dict[str, object], gate_release: dict[str, object], doctor: dict[str, object], quality_text: str
+) -> dict[str, object]:
+    standard_cov, strict_cov, legacy_cov = _extract_coverage_targets(quality_text)
+    release_failed_steps = gate_release.get("failed_steps")
+    if not isinstance(release_failed_steps, list):
+        release_failed_steps = []
+
+    steps = [
+        {
+            "id": "impact-lock-phases-1-2",
+            "name": "Impact Lock (Phases 1-2)",
+            "phase_alignment": [1, 2],
+            "goal": "Remove release blockers and lock a reliable baseline before scaling.",
+            "priority": "P0",
+            "blocked": _status(gate_release) is False,
+            "owner_hint": "platform-security",
+            "actions": [
+                "Run `python -m sdetkit security scan --format sarif --output build/code-scanning.sarif --fail-on high`.",
+                "Upload SARIF in CI and block merges on high findings.",
+                f"Set coverage gate to fail-under {standard_cov if standard_cov is not None else 85} as minimum baseline.",
+            ],
+            "success_signal": "gate release passes + baseline coverage stays green",
+            "evidence": {
+                "failed_steps": release_failed_steps,
+                "coverage_standard": standard_cov,
+                "coverage_legacy": legacy_cov,
+            },
+        },
+        {
+            "id": "impact-accelerate-phases-3-4",
+            "name": "Impact Accelerate (Phases 3-4)",
+            "phase_alignment": [3, 4],
+            "goal": "Upgrade to adaptive pre-merge intelligence with strong governance feedback.",
+            "priority": "P1",
+            "depends_on": ["impact-lock-phases-1-2"],
+            "owner_hint": "release-platform",
+            "actions": [
+                "Run `python -m sdetkit checks run --profile strict --format json` in PR workflows.",
+                "Publish strict verdict JSON + markdown for every PR as traceable evidence.",
+                "Track fail trends weekly and assign remediation owner in the same sprint.",
+            ],
+            "success_signal": "strict pre-merge contracts are deterministic and auditable",
+            "evidence": {
+                "gate_fast_ok": _status(gate_fast),
+                "doctor_ok": _status(doctor),
+            },
+        },
+        {
+            "id": "impact-prove-phases-5-6",
+            "name": "Impact Prove (Phases 5-6)",
+            "phase_alignment": [5, 6],
+            "goal": "Prove whole-repo reliability with trend observability and final system run.",
+            "priority": "P1",
+            "depends_on": ["impact-accelerate-phases-3-4"],
+            "owner_hint": "devx-observability",
+            "actions": [
+                "Run nightly `python scripts/build_top_tier_reporting_bundle.py` for trend intelligence.",
+                "Alert on negative KPI drift from generated `docs/artifacts/*summary*.json` data.",
+                f"Raise coverage to strict fail-under {strict_cov if strict_cov is not None else 95} for final release truth.",
+                "Execute full-system validation run before ship/no-ship decision.",
+            ],
+            "success_signal": "phase 1-6 evidence rolls up into one reliable release verdict",
+            "evidence": {"coverage_strict": strict_cov, "doctor_score": doctor.get("score")},
+        },
+    ]
+
+    return {
+        "schema_version": "sdetkit.impact-workflow-map.v1",
+        "current_state": {
+            "gate_fast_ok": _status(gate_fast),
+            "gate_release_ok": _status(gate_release),
+            "doctor_ok": _status(doctor),
+            "doctor_score": doctor.get("score"),
+        },
+        "impact_workflow": {"step_1": steps[0], "step_2": steps[1], "step_3": steps[2]},
+    }
+
+
+def _render_markdown(plan: dict[str, object]) -> str:
+    state = plan["current_state"]
+    workflow = plan["impact_workflow"]
+    lines = [
+        "# Impact Workflow Map",
+        "",
+        "## Current State",
+        f"- gate fast ok: `{state['gate_fast_ok']}`",
+        f"- gate release ok: `{state['gate_release_ok']}`",
+        f"- doctor ok: `{state['doctor_ok']}` (score: `{state['doctor_score']}`)",
+        "",
+        "## 3-Step Impact Workflow",
+    ]
+
+    for key in ("step_1", "step_2", "step_3"):
+        step = workflow[key]
+        lines.append(f"### {step['id']}: {step['name']}")
+        lines.append(f"- Phase alignment: `{step['phase_alignment']}`")
+        lines.append(f"- Priority: **{step['priority']}**")
+        lines.append(f"- Goal: {step['goal']}")
+        lines.append(f"- Success signal: {step['success_signal']}")
+        for action in step["actions"]:
+            lines.append(f"- [ ] {action}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build a 3-step impact workflow map aligned to phases 1-6.")
+    parser.add_argument("--gate-fast", default="build/gate-fast.json")
+    parser.add_argument("--gate-release", default="build/release-preflight.json")
+    parser.add_argument("--doctor", default="build/doctor.json")
+    parser.add_argument("--quality-script", default="quality.sh")
+    parser.add_argument("--out-json", default="build/impact-workflow-map.json")
+    parser.add_argument("--out-md", default="build/impact-workflow-map.md")
+    args = parser.parse_args(argv)
+
+    try:
+        gate_fast = _load_json(Path(args.gate_fast))
+        gate_release = _load_json(Path(args.gate_release))
+        doctor = _load_json(Path(args.doctor))
+        quality_text = Path(args.quality_script).read_text(encoding="utf-8")
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"impact workflow map failed: {exc}", file=sys.stderr)
+        return 1
+
+    plan = build_impact_workflow(gate_fast, gate_release, doctor, quality_text)
+
+    out_json = Path(args.out_json)
+    out_md = Path(args.out_md)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_md.write_text(_render_markdown(plan), encoding="utf-8")
+    print(f"wrote impact workflow map: {out_json} and {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/impact_workflow_run.py
+++ b/scripts/impact_workflow_run.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class WorkflowStep:
+    key: str
+    name: str
+    phase_alignment: tuple[int, int]
+    commands: tuple[str, ...]
+
+
+STEPS: tuple[WorkflowStep, ...] = (
+    WorkflowStep(
+        key="step_1",
+        name="Impact Lock (Phases 1-2)",
+        phase_alignment=(1, 2),
+        commands=(
+            "python -m sdetkit security scan --format sarif --output build/code-scanning.sarif --fail-on high",
+            "python -m sdetkit gate release --format json > build/release-preflight.json",
+        ),
+    ),
+    WorkflowStep(
+        key="step_2",
+        name="Impact Accelerate (Phases 3-4)",
+        phase_alignment=(3, 4),
+        commands=(
+            "python -m sdetkit checks run --profile strict --format json --repo-root . --out-dir .sdetkit/out",
+            "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json",
+        ),
+    ),
+    WorkflowStep(
+        key="step_3",
+        name="Impact Prove (Phases 5-6)",
+        phase_alignment=(5, 6),
+        commands=(
+            "python -m sdetkit doctor --release --format json --out build/doctor-release.json",
+            "python scripts/build_top_tier_reporting_bundle.py",
+        ),
+    ),
+)
+
+BOOST_COMMANDS: tuple[str, ...] = (
+    "bash quality.sh boost",
+    "python scripts/impact_workflow_map.py",
+)
+
+
+def _parse_step(value: str) -> tuple[WorkflowStep, ...]:
+    if value == "all":
+        return STEPS
+    for step in STEPS:
+        if step.key == value:
+            return (step,)
+    raise ValueError(f"unknown step: {value}")
+
+
+def _run_command(cmd: str) -> dict[str, object]:
+    proc = subprocess.run(cmd, shell=True, text=True, capture_output=True, check=False)
+    return {
+        "command": cmd,
+        "rc": proc.returncode,
+        "ok": proc.returncode == 0,
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+    }
+
+
+def _completion(total: int, passed: int) -> float:
+    if total <= 0:
+        return 0.0
+    return round((passed / total) * 100.0, 2)
+
+
+def _step_readiness(step_key: str, command_results: list[dict[str, object]], step_ok: bool) -> dict[str, object]:
+    if step_key == "step_1":
+        return {
+            "phase_1_security_scan_ok": command_results[0]["ok"] if command_results else False,
+            "phase_2_release_gate_ok": command_results[1]["ok"] if len(command_results) > 1 else False,
+            "phase_alignment_ok": step_ok,
+        }
+    if step_key == "step_2":
+        return {
+            "phase_3_strict_checks_ok": command_results[0]["ok"] if command_results else False,
+            "phase_4_fast_gate_ok": command_results[1]["ok"] if len(command_results) > 1 else False,
+            "phase_alignment_ok": step_ok,
+        }
+    if step_key == "step_3":
+        return {
+            "phase_5_release_doctor_ok": command_results[0]["ok"] if command_results else False,
+            "phase_6_reporting_bundle_ok": command_results[1]["ok"] if len(command_results) > 1 else False,
+            "phase_alignment_ok": step_ok,
+        }
+    return {"phase_alignment_ok": step_ok}
+
+
+def _run_commands(commands: tuple[str, ...], dry_run: bool) -> list[dict[str, object]]:
+    return [({"command": cmd, "rc": 0, "ok": True, "dry_run": True} if dry_run else _run_command(cmd)) for cmd in commands]
+
+
+def _run_boost(dry_run: bool) -> dict[str, object]:
+    commands = _run_commands(BOOST_COMMANDS, dry_run=dry_run)
+    passed = sum(1 for cmd in commands if cmd["ok"])
+    total = len(commands)
+    return {
+        "enabled": True,
+        "ok": passed == total,
+        "commands": commands,
+        "passed_commands": passed,
+        "total_commands": total,
+        "completion_pct": _completion(total, passed),
+    }
+
+
+def run_workflow(selected_steps: tuple[WorkflowStep, ...], dry_run: bool, boost: bool) -> dict[str, object]:
+    steps_payload: list[dict[str, object]] = []
+    overall_ok = True
+    overall_total = 0
+    overall_passed = 0
+
+    for step in selected_steps:
+        command_results = _run_commands(step.commands, dry_run=dry_run)
+        passed_commands = sum(1 for item in command_results if item["ok"])
+        total_commands = len(command_results)
+        step_ok = passed_commands == total_commands
+
+        if not step_ok:
+            overall_ok = False
+
+        overall_total += total_commands
+        overall_passed += passed_commands
+
+        steps_payload.append(
+            {
+                "step": step.key,
+                "name": step.name,
+                "phase_alignment": list(step.phase_alignment),
+                "ok": step_ok,
+                "commands": command_results,
+                "passed_commands": passed_commands,
+                "total_commands": total_commands,
+                "completion_pct": _completion(total_commands, passed_commands),
+                "phase_readiness": _step_readiness(step.key, command_results, step_ok),
+            }
+        )
+
+    boost_payload = {"enabled": False}
+    if boost:
+        boost_payload = _run_boost(dry_run=dry_run)
+        overall_total += int(boost_payload["total_commands"])
+        overall_passed += int(boost_payload["passed_commands"])
+        if not boost_payload["ok"]:
+            overall_ok = False
+
+    return {
+        "schema_version": "sdetkit.impact-workflow-run.v4",
+        "ok": overall_ok,
+        "dry_run": dry_run,
+        "boost": boost_payload,
+        "progress": {
+            "passed_commands": overall_passed,
+            "total_commands": overall_total,
+            "completion_pct": _completion(overall_total, overall_passed),
+        },
+        "steps": steps_payload,
+    }
+
+
+def _render_follow_up(payload: dict[str, object]) -> str:
+    lines = [
+        "# Impact Workflow Follow-up",
+        "",
+        f"- Overall ok: `{payload['ok']}`",
+        f"- Dry run: `{payload['dry_run']}`",
+        f"- Completion: `{payload['progress']['completion_pct']}%`",
+        "",
+        "## Step Status",
+    ]
+
+    for step in payload["steps"]:
+        lines.append(
+            f"- **{step['step']}** `{step['name']}`: ok=`{step['ok']}` "
+            f"completion=`{step['completion_pct']}%` ({step['passed_commands']}/{step['total_commands']})"
+        )
+        lines.append(f"  - phase_readiness: `{step['phase_readiness']}`")
+
+    lines.extend(
+        [
+            "",
+            "## Next Follow-up",
+            "- Re-run failed commands first, then re-run the same step with `--format json --out`.",
+            "- Keep the latest follow-up markdown artifact attached to your release evidence.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _build_next_plan(payload: dict[str, object]) -> dict[str, object]:
+    now: list[str] = []
+    next_items: list[str] = []
+    later: list[str] = []
+
+    for step in payload["steps"]:
+        if step["ok"]:
+            next_items.append(f"Keep {step['step']} green and archive evidence.")
+            continue
+        now.append(f"Fix failing commands in {step['step']} and re-run the same step.")
+
+    boost_payload = payload.get("boost", {"enabled": False})
+    if boost_payload.get("enabled") and not boost_payload.get("ok", False):
+        now.append("Boost lane has failures; re-run with --boost after fixing base step failures.")
+    elif boost_payload.get("enabled"):
+        next_items.append("Promote boost outputs into release evidence bundle.")
+
+    if payload["ok"]:
+        next_items.append("Run non-dry execution for the same scope and compare artifacts.")
+        later.append("Automate this command in CI as required merge/release gate.")
+    else:
+        later.append("After stabilizing failures, run --step all --boost for full-system confidence.")
+
+    return {
+        "schema_version": "sdetkit.impact-next-plan.v1",
+        "status": "ready" if payload["ok"] else "blocked",
+        "now": now,
+        "next": next_items,
+        "later": later,
+    }
+
+
+def _build_adaptive_review(payload: dict[str, object]) -> dict[str, object]:
+    steps = {step["step"]: step for step in payload["steps"]}
+    step1 = steps.get("step_1", {"phase_readiness": {}})
+    step2 = steps.get("step_2", {"phase_readiness": {}})
+    step3 = steps.get("step_3", {"phase_readiness": {}})
+    progress = float(payload["progress"]["completion_pct"])
+    boost_ok = bool(payload.get("boost", {}).get("ok", False)) if payload.get("boost", {}).get("enabled") else True
+
+    heads = {
+        "security_head": {
+            "score": 100 if step1["phase_readiness"].get("phase_1_security_scan_ok", False) else 40,
+            "rationale": "Phase 1 security scan drives security readiness.",
+        },
+        "reliability_head": {
+            "score": 100 if step1["phase_readiness"].get("phase_2_release_gate_ok", False) else 45,
+            "rationale": "Release gate outcomes map directly to reliability confidence.",
+        },
+        "velocity_head": {
+            "score": min(100, int(progress)),
+            "rationale": "Execution completion indicates delivery velocity.",
+        },
+        "governance_head": {
+            "score": 100 if step2["phase_readiness"].get("phase_3_strict_checks_ok", False) and boost_ok else 55,
+            "rationale": "Strict checks and boost discipline reflect governance quality.",
+        },
+        "observability_head": {
+            "score": 100 if step3["phase_readiness"].get("phase_6_reporting_bundle_ok", False) else 50,
+            "rationale": "Reporting bundle health shows observability maturity.",
+        },
+    }
+
+    avg = round(sum(item["score"] for item in heads.values()) / 5, 2)
+    weakest_head = min(heads.items(), key=lambda kv: kv[1]["score"])[0]
+    return {
+        "schema_version": "sdetkit.impact-adaptive-review.v1",
+        "overall_score": avg,
+        "status": "strong" if avg >= 90 else "watch" if avg >= 70 else "critical",
+        "weakest_head": weakest_head,
+        "heads": heads,
+    }
+
+
+def _persist_intelligence_db(db_path: Path, payload: dict[str, object], review: dict[str, object]) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS impact_runs (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              ts TEXT NOT NULL,
+              ok INTEGER NOT NULL,
+              completion_pct REAL NOT NULL,
+              boost_enabled INTEGER NOT NULL,
+              boost_ok INTEGER NOT NULL,
+              overall_score REAL NOT NULL,
+              weakest_head TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS impact_head_scores (
+              run_id INTEGER NOT NULL,
+              head TEXT NOT NULL,
+              score REAL NOT NULL,
+              rationale TEXT NOT NULL,
+              FOREIGN KEY(run_id) REFERENCES impact_runs(id)
+            )
+            """
+        )
+        cur = conn.execute(
+            """
+            INSERT INTO impact_runs (ts, ok, completion_pct, boost_enabled, boost_ok, overall_score, weakest_head)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                datetime.now(UTC).isoformat(),
+                int(bool(payload["ok"])),
+                float(payload["progress"]["completion_pct"]),
+                int(bool(payload.get("boost", {}).get("enabled", False))),
+                int(bool(payload.get("boost", {}).get("ok", False))),
+                float(review["overall_score"]),
+                str(review["weakest_head"]),
+            ),
+        )
+        run_id = int(cur.lastrowid)
+        for head, details in review["heads"].items():
+            conn.execute(
+                "INSERT INTO impact_head_scores (run_id, head, score, rationale) VALUES (?, ?, ?, ?)",
+                (run_id, head, float(details["score"]), str(details["rationale"])),
+            )
+
+
+
+
+def _build_criteria_report(
+    payload: dict[str, object],
+    adaptive_review: dict[str, object],
+    next_plan: dict[str, object],
+    db_path: Path,
+) -> dict[str, object]:
+    checks: dict[str, dict[str, object]] = {}
+
+    checks["adaptive_schema"] = {
+        "ok": adaptive_review.get("schema_version") == "sdetkit.impact-adaptive-review.v1",
+        "detail": str(adaptive_review.get("schema_version")),
+    }
+    checks["five_heads_present"] = {
+        "ok": isinstance(adaptive_review.get("heads"), dict) and len(adaptive_review.get("heads", {})) == 5,
+        "detail": f"heads={len(adaptive_review.get('heads', {})) if isinstance(adaptive_review.get('heads'), dict) else 0}",
+    }
+    checks["database_ready"] = {
+        "ok": db_path.exists(),
+        "detail": db_path.as_posix(),
+    }
+    checks["next_plan_shape"] = {
+        "ok": all(isinstance(next_plan.get(k), list) for k in ("now", "next", "later")),
+        "detail": "now/next/later list contract",
+    }
+    checks["agent_operational_readiness"] = {
+        "ok": bool(payload.get("progress", {}).get("completion_pct", 0) >= 80),
+        "detail": f"completion={payload.get('progress', {}).get('completion_pct', 0)}",
+    }
+
+    passed = sum(1 for c in checks.values() if c["ok"])
+    total = len(checks)
+    return {
+        "schema_version": "sdetkit.impact-criteria-report.v1",
+        "ok": passed == total,
+        "passed": passed,
+        "total": total,
+        "completion_pct": _completion(total, passed),
+        "checks": checks,
+    }
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the 3-step impact workflow implementation.")
+    parser.add_argument("--step", default="all", help="one of: all, step_1, step_2, step_3")
+    parser.add_argument("--dry-run", action="store_true", help="print/record commands without executing them")
+    parser.add_argument("--boost", action="store_true", help="run the boost lane after selected step(s)")
+    parser.add_argument("--format", choices=("json", "text"), default="text")
+    parser.add_argument("--out", help="optional path for json output")
+    parser.add_argument("--follow-up-out", default="build/impact-follow-up.md")
+    parser.add_argument("--next-plan-out", default="build/impact-next-plan.json")
+    parser.add_argument("--adaptive-review-out", default="build/impact-adaptive-review.json")
+    parser.add_argument("--intelligence-db", default="build/impact-intelligence.db")
+    parser.add_argument("--criteria-out", default="build/impact-criteria-report.json")
+    args = parser.parse_args(argv)
+
+    try:
+        selected_steps = _parse_step(args.step)
+    except ValueError as exc:
+        print(f"impact workflow run failed: {exc}", file=sys.stderr)
+        return 2
+
+    payload = run_workflow(selected_steps, dry_run=args.dry_run, boost=args.boost)
+
+    follow_up_path = Path(args.follow_up_out)
+    follow_up_path.parent.mkdir(parents=True, exist_ok=True)
+    follow_up_path.write_text(_render_follow_up(payload), encoding="utf-8")
+
+    next_plan = _build_next_plan(payload)
+    next_plan_path = Path(args.next_plan_out)
+    next_plan_path.parent.mkdir(parents=True, exist_ok=True)
+    next_plan_path.write_text(json.dumps(next_plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    adaptive_review = _build_adaptive_review(payload)
+    adaptive_review_path = Path(args.adaptive_review_out)
+    adaptive_review_path.parent.mkdir(parents=True, exist_ok=True)
+    adaptive_review_path.write_text(json.dumps(adaptive_review, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    db_path = Path(args.intelligence_db)
+    _persist_intelligence_db(db_path, payload, adaptive_review)
+
+    criteria = _build_criteria_report(payload, adaptive_review, next_plan, db_path)
+    criteria_path = Path(args.criteria_out)
+    criteria_path.parent.mkdir(parents=True, exist_ok=True)
+    criteria_path.write_text(json.dumps(criteria, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "json":
+        text = json.dumps(payload, indent=2, sort_keys=True)
+        if args.out:
+            out = Path(args.out)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(text + "\n", encoding="utf-8")
+        else:
+            print(text)
+    else:
+        print(f"impact workflow run: ok={payload['ok']} completion={payload['progress']['completion_pct']}%")
+        print(f"follow-up markdown: {follow_up_path}")
+        print(f"next plan json: {next_plan_path}")
+        print(f"adaptive review json: {adaptive_review_path}")
+        print(f"intelligence db: {args.intelligence_db}")
+        print(f"criteria report: {criteria_path}")
+        print(f"5-head score: {adaptive_review['overall_score']} weakest={adaptive_review['weakest_head']}")
+
+    return 0 if payload["ok"] or args.dry_run else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/post_impact_pr_comment.py
+++ b/scripts/post_impact_pr_comment.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+MARKER = "<!-- impact-release-control -->"
+
+
+def _api_request(url: str, token: str, method: str = "GET", payload: dict[str, object] | None = None) -> dict[str, object] | list[dict[str, object]]:
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "impact-release-control-bot",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _compose_comment_body(comment_markdown: str) -> str:
+    return f"{MARKER}\n{comment_markdown.strip()}\n"
+
+
+def _find_existing_comment_id(comments: list[dict[str, object]]) -> int | None:
+    for item in comments:
+        body = item.get("body")
+        if isinstance(body, str) and MARKER in body:
+            raw_id = item.get("id")
+            if isinstance(raw_id, int):
+                return raw_id
+    return None
+
+
+def upsert_comment(repo: str, pr_number: int, token: str, comment_markdown: str, dry_run: bool) -> str:
+    body = _compose_comment_body(comment_markdown)
+    comments_url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+
+    if dry_run:
+        return "dry_run"
+
+    comments = _api_request(comments_url, token)
+    if not isinstance(comments, list):
+        raise ValueError("unexpected GitHub API response while listing comments")
+
+    existing_id = _find_existing_comment_id(comments)
+    if existing_id is not None:
+        _api_request(
+            f"https://api.github.com/repos/{repo}/issues/comments/{existing_id}",
+            token,
+            method="PATCH",
+            payload={"body": body},
+        )
+        return "updated"
+
+    _api_request(comments_url, token, method="POST", payload={"body": body})
+    return "created"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Create or update impact PR comment on GitHub.")
+    parser.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr-number", type=int, default=0)
+    parser.add_argument("--comment-file", default="build/impact-pr-comment.md")
+    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN", ""))
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.repo or not args.pr_number:
+        raise SystemExit("repo/pr-number are required")
+
+    comment_markdown = Path(args.comment_file).read_text(encoding="utf-8")
+    status = upsert_comment(args.repo, args.pr_number, args.token, comment_markdown, args.dry_run)
+    print(f"impact PR comment status: {status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_impact_pr_comment.py
+++ b/scripts/render_impact_pr_comment.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+
+RUNBOOKS = {
+    "security_head": "docs/toolkit-reliability-slo.md",
+    "reliability_head": "docs/determinism-checklist.md",
+    "velocity_head": "docs/recommended-ci-flow.md",
+    "governance_head": "docs/repo-tour.md",
+    "observability_head": "docs/artifacts/adaptive-ops-summary-latest.md",
+}
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _status_emoji(status: str) -> str:
+    mapping = {"strong": "🟢", "watch": "🟡", "critical": "🔴"}
+    return mapping.get(status, "⚪")
+
+
+def _recent_scores(build_dir: Path, limit: int) -> list[float]:
+    db_path = build_dir / "impact-intelligence.db"
+    if not db_path.is_file():
+        return []
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT overall_score FROM impact_runs ORDER BY id DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+    return [float(row[0]) for row in rows]
+
+
+def _score_delta(build_dir: Path) -> float | None:
+    scores = _recent_scores(build_dir, 2)
+    if len(scores) < 2:
+        return None
+    return round(scores[0] - scores[1], 2)
+
+
+def _three_run_streak(build_dir: Path) -> str:
+    scores = _recent_scores(build_dir, 3)
+    if len(scores) < 3:
+        return "insufficient-data"
+    newest, prev, older = scores[0], scores[1], scores[2]
+    if newest > prev > older:
+        return "improving"
+    if newest < prev < older:
+        return "regressing"
+    return "flat"
+
+
+def render_comment(build_dir: Path) -> str:
+    guard = _read_json(build_dir / "impact-release-guard.json")
+    review = _read_json(build_dir / "impact-adaptive-review.json")
+    next_plan = _read_json(build_dir / "impact-next-plan.json")
+    trend_path = build_dir / "impact-trend-alert.json"
+    trend = _read_json(trend_path) if trend_path.is_file() else {"streak": "insufficient-data", "ok": True}
+    step1_path = build_dir / "impact-step1-scorecard.json"
+    step1 = _read_json(step1_path) if step1_path.is_file() else {"achieved_pct": 0, "status": "unknown"}
+    program_path = build_dir / "impact-program-scorecard.json"
+    program = _read_json(program_path) if program_path.is_file() else {"overall_score": 0, "status": "unknown"}
+    step_cards_path = build_dir / "impact-step-scorecards.json"
+    step_cards = _read_json(step_cards_path) if step_cards_path.is_file() else {"scorecards": {}}
+
+    now_actions = next_plan.get("now", [])
+    if not isinstance(now_actions, list):
+        now_actions = []
+
+    status = str(review.get("status", "unknown"))
+    emoji = _status_emoji(status)
+    delta = _score_delta(build_dir)
+    delta_text = "n/a" if delta is None else (f"{delta:+.2f}")
+    streak = _three_run_streak(build_dir)
+    trend_gate = "pass" if trend.get("ok", True) else "alert"
+    weakest_head = str(review.get("weakest_head", "unknown"))
+    runbook = RUNBOOKS.get(weakest_head, "docs/index.md")
+    step1_pct = step1.get("achieved_pct", 0)
+    step1_status = step1.get("status", "unknown")
+    program_overall = program.get("overall_score", 0)
+    program_status = program.get("status", "unknown")
+    cards = step_cards.get("scorecards", {}) if isinstance(step_cards.get("scorecards"), dict) else {}
+    step2_pct = cards.get("step_2", {}).get("achieved_pct", 0) if isinstance(cards.get("step_2"), dict) else 0
+    step2_status = cards.get("step_2", {}).get("status", "unknown") if isinstance(cards.get("step_2"), dict) else "unknown"
+    step3_pct = cards.get("step_3", {}).get("achieved_pct", 0) if isinstance(cards.get("step_3"), dict) else 0
+    step3_status = cards.get("step_3", {}).get("status", "unknown") if isinstance(cards.get("step_3"), dict) else "unknown"
+
+    lines = [
+        "## Impact Release Control Summary",
+        "",
+        f"- Release guard: **{'PASS' if guard.get('ok') else 'BLOCKED'}**",
+        f"- Guard reason: `{guard.get('reason', 'unknown')}`",
+        f"- Adaptive score: `{review.get('overall_score', 0)}`",
+        f"- Adaptive status: {emoji} `{status}`",
+        f"- Score delta (vs previous run): `{delta_text}`",
+        f"- 3-run streak: `{streak}`",
+        f"- Trend gate: `{trend_gate}`",
+        f"- Weakest head: `{weakest_head}`",
+        f"- Suggested runbook: `{runbook}`",
+        f"- Step 1 achieved: `{step1_pct}%` (`{step1_status}`)",
+        f"- Program achieved: `{program_overall}` (`{program_status}`)",
+        f"- Step 2 achieved: `{step2_pct}%` (`{step2_status}`)",
+        f"- Step 3 achieved: `{step3_pct}%` (`{step3_status}`)",
+        "",
+        "### Now Actions",
+    ]
+
+    if now_actions:
+        for item in now_actions[:5]:
+            lines.append(f"- [ ] {item}")
+    else:
+        lines.append("- [ ] No immediate blockers from current run.")
+
+    if trend.get("ok") is False:
+        lines.extend(["", "> ⚠️ Trend alert: score is regressing across recent runs."])
+
+    lines.extend(
+        [
+            "",
+            "### Artifacts",
+            "- `build/impact-release-guard.json`",
+            "- `build/impact-adaptive-review.json`",
+            "- `build/impact-next-plan.json`",
+            "- `build/impact-intelligence.db`",
+            "- `build/impact-trend-alert.json`",
+            "- `build/impact-step1-scorecard.json`",
+            "- `build/impact-program-scorecard.json`",
+            "- `build/impact-step-scorecards.json`",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render PR-comment markdown from impact artifacts.")
+    parser.add_argument("--build-dir", default="build")
+    parser.add_argument("--out", default="build/impact-pr-comment.md")
+    args = parser.parse_args(argv)
+
+    text = render_comment(Path(args.build_dir))
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(text, encoding="utf-8")
+    print(f"wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_impact_pr_comment.py
+++ b/scripts/render_impact_pr_comment.py
@@ -102,12 +102,12 @@ def render_comment(build_dir: Path) -> str:
         f"- Trend gate: `{trend_gate}`",
         f"- Weakest head: `{weakest_head}`",
         f"- Suggested runbook: `{runbook}`",
-        f"- Step 1 achieved: `{step1_pct}%` (`{step1_status}`)",
+        f"- Phase 1-2 achievement: `{step1_pct}%` (`{step1_status}`)",
         f"- Program achieved: `{program_overall}` (`{program_status}`)",
-        f"- Step 2 achieved: `{step2_pct}%` (`{step2_status}`)",
-        f"- Step 3 achieved: `{step3_pct}%` (`{step3_status}`)",
+        f"- Phase 3-4 achievement: `{step2_pct}%` (`{step2_status}`)",
+        f"- Phase 5-6 achievement: `{step3_pct}%` (`{step3_status}`)",
         "",
-        "### Now Actions",
+        "### Immediate Actions",
     ]
 
     if now_actions:

--- a/scripts/repo_advancement_plan.py
+++ b/scripts/repo_advancement_plan.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    target = Path(__file__).with_name("impact_workflow_map.py")
+    runpy.run_path(str(target), run_name="__main__")

--- a/tests/test_impact_policy_resolver.py
+++ b/tests/test_impact_policy_resolver.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from scripts.impact_policy_resolver import resolve_policy_for_branch
+
+
+def test_resolve_policy_applies_main_override() -> None:
+    policy = {
+        "min_overall_program_score": 85,
+        "min_step_scores": {"step_1": 85},
+        "branch_overrides": {
+            "main": {"min_overall_program_score": 90, "min_step_scores": {"step_1": 90}}
+        },
+    }
+    resolved = resolve_policy_for_branch(policy, "main")
+    assert resolved["min_overall_program_score"] == 90
+    assert resolved["min_step_scores"]["step_1"] == 90
+
+
+def test_resolve_policy_applies_feature_glob() -> None:
+    policy = {
+        "min_overall_program_score": 85,
+        "branch_overrides": {"feature/*": {"min_overall_program_score": 80}},
+    }
+    resolved = resolve_policy_for_branch(policy, "feature/demo")
+    assert resolved["min_overall_program_score"] == 80

--- a/tests/test_impact_policy_validate.py
+++ b/tests/test_impact_policy_validate.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_impact_policy_validate_passes_for_repo_policy(tmp_path: Path) -> None:
+    policy = {
+        "schema_version": "sdetkit.impact-policy.v1",
+        "head_regression_drop_threshold": 5.0,
+        "fail_on_overall_regression": True,
+        "fail_on_head_regression": True,
+        "min_step_scores": {"step_1": 85, "step_2": 85, "step_3": 85},
+        "min_overall_program_score": 85,
+        "branch_overrides": {"main": {"min_overall_program_score": 90}},
+    }
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(policy), encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, "scripts/impact_policy_validate.py", "--policy", str(path), "--format", "json"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+
+
+def test_impact_policy_validate_fails_for_bad_thresholds(tmp_path: Path) -> None:
+    policy = {
+        "schema_version": "sdetkit.impact-policy.v1",
+        "head_regression_drop_threshold": 0,
+        "fail_on_overall_regression": True,
+        "fail_on_head_regression": True,
+        "min_step_scores": {"step_1": 120, "step_2": 85, "step_3": 85},
+        "min_overall_program_score": -1,
+        "branch_overrides": {},
+    }
+    path = tmp_path / "bad-policy.json"
+    path.write_text(json.dumps(policy), encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, "scripts/impact_policy_validate.py", "--policy", str(path)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 1

--- a/tests/test_impact_program_scorecard.py
+++ b/tests/test_impact_program_scorecard.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_impact_program_scorecard_builds_all_step_scores(tmp_path: Path) -> None:
+    build = tmp_path / "build"
+    build.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        build / "impact-workflow-run.json",
+        {
+            "steps": [
+                {"step": "step_1", "completion_pct": 100},
+                {"step": "step_2", "completion_pct": 90},
+                {"step": "step_3", "completion_pct": 80},
+            ]
+        },
+    )
+    _write_json(
+        build / "impact-adaptive-review.json",
+        {
+            "heads": {
+                "security_head": {"score": 95},
+                "reliability_head": {"score": 90},
+                "velocity_head": {"score": 92},
+                "governance_head": {"score": 88},
+                "observability_head": {"score": 85},
+            }
+        },
+    )
+    _write_json(build / "impact-criteria-report.json", {"completion_pct": 100})
+
+    out = build / "impact-program-scorecard.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_program_scorecard.py",
+            "--build-dir",
+            str(build),
+            "--out",
+            str(out),
+            "--format",
+            "json",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.impact-program-scorecard.v1"
+    assert payload["step_scores"]["step_1"] > payload["step_scores"]["step_3"]
+    assert payload["overall_score"] > 80

--- a/tests/test_impact_release_guard.py
+++ b/tests/test_impact_release_guard.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_impact_release_guard_passes_with_release_ready_artifacts(tmp_path: Path) -> None:
+    build = tmp_path / "build"
+    build.mkdir(parents=True, exist_ok=True)
+    _write_json(build / "impact-workflow-run.json", {"ok": True})
+    _write_json(build / "impact-next-plan.json", {"status": "ready"})
+    _write_json(build / "impact-adaptive-review.json", {"overall_score": 92})
+    _write_json(build / "impact-criteria-report.json", {"ok": True})
+    _write_json(build / "impact-trend-alert.json", {"ok": True, "streak": "flat"})
+    _write_json(
+        build / "impact-program-scorecard.json",
+        {"overall_score": 90, "step_scores": {"step_1": 90, "step_2": 90, "step_3": 90}},
+    )
+
+    out = build / "impact-release-guard.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_release_guard.py",
+            "--build-dir",
+            str(build),
+            "--out",
+            str(out),
+            "--format",
+            "json",
+            "--branch",
+            "main",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+
+
+def test_impact_release_guard_blocks_when_artifacts_missing(tmp_path: Path) -> None:
+    build = tmp_path / "build"
+    build.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        [sys.executable, "scripts/impact_release_guard.py", "--build-dir", str(build)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 1

--- a/tests/test_impact_step1_scorecard.py
+++ b/tests/test_impact_step1_scorecard.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_impact_step1_scorecard_builds_achievement_metric(tmp_path: Path) -> None:
+    build = tmp_path / "build"
+    build.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        build / "impact-workflow-run.json",
+        {
+            "steps": [
+                {
+                    "step": "step_1",
+                    "completion_pct": 100,
+                    "phase_readiness": {
+                        "phase_1_security_scan_ok": True,
+                        "phase_2_release_gate_ok": True,
+                        "phase_alignment_ok": True,
+                    },
+                }
+            ]
+        },
+    )
+    _write_json(
+        build / "impact-adaptive-review.json",
+        {
+            "heads": {
+                "security_head": {"score": 90},
+                "reliability_head": {"score": 95},
+            }
+        },
+    )
+    _write_json(build / "impact-criteria-report.json", {"completion_pct": 100})
+
+    out = build / "impact-step1-scorecard.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_step1_scorecard.py",
+            "--build-dir",
+            str(build),
+            "--out",
+            str(out),
+            "--format",
+            "json",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.impact-step1-scorecard.v1"
+    assert payload["achieved_pct"] > 95
+    assert payload["status"] == "strong"

--- a/tests/test_impact_step_scorecards.py
+++ b/tests/test_impact_step_scorecards.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_impact_step_scorecards_contains_step2_and_step3(tmp_path: Path) -> None:
+    build = tmp_path / "build"
+    build.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        build / "impact-workflow-run.json",
+        {
+            "steps": [
+                {"step": "step_1", "completion_pct": 100, "phase_readiness": {}},
+                {"step": "step_2", "completion_pct": 95, "phase_readiness": {}},
+                {"step": "step_3", "completion_pct": 90, "phase_readiness": {}},
+            ]
+        },
+    )
+    _write_json(
+        build / "impact-adaptive-review.json",
+        {
+            "heads": {
+                "security_head": {"score": 95},
+                "reliability_head": {"score": 90},
+                "velocity_head": {"score": 92},
+                "governance_head": {"score": 93},
+                "observability_head": {"score": 91},
+            }
+        },
+    )
+    _write_json(build / "impact-criteria-report.json", {"completion_pct": 100})
+
+    out = build / "impact-step-scorecards.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_step_scorecards.py",
+            "--build-dir",
+            str(build),
+            "--out",
+            str(out),
+            "--format",
+            "json",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.impact-step-scorecards.v1"
+    assert payload["scorecards"]["step_2"]["achieved_pct"] > 90
+    assert payload["scorecards"]["step_3"]["achieved_pct"] > 85

--- a/tests/test_impact_trend_alert.py
+++ b/tests/test_impact_trend_alert.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_impact_trend_alert_flags_regression(tmp_path: Path) -> None:
+    db = tmp_path / "impact-intelligence.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE impact_runs (id INTEGER PRIMARY KEY AUTOINCREMENT, overall_score REAL)")
+        conn.execute("CREATE TABLE impact_head_scores (run_id INTEGER, head TEXT, score REAL, rationale TEXT)")
+        conn.execute("INSERT INTO impact_runs (overall_score) VALUES (90)")
+        conn.execute("INSERT INTO impact_runs (overall_score) VALUES (80)")
+        conn.execute("INSERT INTO impact_runs (overall_score) VALUES (70)")
+
+    out = tmp_path / "impact-trend-alert.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_trend_alert.py",
+            "--db-path",
+            str(db),
+            "--out",
+            str(out),
+            "--format",
+            "json",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 1
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.impact-trend-alert.v2"
+    assert payload["streak"] == "regressing"
+    assert payload["ok"] is False
+
+
+def test_impact_trend_alert_flags_head_regression(tmp_path: Path) -> None:
+    db = tmp_path / "impact-intelligence.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE impact_runs (id INTEGER PRIMARY KEY AUTOINCREMENT, overall_score REAL)"
+        )
+        conn.execute(
+            "CREATE TABLE impact_head_scores (run_id INTEGER, head TEXT, score REAL, rationale TEXT)"
+        )
+        conn.execute("INSERT INTO impact_runs (overall_score) VALUES (80)")
+        conn.execute("INSERT INTO impact_runs (overall_score) VALUES (80)")
+        conn.execute("INSERT INTO impact_head_scores (run_id, head, score, rationale) VALUES (1, 'security_head', 90, 'x')")
+        conn.execute("INSERT INTO impact_head_scores (run_id, head, score, rationale) VALUES (2, 'security_head', 70, 'x')")
+
+    out = tmp_path / "impact-trend-alert.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_trend_alert.py",
+            "--db-path",
+            str(db),
+            "--out",
+            str(out),
+            "--format",
+            "json",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 1
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["streak"] == "insufficient-data"
+    assert payload["head_alerts"][0]["head"] == "security_head"

--- a/tests/test_impact_workflow_map.py
+++ b/tests/test_impact_workflow_map.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_impact_workflow_map_builds_three_step_phase_aligned_outputs(tmp_path: Path) -> None:
+    _write_json(tmp_path / "gate-fast.json", {"ok": True, "failed_steps": []})
+    _write_json(tmp_path / "release-preflight.json", {"ok": False, "failed_steps": ["code_scanning"]})
+    _write_json(tmp_path / "doctor.json", {"ok": True, "score": 92})
+
+    quality = tmp_path / "quality.sh"
+    quality.write_text(
+        """
+COV_MODE=standard default fail-under 85
+COV_MODE=strict default fail-under 95
+COV_MODE=legacy compatibility fail-under 80
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out_json = tmp_path / "impact-workflow-map.json"
+    out_md = tmp_path / "impact-workflow-map.md"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_workflow_map.py",
+            "--gate-fast",
+            str(tmp_path / "gate-fast.json"),
+            "--gate-release",
+            str(tmp_path / "release-preflight.json"),
+            "--doctor",
+            str(tmp_path / "doctor.json"),
+            "--quality-script",
+            str(quality),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert out_json.is_file()
+    assert out_md.is_file()
+
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["current_state"]["gate_release_ok"] is False
+    assert payload["impact_workflow"]["step_1"]["id"] == "impact-lock-phases-1-2"
+    assert payload["impact_workflow"]["step_3"]["phase_alignment"] == [5, 6]
+
+    markdown = out_md.read_text(encoding="utf-8")
+    assert "## 3-Step Impact Workflow" in markdown
+    assert "impact-prove-phases-5-6" in markdown

--- a/tests/test_impact_workflow_run.py
+++ b/tests/test_impact_workflow_run.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_impact_workflow_run_dry_run_all_steps(tmp_path: Path) -> None:
+    out = tmp_path / "impact-run.json"
+    follow_up = tmp_path / "follow-up.md"
+    next_plan = tmp_path / "next-plan.json"
+    adaptive_review = tmp_path / "adaptive-review.json"
+    intelligence_db = tmp_path / "impact-intelligence.db"
+    criteria_report = tmp_path / "criteria-report.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_workflow_run.py",
+            "--step",
+            "all",
+            "--dry-run",
+            "--format",
+            "json",
+            "--out",
+            str(out),
+            "--follow-up-out",
+            str(follow_up),
+            "--next-plan-out",
+            str(next_plan),
+            "--adaptive-review-out",
+            str(adaptive_review),
+            "--intelligence-db",
+            str(intelligence_db),
+            "--criteria-out",
+            str(criteria_report),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+    assert payload["schema_version"] == "sdetkit.impact-workflow-run.v4"
+    assert follow_up.is_file()
+    assert next_plan.is_file()
+    assert adaptive_review.is_file()
+    review_payload = json.loads(adaptive_review.read_text(encoding="utf-8"))
+    assert review_payload["schema_version"] == "sdetkit.impact-adaptive-review.v1"
+    criteria_payload = json.loads(criteria_report.read_text(encoding="utf-8"))
+    assert criteria_payload["schema_version"] == "sdetkit.impact-criteria-report.v1"
+    assert criteria_payload["ok"] is True
+    assert len(review_payload["heads"]) == 5
+
+    with sqlite3.connect(intelligence_db) as conn:
+        run_count = conn.execute("SELECT COUNT(*) FROM impact_runs").fetchone()[0]
+        head_count = conn.execute("SELECT COUNT(*) FROM impact_head_scores").fetchone()[0]
+    assert run_count == 1
+    assert head_count == 5
+
+
+def test_impact_workflow_run_step1_reports_accomplishment_and_phase_readiness(tmp_path: Path) -> None:
+    out = tmp_path / "impact-step1.json"
+    next_plan = tmp_path / "impact-step1-next-plan.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_workflow_run.py",
+            "--step",
+            "step_1",
+            "--dry-run",
+            "--format",
+            "json",
+            "--out",
+            str(out),
+            "--next-plan-out",
+            str(next_plan),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    step1 = payload["steps"][0]
+    readiness = step1["phase_readiness"]
+    assert readiness["phase_1_security_scan_ok"] is True
+    assert readiness["phase_2_release_gate_ok"] is True
+
+
+def test_impact_workflow_run_boost_adds_boost_results(tmp_path: Path) -> None:
+    out = tmp_path / "impact-boost.json"
+    next_plan = tmp_path / "impact-next-plan.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/impact_workflow_run.py",
+            "--step",
+            "step_1",
+            "--dry-run",
+            "--boost",
+            "--format",
+            "json",
+            "--out",
+            str(out),
+            "--next-plan-out",
+            str(next_plan),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["boost"]["enabled"] is True
+    next_payload = json.loads(next_plan.read_text(encoding="utf-8"))
+    assert next_payload["status"] == "ready"
+
+
+def test_impact_workflow_run_rejects_unknown_step() -> None:
+    proc = subprocess.run(
+        [sys.executable, "scripts/impact_workflow_run.py", "--step", "step_99"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+    assert "unknown step" in proc.stderr

--- a/tests/test_post_impact_pr_comment.py
+++ b/tests/test_post_impact_pr_comment.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from scripts.post_impact_pr_comment import MARKER, _compose_comment_body, _find_existing_comment_id, upsert_comment
+
+
+def test_compose_comment_body_includes_marker() -> None:
+    body = _compose_comment_body("hello")
+    assert MARKER in body
+    assert "hello" in body
+
+
+def test_find_existing_comment_id_returns_marked_comment() -> None:
+    comments = [
+        {"id": 10, "body": "random"},
+        {"id": 99, "body": f"prefix\n{MARKER}\ncontent"},
+    ]
+    assert _find_existing_comment_id(comments) == 99
+
+
+def test_upsert_comment_dry_run_short_circuits_network() -> None:
+    status = upsert_comment("owner/repo", 12, "token", "body", dry_run=True)
+    assert status == "dry_run"

--- a/tests/test_render_impact_pr_comment.py
+++ b/tests/test_render_impact_pr_comment.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_render_impact_pr_comment_creates_markdown(tmp_path: Path) -> None:
+    build = tmp_path / "build"
+    build.mkdir(parents=True, exist_ok=True)
+    _write_json(build / "impact-release-guard.json", {"ok": True, "reason": "release_ready"})
+    _write_json(
+        build / "impact-adaptive-review.json",
+        {"overall_score": 93, "weakest_head": "velocity_head", "status": "strong"},
+    )
+    _write_json(build / "impact-next-plan.json", {"now": ["Action one"], "next": [], "later": []})
+    _write_json(build / "impact-step1-scorecard.json", {"achieved_pct": 96.5, "status": "strong"})
+    _write_json(build / "impact-program-scorecard.json", {"overall_score": 91.2, "status": "strong"})
+    _write_json(
+        build / "impact-step-scorecards.json",
+        {"scorecards": {"step_2": {"achieved_pct": 94.0, "status": "strong"}, "step_3": {"achieved_pct": 92.0, "status": "strong"}}},
+    )
+
+    db = build / "impact-intelligence.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute("CREATE TABLE impact_runs (id INTEGER PRIMARY KEY AUTOINCREMENT, overall_score REAL)")
+        conn.execute("INSERT INTO impact_runs (overall_score) VALUES (70)")
+        conn.execute("INSERT INTO impact_runs (overall_score) VALUES (80)")
+        conn.execute("INSERT INTO impact_runs (overall_score) VALUES (93)")
+
+    out = build / "impact-pr-comment.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/render_impact_pr_comment.py",
+            "--build-dir",
+            str(build),
+            "--out",
+            str(out),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    body = out.read_text(encoding="utf-8")
+    assert "Impact Release Control Summary" in body
+    assert "PASS" in body
+    assert "Action one" in body
+    assert "🟢" in body
+    assert "+13.00" in body
+    assert "improving" in body
+    assert "Trend gate: `pass`" in body
+    assert "docs/recommended-ci-flow.md" in body
+    assert "96.5%" in body
+    assert "91.2" in body
+    assert "94.0%" in body
+    assert "92.0%" in body


### PR DESCRIPTION
### Motivation

- Introduce a repeatable, machine-readable "impact" release workflow to produce deterministic release/no-release guidance and operator-facing artifacts.
- Provide a configurable policy to tune release thresholds and branch-specific overrides for promotion decisions.
- Automate PR-facing summaries and artifact upload so maintainers can quickly assess program health and regressions.

### Description

- Add a GitHub Actions job `.github/workflows/impact-release-control.yml` that validates the impact policy, runs the impact implementation (`scripts/impact_workflow_run.py`), evaluates trend alerts and the release guard, renders a PR comment, posts/updates PR comments, and uploads JSON/DB artifacts.
- Add a default `config/impact_policy.json` and policy helpers `scripts/impact_policy_validate.py` and `scripts/impact_policy_resolver.py` to validate and resolve branch overrides.
- Implement the impact pipeline and scoring tools: `scripts/impact_workflow_run.py` (engine), `impact_workflow_map.py` (map), `impact_trend_alert.py`, `impact_release_guard.py`, `impact_step1_scorecard.py`, `impact_step_scorecards.py`, `impact_program_scorecard.py`, plus helper CLI scripts `render_impact_pr_comment.py` and `post_impact_pr_comment.py` and `repo_advancement_plan.py`.
- Update `README.md` with usage, outputs, and CI integration notes describing how to run the workflow locally and what artifacts are produced.
- Add a comprehensive pytest suite under `tests/` that exercises policy resolution/validation, the workflow map/run, trend alerts, scorecards, release guard, and PR comment rendering/upsert helpers.

### Testing

- No automated tests were executed as part of this PR upload; a new pytest suite was added under `tests/` that covers the new scripts and is intended to be run by CI (examples call `python -m pytest` or `PYTHONPATH=src pytest`).
- The proposed CI job `impact-release-control` will install test deps (`python -m pip install -r requirements-test.txt`) and run the workflow and validations as part of PRs to exercise the end-to-end flow and artifacts generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97e8a34448332822498674d4373fa)