### PR TITLE
Add owner escalation payload builder, Make target, tests, and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GENERATED_AT ?= 2026-04-17T10:00:00Z
 ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 
-.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck adaptive-premerge adaptive-ops-bundle repo-alignment-check test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-workflow phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-start phase2-workflow phase2-status phase2-start-contract phase2-seed phase2-complete phase2-progress phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract
+.PHONY: bootstrap max brutal venv install test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck owner-escalation-payload adaptive-premerge adaptive-ops-bundle repo-alignment-check test-bootstrap test-bootstrap-contract merge-ready phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-workflow phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-start phase2-workflow phase2-status phase2-start-contract phase2-seed phase2-complete phase2-progress phase2-surface-clarity phase3-quality-contract phase4-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -145,6 +145,10 @@ premerge-release-room: venv
 
 adaptive-postcheck: adaptive-scenario-db
 	@bash -lc '. .venv/bin/activate && PYTHONPATH=src python scripts/adaptive_postcheck.py . --scenario $(ADAPTIVE_SCENARIO) --out docs/artifacts/adaptive-postcheck-$(DATE_TAG).json'
+
+
+owner-escalation-payload: venv
+	@bash -lc '. .venv/bin/activate && python scripts/build_owner_escalation_payload.py --out build/owner-escalation-payload.json'
 
 
 adaptive-premerge: adaptive-scenario-db

--- a/docs/enterprise-plan-execution.md
+++ b/docs/enterprise-plan-execution.md
@@ -259,6 +259,26 @@ We will execute **one concrete deliverable at a time**, and each cycle will incl
 - Adaptive post-check automation is live and database-ready.
 - Next hardening step: wire scheduled CI job to persist post-check outputs per run.
 
+## Owner escalation payload usage
+
+Generate a ticket-system-ready escalation payload from adaptive postcheck owner routing:
+
+```bash
+python scripts/build_owner_escalation_payload.py \
+  --postcheck build/adaptive-postcheck-fast.json \
+  --out build/owner-escalation-payload.json
+```
+
+Make shortcut:
+
+```bash
+make owner-escalation-payload
+```
+
+The generated payload preserves route escalation plus adaptive `suggestions` and `follow_up_plan`
+within owner recommendation groups for downstream ticketing/work-tracking systems.
+When no owner routes fail, suggestions/follow-ups are retained under an `unassigned` recommendation group.
+
 
 ### Iteration 14 (adaptive hardening)
 

--- a/scripts/build_owner_escalation_payload.py
+++ b/scripts/build_owner_escalation_payload.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Build deterministic owner escalation payloads from adaptive postcheck artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+ARTIFACTS_DIR = ROOT / "docs" / "artifacts"
+
+_SEVERITY_PRIORITY = {
+    "critical": 0,
+    "high": 1,
+    "medium": 2,
+    "low": 3,
+    "warn": 4,
+}
+
+_PRIORITY_ORDER = {
+    "p0": 0,
+    "critical": 0,
+    "p1": 1,
+    "high": 1,
+    "p2": 2,
+    "medium": 2,
+    "p3": 3,
+    "low": 3,
+    "warn": 4,
+}
+
+_ACTION_TEMPLATES: dict[str, tuple[str, str]] = {
+    "critical": ("P0", "Open an immediate escalation ticket and page the on-call owner."),
+    "high": ("P1", "Create a high-priority ticket with remediation owner and ETA."),
+    "medium": ("P2", "Add to planned remediation backlog and track in weekly ops review."),
+    "low": ("P3", "Track as routine quality debt and monitor for regression."),
+    "warn": ("P3", "Track as advisory action and reassess in the next postcheck cycle."),
+}
+
+
+def _extract_suggestions(postcheck: dict[str, Any]) -> list[dict[str, str]]:
+    rows = postcheck.get("follow_up_enhancements", [])
+    if not isinstance(rows, list):
+        return []
+    suggestions: list[dict[str, str]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        suggestions.append(
+            {
+                "id": str(row.get("id", "unknown")),
+                "priority": str(row.get("priority", "medium")),
+                "suggestion": str(row.get("feature", "")),
+                "follow_up_command": str(row.get("next_command", "")),
+            }
+        )
+    return sorted(
+        suggestions,
+        key=lambda item: (
+            _PRIORITY_ORDER.get(item["priority"].lower(), 99),
+            item["id"],
+            item["suggestion"],
+            item["follow_up_command"],
+        ),
+    )
+
+
+def _extract_follow_up_plan(postcheck: dict[str, Any]) -> list[dict[str, str]]:
+    rows = postcheck.get("next_follow_up_plan", [])
+    if not isinstance(rows, list):
+        return []
+    plan: list[dict[str, str]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        plan.append(
+            {
+                "id": str(row.get("id", "unknown")),
+                "priority": str(row.get("priority", "medium")),
+                "task": str(row.get("task", "")),
+                "command": str(row.get("command", "")),
+            }
+        )
+    return sorted(
+        plan,
+        key=lambda item: (
+            _PRIORITY_ORDER.get(item["priority"].lower(), 99),
+            item["id"],
+            item["task"],
+            item["command"],
+        ),
+    )
+
+
+def _latest_postcheck_path() -> Path:
+    matches = sorted(ARTIFACTS_DIR.glob("adaptive-postcheck-*.json"))
+    if not matches:
+        raise SystemExit("missing adaptive postcheck artifact: docs/artifacts/adaptive-postcheck-*.json")
+    return matches[-1]
+
+
+def _normalize_severity(value: Any) -> str:
+    candidate = str(value or "medium").strip().lower()
+    return candidate if candidate in _SEVERITY_PRIORITY else "medium"
+
+
+def _severity_sort_key(route: dict[str, str]) -> tuple[int, str, str, str, str]:
+    severity = _normalize_severity(route.get("severity"))
+    return (
+        _SEVERITY_PRIORITY.get(severity, 99),
+        str(route.get("owner", "")),
+        str(route.get("check", "")),
+        str(route.get("sla", "")),
+        str(route.get("details", "")),
+    )
+
+
+def _build_routes(postcheck: dict[str, Any]) -> list[dict[str, str]]:
+    scenario = str(postcheck.get("scenario", "unknown"))
+    owner_routing = postcheck.get("owner_routing", [])
+    if not isinstance(owner_routing, list):
+        return []
+
+    routes: list[dict[str, str]] = []
+    for row in owner_routing:
+        if not isinstance(row, dict):
+            continue
+        routes.append(
+            {
+                "check": str(row.get("check", "unknown")),
+                "owner": str(row.get("owner", "platform-ops")),
+                "severity": _normalize_severity(row.get("severity", "medium")),
+                "sla": str(row.get("sla", "7d")),
+                "details": str(row.get("details", "")),
+                "source_scenario": str(row.get("source_scenario", scenario)),
+            }
+        )
+    return sorted(routes, key=_severity_sort_key)
+
+
+def _build_summary(routes: list[dict[str, str]]) -> dict[str, int]:
+    return {
+        "total_routes": len(routes),
+        "critical": sum(1 for row in routes if row.get("severity") == "critical"),
+        "high": sum(1 for row in routes if row.get("severity") == "high"),
+        "medium": sum(1 for row in routes if row.get("severity") == "medium"),
+    }
+
+
+def _build_recommendations(
+    routes: list[dict[str, str]],
+    *,
+    suggestions: list[dict[str, str]],
+    follow_up_plan: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, list[dict[str, str]]]] = {}
+    for row in routes:
+        owner = row["owner"]
+        severity = _normalize_severity(row.get("severity"))
+        owner_bucket = grouped.setdefault(owner, {})
+        owner_bucket.setdefault(severity, []).append(row)
+
+    recommendations: list[dict[str, Any]] = []
+    for owner in sorted(grouped):
+        severities = grouped[owner]
+        prioritized_actions: list[dict[str, Any]] = []
+        for severity in sorted(severities, key=lambda item: _SEVERITY_PRIORITY.get(item, 99)):
+            rows = sorted(severities[severity], key=lambda row: (row["check"], row["sla"], row["details"]))
+            priority, action = _ACTION_TEMPLATES.get(severity, _ACTION_TEMPLATES["medium"])
+            prioritized_actions.append(
+                {
+                    "priority": priority,
+                    "severity": severity,
+                    "action": action,
+                    "route_count": len(rows),
+                    "checks": [row["check"] for row in rows],
+                    "sla_targets": sorted({row["sla"] for row in rows}),
+                }
+            )
+        recommendations.append(
+            {
+                "owner": owner,
+                "total_routes": sum(len(rows) for rows in severities.values()),
+                "prioritized_actions": prioritized_actions,
+                "suggestions": [dict(item) for item in suggestions],
+                "follow_up_plan": [dict(item) for item in follow_up_plan],
+            }
+        )
+
+    if not recommendations and (suggestions or follow_up_plan):
+        recommendations.append(
+            {
+                "owner": "unassigned",
+                "total_routes": 0,
+                "prioritized_actions": [],
+                "suggestions": [dict(item) for item in suggestions],
+                "follow_up_plan": [dict(item) for item in follow_up_plan],
+            }
+        )
+
+    return recommendations
+
+
+def build_payload(postcheck: dict[str, Any]) -> dict[str, Any]:
+    routes = _build_routes(postcheck)
+    suggestions = _extract_suggestions(postcheck)
+    follow_up_plan = _extract_follow_up_plan(postcheck)
+    return {
+        "schema_version": "sdetkit.owner-escalation-payload.v1",
+        "generated_at_utc": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "summary": _build_summary(routes),
+        "routes": routes,
+        "recommendations": _build_recommendations(
+            routes, suggestions=suggestions, follow_up_plan=follow_up_plan
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--postcheck",
+        default=None,
+        help="Adaptive postcheck JSON input path (default: latest docs/artifacts/adaptive-postcheck-*.json)",
+    )
+    parser.add_argument(
+        "--out",
+        default="build/owner-escalation-payload.json",
+        help="Output escalation payload path.",
+    )
+    args = parser.parse_args()
+
+    postcheck_path = Path(args.postcheck) if args.postcheck else _latest_postcheck_path()
+    postcheck = json.loads(postcheck_path.read_text(encoding="utf-8"))
+    payload = build_payload(postcheck)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "postcheck": postcheck_path.as_posix(),
+                "out": out_path.as_posix(),
+                "total_routes": payload["summary"]["total_routes"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_owner_escalation_payload.py
+++ b/tests/test_build_owner_escalation_payload.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "build_owner_escalation_payload.py"
+_SPEC = importlib.util.spec_from_file_location("build_owner_escalation_payload_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+owner_escalation = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(owner_escalation)
+
+
+def test_build_payload_handles_empty_owner_routing() -> None:
+    payload = owner_escalation.build_payload({"scenario": "fast", "owner_routing": []})
+    assert payload["schema_version"] == "sdetkit.owner-escalation-payload.v1"
+    assert payload["summary"] == {"total_routes": 0, "critical": 0, "high": 0, "medium": 0}
+    assert payload["routes"] == []
+    assert payload["recommendations"] == []
+
+
+def test_build_payload_summarizes_mixed_severities() -> None:
+    payload = owner_escalation.build_payload(
+        {
+            "scenario": "strict",
+            "owner_routing": [
+                {"check": "c-medium", "owner": "team-b", "severity": "medium", "sla": "7d", "details": "m"},
+                {"check": "c-critical", "owner": "team-a", "severity": "critical", "sla": "24h", "details": "x"},
+                {"check": "c-high", "owner": "team-a", "severity": "high", "sla": "72h", "details": "y"},
+            ],
+        }
+    )
+
+    assert payload["summary"] == {"total_routes": 3, "critical": 1, "high": 1, "medium": 1}
+    assert [row["check"] for row in payload["routes"]] == ["c-critical", "c-high", "c-medium"]
+    assert all(row["source_scenario"] == "strict" for row in payload["routes"])
+
+
+def test_recommendations_group_by_owner_with_prioritized_actions() -> None:
+    payload = owner_escalation.build_payload(
+        {
+            "scenario": "balanced",
+            "owner_routing": [
+                {"check": "check-2", "owner": "owner-x", "severity": "high", "sla": "72h", "details": "high route"},
+                {"check": "check-1", "owner": "owner-x", "severity": "critical", "sla": "24h", "details": "critical route"},
+                {"check": "check-3", "owner": "owner-y", "severity": "medium", "sla": "7d", "details": "medium route"},
+            ],
+        }
+    )
+
+    assert [row["owner"] for row in payload["recommendations"]] == ["owner-x", "owner-y"]
+    owner_x = payload["recommendations"][0]
+    assert [row["priority"] for row in owner_x["prioritized_actions"]] == ["P0", "P1"]
+    assert owner_x["prioritized_actions"][0]["checks"] == ["check-1"]
+    assert owner_x["suggestions"] == []
+    assert owner_x["follow_up_plan"] == []
+
+
+def test_build_payload_is_deterministic_for_route_and_recommendation_ordering() -> None:
+    postcheck = {
+        "scenario": "balanced",
+        "owner_routing": [
+            {"check": "z-check", "owner": "owner-b", "severity": "high", "sla": "72h", "details": "z"},
+            {"check": "a-check", "owner": "owner-a", "severity": "critical", "sla": "24h", "details": "a"},
+            {"check": "m-check", "owner": "owner-a", "severity": "high", "sla": "72h", "details": "m"},
+        ],
+    }
+
+    first = owner_escalation.build_payload(postcheck)
+    second = owner_escalation.build_payload(postcheck)
+
+    assert [row["check"] for row in first["routes"]] == ["a-check", "m-check", "z-check"]
+    assert [row["owner"] for row in first["recommendations"]] == ["owner-a", "owner-b"]
+
+    # Exclude runtime timestamp from strict comparison.
+    first_fixed = dict(first)
+    second_fixed = dict(second)
+    first_fixed["generated_at_utc"] = "fixed"
+    second_fixed["generated_at_utc"] = "fixed"
+    assert json.dumps(first_fixed, sort_keys=True) == json.dumps(second_fixed, sort_keys=True)
+
+
+def test_build_payload_prefers_route_level_source_scenario_when_present() -> None:
+    payload = owner_escalation.build_payload(
+        {
+            "scenario": "balanced",
+            "owner_routing": [
+                {
+                    "check": "check-1",
+                    "owner": "owner-a",
+                    "severity": "high",
+                    "sla": "72h",
+                    "details": "route detail",
+                    "source_scenario": "strict",
+                }
+            ],
+        }
+    )
+    assert payload["routes"][0]["source_scenario"] == "strict"
+
+
+def test_build_payload_keeps_suggestion_and_follow_up_entries() -> None:
+    payload = owner_escalation.build_payload(
+        {
+            "scenario": "balanced",
+            "owner_routing": [
+                {"check": "check-1", "owner": "owner-a", "severity": "high", "sla": "72h", "details": "route detail"}
+            ],
+            "follow_up_enhancements": [
+                {
+                    "id": "b-item",
+                    "priority": "high",
+                    "feature": "Increase flake classification coverage.",
+                    "next_command": "make adaptive-ops-bundle",
+                },
+                {
+                    "id": "a-item",
+                    "priority": "critical",
+                    "feature": "Backfill owner mappings for strict checks.",
+                    "next_command": "python scripts/adaptive_postcheck.py . --scenario strict",
+                },
+            ],
+            "next_follow_up_plan": [
+                {
+                    "id": "weekly",
+                    "priority": "medium",
+                    "task": "Run weekly adaptive review.",
+                    "command": "make adaptive-ops-bundle",
+                }
+            ],
+        }
+    )
+    owner_a_recommendation = payload["recommendations"][0]
+    assert [row["id"] for row in owner_a_recommendation["suggestions"]] == ["a-item", "b-item"]
+    assert owner_a_recommendation["follow_up_plan"] == [
+        {
+            "id": "weekly",
+            "priority": "medium",
+            "task": "Run weekly adaptive review.",
+            "command": "make adaptive-ops-bundle",
+        }
+    ]
+
+
+def test_suggestion_priority_ordering_is_ranked_not_lexicographic() -> None:
+    payload = owner_escalation.build_payload(
+        {
+            "scenario": "balanced",
+            "owner_routing": [
+                {"check": "check-1", "owner": "owner-a", "severity": "high", "sla": "72h", "details": "route detail"}
+            ],
+            "follow_up_enhancements": [
+                {"id": "p2-item", "priority": "P2", "feature": "Later", "next_command": "echo later"},
+                {"id": "p0-item", "priority": "P0", "feature": "Now", "next_command": "echo now"},
+            ],
+        }
+    )
+    assert [row["id"] for row in payload["recommendations"][0]["suggestions"]] == ["p0-item", "p2-item"]
+
+
+def test_suggestions_and_followups_are_preserved_without_routes() -> None:
+    payload = owner_escalation.build_payload(
+        {
+            "scenario": "balanced",
+            "owner_routing": [],
+            "follow_up_enhancements": [
+                {"id": "s1", "priority": "high", "feature": "Sync owners", "next_command": "make adaptive-ops-bundle"}
+            ],
+            "next_follow_up_plan": [
+                {"id": "f1", "priority": "P1", "task": "Run strict postcheck", "command": "make adaptive-postcheck"}
+            ],
+        }
+    )
+    assert payload["recommendations"] == [
+        {
+            "owner": "unassigned",
+            "total_routes": 0,
+            "prioritized_actions": [],
+            "suggestions": [
+                {
+                    "id": "s1",
+                    "priority": "high",
+                    "suggestion": "Sync owners",
+                    "follow_up_command": "make adaptive-ops-bundle",
+                }
+            ],
+            "follow_up_plan": [
+                {
+                    "id": "f1",
+                    "priority": "P1",
+                    "task": "Run strict postcheck",
+                    "command": "make adaptive-postcheck",
+                }
+            ],
+        }
+    ]
+
+
+def test_generated_timestamp_uses_utc_z_suffix() -> None:
+    payload = owner_escalation.build_payload({"scenario": "fast", "owner_routing": []})
+    assert payload["generated_at_utc"].endswith("Z")


### PR DESCRIPTION
### Motivation

- Provide a deterministic, machine-readable escalation payload derived from adaptive postcheck artifacts to drive ticketing/work-tracking systems.
- Offer a repeatable local/CI entry point to generate owner escalation payloads as part of the adaptive postcheck workflow.
- Preserve owner recommendations, suggestions, and follow-up plans even when no owner routes are present to ensure downstream systems receive actionable items.

### Description

- Add `scripts/build_owner_escalation_payload.py` which loads the latest (or provided) `adaptive-postcheck-*.json`, normalizes severities and routing, extracts suggestions and follow-up plans, and emits a `sdetkit.owner-escalation-payload.v1` JSON payload.
- Add a `Makefile` target `owner-escalation-payload` and include it in `.PHONY` to provide a shortcut for generating `build/owner-escalation-payload.json` via the project venv.
- Add `tests/test_build_owner_escalation_payload.py` covering empty routing, mixed severities, deterministic ordering, suggestions/follow-ups preservation, priority ordering, and timestamp format.
- Update `docs/enterprise-plan-execution.md` with usage examples and notes about how the payload preserves escalation routing and suggestions.

### Testing

- Executed the new unit tests in `tests/test_build_owner_escalation_payload.py` under `pytest -q` and they passed.
- The `pytest` run covered routing sorting, recommendations grouping, suggestion and follow-up preservation, priority ordering, and UTC timestamp formatting and reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c8a6700883328030a99134dcd09f)