### PR TITLE
Reject unsupported Python runtimes in CLI entrypoint and adjust tests

### DIFF
--- a/src/sdetkit/__main__.py
+++ b/src/sdetkit/__main__.py
@@ -2,6 +2,20 @@ from __future__ import annotations
 
 import sys
 
+MIN_RUNTIME_PYTHON: tuple[int, int] = (3, 11)
+
+
+def _validate_runtime_python() -> str | None:
+    if sys.version_info >= MIN_RUNTIME_PYTHON:
+        return None
+    current = f"{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}"
+    required = f"{MIN_RUNTIME_PYTHON[0]}.{MIN_RUNTIME_PYTHON[1]}+"
+    return (
+        "sdetkit requires Python "
+        f"{required}. Detected {current}. "
+        "Use a 3.11+ interpreter before running the CLI."
+    )
+
 
 def _cassette_get(argv: list[str]) -> int:
     from .cassette_get import cassette_get
@@ -16,6 +30,11 @@ def _run_cli_main() -> int | None:
 
 
 def main() -> int:
+    version_error = _validate_runtime_python()
+    if version_error is not None:
+        sys.stderr.write(f"{version_error}\n")
+        return 2
+
     argv = sys.argv
     if len(argv) > 1 and argv[1] == "cassette-get":
         try:

--- a/tests/test_cli_sdetkit.py
+++ b/tests/test_cli_sdetkit.py
@@ -117,6 +117,7 @@ def test_sdetkit_version_flag_uses_unknown_when_metadata_missing(monkeypatch):
 
 def test_kvcli_help():
     import subprocess
+    import sys
     import sysconfig
     from pathlib import Path
 
@@ -125,8 +126,9 @@ def test_kvcli_help():
     if not kv.exists():
         kv = scripts / "kvcli.exe"
 
+    cmd = [str(kv), "--help"] if kv.exists() else [sys.executable, "-m", "sdetkit.kvcli", "--help"]
     p = subprocess.run(
-        [str(kv) if kv.exists() else "kvcli", "--help"],
+        cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -137,6 +139,7 @@ def test_kvcli_help():
 
 def test_apigetcli_help():
     import subprocess
+    import sys
     import sysconfig
     from pathlib import Path
 
@@ -145,8 +148,13 @@ def test_apigetcli_help():
     if not apiget.exists():
         apiget = scripts / "apigetcli.exe"
 
+    cmd = (
+        [str(apiget), "--help"]
+        if apiget.exists()
+        else [sys.executable, "-m", "sdetkit.apiget", "--help"]
+    )
     p = subprocess.run(
-        [str(apiget) if apiget.exists() else "apigetcli", "--help"],
+        cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/tests/test_main_entrypoint_coverage.py
+++ b/tests/test_main_entrypoint_coverage.py
@@ -99,3 +99,16 @@ def test_main_cli_string_code_is_cast_to_int(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(entry, "_run_cli_main", lambda: "9")
 
     assert entry.main() == 9
+
+
+def test_main_rejects_unsupported_python(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(entry.sys, "version_info", (3, 10, 9))
+    monkeypatch.setattr(entry.sys, "argv", ["sdetkit"])
+
+    assert entry.main() == 2
+    assert (
+        capsys.readouterr().err
+        == "sdetkit requires Python 3.11+. Detected 3.10.9. Use a 3.11+ interpreter before running the CLI.\n"
+    )


### PR DESCRIPTION
### Motivation
- Ensure the CLI entrypoint refuses to run on Python versions older than 3.11 with a clear message and non-zero exit code.
- Make script-invocation tests robust by falling back to invoking modules with the test interpreter when packaged scripts are not present.
- Add coverage for the new runtime validation behavior.

### Description
- Add `MIN_RUNTIME_PYTHON = (3, 11)` and a `_validate_runtime_python()` helper in `src/sdetkit/__main__.py` to detect unsupported runtimes and return a descriptive error string.
- Have `main()` write the error to `stderr` and return exit code `2` when the runtime is below Python 3.11.
- Update CLI tests in `tests/test_cli_sdetkit.py` to import `sys` and use a `sys.executable -m` fallback when script entrypoints are not present, and add `test_main_rejects_unsupported_python` to `tests/test_main_entrypoint_coverage.py` to assert the new behavior.

### Testing
- Ran the test suite with `pytest`, including `test_main_rejects_unsupported_python`, `test_kvcli_help`, and `test_apigetcli_help`, and they passed.
- Existing entrypoint coverage tests in `tests/test_main_entrypoint_coverage.py` were executed and succeeded.
- Script help tests updated to use the `sys.executable -m` fallback were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9ec2b90e4832d9ebd7304d430581d)