### PR TITLE
Support Python 3.10: add runtime guards, toml shim, and datetime compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sdetkit"
 version = "1.0.3"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 readme = "README.md"
 description = "Operator-grade release confidence and test intelligence platform: deterministic gates, evidence, integration assurance, and failure forensics."
 license = "Apache-2.0"
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Testing",
@@ -27,7 +28,8 @@ classifiers = [
   "Topic :: Utilities",
 ]
 dependencies = [
-  "httpx>=0.28.1,<1"
+  "httpx>=0.28.1,<1",
+  "tomli>=2.0.1; python_version < '3.11'"
 ]
 [project.urls]
 Homepage = "https://github.com/sherif69-sa/DevS69-sdetkit"

--- a/src/sdetkit/__main__.py
+++ b/src/sdetkit/__main__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 
-MIN_RUNTIME_PYTHON: tuple[int, int] = (3, 11)
+MIN_RUNTIME_PYTHON: tuple[int, int] = (3, 10)
 
 
 def _validate_runtime_python() -> str | None:
@@ -13,7 +13,7 @@ def _validate_runtime_python() -> str | None:
     return (
         "sdetkit requires Python "
         f"{required}. Detected {current}. "
-        "Use a 3.11+ interpreter before running the CLI."
+        "Use a 3.10+ interpreter before running the CLI."
     )
 
 

--- a/src/sdetkit/cli/serve.py
+++ b/src/sdetkit/cli/serve.py
@@ -17,7 +17,7 @@ from ..security import SecurityError, safe_path
 SERVE_CONTRACT_VERSION = "sdetkit.serve.contract.v1"
 _MAX_BODY_BYTES = 1_048_576
 _OBS_DEFAULT_STALE_SECONDS = 24 * 60 * 60
-UTC = getattr(_dt, "UTC", _dt.timezone.utc)
+UTC = getattr(_dt, "UTC", _dt.timezone.utc)  # noqa: UP017
 datetime = _dt.datetime
 
 

--- a/src/sdetkit/cli/serve.py
+++ b/src/sdetkit/cli/serve.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import json
 import os
 import re
 import time
-from datetime import UTC, datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -17,6 +17,8 @@ from ..security import SecurityError, safe_path
 SERVE_CONTRACT_VERSION = "sdetkit.serve.contract.v1"
 _MAX_BODY_BYTES = 1_048_576
 _OBS_DEFAULT_STALE_SECONDS = 24 * 60 * 60
+UTC = getattr(_dt, "UTC", _dt.timezone.utc)
+datetime = _dt.datetime
 
 
 class RequestValidationError(ValueError):

--- a/src/sdetkit/core/__init__.py
+++ b/src/sdetkit/core/__init__.py
@@ -112,10 +112,15 @@ def __getattr__(name: str) -> Any:
         return import_module(f".{alias_target}", __name__)
 
     if name not in _missing_module_cache:
-        from . import playbooks_cli
+        playbooks_cli = import_module("sdetkit.playbooks_cli")
 
         class _CompatModule(ModuleType):
             def main(self, argv: list[str] | None = None) -> int:
+                from ._runtime import ensure_supported_python
+
+                unsupported_rc = ensure_supported_python(component="sdetkit core")
+                if unsupported_rc is not None:
+                    return unsupported_rc
                 args = list(argv or [])
                 cmd = name.replace("_", "-")
                 return playbooks_cli.main([cmd, *args])

--- a/src/sdetkit/core/__main__.py
+++ b/src/sdetkit/core/__main__.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
 import sys
+from importlib import import_module
 
-from . import cassette_get as _cassette_get_module
-from .atomicio import atomic_write_text
-from .security import SecurityError, safe_path
+from sdetkit.core._runtime import ensure_supported_python
+
+
+def _ensure_supported_python(version_info: tuple[int, int] | None = None) -> int | None:
+    return ensure_supported_python(
+        component="sdetkit core",
+        version_info=version_info,
+    )
 
 
 def _cassette_get(argv: list[str]) -> int:
+    _cassette_get_module = import_module("sdetkit.cassette_get")
+    from sdetkit.atomicio import atomic_write_text
+    from sdetkit.security import SecurityError, safe_path
+
     # Compatibility shim for tests that monkeypatch __main__ symbols directly.
     _cassette_get_module.atomic_write_text = atomic_write_text
     _cassette_get_module.safe_path = safe_path
@@ -16,6 +26,10 @@ def _cassette_get(argv: list[str]) -> int:
 
 
 def main() -> int:
+    unsupported_rc = _ensure_supported_python()
+    if unsupported_rc is not None:
+        return unsupported_rc
+
     argv = sys.argv[1:]
     if argv and argv[0] == "cassette-get":
         try:
@@ -24,7 +38,7 @@ def main() -> int:
             sys.stderr.write(str(e) + "\n")
             return 2
 
-    from .cli import main as cli_main
+    from sdetkit.cli import main as cli_main
 
     try:
         return int(cli_main() or 0)

--- a/src/sdetkit/core/_entrypoints.py
+++ b/src/sdetkit/core/_entrypoints.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
-from .apiget import main as apiget_main
-from .kvcli import main as kvcli_main
+from sdetkit.apiget import main as apiget_main
+from sdetkit.core._runtime import ensure_supported_python
+from sdetkit.kvcli import cli_entry as kvcli_main
 
 
 def kvcli() -> int:
-    return kvcli_main()
+    unsupported_rc = ensure_supported_python(component="sdetkit core")
+    if unsupported_rc is not None:
+        return unsupported_rc
+    return int(kvcli_main())
 
 
 def apigetcli() -> int:
-    return apiget_main()
+    unsupported_rc = ensure_supported_python(component="sdetkit core")
+    if unsupported_rc is not None:
+        return unsupported_rc
+    return int(apiget_main())

--- a/src/sdetkit/core/_runtime.py
+++ b/src/sdetkit/core/_runtime.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+from typing import TextIO
+
+MIN_RUNTIME_PYTHON: tuple[int, int] = (3, 10)
+
+
+def ensure_supported_python(
+    *,
+    component: str = "sdetkit core",
+    version_info: tuple[int, int] | None = None,
+    stderr: TextIO | None = None,
+) -> int | None:
+    if version_info is None:
+        current = (sys.version_info[0], sys.version_info[1])
+    else:
+        current = version_info
+    if current >= MIN_RUNTIME_PYTHON:
+        return None
+    stream = stderr or sys.stderr
+    stream.write(
+        f"{component} requires Python 3.10+. "
+        f"Detected {current[0]}.{current[1]}. Use a 3.10+ interpreter before running.\n"
+    )
+    return 2

--- a/src/sdetkit/intelligence/review.py
+++ b/src/sdetkit/intelligence/review.py
@@ -39,7 +39,7 @@ SCHEMA_VERSION = "sdetkit.review.v3"
 REVIEW_CONTRACT_VERSION = "sdetkit.review.contract.v1"
 EXIT_OK = 0
 EXIT_FINDINGS = 2
-UTC = getattr(_dt, "UTC", _dt.timezone.utc)
+UTC = getattr(_dt, "UTC", _dt.timezone.utc)  # noqa: UP017
 datetime = _dt.datetime
 timedelta = _dt.timedelta
 

--- a/src/sdetkit/intelligence/review.py
+++ b/src/sdetkit/intelligence/review.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import datetime as _dt
 import hashlib
 import io
 import json
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +39,9 @@ SCHEMA_VERSION = "sdetkit.review.v3"
 REVIEW_CONTRACT_VERSION = "sdetkit.review.contract.v1"
 EXIT_OK = 0
 EXIT_FINDINGS = 2
+UTC = getattr(_dt, "UTC", _dt.timezone.utc)
+datetime = _dt.datetime
+timedelta = _dt.timedelta
 
 
 @dataclass(frozen=True)

--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as _dt
 import random
 import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-import datetime as _dt
 from email.utils import parsedate_to_datetime
 from typing import Any, Literal
 from urllib.parse import urljoin

--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -15,7 +15,7 @@ from .optional_httpx import load_httpx
 from .security import default_http_timeout, ensure_allowed_scheme
 
 httpx = load_httpx(feature="sdetkit network workflows")
-UTC = getattr(_dt, "UTC", _dt.timezone.utc)
+UTC = getattr(_dt, "UTC", _dt.timezone.utc)  # noqa: UP017
 datetime = _dt.datetime
 
 EventType = Literal[

--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime
+import datetime as _dt
 from email.utils import parsedate_to_datetime
 from typing import Any, Literal
 from urllib.parse import urljoin
@@ -15,6 +15,8 @@ from .optional_httpx import load_httpx
 from .security import default_http_timeout, ensure_allowed_scheme
 
 httpx = load_httpx(feature="sdetkit network workflows")
+UTC = getattr(_dt, "UTC", _dt.timezone.utc)
+datetime = _dt.datetime
 
 EventType = Literal[
     "attempt_start",

--- a/src/sdetkit/playbooks_cli.py
+++ b/src/sdetkit/playbooks_cli.py
@@ -1,9 +1,9 @@
-"""Compatibility wrapper for historical `sdetkit.playbooks_cli` imports."""
+"""Compatibility alias for historical ``sdetkit.playbooks_cli`` imports."""
 
 from __future__ import annotations
 
-from importlib import import_module as _import_module
+import sys
+from importlib import import_module
 
-_IMPL = _import_module("sdetkit.cli.playbooks_cli")
-__all__ = getattr(_IMPL, "__all__", [name for name in dir(_IMPL) if not name.startswith("__")])
-globals().update({name: getattr(_IMPL, name) for name in __all__})
+_IMPL = import_module("sdetkit.cli.playbooks_cli")
+sys.modules[__name__] = _IMPL

--- a/src/sdetkit/test_bootstrap.py
+++ b/src/sdetkit/test_bootstrap.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Sequence
 
 REQUIRED_TEST_MODULES: tuple[str, ...] = ("httpx", "yaml", "hypothesis")
-MIN_TEST_PYTHON: tuple[int, int] = (3, 11)
+MIN_TEST_PYTHON: tuple[int, int] = (3, 10)
 TEST_BOOTSTRAP_REMEDIATION = "python -m pip install -r requirements-test.txt"
 
 

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -7,13 +7,13 @@ import fnmatch
 import json
 import re
 import sys
-import tomllib
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+from ._toml import loads as toml_loads
 from .bools import coerce_bool
 
 REQ_NAME_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)")
@@ -100,6 +100,7 @@ COMMON_IMPORT_ALIASES = {
     "cyclonedx-bom": {"cyclonedx_py"},
     "pre-commit": {"pre_commit"},
 }
+DT_UTC = getattr(dt, "UTC", dt.timezone.utc)
 
 
 def _parse_dep_name(raw_requirement: str) -> str:
@@ -155,7 +156,7 @@ def _normalize_requirement_line(line: str) -> str | None:
 
 
 def _load_pyproject_dependencies(pyproject_path: Path) -> list[Dependency]:
-    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    data = toml_loads(pyproject_path.read_text(encoding="utf-8"))
     project = data.get("project", {})
     deps: list[Dependency] = []
 
@@ -353,7 +354,7 @@ def _load_cache(cache_path: Path) -> dict[str, dict[str, str | float | None]]:
 def _persist_cache(cache_path: Path, cache: dict[str, dict[str, str | float | None]]) -> None:
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
-        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "generated_at": dt.datetime.now(DT_UTC).isoformat(),
         "packages": cache,
     }
     cache_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -370,7 +371,7 @@ def _cache_entry_fresh(
         return False
     if entry.get("include_prereleases") is not include_prereleases:
         return False
-    age_s = dt.datetime.now(dt.UTC).timestamp() - float(fetched_at)
+    age_s = dt.datetime.now(DT_UTC).timestamp() - float(fetched_at)
     return age_s <= max(ttl_hours, 0) * 3600
 
 
@@ -462,7 +463,7 @@ def _fetch_package_metadata(
         compatible_version, compatible_release_date, compatibility_status = None, None, "unknown"
 
     cache[package] = {
-        "fetched_at": dt.datetime.now(dt.UTC).timestamp(),
+        "fetched_at": dt.datetime.now(DT_UTC).timestamp(),
         "include_prereleases": include_prereleases,
         "latest_version": latest_version,
         "release_date": release_date,
@@ -529,7 +530,7 @@ def _collect_package_metadata(
 
 
 def _load_project_python_requires(pyproject_path: Path) -> str | None:
-    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    data = toml_loads(pyproject_path.read_text(encoding="utf-8"))
     project = data.get("project", {})
     value = project.get("requires-python")
     return str(value).strip() if isinstance(value, str) and value.strip() else None
@@ -918,8 +919,8 @@ def _release_age_days(release_date: str | None) -> int | None:
     except ValueError:
         return None
     if uploaded.tzinfo is None:
-        uploaded = uploaded.replace(tzinfo=dt.UTC)
-    now = dt.datetime.now(dt.UTC)
+        uploaded = uploaded.replace(tzinfo=DT_UTC)
+    now = dt.datetime.now(DT_UTC)
     return max((now - uploaded).days, 0)
 
 

--- a/src/sdetkit/upgrade_audit.py
+++ b/src/sdetkit/upgrade_audit.py
@@ -100,7 +100,7 @@ COMMON_IMPORT_ALIASES = {
     "cyclonedx-bom": {"cyclonedx_py"},
     "pre-commit": {"pre_commit"},
 }
-DT_UTC = getattr(dt, "UTC", dt.timezone.utc)
+DT_UTC = getattr(dt, "UTC", dt.timezone.utc)  # noqa: UP017
 
 
 def _parse_dep_name(raw_requirement: str) -> str:

--- a/src/sitecustomize.py
+++ b/src/sitecustomize.py
@@ -5,7 +5,7 @@ import importlib.util
 import sys
 
 if not hasattr(_dt, "UTC"):
-    _dt.UTC = _dt.timezone.utc  # type: ignore[attr-defined]  # noqa: UP017
+    _dt.UTC = _dt.timezone.utc  # noqa: UP017
 
 if importlib.util.find_spec("tomllib") is None and importlib.util.find_spec("tomli") is not None:
     import tomli as _tomli

--- a/src/sitecustomize.py
+++ b/src/sitecustomize.py
@@ -5,7 +5,7 @@ import importlib.util
 import sys
 
 if not hasattr(_dt, "UTC"):
-    _dt.UTC = _dt.timezone.utc  # type: ignore[attr-defined]
+    _dt.UTC = _dt.timezone.utc  # type: ignore[attr-defined]  # noqa: UP017
 
 if importlib.util.find_spec("tomllib") is None and importlib.util.find_spec("tomli") is not None:
     import tomli as _tomli

--- a/src/sitecustomize.py
+++ b/src/sitecustomize.py
@@ -4,7 +4,6 @@ import datetime as _dt
 import importlib.util
 import sys
 
-
 if not hasattr(_dt, "UTC"):
     _dt.UTC = _dt.timezone.utc  # type: ignore[attr-defined]
 

--- a/src/sitecustomize.py
+++ b/src/sitecustomize.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import datetime as _dt
+import importlib.util
+import sys
+
+
+if not hasattr(_dt, "UTC"):
+    _dt.UTC = _dt.timezone.utc  # type: ignore[attr-defined]
+
+if importlib.util.find_spec("tomllib") is None and importlib.util.find_spec("tomli") is not None:
+    import tomli as _tomli
+
+    sys.modules.setdefault("tomllib", _tomli)

--- a/templates/platform_problem/rich/generate_test_problem.py
+++ b/templates/platform_problem/rich/generate_test_problem.py
@@ -24,13 +24,28 @@ def _text_from_markup_with_metadata(
     end: str,
     tab_size: int,
 ) -> Text:
-    text = Text.from_markup(markup)
+    try:
+        text = Text.from_markup(markup)
+    except TypeError:
+        text = _construct_with_init_alias(Text, markup)
     text.justify = justify
     text.overflow = overflow
     text.no_wrap = no_wrap
     text.end = end
     text.tab_size = tab_size
     return text
+
+
+def _construct_with_init_alias(factory, *args, **kwargs):
+    try:
+        return factory(*args, **kwargs)
+    except TypeError:
+        instance = factory()
+        init_alias = getattr(instance, "init_", None)
+        if callable(init_alias):
+            init_alias(*args, **kwargs)
+            return instance
+        raise
 
 
 def _build_case_data() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
@@ -79,10 +94,10 @@ def _build_case_data() -> tuple[list[dict[str, object]], list[dict[str, object]]
         link = f"https://example.org/problem/{i:04d}" if i % 3 != 1 else ""
         meta = meta_templates[i % len(meta_templates)](i)
         meta.update(handler_templates[i % len(handler_templates)](i))
-        text = Text(plain, style=base_style)
+        text = _construct_with_init_alias(Text, plain, style=base_style)
         if link:
-            text.stylize(Style(link=link), 0, len(text))
-        text.stylize(Style(meta=meta), 0, len(text))
+            text.stylize(_construct_with_init_alias(Style, link=link), 0, len(text))
+        text.stylize(_construct_with_init_alias(Style, meta=meta), 0, len(text))
         if inner_style:
             start = 5 + (i % 4)
             end = len(plain) - (3 + (i % 5))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,9 +30,9 @@ def pytest_sessionstart(session: pytest.Session) -> None:
 
     if not py["supported"]:
         pytest.exit(
-            "sdetkit tests require Python >=3.11. "
+            "sdetkit tests require Python >=3.10. "
             f"Detected {py['current']}. "
-            "Use a 3.11+ interpreter before running pytest.",
+            "Use a 3.10+ interpreter before running pytest.",
             returncode=2,
         )
 

--- a/tests/test_core_and_intelligence_init_unit.py
+++ b/tests/test_core_and_intelligence_init_unit.py
@@ -14,17 +14,20 @@ def test_core_dunder_getattr_exports_and_compat_module(monkeypatch) -> None:
     with pytest.raises(ModuleNotFoundError):
         core.__getattr__("register_scalar_function")
 
-    with pytest.raises(RecursionError):
-        core.__getattr__("main_")
+    main_module = core.__getattr__("main_")
+    assert hasattr(main_module, "main")
 
     calls: list[list[str]] = []
-    fake_playbooks = ModuleType("sdetkit.core.playbooks_cli")
+    fake_playbooks = ModuleType("sdetkit.playbooks_cli")
     fake_playbooks.main = lambda argv=None: calls.append(list(argv or [])) or 77  # type: ignore[attr-defined]
-    monkeypatch.setitem(__import__("sys").modules, "sdetkit.core.playbooks_cli", fake_playbooks)
+    monkeypatch.setitem(__import__("sys").modules, "sdetkit.playbooks_cli", fake_playbooks)
 
     compat = core.__getattr__("totally_missing_lane")
     assert compat.main(["--x"]) == 77
     assert calls[0][0] == "totally-missing-lane"
+    runtime_guard = __import__("sdetkit.core._runtime", fromlist=["ensure_supported_python"])
+    monkeypatch.setattr(runtime_guard, "ensure_supported_python", lambda **_k: 2)
+    assert compat.main(["--x"]) == 2
 
     closeout_mod = core.__getattr__("launch_readiness_closeout")
     assert hasattr(closeout_mod, "main")

--- a/tests/test_core_main_edge_unit.py
+++ b/tests/test_core_main_edge_unit.py
@@ -9,21 +9,21 @@ def _load_core_main(monkeypatch):
     src_root = Path(__file__).resolve().parents[1] / "src" / "sdetkit" / "core"
     core_pkg = ModuleType("sdetkit.core")
     core_pkg.__path__ = [str(src_root)]  # type: ignore[attr-defined]
-    cassette_get_mod = ModuleType("sdetkit.core.cassette_get")
+    cassette_get_mod = ModuleType("sdetkit.cassette_get")
     cassette_get_mod.cassette_get = lambda argv: len(argv)  # type: ignore[attr-defined]
-    atomicio_mod = ModuleType("sdetkit.core.atomicio")
+    atomicio_mod = ModuleType("sdetkit.atomicio")
     atomicio_mod.atomic_write_text = lambda *_a, **_k: None  # type: ignore[attr-defined]
-    security_mod = ModuleType("sdetkit.core.security")
+    security_mod = ModuleType("sdetkit.security")
     security_mod.SecurityError = RuntimeError  # type: ignore[attr-defined]
     security_mod.safe_path = lambda p: p  # type: ignore[attr-defined]
-    cli_mod = ModuleType("sdetkit.core.cli")
+    cli_mod = ModuleType("sdetkit.cli")
     cli_mod.main = lambda: 0  # type: ignore[attr-defined]
 
     monkeypatch.setitem(__import__("sys").modules, "sdetkit.core", core_pkg)
-    monkeypatch.setitem(__import__("sys").modules, "sdetkit.core.cassette_get", cassette_get_mod)
-    monkeypatch.setitem(__import__("sys").modules, "sdetkit.core.atomicio", atomicio_mod)
-    monkeypatch.setitem(__import__("sys").modules, "sdetkit.core.security", security_mod)
-    monkeypatch.setitem(__import__("sys").modules, "sdetkit.core.cli", cli_mod)
+    monkeypatch.setitem(__import__("sys").modules, "sdetkit.cassette_get", cassette_get_mod)
+    monkeypatch.setitem(__import__("sys").modules, "sdetkit.atomicio", atomicio_mod)
+    monkeypatch.setitem(__import__("sys").modules, "sdetkit.security", security_mod)
+    monkeypatch.setitem(__import__("sys").modules, "sdetkit.cli", cli_mod)
 
     spec = importlib.util.spec_from_file_location("sdetkit.core.__main__", src_root / "__main__.py")
     assert spec and spec.loader
@@ -59,3 +59,9 @@ def test_core_main_cassette_get_exception_path(monkeypatch, capsys) -> None:
     monkeypatch.setattr(module.sys, "argv", ["prog", "cassette-get", "x"])
     assert module.main() == 2
     assert "kaboom" in capsys.readouterr().err
+
+
+def test_core_main_returns_error_for_unsupported_python(monkeypatch, capsys) -> None:
+    module, _ = _load_core_main(monkeypatch)
+    assert module._ensure_supported_python((3, 9)) == 2
+    assert "requires Python 3.10+" in capsys.readouterr().err

--- a/tests/test_main_entrypoint_coverage.py
+++ b/tests/test_main_entrypoint_coverage.py
@@ -104,11 +104,11 @@ def test_main_cli_string_code_is_cast_to_int(monkeypatch: pytest.MonkeyPatch) ->
 def test_main_rejects_unsupported_python(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(entry.sys, "version_info", (3, 10, 9))
+    monkeypatch.setattr(entry.sys, "version_info", (3, 9, 9))
     monkeypatch.setattr(entry.sys, "argv", ["sdetkit"])
 
     assert entry.main() == 2
     assert (
         capsys.readouterr().err
-        == "sdetkit requires Python 3.11+. Detected 3.10.9. Use a 3.11+ interpreter before running the CLI.\n"
+        == "sdetkit requires Python 3.10+. Detected 3.9.9. Use a 3.10+ interpreter before running the CLI.\n"
     )

--- a/tests/test_validate_test_bootstrap.py
+++ b/tests/test_validate_test_bootstrap.py
@@ -17,7 +17,7 @@ def test_build_report_ok(monkeypatch):
 
 
 def test_build_report_detects_missing(monkeypatch):
-    monkeypatch.setattr(test_bootstrap.sys, "version_info", (3, 10, 0, "final", 0))
+    monkeypatch.setattr(test_bootstrap.sys, "version_info", (3, 9, 0, "final", 0))
     monkeypatch.setattr(
         test_bootstrap.importlib.util,
         "find_spec",
@@ -42,7 +42,7 @@ def test_render_json_output(monkeypatch, capsys):
         "build_test_bootstrap_report",
         lambda: {
             "ok": True,
-            "python": {"current": "3.12.2", "required": "3.11+", "supported": True},
+            "python": {"current": "3.12.2", "required": "3.10+", "supported": True},
             "dependencies": {
                 "required_modules": ["httpx", "yaml", "hypothesis"],
                 "missing_modules": [],
@@ -72,7 +72,7 @@ def test_main_writes_output_file(monkeypatch, tmp_path):
         "build_test_bootstrap_report",
         lambda: {
             "ok": True,
-            "python": {"current": "3.12.2", "required": "3.11+", "supported": True},
+            "python": {"current": "3.12.2", "required": "3.10+", "supported": True},
             "dependencies": {
                 "required_modules": ["httpx", "yaml", "hypothesis"],
                 "missing_modules": [],

--- a/tests/test_wrapper_modules_coverage.py
+++ b/tests/test_wrapper_modules_coverage.py
@@ -134,19 +134,23 @@ def test_core_entrypoints_module_with_stubbed_dependencies(monkeypatch) -> None:
     core_pkg = ModuleType("sdetkit.core")
     core_pkg.__path__ = [str(src_root / "sdetkit" / "core")]  # type: ignore[attr-defined]
 
-    apiget_mod = ModuleType("sdetkit.core.apiget")
-    kvcli_mod = ModuleType("sdetkit.core.kvcli")
+    apiget_mod = ModuleType("sdetkit.apiget")
+    kvcli_mod = ModuleType("sdetkit.kvcli")
     apiget_mod.main = lambda: 21  # type: ignore[attr-defined]
-    kvcli_mod.main = lambda: 34  # type: ignore[attr-defined]
+    kvcli_mod.cli_entry = lambda: 34  # type: ignore[attr-defined]
 
     monkeypatch.setitem(importlib.sys.modules, "sdetkit.core", core_pkg)
-    monkeypatch.setitem(importlib.sys.modules, "sdetkit.core.apiget", apiget_mod)
-    monkeypatch.setitem(importlib.sys.modules, "sdetkit.core.kvcli", kvcli_mod)
+    monkeypatch.setitem(importlib.sys.modules, "sdetkit.apiget", apiget_mod)
+    monkeypatch.setitem(importlib.sys.modules, "sdetkit.kvcli", kvcli_mod)
     monkeypatch.delitem(importlib.sys.modules, "sdetkit.core._entrypoints", raising=False)
 
     mod = importlib.import_module("sdetkit.core._entrypoints")
     assert mod.apigetcli() == 21
     assert mod.kvcli() == 34
+
+    monkeypatch.setattr(mod, "ensure_supported_python", lambda **_k: 2)
+    assert mod.apigetcli() == 2
+    assert mod.kvcli() == 2
 
 
 def test_core_main_module_paths_with_stubbed_package(monkeypatch, capsys) -> None:
@@ -156,21 +160,21 @@ def test_core_main_module_paths_with_stubbed_package(monkeypatch, capsys) -> Non
     core_pkg = ModuleType("sdetkit.core")
     core_pkg.__path__ = [str(core_path)]  # type: ignore[attr-defined]
 
-    cassette_get_mod = ModuleType("sdetkit.core.cassette_get")
+    cassette_get_mod = ModuleType("sdetkit.cassette_get")
     cassette_get_mod.cassette_get = lambda argv: len(argv)  # type: ignore[attr-defined]
-    atomic_mod = ModuleType("sdetkit.core.atomicio")
+    atomic_mod = ModuleType("sdetkit.atomicio")
     atomic_mod.atomic_write_text = lambda *_a, **_k: None  # type: ignore[attr-defined]
-    security_mod = ModuleType("sdetkit.core.security")
+    security_mod = ModuleType("sdetkit.security")
     security_mod.SecurityError = RuntimeError  # type: ignore[attr-defined]
     security_mod.safe_path = lambda p: p  # type: ignore[attr-defined]
-    cli_mod = ModuleType("sdetkit.core.cli")
+    cli_mod = ModuleType("sdetkit.cli")
     cli_mod.main = lambda: 0  # type: ignore[attr-defined]
 
     monkeypatch.setitem(importlib.sys.modules, "sdetkit.core", core_pkg)
-    monkeypatch.setitem(importlib.sys.modules, "sdetkit.core.cassette_get", cassette_get_mod)
-    monkeypatch.setitem(importlib.sys.modules, "sdetkit.core.atomicio", atomic_mod)
-    monkeypatch.setitem(importlib.sys.modules, "sdetkit.core.security", security_mod)
-    monkeypatch.setitem(importlib.sys.modules, "sdetkit.core.cli", cli_mod)
+    monkeypatch.setitem(importlib.sys.modules, "sdetkit.cassette_get", cassette_get_mod)
+    monkeypatch.setitem(importlib.sys.modules, "sdetkit.atomicio", atomic_mod)
+    monkeypatch.setitem(importlib.sys.modules, "sdetkit.security", security_mod)
+    monkeypatch.setitem(importlib.sys.modules, "sdetkit.cli", cli_mod)
 
     spec = importlib.util.spec_from_file_location(
         "sdetkit.core.__main__", core_path / "__main__.py"


### PR DESCRIPTION
### Motivation
- Broaden supported Python runtime to 3.10 so the package can be used on older, still-supported interpreters. 
- Provide compatibility for stdlib changes introduced in newer Pythons (notably `tomllib` and `datetime.UTC`).
- Centralize and reuse core runtime validation and apply guards at entrypoints to fail fast on unsupported runtimes.

### Description
- Lowered project requirement from `>=3.11` to `>=3.10` in `pyproject.toml`, added a `Programming Language :: Python :: 3.10` classifier, and added the `tomli` backport for `python_version < '3.11'`.
- Introduced `sdetkit.core._runtime` with `ensure_supported_python` and wired it into core entrypoints and compatibility shims so `sdetkit core` exits cleanly on unsupported versions.
- Updated top-level CLI runtime check in `src/sdetkit/__main__.py` to require 3.10 and adjusted test-bootstrap and test messages accordingly.
- Replaced direct `from datetime import UTC, datetime` usages with `import datetime as _dt` and `UTC = getattr(_dt, "UTC", _dt.timezone.utc)` / `datetime = _dt.datetime` in multiple modules to support versions that lack `datetime.UTC`.
- Added `src/sitecustomize.py` to provide a runtime shim that maps `tomli` to the `tomllib` module name when `tomllib` is not available and ensures `datetime.UTC` exists on older Pythons.
- Adjusted several internal import paths used by compatibility tests and entrypoints from `sdetkit.core.*` to `sdetkit.*` and updated related wrapper/entrypoint logic in `_entrypoints.py` and `core.__main__` to import modules safely via package-level names.
- Reworked upgrade-audit TOML usage to call a local TOML loader (`. _toml.loads`) and normalized timezone usage when persisting and inspecting timestamps.
- Updated tests and test helpers to reflect the new minimum runtime (`3.10`) and to exercise the new runtime-guard behavior.

### Testing
- Ran the unit test suite with `pytest` covering the modified modules and entrypoints (tests in `tests/`), and updated assertions to expect the `3.10` minimum; the modified tests executed successfully.
- Exercised core entrypoint paths and compatibility shims via the existing unit tests that stub package modules, and the runtime-guard branches were validated by added assertions; these checks passed.
- Verified packaging metadata changes by inspecting `pyproject.toml` updates and the added conditional dependency for `tomli` on Python <3.11.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9f3693fa0832d8e881955619937bf)