### PR TITLE
Fix board detection logic, clarify release-prioritization templates, and add tests

### DIFF
--- a/docs/integrations-release-prioritization-closeout.md
+++ b/docs/integrations-release-prioritization-closeout.md
@@ -1,14 +1,14 @@
 # Release Prioritization Closeout — Release prioritization closeout lane
 
-Lane closes with a major upgrade that converts Lane evidence narrative outcomes into a deterministic release prioritization operating lane.
+This lane closes with a major upgrade that converts evidence narrative outcomes into a deterministic release prioritization operating lane.
 
 ## Why Release Prioritization Closeout matters
 
-- Converts Lane evidence narrative outcomes into reusable release prioritization decisions across docs, release notes, and escalation playbooks.
+- Converts evidence narrative outcomes into reusable release prioritization decisions across docs, release notes, and escalation playbooks.
 - Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.
-- Creates a deterministic handoff from Lane closeout into Lane launch priorities.
+- Creates a deterministic handoff from this closeout into launch priorities.
 
-## Required inputs (Lane)
+## Required inputs (Release prioritization closeout lane)
 
 - `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-closeout-summary.json`
 - `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md`
@@ -25,10 +25,10 @@ python scripts/check_release_prioritization_closeout_contract.py
 
 ## Release prioritization contract
 
-- Single owner + backup reviewer are assigned for Lane release prioritization execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
-- Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
-- Lane closeout records release prioritization pack upgrades, storyline outcomes, and Lane launch priorities.
+- Single owner + backup reviewer are assigned for this release prioritization execution and signoff.
+- This lane references evidence narrative outcomes, controls, and trust continuity signals.
+- Every section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
+- This closeout records release prioritization pack upgrades, storyline outcomes, and launch priorities.
 
 ## Release prioritization quality checklist
 
@@ -40,12 +40,12 @@ python scripts/check_release_prioritization_closeout_contract.py
 
 ## Delivery board
 
-- [ ] Lane evidence brief committed
-- [ ] Lane release prioritization plan committed
-- [ ] Lane narrative template upgrade ledger exported
-- [ ] Lane storyline outcomes ledger exported
-- [ ] Lane launch priorities drafted from Lane outcomes
+- [ ] Release prioritization evidence brief committed
+- [ ] Release prioritization plan committed
+- [ ] Narrative template upgrade ledger exported
+- [ ] Storyline outcomes ledger exported
+- [ ] Launch priorities drafted from evidence narrative outcomes
 
 ## Scoring model
 
-Lane weights continuity + execution contract + release-priority artifact readiness for a 100-point activation score.
+This lane weights continuity + execution contract + release-priority artifact readiness for a 100-point activation score.

--- a/src/sdetkit/evidence/evidence_narrative_closeout_84.py
+++ b/src/sdetkit/evidence/evidence_narrative_closeout_84.py
@@ -119,7 +119,7 @@ def build_evidence_narrative_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(trust_faq_expansion_board)
     board_count = _checklist_count(board_text)
-    board_has_trust_faq_expansion = "trust faq expansion" in board_text.lower() or "" in board_text
+    board_has_trust_faq_expansion = "trust faq expansion" in board_text.lower()
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]

--- a/src/sdetkit/evidence/trust_faq_expansion_closeout_83.py
+++ b/src/sdetkit/evidence/trust_faq_expansion_closeout_83.py
@@ -123,9 +123,7 @@ def build_trust_faq_expansion_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(integration_feedback_board)
     board_count = _checklist_count(board_text)
-    board_has_integration_feedback = (
-        "integration feedback" in board_text.lower() or "" in board_text
-    )
+    board_has_integration_feedback = "integration feedback" in board_text.lower()
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]

--- a/src/sdetkit/growth_campaign_closeout_81.py
+++ b/src/sdetkit/growth_campaign_closeout_81.py
@@ -110,7 +110,7 @@ def build_growth_campaign_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(partner_outreach_board)
     board_count = _checklist_count(board_text)
-    board_has_partner_outreach = "partner outreach" in board_text.lower() or "" in board_text
+    board_has_partner_outreach = "partner outreach" in board_text.lower()
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]

--- a/src/sdetkit/integration_feedback_closeout_82.py
+++ b/src/sdetkit/integration_feedback_closeout_82.py
@@ -119,7 +119,7 @@ def build_integration_feedback_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(growth_campaign_board)
     board_count = _checklist_count(board_text)
-    board_has_growth_campaign = "growth campaign" in board_text.lower() or "" in board_text
+    board_has_growth_campaign = "growth campaign" in board_text.lower()
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]

--- a/src/sdetkit/release_prioritization_closeout_85.py
+++ b/src/sdetkit/release_prioritization_closeout_85.py
@@ -19,10 +19,10 @@ _DAY84_BOARD_PATH = (
     "docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md"
 )
 _PLAN_PATH = "docs/roadmap/plans/release-prioritization-plan.json"
-_SECTION_HEADER = "#  — Release prioritization closeout lane"
+_SECTION_HEADER = "# Release Prioritization Closeout — Release prioritization closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why Release Prioritization Closeout matters",
-    "## Required inputs ()",
+    "## Required inputs (Release prioritization closeout lane)",
     "## Command lane",
     "## Release prioritization contract",
     "## Release prioritization quality checklist",
@@ -41,10 +41,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_release_prioritization_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    "Single owner + backup reviewer are assigned for  release prioritization execution and signoff.",
-    "The  lane references  outcomes, controls, and trust continuity signals.",
-    "Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
-    " closeout records release prioritization pack upgrades, storyline outcomes, and  launch priorities.",
+    "Single owner + backup reviewer are assigned for this release prioritization execution and signoff.",
+    "This lane references evidence narrative outcomes, controls, and trust continuity signals.",
+    "Every section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.",
+    "This closeout records release prioritization pack upgrades, storyline outcomes, and launch priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets",
@@ -54,11 +54,11 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    "- [ ]  evidence brief committed",
-    "- [ ]  release prioritization plan committed",
-    "- [ ]  narrative template upgrade ledger exported",
-    "- [ ]  storyline outcomes ledger exported",
-    "- [ ]  launch priorities drafted from  outcomes",
+    "- [ ] Release prioritization evidence brief committed",
+    "- [ ] Release prioritization plan committed",
+    "- [ ] Narrative template upgrade ledger exported",
+    "- [ ] Storyline outcomes ledger exported",
+    "- [ ] Launch priorities drafted from evidence narrative outcomes",
 ]
 _REQUIRED_DATA_KEYS = [
     '"plan_id"',
@@ -69,7 +69,7 @@ _REQUIRED_DATA_KEYS = [
     '"owner"',
 ]
 
-_DEFAULT_PAGE_TEMPLATE = "#  — Release prioritization closeout lane\n\n closes with a major upgrade that converts  evidence narrative outcomes into a deterministic release prioritization operating lane.\n\n## Why Release Prioritization Closeout matters\n\n- Converts  evidence narrative outcomes into reusable release prioritization decisions across docs, release notes, and escalation playbooks.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from  closeout into  launch priorities.\n\n## Required inputs ()\n\n- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-closeout-summary.json`\n- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md`\n- `docs/roadmap/plans/release-prioritization-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit release-prioritization-closeout --format json --strict\npython -m sdetkit release-prioritization-closeout --emit-pack-dir docs/artifacts/release-prioritization-closeout-pack --format json --strict\npython -m sdetkit release-prioritization-closeout --execute --evidence-dir docs/artifacts/release-prioritization-closeout-pack/evidence --format json --strict\npython scripts/check_release_prioritization_closeout_contract.py\n```\n\n## Release prioritization contract\n\n- Single owner + backup reviewer are assigned for  release prioritization execution and signoff.\n- The  lane references  outcomes, controls, and trust continuity signals.\n- Every  section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n-  closeout records release prioritization pack upgrades, storyline outcomes, and  launch priorities.\n\n## Release prioritization quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures release prioritization adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  evidence brief committed\n- [ ]  release prioritization plan committed\n- [ ]  narrative template upgrade ledger exported\n- [ ]  storyline outcomes ledger exported\n- [ ]  launch priorities drafted from  outcomes\n\n## Scoring model\n\n weights continuity + execution contract + release-priority artifact readiness for a 100-point activation score.\n"
+_DEFAULT_PAGE_TEMPLATE = "# Release Prioritization Closeout — Release prioritization closeout lane\n\nThis lane closes with a major upgrade that converts evidence narrative outcomes into a deterministic release prioritization operating lane.\n\n## Why Release Prioritization Closeout matters\n\n- Converts evidence narrative outcomes into reusable release prioritization decisions across docs, release notes, and escalation playbooks.\n- Protects quality with strict contract coverage, runnable commands, KPI thresholds, and rollback safety.\n- Creates a deterministic handoff from this closeout into launch priorities.\n\n## Required inputs (Release prioritization closeout lane)\n\n- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-closeout-summary.json`\n- `docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md`\n- `docs/roadmap/plans/release-prioritization-plan.json`\n\n## Command lane\n\n```bash\npython -m sdetkit release-prioritization-closeout --format json --strict\npython -m sdetkit release-prioritization-closeout --emit-pack-dir docs/artifacts/release-prioritization-closeout-pack --format json --strict\npython -m sdetkit release-prioritization-closeout --execute --evidence-dir docs/artifacts/release-prioritization-closeout-pack/evidence --format json --strict\npython scripts/check_release_prioritization_closeout_contract.py\n```\n\n## Release prioritization contract\n\n- Single owner + backup reviewer are assigned for this release prioritization execution and signoff.\n- This lane references evidence narrative outcomes, controls, and trust continuity signals.\n- Every section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.\n- This closeout records release prioritization pack upgrades, storyline outcomes, and launch priorities.\n\n## Release prioritization quality checklist\n\n- [ ] Includes baseline evidence coverage, objection segmentation assumptions, and response SLA targets\n- [ ] Every narrative lane row has owner, execution window, KPI threshold, and risk flag\n- [ ] CTA links point to narrative docs/templates + runnable command evidence\n- [ ] Scorecard captures release prioritization adoption delta, objection deflection delta, confidence, and rollback owner\n- [ ] Artifact pack includes narrative brief, evidence plan, template diffs, outcome ledger, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ] Release prioritization evidence brief committed\n- [ ] Release prioritization plan committed\n- [ ] Narrative template upgrade ledger exported\n- [ ] Storyline outcomes ledger exported\n- [ ] Launch priorities drafted from evidence narrative outcomes\n\n## Scoring model\n\nThis lane weights continuity + execution contract + release-priority artifact readiness for a 100-point activation score.\n"
 
 
 def _read_text(path: Path) -> str:
@@ -117,7 +117,7 @@ def build_release_prioritization_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(evidence_narrative_board)
     board_count = _checklist_count(board_text)
-    board_has_evidence_narrative = "evidence narrative" in board_text.lower() or "" in board_text
+    board_has_evidence_narrative = "evidence narrative" in board_text.lower()
 
     missing_sections = [section for section in _REQUIRED_SECTIONS if section not in page_text]
     missing_commands = [command for command in _REQUIRED_COMMANDS if command not in page_text]

--- a/src/sdetkit/scale_upgrade_closeout_79.py
+++ b/src/sdetkit/scale_upgrade_closeout_79.py
@@ -107,9 +107,7 @@ def build_scale_upgrade_closeout_summary(root: Path) -> dict[str, Any]:
 
     board_text = _read_text(ecosystem_priorities_board)
     board_count = sum(1 for line in board_text.splitlines() if line.strip().startswith("- [ ]"))
-    board_has_ecosystem_priorities = (
-        "ecosystem priorities" in board_text.lower() or "" in board_text
-    )
+    board_has_ecosystem_priorities = "ecosystem priorities" in board_text.lower()
 
     plan_text = _read_text(plan_path)
 

--- a/tests/test_release_prioritization_closeout.py
+++ b/tests/test_release_prioritization_closeout.py
@@ -96,6 +96,50 @@ def test_lane85_json(tmp_path: Path, capsys) -> None:
     out = json.loads(capsys.readouterr().out)
     assert out["name"] == "release-prioritization-closeout"
     assert out["summary"]["activation_score"] >= 95
+    assert "Lane lane" not in d85._DEFAULT_PAGE_TEMPLATE
+    assert "## Required inputs ()" not in d85._DEFAULT_PAGE_TEMPLATE
+
+
+def test_lane85_board_keyword_required(tmp_path: Path, capsys) -> None:
+    _seed_repo(tmp_path)
+    board = (
+        tmp_path
+        / "docs/artifacts/evidence-narrative-closeout-pack/evidence-narrative-delivery-board.md"
+    )
+    board.write_text(
+        "\n".join(
+            [
+                "# release delivery board",
+                "- [ ] Release prioritization evidence brief committed",
+                "- [ ] Release prioritization plan committed",
+                "- [ ] Narrative template upgrade ledger exported",
+                "- [ ] Storyline outcomes ledger exported",
+                "- [ ] Launch priorities drafted from outcomes",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rc = d85.main(["--root", str(tmp_path), "--format", "json", "--strict"])
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out)
+    evidence_check = next(
+        c for c in out["checks"] if c["check_id"] == "evidence_narrative_board_integrity"
+    )
+    assert evidence_check["passed"] is False
+    assert out["summary"]["strict_pass"] is False
+
+
+def test_lane85_docs_page_matches_default_template() -> None:
+    docs_page = (
+        Path(__file__).resolve().parents[1] / "docs/integrations-release-prioritization-closeout.md"
+    )
+    page_text = docs_page.read_text(encoding="utf-8")
+    assert "Lane lane" not in page_text
+    assert "## Required inputs ()" not in page_text
+    assert d85._SECTION_HEADER in page_text
+    for line in d85._REQUIRED_CONTRACT_LINES:
+        assert line in page_text
 
 
 def test_lane85_emit_pack_and_execute(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Prevent false-positive board detections caused by an always-true check and make board presence detection reliable.
- Clarify and normalize wording in the Release Prioritization Closeout page and its default template to remove placeholder artifacts.
- Add tests to assert the template and delivery-board behavior to avoid regressions.

### Description

- Removed the redundant `or "" in board_text` checks from multiple closeout modules to fix incorrect truthiness in `board_has_*` flags (`evidence_narrative`, `integration_feedback`, `trust_faq_expansion`, `growth_campaign`, `ecosystem_priorities`, etc.).
- Updated `release_prioritization_closeout_85.py` to normalize `_SECTION_HEADER`, `_REQUIRED_SECTIONS`, `_REQUIRED_CONTRACT_LINES`, `_REQUIRED_DELIVERY_BOARD_LINES`, and the `_DEFAULT_PAGE_TEMPLATE` to use explicit, human-friendly wording and to match the docs file.
- Updated `docs/integrations-release-prioritization-closeout.md` content to match the new template wording and removed leftover placeholder tokens.
- Added and extended unit tests in `tests/test_release_prioritization_closeout.py` to verify that the default template and docs page do not contain placeholder text and to validate delivery-board keyword requirements.

### Testing

- Ran the updated unit tests including `tests/test_release_prioritization_closeout.py` which exercise template contents, board keyword validation, emit-and-execute flow, and JSON output; all tests passed.
- Executed the repository test suite to validate other closeout modules affected by the logic change; automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6d4360b88332a2b7622284c2edc1)