### PR TITLE
Improve subprocess AST detection, canonicalize phase-boost blueprint path, and update docs/tests

### DIFF
--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -44,4 +44,4 @@ Generated artifacts:
 1. Run the readiness check at least weekly.
 2. Track score trend in release planning.
 3. Resolve failed checks before major release milestones.
-4. Pair this with the [Production S-class tier blueprint](production-s-class-90--boost.md) for 90-impact execution planning.
+4. Pair this with the [Production S-class tier blueprint](production-s-class-90-day-boost.md) for 90-impact execution planning.

--- a/docs/production-s-class-90-day-boost.md
+++ b/docs/production-s-class-90-day-boost.md
@@ -9,7 +9,7 @@ Move the repository from "well-structured toolkit" to "first-class production en
 ## How to generate the program artifact
 
 ```bash
-python -m sdetkit phase-boost --repo-name DevS69-sdetkit --start-date 2026-03-01
+python -m sdetkit phase-boost --repo-name DevS69-sdetkit --start-date 2026-03-01 --output docs/artifacts/production-s-class-90-impact-plan.md --json-output docs/artifacts/production-s-class-90-impact-plan.json
 ```
 
 Default outputs:

--- a/src/sdetkit/readiness/production_readiness.py
+++ b/src/sdetkit/readiness/production_readiness.py
@@ -7,9 +7,7 @@ from pathlib import Path
 from typing import Any
 
 _PHASE_BOOST_BLUEPRINT_FILES = (
-    "docs/production-s-class-90-impact-boost.md",
     "docs/production-s-class-90-day-boost.md",
-    "docs/production-s-class-90--boost.md",
 )
 
 

--- a/src/sdetkit/repo.py
+++ b/src/sdetkit/repo.py
@@ -940,7 +940,8 @@ def _scan_python_ast(rel: str, text: str) -> list[Finding]:
             is_subprocess_shell_call = False
             if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
                 is_subprocess_shell_call = (
-                    node.func.value.id in subprocess_aliases and node.func.attr in subprocess_targets
+                    node.func.value.id in subprocess_aliases
+                    and node.func.attr in subprocess_targets
                 )
             elif isinstance(node.func, ast.Name):
                 is_subprocess_shell_call = node.func.id in direct_subprocess_imports

--- a/src/sdetkit/repo.py
+++ b/src/sdetkit/repo.py
@@ -905,6 +905,18 @@ def _scan_python_ast(rel: str, text: str) -> list[Finding]:
         tree = ast.parse(text)
     except SyntaxError:
         return out
+    subprocess_targets = {"run", "Popen", "call", "check_call", "check_output"}
+    subprocess_aliases = {"subprocess"}
+    direct_subprocess_imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "subprocess":
+                    subprocess_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for alias in node.names:
+                if alias.name in subprocess_targets:
+                    direct_subprocess_imports.add(alias.asname or alias.name)
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
             name = ""
@@ -925,25 +937,44 @@ def _scan_python_ast(rel: str, text: str) -> list[Finding]:
                         remediation="use safer alternatives",
                     )
                 )
-            if name == "subprocess.run" or name == "subprocess.Popen":
+            is_subprocess_shell_call = False
+            if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
+                is_subprocess_shell_call = (
+                    node.func.value.id in subprocess_aliases and node.func.attr in subprocess_targets
+                )
+            elif isinstance(node.func, ast.Name):
+                is_subprocess_shell_call = node.func.id in direct_subprocess_imports
+            if is_subprocess_shell_call:
                 for kw in node.keywords:
-                    if (
-                        kw.arg == "shell"
-                        and isinstance(kw.value, ast.Constant)
-                        and kw.value.value is True
-                    ):
-                        out.append(
-                            Finding(
-                                "code_risk",
-                                "error",
-                                rel,
-                                node.lineno,
-                                node.col_offset + 1,
-                                "subprocess_shell_true",
-                                "subprocess with shell=True",
-                                remediation="pass argv list and keep shell=False",
+                    if kw.arg != "shell":
+                        continue
+                    if isinstance(kw.value, ast.Constant):
+                        if kw.value.value is True:
+                            out.append(
+                                Finding(
+                                    "code_risk",
+                                    "error",
+                                    rel,
+                                    node.lineno,
+                                    node.col_offset + 1,
+                                    "subprocess_shell_true",
+                                    "subprocess with shell=True",
+                                    remediation="pass argv list and keep shell=False",
+                                )
                             )
+                        continue
+                    out.append(
+                        Finding(
+                            "code_risk",
+                            "warn",
+                            rel,
+                            node.lineno,
+                            node.col_offset + 1,
+                            "subprocess_shell_nonliteral",
+                            "subprocess with non-literal shell argument",
+                            remediation="use shell=False literal or pass argv list",
                         )
+                    )
     return out
 
 

--- a/tests/test_phase_boost.py
+++ b/tests/test_phase_boost.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 from sdetkit import cli, phase_boost
@@ -85,3 +86,16 @@ def test_phase_boost_main_json_output_contract(tmp_path: Path) -> None:
     assert payload["start_date"] == "2026-03-01"
     assert payload["goal"] == "S-class production readiness"
     assert isinstance(payload["phases"], list)
+
+
+def test_phase_boost_main_does_not_write_default_artifacts_without_flags(tmp_path: Path) -> None:
+    cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        rc = phase_boost.main(["--repo-name", "repo-prod", "--start-date", "2026-03-01"])
+    finally:
+        os.chdir(cwd)
+
+    assert rc == 0
+    assert not (tmp_path / "docs/artifacts/production-s-class-90-impact-plan.md").exists()
+    assert not (tmp_path / "docs/artifacts/production-s-class-90-impact-plan.json").exists()

--- a/tests/test_production_readiness_extra.py
+++ b/tests/test_production_readiness_extra.py
@@ -55,7 +55,7 @@ def test_main_markdown_and_text_output_modes(tmp_path: Path, capsys) -> None:
     assert text_out.startswith("production-readiness")
 
 
-def test_phase_boost_check_accepts_supported_blueprint_variants(tmp_path: Path) -> None:
+def test_phase_boost_check_accepts_canonical_blueprint_path(tmp_path: Path) -> None:
     (tmp_path / "docs").mkdir(parents=True)
     (tmp_path / "docs/production-s-class-90-day-boost.md").write_text(
         "# phase boost\n", encoding="utf-8"

--- a/tests/test_repo_audit.py
+++ b/tests/test_repo_audit.py
@@ -202,10 +202,21 @@ def test_repo_scanner_helpers_cover_workflow_dependency_and_baseline(tmp_path: P
 eval('1')
 exec('2')
 import pickle, yaml, subprocess
+import subprocess as sp
+from subprocess import check_call as cc
+from subprocess import check_output as co
+from subprocess import run
 pickle.loads(data)
 yaml.load(doc)
 subprocess.run('echo x', shell=True)
 subprocess.Popen('echo y', shell=True)
+subprocess.call('echo z', shell=True)
+subprocess.check_call('echo zz', shell=True)
+subprocess.check_output('echo zzz', shell=True)
+sp.run('echo alias', shell=True)
+cc('echo alias-cc', shell=True)
+co('echo alias-co', shell=True)
+run('echo direct-import-run', shell=True)
 """.strip()
     py_findings = repo_mod._scan_python_ast("src/a.py", py_text)
     codes = {f.code for f in py_findings}
@@ -255,6 +266,17 @@ run: curl https://x | bash
 
     assert repo_mod._severity_rank("info") < repo_mod._severity_rank("warn")
     assert repo_mod._score([]) == 100
+
+
+def test_repo_scanner_flags_nonliteral_shell_kwarg() -> None:
+    py_text = """
+import subprocess
+shell_flag = env.get("USE_SHELL", False)
+subprocess.run("echo dynamic", shell=shell_flag)
+    """.strip()
+    findings = repo_mod._scan_python_ast("src/dynamic.py", py_text)
+    codes = {(f.code, f.severity) for f in findings}
+    assert ("subprocess_shell_nonliteral", "warn") in codes
 
 
 def test_repo_init_template_planning_helpers(


### PR DESCRIPTION
### Motivation

- Canonicalize the phase-boost blueprint path referenced by the readiness check and docs so the program looks for the correct artifact.
- Strengthen static analysis to catch risky `subprocess` usage including aliased and directly-imported calls and surface non-literal `shell` usage as a warning.
- Ensure `phase-boost` CLI does not write default artifact files unless explicit output flags are provided.

### Description

- Updated documentation references and examples, replacing the old blueprint link with `docs/production-s-class-90-day-boost.md` and adding `--output`/`--json-output` examples in the blueprint generation command. 
- Adjusted `production_readiness` blueprint lookup by removing stale entries and using the canonical `docs/production-s-class-90-day-boost.md` path in `_PHASE_BOOST_BLUEPRINT_FILES`.
- Enhanced `_scan_python_ast` in `repo.py` to detect `subprocess` calls imported via aliases or direct `from subprocess import run` style imports, and to treat non-literal `shell=` arguments as a `warn` finding with code `subprocess_shell_nonliteral` while preserving the existing `subprocess_shell_true` error for literal `True`.
- Added and updated unit tests to cover the new behaviors: `test_phase_boost_main_does_not_write_default_artifacts_without_flags`, `test_repo_scanner_flags_nonliteral_shell_kwarg`, expanded `_scan_python_ast` cases to include aliases and direct imports, and renamed a production-readiness test to reflect the canonical path check.

### Testing

- Ran the test suite with `pytest` and all unit tests passed, including the new tests for non-literal `shell` detection and CLI artifact behavior. 
- Verified `phase-boost` CLI flows in tests by exercising `phase_boost.main` with and without `--json-output`/`--output` and asserting artifact files are only created when flags are provided. 
- Exercised `repo._scan_python_ast` test cases covering aliased imports and direct imports, and asserted both `subprocess_shell_true` (error) and `subprocess_shell_nonliteral` (warn) findings are produced as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9a11b97483329ed3cf180f5c79d7)