### PR TITLE
Fix case-insensitive Link rel parsing in pagination client

### DIFF
--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -147,7 +147,7 @@ def _link_next_url(r: httpx.Response) -> str | None:
         return None
 
     for part in (p.strip() for p in link.split(",")):
-        if "rel=" not in part:
+        if "rel=" not in part.lower():
             continue
         segs = [s.strip() for s in part.split(";")]
         if not segs:
@@ -160,11 +160,14 @@ def _link_next_url(r: httpx.Response) -> str | None:
 
         rel = None
         for s in segs[1:]:
-            if s.startswith("rel="):
-                rel = s[4:].strip()
-                if rel.startswith('"') and rel.endswith('"') and len(rel) >= 2:
-                    rel = rel[1:-1]
-                break
+            name, sep, value = s.partition("=")
+            if sep != "=" or name.strip().lower() != "rel":
+                continue
+            rel = value.strip()
+            if rel.startswith('"') and rel.endswith('"') and len(rel) >= 2:
+                rel = rel[1:-1]
+            rel = rel.lower()
+            break
 
         if rel == "next":
             return str(urljoin(str(r.url), url))

--- a/src/sdetkit/readiness/production_readiness.py
+++ b/src/sdetkit/readiness/production_readiness.py
@@ -6,9 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-_PHASE_BOOST_BLUEPRINT_FILES = (
-    "docs/production-s-class-90-day-boost.md",
-)
+_PHASE_BOOST_BLUEPRINT_FILES = ("docs/production-s-class-90-day-boost.md",)
 
 
 @dataclass(frozen=True)

--- a/tests/test_netclient_branches_wave6.py
+++ b/tests/test_netclient_branches_wave6.py
@@ -61,6 +61,12 @@ def test_link_next_url_returns_none_when_no_next() -> None:
     assert netclient._link_next_url(r) is None
 
 
+def test_link_next_url_treats_rel_parameter_name_and_value_case_insensitively() -> None:
+    req = httpx.Request("GET", "https://example.test/base")
+    r = httpx.Response(200, request=req, headers={"Link": "<page2>; REL=NEXT"})
+    assert netclient._link_next_url(r) == "https://example.test/page2"
+
+
 @dataclass
 class SpyBreaker:
     allow_calls: int = 0


### PR DESCRIPTION
### Motivation
- Pagination failed for some real-world `Link` headers because the `rel` parameter name and value were only matched in lowercase, causing `REL=NEXT` to be ignored.

### Description
- Update `_link_next_url` in `src/sdetkit/netclient.py` to check for `rel` in a case-insensitive way and to parse `name=value` pairs robustly using `partition("=")`.
- Normalize quoted relation values and lowercase the relation value before comparison so `REL=NEXT` and variants are accepted.
- Add a regression test `test_link_next_url_treats_rel_parameter_name_and_value_case_insensitively` to `tests/test_netclient_branches_wave6.py` that verifies `Link: <page2>; REL=NEXT` is handled.

### Testing
- Ran `pytest -q tests/test_netclient_branches_wave6.py tests/test_apiclient_pagination.py tests/test_apiclient_async_pagination.py` and all tests passed (16 passed).
- Additional related tests `pytest -q tests/test_netclient_retry_after_http_date.py tests/test_apiclient_retry_helpers_extra.py` were run and passed (3 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf8339ae88332aa1c880b3515be1d)