### PR TITLE
Use latest dated entry for changelog check; add tests; minor script cleanups

### DIFF
--- a/scripts/check_onboarding_optimization_contract.py
+++ b/scripts/check_onboarding_optimization_contract.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
-from sdetkit import onboarding_optimization as otu
+from sdetkit import onboarding_optimization as onb_opt
 
 
 def main() -> int:
@@ -14,15 +14,15 @@ def main() -> int:
     ns = parser.parse_args()
 
     root = Path(ns.root).resolve()
-    payload = otu.build_onboarding_time_summary(root)
+    payload = onb_opt.build_onboarding_time_summary(root)
 
     strict_failures: list[str] = []
-    page = root / otu._PAGE_PATH
+    page = root / onb_opt._PAGE_PATH
     page_text = page.read_text(encoding="utf-8") if page.exists() else ""
-    for section in [otu._SECTION_HEADER, *otu._REQUIRED_SECTIONS]:
+    for section in [onb_opt._SECTION_HEADER, *onb_opt._REQUIRED_SECTIONS]:
         if section not in page_text:
             strict_failures.append(section)
-    for command in otu._REQUIRED_COMMANDS:
+    for command in onb_opt._REQUIRED_COMMANDS:
         if command not in page_text:
             strict_failures.append(command)
 

--- a/scripts/phase1_next_actions.py
+++ b/scripts/phase1_next_actions.py
@@ -48,7 +48,10 @@ def main() -> int:
     for item in not_yet:
         text = str(item)
         if text.startswith("python_version>=3.11"):
-            next_actions.append("Use Python 3.11+ environment then rerun: make phase1-baseline")
+            next_actions.append(
+                "Use Python 3.11+ for phase1 baseline checks (core CLI runtime supports 3.10+) "
+                "then rerun: make phase1-baseline"
+            )
         elif text == "optional_check_ok::ruff":
             next_actions.append("Run lint remediation: ruff check . --fix")
         elif text == "optional_check_ok::pytest":

--- a/src/sdetkit/readiness/readiness.py
+++ b/src/sdetkit/readiness/readiness.py
@@ -5,6 +5,7 @@ import json
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 
 
@@ -118,10 +119,16 @@ def _check_recent_changelog(root: Path) -> ReadinessResult:
     if not text:
         return ReadinessResult(False, "missing CHANGELOG.md")
 
-    match = re.search(r"20\d{2}-\d{2}-\d{2}", text)
-    if not match:
+    dates: list[date] = []
+    for token in re.findall(r"20\d{2}-\d{2}-\d{2}", text):
+        try:
+            dates.append(date.fromisoformat(token))
+        except ValueError:
+            continue
+    if not dates:
         return ReadinessResult(False, "no dated release entries found")
-    return ReadinessResult(True, f"latest dated entry found: {match.group(0)}")
+    latest = max(dates).isoformat()
+    return ReadinessResult(True, f"latest dated entry found: {latest}")
 
 
 def _scan_test_scenario_capacity(root: Path) -> dict[str, object]:

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -103,3 +103,45 @@ def test_cli_readiness_json_output(capsys):
     payload = json.loads(out)
     assert payload["schema_version"] == "sdetkit.readiness.v2"
     assert "checks" in payload
+
+
+def test_check_recent_changelog_uses_latest_date_not_first_match(tmp_path):
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## 2024-01-01\n- old\n\n## 2026-02-12\n- latest\n\n## 2025-11-05\n- mid\n",
+        encoding="utf-8",
+    )
+
+    result = readiness._check_recent_changelog(tmp_path)
+
+    assert result.passed is True
+    assert result.evidence == "latest dated entry found: 2026-02-12"
+
+
+def test_scan_test_scenario_capacity_counts_only_top_level_test_defs(tmp_path):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_mixed.py").write_text(
+        "\n".join(
+            [
+                "def test_top_level_one():",
+                "    assert True",
+                "",
+                "class TestSuite:",
+                "    def test_method_should_not_count(self):",
+                "        assert True",
+                "",
+                "def helper():",
+                "    def test_nested_should_not_count():",
+                "        assert True",
+                "    return test_nested_should_not_count",
+                "",
+                "async def test_async_should_not_count_with_current_regex():",
+                "    assert True",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    capacity = readiness._scan_test_scenario_capacity(tmp_path)
+
+    assert capacity["detected_scenarios"] == 1


### PR DESCRIPTION
### Motivation
- Ensure the readiness changelog check reports the most recent release date rather than the first matched date.
- Improve guidance text shown by the phase1 next-actions script for Python version issues.
- Clean up a script import alias for clarity.

### Description
- Update `_check_recent_changelog` to parse all ISO-8601 dates from `CHANGELOG.md`, pick the latest via `date.fromisoformat`, and report that date in the evidence string.
- Add unit tests `test_check_recent_changelog_uses_latest_date_not_first_match` and `test_scan_test_scenario_capacity_counts_only_top_level_test_defs` to validate the changelog behavior and test-scenario counting.
- Adjust `phase1_next_actions.py` to provide a clearer advisory message for `python_version>=3.11` cases.
- Rename the onboarding optimization import alias in `scripts/check_onboarding_optimization_contract.py` from `otu` to `onb_opt` and update its usages.

### Testing
- Ran the unit test suite with `pytest -q` which included the new tests and completed successfully (tests passed).
- Exercised the readiness report generation via the existing `readiness` tests which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec060b202083329cff0993caec2424)