### PR TITLE
Fix pagination cycle detection and add tests; small docs tweaks

### DIFF
--- a/docs/integrations-phase2-hardening-closeout.md
+++ b/docs/integrations-phase2-hardening-closeout.md
@@ -25,7 +25,7 @@ python scripts/check_phase2_hardening_closeout_contract.py
 ## Phase-2 hardening contract
 
 - Single owner + backup reviewer are assigned for Lane Phase-2 hardening execution and signal triage.
-- The Lane lane references Lane KPI deep-audit outcomes and unresolved risks.
+- The Lane references Lane KPI deep-audit outcomes and unresolved risks.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records hardening outcomes and Lane pre-plan priorities.
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -29,7 +29,7 @@ This page is the quickest way to understand **where things are**, **where new fi
 | --- | --- | --- |
 | New contributor | `README.md` | `CONTRIBUTING.md`, `docs/project-structure.md` |
 | CLI user | `docs/cli.md` | `docs/doctor.md`, `docs/repo-audit.md` |
-| Maintainer | `quality.sh` | `scripts/bootstrap.sh`, `noxfile.py`, `Makefile` |
+| Maintainer | `quality.sh` | `scripts/bootstrap.sh`, `pyproject.toml`, `Makefile` |
 | Release owner | `RELEASE.md` | `docs/releasing.md`, `CHANGELOG.md` |
 | Docs editor | `docs/index.md` | `mkdocs.yml`, `docs/contributing.md` |
 

--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -467,7 +467,7 @@ class SdetHttpClient:
             raise ValueError("max_pages must be >= 1")
 
         out: list = []
-        seen: set[str] = set()
+        seen: set[str] = {str(url)}
         cur = url
 
         for _ in range(max_pages):
@@ -845,7 +845,7 @@ class SdetAsyncHttpClient:
             raise ValueError("max_pages must be >= 1")
 
         out: list = []
-        seen: set[str] = set()
+        seen: set[str] = {str(url)}
         cur = url
 
         for _ in range(max_pages):

--- a/tests/test_netclient_async_extra.py
+++ b/tests/test_netclient_async_extra.py
@@ -25,3 +25,24 @@ async def test_emit_async_and_async_client_error_paths() -> None:
         c = netclient.SdetAsyncHttpClient(raw, retry=netclient.RetryPolicy(retries=1))
         with pytest.raises(RuntimeError):
             await c.get_json_dict("https://example.test/x")
+
+
+@pytest.mark.asyncio
+async def test_async_paginated_list_detects_cycle_back_to_origin_without_extra_fetch() -> None:
+    calls = {"n": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(
+            200,
+            json=[1],
+            headers={"Link": '<https://example.test/p>; rel="next"'},
+            request=request,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as raw:
+        c = netclient.SdetAsyncHttpClient(raw)
+        with pytest.raises(RuntimeError, match="pagination impact"):
+            await c.get_json_list_paginated("https://example.test/p")
+
+    assert calls["n"] == 1

--- a/tests/test_netclient_branches_wave6.py
+++ b/tests/test_netclient_branches_wave6.py
@@ -183,6 +183,26 @@ def test_get_json_list_paginated_max_pages_and_limit_exceeded() -> None:
             c.get_json_list_paginated("https://example.test/p", max_pages=1)
 
 
+def test_get_json_list_paginated_detects_cycle_back_to_origin_without_extra_fetch() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(
+            200,
+            json=[1],
+            headers={"Link": '<https://example.test/p>; rel="next"'},
+            request=request,
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        c = SdetHttpClient(client)
+        with pytest.raises(RuntimeError, match="pagination impact"):
+            c.get_json_list_paginated("https://example.test/p")
+
+    assert calls["n"] == 1
+
+
 def test_get_json_list_paginated_envelope_validation_and_limit_exceeded() -> None:
     def handler_bad_obj(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json=[1], request=request)


### PR DESCRIPTION
### Motivation

- Prevent repeated fetches when a paginated `Link: rel="next"` cycles back to the original URL and ensure such cycles are detected as an error. 
- Clarify a couple of documentation lines for maintainability and correct references.

### Description

- Initialize the `seen` set with the stringified starting URL in `SdetHttpClient.get_json_list_paginated` to treat the origin as already visited. 
- Do the same initialization in `SdetAsyncHttpClient.get_json_list_paginated` to mirror the sync client behavior. 
- Add unit tests `test_get_json_list_paginated_detects_cycle_back_to_origin_without_extra_fetch` and `test_async_paginated_list_detects_cycle_back_to_origin_without_extra_fetch` to verify that a next link pointing back to the origin triggers a `RuntimeError` and does not perform an extra fetch. 
- Apply two small docs fixes in `docs/integrations-phase2-hardening-closeout.md` and `docs/project-structure.md` to improve wording and update a reference from `noxfile.py` to `pyproject.toml` in the maintainer reading suggestions.

### Testing

- Ran the new sync unit test `tests/test_netclient_branches_wave6.py::test_get_json_list_paginated_detects_cycle_back_to_origin_without_extra_fetch`, which passed. 
- Ran the new async unit test `tests/test_netclient_async_extra.py::test_async_paginated_list_detects_cycle_back_to_origin_without_extra_fetch`, which passed. 
- Ran the existing `netclient` related tests to ensure no regressions in pagination behavior, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec228cd0ec8332a6e07879bee52c3e)