### PR TITLE
Normalize scale closeout wording, tighten validation logic, and add alignment tests

### DIFF
--- a/docs/integrations-scale-closeout.md
+++ b/docs/integrations-scale-closeout.md
@@ -1,19 +1,19 @@
-# Lane — Scale closeout lane
+# Scale closeout lane
 
-Lane closes with a big scale upgrade that converts Lane acceleration evidence into deterministic scale loops.
+Scale closeout converts acceleration evidence into deterministic scale execution loops.
 
-## Why Lane matters
+## Why this lane matters
 
-- Converts Lane acceleration proof into a scale-first operating motion.
+- Converts acceleration proof into a scale-first operating motion.
 - Protects quality with owner accountability, command proof, and KPI guardrails.
-- Produces a deterministic handoff from Lane outcomes into Lane expansion priorities.
+- Produces a deterministic handoff from scale outcomes into expansion priorities.
 
-## Required inputs (Lane)
+## Required inputs (acceleration closeout)
 
 - `docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json`
 - `docs/artifacts/acceleration-closeout-pack/delivery-board.md`
 
-## Lane command lane
+## Command lane
 
 ```bash
 python -m sdetkit scale-closeout --format json --strict
@@ -24,10 +24,10 @@ python scripts/check_scale_closeout_contract.py
 
 ## Scale closeout contract
 
-- Single owner + backup reviewer are assigned for Lane scale lane execution and KPI follow-up.
-- The Lane scale lane references Lane acceleration winners and misses with deterministic growth loops.
-- Every Lane section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.
-- Lane closeout records scale learnings and Lane expansion priorities.
+- Single owner + backup reviewer are assigned for the scale lane execution and KPI follow-up.
+- The scale lane references acceleration winners and misses with deterministic growth loops.
+- Every section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.
+- Scale closeout records learnings and expansion priorities.
 
 ## Scale quality checklist
 
@@ -37,19 +37,19 @@ python scripts/check_scale_closeout_contract.py
 - [ ] Scorecard captures baseline, current, delta, and confidence for each KPI
 - [ ] Artifact pack includes scale plan, growth matrix, KPI scorecard, and execution log
 
-## Lane delivery board
+## Delivery board
 
-- [ ] Lane scale plan draft committed
-- [ ] Lane review notes captured with owner + backup
-- [ ] Lane growth matrix exported
-- [ ] Lane KPI scorecard snapshot exported
-- [ ] Lane expansion priorities drafted from Lane learnings
+- [ ] Scale plan draft committed
+- [ ] Review notes captured with owner + backup
+- [ ] Growth matrix exported
+- [ ] KPI scorecard snapshot exported
+- [ ] Expansion priorities drafted from learnings
 
 ## Scoring model
 
-Lane weighted score (0-100):
+Weighted score (0-100):
 
 - Docs contract + command lane completeness: 30 points.
 - Discoverability alignment (README/docs index/top-10): 20 points.
-- Lane continuity and strict baseline carryover: 35 points.
+- Scale continuity and strict baseline carryover: 35 points.
 - Scale contract lock + delivery board readiness: 15 points.

--- a/src/sdetkit/scale_closeout_44.py
+++ b/src/sdetkit/scale_closeout_44.py
@@ -18,7 +18,7 @@ _DAY43_LEGACY_SUMMARY_PATH = (
     "docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
 )
 _DAY43_LEGACY_BOARD_PATH = "docs/artifacts/acceleration-closeout-pack/delivery-board.md"
-_SECTION_HEADER = "#  — Scale closeout lane"
+_SECTION_HEADER = "# Scale closeout lane"
 _REQUIRED_SECTIONS = [
     "## Why this lane matters",
     "## Required inputs (acceleration closeout)",
@@ -40,10 +40,10 @@ _EXECUTION_COMMANDS = [
     "python scripts/check_scale_closeout_contract.py --skip-evidence",
 ]
 _REQUIRED_CONTRACT_LINES = [
-    "Single owner + backup reviewer are assigned for  scale lane execution and KPI follow-up.",
-    "The  scale lane references  acceleration winners and misses with deterministic growth loops.",
-    "Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.",
-    " closeout records scale learnings and  expansion priorities.",
+    "Single owner + backup reviewer are assigned for the scale lane execution and KPI follow-up.",
+    "The scale lane references acceleration winners and misses with deterministic growth loops.",
+    "Every section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.",
+    "Scale closeout records learnings and expansion priorities.",
 ]
 _REQUIRED_QUALITY_LINES = [
     "- [ ] Includes scale summary, growth matrix, and rollback strategy",
@@ -53,14 +53,14 @@ _REQUIRED_QUALITY_LINES = [
     "- [ ] Artifact pack includes scale plan, growth matrix, KPI scorecard, and execution log",
 ]
 _REQUIRED_DELIVERY_BOARD_LINES = [
-    "- [ ]  scale plan draft committed",
-    "- [ ]  review notes captured with owner + backup",
-    "- [ ]  growth matrix exported",
-    "- [ ]  KPI scorecard snapshot exported",
-    "- [ ]  expansion priorities drafted from  learnings",
+    "- [ ] Scale plan draft committed",
+    "- [ ] Review notes captured with owner + backup",
+    "- [ ] Growth matrix exported",
+    "- [ ] KPI scorecard snapshot exported",
+    "- [ ] Expansion priorities drafted from learnings",
 ]
 
-_DEFAULT_PAGE_TEMPLATE = "#  — Scale closeout lane\n\nThis lane closes with a major scale upgrade that converts acceleration evidence into deterministic improvement loops.\n\n## Why this lane matters\n\n- Converts  acceleration proof into growth-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from scale outcomes into  expansion priorities.\n\n## Required inputs (acceleration closeout)\n\n- `docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json`\n- `docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md`\n\n## Command lane\n\n```bash\npython -m sdetkit scale-closeout --format json --strict\npython -m sdetkit scale-closeout --emit-pack-dir docs/artifacts/scale-closeout-pack --format json --strict\npython -m sdetkit scale-closeout --execute --evidence-dir docs/artifacts/scale-closeout-pack/evidence --format json --strict\npython scripts/check_scale_closeout_contract.py\n```\n\n## Scale closeout contract\n\n- Single owner + backup reviewer are assigned for  scale lane execution and KPI follow-up.\n- The  scale lane references  acceleration winners and misses with deterministic growth loops.\n- Every  section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n-  closeout records scale learnings and  expansion priorities.\n\n## Scale quality checklist\n\n- [ ] Includes scale summary, growth matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes scale plan, growth matrix, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ]  scale plan draft committed\n- [ ]  review notes captured with owner + backup\n- [ ]  growth matrix exported\n- [ ]  KPI scorecard snapshot exported\n- [ ]  expansion priorities drafted from  learnings\n\n## Scoring model\n\nWeighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n-  continuity and strict baseline carryover: 35 points.\n- Scale contract lock + delivery board readiness: 15 points.\n"
+_DEFAULT_PAGE_TEMPLATE = "# Scale closeout lane\n\nThis lane closes with a major scale upgrade that converts acceleration evidence into deterministic improvement loops.\n\n## Why this lane matters\n\n- Converts acceleration proof into growth-first operating motion.\n- Protects quality with owner accountability, command proof, and KPI guardrails.\n- Produces a deterministic handoff from scale outcomes into expansion priorities.\n\n## Required inputs (acceleration closeout)\n\n- `docs/artifacts/acceleration-closeout-pack-43/acceleration-closeout-summary-43.json`\n- `docs/artifacts/acceleration-closeout-pack-43/delivery-board-43.md`\n\n## Command lane\n\n```bash\npython -m sdetkit scale-closeout --format json --strict\npython -m sdetkit scale-closeout --emit-pack-dir docs/artifacts/scale-closeout-pack --format json --strict\npython -m sdetkit scale-closeout --execute --evidence-dir docs/artifacts/scale-closeout-pack/evidence --format json --strict\npython scripts/check_scale_closeout_contract.py\n```\n\n## Scale closeout contract\n\n- Single owner + backup reviewer are assigned for the scale lane execution and KPI follow-up.\n- The scale lane references acceleration winners and misses with deterministic growth loops.\n- Every section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.\n- Scale closeout records learnings and expansion priorities.\n\n## Scale quality checklist\n\n- [ ] Includes scale summary, growth matrix, and rollback strategy\n- [ ] Every section has owner, publish window, KPI target, and risk flag\n- [ ] CTA links point to docs + runnable command evidence\n- [ ] Scorecard captures baseline, current, delta, and confidence for each KPI\n- [ ] Artifact pack includes scale plan, growth matrix, KPI scorecard, and execution log\n\n## Delivery board\n\n- [ ] Scale plan draft committed\n- [ ] Review notes captured with owner + backup\n- [ ] Growth matrix exported\n- [ ] KPI scorecard snapshot exported\n- [ ] Expansion priorities drafted from learnings\n\n## Scoring model\n\nWeighted score (0-100):\n\n- Docs contract + command lane completeness: 30 points.\n- Discoverability alignment (README/docs index/top-10): 20 points.\n- Scale continuity and strict baseline carryover: 35 points.\n- Scale contract lock + delivery board readiness: 15 points.\n"
 
 
 def _read(path: Path) -> str:
@@ -99,8 +99,9 @@ def _load_acceleration_closeout(path: Path) -> tuple[float, bool, int]:
 
 def _board_stats(path: Path) -> tuple[int, bool, bool]:
     text = _read(path)
+    lowered = text.lower()
     items = [line for line in text.splitlines() if line.strip().startswith("- [")]
-    return len(items), "" in text, "" in text
+    return len(items), "acceleration" in lowered, "scale" in lowered
 
 
 def _contains_all_lines(text: str, expected: list[str]) -> list[str]:
@@ -183,8 +184,11 @@ def build_scale_closeout_summary(root: Path) -> dict[str, Any]:
         {
             "check_id": "top10_scale_closeout_alignment",
             "weight": 5,
-            "passed": ("" in top10_text and "" in top10_text),
-            "evidence": "Scale closeout + expansion closeout strategy chain",
+            "passed": (
+                "scale closeout lane" in top10_text.lower()
+                and "expansion lane continuation" in top10_text.lower()
+            ),
+            "evidence": "Scale closeout lane + expansion lane continuation",
         },
         {
             "check_id": "acceleration_closeout_summary_present",

--- a/tests/test_scale_closeout.py
+++ b/tests/test_scale_closeout.py
@@ -29,14 +29,14 @@ def _seed_repo(root: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/top-10-github-strategy.md").write_text(
-        "- ** — Scale closeout lane:** convert  acceleration proof into deterministic scale loops.\n"
-        "- ** — Expansion lane continuation:** convert  scale wins into expansion plays.\n",
+        "- **Scale closeout lane:** convert acceleration proof into deterministic scale loops.\n"
+        "- **Expansion lane continuation:** convert scale wins into expansion plays.\n",
         encoding="utf-8",
     )
     (root / "docs/integrations-scale-closeout.md").write_text(
         d44._DEFAULT_PAGE_TEMPLATE, encoding="utf-8"
     )
-    (root / "docs/impact-44-big-upgrade-report.md").write_text("#  report\n", encoding="utf-8")
+    (root / "docs/impact-44-big-upgrade-report.md").write_text("# Scale report\n", encoding="utf-8")
 
     summary = root / "docs/artifacts/acceleration-closeout-pack/acceleration-closeout-summary.json"
     summary.parent.mkdir(parents=True, exist_ok=True)
@@ -54,12 +54,12 @@ def _seed_repo(root: Path) -> None:
     board.write_text(
         "\n".join(
             [
-                "#  delivery board",
-                "- [ ]  acceleration plan draft committed",
-                "- [ ]  review notes captured with owner + backup",
-                "- [ ]  remediation matrix exported",
-                "- [ ]  KPI scorecard snapshot exported",
-                "- [ ]  scale priorities drafted from  learnings",
+                "# Acceleration delivery board",
+                "- [ ] Acceleration plan draft committed",
+                "- [ ] Review notes captured with owner + backup",
+                "- [ ] Remediation matrix exported",
+                "- [ ] KPI scorecard snapshot exported",
+                "- [ ] Scale priorities drafted from learnings",
             ]
         )
         + "\n",
@@ -120,3 +120,19 @@ def test_lane44_cli_dispatch(tmp_path: Path, capsys) -> None:
     rc = cli.main(["scale-closeout", "--root", str(tmp_path), "--format", "text"])
     assert rc == 0
     assert "Scale closeout summary" in capsys.readouterr().out
+
+
+def test_lane44_alignment_checks_fail_when_top10_and_board_missing_markers(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "docs/top-10-github-strategy.md").write_text("- unrelated strategy item\n", encoding="utf-8")
+    (tmp_path / "docs/artifacts/acceleration-closeout-pack/delivery-board.md").write_text(
+        "# Delivery board\n- [ ] Task one\n- [ ] Task two\n- [ ] Task three\n- [ ] Task four\n- [ ] Task five\n",
+        encoding="utf-8",
+    )
+
+    summary = d44.build_scale_closeout_summary(tmp_path)
+    checks = {check["check_id"]: check for check in summary["checks"]}
+
+    assert checks["top10_scale_closeout_alignment"]["passed"] is False
+    assert checks["acceleration_closeout_board_integrity"]["passed"] is False
+

--- a/tests/test_scale_closeout.py
+++ b/tests/test_scale_closeout.py
@@ -124,7 +124,9 @@ def test_lane44_cli_dispatch(tmp_path: Path, capsys) -> None:
 
 def test_lane44_alignment_checks_fail_when_top10_and_board_missing_markers(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
-    (tmp_path / "docs/top-10-github-strategy.md").write_text("- unrelated strategy item\n", encoding="utf-8")
+    (tmp_path / "docs/top-10-github-strategy.md").write_text(
+        "- unrelated strategy item\n", encoding="utf-8"
+    )
     (tmp_path / "docs/artifacts/acceleration-closeout-pack/delivery-board.md").write_text(
         "# Delivery board\n- [ ] Task one\n- [ ] Task two\n- [ ] Task three\n- [ ] Task four\n- [ ] Task five\n",
         encoding="utf-8",
@@ -135,4 +137,3 @@ def test_lane44_alignment_checks_fail_when_top10_and_board_missing_markers(tmp_p
 
     assert checks["top10_scale_closeout_alignment"]["passed"] is False
     assert checks["acceleration_closeout_board_integrity"]["passed"] is False
-


### PR DESCRIPTION
### Motivation

- Standardize naming and copy from generic "Lane" language to `scale`-focused terminology and clarify the scale closeout intent.
- Make the page template and programmatic checks consistent so validation reliably detects required markers in docs and top-10 strategy files.

### Description

- Updated `docs/integrations-scale-closeout.md` to normalize headings and wording (replaced various "Lane" references with scale-focused language and simplified copy).
- Refactored `src/sdetkit/scale_closeout_44.py` to align `_SECTION_HEADER`, `_DEFAULT_PAGE_TEMPLATE`, `_REQUIRED_CONTRACT_LINES`, and `_REQUIRED_DELIVERY_BOARD_LINES` with the new copy and to make top-10 and delivery-board checks case-insensitive and phrase-specific by lowercasing text and checking for `scale closeout lane` and `expansion lane continuation`.
- Fixed `_board_stats` to inspect lowered text and look for `acceleration` and `scale` markers and adjusted the top-10 alignment check to use `.lower()` comparisons.
- Updated `tests/test_scale_closeout.py` seed data to match the new copy, changed the sample impact report title, and added `test_lane44_alignment_checks_fail_when_top10_and_board_missing_markers` to assert alignment checks fail when markers are absent.

### Testing

- Ran the unit tests in `tests/test_scale_closeout.py` with `pytest` and the suite passed. 
- Exercised the CLI flows via the existing tests which cover `build_scale_closeout_summary`, JSON output (`--format json`), pack emission/execute (`--emit-pack-dir` + `--execute`), and strict-mode failure behavior, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2d34b9a883328d2e5329c20e2669)