### PR TITLE
Fix 'Lane lane' typo in docs, add `demo` CLI help, adjust readiness summary, and add tests

### DIFF
--- a/docs/integrations-case-study-launch-closeout.md
+++ b/docs/integrations-case-study-launch-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_case_study_launch_closeout_contract.py
 ## Case-study launch contract
 
 - Single owner + backup reviewer are assigned for Lane published case-study launch execution and signoff.
-- The Lane lane references Lane prep outputs, governance decisions, and KPI continuity signals.
+- This lane references Lane prep outputs, governance decisions, and KPI continuity signals.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records publication outcomes, evidence confidence notes, and Lane scaling priorities.
 

--- a/docs/integrations-case-study-prep1-closeout.md
+++ b/docs/integrations-case-study-prep1-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_case_study_prep1_closeout_contract.py
 ## Case-study prep contract
 
 - Single owner + backup reviewer are assigned for Lane reliability case-study prep and signoff.
-- The Lane lane references Lane integration expansion outputs, governance decisions, and KPI continuity signals.
+- This lane references Lane integration expansion outputs, governance decisions, and KPI continuity signals.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records before/after reliability deltas, evidence confidence notes, and Lane prep priorities.
 

--- a/docs/integrations-case-study-prep2-closeout.md
+++ b/docs/integrations-case-study-prep2-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_case_study_prep2_closeout_contract.py
 ## Case-study prep contract
 
 - Single owner + backup reviewer are assigned for Lane triage-speed case-study prep and signoff.
-- The Lane lane references Lane case-study prep outputs, governance decisions, and KPI continuity signals.
+- This lane references Lane case-study prep outputs, governance decisions, and KPI continuity signals.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records before/after triage-speed deltas, evidence confidence notes, and Lane prep priorities.
 

--- a/docs/integrations-case-study-prep3-closeout.md
+++ b/docs/integrations-case-study-prep3-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_case_study_prep3_closeout_contract.py
 ## Case-study prep contract
 
 - Single owner + backup reviewer are assigned for Lane escalation-quality case-study prep and signoff.
-- The Lane lane references Lane case-study prep outputs, governance decisions, and KPI continuity signals.
+- This lane references Lane case-study prep outputs, governance decisions, and KPI continuity signals.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records before/after escalation-quality deltas, evidence confidence notes, and Lane prep priorities.
 

--- a/docs/integrations-community-program-closeout.md
+++ b/docs/integrations-community-program-closeout.md
@@ -25,7 +25,7 @@ python scripts/check_community_program_closeout_contract.py
 ## Community program execution contract
 
 - Single owner + backup reviewer are assigned for Lane community office-hours execution and moderation safety.
-- The Lane lane references Lane Phase-3 kickoff outcomes, trust guardrails, and KPI continuity evidence.
+- This lane references Lane Phase-3 kickoff outcomes, trust guardrails, and KPI continuity evidence.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records office-hours cadence, participation rules, moderation SOPs, and Lane onboarding priorities.
 

--- a/docs/integrations-community-touchpoint-closeout.md
+++ b/docs/integrations-community-touchpoint-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_community_touchpoint_closeout_contract.py
 ## Community touchpoint contract
 
 - Single owner + backup reviewer are assigned for Lane community touchpoint execution and signoff.
-- The Lane lane references Lane outcomes, controls, and KPI continuity signals.
+- This lane references Lane outcomes, controls, and KPI continuity signals.
 - Every Lane section includes community CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records touchpoint outcomes, confidence notes, and Lane ecosystem priorities.
 

--- a/docs/integrations-continuous-upgrade-closeout-1.md
+++ b/docs/integrations-continuous-upgrade-closeout-1.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_contract_1.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references phase-3 wrap publication outcomes, controls, and trust continuity signals.
+- This lane references phase-3 wrap publication outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-10.md
+++ b/docs/integrations-continuous-upgrade-closeout-10.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-11.md
+++ b/docs/integrations-continuous-upgrade-closeout-11.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-2.md
+++ b/docs/integrations-continuous-upgrade-closeout-2.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-3.md
+++ b/docs/integrations-continuous-upgrade-closeout-3.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-4.md
+++ b/docs/integrations-continuous-upgrade-closeout-4.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-5.md
+++ b/docs/integrations-continuous-upgrade-closeout-5.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-6.md
+++ b/docs/integrations-continuous-upgrade-closeout-6.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-7.md
+++ b/docs/integrations-continuous-upgrade-closeout-7.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-8.md
+++ b/docs/integrations-continuous-upgrade-closeout-8.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-continuous-upgrade-closeout-9.md
+++ b/docs/integrations-continuous-upgrade-closeout-9.md
@@ -26,7 +26,7 @@ python scripts/check_continuous_upgrade_closeout_contract.py
 ## Continuous upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane continuous upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records continuous upgrade outputs, report publication status, and backlog inputs.
 

--- a/docs/integrations-contributor-activation-closeout.md
+++ b/docs/integrations-contributor-activation-closeout.md
@@ -25,7 +25,7 @@ python scripts/check_contributor_activation_closeout_contract.py
 ## Contributor activation contract
 
 - Single owner + backup reviewer are assigned for Lane contributor-activation execution and KPI follow-up.
-- The Lane lane references Lane docs-loop wins and misses with deterministic contributor follow-up loops.
+- This lane references Lane docs-loop wins and misses with deterministic contributor follow-up loops.
 - Every Lane section includes docs CTA, runnable command CTA, KPI target, and rollout guardrail.
 - Lane closeout records contributor-activation learnings and Lane prioritization inputs.
 

--- a/docs/integrations-contributor-recognition-closeout.md
+++ b/docs/integrations-contributor-recognition-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_contributor_recognition_closeout_contract.py
 ## Contributor recognition contract
 
 - Single owner + backup reviewer are assigned for Lane contributor recognition execution and signoff.
-- The Lane lane references Lane outcomes, controls, and KPI continuity signals.
+- This lane references Lane outcomes, controls, and KPI continuity signals.
 - Every Lane section includes contributor CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records recognition outcomes, confidence notes, and Lane scale priorities.
 

--- a/docs/integrations-distribution-scaling-closeout.md
+++ b/docs/integrations-distribution-scaling-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_distribution_scaling_closeout_contract.py
 ## Distribution scaling contract
 
 - Single owner + backup reviewer are assigned for Lane distribution scaling execution and signoff.
-- The Lane lane references Lane publication outcomes, controls, and KPI continuity signals.
+- This lane references Lane publication outcomes, controls, and KPI continuity signals.
 - Every Lane section includes channel CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records distribution outcomes, confidence notes, and Lane trust refresh priorities.
 

--- a/docs/integrations-ecosystem-priorities-closeout.md
+++ b/docs/integrations-ecosystem-priorities-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_ecosystem_priorities_closeout_contract.py
 ## Ecosystem priorities contract
 
 - Single owner + backup reviewer are assigned for Lane ecosystem priorities execution and signoff.
-- The Lane lane references Lane outcomes, controls, and KPI continuity signals.
+- This lane references Lane outcomes, controls, and KPI continuity signals.
 - Every Lane section includes ecosystem CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records ecosystem outcomes, confidence notes, and Lane scale priorities.
 

--- a/docs/integrations-evidence-narrative-closeout.md
+++ b/docs/integrations-evidence-narrative-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_evidence_narrative_closeout_contract.py
 ## Evidence narrative contract
 
 - Single owner + backup reviewer are assigned for Lane evidence narrative execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records evidence narrative pack upgrades, storyline outcomes, and Lane release priorities.
 

--- a/docs/integrations-governance-handoff-closeout.md
+++ b/docs/integrations-governance-handoff-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_governance_handoff_closeout_contract.py
 ## Governance handoff contract
 
 - Single owner + backup reviewer are assigned for Lane governance handoff execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records governance handoff pack upgrades, storyline outcomes, and Lane governance priorities.
 

--- a/docs/integrations-governance-priorities-closeout.md
+++ b/docs/integrations-governance-priorities-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_governance_priorities_closeout_contract.py
 ## Governance priorities contract
 
 - Single owner + backup reviewer are assigned for Lane governance priorities execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records governance priorities pack upgrades, storyline outcomes, and Lane governance priorities.
 

--- a/docs/integrations-governance-scale-closeout.md
+++ b/docs/integrations-governance-scale-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_governance_scale_closeout_contract.py
 ## Governance scale contract
 
 - Single owner + backup reviewer are assigned for Lane governance scale execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records governance scale pack upgrades, storyline outcomes, and Lane governance planning inputs.
 

--- a/docs/integrations-growth-campaign-closeout.md
+++ b/docs/integrations-growth-campaign-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_growth_campaign_closeout_contract.py
 ## Growth campaign contract
 
 - Single owner + backup reviewer are assigned for Lane growth campaign execution and signoff.
-- The Lane lane references Lane outcomes, controls, and KPI continuity signals.
+- This lane references Lane outcomes, controls, and KPI continuity signals.
 - Every Lane section includes campaign CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records campaign outcomes, confidence notes, and Lane execution priorities.
 

--- a/docs/integrations-integration-expansion-closeout.md
+++ b/docs/integrations-integration-expansion-closeout.md
@@ -25,7 +25,7 @@ python scripts/check_integration_expansion_closeout_contract.py
 ## Integration expansion contract
 
 - Single owner + backup reviewer are assigned for Lane advanced GitHub Actions workflow execution and rollout signoff.
-- The Lane lane references Lane onboarding outcomes, ownership handoff evidence, and KPI continuity signals.
+- This lane references Lane onboarding outcomes, ownership handoff evidence, and KPI continuity signals.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records reusable workflow design, matrix strategy, caching/concurrency controls, and Lane review priorities.
 

--- a/docs/integrations-integration-expansion2-closeout.md
+++ b/docs/integrations-integration-expansion2-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_integration_expansion2_closeout_contract.py
 ## Integration expansion contract
 
 - Single owner + backup reviewer are assigned for Lane advanced GitLab CI rollout and signoff.
-- The Lane lane references Lane weekly review outputs, governance decisions, and KPI continuity signals.
+- This lane references Lane weekly review outputs, governance decisions, and KPI continuity signals.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records GitLab pipeline stages, parallel matrix controls, cache strategy, and Lane integration priorities.
 

--- a/docs/integrations-integration-expansion3-closeout.md
+++ b/docs/integrations-integration-expansion3-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_integration_expansion3_closeout_contract.py
 ## Integration expansion contract
 
 - Single owner + backup reviewer are assigned for Lane advanced Jenkins rollout and signoff.
-- The Lane lane references Lane integration expansion outputs, governance decisions, and KPI continuity signals.
+- This lane references Lane integration expansion outputs, governance decisions, and KPI continuity signals.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records Jenkins pipeline stages, matrix controls, shared library strategy, and Lane integration priorities.
 

--- a/docs/integrations-integration-expansion4-closeout.md
+++ b/docs/integrations-integration-expansion4-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_integration_expansion4_closeout_contract.py
 ## Integration expansion contract
 
 - Single owner + backup reviewer are assigned for Lane self-hosted enterprise rollout and signoff.
-- The Lane lane references Lane integration expansion outputs, governance decisions, and KPI continuity signals.
+- This lane references Lane integration expansion outputs, governance decisions, and KPI continuity signals.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records self-hosted pipeline stages, identity controls, runner policy strategy, and Lane case-study prep priorities.
 

--- a/docs/integrations-integration-feedback-closeout.md
+++ b/docs/integrations-integration-feedback-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_integration_feedback_closeout_contract.py
 ## Integration feedback contract
 
 - Single owner + backup reviewer are assigned for Lane integration feedback execution and signoff.
-- The Lane lane references Lane outcomes, controls, and campaign continuity signals.
+- This lane references Lane outcomes, controls, and campaign continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records docs-template upgrades, community touchpoint outcomes, and Lane trust FAQ priorities.
 

--- a/docs/integrations-kpi-deep-audit-closeout.md
+++ b/docs/integrations-kpi-deep-audit-closeout.md
@@ -25,7 +25,7 @@ python scripts/check_kpi_deep_audit_closeout_contract.py
 ## KPI deep audit contract
 
 - Single owner + backup reviewer are assigned for Lane KPI deep-audit execution and signal triage.
-- The Lane lane references Lane stabilization outcomes and unresolved risks.
+- This lane references Lane stabilization outcomes and unresolved risks.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records deep-audit outcomes and Lane execution priorities.
 

--- a/docs/integrations-launch-readiness-closeout.md
+++ b/docs/integrations-launch-readiness-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_launch_readiness_closeout_contract.py
 ## Launch readiness contract
 
 - Single owner + backup reviewer are assigned for Lane launch readiness execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records launch readiness pack upgrades, storyline outcomes, and Lane launch priorities.
 

--- a/docs/integrations-onboarding-activation-closeout.md
+++ b/docs/integrations-onboarding-activation-closeout.md
@@ -25,7 +25,7 @@ python scripts/check_onboarding_activation_closeout_contract_63.py
 ## Onboarding activation contract
 
 - Single owner + backup reviewer are assigned for Lane onboarding activation execution and roadmap-voting facilitation.
-- The Lane lane references Lane community-program outcomes, moderation guardrails, and KPI continuity evidence.
+- This lane references Lane community-program outcomes, moderation guardrails, and KPI continuity evidence.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records onboarding orientation flow, ownership handoff SOP, roadmap voting launch, and Lane pipeline priorities.
 

--- a/docs/integrations-partner-outreach-closeout.md
+++ b/docs/integrations-partner-outreach-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_partner_outreach_closeout_contract.py
 ## Partner outreach contract
 
 - Single owner + backup reviewer are assigned for Lane partner outreach execution and signoff.
-- The Lane lane references Lane outcomes, controls, and KPI continuity signals.
+- This lane references Lane outcomes, controls, and KPI continuity signals.
 - Every Lane section includes partner CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records partner onboarding outcomes, confidence notes, and Lane growth campaign priorities.
 

--- a/docs/integrations-phase3-kickoff-closeout.md
+++ b/docs/integrations-phase3-kickoff-closeout.md
@@ -25,7 +25,7 @@ python scripts/check_phase3_kickoff_closeout_contract.py
 ## Phase-3 kickoff execution contract
 
 - Single owner + backup reviewer are assigned for Lane Phase-3 kickoff execution and trust-signal triage.
-- The Lane lane references Lane Phase-2 wrap outcomes, risks, and KPI continuity evidence.
+- This lane references Lane Phase-2 wrap outcomes, risks, and KPI continuity evidence.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records Phase-3 baseline activation, trust KPI owners, and Lane community program priorities.
 

--- a/docs/integrations-phase3-preplan-closeout.md
+++ b/docs/integrations-phase3-preplan-closeout.md
@@ -25,7 +25,7 @@ python scripts/check_phase3_preplan_closeout_contract.py
 ## Phase-3 pre-plan contract
 
 - Single owner + backup reviewer are assigned for Lane Phase-3 pre-plan execution and signal triage.
-- The Lane lane references Lane Phase-2 hardening outcomes and unresolved risks.
+- This lane references Lane Phase-2 hardening outcomes and unresolved risks.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records pre-plan outcomes and Lane execution priorities.
 

--- a/docs/integrations-phase3-wrap-publication-closeout.md
+++ b/docs/integrations-phase3-wrap-publication-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_phase3_wrap_publication_closeout_contract.py
 ## Phase-3 wrap publication contract
 
 - Single owner + backup reviewer are assigned for Lane phase-3 wrap publication execution and signoff.
-- The Lane lane references Lane outcomes, controls, and trust continuity signals.
+- This lane references Lane outcomes, controls, and trust continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records phase-3 wrap publication outputs, final report publication status, and next-impact roadmap inputs.
 

--- a/docs/integrations-scale-upgrade-closeout.md
+++ b/docs/integrations-scale-upgrade-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_scale_upgrade_closeout_contract.py
 ## Scale upgrade contract
 
 - Single owner + backup reviewer are assigned for Lane scale upgrade execution and signoff.
-- The Lane lane references Lane outcomes, controls, and KPI continuity signals.
+- This lane references Lane outcomes, controls, and KPI continuity signals.
 - Every Lane section includes enterprise CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records enterprise onboarding outcomes, confidence notes, and Lane partner outreach priorities.
 

--- a/docs/integrations-stabilization-closeout.md
+++ b/docs/integrations-stabilization-closeout.md
@@ -25,7 +25,7 @@ python scripts/check_stabilization_closeout_contract.py
 ## Stabilization contract
 
 - Single owner + backup reviewer are assigned for Lane stabilization execution and KPI recovery.
-- The Lane lane references Lane contributor activation outcomes and unresolved risks.
+- This lane references Lane contributor activation outcomes and unresolved risks.
 - Every Lane section includes docs CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records stabilization outcomes and Lane deep-audit priorities.
 

--- a/docs/integrations-trust-assets-refresh-closeout.md
+++ b/docs/integrations-trust-assets-refresh-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_trust_assets_refresh_closeout_contract.py
 ## Trust assets refresh contract
 
 - Single owner + backup reviewer are assigned for Lane trust assets refresh execution and signoff.
-- The Lane lane references Lane outcomes, controls, and KPI continuity signals.
+- This lane references Lane outcomes, controls, and KPI continuity signals.
 - Every Lane section includes trust-surface CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records trust outcomes, confidence notes, and Lane contributor-recognition priorities.
 

--- a/docs/integrations-trust-faq-expansion-closeout.md
+++ b/docs/integrations-trust-faq-expansion-closeout.md
@@ -26,7 +26,7 @@ python scripts/check_trust_faq_expansion_closeout_contract.py
 ## Trust FAQ expansion contract
 
 - Single owner + backup reviewer are assigned for Lane trust FAQ expansion execution and signoff.
-- The Lane lane references Lane outcomes, controls, and campaign continuity signals.
+- This lane references Lane outcomes, controls, and campaign continuity signals.
 - Every Lane section includes docs/template CTA, runnable command CTA, KPI threshold, and rollback guardrail.
 - Lane closeout records trust FAQ content upgrades, escalation outcomes, and Lane evidence narrative priorities.
 

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -609,7 +609,7 @@ Then use stability-aware command discovery:
     obj = sub.add_parser("objection-handling", help="Objection handling playbook")
     obj.add_argument("args", nargs=argparse.REMAINDER)
 
-    dmo = sub.add_parser("demo")
+    dmo = sub.add_parser("demo", help="Demo playbook")
     dmo.add_argument("args", nargs=argparse.REMAINDER)
 
     fct = sub.add_parser("first-contribution", help="First contribution playbook")

--- a/src/sdetkit/readiness/production_readiness.py
+++ b/src/sdetkit/readiness/production_readiness.py
@@ -94,20 +94,6 @@ def _main_aspect_readiness(checks: list[ReadinessCheck]) -> list[dict[str, Any]]
 
 def build_production_readiness_summary(root: Path) -> dict[str, Any]:
     phase_boost_path = _first_existing(root, _PHASE_BOOST_BLUEPRINT_FILES)
-    required_files = [
-        "README.md",
-        "CONTRIBUTING.md",
-        "SECURITY.md",
-        "CODE_OF_CONDUCT.md",
-        "pyproject.toml",
-        "Dockerfile",
-        "noxfile.py",
-        "docs/index.md",
-        "docs/repo-audit.md",
-        "docs/security.md",
-        _PHASE_BOOST_BLUEPRINT_FILES[0],
-        "tests/test_cli_sdetkit.py",
-    ]
     required_workflows = [
         ".github/workflows/ci.yml",
         ".github/workflows/quality.yml",
@@ -221,7 +207,6 @@ def build_production_readiness_summary(root: Path) -> dict[str, Any]:
             "job_done_ready": main_aspects_ready == len(main_aspects) and not missing_items,
             "main_aspects_ready_count": main_aspects_ready,
             "main_aspects_total": len(main_aspects),
-            "required_files_count": len(required_files),
             "required_workflows_count": len(required_workflows),
         },
         "main_aspects": main_aspects,

--- a/tests/test_cli_help_lists_subcommands.py
+++ b/tests/test_cli_help_lists_subcommands.py
@@ -38,6 +38,7 @@ def test_help_lists_doctor_patch_cassette_get_repo_dev_report_maintenance_agent_
     assert "weekly-review" in out
     assert "first-contribution" in out
     assert "contributor-funnel" in out
+    assert "demo" in out
     assert "triage-templates" in out
     assert "docs-governance" in out
     assert "docs-nav" not in out

--- a/tests/test_docs_lane_lane_typos.py
+++ b/tests/test_docs_lane_lane_typos.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_integration_closeout_docs_do_not_contain_lane_lane_typo() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    offenders: list[str] = []
+    for path in sorted((repo_root / "docs").glob("integrations-*.md")):
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if "Lane lane" in line:
+                offenders.append(f"{path.relative_to(repo_root)}:{line_no}")
+    assert not offenders, "Found 'Lane lane' typo in:\n" + "\n".join(offenders)


### PR DESCRIPTION
### Motivation

- Remove a recurring copy/paste typo that produced the phrase "Lane lane" in many integration closeout docs to improve readability and consistency.
- Expose a brief help string for the `demo` CLI subcommand so it appears in help output.
- Simplify the production readiness summary payload by removing an unused `required_files` count.

### Description

- Replaced occurrences of the sentence starting with "The Lane lane references..." with "This lane references..." across multiple `docs/integrations-*.md` files.
- Added a help string to the `demo` subcommand in `src/sdetkit/cli.py` via `sub.add_parser("demo", help="Demo playbook")` and updated the CLI help test to assert `demo` is listed.
- Removed the `required_files` list and the `required_files_count` field from `build_production_readiness_summary` in `src/sdetkit/readiness/production_readiness.py`.
- Added a new test `tests/test_docs_lane_lane_typos.py` that scans `docs/integrations-*.md` files for the "Lane lane" typo and fails if any occurrences are found.

### Testing

- Ran `pytest tests/test_docs_lane_lane_typos.py` which asserts there are no "Lane lane" occurrences, and it passed.
- Ran `pytest tests/test_cli_help_lists_subcommands.py` to verify the `demo` subcommand appears in CLI help, and it passed.
- Ran the full test suite with `pytest` and observed no failures related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec38d09b4883328e48096a3ca15979)