### PR TITLE
Fail fast on unknown legacy subcommand; update public surface and tests

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -35,7 +35,7 @@ This table is sourced from `src/sdetkit/public_surface_contract.py`.
 
 - Advanced kits and discovery: `sdetkit kits list`, `sdetkit kits describe <kit>`, then `release`, `intelligence`, `integration`, `forensics`
 - Compatibility aliases: `gate`, `doctor`, `security`, `repo`, `evidence`, `report`, `policy`
-- Supporting utilities and automation: `kv`, `apiget`, `cassette-get`, `patch`, `maintenance`, `dev`, `ci`, `ops`, `notify`, `agent`
+- Supporting utilities and automation: `kv`, `inspect`, `review`, `apiget`, `cassette-get`, `patch`, `maintenance`, `dev`, `ci`, `ops`, `notify`, `agent`, `feature-registry`
 
 ## Transition-era and historical lanes
 

--- a/src/sdetkit/legacy_namespace.py
+++ b/src/sdetkit/legacy_namespace.py
@@ -18,4 +18,5 @@ def handle_legacy_namespace(argv: Sequence[str]) -> int | None:
         return 0
     if argv[1] == "migrate-hint":
         return run_legacy_migrate_hint(list(argv[2:]))
-    return None
+    sys.stderr.write(f"legacy error: unknown subcommand '{argv[1]}'\n")
+    return 2

--- a/src/sdetkit/legacy_namespace.py
+++ b/src/sdetkit/legacy_namespace.py
@@ -18,5 +18,7 @@ def handle_legacy_namespace(argv: Sequence[str]) -> int | None:
         return 0
     if argv[1] == "migrate-hint":
         return run_legacy_migrate_hint(list(argv[2:]))
+    if argv[1] in LEGACY_NAMESPACE_COMMANDS:
+        return None
     sys.stderr.write(f"legacy error: unknown subcommand '{argv[1]}'\n")
     return 2

--- a/tests/test_legacy_namespace.py
+++ b/tests/test_legacy_namespace.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from sdetkit import cli
-from sdetkit import legacy_namespace
+from sdetkit import cli, legacy_namespace
 
 
 def test_handle_legacy_namespace_returns_none_for_non_legacy() -> None:
@@ -32,6 +31,10 @@ def test_handle_legacy_namespace_unknown_subcommand_errors(capsys) -> None:
     assert rc == 2
     err = capsys.readouterr().err
     assert "legacy error: unknown subcommand 'unknown-subcmd'" in err
+
+
+def test_handle_legacy_namespace_known_legacy_command_passthrough() -> None:
+    assert legacy_namespace.handle_legacy_namespace(["legacy", "weekly-review-lane", "--help"]) is None
 
 
 def test_cli_main_unknown_legacy_subcommand_fails_fast(capsys) -> None:

--- a/tests/test_legacy_namespace.py
+++ b/tests/test_legacy_namespace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sdetkit import cli
 from sdetkit import legacy_namespace
 
 
@@ -26,5 +27,15 @@ def test_handle_legacy_namespace_routes_migrate_hint(monkeypatch) -> None:
     assert legacy_namespace.handle_legacy_namespace(["legacy", "migrate-hint", "x"]) == 7
 
 
-def test_handle_legacy_namespace_unknown_subcommand_returns_none() -> None:
-    assert legacy_namespace.handle_legacy_namespace(["legacy", "unknown-subcmd"]) is None
+def test_handle_legacy_namespace_unknown_subcommand_errors(capsys) -> None:
+    rc = legacy_namespace.handle_legacy_namespace(["legacy", "unknown-subcmd"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "legacy error: unknown subcommand 'unknown-subcmd'" in err
+
+
+def test_cli_main_unknown_legacy_subcommand_fails_fast(capsys) -> None:
+    rc = cli.main(["legacy", "unknown-subcmd"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "legacy error: unknown subcommand 'unknown-subcmd'" in err

--- a/tests/test_legacy_namespace.py
+++ b/tests/test_legacy_namespace.py
@@ -34,7 +34,9 @@ def test_handle_legacy_namespace_unknown_subcommand_errors(capsys) -> None:
 
 
 def test_handle_legacy_namespace_known_legacy_command_passthrough() -> None:
-    assert legacy_namespace.handle_legacy_namespace(["legacy", "weekly-review-lane", "--help"]) is None
+    assert (
+        legacy_namespace.handle_legacy_namespace(["legacy", "weekly-review-lane", "--help"]) is None
+    )
 
 
 def test_cli_main_unknown_legacy_subcommand_fails_fast(capsys) -> None:

--- a/tests/test_netclient_branches_wave6.py
+++ b/tests/test_netclient_branches_wave6.py
@@ -98,7 +98,7 @@ def test_request_timeout_records_failure_and_raises_timeout_error() -> None:
     assert spy.success_calls == 0
 
 
-def test_request_request_error_then_success_records_failure_then_success() -> None:
+def test_request_error_then_success_records_failure_then_success() -> None:
     calls = {"n": 0}
 
     def handler(request: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
### Motivation
- Make the `legacy` namespace fail fast and give a clear error when an unknown subcommand is invoked. 
- Keep the public command surface documentation up to date with newly exposed utilities. 
- Align unit tests with the new error behavior and ensure CLI integrates the change.

### Description
- Change `handle_legacy_namespace` to write a descriptive error to `stderr` and return exit code `2` for unknown legacy subcommands instead of returning `None`.
- Add `inspect`, `review`, and `feature-registry` to the `Supporting utilities and automation` list in `docs/command-surface.md`.
- Update `tests/test_legacy_namespace.py` to assert the new error behavior and add a `cli.main` integration test that verifies CLI exit code and error output for an unknown legacy subcommand.
- Rename a test in `tests/test_netclient_branches_wave6.py` for clarity (no behavior change to production code).

### Testing
- Ran the test suite with `pytest`, and the updated legacy namespace tests for unknown subcommands passed. 
- The newly added CLI integration test for `legacy unknown-subcmd` passed and observed the expected `rc == 2` and stderr message. 
- All other unit tests touched by the change passed locally under `pytest -q`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca916af5c8332905a35e7712b5888)