### PR TITLE
Repair Top journeys in docs navigation without duplication and strengthen typo test

### DIFF
--- a/docs/artifacts/weekly-review-sample-14.md
+++ b/docs/artifacts/weekly-review-sample-14.md
@@ -7,7 +7,7 @@
 | 8 | Good-first-issue accelerator pack | `docs/name-8-ultra-upgrade-report.md` | `docs/artifacts/name8-good-first-issues-sample.md` | shipped ✅ |
 | 9 | Triage-ready issue + PR templates | `docs/name-9-ultra-upgrade-report.md` | `docs/artifacts/name9-triage-templates-sample.md` | shipped ✅ |
 | 10 | First-contribution checklist | `docs/name-10-ultra-upgrade-report.md` | `docs/artifacts/name10-first-contribution-checklist-sample.md` | shipped ✅ |
-| 11 | Docs navigation tune-up | `docs/name-11-ultra-upgrade-report.md` | `docs/artifacts/name11-docs-navigation-sample.md` | shipped ✅ |
+| 11 | Docs navigation tune-up | `docs/impact-11-ultra-upgrade-report.md` | `docs/artifacts/name11-docs-navigation-sample.md` | shipped ✅ |
 | 12 | Startup/small-team workflow | `docs/startup-readiness-report.md` | `docs/artifacts/startup-readiness-sample.md` | shipped ✅ |
 | 13 | Enterprise/regulated workflow | `docs/enterprise-readiness-report.md` | `docs/artifacts/enterprise-readiness-sample.md` | shipped ✅ |
 

--- a/docs/impact-11-ultra-upgrade-report.md
+++ b/docs/impact-11-ultra-upgrade-report.md
@@ -1,4 +1,4 @@
-#  big upgrade report
+# Impact 11 Ultra Upgrade Report
 
 ## What shipped
 
@@ -16,4 +16,4 @@ python scripts/check_docs_navigation_contract_11.py
 
 ## Handoff
 
- big upgrade closes docs navigation fundamentals with reproducible checks and report artifacts.
+This upgrade closes docs navigation fundamentals with reproducible checks and report artifacts.

--- a/src/sdetkit/docs_navigation.py
+++ b/src/sdetkit/docs_navigation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -111,10 +112,25 @@ def _ensure_legacy_reports_section_header(text: str) -> tuple[str, bool]:
 
 
 def _ensure_journey_block(text: str) -> tuple[str, bool]:
-    if _TOP_JOURNEYS_HEADER in text and all(f"- {journey}" in text for journey in _TOP_JOURNEYS):
+    if _TOP_JOURNEYS_HEADER not in text:
+        updated = text.rstrip() + "\n\n" + _DEFAULT_JOURNEYS_BLOCK + "\n"
+        return updated, updated != text
+
+    pattern = re.compile(
+        rf"(?ms)^{re.escape(_TOP_JOURNEYS_HEADER)}\n(?P<body>.*?)(?=^##\s|^###\s|\Z)"
+    )
+    match = pattern.search(text)
+    if not match:
         return text, False
 
-    updated = text.rstrip() + "\n\n" + _DEFAULT_JOURNEYS_BLOCK + "\n"
+    section = match.group(0).rstrip()
+    missing = [journey for journey in _TOP_JOURNEYS if f"- {journey}" not in section]
+    if not missing:
+        return text, False
+
+    additions = "".join(f"\n- {journey}" for journey in missing)
+    updated_section = section + additions + "\n"
+    updated = text[: match.start()] + updated_section + text[match.end() :]
     return updated, updated != text
 
 

--- a/tests/test_docs_lane_lane_typos.py
+++ b/tests/test_docs_lane_lane_typos.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
 def test_integration_closeout_docs_do_not_contain_lane_lane_typo() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     offenders: list[str] = []
-    for path in sorted((repo_root / "docs").glob("integrations-*.md")):
+    pattern = re.compile(r"\blane\s+lane\b", re.IGNORECASE)
+    for path in sorted((repo_root / "docs").glob("**/*.md")):
         for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-            if "Lane lane" in line:
+            if pattern.search(line):
                 offenders.append(f"{path.relative_to(repo_root)}:{line_no}")
     assert not offenders, "Found 'Lane lane' typo in:\n" + "\n".join(offenders)

--- a/tests/test_docs_navigation.py
+++ b/tests/test_docs_navigation.py
@@ -108,6 +108,29 @@ def test_docs_navigation_write_defaults_noop_when_already_clean(tmp_path):
     assert second == []
 
 
+def test_docs_navigation_write_defaults_repairs_existing_top_journeys_without_duplication(tmp_path):
+    (tmp_path / "docs").mkdir(parents=True)
+    content = (
+        "# Documentation Home\n\n"
+        + docs_navigation._DEFAULT_QUICK_JUMP_BLOCK
+        + "\n\n"
+        + docs_navigation._LEGACY_REPORTS_SECTION_HEADER
+        + "\n\n"
+        + "### Top journeys\n\n"
+        + "- Run first command in under 60 seconds\n"
+        + "\n## Next section\n"
+    )
+    (tmp_path / "docs/index.md").write_text(content, encoding="utf-8")
+
+    touched = docs_navigation._write_defaults(tmp_path)
+    assert touched == ["docs/index.md"]
+
+    repaired = (tmp_path / "docs/index.md").read_text(encoding="utf-8")
+    assert repaired.count("### Top journeys") == 1
+    for journey in docs_navigation._TOP_JOURNEYS:
+        assert f"- {journey}" in repaired
+
+
 def test_docs_navigation_markdown_output_file_written(tmp_path, capsys):
     (tmp_path / "docs").mkdir(parents=True)
     content = (


### PR DESCRIPTION
### Motivation

- Make the docs navigation default/writer robust by inserting only missing "Top journeys" items without duplicating the section header. 
- Broaden and harden the automated check for the "Lane lane" typo to scan all markdown files and match word boundaries/case variations. 

### Description

- Update `src/sdetkit/docs_navigation.py` to import `re` and replace `_ensure_journey_block` with logic that finds the existing "### Top journeys" section using a regex, computes any missing journey items, and appends only those items to avoid duplication; if the header is missing the default block is appended. 
- Add `docs/impact-11-ultra-upgrade-report.md` with a cleaned-up title and handoff wording and update `docs/artifacts/weekly-review-sample-14.md` to reference the new report path. 
- Tighten the typo test in `tests/test_docs_lane_lane_typos.py` by compiling a case-insensitive regex `r"\blane\s+lane\b"` and expanding the file search to all `**/*.md` files. 
- Add a new integration test `test_docs_navigation_write_defaults_repairs_existing_top_journeys_without_duplication` in `tests/test_docs_navigation.py` to verify `_write_defaults` repairs the Top journeys section without duplicating the header and ensures all journey items are present. 

### Testing

- Ran the docs navigation unit tests via `pytest tests/test_docs_navigation.py -q`, including the new repair/duplication test, and they passed. 
- Ran the typo test via `pytest tests/test_docs_lane_lane_typos.py -q` which passed and correctly detects occurrences using the new regex. 
- Ran the full test suite with `pytest -q` and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edca25d24c8332ba83785d30b4eb1c)