### PR TITLE
Ignore absolute external paths in check cache fingerprint

### DIFF
--- a/src/sdetkit/checks/cache.py
+++ b/src/sdetkit/checks/cache.py
@@ -127,10 +127,16 @@ class CheckCache:
                 yield current / filename
 
     def _iter_paths(self, repo_root: Path, changed_paths: tuple[str, ...]):
+        repo_root_resolved = repo_root.resolve()
         if changed_paths:
             seen: set[Path] = set()
             for rel in changed_paths:
-                path = repo_root / rel
+                hinted = Path(rel)
+                path = hinted if hinted.is_absolute() else (repo_root / hinted)
+                try:
+                    path.resolve().relative_to(repo_root_resolved)
+                except ValueError:
+                    continue
                 if path.is_file():
                     seen.add(path)
                     continue

--- a/tests/test_checks_cache.py
+++ b/tests/test_checks_cache.py
@@ -73,3 +73,21 @@ def test_compute_repo_fingerprint_ignores_outside_repo_hint_paths(tmp_path: Path
     with_outside_hint = cache.compute_repo_fingerprint(repo_root, ("../outside", "tracked.txt"))
 
     assert inside_only == with_outside_hint
+
+
+def test_compute_repo_fingerprint_ignores_absolute_outside_repo_hint_paths(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "tracked.txt").write_text("ok\n", encoding="utf-8")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("nope\n", encoding="utf-8")
+
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    inside_only = cache.compute_repo_fingerprint(repo_root, ("tracked.txt",))
+
+    cache = CheckCache(tmp_path / ".sdetkit-cache")
+    with_outside_hint = cache.compute_repo_fingerprint(
+        repo_root, (str(outside_file), "tracked.txt")
+    )
+
+    assert inside_only == with_outside_hint


### PR DESCRIPTION
### Motivation

- Prevent out-of-repo absolute paths passed as `changed_paths` from affecting or breaking repository fingerprint computation in the cache layer.
- Harden `CheckCache._iter_paths` so external hints cannot cause `ValueError` or unintentionally include files outside the repository scope.

### Description

- Update `src/sdetkit/checks/cache.py` to resolve `repo_root` and individually handle `changed_paths` entries, skipping absolute paths that resolve outside the repository root and preserving existing behavior for in-repo hints.
- When a `changed_paths` entry is absolute, treat it as-is and drop it if it resolves outside `repo_root`; when relative, resolve it against `repo_root` before use.
- Add a regression test `test_compute_repo_fingerprint_ignores_absolute_outside_repo_hint_paths` in `tests/test_checks_cache.py` that verifies an absolute outside-repo file does not change the fingerprint.

### Testing

- Ran the existing full test suite earlier: `pytest -q` (previous run reported `2344 passed, 3 deselected`).
- Ran the modified cache tests: `pytest -q tests/test_checks_cache.py` which returned `5 passed`.
- Ran related cache/registry tests: `pytest -q tests/test_checks_runner_cache_registry_unit.py tests/test_checks_additional_coverage_unit.py` which returned `13 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edccafd3f483329fd75ced6482c3b7)