### PR TITLE
Improve httpx fallback errors and update related tests and CLI test helpers

### DIFF
--- a/src/sdetkit/optional_httpx.py
+++ b/src/sdetkit/optional_httpx.py
@@ -1,4 +1,8 @@
-"""Utility for optional `httpx` loading in environments without network extras."""
+"""Compatibility loader for `httpx`.
+
+`httpx` is a runtime dependency, but this module keeps a defensive fallback for
+degraded environments where imports are partially unavailable.
+"""
 
 from __future__ import annotations
 
@@ -10,7 +14,7 @@ __all__ = ["load_httpx"]
 
 
 def _missing_message(feature: str) -> str:
-    return f"httpx is required for {feature}; install optional network dependencies."
+    return f"httpx is required for {feature}; install runtime dependencies (for example: pip install -e .)."
 
 
 def _build_missing_httpx_module(*, feature: str) -> Any:
@@ -27,11 +31,12 @@ def _build_missing_httpx_module(*, feature: str) -> Any:
             pass
 
         class Response:
-            status_code = 0
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise ModuleNotFoundError(message)
 
         class URL:
-            def __str__(self) -> str:
-                return ""
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise ModuleNotFoundError(message)
 
         class Client:  # pragma: no cover - defensive fallback only
             def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/tests/test_docs_lane_typos.py
+++ b/tests/test_docs_lane_typos.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 
 
-def test_integration_closeout_docs_do_not_contain_lane_lane_typo() -> None:
+def test_integration_closeout_docs_do_not_contain_lane_typo() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     offenders: list[str] = []
     pattern = re.compile(r"\blane\s+lane\b", re.IGNORECASE)

--- a/tests/test_entrypoints_smoke.py
+++ b/tests/test_entrypoints_smoke.py
@@ -5,7 +5,15 @@ import sys
 import pytest
 
 
-def _run_cli(argv: list[str]) -> None:
+def _exit_code(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    return 1
+
+
+def _run_cli(argv: list[str]) -> int:
     mod = importlib.import_module("sdetkit.cli")
     main = mod.main
     old_argv = sys.argv[:]
@@ -13,38 +21,49 @@ def _run_cli(argv: list[str]) -> None:
         sys.argv = ["sdetkit", *argv]
         try:
             main()
-        except SystemExit:
-            pass
+        except SystemExit as exc:
+            return _exit_code(exc.code)
+        return 0
     finally:
         sys.argv = old_argv
 
 
-def _run_entrypoint(fn_name: str, argv0: str, argv: list[str]) -> None:
+def _run_entrypoint(fn_name: str, argv0: str, argv: list[str]) -> int:
     mod = importlib.import_module("sdetkit.entrypoints")
     fn = getattr(mod, fn_name)
     old_argv = sys.argv[:]
     try:
         sys.argv = [argv0, *argv]
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as excinfo:
             fn()
+        return _exit_code(excinfo.value.code)
     finally:
         sys.argv = old_argv
 
 
-def test_kvcli_entrypoint_help_executes_wrapper() -> None:
-    _run_entrypoint("kvcli", "kvcli", ["--help"])
+def test_kvcli_entrypoint_help_executes_wrapper(capsys) -> None:
+    assert _run_entrypoint("kvcli", "kvcli", ["--help"]) == 0
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out.lower()
 
 
-def test_apigetcli_entrypoint_help_executes_wrapper() -> None:
-    _run_entrypoint("apigetcli", "apigetcli", ["--help"])
+def test_apigetcli_entrypoint_help_executes_wrapper(capsys) -> None:
+    assert _run_entrypoint("apigetcli", "apigetcli", ["--help"]) == 0
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out.lower()
 
 
-def test_cli_help_smoke() -> None:
-    _run_cli(["--help"])
+def test_cli_help_smoke(capsys) -> None:
+    assert _run_cli(["--help"]) == 0
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out.lower()
 
 
-def test_cli_unknown_command_smoke() -> None:
-    _run_cli(["__definitely_not_a_command__"])
+def test_cli_unknown_command_smoke(capsys) -> None:
+    code = _run_cli(["__definitely_not_a_command__"])
+    captured = capsys.readouterr()
+    assert code != 0
+    assert "invalid choice" in captured.err.lower() or "usage:" in captured.err.lower()
 
 
 def test_cli_module_main_guard_smoke() -> None:

--- a/tests/test_optional_httpx.py
+++ b/tests/test_optional_httpx.py
@@ -21,7 +21,13 @@ def test_load_httpx_returns_fallback_when_module_missing(monkeypatch) -> None:
         module.HTTPTransport()
         raise AssertionError("expected fallback HTTPTransport() to raise ModuleNotFoundError")
     except ModuleNotFoundError as exc:
-        assert "optional network dependencies" in str(exc)
+        assert "runtime dependencies" in str(exc)
+
+    try:
+        module.Response()
+        raise AssertionError("expected fallback Response() to raise ModuleNotFoundError")
+    except ModuleNotFoundError as exc:
+        assert "sdetkit apiget" in str(exc)
 
 
 def test_load_httpx_imports_module_when_available(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation

- Provide clearer, actionable errors when `httpx` is unavailable and make the fallback behavior fail fast instead of returning silent defaults.
- Harden tests that exercise CLI entrypoints by capturing exit codes and output to assert behavior more precisely.
- Fix a test filename and function name that contained a duplicated word.

### Description

- Clarified the module docstring and changed the missing dependency message to recommend installing runtime dependencies (example: `pip install -e .`).
- Updated the optional `httpx` fallback so `Response` and `URL` raise `ModuleNotFoundError` in their `__init__` rather than exposing empty/no-op defaults, and preserved raising behavior for client/transport classes.
- Adjusted tests in `tests/test_optional_httpx.py` to expect the new message and to assert that `Response()` raises `ModuleNotFoundError`.
- Improved CLI test helpers in `tests/test_entrypoints_smoke.py` by adding `_exit_code` helper, making `_run_cli` and `_run_entrypoint` return exit codes, and asserting CLI help/usage text via `capsys`.
- Renamed `tests/test_docs_lane_lane_typos.py` to `tests/test_docs_lane_typos.py` and simplified the test function name.

### Testing

- Ran the modified unit tests with `pytest tests/test_optional_httpx.py tests/test_entrypoints_smoke.py tests/test_docs_lane_typos.py` and all tests passed.
- Ran the full test suite with `pytest -q` to verify integration with other tests and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eddea37bac83328a3609b4a5307d5d)