### PR TITLE
Bump docs version to v1.0.3, centralize tool version retrieval, and add version-alignment test

### DIFF
--- a/docs/artifacts/repo-visual-snapshot.md
+++ b/docs/artifacts/repo-visual-snapshot.md
@@ -42,7 +42,7 @@ This artifact summarizes README live signals, docs palette settings, and proof m
 | Pages | https://sherif69-sa.github.io/DevS69-sdetkit/ |
 | CI | https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/ci.yml |
 | Docs link check | https://github.com/sherif69-sa/DevS69-sdetkit/actions/workflows/docs-link-check.yml |
-| Last commit | https://github.com/sherif69-sa/DevS69-sdetkit/commits/main |
+| Last commit | https://github.com/sherif69-sa/DevS69-sdetkit/commits |
 | Latest release | https://github.com/sherif69-sa/DevS69-sdetkit/releases |
 | Open issues | https://github.com/sherif69-sa/DevS69-sdetkit/issues |
 | Community | CONTRIBUTING.md |

--- a/docs/assets/devs69-hero.svg
+++ b/docs/assets/devs69-hero.svg
@@ -70,7 +70,7 @@
   </g>
 
   <rect x="980" y="122" width="170" height="44" rx="22" fill="#0B1D3B" stroke="#2D5EA3" opacity="0.95"/>
-  <text x="1065" y="151" text-anchor="middle" fill="#A7CBFF" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="18" font-weight="700">v1.0.2</text>
+  <text x="1065" y="151" text-anchor="middle" fill="#A7CBFF" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="18" font-weight="700">v1.0.3</text>
 
   <g filter="url(#softGlow)">
     <text x="640" y="210" text-anchor="middle" fill="url(#accent)" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="70" font-weight="850">DevS69 (sdetkit)</text>

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,7 +2,7 @@
 
 This project uses semantic versioning (`MAJOR.MINOR.PATCH`) and a tag-driven release workflow.
 
-Current baseline release: **v1.0.2**.
+Current baseline release: **v1.0.3**.
 
 ## Version bump rules
 

--- a/src/sdetkit/report.py
+++ b/src/sdetkit/report.py
@@ -13,6 +13,7 @@ from typing import Any, TypedDict
 from .atomicio import atomic_write_text, canonical_json_bytes, canonical_json_dumps
 from .bools import coerce_bool
 from .security import SecurityError, safe_path
+from .versioning import tool_version
 
 _UTC = getattr(dt, "UTC", dt.timezone.utc)  # noqa: UP017
 RUN_SCHEMA = "sdetkit.audit.run.v1"
@@ -86,12 +87,7 @@ def _severity_rank(level: str) -> int:
 
 
 def _tool_version() -> str:
-    try:
-        from importlib import metadata
-
-        return metadata.version("sdetkit")
-    except Exception:
-        return "1.0.0"
+    return tool_version()
 
 
 def _captured_at() -> str | None:

--- a/tests/test_report_branches_wave10.py
+++ b/tests/test_report_branches_wave10.py
@@ -45,7 +45,9 @@ def test_select_runs_window_validations_and_skips_bad_captured_at() -> None:
     assert out == []
 
 
-def test_tool_version_delegates_to_shared_versioning_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_tool_version_delegates_to_shared_versioning_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(r, "tool_version", lambda: "0+unknown")
     assert r._tool_version() == "0+unknown"
 

--- a/tests/test_report_branches_wave10.py
+++ b/tests/test_report_branches_wave10.py
@@ -45,11 +45,9 @@ def test_select_runs_window_validations_and_skips_bad_captured_at() -> None:
     assert out == []
 
 
-def test_tool_version_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    import importlib.metadata as md
-
-    monkeypatch.setattr(md, "version", lambda _n: (_ for _ in ()).throw(RuntimeError("nope")))
-    assert r._tool_version() == "1.0.0"
+def test_tool_version_delegates_to_shared_versioning_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(r, "tool_version", lambda: "0+unknown")
+    assert r._tool_version() == "0+unknown"
 
 
 def test_captured_at_invalid_epoch_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_version_alignment_docs.py
+++ b/tests/test_version_alignment_docs.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+
+
+def test_releasing_doc_and_hero_badge_match_pyproject_version() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    pyproject = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    project_version = str(pyproject["project"]["version"])
+    version_tag = f"v{project_version}"
+
+    releasing = (repo_root / "docs" / "releasing.md").read_text(encoding="utf-8")
+    assert f"Current baseline release: **{version_tag}**." in releasing
+
+    hero_svg = (repo_root / "docs" / "assets" / "devs69-hero.svg").read_text(encoding="utf-8")
+    assert version_tag in hero_svg


### PR DESCRIPTION
### Motivation

- Update visible project version strings to reflect the new baseline release and ensure consistency across docs and assets.
- Centralize how the runtime tool version is obtained so multiple modules can reuse a single helper implementation.
- Add an automated check to keep the docs and hero badge aligned with the `pyproject.toml` version.

### Description

- Updated the hero SVG badge in `docs/assets/devs69-hero.svg` to `v1.0.3`.
- Updated the releasing note in `docs/releasing.md` to `Current baseline release: **v1.0.3**`.
- Replaced the inline `_tool_version` importlib-based fallback in `src/sdetkit/report.py` with a call to the shared `tool_version` helper from `src/sdetkit/versioning.py`.
- Adjusted the existing test in `tests/test_report_branches_wave10.py` to assert delegation to the shared `tool_version` helper.
- Added a new test `tests/test_version_alignment_docs.py` that verifies `pyproject.toml`, `docs/releasing.md`, and the hero SVG badge remain aligned with the packaged version.

### Testing

- Ran the updated report test `pytest tests/test_report_branches_wave10.py::test_tool_version_delegates_to_shared_versioning_helper` and it passed.
- Ran the new doc alignment test `pytest tests/test_version_alignment_docs.py` and it passed.
- Ran the test suite with `pytest -q` to validate integration with existing tests and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf4649dac833285b1e1fda20cb341)