### PR TITLE
Fix tool script entrypoints, simplify triage run logic, add entrypoint tests, and lower Python floor to 3.10

### DIFF
--- a/docs/versioning-and-support.md
+++ b/docs/versioning-and-support.md
@@ -12,7 +12,7 @@ deprecation. It intentionally avoids guarantees we do not operationally enforce.
 
 ## Quick support snapshot
 
-- **Supported Python floor:** **3.11+**
+- **Supported Python floor:** **3.10+**
 - **Preferred install mode:** isolated environments (`venv` or `pipx`)
 - **First dependency target for adopters:** canonical command path artifacts and decision flow
 - **Support model:** best-effort public support (no contractual SLA stated in project policy)

--- a/tests/test_tools_script_entrypoints.py
+++ b/tests/test_tools_script_entrypoints.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_tools_script_entrypoints.py
+++ b/tests/test_tools_script_entrypoints.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_help(script_rel: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(ROOT / script_rel), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_triage_script_help_entrypoint() -> None:
+    proc = _run_help("tools/triage.py")
+    assert proc.returncode == 0
+    assert "usage:" in proc.stdout
+
+
+def test_render_public_surface_script_help_entrypoint() -> None:
+    proc = _run_help("tools/render_public_surface_contract_table.py")
+    assert proc.returncode == 0
+    assert "usage:" in proc.stdout
+
+
+def test_patch_harness_script_help_entrypoint() -> None:
+    proc = _run_help("tools/patch_harness.py")
+    assert proc.returncode == 0
+    assert "usage:" in proc.stdout

--- a/tests/test_triage_tool.py
+++ b/tests/test_triage_tool.py
@@ -98,6 +98,22 @@ def test_parse_pytest_log_pass_only_returns_ok(tmp_path: Path) -> None:
     assert "no failures found in log" in out
 
 
+def test_pytest_mode_without_run_or_log_executes_pytest(tmp_path: Path, monkeypatch) -> None:
+    triage = _load_triage()
+
+    class R:
+        returncode = 0
+        stdout = "3 passed in 0.01s\n"
+
+    def fake_run(*a, **k):
+        return R()
+
+    monkeypatch.setattr(triage.subprocess, "run", fake_run)
+    rc, out = _run(triage, ["--path", str(tmp_path), "--mode", "pytest"], tmp_path)
+    assert rc == 0
+    assert "pytest ok" in out
+
+
 def test_run_pytest_success_writes_tee(tmp_path: Path, monkeypatch) -> None:
     triage = _load_triage()
 

--- a/tools/patch_harness.py
+++ b/tools/patch_harness.py
@@ -10,5 +10,5 @@ if str(SRC) not in sys.path:
 
 from sdetkit.patch import main  # noqa: E402
 
-if __name__ == "main_":
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/tools/render_public_surface_contract_table.py
+++ b/tools/render_public_surface_contract_table.py
@@ -82,5 +82,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == "main_":
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/tools/triage.py
+++ b/tools/triage.py
@@ -446,7 +446,7 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  pytest -q 2>&1 | tee {logp}")
                 return 2
 
-        run_now = bool(args.run) or (not args.parse_pytest_log and (bool(args.tee) or True))
+        run_now = bool(args.run) or (not args.parse_pytest_log)
         if not args.parse_pytest_log and run_now:
             rc, text = _run_pytest(args, root)
             if rc == 0:
@@ -495,5 +495,5 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-if __name__ == "main_":
+if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Correct command-line entrypoints so tooling scripts run when executed directly and ensure CI validates those entrypoints. 
- Make the triage flow's `pytest` execution logic clearer and cover its behavior with tests. 
- Update project policy to reflect a wider supported Python floor. 

### Description

- Fixed incorrect `if __name__` checks in `tools/patch_harness.py`, `tools/render_public_surface_contract_table.py`, and `tools/triage.py` to use `if __name__ == "__main__":` so each script exits via `SystemExit(main())` when run directly. 
- Simplified the `run_now` calculation in `tools/triage.py` to `run_now = bool(args.run) or (not args.parse_pytest_log)`, making intent clearer without changing behavior. 
- Added `tests/test_tools_script_entrypoints.py` to verify `--help` works for `tools/triage.py`, `tools/render_public_surface_contract_table.py`, and `tools/patch_harness.py`. 
- Added a unit test `test_pytest_mode_without_run_or_log_executes_pytest` to `tests/test_triage_tool.py` to assert that `--mode pytest` runs `pytest` when no `--run` or `--parse-pytest-log` is supplied. 
- Updated documentation in `docs/versioning-and-support.md` to change the supported Python floor from `3.11+` to `3.10+`. 

### Testing

- Ran the unit test suite with `pytest -q` which included the new entrypoint tests and the updated triage tests, and the test run completed successfully. 
- The new `tests/test_tools_script_entrypoints.py` confirms `--help` returns exit code `0` and prints usage for each script. 
- The new triage unit test verifies `pytest` mode without `--run` or `--parse-pytest-log` invokes the test runner and prints `triage: pytest ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee09b0c5348332936d40216b734877)