### PR TITLE
ci: enforce branch protection checks for admins

### DIFF
--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -37,5 +37,6 @@ jobs:
             --token "${BRANCH_PROTECTION_TOKEN}" \
             --required-check "ci" \
             --required-check "maintenance-autopilot" \
+            --enforce-admins \
             --required-approving-review-count 0 \
             --disable-pr-reviews

--- a/tests/test_branch_protection_workflow_alignment.py
+++ b/tests/test_branch_protection_workflow_alignment.py
@@ -28,6 +28,7 @@ def test_enforcement_workflow_uses_default_required_checks() -> None:
     text = ENFORCE_WORKFLOW.read_text(encoding="utf-8")
     assert "pull_request:" in text
     assert "pull_request_target:" not in text
+    assert "--enforce-admins" in text
     assert "--disable-pr-reviews" in text
     for context in _MOD.DEFAULT_REQUIRED_CHECKS:
         assert f'--required-check "{context}"' in text


### PR DESCRIPTION
### Motivation
- Prevent admin-level bypass of required checks so merges to `main` must pass the `ci` and `maintenance-autopilot` contexts before a PR can be merged.

### Description
- Add `--enforce-admins` to the branch-protection enforcement workflow (`.github/workflows/enforce-branch-protection.yml`) and update `tests/test_branch_protection_workflow_alignment.py` to assert the flag remains present.

### Testing
- Ran `pytest -q tests/test_branch_protection_workflow_alignment.py` and it passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eec1f8b6d8832dad0fbdd718ac1159)