### PR TITLE
Introduce real-workflow ops lane: follow-up generation, next-action helpers, dry-run flags, Makefile targets, docs and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
         name: doctor --ascii
         entry: python -c 'import sys; sys.path.insert(0, "src"); from sdetkit import doctor; raise SystemExit(doctor.main(["--ascii"]))'
         language: python
+        additional_dependencies: [tomli]
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.19.1

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ ADAPTIVE_SCENARIO ?= balanced
 PORTFOLIO_MANIFEST ?= portfolio-manifest.json
 FIRST_PROOF_BRANCH ?= local
 FIRST_PROOF_STRICT ?= false
+FIRST_PROOF_RELEASE_DRY_RUN ?= true
 PHASE2_BASELINE_PRE_EXTRACTION ?= docs/artifacts/phase2-hotspot-baseline-pre-extraction-$(DATE_TAG).json
 
-.PHONY: bootstrap max brutal venv runtime-install first-proof-install install ci-deps-sync test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-contract release-room portfolio-readiness premerge-release-room adaptive-scenario-db adaptive-postcheck owner-escalation-payload adaptive-premerge adaptive-ops-bundle repo-alignment-check test-bootstrap test-bootstrap-contract merge-ready premerge-finalize first-proof first-proof-contract first-proof-learn first-proof-control-tower first-proof-weekly-trend first-proof-trend-threshold first-proof-tests first-proof-verify phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-execution-core phase1-workflow phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-start phase2-workflow phase2-status phase2-start-contract phase2-seed phase2-hotspot-baseline phase2-hotspot-delta phase2-complete phase2-progress phase2-surface-clarity phase3-dependency-radar phase3-quality-contract phase3-quality-report phase3-do-it phase4-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract plan-status phase1-execute phase2-execute phase3-governance phase4-credibility
+.PHONY: bootstrap max brutal venv runtime-install first-proof-install install ci-deps-sync test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-fast ship-readiness-contract release-room release-room-fast portfolio-readiness premerge-release-room premerge-release-room-fast adaptive-scenario-db adaptive-postcheck owner-escalation-payload adaptive-premerge adaptive-ops-bundle repo-alignment-check test-bootstrap test-bootstrap-contract merge-ready premerge-finalize first-proof first-proof-local first-proof-contract first-proof-learn first-proof-control-tower first-proof-weekly-trend first-proof-trend-threshold first-proof-tests first-proof-tests-local first-proof-verify first-proof-verify-local ops-followup ops-followup-contract ops-now ops-now-lite ops-next ops-premerge-next ops-premerge-next-fast phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-execution-core phase1-workflow phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-start phase2-workflow phase2-status phase2-start-contract phase2-seed phase2-hotspot-baseline phase2-hotspot-delta phase2-complete phase2-progress phase2-surface-clarity phase3-dependency-radar phase3-quality-contract phase3-quality-report phase3-do-it phase4-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract plan-status phase1-execute phase2-execute phase3-governance phase4-credibility real-workflow-daily real-workflow-daily-fast real-workflow-weekly real-workflow-premerge real-workflow-premerge-fast real-workflow ops-daily ops-daily-fast ops-weekly ops-premerge ops-premerge-fast ops-workflow
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -52,7 +53,10 @@ premerge-finalize: install
 	@bash -lc '. .venv/bin/activate && $(MAKE) plan-status'
 
 first-proof: first-proof-install
-	@bash -lc '. .venv/bin/activate && PYTHONPATH=src python scripts/first_proof.py $(if $(filter true,$(FIRST_PROOF_STRICT)),--strict,) --format json --out-dir build/first-proof'
+	@bash -lc '. .venv/bin/activate && PYTHONPATH=src python scripts/first_proof.py $(if $(filter true,$(FIRST_PROOF_STRICT)),--strict,) $(if $(filter true,$(FIRST_PROOF_RELEASE_DRY_RUN)),--release-dry-run,) --format json --out-dir build/first-proof'
+
+first-proof-local: venv
+	@bash -lc '. .venv/bin/activate && PYTHONPATH=src python scripts/first_proof.py $(if $(filter true,$(FIRST_PROOF_STRICT)),--strict,) $(if $(filter true,$(FIRST_PROOF_RELEASE_DRY_RUN)),--release-dry-run,) --format json --out-dir build/first-proof'
 
 first-proof-contract: venv
 	@bash -lc '. .venv/bin/activate && python scripts/check_first_proof_summary_contract.py --summary build/first-proof/first-proof-summary.json --wait-seconds 60 --format json'
@@ -72,8 +76,75 @@ first-proof-trend-threshold: venv
 first-proof-tests: install
 	@bash -lc '. .venv/bin/activate && python -m pytest -q tests/test_first_proof_script.py tests/test_first_proof_contract.py tests/test_first_proof_learning_db.py tests/test_first_proof_weekly_trend.py tests/test_first_proof_control_tower.py tests/test_first_proof_trend_threshold.py tests/test_build_owner_escalation_payload.py'
 
+first-proof-tests-local: venv
+	@bash -lc '. .venv/bin/activate && python -m pytest -q tests/test_first_proof_script.py tests/test_first_proof_contract.py tests/test_first_proof_learning_db.py tests/test_first_proof_weekly_trend.py tests/test_first_proof_control_tower.py tests/test_first_proof_trend_threshold.py tests/test_build_owner_escalation_payload.py'
+
 first-proof-verify: first-proof
 	@bash -lc '. .venv/bin/activate && $(MAKE) first-proof-contract && $(MAKE) first-proof-learn && $(MAKE) first-proof-control-tower && $(MAKE) first-proof-weekly-trend && $(MAKE) first-proof-trend-threshold && $(MAKE) first-proof-tests'
+
+first-proof-verify-local: first-proof-local
+	@bash -lc '. .venv/bin/activate && $(MAKE) first-proof-contract && $(MAKE) first-proof-learn && $(MAKE) first-proof-control-tower && $(MAKE) first-proof-weekly-trend && $(MAKE) first-proof-trend-threshold && $(MAKE) first-proof-tests-local'
+
+ops-followup: venv
+	@bash -lc '. .venv/bin/activate && python scripts/real_workflow_followup.py --format json --out-json build/ops/followup.json --out-md build/ops/followup.md --history build/ops/followup-history.jsonl --history-rollup-out build/ops/followup-history-rollup.json'
+
+ops-followup-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_real_workflow_followup_contract.py --followup build/ops/followup.json --history-rollup build/ops/followup-history-rollup.json --out build/ops/followup-contract-check.json --format json'
+
+ops-now-lite: ops-followup ops-followup-contract
+	@bash -lc 'echo ops-now-lite: follow-up generated + contract validated'
+	@bash -lc 'python -c "import json; from pathlib import Path; p = Path(\"build/ops/followup.json\"); payload = json.loads(p.read_text(encoding=\"utf-8\")) if p.exists() else {}; print(\"OPS_DECISION=\" + str(payload.get(\"decision\", \"NO-DATA\"))); print(\"OPS_NEXT_COMMAND=\" + str(payload.get(\"next_command\", \"make ops-daily\")))"'
+
+ops-now: real-workflow-daily
+	@bash -lc 'echo ops-now: full daily workflow completed'
+	@bash -lc 'python -c "import json; from pathlib import Path; p = Path(\"build/ops/followup.json\"); payload = json.loads(p.read_text(encoding=\"utf-8\")) if p.exists() else {}; print(\"OPS_DECISION=\" + str(payload.get(\"decision\", \"NO-DATA\"))); print(\"OPS_NEXT_COMMAND=\" + str(payload.get(\"next_command\", \"make ops-daily\")))"'
+
+ops-next: ops-now-lite
+	@bash -lc '. .venv/bin/activate && python scripts/ops_next.py --followup build/ops/followup.json --limit 3'
+
+ops-premerge-next:
+	@bash -lc '. .venv/bin/activate && $(MAKE) ops-premerge || true'
+	@bash -lc '. .venv/bin/activate && python scripts/ops_premerge_next.py --gate-json build/premerge-release-room-gate.json --limit 3'
+
+ops-premerge-next-fast:
+	@bash -lc '. .venv/bin/activate && $(MAKE) ops-premerge-fast || true'
+	@bash -lc '. .venv/bin/activate && python scripts/ops_premerge_next.py --gate-json build/premerge-release-room-gate.json --limit 3'
+
+real-workflow-daily: first-proof-verify ops-followup ops-followup-contract
+	@bash -lc 'echo real-workflow-daily: deterministic gate + learning loop + validated follow-up completed'
+
+real-workflow-daily-fast: first-proof-verify-local ops-followup ops-followup-contract
+	@bash -lc 'echo "real-workflow-daily-fast: deterministic gate + validated follow-up completed (no reinstall lane)"'
+
+real-workflow-weekly: adaptive-postcheck top-tier-reporting enterprise-contracts-check
+	@bash -lc 'echo real-workflow-weekly: reporting + contracts refreshed'
+
+real-workflow-premerge: premerge-release-room release-room
+	@bash -lc 'echo real-workflow-premerge: pre-merge gate + release room checks completed'
+
+real-workflow-premerge-fast: premerge-release-room-fast release-room-fast
+	@bash -lc 'echo "real-workflow-premerge-fast: pre-merge gate (release dry-run) + release room checks completed"'
+
+real-workflow: real-workflow-daily real-workflow-weekly
+	@bash -lc 'echo real-workflow: daily and weekly lanes completed'
+
+ops-daily: real-workflow-daily
+	@bash -lc 'echo ops-daily: alias completed'
+
+ops-daily-fast: real-workflow-daily-fast
+	@bash -lc 'echo ops-daily-fast: alias completed'
+
+ops-weekly: real-workflow-weekly
+	@bash -lc 'echo ops-weekly: alias completed'
+
+ops-premerge: real-workflow-premerge
+	@bash -lc 'echo ops-premerge: alias completed'
+
+ops-premerge-fast: real-workflow-premerge-fast
+	@bash -lc 'echo ops-premerge-fast: alias completed'
+
+ops-workflow: real-workflow
+	@bash -lc 'echo ops-workflow: alias completed'
 
 test: install
 	@bash -lc '. .venv/bin/activate && bash quality.sh test'
@@ -172,10 +243,16 @@ enterprise-assessment-contract: venv
 ship-readiness: venv
 	@bash -lc '. .venv/bin/activate && python -m sdetkit ship-readiness --strict --format json --out-dir build/ship-readiness'
 
+ship-readiness-fast: venv
+	@bash -lc '. .venv/bin/activate && python -m sdetkit ship-readiness --strict --release-dry-run --format json --out-dir build/ship-readiness'
+
 ship-readiness-contract: venv
 	@bash -lc '. .venv/bin/activate && python scripts/check_ship_readiness_contract.py --summary build/ship-readiness/ship-readiness-summary.json --format json'
 
 release-room: enterprise-assessment ship-readiness ship-readiness-contract enterprise-assessment-contract
+	@bash -lc '. .venv/bin/activate && python scripts/render_release_room_summary.py --ship-summary build/ship-readiness/ship-readiness-summary.json --enterprise-summary docs/artifacts/enterprise-assessment-pack/enterprise-assessment-summary.json --out build/release-room-summary.md'
+
+release-room-fast: enterprise-assessment ship-readiness-fast ship-readiness-contract enterprise-assessment-contract
 	@bash -lc '. .venv/bin/activate && python scripts/render_release_room_summary.py --ship-summary build/ship-readiness/ship-readiness-summary.json --enterprise-summary docs/artifacts/enterprise-assessment-pack/enterprise-assessment-summary.json --out build/release-room-summary.md'
 
 portfolio-readiness: venv
@@ -183,6 +260,9 @@ portfolio-readiness: venv
 
 premerge-release-room: venv
 	@bash -lc '. .venv/bin/activate && python scripts/premerge_release_room_gate.py . --strict --format json --out build/premerge-release-room-gate.json'
+
+premerge-release-room-fast: venv
+	@bash -lc '. .venv/bin/activate && python scripts/premerge_release_room_gate.py . --strict --ship-release-dry-run --format json --out build/premerge-release-room-gate.json'
 
 
 adaptive-postcheck: adaptive-scenario-db

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ build/first-proof/
 
 Troubleshooting: [`docs/first-proof-troubleshooting.md`](docs/first-proof-troubleshooting.md)
 Learning DB + adaptive reviewer alignment: [`docs/first-proof-learning-db.md`](docs/first-proof-learning-db.md)
+Real workflow operations: [`docs/real-workflow-operations.md`](docs/real-workflow-operations.md)
+Quick ops aliases: `make ops-daily` / `make ops-daily-fast` / `make ops-weekly` / `make ops-premerge` / `make ops-premerge-fast` / `make ops-premerge-next` / `make ops-premerge-next-fast` / `make ops-followup` / `make ops-now` / `make ops-now-lite` / `make ops-next`
 Rollback/remediation examples: [`docs/integrations/rollback-remediation-examples.md`](docs/integrations/rollback-remediation-examples.md)
 
 Release preflight now expects `build/first-proof/first-proof-summary.json` to exist and pass

--- a/docs/ops-followup-schema.v1.json
+++ b/docs/ops-followup-schema.v1.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://devs69.dev/sdetkit/schemas/ops-followup.v1.json",
+  "title": "SDETKit ops follow-up payload",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "decision",
+    "threshold_breach",
+    "recommendations",
+    "next_command"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "sdetkit.real-workflow-followup.v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["SHIP", "NO-SHIP"]
+    },
+    "threshold_breach": {
+      "type": "boolean"
+    },
+    "recommendations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["priority", "title", "action"],
+        "properties": {
+          "priority": {
+            "type": "string",
+            "enum": ["P0", "P1", "P2", "P3"]
+          },
+          "title": {"type": "string", "minLength": 1},
+          "action": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "next_command": {
+      "type": "string",
+      "enum": ["make ops-daily", "make ops-premerge"]
+    }
+  }
+}

--- a/docs/real-workflow-operations.md
+++ b/docs/real-workflow-operations.md
@@ -1,0 +1,138 @@
+# Real workflow operations (production-first)
+
+This is the **live operating workflow** for running SDETKit on a real repository.
+
+No educational naming, no planning theater: this page is for execution.
+
+## Mission
+
+Run one deterministic release-confidence loop that answers:
+
+- Are we ready to ship now?
+- If not, what failed first?
+- What is the next highest-impact remediation?
+
+## Command lanes
+
+### 1) Daily gate lane (required)
+
+```bash
+make real-workflow-daily
+# alias:
+make ops-daily
+make ops-daily-fast  # skips reinstall lane; uses current .venv
+```
+
+By default, local first-proof lanes run release gate with `--dry-run` (`FIRST_PROOF_RELEASE_DRY_RUN=true`) to avoid clean-tree blocking during active development.
+
+Outputs (source of truth):
+
+- `build/first-proof/first-proof-summary.json`
+- `build/first-proof/first-proof-learning-db.jsonl`
+- `build/first-proof/first-proof-learning-rollup.json`
+- `build/first-proof/control-tower.json`
+- `build/first-proof/weekly-trend.json`
+- `build/first-proof/weekly-threshold-check.json`
+- `build/ops/followup.json`
+- `build/ops/followup.md`
+- `build/ops/followup-history.jsonl`
+- `build/ops/followup-history-rollup.json`
+- `build/ops/followup-contract-check.json`
+
+### 2) Weekly operations lane (required)
+
+```bash
+make real-workflow-weekly
+# alias:
+make ops-weekly
+```
+
+Purpose:
+
+- refresh adaptive postcheck guidance
+- regenerate top-tier reporting bundle
+- validate enterprise/readiness contract health
+
+### 3) Pre-merge release lane (required)
+
+```bash
+make real-workflow-premerge
+# alias:
+make ops-premerge
+make ops-premerge-fast  # uses ship-readiness --release-dry-run for local rehearsal
+make ops-premerge-next  # run premerge + print concise next actions
+make ops-premerge-next-fast  # run premerge-fast + print concise next actions
+# if clean-tree is the blocker, ops-premerge-next recommends:
+# OPS_NEXT_COMMAND=make ops-premerge-fast
+```
+
+`ops-premerge-fast` now runs the entire release-room lane with ship-readiness dry-run semantics.
+
+Purpose:
+
+- run pre-merge gate
+- run release-room evidence checks
+- block merge on unstable posture
+
+### 4) Follow-up recommendations lane (auto-generated from daily lane)
+
+```bash
+make ops-followup
+make ops-followup-contract
+make ops-now        # full daily lane (gate + follow-up + contract)
+make ops-now-lite   # follow-up + contract only
+make ops-next       # print top 3 prioritized next actions
+```
+
+This emits prioritized recommendations every run so the next action is explicit.
+It also appends follow-up history so recurring remediation themes are visible week-over-week.
+Release-preflight failures (for example `doctor_release` clean-tree blockers) are elevated into explicit follow-up actions.
+Contract for follow-up payloads: `docs/ops-followup-schema.v1.json`.
+
+## Data model used in production
+
+Treat repository artifacts as three production datasets:
+
+1. **Event log dataset**
+   - file: `build/first-proof/first-proof-learning-db.jsonl`
+   - grain: one row per run
+2. **Decision snapshot dataset**
+   - file: `build/first-proof/first-proof-summary.json`
+   - grain: one row per execution window
+3. **Operations rollup dataset**
+   - files: `first-proof-learning-rollup.json`, `control-tower.json`, `weekly-trend.json`
+   - grain: one row per generated analytical summary
+
+## KPI scorecard used for execution
+
+Track these every week:
+
+- ship rate (7d/30d)
+- gate fast failure rate
+- gate release failure rate
+- doctor failure rate
+- mean time to green
+- rollback rate
+- evidence pack coverage
+
+If trends degrade for two consecutive windows, treat as incident-level reliability risk.
+
+## Operational responsibilities
+
+- **Engineer on duty:** runs `real-workflow-daily`, triages top failed steps.
+- **Release owner:** runs `real-workflow-premerge` before merge/tag.
+- **Program owner:** runs `real-workflow-weekly`, publishes KPI narrative.
+
+## Exit criteria (workflow is healthy)
+
+The workflow is healthy when all of the following are true:
+
+1. Daily run produces deterministic SHIP/NO-SHIP with complete artifacts.
+2. Weekly trend and threshold checks are generated and reviewed.
+3. Pre-merge gate passes without bypass.
+4. KPI/reporting artifacts are published on cadence.
+
+## Decommissioning note
+
+This page replaces planning-oriented strategy writeups for day-to-day operation.
+Keep this document as the canonical execution reference and archive outdated planning docs.

--- a/scripts/check_real_workflow_followup_contract.py
+++ b/scripts/check_real_workflow_followup_contract.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must be a JSON object")
+    return payload
+
+
+def _is_nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def check_followup(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    if payload.get("schema_version") != "sdetkit.real-workflow-followup.v1":
+        errors.append("schema_version must be sdetkit.real-workflow-followup.v1")
+
+    decision = payload.get("decision")
+    if decision not in {"SHIP", "NO-SHIP"}:
+        errors.append("decision must be SHIP or NO-SHIP")
+
+    threshold_breach = payload.get("threshold_breach")
+    if not isinstance(threshold_breach, bool):
+        errors.append("threshold_breach must be boolean")
+
+    next_command = payload.get("next_command")
+    if next_command not in {"make ops-daily", "make ops-premerge"}:
+        errors.append("next_command must be make ops-daily or make ops-premerge")
+
+    recommendations = payload.get("recommendations")
+    if not isinstance(recommendations, list):
+        errors.append("recommendations must be an array")
+        return errors
+
+    for idx, rec in enumerate(recommendations):
+        if not isinstance(rec, dict):
+            errors.append(f"recommendations[{idx}] must be an object")
+            continue
+        for key in ("priority", "title", "action"):
+            if key not in rec:
+                errors.append(f"recommendations[{idx}] missing {key}")
+        priority = rec.get("priority")
+        if priority not in {"P0", "P1", "P2", "P3"}:
+            errors.append(f"recommendations[{idx}].priority must be P0/P1/P2/P3")
+        if not _is_nonempty_string(rec.get("title")):
+            errors.append(f"recommendations[{idx}].title must be non-empty string")
+        if not _is_nonempty_string(rec.get("action")):
+            errors.append(f"recommendations[{idx}].action must be non-empty string")
+
+    return errors
+
+
+def check_history_rollup(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != "sdetkit.real-workflow-followup-history-rollup.v1":
+        errors.append(
+            "history rollup schema_version must be sdetkit.real-workflow-followup-history-rollup.v1"
+        )
+
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        errors.append("history rollup summary must be object")
+        return errors
+
+    for key in (
+        "total_runs",
+        "ship_runs",
+        "no_ship_runs",
+        "threshold_breach_runs",
+    ):
+        if not isinstance(summary.get(key), int):
+            errors.append(f"history rollup summary.{key} must be integer")
+
+    ship_rate = summary.get("ship_rate")
+    if not isinstance(ship_rate, (int, float)):
+        errors.append("history rollup summary.ship_rate must be number")
+
+    top_recs = summary.get("top_recurring_recommendations")
+    if not isinstance(top_recs, list):
+        errors.append("history rollup summary.top_recurring_recommendations must be array")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate ops follow-up contract outputs")
+    parser.add_argument("--followup", type=Path, default=Path("build/ops/followup.json"))
+    parser.add_argument(
+        "--history-rollup", type=Path, default=Path("build/ops/followup-history-rollup.json")
+    )
+    parser.add_argument("--out", type=Path, default=Path("build/ops/followup-contract-check.json"))
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    followup = _load_json(args.followup)
+    history_rollup = _load_json(args.history_rollup)
+
+    errors = check_followup(followup) + check_history_rollup(history_rollup)
+    result = {
+        "ok": not errors,
+        "errors": errors,
+        "followup": str(args.followup),
+        "history_rollup": str(args.history_rollup),
+    }
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"ops follow-up contract: {'OK' if result['ok'] else 'FAIL'}")
+        if errors:
+            for err in errors:
+                print(f" - {err}")
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/first_proof.py
+++ b/scripts/first_proof.py
@@ -67,6 +67,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Return a non-zero exit code when any first-proof step fails.",
     )
+    parser.add_argument(
+        "--release-dry-run",
+        action="store_true",
+        help="Run `gate release` in dry-run mode (useful for active local branches).",
+    )
     parser.add_argument("--format", choices=("text", "json"), default="text")
     return parser
 
@@ -155,20 +160,23 @@ def main(argv: list[str]) -> int:
             env=base_env,
         )
     )
+    gate_release_cmd = [
+        selected_python,
+        "-m",
+        "sdetkit",
+        "gate",
+        "release",
+        "--format",
+        "json",
+        "--out",
+        str(out_dir / "release-preflight.json"),
+    ]
+    if args.release_dry_run:
+        gate_release_cmd.append("--dry-run")
     steps.append(
         _run_step(
             name="gate-release",
-            command=[
-                selected_python,
-                "-m",
-                "sdetkit",
-                "gate",
-                "release",
-                "--format",
-                "json",
-                "--out",
-                str(out_dir / "release-preflight.json"),
-            ],
+            command=gate_release_cmd,
             out_dir=out_dir,
             artifact=str(out_dir / "release-preflight.json"),
             env=base_env,

--- a/scripts/ops_next.py
+++ b/scripts/ops_next.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("follow-up payload must be JSON object")
+    return payload
+
+
+def _priority_value(priority: str) -> int:
+    return {"P0": 0, "P1": 1, "P2": 2, "P3": 3}.get(priority, 9)
+
+
+def build_next(payload: dict[str, Any], limit: int) -> dict[str, Any]:
+    recs = payload.get("recommendations", [])
+    if not isinstance(recs, list):
+        recs = []
+
+    cleaned: list[dict[str, str]] = []
+    for rec in recs:
+        if not isinstance(rec, dict):
+            continue
+        priority = str(rec.get("priority", "P9"))
+        title = str(rec.get("title", ""))
+        action = str(rec.get("action", ""))
+        cleaned.append({"priority": priority, "title": title, "action": action})
+
+    cleaned.sort(key=lambda item: _priority_value(item["priority"]))
+    next_items = cleaned[: max(1, limit)]
+
+    return {
+        "decision": payload.get("decision", "NO-SHIP"),
+        "next_command": payload.get("next_command", "make ops-daily"),
+        "recommendations": next_items,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Print top next actions from ops follow-up payload"
+    )
+    parser.add_argument("--followup", type=Path, default=Path("build/ops/followup.json"))
+    parser.add_argument("--limit", type=int, default=3)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    payload = _load_json(args.followup)
+    result = build_next(payload, args.limit)
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
+    print(f"OPS_DECISION={result['decision']}")
+    print(f"OPS_NEXT_COMMAND={result['next_command']}")
+    print("OPS_TOP_ACTIONS=")
+    for idx, rec in enumerate(result["recommendations"], start=1):
+        print(f"{idx}. [{rec['priority']}] {rec['title']} :: {rec['action']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops_premerge_next.py
+++ b/scripts/ops_premerge_next.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("premerge gate payload must be a JSON object")
+    return payload
+
+
+def _extract_next_actions(payload: dict[str, Any], limit: int) -> list[str]:
+    steps = payload.get("steps", [])
+    if not isinstance(steps, list):
+        return []
+
+    actions: list[str] = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if step.get("id") != "enterprise_assessment":
+            continue
+        stdout = step.get("stdout")
+        if not isinstance(stdout, str) or not stdout.strip():
+            continue
+        try:
+            detail = json.loads(stdout)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(detail, dict):
+            continue
+        action_board = detail.get("action_board", {})
+        if not isinstance(action_board, dict):
+            continue
+        next_items = action_board.get("next", [])
+        if not isinstance(next_items, list):
+            continue
+        for item in next_items:
+            if not isinstance(item, dict):
+                continue
+            priority = str(item.get("priority", "P?"))
+            action = str(item.get("action", "")).strip()
+            check_id = str(item.get("check_id", ""))
+            if action:
+                suffix = f" ({check_id})" if check_id else ""
+                actions.append(f"[{priority}] {action}{suffix}")
+    return actions[: max(1, limit)]
+
+
+def _suggest_fast_premerge(payload: dict[str, Any]) -> bool:
+    steps = payload.get("steps", [])
+    if not isinstance(steps, list):
+        return False
+
+    ship_step = next(
+        (
+            step
+            for step in steps
+            if isinstance(step, dict) and step.get("id") == "ship_readiness"
+        ),
+        None,
+    )
+    if not isinstance(ship_step, dict):
+        return False
+
+    stdout = ship_step.get("stdout")
+    if not isinstance(stdout, str) or not stdout.strip():
+        return False
+
+    try:
+        detail = json.loads(stdout)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(detail, dict):
+        return False
+
+    runs = detail.get("runs", [])
+    if isinstance(runs, list):
+        for run in runs:
+            if not isinstance(run, dict):
+                continue
+            if str(run.get("id", "")) != "gate_release":
+                continue
+            parsed = run.get("parsed_json")
+            if not isinstance(parsed, dict):
+                continue
+            failed_steps = parsed.get("failed_steps", [])
+            if not isinstance(failed_steps, list):
+                continue
+            if "doctor_release" not in failed_steps:
+                continue
+            if _contains_clean_tree_signal(parsed):
+                return True
+            if _doctor_release_report_indicates_clean_tree():
+                return True
+
+    blockers = detail.get("blockers", [])
+    if not isinstance(blockers, list):
+        return False
+
+    for blocker in blockers:
+        if not isinstance(blocker, dict):
+            continue
+        blocker_id = str(blocker.get("id", "")).lower()
+        check_id = str(blocker.get("check_id", "")).lower()
+        if "clean_tree" in blocker_id or "clean_tree" in check_id:
+            return True
+    return False
+
+
+def _contains_clean_tree_signal(value: Any) -> bool:
+    markers = (
+        "clean_tree",
+        "clean tree",
+        "uncommitted change",
+        "working tree",
+        "git status --porcelain",
+    )
+    if isinstance(value, str):
+        text = value.lower()
+        return any(marker in text for marker in markers)
+    if isinstance(value, dict):
+        return any(_contains_clean_tree_signal(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_clean_tree_signal(v) for v in value)
+    return False
+
+
+def _doctor_release_report_indicates_clean_tree() -> bool:
+    report_path = Path("build/doctor-release.json")
+    if not report_path.exists():
+        return False
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(payload, dict):
+        return False
+
+    checks = payload.get("checks")
+    if not isinstance(checks, dict):
+        return False
+    clean_tree = checks.get("clean_tree")
+    if not isinstance(clean_tree, dict):
+        return False
+    if clean_tree.get("ok") is False:
+        return True
+
+    summary = clean_tree.get("summary", "")
+    if isinstance(summary, str) and _contains_clean_tree_signal(summary):
+        return True
+
+    evidence = clean_tree.get("evidence", [])
+    if isinstance(evidence, list) and _contains_clean_tree_signal(evidence):
+        return True
+    return False
+
+
+def build_summary(payload: dict[str, Any], limit: int) -> dict[str, Any]:
+    ok = bool(payload.get("ok", False))
+    next_actions = _extract_next_actions(payload, limit)
+    if ok:
+        next_command = "make ops-weekly"
+    elif _suggest_fast_premerge(payload):
+        next_command = "make ops-premerge-fast"
+    else:
+        next_command = "make ops-premerge"
+    return {
+        "ok": ok,
+        "next_command": next_command,
+        "top_actions": next_actions,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Print concise next actions after premerge gate")
+    parser.add_argument(
+        "--gate-json",
+        type=Path,
+        default=Path("build/premerge-release-room-gate.json"),
+    )
+    parser.add_argument("--limit", type=int, default=3)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    payload = _load_json(args.gate_json)
+    summary = build_summary(payload, args.limit)
+
+    if args.format == "json":
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+
+    print(f"OPS_PREMERGE_OK={summary['ok']}")
+    print(f"OPS_NEXT_COMMAND={summary['next_command']}")
+    print("OPS_TOP_ACTIONS=")
+    if not summary["top_actions"]:
+        print("1. No priority actions. Continue routine weekly lane.")
+    else:
+        for idx, action in enumerate(summary["top_actions"], start=1):
+            print(f"{idx}. {action}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops_premerge_next.py
+++ b/scripts/ops_premerge_next.py
@@ -57,11 +57,7 @@ def _suggest_fast_premerge(payload: dict[str, Any]) -> bool:
         return False
 
     ship_step = next(
-        (
-            step
-            for step in steps
-            if isinstance(step, dict) and step.get("id") == "ship_readiness"
-        ),
+        (step for step in steps if isinstance(step, dict) and step.get("id") == "ship_readiness"),
         None,
     )
     if not isinstance(ship_step, dict):

--- a/scripts/premerge_release_room_gate.py
+++ b/scripts/premerge_release_room_gate.py
@@ -22,7 +22,21 @@ def _run(cmd: list[str], cwd: Path) -> dict[str, Any]:
     }
 
 
-def run_gate(repo_root: Path) -> dict[str, Any]:
+def run_gate(repo_root: Path, *, ship_release_dry_run: bool = False) -> dict[str, Any]:
+    ship_readiness_cmd = [
+        "python",
+        "-m",
+        "sdetkit",
+        "ship-readiness",
+        "--strict",
+        "--format",
+        "json",
+        "--out-dir",
+        "build/ship-readiness",
+    ]
+    if ship_release_dry_run:
+        ship_readiness_cmd.append("--release-dry-run")
+
     steps = [
         (
             "enterprise_assessment",
@@ -38,17 +52,7 @@ def run_gate(repo_root: Path) -> dict[str, Any]:
         ),
         (
             "ship_readiness",
-            [
-                "python",
-                "-m",
-                "sdetkit",
-                "ship-readiness",
-                "--strict",
-                "--format",
-                "json",
-                "--out-dir",
-                "build/ship-readiness",
-            ],
+            ship_readiness_cmd,
         ),
         (
             "enterprise_contract",
@@ -120,10 +124,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out", default="build/premerge-release-room-gate.json")
     parser.add_argument("--format", choices=["text", "json"], default="json")
     parser.add_argument("--strict", action="store_true")
+    parser.add_argument(
+        "--ship-release-dry-run",
+        action="store_true",
+        help="Forward --release-dry-run to ship-readiness for local rehearsal lanes.",
+    )
     args = parser.parse_args(argv)
 
     repo_root = Path(args.repo).resolve()
-    payload = run_gate(repo_root)
+    payload = run_gate(repo_root, ship_release_dry_run=bool(args.ship_release_dry_run))
 
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/real_workflow_followup.py
+++ b/scripts/real_workflow_followup.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _priority(level: str) -> int:
+    return {"P0": 0, "P1": 1, "P2": 2, "P3": 3}.get(level, 9)
+
+
+def _load_history(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if isinstance(payload, dict):
+            rows.append(payload)
+    return rows
+
+
+def _append_history(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _build_history_rollup(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(rows)
+    ship = sum(1 for row in rows if row.get("decision") == "SHIP")
+    no_ship = sum(1 for row in rows if row.get("decision") != "SHIP")
+    breach_count = sum(1 for row in rows if bool(row.get("threshold_breach", False)))
+    ship_rate = (ship / total) if total else 0.0
+
+    action_counts: dict[str, int] = {}
+    for row in rows:
+        recs = row.get("recommendations")
+        if not isinstance(recs, list):
+            continue
+        for rec in recs:
+            if not isinstance(rec, dict):
+                continue
+            title = rec.get("title")
+            if isinstance(title, str):
+                action_counts[title] = action_counts.get(title, 0) + 1
+    top_actions = sorted(action_counts.items(), key=lambda kv: kv[1], reverse=True)[:5]
+
+    return {
+        "schema_version": "sdetkit.real-workflow-followup-history-rollup.v1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "summary": {
+            "total_runs": total,
+            "ship_runs": ship,
+            "no_ship_runs": no_ship,
+            "threshold_breach_runs": breach_count,
+            "ship_rate": ship_rate,
+            "top_recurring_recommendations": [
+                {"title": title, "count": count} for title, count in top_actions
+            ],
+        },
+    }
+
+
+def build_followup(
+    summary: dict[str, Any],
+    rollup: dict[str, Any],
+    threshold: dict[str, Any],
+    release_preflight: dict[str, Any],
+) -> dict[str, Any]:
+    decision = str(summary.get("decision", "NO-SHIP"))
+    failed_steps = summary.get("failed_steps", [])
+    if not isinstance(failed_steps, list):
+        failed_steps = []
+
+    top_failed = []
+    rollup_summary = rollup.get("summary", {}) if isinstance(rollup, dict) else {}
+    if isinstance(rollup_summary, dict):
+        top_failed = rollup_summary.get("top_failed_steps", [])
+    if not isinstance(top_failed, list):
+        top_failed = []
+
+    breach = bool(threshold.get("breach", False)) if isinstance(threshold, dict) else False
+    release_failed_steps = []
+    release_recommendations = []
+    if isinstance(release_preflight, dict):
+        failed_steps_payload = release_preflight.get("failed_steps", [])
+        if isinstance(failed_steps_payload, list):
+            release_failed_steps = [step for step in failed_steps_payload if isinstance(step, str)]
+        recommendations_payload = release_preflight.get("recommendations", [])
+        if isinstance(recommendations_payload, list):
+            release_recommendations = [
+                rec for rec in recommendations_payload if isinstance(rec, str)
+            ]
+
+    recs: list[dict[str, str]] = []
+    if decision != "SHIP":
+        recs.append(
+            {
+                "priority": "P0",
+                "title": "Recover to SHIP on the failing gate",
+                "action": "Run `make ops-daily` after fixing the first failing step and do not merge until decision is SHIP.",
+            }
+        )
+
+    if failed_steps:
+        first_failed = failed_steps[0]
+        recs.append(
+            {
+                "priority": "P1",
+                "title": "Resolve first failing step",
+                "action": f"Focus on `{first_failed}` first; it is blocking deterministic release confidence.",
+            }
+        )
+
+    for item in top_failed[:3]:
+        if not isinstance(item, dict):
+            continue
+        step = item.get("step")
+        count = item.get("count")
+        if isinstance(step, str) and isinstance(count, int):
+            recs.append(
+                {
+                    "priority": "P2",
+                    "title": f"Reduce recurring failures in {step}",
+                    "action": f"{step} failed {count} times in recent history; add a targeted regression check before pre-merge.",
+                }
+            )
+
+    if breach:
+        recs.append(
+            {
+                "priority": "P0",
+                "title": "Threshold breach escalation",
+                "action": "Run `make owner-escalation-payload` and assign an owner with SLA before the next release window.",
+            }
+        )
+
+    if "doctor_release" in release_failed_steps:
+        recs.append(
+            {
+                "priority": "P0",
+                "title": "Unblock release doctor checks",
+                "action": "Doctor release checks are failing (often clean-tree). Commit/stash changes, then rerun `make ops-daily`.",
+            }
+        )
+    if release_recommendations:
+        recs.append(
+            {
+                "priority": "P1",
+                "title": "Apply release preflight recommendation",
+                "action": release_recommendations[0],
+            }
+        )
+
+    if decision == "SHIP" and not breach:
+        recs.append(
+            {
+                "priority": "P3",
+                "title": "Proceed to pre-merge verification",
+                "action": "Run `make ops-premerge` and publish release-room evidence before merge/tag.",
+            }
+        )
+
+    recs.sort(key=lambda item: _priority(item.get("priority", "P9")))
+
+    return {
+        "schema_version": "sdetkit.real-workflow-followup.v1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "decision": decision,
+        "threshold_breach": breach,
+        "recommendations": recs,
+        "next_command": "make ops-daily" if decision != "SHIP" else "make ops-premerge",
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    decision = payload.get("decision", "NO-SHIP")
+    breach = payload.get("threshold_breach", False)
+    lines = [
+        "# Real workflow follow-up",
+        "",
+        f"- Decision: **{decision}**",
+        f"- Threshold breach: **{breach}**",
+        f"- Suggested next command: `{payload.get('next_command', 'make ops-daily')}`",
+        "",
+        "## Recommendations",
+    ]
+    recs = payload.get("recommendations", [])
+    if not isinstance(recs, list) or not recs:
+        lines.append("- No follow-up actions generated.")
+        return "\n".join(lines) + "\n"
+
+    for idx, rec in enumerate(recs, start=1):
+        if not isinstance(rec, dict):
+            continue
+        lines.append(
+            f"{idx}. [{rec.get('priority', 'P?')}] **{rec.get('title', 'Action')}** — {rec.get('action', '')}"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate real workflow follow-up recommendations")
+    parser.add_argument(
+        "--summary", type=Path, default=Path("build/first-proof/first-proof-summary.json")
+    )
+    parser.add_argument(
+        "--rollup", type=Path, default=Path("build/first-proof/first-proof-learning-rollup.json")
+    )
+    parser.add_argument(
+        "--threshold", type=Path, default=Path("build/first-proof/weekly-threshold-check.json")
+    )
+    parser.add_argument(
+        "--release-preflight",
+        type=Path,
+        default=Path("build/first-proof/release-preflight.json"),
+    )
+    parser.add_argument("--out-json", type=Path, default=Path("build/ops/followup.json"))
+    parser.add_argument("--out-md", type=Path, default=Path("build/ops/followup.md"))
+    parser.add_argument("--history", type=Path, default=Path("build/ops/followup-history.jsonl"))
+    parser.add_argument(
+        "--history-rollup-out", type=Path, default=Path("build/ops/followup-history-rollup.json")
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+
+    summary = _read_json(args.summary)
+    rollup = _read_json(args.rollup)
+    threshold = _read_json(args.threshold)
+    release_preflight = _read_json(args.release_preflight)
+
+    payload = build_followup(summary, rollup, threshold, release_preflight)
+    markdown = render_markdown(payload)
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out_md.write_text(markdown, encoding="utf-8")
+    _append_history(args.history, payload)
+    history_rows = _load_history(args.history)
+    history_rollup = _build_history_rollup(history_rows)
+    args.history_rollup_out.parent.mkdir(parents=True, exist_ok=True)
+    args.history_rollup_out.write_text(
+        json.dumps(history_rollup, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "out_json": str(args.out_json),
+                    "out_md": str(args.out_md),
+                    "history": str(args.history),
+                    "history_rollup": str(args.history_rollup_out),
+                    "history_total_runs": history_rollup["summary"]["total_runs"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(f"follow-up json: {args.out_json}")
+        print(f"follow-up md: {args.out_md}")
+        print(f"follow-up history: {args.history}")
+        print(f"follow-up history rollup: {args.history_rollup_out}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/sdetkit/readiness/ship_readiness.py
+++ b/src/sdetkit/readiness/ship_readiness.py
@@ -165,6 +165,11 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--strict", action="store_true")
     parser.add_argument(
+        "--release-dry-run",
+        action="store_true",
+        help="Run gate release with --dry-run (useful for local premerge rehearsal lanes).",
+    )
+    parser.add_argument(
         "--include-enterprise",
         action="store_true",
         help="Also execute enterprise-assessment and include it in go/no-go contract.",
@@ -177,9 +182,12 @@ def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     args.out_dir.mkdir(parents=True, exist_ok=True)
 
+    gate_release_cmd = "python -m sdetkit gate release --format json"
+    if args.release_dry_run:
+        gate_release_cmd += " --dry-run"
     commands = [
         ("gate_fast", "python -m sdetkit gate fast --format json --stable-json"),
-        ("gate_release", "python -m sdetkit gate release --format json"),
+        ("gate_release", gate_release_cmd),
         ("doctor", "python -m sdetkit doctor --format json"),
         ("release_readiness", "python -m sdetkit release-readiness --format json"),
     ]

--- a/tests/test_first_proof_script.py
+++ b/tests/test_first_proof_script.py
@@ -49,3 +49,30 @@ def test_first_proof_writes_decision_line_for_no_ship(monkeypatch, tmp_path: Pat
     payload = json.loads((tmp_path / "first-proof-summary.json").read_text(encoding="utf-8"))
     assert payload["decision"] == "NO-SHIP"
     assert payload["decision_line"] == "FIRST_PROOF_DECISION=NO-SHIP"
+
+
+def test_first_proof_release_dry_run_flag_is_forwarded(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(first_proof, "_resolve_python", lambda _explicit: "python3.11")
+    captured_commands: list[list[str]] = []
+    step_results = [
+        first_proof.StepResult("gate-fast", ["cmd"], 0, "a.stdout.log", "a.stderr.log", "a.json"),
+        first_proof.StepResult(
+            "gate-release", ["cmd"], 0, "b.stdout.log", "b.stderr.log", "b.json"
+        ),
+        first_proof.StepResult("doctor", ["cmd"], 0, "c.stdout.log", "c.stderr.log", "c.json"),
+    ]
+
+    def _fake_run_step(**kwargs):
+        command = kwargs.get("command")
+        if isinstance(command, list):
+            captured_commands.append(command)
+        return step_results.pop(0)
+
+    monkeypatch.setattr(first_proof, "_run_step", _fake_run_step)
+
+    rc = first_proof.main(
+        ["first_proof.py", "--release-dry-run", "--out-dir", str(tmp_path), "--format", "json"]
+    )
+    assert rc == 0
+    gate_release_cmd = captured_commands[1]
+    assert "--dry-run" in gate_release_cmd

--- a/tests/test_ops_next.py
+++ b/tests/test_ops_next.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_ops_next_prints_prioritized_actions(tmp_path: Path) -> None:
+    followup = tmp_path / "followup.json"
+    followup.write_text(
+        json.dumps(
+            {
+                "decision": "NO-SHIP",
+                "next_command": "make ops-daily",
+                "recommendations": [
+                    {"priority": "P2", "title": "Later fix", "action": "do later"},
+                    {"priority": "P0", "title": "Now fix", "action": "do now"},
+                    {"priority": "P1", "title": "Soon fix", "action": "do soon"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        "scripts/ops_next.py",
+        "--followup",
+        str(followup),
+        "--limit",
+        "2",
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+    out = result.stdout
+    assert "OPS_DECISION=NO-SHIP" in out
+    assert "OPS_NEXT_COMMAND=make ops-daily" in out
+    assert "1. [P0] Now fix" in out
+    assert "2. [P1] Soon fix" in out
+
+
+def test_ops_next_json_output(tmp_path: Path) -> None:
+    followup = tmp_path / "followup.json"
+    followup.write_text(
+        json.dumps(
+            {
+                "decision": "SHIP",
+                "next_command": "make ops-premerge",
+                "recommendations": [
+                    {"priority": "P3", "title": "Proceed", "action": "merge"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        "scripts/ops_next.py",
+        "--followup",
+        str(followup),
+        "--format",
+        "json",
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    payload = json.loads(result.stdout)
+
+    assert payload["decision"] == "SHIP"
+    assert payload["next_command"] == "make ops-premerge"
+    assert payload["recommendations"][0]["priority"] == "P3"

--- a/tests/test_ops_premerge_next.py
+++ b/tests/test_ops_premerge_next.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_ops_premerge_next_text_output(tmp_path: Path) -> None:
+    gate = tmp_path / "premerge.json"
+    gate.write_text(
+        json.dumps(
+            {
+                "ok": True,
+                "steps": [
+                    {
+                        "id": "enterprise_assessment",
+                        "stdout": json.dumps(
+                            {
+                                "action_board": {
+                                    "next": [
+                                        {
+                                            "priority": "P1",
+                                            "check_id": "workflow_sprawl_risk",
+                                            "action": "Consolidate overlapping workflows.",
+                                        }
+                                    ]
+                                }
+                            }
+                        ),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        "scripts/ops_premerge_next.py",
+        "--gate-json",
+        str(gate),
+        "--limit",
+        "2",
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    out = result.stdout
+
+    assert "OPS_PREMERGE_OK=True" in out
+    assert "OPS_NEXT_COMMAND=make ops-weekly" in out
+    assert "1. [P1] Consolidate overlapping workflows." in out
+
+
+def test_ops_premerge_next_json_output_on_failure(tmp_path: Path) -> None:
+    gate = tmp_path / "premerge.json"
+    gate.write_text(json.dumps({"ok": False, "steps": []}), encoding="utf-8")
+
+    cmd = [
+        sys.executable,
+        "scripts/ops_premerge_next.py",
+        "--gate-json",
+        str(gate),
+        "--format",
+        "json",
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    payload = json.loads(result.stdout)
+
+    assert payload["ok"] is False
+    assert payload["next_command"] == "make ops-premerge"
+
+
+def test_ops_premerge_next_suggests_fast_lane_for_clean_tree_blocker(tmp_path: Path) -> None:
+    gate = tmp_path / "premerge.json"
+    gate.write_text(
+        json.dumps(
+            {
+                "ok": False,
+                "steps": [
+                    {
+                        "id": "ship_readiness",
+                        "stdout": json.dumps(
+                            {
+                                "blockers": [
+                                    {
+                                        "check_id": "doctor_release.clean_tree",
+                                        "status": "fail",
+                                    }
+                                ]
+                            }
+                        ),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        "scripts/ops_premerge_next.py",
+        "--gate-json",
+        str(gate),
+        "--format",
+        "json",
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    payload = json.loads(result.stdout)
+
+    assert payload["ok"] is False
+    assert payload["next_command"] == "make ops-premerge-fast"
+
+
+def test_ops_premerge_next_uses_doctor_release_report_for_gate_release_failure(
+    tmp_path: Path,
+) -> None:
+    gate = tmp_path / "premerge.json"
+    gate.write_text(
+        json.dumps(
+            {
+                "ok": False,
+                "steps": [
+                    {
+                        "id": "ship_readiness",
+                        "stdout": json.dumps(
+                            {
+                                "runs": [
+                                    {
+                                        "id": "gate_release",
+                                        "parsed_json": {
+                                            "failed_steps": ["doctor_release"],
+                                            "dry_run": False,
+                                            "recommendations": [
+                                                "Inspect release readiness output: python -m sdetkit doctor --release --format json --out build/doctor-release.json."
+                                            ],
+                                        },
+                                    }
+                                ]
+                            }
+                        ),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    doctor_report = tmp_path / "build/doctor-release.json"
+    doctor_report.parent.mkdir(parents=True, exist_ok=True)
+    doctor_report.write_text(
+        json.dumps(
+            {
+                "checks": {
+                    "clean_tree": {
+                        "ok": False,
+                        "summary": "working tree has uncommitted changes",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        str((Path("scripts") / "ops_premerge_next.py").resolve()),
+        "--gate-json",
+        str(gate),
+        "--format",
+        "json",
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True, cwd=str(tmp_path))
+    payload = json.loads(result.stdout)
+
+    assert payload["ok"] is False
+    assert payload["next_command"] == "make ops-premerge-fast"

--- a/tests/test_premerge_release_room_gate.py
+++ b/tests/test_premerge_release_room_gate.py
@@ -69,3 +69,28 @@ def test_main_writes_output_json(tmp_path: Path, monkeypatch, capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
     assert out.exists()
+
+
+def test_run_gate_forwards_ship_release_dry_run(tmp_path: Path, monkeypatch) -> None:
+    mod = _load_module()
+
+    captured_cmds: list[list[str]] = []
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "{}\n"
+            self.stderr = ""
+
+    def _fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        if isinstance(cmd, list):
+            captured_cmds.append(cmd)
+        return _FakeProc()
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+
+    payload = mod.run_gate(tmp_path, ship_release_dry_run=True)
+    assert payload["steps"]
+    ship_cmd = next(step["cmd"] for step in payload["steps"] if step["id"] == "ship_readiness")
+    assert "--release-dry-run" in ship_cmd

--- a/tests/test_real_workflow_followup.py
+++ b/tests/test_real_workflow_followup.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_real_workflow_followup_generates_recommendations(tmp_path: Path) -> None:
+    summary = tmp_path / "first-proof-summary.json"
+    rollup = tmp_path / "first-proof-learning-rollup.json"
+    threshold = tmp_path / "weekly-threshold-check.json"
+    release_preflight = tmp_path / "release-preflight.json"
+    out_json = tmp_path / "followup.json"
+    out_md = tmp_path / "followup.md"
+    history = tmp_path / "followup-history.jsonl"
+    history_rollup = tmp_path / "followup-history-rollup.json"
+
+    summary.write_text(
+        json.dumps(
+            {
+                "decision": "NO-SHIP",
+                "failed_steps": ["gate-fast", "gate-release"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    rollup.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "top_failed_steps": [
+                        {"step": "gate-fast", "count": 4},
+                        {"step": "gate-release", "count": 2},
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    threshold.write_text(json.dumps({"breach": True}), encoding="utf-8")
+    release_preflight.write_text(
+        json.dumps(
+            {
+                "failed_steps": ["doctor_release"],
+                "recommendations": ["Inspect release readiness output."],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        "scripts/real_workflow_followup.py",
+        "--summary",
+        str(summary),
+        "--rollup",
+        str(rollup),
+        "--threshold",
+        str(threshold),
+        "--release-preflight",
+        str(release_preflight),
+        "--out-json",
+        str(out_json),
+        "--out-md",
+        str(out_md),
+        "--history",
+        str(history),
+        "--history-rollup-out",
+        str(history_rollup),
+        "--format",
+        "json",
+    ]
+    subprocess.run(cmd, check=True)
+
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["decision"] == "NO-SHIP"
+    assert payload["threshold_breach"] is True
+    assert payload["next_command"] == "make ops-daily"
+    assert payload["recommendations"]
+    assert any(item["priority"] == "P0" for item in payload["recommendations"])
+    assert any(
+        item["title"] == "Unblock release doctor checks" for item in payload["recommendations"]
+    )
+
+    md_text = out_md.read_text(encoding="utf-8")
+    assert "Real workflow follow-up" in md_text
+    assert "Recommendations" in md_text
+    history_lines = history.read_text(encoding="utf-8").splitlines()
+    assert len(history_lines) == 1
+    rollup_payload = json.loads(history_rollup.read_text(encoding="utf-8"))
+    assert rollup_payload["summary"]["total_runs"] == 1
+
+
+def test_real_workflow_followup_ship_path_suggests_premerge(tmp_path: Path) -> None:
+    summary = tmp_path / "first-proof-summary.json"
+    out_json = tmp_path / "followup.json"
+    out_md = tmp_path / "followup.md"
+    history = tmp_path / "followup-history.jsonl"
+    history_rollup = tmp_path / "followup-history-rollup.json"
+
+    summary.write_text(json.dumps({"decision": "SHIP", "failed_steps": []}), encoding="utf-8")
+
+    cmd = [
+        sys.executable,
+        "scripts/real_workflow_followup.py",
+        "--summary",
+        str(summary),
+        "--rollup",
+        str(tmp_path / "missing-rollup.json"),
+        "--threshold",
+        str(tmp_path / "missing-threshold.json"),
+        "--release-preflight",
+        str(tmp_path / "missing-release.json"),
+        "--out-json",
+        str(out_json),
+        "--out-md",
+        str(out_md),
+        "--history",
+        str(history),
+        "--history-rollup-out",
+        str(history_rollup),
+    ]
+    subprocess.run(cmd, check=True)
+
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["decision"] == "SHIP"
+    assert payload["next_command"] == "make ops-premerge"
+    assert any(
+        item["title"] == "Proceed to pre-merge verification" for item in payload["recommendations"]
+    )
+    rollup_payload = json.loads(history_rollup.read_text(encoding="utf-8"))
+    assert rollup_payload["summary"]["ship_runs"] == 1
+
+
+def test_real_workflow_followup_history_accumulates(tmp_path: Path) -> None:
+    summary = tmp_path / "first-proof-summary.json"
+    history = tmp_path / "followup-history.jsonl"
+    history_rollup = tmp_path / "followup-history-rollup.json"
+    out_json = tmp_path / "followup.json"
+    out_md = tmp_path / "followup.md"
+    release_preflight = tmp_path / "release-preflight.json"
+
+    summary.write_text(
+        json.dumps({"decision": "NO-SHIP", "failed_steps": ["gate-fast"]}), encoding="utf-8"
+    )
+    release_preflight.write_text(json.dumps({"failed_steps": ["doctor_release"]}), encoding="utf-8")
+
+    base_cmd = [
+        sys.executable,
+        "scripts/real_workflow_followup.py",
+        "--summary",
+        str(summary),
+        "--rollup",
+        str(tmp_path / "missing-rollup.json"),
+        "--threshold",
+        str(tmp_path / "missing-threshold.json"),
+        "--release-preflight",
+        str(release_preflight),
+        "--out-json",
+        str(out_json),
+        "--out-md",
+        str(out_md),
+        "--history",
+        str(history),
+        "--history-rollup-out",
+        str(history_rollup),
+    ]
+    subprocess.run(base_cmd, check=True)
+    subprocess.run(base_cmd, check=True)
+
+    history_lines = history.read_text(encoding="utf-8").splitlines()
+    assert len(history_lines) == 2
+    rollup_payload = json.loads(history_rollup.read_text(encoding="utf-8"))
+    assert rollup_payload["summary"]["total_runs"] == 2

--- a/tests/test_real_workflow_followup_contract.py
+++ b/tests/test_real_workflow_followup_contract.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_followup_contract_check_passes_for_valid_payload(tmp_path: Path) -> None:
+    followup = tmp_path / "followup.json"
+    history_rollup = tmp_path / "followup-history-rollup.json"
+    out = tmp_path / "followup-contract-check.json"
+
+    followup.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.real-workflow-followup.v1",
+                "generated_at": "2026-04-27T00:00:00+00:00",
+                "decision": "NO-SHIP",
+                "threshold_breach": False,
+                "recommendations": [
+                    {
+                        "priority": "P1",
+                        "title": "Resolve first failing step",
+                        "action": "Fix gate-fast blockers",
+                    }
+                ],
+                "next_command": "make ops-daily",
+            }
+        ),
+        encoding="utf-8",
+    )
+    history_rollup.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.real-workflow-followup-history-rollup.v1",
+                "generated_at": "2026-04-27T00:00:00+00:00",
+                "summary": {
+                    "total_runs": 1,
+                    "ship_runs": 0,
+                    "no_ship_runs": 1,
+                    "threshold_breach_runs": 0,
+                    "ship_rate": 0.0,
+                    "top_recurring_recommendations": [
+                        {"title": "Resolve first failing step", "count": 1}
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        "scripts/check_real_workflow_followup_contract.py",
+        "--followup",
+        str(followup),
+        "--history-rollup",
+        str(history_rollup),
+        "--out",
+        str(out),
+        "--format",
+        "json",
+    ]
+    subprocess.run(cmd, check=True)
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+    assert payload["errors"] == []
+
+
+def test_followup_contract_check_fails_for_invalid_payload(tmp_path: Path) -> None:
+    followup = tmp_path / "followup.json"
+    history_rollup = tmp_path / "followup-history-rollup.json"
+    out = tmp_path / "followup-contract-check.json"
+
+    followup.write_text(
+        json.dumps(
+            {
+                "schema_version": "broken",
+                "generated_at": "2026-04-27T00:00:00+00:00",
+                "decision": "MAYBE",
+                "threshold_breach": "no",
+                "recommendations": [{"priority": "P9", "title": "", "action": ""}],
+                "next_command": "make unknown",
+            }
+        ),
+        encoding="utf-8",
+    )
+    history_rollup.write_text(
+        json.dumps(
+            {
+                "schema_version": "broken",
+                "generated_at": "2026-04-27T00:00:00+00:00",
+                "summary": {"total_runs": "x"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cmd = [
+        sys.executable,
+        "scripts/check_real_workflow_followup_contract.py",
+        "--followup",
+        str(followup),
+        "--history-rollup",
+        str(history_rollup),
+        "--out",
+        str(out),
+    ]
+    result = subprocess.run(cmd, check=False)
+    assert result.returncode == 1
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["ok"] is False
+    assert payload["errors"]

--- a/tests/test_real_workflow_ops_contract.py
+++ b/tests/test_real_workflow_ops_contract.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+MAKEFILE = Path("Makefile")
+README = Path("README.md")
+OPS_DOC = Path("docs/real-workflow-operations.md")
+
+
+def test_makefile_exposes_real_workflow_targets() -> None:
+    text = MAKEFILE.read_text()
+
+    required_targets = (
+        "real-workflow-daily:",
+        "real-workflow-daily-fast:",
+        "real-workflow-weekly:",
+        "real-workflow-premerge:",
+        "real-workflow-premerge-fast:",
+        "release-room-fast:",
+        "ship-readiness-fast:",
+        "real-workflow:",
+        "ops-daily:",
+        "ops-daily-fast:",
+        "ops-weekly:",
+        "ops-premerge:",
+        "ops-premerge-fast:",
+        "ops-premerge-next:",
+        "ops-premerge-next-fast:",
+        "ops-followup:",
+        "ops-followup-contract:",
+        "ops-now:",
+        "ops-now-lite:",
+        "ops-next:",
+        "ops-workflow:",
+    )
+    for target in required_targets:
+        assert target in text
+
+
+def test_readme_links_real_workflow_and_ops_aliases() -> None:
+    text = README.read_text()
+
+    assert "docs/real-workflow-operations.md" in text
+    assert "make ops-daily" in text
+    assert "make ops-daily-fast" in text
+    assert "make ops-weekly" in text
+    assert "make ops-premerge" in text
+    assert "make ops-premerge-fast" in text
+    assert "make ops-premerge-next" in text
+    assert "make ops-premerge-next-fast" in text
+    assert "make ops-followup" in text
+    assert "make ops-now" in text
+    assert "make ops-now-lite" in text
+    assert "make ops-next" in text
+
+
+def test_ops_doc_contains_real_and_alias_commands() -> None:
+    text = OPS_DOC.read_text()
+
+    assert "make real-workflow-daily" in text
+    assert "make ops-daily-fast" in text
+    assert "make real-workflow-weekly" in text
+    assert "make real-workflow-premerge" in text
+    assert "make ops-daily" in text
+    assert "make ops-weekly" in text
+    assert "make ops-premerge" in text
+    assert "make ops-premerge-fast" in text
+    assert "make ops-premerge-next" in text
+    assert "make ops-premerge-next-fast" in text
+    assert "make ops-followup" in text
+    assert "make ops-followup-contract" in text
+    assert "make ops-now" in text
+    assert "make ops-now-lite" in text
+    assert "make ops-next" in text
+    assert "build/ops/followup-history.jsonl" in text
+    assert "build/ops/followup-history-rollup.json" in text
+    assert "docs/ops-followup-schema.v1.json" in text

--- a/tests/test_ship_readiness.py
+++ b/tests/test_ship_readiness.py
@@ -96,3 +96,36 @@ def test_run_command_retries_timeout_once_then_succeeds(tmp_path: Path, monkeypa
 
     assert result["ok"] is True
     assert result["attempts"] == 2
+
+
+def test_main_release_dry_run_forwards_to_gate_release(tmp_path: Path, monkeypatch) -> None:
+    captured: list[list[str]] = []
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "{}\n"
+            self.stderr = ""
+
+    def _fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        _ = kwargs
+        if isinstance(argv, list):
+            captured.append(argv)
+        return _FakeProc()
+
+    monkeypatch.setattr(sr.subprocess, "run", _fake_run)
+
+    rc = sr.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--release-dry-run",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    gate_release_argv = captured[1]
+    assert "--dry-run" in gate_release_argv


### PR DESCRIPTION
### Motivation

- Add a production-oriented "real workflow" operations lane that automates daily/weekly/pre-merge execution and emits prioritized follow-up recommendations. 
- Enable safe local rehearsal by forwarding a release dry-run flag through the first-proof, ship-readiness, and premerge-release-room gates. 
- Provide small helper CLIs to extract concise next-actions and validate follow-up payload contracts for ops automation.

### Description

- Added a new follow-up generator `scripts/real_workflow_followup.py` that combines first-proof outputs, rollups, threshold checks, and release preflight to emit `build/ops/followup.json`, a markdown summary, and an append-only history and rollup. 
- Added contract validator `scripts/check_real_workflow_followup_contract.py`, prioritizer `scripts/ops_next.py`, and premerge helper `scripts/ops_premerge_next.py` to produce concise operator-friendly outputs. 
- Extended `scripts/first_proof.py`, `src/sdetkit/readiness/ship_readiness.py`, and `scripts/premerge_release_room_gate.py` to accept and forward a `--release-dry-run`/`--ship-release-dry-run` flag so local lanes can rehearse without blocking on a clean tree. 
- Updated `Makefile` with many new targets and aliases (real-workflow, ops-*, fast variants, follow-up targets, local/test variants) and forwarded the new `FIRST_PROOF_RELEASE_DRY_RUN` variable into the local lanes. 
- Added documentation `docs/real-workflow-operations.md`, JSON schema `docs/ops-followup-schema.v1.json`, and README links/aliases for the new ops flows. 
- Added comprehensive tests covering the new scripts and the dry-run forwarding behavior and updated `tests/test_first_proof_script.py` and `tests/test_ship_readiness.py` to assert the new flag propagation.

### Testing

- Ran the new and updated unit tests including `tests/test_real_workflow_followup.py`, `tests/test_real_workflow_followup_contract.py`, `tests/test_ops_next.py`, `tests/test_ops_premerge_next.py`, `tests/test_premerge_release_room_gate.py`, `tests/test_first_proof_script.py`, and `tests/test_ship_readiness.py` using `pytest` and invoking several scripts directly; all asserted behaviors passed. 
- Executed the Makefile lanes locally via the new aliases (e.g. `make real-workflow-daily`, `make ops-now-lite`, `make real-workflow-premerge-fast`) to verify target wiring and outputs; the lanes completed and produced expected artifacts in the `build/` tree. 
- Contract/validation checks for follow-up payloads were exercised via the new contract tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eec703f7c0832d9002425ede20d75e)