### PR TITLE
Add repository-wide CODEOWNERS entry to set @sherif69-sa as default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,2 @@
-# Default ownership for the repository
+# Default code owner for the entire repository
 * @sherif69-sa
-
-# CI/CD and release automation
-/.github/workflows/ @sherif69-sa
-
-# Packaging metadata
-/pyproject.toml @sherif69-sa


### PR DESCRIPTION
### Motivation
- Ensure repository review ownership defaults to the repository owner by adding a repo-wide CODEOWNERS entry.

### Description
- Added `.github/CODEOWNERS` with a repository-wide rule `* @sherif69-sa`, replacing prior per-path owner entries.

### Testing
- Ran `git status --short` to verify the working tree is clean after the commit; no runtime tests required for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef85fb9030832da24689a61b1eac61)