### PR TITLE
Run branch-protection on push to main and remove --enforce-admins flag

### DIFF
--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -3,6 +3,8 @@ name: enforce-branch-protection
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
   schedule:
     - cron: "15 7 * * 1"
   workflow_dispatch:
@@ -37,6 +39,5 @@ jobs:
             --token "${BRANCH_PROTECTION_TOKEN}" \
             --required-check "ci" \
             --required-check "maintenance-autopilot" \
-            --enforce-admins \
             --required-approving-review-count 0 \
             --disable-pr-reviews


### PR DESCRIPTION
### Motivation
- Ensure the `enforce-branch-protection` workflow runs on direct `push` to `main` and avoid forcing admin protection changes by removing the `--enforce-admins` flag.

### Description
- Added a `push` trigger for `branches: [main]` in `.github/workflows/enforce-branch-protection.yml` and removed the `--enforce-admins` argument from the `python tools/enforce_branch_protection.py` invocation.

### Testing
- No automated tests were executed for this workflow modification; behavior will be validated by the next scheduled or triggered run of the workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef85fb9030832da24689a61b1eac61)