### PR TITLE
Add business-execution week-1 pipeline: scripts, contracts, Make targets, docs and tests

### DIFF
--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -40,4 +40,5 @@ jobs:
             --required-check "ci" \
             --required-check "maintenance-autopilot" \
             --required-approving-review-count 0 \
+            --enforce-admins \
             --disable-pr-reviews

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ FIRST_PROOF_BRANCH ?= local
 FIRST_PROOF_STRICT ?= false
 FIRST_PROOF_RELEASE_DRY_RUN ?= true
 PHASE2_BASELINE_PRE_EXTRACTION ?= docs/artifacts/phase2-hotspot-baseline-pre-extraction-$(DATE_TAG).json
+BUSINESS_EXECUTION_OPERATOR ?= sherif69-sa
 
 .PHONY: bootstrap max brutal venv runtime-install first-proof-install install ci-deps-sync test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-fast ship-readiness-contract release-room release-room-fast portfolio-readiness premerge-release-room premerge-release-room-fast adaptive-scenario-db adaptive-postcheck owner-escalation-payload adaptive-premerge adaptive-ops-bundle repo-alignment-check test-bootstrap test-bootstrap-contract merge-ready premerge-finalize first-proof first-proof-local first-proof-contract first-proof-learn first-proof-control-tower first-proof-weekly-trend first-proof-trend-threshold first-proof-tests first-proof-tests-local first-proof-verify first-proof-verify-local gate-decision-summary gate-decision-summary-contract fit-check adoption-followup adoption-followup-contract adoption-control-loop adoption-control-loop-contract adoption-posture adoption-validate adoption-control-loop-full ops-followup ops-followup-contract ops-now ops-now-lite ops-next ops-premerge-next ops-premerge-next-fast phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-execution-core phase1-workflow phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-start phase2-workflow phase2-status phase2-start-contract phase2-seed phase2-hotspot-baseline phase2-hotspot-delta phase2-complete phase2-progress phase2-surface-clarity phase3-dependency-radar phase3-quality-contract phase3-quality-report phase3-do-it phase4-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract plan-status phase1-execute phase2-execute phase3-governance phase4-credibility real-workflow-daily real-workflow-daily-fast real-workflow-weekly real-workflow-premerge real-workflow-premerge-fast real-workflow ops-daily ops-daily-fast ops-weekly ops-premerge ops-premerge-fast ops-workflow
+.PHONY: business-execution-start business-execution-start-contract business-execution-go-gate business-execution-progress business-execution-progress-contract business-execution-next business-execution-next-contract business-execution-handoff business-execution-handoff-contract business-execution-escalation business-execution-escalation-contract business-execution-followup business-execution-followup-contract business-execution-continue business-execution-continue-contract business-execution-horizon business-execution-horizon-contract business-execution-inputs-contract business-execution-pipeline business-execution-week1-pipeline
 
 bootstrap: venv
 	@bash -lc '. .venv/bin/activate && bash scripts/bootstrap.sh'
@@ -182,6 +184,66 @@ ops-premerge-fast: real-workflow-premerge-fast
 
 ops-workflow: real-workflow
 	@bash -lc 'echo ops-workflow: alias completed'
+
+business-execution-start: venv
+	@bash -lc '. .venv/bin/activate && python scripts/business_execution_start.py --single-operator "$(BUSINESS_EXECUTION_OPERATOR)"'
+
+business-execution-start-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_start_contract.py'
+
+business-execution-go-gate: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_start_contract.py --require-go'
+
+business-execution-progress: venv
+	@bash -lc '. .venv/bin/activate && python scripts/business_execution_progress.py'
+
+business-execution-progress-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_progress_contract.py'
+
+business-execution-next: venv
+	@bash -lc '. .venv/bin/activate && python scripts/business_execution_next.py'
+
+business-execution-next-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_next_contract.py'
+
+business-execution-handoff: venv
+	@bash -lc '. .venv/bin/activate && python scripts/business_execution_handoff.py'
+
+business-execution-handoff-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_handoff_contract.py'
+
+business-execution-escalation: venv
+	@bash -lc '. .venv/bin/activate && python scripts/business_execution_escalation.py'
+
+business-execution-escalation-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_escalation_contract.py'
+
+business-execution-followup: venv
+	@bash -lc '. .venv/bin/activate && python scripts/business_execution_followup.py'
+
+business-execution-followup-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_followup_contract.py'
+
+business-execution-continue: venv
+	@bash -lc '. .venv/bin/activate && python scripts/business_execution_continue.py'
+
+business-execution-continue-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_continue_contract.py'
+
+business-execution-horizon: venv
+	@bash -lc '. .venv/bin/activate && python scripts/business_execution_horizon.py'
+
+business-execution-horizon-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_horizon_contract.py'
+
+business-execution-inputs-contract: venv
+	@bash -lc '. .venv/bin/activate && python scripts/check_business_execution_inputs_contract.py'
+
+business-execution-pipeline: venv
+	@bash -lc '. .venv/bin/activate && python scripts/business_execution_pipeline.py --single-operator "$(BUSINESS_EXECUTION_OPERATOR)"'
+
+business-execution-week1-pipeline: business-execution-pipeline
+	@bash -lc 'echo business-execution-week1-pipeline: alias completed'
 
 test: install
 	@bash -lc '. .venv/bin/activate && bash quality.sh test'

--- a/docs/business_execution/index.md
+++ b/docs/business_execution/index.md
@@ -33,3 +33,211 @@ Before merge/use:
 3. KPI threshold owners are named.
 4. First pilot cohort is identified.
 5. Execution checklist has an assigned accountable owner.
+
+## Execute now (week-1 bootstrap)
+
+Generate execution artifacts (JSON + operating memo) instead of staying at planning level:
+
+```bash
+make business-execution-start
+make business-execution-start-contract
+make business-execution-go-gate
+make business-execution-progress
+make business-execution-progress-contract
+make business-execution-next
+make business-execution-next-contract
+make business-execution-handoff
+make business-execution-handoff-contract
+make business-execution-escalation
+make business-execution-escalation-contract
+make business-execution-followup
+make business-execution-followup-contract
+make business-execution-continue
+make business-execution-continue-contract
+make business-execution-horizon
+make business-execution-horizon-contract
+make business-execution-inputs-contract
+make business-execution-pipeline
+make business-execution-week1-pipeline
+```
+
+Default repo operator for make-based business execution commands is `sherif69-sa` (`BUSINESS_EXECUTION_OPERATOR` in Makefile), so one operator owns all generated execution roles unless you override it.
+
+Default runtime outputs are written to:
+- `build/business-execution/business-execution-week1.json`
+- `build/business-execution/business-execution-week1-memo.md`
+- `build/business-execution/business-execution-week1-progress.json`
+- `build/business-execution/business-execution-week1-progress.md`
+- `build/business-execution/business-execution-week1-progress-history.jsonl`
+- `build/business-execution/business-execution-week1-progress-rollup.json`
+- `build/business-execution/business-execution-week1-next.json`
+- `build/business-execution/business-execution-week1-next.md`
+- `build/business-execution/business-execution-handoff.json`
+- `build/business-execution/business-execution-handoff.md`
+- `build/business-execution/business-execution-escalation.json`
+- `build/business-execution/business-execution-escalation.md`
+- `build/business-execution/business-execution-followup.json`
+- `build/business-execution/business-execution-followup.md`
+- `build/business-execution/business-execution-followup-history.jsonl`
+- `build/business-execution/business-execution-followup-rollup.json`
+- `build/business-execution/business-execution-continue.json`
+- `build/business-execution/business-execution-continue.md`
+- `build/business-execution/business-execution-horizon.json`
+- `build/business-execution/business-execution-horizon.md`
+- `build/business-execution/business-execution-inputs.json`
+
+Or run directly with named owners:
+
+```bash
+python scripts/business_execution_start.py \
+  --start-date 2026-04-28 \
+  --program-owner "Founder/GM" \
+  --gtm-owner "GTM Lead" \
+  --commercial-owner "Commercial Lead" \
+  --solutions-owner "Solutions Lead" \
+  --ops-owner "Ops Analyst"
+```
+
+If you want to run everything as a single operator (only you own all actions), use:
+
+```bash
+python scripts/business_execution_start.py --single-operator "Your Name"
+```
+
+Execution status is automatic:
+- `go` when all owners are assigned.
+- `needs-owner-assignment` when one or more owners are still `TBD`.
+
+To fail fast when ownership is incomplete:
+
+```bash
+python scripts/business_execution_start.py --strict-owner-assignment
+```
+
+Generate a day-by-day progress scorecard and gate summary:
+
+```bash
+python scripts/business_execution_progress.py \
+  --done "Confirm owners and operating cadence." \
+  --done "Finalize ICP shortlist."
+```
+
+Progress owner-gate behavior:
+- Default is `--owner-gate-mode relaxed` so execution can continue before all owners are assigned.
+- Use `--owner-gate-mode strict` when you want missing owners to force a `fail` gate.
+
+Validate progress artifact contract:
+
+```bash
+python scripts/check_business_execution_progress_contract.py
+```
+
+Generate prioritized next tasks from progress:
+
+```bash
+python scripts/business_execution_next.py --limit 3
+```
+
+Validate next-actions contract:
+
+```bash
+python scripts/check_business_execution_next_contract.py
+```
+
+Generate an executive handoff summary:
+
+```bash
+python scripts/business_execution_handoff.py
+```
+
+Validate handoff contract:
+
+```bash
+python scripts/check_business_execution_handoff_contract.py
+```
+
+Generate execution escalation snapshot:
+
+```bash
+python scripts/business_execution_escalation.py
+```
+
+Validate escalation contract:
+
+```bash
+python scripts/check_business_execution_escalation_contract.py
+```
+
+Generate continuous follow-up actions (so execution keeps moving between checkpoints):
+
+```bash
+python scripts/business_execution_followup.py
+```
+
+This command also appends follow-up history, refreshes a rollup summary, and computes `next_checkpoint_at`, `checkpoint_status`, `checkpoint_due_in_hours`, and `checkpoint_command` so continuity can be tracked over time.
+
+Validate follow-up contract:
+
+```bash
+python scripts/check_business_execution_followup_contract.py
+```
+
+Generate the next command decision artifact from follow-up:
+
+```bash
+python scripts/business_execution_continue.py
+```
+
+Validate continue-decision contract:
+
+```bash
+python scripts/check_business_execution_continue_contract.py
+```
+
+Generate week-2 and day-90 horizon plan:
+
+```bash
+python scripts/business_execution_horizon.py
+```
+
+Validate horizon-plan contract:
+
+```bash
+python scripts/check_business_execution_horizon_contract.py
+```
+
+Run the full pipeline (all generation + all contracts) in one command:
+
+```bash
+python scripts/business_execution_pipeline.py
+```
+
+Single-operator pipeline mode:
+
+```bash
+python scripts/business_execution_pipeline.py --single-operator "Your Name"
+```
+
+Repository code ownership is mapped to `@sherif69-sa` for all files via `.github/CODEOWNERS`.
+
+Attach external execution inputs (prompt + guidelines bundle) with traceable hashes:
+
+```bash
+python scripts/business_execution_pipeline.py \
+  --challenge-prompt workflow_execution_prompt.md \
+  --guidelines-zip workflow_execution_guidelines_bundle.zip
+```
+
+If those canonical filenames are present in the current working directory, the pipeline auto-discovers them and attaches them without extra flags.
+
+Input bundle policy:
+- Markdown input records heading + line count metadata.
+- Guidelines zip records entry count + preview.
+- Zip bundles with more than 25 files are rejected by the pipeline.
+- External inputs must be supplied as a pair (prompt + zip) for reproducible runs.
+
+Validate input manifest contract directly:
+
+```bash
+python scripts/check_business_execution_inputs_contract.py
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ dev = [
   "build==1.4.4",
   "mypy==1.20.2",
   "pre-commit==4.6.0",
-  "ruff==0.15.12",
+  "ruff==0.15.11",
   "twine==6.2.0"
 ]
 test = [
-  "hypothesis==6.152.3",
+  "hypothesis==6.152.2",
   "PyYAML",
   "pytest",
   "pytest-asyncio",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,9 +3,9 @@ pygments==2.20.0
 pytest-cov==7.1.0
 pytest-asyncio==1.3.0
 pytest-xdist[psutil]==3.8.0
-hypothesis==6.152.3
+hypothesis==6.152.2
 PyYAML==6.0.3
 httpx==0.28.1
-ruff==0.15.12
+ruff==0.15.11
 mypy==1.20.2
 mutmut==3.5.0

--- a/scripts/business_execution_continue.py
+++ b/scripts/business_execution_continue.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.business-execution-continue.v1"
+
+
+def build_continue_payload(followup: dict[str, Any]) -> dict[str, Any]:
+    checkpoint_status = str(followup.get("checkpoint_status", "on-track"))
+    keep_moving = bool(followup.get("keep_moving", True))
+    recommended = str(followup.get("recommended_command", "make business-execution-pipeline"))
+    checkpoint_command = str(followup.get("checkpoint_command", "make business-execution-followup"))
+
+    if checkpoint_status == "due":
+        selected_command = checkpoint_command
+        reason = "Checkpoint is due now; run checkpoint command immediately."
+        should_run_now = True
+    elif keep_moving:
+        selected_command = recommended
+        reason = "Execution should keep moving; run recommended command."
+        should_run_now = True
+    else:
+        selected_command = checkpoint_command
+        reason = "No immediate movement required; keep checkpoint command ready."
+        should_run_now = False
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "checkpoint_status": checkpoint_status,
+        "keep_moving": keep_moving,
+        "selected_command": selected_command,
+        "reason": reason,
+        "should_run_now": should_run_now,
+    }
+
+
+def render_continue_md(payload: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "# Business Execution Continue Command",
+            "",
+            f"- Checkpoint status: {payload.get('checkpoint_status')}",
+            f"- Keep moving: {payload.get('keep_moving')}",
+            f"- Should run now: {payload.get('should_run_now')}",
+            f"- Reason: {payload.get('reason')}",
+            "",
+            "## Selected command",
+            f"`{payload.get('selected_command')}`",
+            "",
+        ]
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Select the next execution command from follow-up artifact.")
+    parser.add_argument("--followup", default="build/business-execution/business-execution-followup.json")
+    parser.add_argument("--out-json", default="build/business-execution/business-execution-continue.json")
+    parser.add_argument("--out-md", default="build/business-execution/business-execution-continue.md")
+    args = parser.parse_args(argv)
+
+    followup = json.loads(Path(args.followup).read_text(encoding="utf-8"))
+    payload = build_continue_payload(followup)
+
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(render_continue_md(payload), encoding="utf-8")
+
+    print(f"business-execution-continue: wrote {out_json} and {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/business_execution_continue.py
+++ b/scripts/business_execution_continue.py
@@ -56,10 +56,18 @@ def render_continue_md(payload: dict[str, Any]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Select the next execution command from follow-up artifact.")
-    parser.add_argument("--followup", default="build/business-execution/business-execution-followup.json")
-    parser.add_argument("--out-json", default="build/business-execution/business-execution-continue.json")
-    parser.add_argument("--out-md", default="build/business-execution/business-execution-continue.md")
+    parser = argparse.ArgumentParser(
+        description="Select the next execution command from follow-up artifact."
+    )
+    parser.add_argument(
+        "--followup", default="build/business-execution/business-execution-followup.json"
+    )
+    parser.add_argument(
+        "--out-json", default="build/business-execution/business-execution-continue.json"
+    )
+    parser.add_argument(
+        "--out-md", default="build/business-execution/business-execution-continue.md"
+    )
     args = parser.parse_args(argv)
 
     followup = json.loads(Path(args.followup).read_text(encoding="utf-8"))

--- a/scripts/business_execution_escalation.py
+++ b/scripts/business_execution_escalation.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.business-execution-escalation.v1"
+
+
+def build_escalation_payload(
+    week1: dict[str, Any],
+    progress: dict[str, Any],
+    next_payload: dict[str, Any],
+    handoff: dict[str, Any],
+) -> dict[str, Any]:
+    week1_status = str(week1.get("status", "needs-owner-assignment"))
+    gate = str(progress.get("gate_decision", {}).get("status", "fail"))
+    completion = float(progress.get("task_summary", {}).get("completion_percent", 0.0))
+    pending_tasks = [task for task in next_payload.get("next_tasks", []) if isinstance(task, str)]
+    owners = week1.get("owners", week1.get("owner_assignments", {}))
+
+    reasons: list[str] = []
+    decision = "none"
+    if week1_status != "go":
+        decision = "watch"
+        reasons.append("Week-1 owners are not fully assigned yet.")
+    if gate == "fail":
+        decision = "escalate"
+        reasons.append("Execution gate is failing.")
+    elif gate == "conditional-pass" and decision != "escalate":
+        decision = "watch"
+        reasons.append("Execution is in progress and requires daily follow-up.")
+    if completion < 50 and decision != "escalate":
+        decision = "watch"
+        reasons.append("Completion is below 50 percent.")
+
+    owners_to_ping: list[str] = []
+    if isinstance(owners, dict):
+        owners_to_ping = [
+            str(owner).strip()
+            for owner in owners.values()
+            if isinstance(owner, str) and str(owner).strip() and str(owner).strip().upper() != "TBD"
+        ]
+    if decision == "escalate" and not owners_to_ping:
+        owners_to_ping = ["Program Owner"]
+
+    recommended_actions: list[str] = []
+    if decision == "escalate":
+        recommended_actions = [
+            "Assign all missing owners immediately.",
+            "Run `make business-execution-go-gate` after owner updates.",
+            "Review and execute the top pending tasks today.",
+        ]
+    elif decision == "watch":
+        recommended_actions = [
+            "Close the top pending tasks by end of day.",
+            "Refresh progress and handoff artifacts.",
+        ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "week1_status": week1_status,
+        "progress_gate": gate,
+        "completion_percent": completion,
+        "handoff_recommended_command": handoff.get("recommended_command"),
+        "pending_count": len(pending_tasks),
+        "pending_tasks": pending_tasks,
+        "decision": decision,
+        "reasons": reasons,
+        "owners_to_ping": owners_to_ping,
+        "recommended_actions": recommended_actions,
+    }
+
+
+def render_escalation_md(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Business Execution Escalation",
+        "",
+        f"- Decision: {payload.get('decision')}",
+        f"- Week-1 status: {payload.get('week1_status')}",
+        f"- Progress gate: {payload.get('progress_gate')}",
+        f"- Completion percent: {payload.get('completion_percent')}",
+        f"- Pending tasks: {payload.get('pending_count')}",
+        "",
+        "## Reasons",
+    ]
+    reasons = payload.get("reasons") or []
+    if reasons:
+        for reason in reasons:
+            lines.append(f"- {reason}")
+    else:
+        lines.append("- No escalation reasons.")
+    lines.extend(["", "## Owners to ping"])
+    owners = payload.get("owners_to_ping") or []
+    if owners:
+        for owner in owners:
+            lines.append(f"- {owner}")
+    else:
+        lines.append("- None")
+    lines.extend(["", "## Recommended actions"])
+    actions = payload.get("recommended_actions") or []
+    if actions:
+        for action in actions:
+            lines.append(f"- [ ] {action}")
+    else:
+        lines.append("- No immediate escalation actions.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate business execution escalation artifact.")
+    parser.add_argument("--week1", default="build/business-execution/business-execution-week1.json")
+    parser.add_argument("--progress", default="build/business-execution/business-execution-week1-progress.json")
+    parser.add_argument("--next", dest="next_json", default="build/business-execution/business-execution-week1-next.json")
+    parser.add_argument("--handoff", default="build/business-execution/business-execution-handoff.json")
+    parser.add_argument("--out-json", default="build/business-execution/business-execution-escalation.json")
+    parser.add_argument("--out-md", default="build/business-execution/business-execution-escalation.md")
+    args = parser.parse_args(argv)
+
+    week1 = json.loads(Path(args.week1).read_text(encoding="utf-8"))
+    progress = json.loads(Path(args.progress).read_text(encoding="utf-8"))
+    next_payload = json.loads(Path(args.next_json).read_text(encoding="utf-8"))
+    handoff = json.loads(Path(args.handoff).read_text(encoding="utf-8"))
+    payload = build_escalation_payload(week1, progress, next_payload, handoff)
+
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(render_escalation_md(payload), encoding="utf-8")
+
+    print(f"business-execution-escalation: wrote {out_json} and {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/business_execution_escalation.py
+++ b/scripts/business_execution_escalation.py
@@ -113,11 +113,23 @@ def render_escalation_md(payload: dict[str, Any]) -> str:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Generate business execution escalation artifact.")
     parser.add_argument("--week1", default="build/business-execution/business-execution-week1.json")
-    parser.add_argument("--progress", default="build/business-execution/business-execution-week1-progress.json")
-    parser.add_argument("--next", dest="next_json", default="build/business-execution/business-execution-week1-next.json")
-    parser.add_argument("--handoff", default="build/business-execution/business-execution-handoff.json")
-    parser.add_argument("--out-json", default="build/business-execution/business-execution-escalation.json")
-    parser.add_argument("--out-md", default="build/business-execution/business-execution-escalation.md")
+    parser.add_argument(
+        "--progress", default="build/business-execution/business-execution-week1-progress.json"
+    )
+    parser.add_argument(
+        "--next",
+        dest="next_json",
+        default="build/business-execution/business-execution-week1-next.json",
+    )
+    parser.add_argument(
+        "--handoff", default="build/business-execution/business-execution-handoff.json"
+    )
+    parser.add_argument(
+        "--out-json", default="build/business-execution/business-execution-escalation.json"
+    )
+    parser.add_argument(
+        "--out-md", default="build/business-execution/business-execution-escalation.md"
+    )
     args = parser.parse_args(argv)
 
     week1 = json.loads(Path(args.week1).read_text(encoding="utf-8"))

--- a/scripts/business_execution_followup.py
+++ b/scripts/business_execution_followup.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.business-execution-followup.v1"
+
+
+def build_followup_payload(
+    progress: dict[str, Any],
+    next_payload: dict[str, Any],
+    escalation: dict[str, Any],
+    window_hours: int,
+) -> dict[str, Any]:
+    gate_status = str(progress.get("gate_decision", {}).get("status", "conditional-pass"))
+    escalation_decision = str(escalation.get("decision", "watch"))
+    next_tasks = [task for task in next_payload.get("next_tasks", []) if isinstance(task, str)]
+    immediate_actions = [f"Complete: {task}" for task in next_tasks]
+
+    if escalation_decision == "escalate":
+        immediate_actions.extend(
+            [
+                "Review escalation reasons with the operator now.",
+                "Execute escalation recommended actions before next checkpoint.",
+            ]
+        )
+    if not immediate_actions:
+        immediate_actions.append("No pending tasks. Keep monitoring execution health.")
+
+    keep_moving = gate_status in {"conditional-pass", "fail"} or escalation_decision in {"watch", "escalate"}
+    recommended_command = next_payload.get("recommended_command")
+    if not isinstance(recommended_command, str) or not recommended_command.strip():
+        recommended_command = "make business-execution-pipeline"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "progress_gate": gate_status,
+        "escalation_decision": escalation_decision,
+        "window_hours": max(1, window_hours),
+        "pending_count": len(next_tasks),
+        "next_tasks": next_tasks,
+        "immediate_actions": immediate_actions,
+        "recommended_command": recommended_command,
+        "keep_moving": keep_moving,
+    }
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(json.loads(line))
+    return rows
+
+
+def render_followup_md(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Business Execution Follow-up Loop",
+        "",
+        f"- Progress gate: {payload.get('progress_gate')}",
+        f"- Escalation decision: {payload.get('escalation_decision')}",
+        f"- Follow-up window (hours): {payload.get('window_hours')}",
+        f"- Pending tasks: {payload.get('pending_count')}",
+        f"- Keep moving: {payload.get('keep_moving')}",
+        f"- Next checkpoint: {payload.get('next_checkpoint_at')}",
+        f"- Checkpoint status: {payload.get('checkpoint_status')}",
+        f"- Checkpoint due in (hours): {payload.get('checkpoint_due_in_hours')}",
+        f"- Checkpoint command: {payload.get('checkpoint_command')}",
+        "",
+        "## Immediate actions",
+    ]
+    for action in payload.get("immediate_actions", []):
+        lines.append(f"- [ ] {action}")
+    lines.extend(["", "## Recommended command", f"`{payload.get('recommended_command')}`", ""])
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate continuous follow-up actions from current execution artifacts.")
+    parser.add_argument("--progress", default="build/business-execution/business-execution-week1-progress.json")
+    parser.add_argument("--next", dest="next_json", default="build/business-execution/business-execution-week1-next.json")
+    parser.add_argument("--escalation", default="build/business-execution/business-execution-escalation.json")
+    parser.add_argument("--window-hours", type=int, default=24)
+    parser.add_argument(
+        "--history",
+        default="build/business-execution/business-execution-followup-history.jsonl",
+        help="Append follow-up snapshots as JSONL events.",
+    )
+    parser.add_argument(
+        "--history-rollup-out",
+        default="build/business-execution/business-execution-followup-rollup.json",
+        help="Write follow-up history rollup summary.",
+    )
+    parser.add_argument("--out-json", default="build/business-execution/business-execution-followup.json")
+    parser.add_argument("--out-md", default="build/business-execution/business-execution-followup.md")
+    args = parser.parse_args(argv)
+
+    progress = json.loads(Path(args.progress).read_text(encoding="utf-8"))
+    next_payload = json.loads(Path(args.next_json).read_text(encoding="utf-8"))
+    escalation = json.loads(Path(args.escalation).read_text(encoding="utf-8"))
+    payload = build_followup_payload(progress, next_payload, escalation, window_hours=args.window_hours)
+
+    history_path = Path(args.history)
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    history_event = {
+        "recorded_at": datetime.now(UTC).isoformat(),
+        "progress_gate": payload["progress_gate"],
+        "escalation_decision": payload["escalation_decision"],
+        "pending_count": payload["pending_count"],
+        "keep_moving": payload["keep_moving"],
+    }
+    with history_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(history_event) + "\n")
+
+    history_rows = _load_jsonl(history_path)
+    decision_counts: dict[str, int] = {"none": 0, "watch": 0, "escalate": 0}
+    for row in history_rows:
+        decision = str(row.get("escalation_decision", ""))
+        if decision in decision_counts:
+            decision_counts[decision] += 1
+    payload["history_records"] = len(history_rows)
+    payload["decision_counts"] = decision_counts
+    payload["latest_recorded_at"] = history_rows[-1]["recorded_at"] if history_rows else None
+    latest_recorded_at = payload["latest_recorded_at"]
+    if isinstance(latest_recorded_at, str):
+        latest_dt = datetime.fromisoformat(latest_recorded_at)
+        next_checkpoint_dt = latest_dt + timedelta(hours=payload["window_hours"])
+        payload["next_checkpoint_at"] = next_checkpoint_dt.isoformat()
+        now_utc = datetime.now(UTC)
+        due_in_hours = round((next_checkpoint_dt - now_utc).total_seconds() / 3600, 2)
+        payload["checkpoint_due_in_hours"] = due_in_hours
+        if now_utc >= next_checkpoint_dt:
+            payload["checkpoint_status"] = "due"
+            payload["checkpoint_command"] = "make business-execution-followup"
+        else:
+            payload["checkpoint_status"] = "on-track"
+            payload["checkpoint_command"] = "make business-execution-followup"
+    else:
+        payload["next_checkpoint_at"] = None
+        payload["checkpoint_status"] = "on-track"
+        payload["checkpoint_due_in_hours"] = float(payload["window_hours"])
+        payload["checkpoint_command"] = "make business-execution-followup"
+
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(render_followup_md(payload), encoding="utf-8")
+
+    rollup = {
+        "schema_version": "sdetkit.business-execution-followup-rollup.v1",
+        "history_records": len(history_rows),
+        "decision_counts": decision_counts,
+        "latest": history_rows[-1] if history_rows else None,
+        "next_checkpoint_at": payload["next_checkpoint_at"],
+        "checkpoint_status": payload["checkpoint_status"],
+        "checkpoint_due_in_hours": payload["checkpoint_due_in_hours"],
+        "checkpoint_command": payload["checkpoint_command"],
+    }
+    rollup_path = Path(args.history_rollup_out)
+    rollup_path.parent.mkdir(parents=True, exist_ok=True)
+    rollup_path.write_text(json.dumps(rollup, indent=2) + "\n", encoding="utf-8")
+
+    print(f"business-execution-followup: wrote {out_json} and {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/business_execution_followup.py
+++ b/scripts/business_execution_followup.py
@@ -31,7 +31,10 @@ def build_followup_payload(
     if not immediate_actions:
         immediate_actions.append("No pending tasks. Keep monitoring execution health.")
 
-    keep_moving = gate_status in {"conditional-pass", "fail"} or escalation_decision in {"watch", "escalate"}
+    keep_moving = gate_status in {"conditional-pass", "fail"} or escalation_decision in {
+        "watch",
+        "escalate",
+    }
     recommended_command = next_payload.get("recommended_command")
     if not isinstance(recommended_command, str) or not recommended_command.strip():
         recommended_command = "make business-execution-pipeline"
@@ -84,10 +87,20 @@ def render_followup_md(payload: dict[str, Any]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Generate continuous follow-up actions from current execution artifacts.")
-    parser.add_argument("--progress", default="build/business-execution/business-execution-week1-progress.json")
-    parser.add_argument("--next", dest="next_json", default="build/business-execution/business-execution-week1-next.json")
-    parser.add_argument("--escalation", default="build/business-execution/business-execution-escalation.json")
+    parser = argparse.ArgumentParser(
+        description="Generate continuous follow-up actions from current execution artifacts."
+    )
+    parser.add_argument(
+        "--progress", default="build/business-execution/business-execution-week1-progress.json"
+    )
+    parser.add_argument(
+        "--next",
+        dest="next_json",
+        default="build/business-execution/business-execution-week1-next.json",
+    )
+    parser.add_argument(
+        "--escalation", default="build/business-execution/business-execution-escalation.json"
+    )
     parser.add_argument("--window-hours", type=int, default=24)
     parser.add_argument(
         "--history",
@@ -99,14 +112,20 @@ def main(argv: list[str] | None = None) -> int:
         default="build/business-execution/business-execution-followup-rollup.json",
         help="Write follow-up history rollup summary.",
     )
-    parser.add_argument("--out-json", default="build/business-execution/business-execution-followup.json")
-    parser.add_argument("--out-md", default="build/business-execution/business-execution-followup.md")
+    parser.add_argument(
+        "--out-json", default="build/business-execution/business-execution-followup.json"
+    )
+    parser.add_argument(
+        "--out-md", default="build/business-execution/business-execution-followup.md"
+    )
     args = parser.parse_args(argv)
 
     progress = json.loads(Path(args.progress).read_text(encoding="utf-8"))
     next_payload = json.loads(Path(args.next_json).read_text(encoding="utf-8"))
     escalation = json.loads(Path(args.escalation).read_text(encoding="utf-8"))
-    payload = build_followup_payload(progress, next_payload, escalation, window_hours=args.window_hours)
+    payload = build_followup_payload(
+        progress, next_payload, escalation, window_hours=args.window_hours
+    )
 
     history_path = Path(args.history)
     history_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/business_execution_handoff.py
+++ b/scripts/business_execution_handoff.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.business-execution-handoff.v1"
+
+
+def build_handoff(
+    week1: dict[str, Any],
+    progress: dict[str, Any],
+    rollup: dict[str, Any],
+    next_payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "week1_status": week1.get("status"),
+        "week1_start_date": week1.get("start_date"),
+        "progress_gate": progress.get("gate_decision", {}).get("status"),
+        "progress_completion_percent": progress.get("task_summary", {}).get("completion_percent"),
+        "history_records": rollup.get("history_records"),
+        "latest_gate_counts": rollup.get("gate_counts"),
+        "next_tasks": next_payload.get("next_tasks", []),
+        "recommended_command": next_payload.get("recommended_command"),
+    }
+
+
+def render_handoff_md(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Business Execution Handoff Summary",
+        "",
+        f"- Week-1 status: {payload.get('week1_status')}",
+        f"- Week-1 start date: {payload.get('week1_start_date')}",
+        f"- Progress gate: {payload.get('progress_gate')}",
+        f"- Completion percent: {payload.get('progress_completion_percent')}",
+        f"- History records: {payload.get('history_records')}",
+        "",
+        "## Gate counts",
+    ]
+    for gate, count in (payload.get("latest_gate_counts") or {}).items():
+        lines.append(f"- {gate}: {count}")
+    lines.append("")
+    lines.append("## Next tasks")
+    tasks = payload.get("next_tasks") or []
+    if not tasks:
+        lines.append("- No pending tasks.")
+    else:
+        for task in tasks:
+            lines.append(f"- [ ] {task}")
+    lines.append("")
+    if payload.get("recommended_command"):
+        lines.append("## Recommended command")
+        lines.append(f"`{payload['recommended_command']}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build business execution handoff summary from generated artifacts.")
+    parser.add_argument("--week1", default="build/business-execution/business-execution-week1.json")
+    parser.add_argument("--progress", default="build/business-execution/business-execution-week1-progress.json")
+    parser.add_argument(
+        "--rollup",
+        default="build/business-execution/business-execution-week1-progress-rollup.json",
+    )
+    parser.add_argument("--next", dest="next_json", default="build/business-execution/business-execution-week1-next.json")
+    parser.add_argument("--out-json", default="build/business-execution/business-execution-handoff.json")
+    parser.add_argument("--out-md", default="build/business-execution/business-execution-handoff.md")
+    args = parser.parse_args(argv)
+
+    week1 = json.loads(Path(args.week1).read_text(encoding="utf-8"))
+    progress = json.loads(Path(args.progress).read_text(encoding="utf-8"))
+    rollup = json.loads(Path(args.rollup).read_text(encoding="utf-8"))
+    next_payload = json.loads(Path(args.next_json).read_text(encoding="utf-8"))
+    payload = build_handoff(week1, progress, rollup, next_payload)
+
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(render_handoff_md(payload), encoding="utf-8")
+
+    print(f"business-execution-handoff: wrote {out_json} and {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/business_execution_handoff.py
+++ b/scripts/business_execution_handoff.py
@@ -59,16 +59,28 @@ def render_handoff_md(payload: dict[str, Any]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Build business execution handoff summary from generated artifacts.")
+    parser = argparse.ArgumentParser(
+        description="Build business execution handoff summary from generated artifacts."
+    )
     parser.add_argument("--week1", default="build/business-execution/business-execution-week1.json")
-    parser.add_argument("--progress", default="build/business-execution/business-execution-week1-progress.json")
+    parser.add_argument(
+        "--progress", default="build/business-execution/business-execution-week1-progress.json"
+    )
     parser.add_argument(
         "--rollup",
         default="build/business-execution/business-execution-week1-progress-rollup.json",
     )
-    parser.add_argument("--next", dest="next_json", default="build/business-execution/business-execution-week1-next.json")
-    parser.add_argument("--out-json", default="build/business-execution/business-execution-handoff.json")
-    parser.add_argument("--out-md", default="build/business-execution/business-execution-handoff.md")
+    parser.add_argument(
+        "--next",
+        dest="next_json",
+        default="build/business-execution/business-execution-week1-next.json",
+    )
+    parser.add_argument(
+        "--out-json", default="build/business-execution/business-execution-handoff.json"
+    )
+    parser.add_argument(
+        "--out-md", default="build/business-execution/business-execution-handoff.md"
+    )
     args = parser.parse_args(argv)
 
     week1 = json.loads(Path(args.week1).read_text(encoding="utf-8"))

--- a/scripts/business_execution_horizon.py
+++ b/scripts/business_execution_horizon.py
@@ -86,12 +86,22 @@ def render_horizon_md(payload: dict[str, Any]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Generate week-2 and day-90 execution horizon plan.")
+    parser = argparse.ArgumentParser(
+        description="Generate week-2 and day-90 execution horizon plan."
+    )
     parser.add_argument("--week1", default="build/business-execution/business-execution-week1.json")
-    parser.add_argument("--progress", default="build/business-execution/business-execution-week1-progress.json")
-    parser.add_argument("--followup", default="build/business-execution/business-execution-followup.json")
-    parser.add_argument("--out-json", default="build/business-execution/business-execution-horizon.json")
-    parser.add_argument("--out-md", default="build/business-execution/business-execution-horizon.md")
+    parser.add_argument(
+        "--progress", default="build/business-execution/business-execution-week1-progress.json"
+    )
+    parser.add_argument(
+        "--followup", default="build/business-execution/business-execution-followup.json"
+    )
+    parser.add_argument(
+        "--out-json", default="build/business-execution/business-execution-horizon.json"
+    )
+    parser.add_argument(
+        "--out-md", default="build/business-execution/business-execution-horizon.md"
+    )
     args = parser.parse_args(argv)
 
     week1 = json.loads(Path(args.week1).read_text(encoding="utf-8"))

--- a/scripts/business_execution_horizon.py
+++ b/scripts/business_execution_horizon.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.business-execution-horizon.v1"
+
+
+def build_horizon_payload(
+    week1: dict[str, Any],
+    progress: dict[str, Any],
+    followup: dict[str, Any],
+) -> dict[str, Any]:
+    completed = int(progress.get("task_summary", {}).get("completed", 0))
+    completion_percent = float(progress.get("task_summary", {}).get("completion_percent", 0.0))
+    focus_mode = "execution-acceleration" if completed >= 3 else "foundation-build"
+
+    week_2_plan = {
+        "day_6_7": [
+            "Close remaining week-1 execution tasks.",
+            "Baseline KPI dashboard with first live numbers.",
+        ],
+        "day_8_10": [
+            "Run two design-partner discovery sessions.",
+            "Capture blockers and update operating memo.",
+        ],
+        "day_11_14": [
+            "Finalize pilot charter and commercial guardrails.",
+            "Publish week-2 review with go-forward priorities.",
+        ],
+    }
+    day_90_plan = {
+        "day_30": [
+            "Pilot execution stable with weekly KPI reviews.",
+            "Validated ICP shortlist with conversion evidence.",
+        ],
+        "day_60": [
+            "Two to three active pilots with measured time-to-value.",
+            "Commercial packaging v1 validated by pilot outcomes.",
+        ],
+        "day_90": [
+            "Pilot-to-paid conversion path established.",
+            "Quarter roadmap and hiring/ops priorities locked.",
+        ],
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "week1_status": week1.get("status"),
+        "progress_gate": progress.get("gate_decision", {}).get("status"),
+        "completion_percent": completion_percent,
+        "followup_checkpoint_status": followup.get("checkpoint_status"),
+        "focus_mode": focus_mode,
+        "week_2_plan": week_2_plan,
+        "day_90_plan": day_90_plan,
+    }
+
+
+def render_horizon_md(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Business Execution Horizon Plan (Week-2 + Day-90)",
+        "",
+        f"- Week-1 status: {payload.get('week1_status')}",
+        f"- Progress gate: {payload.get('progress_gate')}",
+        f"- Completion percent: {payload.get('completion_percent')}",
+        f"- Follow-up checkpoint: {payload.get('followup_checkpoint_status')}",
+        f"- Focus mode: {payload.get('focus_mode')}",
+        "",
+        "## Week-2 plan",
+    ]
+    for bucket, items in (payload.get("week_2_plan") or {}).items():
+        lines.append(f"### {bucket}")
+        for item in items:
+            lines.append(f"- [ ] {item}")
+        lines.append("")
+    lines.append("## Day-90 plan")
+    for bucket, items in (payload.get("day_90_plan") or {}).items():
+        lines.append(f"### {bucket}")
+        for item in items:
+            lines.append(f"- [ ] {item}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate week-2 and day-90 execution horizon plan.")
+    parser.add_argument("--week1", default="build/business-execution/business-execution-week1.json")
+    parser.add_argument("--progress", default="build/business-execution/business-execution-week1-progress.json")
+    parser.add_argument("--followup", default="build/business-execution/business-execution-followup.json")
+    parser.add_argument("--out-json", default="build/business-execution/business-execution-horizon.json")
+    parser.add_argument("--out-md", default="build/business-execution/business-execution-horizon.md")
+    args = parser.parse_args(argv)
+
+    week1 = json.loads(Path(args.week1).read_text(encoding="utf-8"))
+    progress = json.loads(Path(args.progress).read_text(encoding="utf-8"))
+    followup = json.loads(Path(args.followup).read_text(encoding="utf-8"))
+    payload = build_horizon_payload(week1, progress, followup)
+
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(render_horizon_md(payload), encoding="utf-8")
+
+    print(f"business-execution-horizon: wrote {out_json} and {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/business_execution_next.py
+++ b/scripts/business_execution_next.py
@@ -52,7 +52,9 @@ def render_next_md(payload: dict[str, Any]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Generate concrete next actions from week-1 progress artifact.")
+    parser = argparse.ArgumentParser(
+        description="Generate concrete next actions from week-1 progress artifact."
+    )
     parser.add_argument(
         "--progress",
         default="build/business-execution/business-execution-week1-progress.json",

--- a/scripts/business_execution_next.py
+++ b/scripts/business_execution_next.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.business-execution-next.v1"
+
+
+def build_next_payload(progress_payload: dict[str, Any], limit: int) -> dict[str, Any]:
+    tasks = progress_payload.get("tasks", [])
+    pending = [row["task"] for row in tasks if isinstance(row, dict) and not row.get("done", False)]
+    selected = pending[: max(0, limit)]
+    command = None
+    if selected:
+        command = "python scripts/business_execution_progress.py " + " ".join(
+            f'--done "{task}"' for task in selected
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_schema_version": progress_payload.get("schema_version"),
+        "gate_status": progress_payload.get("gate_decision", {}).get("status"),
+        "pending_count": len(pending),
+        "next_tasks": selected,
+        "recommended_command": command,
+    }
+
+
+def render_next_md(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Business Execution Next Actions",
+        "",
+        f"- Gate status: {payload.get('gate_status')}",
+        f"- Pending tasks: {payload.get('pending_count')}",
+        "",
+        "## Suggested next tasks",
+    ]
+    tasks = payload.get("next_tasks", [])
+    if not tasks:
+        lines.append("- No pending tasks.")
+    else:
+        for task in tasks:
+            lines.append(f"- [ ] {task}")
+    lines.append("")
+    if payload.get("recommended_command"):
+        lines.append("## Suggested command")
+        lines.append(f"`{payload['recommended_command']}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate concrete next actions from week-1 progress artifact.")
+    parser.add_argument(
+        "--progress",
+        default="build/business-execution/business-execution-week1-progress.json",
+    )
+    parser.add_argument("--limit", type=int, default=3)
+    parser.add_argument(
+        "--out-json",
+        default="build/business-execution/business-execution-week1-next.json",
+    )
+    parser.add_argument(
+        "--out-md",
+        default="build/business-execution/business-execution-week1-next.md",
+    )
+    args = parser.parse_args(argv)
+
+    progress_payload = json.loads(Path(args.progress).read_text(encoding="utf-8"))
+    next_payload = build_next_payload(progress_payload, args.limit)
+
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(next_payload, indent=2) + "\n", encoding="utf-8")
+
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(render_next_md(next_payload), encoding="utf-8")
+
+    print(f"business-execution-next: wrote {out_json} and {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/business_execution_pipeline.py
+++ b/scripts/business_execution_pipeline.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+
+DEFAULT_CHALLENGE_PROMPT = "workflow_execution_prompt.md"
+DEFAULT_GUIDELINES_ZIP = "workflow_execution_guidelines_bundle.zip"
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _script(name: str) -> str:
+    return str(SCRIPT_DIR / name)
+
+
+def _run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def _file_meta(path: Path) -> dict[str, object]:
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    payload: dict[str, object] = {
+        "path": str(path),
+        "size_bytes": path.stat().st_size,
+        "sha256": digest,
+    }
+    if path.suffix.lower() == ".md":
+        text = path.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        heading = next((line.strip("# ").strip() for line in lines if line.startswith("#")), None)
+        payload["line_count"] = len(lines)
+        payload["first_heading"] = heading
+    if path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(path) as zf:
+            names = [name for name in zf.namelist() if not name.endswith("/")]
+        payload["entry_count"] = len(names)
+        payload["entries_preview"] = names[:10]
+        if len(names) > 25:
+            raise ValueError(f"Zip entry_count {len(names)} exceeds max25 policy")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run business execution week-1 pipeline end-to-end.")
+    parser.add_argument("--out-dir", default="build/business-execution")
+    parser.add_argument("--start-date", default=None)
+    parser.add_argument("--program-owner", default=None)
+    parser.add_argument("--gtm-owner", default=None)
+    parser.add_argument("--commercial-owner", default=None)
+    parser.add_argument("--solutions-owner", default=None)
+    parser.add_argument("--ops-owner", default=None)
+    parser.add_argument(
+        "--single-operator",
+        default=None,
+        help="Assign one operator to all owner roles in the week-1 bootstrap.",
+    )
+    parser.add_argument("--done", action="append", default=[])
+    parser.add_argument("--challenge-prompt", default=None, help="Optional path to challenge prompt markdown.")
+    parser.add_argument("--guidelines-zip", default=None, help="Optional path to aligned guidelines zip.")
+    args = parser.parse_args(argv)
+
+    challenge_prompt = args.challenge_prompt
+    guidelines_zip = args.guidelines_zip
+
+    # Auto-discover canonical input files to support a one-command execution path.
+    if not challenge_prompt and Path(DEFAULT_CHALLENGE_PROMPT).exists():
+        challenge_prompt = DEFAULT_CHALLENGE_PROMPT
+    if not guidelines_zip and Path(DEFAULT_GUIDELINES_ZIP).exists():
+        guidelines_zip = DEFAULT_GUIDELINES_ZIP
+
+    if bool(challenge_prompt) ^ bool(guidelines_zip):
+        raise ValueError(
+            "External input policy requires both --challenge-prompt and --guidelines-zip together"
+        )
+
+    out_dir = Path(args.out_dir)
+    week1_json = out_dir / "business-execution-week1.json"
+    week1_memo = out_dir / "business-execution-week1-memo.md"
+    progress_json = out_dir / "business-execution-week1-progress.json"
+    progress_md = out_dir / "business-execution-week1-progress.md"
+    history_jsonl = out_dir / "business-execution-week1-progress-history.jsonl"
+    rollup_json = out_dir / "business-execution-week1-progress-rollup.json"
+    next_json = out_dir / "business-execution-week1-next.json"
+    next_md = out_dir / "business-execution-week1-next.md"
+    handoff_json = out_dir / "business-execution-handoff.json"
+    handoff_md = out_dir / "business-execution-handoff.md"
+    escalation_json = out_dir / "business-execution-escalation.json"
+    escalation_md = out_dir / "business-execution-escalation.md"
+    followup_json = out_dir / "business-execution-followup.json"
+    followup_md = out_dir / "business-execution-followup.md"
+    followup_history_jsonl = out_dir / "business-execution-followup-history.jsonl"
+    followup_rollup_json = out_dir / "business-execution-followup-rollup.json"
+    continue_json = out_dir / "business-execution-continue.json"
+    continue_md = out_dir / "business-execution-continue.md"
+    horizon_json = out_dir / "business-execution-horizon.json"
+    horizon_md = out_dir / "business-execution-horizon.md"
+    inputs_json = out_dir / "business-execution-inputs.json"
+
+    if challenge_prompt and not Path(challenge_prompt).exists():
+        raise FileNotFoundError(f"Missing --challenge-prompt file: {challenge_prompt}")
+    if guidelines_zip and not Path(guidelines_zip).exists():
+        raise FileNotFoundError(f"Missing --guidelines-zip file: {guidelines_zip}")
+
+    input_manifest = {
+        "schema_version": "sdetkit.business-execution-inputs.v1",
+        "challenge_prompt": _file_meta(Path(challenge_prompt)) if challenge_prompt else None,
+        "guidelines_zip": _file_meta(Path(guidelines_zip)) if guidelines_zip else None,
+    }
+    inputs_json.parent.mkdir(parents=True, exist_ok=True)
+    inputs_json.write_text(json.dumps(input_manifest, indent=2) + "\n", encoding="utf-8")
+
+    py = sys.executable
+    _run([py, _script("check_business_execution_inputs_contract.py"), "--artifact", str(inputs_json)])
+
+    start_cmd = [
+        py,
+        _script("business_execution_start.py"),
+        "--out-json",
+        str(week1_json),
+        "--out-memo",
+        str(week1_memo),
+    ]
+    if args.start_date:
+        start_cmd.extend(["--start-date", args.start_date])
+    if args.single_operator:
+        start_cmd.extend(["--single-operator", args.single_operator])
+    for flag, value in (
+        ("--program-owner", args.program_owner),
+        ("--gtm-owner", args.gtm_owner),
+        ("--commercial-owner", args.commercial_owner),
+        ("--solutions-owner", args.solutions_owner),
+        ("--ops-owner", args.ops_owner),
+    ):
+        if value:
+            start_cmd.extend([flag, value])
+    _run(start_cmd)
+
+    _run([py, _script("check_business_execution_start_contract.py"), "--artifact", str(week1_json)])
+
+    progress_cmd = [
+        py,
+        _script("business_execution_progress.py"),
+        "--week1",
+        str(week1_json),
+        "--out-json",
+        str(progress_json),
+        "--out-md",
+        str(progress_md),
+        "--history",
+        str(history_jsonl),
+        "--history-rollup-out",
+        str(rollup_json),
+    ]
+    for done_item in args.done:
+        progress_cmd.extend(["--done", done_item])
+    _run(progress_cmd)
+    _run([py, _script("check_business_execution_progress_contract.py"), "--artifact", str(progress_json)])
+
+    _run(
+        [
+            py,
+            _script("business_execution_next.py"),
+            "--progress",
+            str(progress_json),
+            "--out-json",
+            str(next_json),
+            "--out-md",
+            str(next_md),
+        ]
+    )
+    _run([py, _script("check_business_execution_next_contract.py"), "--artifact", str(next_json)])
+
+    _run(
+        [
+            py,
+            _script("business_execution_handoff.py"),
+            "--week1",
+            str(week1_json),
+            "--progress",
+            str(progress_json),
+            "--rollup",
+            str(rollup_json),
+            "--next",
+            str(next_json),
+            "--out-json",
+            str(handoff_json),
+            "--out-md",
+            str(handoff_md),
+        ]
+    )
+    _run([py, _script("check_business_execution_handoff_contract.py"), "--artifact", str(handoff_json)])
+
+    _run(
+        [
+            py,
+            _script("business_execution_escalation.py"),
+            "--week1",
+            str(week1_json),
+            "--progress",
+            str(progress_json),
+            "--next",
+            str(next_json),
+            "--handoff",
+            str(handoff_json),
+            "--out-json",
+            str(escalation_json),
+            "--out-md",
+            str(escalation_md),
+        ]
+    )
+    _run(
+        [
+            py,
+            _script("check_business_execution_escalation_contract.py"),
+            "--artifact",
+            str(escalation_json),
+        ]
+    )
+    _run(
+        [
+            py,
+            _script("business_execution_followup.py"),
+            "--progress",
+            str(progress_json),
+            "--next",
+            str(next_json),
+            "--escalation",
+            str(escalation_json),
+            "--out-json",
+            str(followup_json),
+            "--out-md",
+            str(followup_md),
+            "--history",
+            str(followup_history_jsonl),
+            "--history-rollup-out",
+            str(followup_rollup_json),
+        ]
+    )
+    _run(
+        [
+            py,
+            _script("check_business_execution_followup_contract.py"),
+            "--artifact",
+            str(followup_json),
+        ]
+    )
+    _run(
+        [
+            py,
+            _script("business_execution_continue.py"),
+            "--followup",
+            str(followup_json),
+            "--out-json",
+            str(continue_json),
+            "--out-md",
+            str(continue_md),
+        ]
+    )
+    _run(
+        [
+            py,
+            _script("check_business_execution_continue_contract.py"),
+            "--artifact",
+            str(continue_json),
+        ]
+    )
+    _run(
+        [
+            py,
+            _script("business_execution_horizon.py"),
+            "--week1",
+            str(week1_json),
+            "--progress",
+            str(progress_json),
+            "--followup",
+            str(followup_json),
+            "--out-json",
+            str(horizon_json),
+            "--out-md",
+            str(horizon_md),
+        ]
+    )
+    _run(
+        [
+            py,
+            _script("check_business_execution_horizon_contract.py"),
+            "--artifact",
+            str(horizon_json),
+        ]
+    )
+
+    print(f"business-execution-pipeline: wrote artifacts to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/business_execution_pipeline.py
+++ b/scripts/business_execution_pipeline.py
@@ -47,7 +47,9 @@ def _file_meta(path: Path) -> dict[str, object]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Run business execution week-1 pipeline end-to-end.")
+    parser = argparse.ArgumentParser(
+        description="Run business execution week-1 pipeline end-to-end."
+    )
     parser.add_argument("--out-dir", default="build/business-execution")
     parser.add_argument("--start-date", default=None)
     parser.add_argument("--program-owner", default=None)
@@ -61,8 +63,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Assign one operator to all owner roles in the week-1 bootstrap.",
     )
     parser.add_argument("--done", action="append", default=[])
-    parser.add_argument("--challenge-prompt", default=None, help="Optional path to challenge prompt markdown.")
-    parser.add_argument("--guidelines-zip", default=None, help="Optional path to aligned guidelines zip.")
+    parser.add_argument(
+        "--challenge-prompt", default=None, help="Optional path to challenge prompt markdown."
+    )
+    parser.add_argument(
+        "--guidelines-zip", default=None, help="Optional path to aligned guidelines zip."
+    )
     args = parser.parse_args(argv)
 
     challenge_prompt = args.challenge_prompt
@@ -116,7 +122,9 @@ def main(argv: list[str] | None = None) -> int:
     inputs_json.write_text(json.dumps(input_manifest, indent=2) + "\n", encoding="utf-8")
 
     py = sys.executable
-    _run([py, _script("check_business_execution_inputs_contract.py"), "--artifact", str(inputs_json)])
+    _run(
+        [py, _script("check_business_execution_inputs_contract.py"), "--artifact", str(inputs_json)]
+    )
 
     start_cmd = [
         py,
@@ -160,7 +168,14 @@ def main(argv: list[str] | None = None) -> int:
     for done_item in args.done:
         progress_cmd.extend(["--done", done_item])
     _run(progress_cmd)
-    _run([py, _script("check_business_execution_progress_contract.py"), "--artifact", str(progress_json)])
+    _run(
+        [
+            py,
+            _script("check_business_execution_progress_contract.py"),
+            "--artifact",
+            str(progress_json),
+        ]
+    )
 
     _run(
         [
@@ -194,7 +209,14 @@ def main(argv: list[str] | None = None) -> int:
             str(handoff_md),
         ]
     )
-    _run([py, _script("check_business_execution_handoff_contract.py"), "--artifact", str(handoff_json)])
+    _run(
+        [
+            py,
+            _script("check_business_execution_handoff_contract.py"),
+            "--artifact",
+            str(handoff_json),
+        ]
+    )
 
     _run(
         [

--- a/scripts/business_execution_pipeline.py
+++ b/scripts/business_execution_pipeline.py
@@ -9,7 +9,6 @@ import sys
 import zipfile
 from pathlib import Path
 
-
 DEFAULT_CHALLENGE_PROMPT = "workflow_execution_prompt.md"
 DEFAULT_GUIDELINES_ZIP = "workflow_execution_guidelines_bundle.zip"
 SCRIPT_DIR = Path(__file__).resolve().parent

--- a/scripts/business_execution_progress.py
+++ b/scripts/business_execution_progress.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.business-execution-progress.v1"
+
+
+def _flatten_plan(plan: dict[str, list[str]]) -> list[str]:
+    ordered_keys = ("day_1", "day_2_3", "day_4_5")
+    tasks: list[str] = []
+    for key in ordered_keys:
+        tasks.extend(plan.get(key, []))
+    return tasks
+
+
+def build_progress(
+    week1_payload: dict[str, Any], done_items: set[str], owner_gate_mode: str = "relaxed"
+) -> dict[str, Any]:
+    plan = week1_payload.get("week_1_execution_plan", {})
+    tasks = _flatten_plan(plan if isinstance(plan, dict) else {})
+    rows = [{"task": task, "done": task in done_items} for task in tasks]
+    completed = sum(1 for row in rows if row["done"])
+    total = len(rows)
+    percent = round((completed / total) * 100, 2) if total else 0.0
+
+    base_status = str(week1_payload.get("status", "needs-owner-assignment"))
+    if base_status != "go":
+        if owner_gate_mode == "strict":
+            gate = "fail"
+            reason = "Owner assignment is incomplete."
+        else:
+            gate = "conditional-pass"
+            reason = "Owner assignment is incomplete, but execution can continue while assigning owners."
+    elif completed == total and total > 0:
+        gate = "pass"
+        reason = "All week-1 execution tasks are complete."
+    else:
+        gate = "conditional-pass"
+        reason = "Execution in progress."
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_schema_version": week1_payload.get("schema_version"),
+        "status": base_status,
+        "task_summary": {"completed": completed, "total": total, "completion_percent": percent},
+        "tasks": rows,
+        "gate_decision": {"status": gate, "reason": reason},
+    }
+
+
+def render_progress_md(progress_payload: dict[str, Any]) -> str:
+    summary = progress_payload["task_summary"]
+    lines = [
+        "# Business Execution Week-1 Progress",
+        "",
+        f"- Status: {progress_payload['status']}",
+        f"- Completed: {summary['completed']}/{summary['total']} ({summary['completion_percent']}%)",
+        f"- Gate: {progress_payload['gate_decision']['status']}",
+        f"- Reason: {progress_payload['gate_decision']['reason']}",
+        "",
+        "## Tasks",
+    ]
+    for row in progress_payload["tasks"]:
+        box = "[x]" if row["done"] else "[ ]"
+        lines.append(f"- {box} {row['task']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(json.loads(line))
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Track business execution week-1 progress and gate status.")
+    parser.add_argument(
+        "--week1",
+        default="build/business-execution/business-execution-week1.json",
+        help="Path to week-1 execution artifact.",
+    )
+    parser.add_argument(
+        "--done",
+        action="append",
+        default=[],
+        help="Task text to mark as completed (repeatable).",
+    )
+    parser.add_argument(
+        "--out-json",
+        default="build/business-execution/business-execution-week1-progress.json",
+    )
+    parser.add_argument(
+        "--out-md",
+        default="build/business-execution/business-execution-week1-progress.md",
+    )
+    parser.add_argument(
+        "--history",
+        default="build/business-execution/business-execution-week1-progress-history.jsonl",
+        help="Append each progress run as one JSON line.",
+    )
+    parser.add_argument(
+        "--history-rollup-out",
+        default="build/business-execution/business-execution-week1-progress-rollup.json",
+        help="Write aggregate trend rollup for the history file.",
+    )
+    parser.add_argument(
+        "--owner-gate-mode",
+        choices=("relaxed", "strict"),
+        default="relaxed",
+        help="Use strict mode to fail when owners are unassigned, or relaxed mode to keep execution moving.",
+    )
+    args = parser.parse_args(argv)
+
+    week1_payload = json.loads(Path(args.week1).read_text(encoding="utf-8"))
+    done_items = {item.strip() for item in args.done if item.strip()}
+    progress_payload = build_progress(week1_payload, done_items, owner_gate_mode=args.owner_gate_mode)
+
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(progress_payload, indent=2) + "\n", encoding="utf-8")
+
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(render_progress_md(progress_payload), encoding="utf-8")
+
+    history_path = Path(args.history)
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    history_event = {
+        "recorded_at": datetime.now(UTC).isoformat(),
+        "status": progress_payload["status"],
+        "gate_status": progress_payload["gate_decision"]["status"],
+        "completion_percent": progress_payload["task_summary"]["completion_percent"],
+        "completed": progress_payload["task_summary"]["completed"],
+        "total": progress_payload["task_summary"]["total"],
+    }
+    with history_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(history_event) + "\n")
+
+    history_rows = _load_jsonl(history_path)
+    gate_counts: dict[str, int] = {"pass": 0, "conditional-pass": 0, "fail": 0}
+    for row in history_rows:
+        gate = str(row.get("gate_status", ""))
+        if gate in gate_counts:
+            gate_counts[gate] += 1
+    latest = history_rows[-1] if history_rows else None
+    rollup = {
+        "schema_version": "sdetkit.business-execution-progress-rollup.v1",
+        "history_records": len(history_rows),
+        "gate_counts": gate_counts,
+        "latest": latest,
+    }
+    rollup_path = Path(args.history_rollup_out)
+    rollup_path.parent.mkdir(parents=True, exist_ok=True)
+    rollup_path.write_text(json.dumps(rollup, indent=2) + "\n", encoding="utf-8")
+
+    print(f"business-execution-progress: wrote {out_json} and {out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/business_execution_progress.py
+++ b/scripts/business_execution_progress.py
@@ -35,7 +35,9 @@ def build_progress(
             reason = "Owner assignment is incomplete."
         else:
             gate = "conditional-pass"
-            reason = "Owner assignment is incomplete, but execution can continue while assigning owners."
+            reason = (
+                "Owner assignment is incomplete, but execution can continue while assigning owners."
+            )
     elif completed == total and total > 0:
         gate = "pass"
         reason = "All week-1 execution tasks are complete."
@@ -85,7 +87,9 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Track business execution week-1 progress and gate status.")
+    parser = argparse.ArgumentParser(
+        description="Track business execution week-1 progress and gate status."
+    )
     parser.add_argument(
         "--week1",
         default="build/business-execution/business-execution-week1.json",
@@ -125,7 +129,9 @@ def main(argv: list[str] | None = None) -> int:
 
     week1_payload = json.loads(Path(args.week1).read_text(encoding="utf-8"))
     done_items = {item.strip() for item in args.done if item.strip()}
-    progress_payload = build_progress(week1_payload, done_items, owner_gate_mode=args.owner_gate_mode)
+    progress_payload = build_progress(
+        week1_payload, done_items, owner_gate_mode=args.owner_gate_mode
+    )
 
     out_json = Path(args.out_json)
     out_json.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/business_execution_start.py
+++ b/scripts/business_execution_start.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.business-execution-start.v1"
+
+
+def _today_utc() -> date:
+    return datetime.now(UTC).date()
+
+
+def build_payload(
+    *,
+    start_date: date,
+    program_owner: str,
+    gtm_owner: str,
+    commercial_owner: str,
+    solutions_owner: str,
+    ops_owner: str,
+) -> dict[str, Any]:
+    owner_values = [
+        program_owner.strip(),
+        gtm_owner.strip(),
+        commercial_owner.strip(),
+        solutions_owner.strip(),
+        ops_owner.strip(),
+    ]
+    owners_assigned = all(value and value.upper() != "TBD" for value in owner_values)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "start_date": start_date.isoformat(),
+        "owners": {
+            "program_owner": program_owner,
+            "gtm_owner": gtm_owner,
+            "commercial_owner": commercial_owner,
+            "solutions_owner": solutions_owner,
+            "ops_owner": ops_owner,
+        },
+        "week_1_execution_plan": {
+            "day_1": [
+                "Confirm owners and operating cadence.",
+                "Finalize ICP shortlist.",
+            ],
+            "day_2_3": [
+                "Run first discovery block.",
+                "Capture baseline KPI values.",
+            ],
+            "day_4_5": [
+                "Draft pilot charter for top candidate.",
+                "Publish week-1 operating memo.",
+            ],
+        },
+        "kpi_baseline_template": [
+            {"kpi": "qualified_accounts", "value": None, "owner": gtm_owner},
+            {"kpi": "discovery_to_pilot_rate", "value": None, "owner": gtm_owner},
+            {"kpi": "pilot_time_to_value_days", "value": None, "owner": solutions_owner},
+            {"kpi": "pilot_to_paid_rate", "value": None, "owner": commercial_owner},
+            {"kpi": "weekly_operating_memo_on_time", "value": None, "owner": program_owner},
+            {"kpi": "dashboard_data_quality_score", "value": None, "owner": ops_owner},
+        ],
+        "status": "go" if owners_assigned else "needs-owner-assignment",
+        "next_action": (
+            "Run execution week with live owners and baseline KPIs."
+            if owners_assigned
+            else "Assign all owners, then rerun this command."
+        ),
+    }
+
+
+def render_weekly_memo(payload: dict[str, Any]) -> str:
+    owners = payload["owners"]
+    start_date = payload["start_date"]
+    status = str(payload.get("status", "needs-owner-assignment")).upper()
+    next_action = str(payload.get("next_action", "Assign owners and rerun command."))
+    return "\n".join(
+        [
+            "# Business Execution Week-1 Operating Memo",
+            "",
+            f"- Start date: {start_date}",
+            f"- Program owner: {owners['program_owner']}",
+            f"- GTM owner: {owners['gtm_owner']}",
+            f"- Commercial owner: {owners['commercial_owner']}",
+            f"- Solutions owner: {owners['solutions_owner']}",
+            f"- Ops owner: {owners['ops_owner']}",
+            "",
+            "## Day 1",
+            "- Confirm owners and operating cadence.",
+            "- Finalize ICP shortlist.",
+            "",
+            "## Day 2-3",
+            "- Run first discovery block.",
+            "- Capture baseline KPI values.",
+            "",
+            "## Day 4-5",
+            "- Draft pilot charter for top candidate.",
+            "- Publish week-1 operating memo.",
+            "",
+            "## End-of-week gate decision",
+            f"- Status: {status}",
+            "- Required evidence: KPI snapshot, owner signoff, risk review, next-step plan.",
+            f"- Next action: {next_action}",
+            "",
+        ]
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap executable business-execution week-1 artifacts."
+    )
+    parser.add_argument(
+        "--start-date",
+        default=_today_utc().isoformat(),
+        help="Week-1 start date in YYYY-MM-DD format (default: today UTC).",
+    )
+    parser.add_argument("--program-owner", default="TBD")
+    parser.add_argument("--gtm-owner", default="TBD")
+    parser.add_argument("--commercial-owner", default="TBD")
+    parser.add_argument("--solutions-owner", default="TBD")
+    parser.add_argument("--ops-owner", default="TBD")
+    parser.add_argument(
+        "--single-operator",
+        default=None,
+        help="Assign one operator to all owner roles so only one person drives execution.",
+    )
+    parser.add_argument(
+        "--out-json",
+        default="build/business-execution/business-execution-week1.json",
+    )
+    parser.add_argument(
+        "--out-memo",
+        default="build/business-execution/business-execution-week1-memo.md",
+    )
+    parser.add_argument(
+        "--strict-owner-assignment",
+        action="store_true",
+        help="Return non-zero when owners are not fully assigned.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    start_date = date.fromisoformat(args.start_date)
+    program_owner = args.program_owner
+    gtm_owner = args.gtm_owner
+    commercial_owner = args.commercial_owner
+    solutions_owner = args.solutions_owner
+    ops_owner = args.ops_owner
+    if args.single_operator:
+        operator = args.single_operator.strip()
+        if operator:
+            program_owner = operator
+            gtm_owner = operator
+            commercial_owner = operator
+            solutions_owner = operator
+            ops_owner = operator
+    payload = build_payload(
+        start_date=start_date,
+        program_owner=program_owner,
+        gtm_owner=gtm_owner,
+        commercial_owner=commercial_owner,
+        solutions_owner=solutions_owner,
+        ops_owner=ops_owner,
+    )
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    out_memo = Path(args.out_memo)
+    out_memo.parent.mkdir(parents=True, exist_ok=True)
+    out_memo.write_text(render_weekly_memo(payload), encoding="utf-8")
+    print(f"business-execution-start: wrote {out_json} and {out_memo}")
+    if args.strict_owner_assignment and payload["status"] != "go":
+        print("business-execution-start: owner assignment incomplete (strict mode).")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_business_execution_continue_contract.py
+++ b/scripts/check_business_execution_continue_contract.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SCHEMA = "sdetkit.business-execution-continue.v1"
+
+
+def validate_continue_contract(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != EXPECTED_SCHEMA:
+        errors.append("schema_version mismatch")
+    for key in ("checkpoint_status", "keep_moving", "selected_command", "reason", "should_run_now"):
+        if key not in payload:
+            errors.append(f"missing {key}")
+    if payload.get("checkpoint_status") not in {"on-track", "due"}:
+        errors.append("checkpoint_status must be on-track or due")
+    if not isinstance(payload.get("keep_moving"), bool):
+        errors.append("keep_moving must be bool")
+    if not isinstance(payload.get("should_run_now"), bool):
+        errors.append("should_run_now must be bool")
+    for key in ("selected_command", "reason"):
+        value = payload.get(key)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{key} must be non-empty string")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate business execution continue artifact contract.")
+    parser.add_argument("--artifact", default="build/business-execution/business-execution-continue.json")
+    args = parser.parse_args(argv)
+    payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
+    errors = validate_continue_contract(payload)
+    result = {"ok": not errors, "errors": errors, "artifact": args.artifact}
+    print(json.dumps(result, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_business_execution_continue_contract.py
+++ b/scripts/check_business_execution_continue_contract.py
@@ -30,8 +30,12 @@ def validate_continue_contract(payload: dict[str, Any]) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate business execution continue artifact contract.")
-    parser.add_argument("--artifact", default="build/business-execution/business-execution-continue.json")
+    parser = argparse.ArgumentParser(
+        description="Validate business execution continue artifact contract."
+    )
+    parser.add_argument(
+        "--artifact", default="build/business-execution/business-execution-continue.json"
+    )
     args = parser.parse_args(argv)
     payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
     errors = validate_continue_contract(payload)

--- a/scripts/check_business_execution_escalation_contract.py
+++ b/scripts/check_business_execution_escalation_contract.py
@@ -46,8 +46,12 @@ def validate_escalation_contract(payload: dict[str, Any]) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate business execution escalation artifact contract.")
-    parser.add_argument("--artifact", default="build/business-execution/business-execution-escalation.json")
+    parser = argparse.ArgumentParser(
+        description="Validate business execution escalation artifact contract."
+    )
+    parser.add_argument(
+        "--artifact", default="build/business-execution/business-execution-escalation.json"
+    )
     args = parser.parse_args(argv)
     payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
     errors = validate_escalation_contract(payload)

--- a/scripts/check_business_execution_escalation_contract.py
+++ b/scripts/check_business_execution_escalation_contract.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SCHEMA = "sdetkit.business-execution-escalation.v1"
+ALLOWED_DECISIONS = {"none", "watch", "escalate"}
+
+
+def validate_escalation_contract(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != EXPECTED_SCHEMA:
+        errors.append("schema_version mismatch")
+    for key in (
+        "week1_status",
+        "progress_gate",
+        "completion_percent",
+        "pending_count",
+        "pending_tasks",
+        "decision",
+        "reasons",
+        "owners_to_ping",
+        "recommended_actions",
+    ):
+        if key not in payload:
+            errors.append(f"missing {key}")
+
+    decision = payload.get("decision")
+    if decision not in ALLOWED_DECISIONS:
+        errors.append("decision must be one of none/watch/escalate")
+    if not isinstance(payload.get("pending_count"), int):
+        errors.append("pending_count must be int")
+    if not isinstance(payload.get("completion_percent"), (int, float)):
+        errors.append("completion_percent must be numeric")
+    for key in ("pending_tasks", "reasons", "owners_to_ping", "recommended_actions"):
+        value = payload.get(key)
+        if not isinstance(value, list):
+            errors.append(f"{key} must be list")
+            continue
+        if not all(isinstance(item, str) and item.strip() for item in value):
+            errors.append(f"{key} entries must be non-empty strings")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate business execution escalation artifact contract.")
+    parser.add_argument("--artifact", default="build/business-execution/business-execution-escalation.json")
+    args = parser.parse_args(argv)
+    payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
+    errors = validate_escalation_contract(payload)
+    result = {"ok": not errors, "errors": errors, "artifact": args.artifact}
+    print(json.dumps(result, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_business_execution_followup_contract.py
+++ b/scripts/check_business_execution_followup_contract.py
@@ -77,8 +77,12 @@ def validate_followup_contract(payload: dict[str, Any]) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate business execution follow-up artifact contract.")
-    parser.add_argument("--artifact", default="build/business-execution/business-execution-followup.json")
+    parser = argparse.ArgumentParser(
+        description="Validate business execution follow-up artifact contract."
+    )
+    parser.add_argument(
+        "--artifact", default="build/business-execution/business-execution-followup.json"
+    )
     args = parser.parse_args(argv)
     payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
     errors = validate_followup_contract(payload)

--- a/scripts/check_business_execution_followup_contract.py
+++ b/scripts/check_business_execution_followup_contract.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SCHEMA = "sdetkit.business-execution-followup.v1"
+ALLOWED_DECISIONS = {"none", "watch", "escalate"}
+
+
+def validate_followup_contract(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != EXPECTED_SCHEMA:
+        errors.append("schema_version mismatch")
+    for key in (
+        "progress_gate",
+        "escalation_decision",
+        "window_hours",
+        "pending_count",
+        "next_tasks",
+        "immediate_actions",
+        "recommended_command",
+        "keep_moving",
+        "history_records",
+        "decision_counts",
+        "latest_recorded_at",
+        "next_checkpoint_at",
+        "checkpoint_status",
+        "checkpoint_due_in_hours",
+        "checkpoint_command",
+    ):
+        if key not in payload:
+            errors.append(f"missing {key}")
+    if payload.get("escalation_decision") not in ALLOWED_DECISIONS:
+        errors.append("escalation_decision must be one of none/watch/escalate")
+    if not isinstance(payload.get("window_hours"), int):
+        errors.append("window_hours must be int")
+    if not isinstance(payload.get("pending_count"), int):
+        errors.append("pending_count must be int")
+    for key in ("next_tasks", "immediate_actions"):
+        value = payload.get(key)
+        if not isinstance(value, list):
+            errors.append(f"{key} must be list")
+            continue
+        if not all(isinstance(item, str) and item.strip() for item in value):
+            errors.append(f"{key} entries must be non-empty strings")
+    cmd = payload.get("recommended_command")
+    if not isinstance(cmd, str) or not cmd.strip():
+        errors.append("recommended_command must be non-empty string")
+    if not isinstance(payload.get("keep_moving"), bool):
+        errors.append("keep_moving must be bool")
+    if not isinstance(payload.get("history_records"), int):
+        errors.append("history_records must be int")
+    decision_counts = payload.get("decision_counts")
+    if not isinstance(decision_counts, dict):
+        errors.append("decision_counts must be object")
+    else:
+        for key in ("none", "watch", "escalate"):
+            if not isinstance(decision_counts.get(key), int):
+                errors.append(f"decision_counts.{key} must be int")
+    latest_recorded_at = payload.get("latest_recorded_at")
+    if latest_recorded_at is not None and not isinstance(latest_recorded_at, str):
+        errors.append("latest_recorded_at must be string or null")
+    next_checkpoint_at = payload.get("next_checkpoint_at")
+    if next_checkpoint_at is not None and not isinstance(next_checkpoint_at, str):
+        errors.append("next_checkpoint_at must be string or null")
+    if payload.get("checkpoint_status") not in {"on-track", "due"}:
+        errors.append("checkpoint_status must be on-track or due")
+    if not isinstance(payload.get("checkpoint_due_in_hours"), (int, float)):
+        errors.append("checkpoint_due_in_hours must be numeric")
+    checkpoint_command = payload.get("checkpoint_command")
+    if not isinstance(checkpoint_command, str) or not checkpoint_command.strip():
+        errors.append("checkpoint_command must be non-empty string")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate business execution follow-up artifact contract.")
+    parser.add_argument("--artifact", default="build/business-execution/business-execution-followup.json")
+    args = parser.parse_args(argv)
+    payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
+    errors = validate_followup_contract(payload)
+    result = {"ok": not errors, "errors": errors, "artifact": args.artifact}
+    print(json.dumps(result, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_business_execution_handoff_contract.py
+++ b/scripts/check_business_execution_handoff_contract.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SCHEMA = "sdetkit.business-execution-handoff.v1"
+
+
+def validate_handoff_contract(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != EXPECTED_SCHEMA:
+        errors.append("schema_version mismatch")
+    for key in (
+        "week1_status",
+        "week1_start_date",
+        "progress_gate",
+        "progress_completion_percent",
+        "history_records",
+        "latest_gate_counts",
+        "next_tasks",
+    ):
+        if key not in payload:
+            errors.append(f"missing {key}")
+    gate_counts = payload.get("latest_gate_counts")
+    if gate_counts is not None and not isinstance(gate_counts, dict):
+        errors.append("latest_gate_counts must be object")
+    tasks = payload.get("next_tasks")
+    if tasks is not None and not isinstance(tasks, list):
+        errors.append("next_tasks must be list")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate business execution handoff artifact contract.")
+    parser.add_argument("--artifact", default="build/business-execution/business-execution-handoff.json")
+    args = parser.parse_args(argv)
+    payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
+    errors = validate_handoff_contract(payload)
+    result = {"ok": not errors, "errors": errors, "artifact": args.artifact}
+    print(json.dumps(result, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_business_execution_handoff_contract.py
+++ b/scripts/check_business_execution_handoff_contract.py
@@ -34,8 +34,12 @@ def validate_handoff_contract(payload: dict[str, Any]) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate business execution handoff artifact contract.")
-    parser.add_argument("--artifact", default="build/business-execution/business-execution-handoff.json")
+    parser = argparse.ArgumentParser(
+        description="Validate business execution handoff artifact contract."
+    )
+    parser.add_argument(
+        "--artifact", default="build/business-execution/business-execution-handoff.json"
+    )
     args = parser.parse_args(argv)
     payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
     errors = validate_handoff_contract(payload)

--- a/scripts/check_business_execution_horizon_contract.py
+++ b/scripts/check_business_execution_horizon_contract.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SCHEMA = "sdetkit.business-execution-horizon.v1"
+FOCUS_MODES = {"foundation-build", "execution-acceleration"}
+
+
+def _validate_plan_section(payload: dict[str, Any], key: str, errors: list[str]) -> None:
+    section = payload.get(key)
+    if not isinstance(section, dict):
+        errors.append(f"{key} must be object")
+        return
+    if not section:
+        errors.append(f"{key} cannot be empty")
+        return
+    for bucket, items in section.items():
+        if not isinstance(bucket, str) or not bucket.strip():
+            errors.append(f"{key} bucket names must be non-empty strings")
+            continue
+        if not isinstance(items, list) or not items:
+            errors.append(f"{key}.{bucket} must be non-empty list")
+            continue
+        if not all(isinstance(item, str) and item.strip() for item in items):
+            errors.append(f"{key}.{bucket} entries must be non-empty strings")
+
+
+def validate_horizon_contract(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != EXPECTED_SCHEMA:
+        errors.append("schema_version mismatch")
+    for key in (
+        "week1_status",
+        "progress_gate",
+        "completion_percent",
+        "followup_checkpoint_status",
+        "focus_mode",
+        "week_2_plan",
+        "day_90_plan",
+    ):
+        if key not in payload:
+            errors.append(f"missing {key}")
+    if not isinstance(payload.get("completion_percent"), (int, float)):
+        errors.append("completion_percent must be numeric")
+    if payload.get("focus_mode") not in FOCUS_MODES:
+        errors.append("focus_mode must be foundation-build or execution-acceleration")
+    _validate_plan_section(payload, "week_2_plan", errors)
+    _validate_plan_section(payload, "day_90_plan", errors)
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate business execution horizon artifact contract.")
+    parser.add_argument("--artifact", default="build/business-execution/business-execution-horizon.json")
+    args = parser.parse_args(argv)
+    payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
+    errors = validate_horizon_contract(payload)
+    result = {"ok": not errors, "errors": errors, "artifact": args.artifact}
+    print(json.dumps(result, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_business_execution_horizon_contract.py
+++ b/scripts/check_business_execution_horizon_contract.py
@@ -54,8 +54,12 @@ def validate_horizon_contract(payload: dict[str, Any]) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate business execution horizon artifact contract.")
-    parser.add_argument("--artifact", default="build/business-execution/business-execution-horizon.json")
+    parser = argparse.ArgumentParser(
+        description="Validate business execution horizon artifact contract."
+    )
+    parser.add_argument(
+        "--artifact", default="build/business-execution/business-execution-horizon.json"
+    )
     args = parser.parse_args(argv)
     payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
     errors = validate_horizon_contract(payload)

--- a/scripts/check_business_execution_inputs_contract.py
+++ b/scripts/check_business_execution_inputs_contract.py
@@ -46,8 +46,12 @@ def validate_inputs_contract(payload: dict[str, Any]) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate business execution input manifest contract.")
-    parser.add_argument("--artifact", default="build/business-execution/business-execution-inputs.json")
+    parser = argparse.ArgumentParser(
+        description="Validate business execution input manifest contract."
+    )
+    parser.add_argument(
+        "--artifact", default="build/business-execution/business-execution-inputs.json"
+    )
     args = parser.parse_args(argv)
     payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
     errors = validate_inputs_contract(payload)

--- a/scripts/check_business_execution_inputs_contract.py
+++ b/scripts/check_business_execution_inputs_contract.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SCHEMA = "sdetkit.business-execution-inputs.v1"
+
+
+def validate_inputs_contract(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != EXPECTED_SCHEMA:
+        errors.append("schema_version mismatch")
+
+    for key in ("challenge_prompt", "guidelines_zip"):
+        value = payload.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, dict):
+            errors.append(f"{key} must be object or null")
+            continue
+        for required in ("path", "size_bytes", "sha256"):
+            if required not in value:
+                errors.append(f"missing {key}.{required}")
+
+    prompt = payload.get("challenge_prompt")
+    if isinstance(prompt, dict):
+        if "line_count" not in prompt:
+            errors.append("missing challenge_prompt.line_count")
+        if "first_heading" not in prompt:
+            errors.append("missing challenge_prompt.first_heading")
+
+    bundle = payload.get("guidelines_zip")
+    if isinstance(bundle, dict):
+        entry_count = bundle.get("entry_count")
+        if not isinstance(entry_count, int):
+            errors.append("guidelines_zip.entry_count must be int")
+        elif entry_count > 25:
+            errors.append("guidelines_zip.entry_count exceeds max25")
+        if "entries_preview" not in bundle:
+            errors.append("missing guidelines_zip.entries_preview")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate business execution input manifest contract.")
+    parser.add_argument("--artifact", default="build/business-execution/business-execution-inputs.json")
+    args = parser.parse_args(argv)
+    payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
+    errors = validate_inputs_contract(payload)
+    result = {"ok": not errors, "errors": errors, "artifact": args.artifact}
+    print(json.dumps(result, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_business_execution_next_contract.py
+++ b/scripts/check_business_execution_next_contract.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SCHEMA = "sdetkit.business-execution-next.v1"
+
+
+def validate_next_contract(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != EXPECTED_SCHEMA:
+        errors.append("schema_version mismatch")
+    if not isinstance(payload.get("pending_count"), int):
+        errors.append("pending_count must be int")
+    tasks = payload.get("next_tasks")
+    if not isinstance(tasks, list):
+        errors.append("next_tasks must be a list")
+    else:
+        for idx, task in enumerate(tasks):
+            if not isinstance(task, str) or not task.strip():
+                errors.append(f"next_tasks[{idx}] must be non-empty string")
+    command = payload.get("recommended_command")
+    if command is not None and not isinstance(command, str):
+        errors.append("recommended_command must be null or string")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate business execution next-actions artifact contract.")
+    parser.add_argument("--artifact", default="build/business-execution/business-execution-week1-next.json")
+    args = parser.parse_args(argv)
+    payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
+    errors = validate_next_contract(payload)
+    result = {"ok": not errors, "errors": errors, "artifact": args.artifact}
+    print(json.dumps(result, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_business_execution_next_contract.py
+++ b/scripts/check_business_execution_next_contract.py
@@ -29,8 +29,12 @@ def validate_next_contract(payload: dict[str, Any]) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate business execution next-actions artifact contract.")
-    parser.add_argument("--artifact", default="build/business-execution/business-execution-week1-next.json")
+    parser = argparse.ArgumentParser(
+        description="Validate business execution next-actions artifact contract."
+    )
+    parser.add_argument(
+        "--artifact", default="build/business-execution/business-execution-week1-next.json"
+    )
     args = parser.parse_args(argv)
     payload = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
     errors = validate_next_contract(payload)

--- a/scripts/check_business_execution_progress_contract.py
+++ b/scripts/check_business_execution_progress_contract.py
@@ -50,7 +50,9 @@ def validate_progress_contract(payload: dict[str, Any]) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate business execution week-1 progress contract.")
+    parser = argparse.ArgumentParser(
+        description="Validate business execution week-1 progress contract."
+    )
     parser.add_argument(
         "--artifact",
         default="build/business-execution/business-execution-week1-progress.json",

--- a/scripts/check_business_execution_progress_contract.py
+++ b/scripts/check_business_execution_progress_contract.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SCHEMA = "sdetkit.business-execution-progress.v1"
+ALLOWED_GATES = {"pass", "conditional-pass", "fail"}
+
+
+def validate_progress_contract(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != EXPECTED_SCHEMA:
+        errors.append("schema_version mismatch")
+
+    summary = payload.get("task_summary")
+    if not isinstance(summary, dict):
+        errors.append("task_summary must be an object")
+    else:
+        for key in ("completed", "total", "completion_percent"):
+            if key not in summary:
+                errors.append(f"missing task_summary.{key}")
+
+    tasks = payload.get("tasks")
+    if not isinstance(tasks, list):
+        errors.append("tasks must be a list")
+    else:
+        for idx, row in enumerate(tasks):
+            if not isinstance(row, dict):
+                errors.append(f"tasks[{idx}] must be an object")
+                continue
+            if not isinstance(row.get("task"), str) or not row.get("task", "").strip():
+                errors.append(f"tasks[{idx}].task must be non-empty string")
+            if not isinstance(row.get("done"), bool):
+                errors.append(f"tasks[{idx}].done must be bool")
+
+    gate = payload.get("gate_decision")
+    if not isinstance(gate, dict):
+        errors.append("gate_decision must be an object")
+    else:
+        if gate.get("status") not in ALLOWED_GATES:
+            errors.append("gate_decision.status must be pass|conditional-pass|fail")
+        reason = gate.get("reason")
+        if not isinstance(reason, str) or not reason.strip():
+            errors.append("gate_decision.reason must be non-empty string")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate business execution week-1 progress contract.")
+    parser.add_argument(
+        "--artifact",
+        default="build/business-execution/business-execution-week1-progress.json",
+    )
+    args = parser.parse_args(argv)
+
+    artifact = Path(args.artifact)
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    errors = validate_progress_contract(payload)
+    result = {"ok": not errors, "errors": errors, "artifact": str(artifact)}
+    print(json.dumps(result, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_business_execution_start_contract.py
+++ b/scripts/check_business_execution_start_contract.py
@@ -43,14 +43,18 @@ def validate_contract(payload: dict[str, Any]) -> list[str]:
         errors.append("next_action must be a non-empty string")
 
     if status == "go":
-        unresolved = [key for key in REQUIRED_OWNER_KEYS if str(owners.get(key, "")).upper() == "TBD"]
+        unresolved = [
+            key for key in REQUIRED_OWNER_KEYS if str(owners.get(key, "")).upper() == "TBD"
+        ]
         if unresolved:
             errors.append("status=go is invalid when owners are TBD")
     return errors
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate business execution week-1 artifact contract.")
+    parser = argparse.ArgumentParser(
+        description="Validate business execution week-1 artifact contract."
+    )
     parser.add_argument(
         "--artifact",
         default="build/business-execution/business-execution-week1.json",

--- a/scripts/check_business_execution_start_contract.py
+++ b/scripts/check_business_execution_start_contract.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SCHEMA = "sdetkit.business-execution-start.v1"
+REQUIRED_OWNER_KEYS = (
+    "program_owner",
+    "gtm_owner",
+    "commercial_owner",
+    "solutions_owner",
+    "ops_owner",
+)
+
+
+def _is_nonempty(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def validate_contract(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("schema_version") != EXPECTED_SCHEMA:
+        errors.append("schema_version mismatch")
+
+    owners = payload.get("owners")
+    if not isinstance(owners, dict):
+        errors.append("owners must be an object")
+        return errors
+
+    for key in REQUIRED_OWNER_KEYS:
+        if not _is_nonempty(owners.get(key)):
+            errors.append(f"missing owners.{key}")
+
+    status = payload.get("status")
+    allowed = {"go", "needs-owner-assignment"}
+    if status not in allowed:
+        errors.append("status must be one of go or needs-owner-assignment")
+
+    if not _is_nonempty(payload.get("next_action")):
+        errors.append("next_action must be a non-empty string")
+
+    if status == "go":
+        unresolved = [key for key in REQUIRED_OWNER_KEYS if str(owners.get(key, "")).upper() == "TBD"]
+        if unresolved:
+            errors.append("status=go is invalid when owners are TBD")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate business execution week-1 artifact contract.")
+    parser.add_argument(
+        "--artifact",
+        default="build/business-execution/business-execution-week1.json",
+    )
+    parser.add_argument(
+        "--require-go",
+        action="store_true",
+        help="Fail validation unless artifact status is go.",
+    )
+    args = parser.parse_args(argv)
+    artifact = Path(args.artifact)
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    errors = validate_contract(payload)
+    if args.require_go and payload.get("status") != "go":
+        errors.append("status must be go when --require-go is set")
+    result = {"ok": not errors, "errors": errors, "artifact": str(artifact)}
+    print(json.dumps(result, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_business_execution_continue.py
+++ b/tests/test_business_execution_continue.py
@@ -15,7 +15,7 @@ def test_build_continue_payload_prefers_checkpoint_when_due() -> None:
     followup = {
         "checkpoint_status": "due",
         "keep_moving": True,
-        "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+        "recommended_command": 'python scripts/business_execution_progress.py --done "Task A"',
         "checkpoint_command": "make business-execution-followup",
     }
     payload = continue_script.build_continue_payload(followup)
@@ -32,7 +32,7 @@ def test_main_writes_continue_artifacts(tmp_path: Path) -> None:
             {
                 "checkpoint_status": "on-track",
                 "keep_moving": True,
-                "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+                "recommended_command": 'python scripts/business_execution_progress.py --done "Task A"',
                 "checkpoint_command": "make business-execution-followup",
             }
         ),

--- a/tests/test_business_execution_continue.py
+++ b/tests/test_business_execution_continue.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "business_execution_continue.py"
+_SPEC = importlib.util.spec_from_file_location("business_execution_continue_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+continue_script = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(continue_script)
+
+
+def test_build_continue_payload_prefers_checkpoint_when_due() -> None:
+    followup = {
+        "checkpoint_status": "due",
+        "keep_moving": True,
+        "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+        "checkpoint_command": "make business-execution-followup",
+    }
+    payload = continue_script.build_continue_payload(followup)
+    assert payload["selected_command"] == "make business-execution-followup"
+    assert payload["should_run_now"] is True
+
+
+def test_main_writes_continue_artifacts(tmp_path: Path) -> None:
+    followup = tmp_path / "followup.json"
+    out_json = tmp_path / "continue.json"
+    out_md = tmp_path / "continue.md"
+    followup.write_text(
+        json.dumps(
+            {
+                "checkpoint_status": "on-track",
+                "keep_moving": True,
+                "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+                "checkpoint_command": "make business-execution-followup",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = continue_script.main(
+        [
+            "--followup",
+            str(followup),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["should_run_now"] is True
+    assert out_md.exists()

--- a/tests/test_business_execution_escalation.py
+++ b/tests/test_business_execution_escalation.py
@@ -18,7 +18,9 @@ def test_build_escalation_payload_returns_watch_for_conditional_pass() -> None:
         "task_summary": {"completion_percent": 40.0},
     }
     next_payload = {"next_tasks": ["Task A", "Task B"]}
-    handoff = {"recommended_command": "python scripts/business_execution_progress.py --done \"Task A\""}
+    handoff = {
+        "recommended_command": 'python scripts/business_execution_progress.py --done "Task A"'
+    }
     payload = escalation_script.build_escalation_payload(week1, progress, next_payload, handoff)
     assert payload["decision"] == "watch"
     assert payload["pending_count"] == 2
@@ -43,11 +45,15 @@ def test_main_writes_escalation_artifacts(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     progress.write_text(
-        json.dumps({"gate_decision": {"status": "fail"}, "task_summary": {"completion_percent": 0.0}}),
+        json.dumps(
+            {"gate_decision": {"status": "fail"}, "task_summary": {"completion_percent": 0.0}}
+        ),
         encoding="utf-8",
     )
     next_json.write_text(json.dumps({"next_tasks": ["Assign owner"]}), encoding="utf-8")
-    handoff.write_text(json.dumps({"recommended_command": "make business-execution-start"}), encoding="utf-8")
+    handoff.write_text(
+        json.dumps({"recommended_command": "make business-execution-start"}), encoding="utf-8"
+    )
 
     rc = escalation_script.main(
         [
@@ -79,6 +85,8 @@ def test_build_escalation_payload_keeps_watch_when_only_owners_missing() -> None
         "task_summary": {"completion_percent": 60.0},
     }
     next_payload = {"next_tasks": ["Task A"]}
-    handoff = {"recommended_command": "python scripts/business_execution_progress.py --done \"Task A\""}
+    handoff = {
+        "recommended_command": 'python scripts/business_execution_progress.py --done "Task A"'
+    }
     payload = escalation_script.build_escalation_payload(week1, progress, next_payload, handoff)
     assert payload["decision"] == "watch"

--- a/tests/test_business_execution_escalation.py
+++ b/tests/test_business_execution_escalation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "business_execution_escalation.py"
+_SPEC = importlib.util.spec_from_file_location("business_execution_escalation_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+escalation_script = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(escalation_script)
+
+
+def test_build_escalation_payload_returns_watch_for_conditional_pass() -> None:
+    week1 = {"status": "go", "owner_assignments": {"program_owner": "Founder"}}
+    progress = {
+        "gate_decision": {"status": "conditional-pass"},
+        "task_summary": {"completion_percent": 40.0},
+    }
+    next_payload = {"next_tasks": ["Task A", "Task B"]}
+    handoff = {"recommended_command": "python scripts/business_execution_progress.py --done \"Task A\""}
+    payload = escalation_script.build_escalation_payload(week1, progress, next_payload, handoff)
+    assert payload["decision"] == "watch"
+    assert payload["pending_count"] == 2
+    assert payload["owners_to_ping"] == ["Founder"]
+
+
+def test_main_writes_escalation_artifacts(tmp_path: Path) -> None:
+    week1 = tmp_path / "week1.json"
+    progress = tmp_path / "progress.json"
+    next_json = tmp_path / "next.json"
+    handoff = tmp_path / "handoff.json"
+    out_json = tmp_path / "escalation.json"
+    out_md = tmp_path / "escalation.md"
+
+    week1.write_text(
+        json.dumps(
+            {
+                "status": "needs-owner-assignment",
+                "owner_assignments": {"program_owner": "TBD"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    progress.write_text(
+        json.dumps({"gate_decision": {"status": "fail"}, "task_summary": {"completion_percent": 0.0}}),
+        encoding="utf-8",
+    )
+    next_json.write_text(json.dumps({"next_tasks": ["Assign owner"]}), encoding="utf-8")
+    handoff.write_text(json.dumps({"recommended_command": "make business-execution-start"}), encoding="utf-8")
+
+    rc = escalation_script.main(
+        [
+            "--week1",
+            str(week1),
+            "--progress",
+            str(progress),
+            "--next",
+            str(next_json),
+            "--handoff",
+            str(handoff),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["decision"] == "escalate"
+    assert out_md.exists()
+
+
+def test_build_escalation_payload_keeps_watch_when_only_owners_missing() -> None:
+    week1 = {"status": "needs-owner-assignment", "owners": {"program_owner": "TBD"}}
+    progress = {
+        "gate_decision": {"status": "conditional-pass"},
+        "task_summary": {"completion_percent": 60.0},
+    }
+    next_payload = {"next_tasks": ["Task A"]}
+    handoff = {"recommended_command": "python scripts/business_execution_progress.py --done \"Task A\""}
+    payload = escalation_script.build_escalation_payload(week1, progress, next_payload, handoff)
+    assert payload["decision"] == "watch"

--- a/tests/test_business_execution_followup.py
+++ b/tests/test_business_execution_followup.py
@@ -15,10 +15,12 @@ def test_build_followup_payload_keeps_momentum() -> None:
     progress = {"gate_decision": {"status": "conditional-pass"}}
     next_payload = {
         "next_tasks": ["Task A", "Task B"],
-        "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+        "recommended_command": 'python scripts/business_execution_progress.py --done "Task A"',
     }
     escalation = {"decision": "watch"}
-    payload = followup_script.build_followup_payload(progress, next_payload, escalation, window_hours=24)
+    payload = followup_script.build_followup_payload(
+        progress, next_payload, escalation, window_hours=24
+    )
     assert payload["keep_moving"] is True
     assert payload["pending_count"] == 2
     assert payload["immediate_actions"][0] == "Complete: Task A"

--- a/tests/test_business_execution_followup.py
+++ b/tests/test_business_execution_followup.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "business_execution_followup.py"
+_SPEC = importlib.util.spec_from_file_location("business_execution_followup_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+followup_script = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(followup_script)
+
+
+def test_build_followup_payload_keeps_momentum() -> None:
+    progress = {"gate_decision": {"status": "conditional-pass"}}
+    next_payload = {
+        "next_tasks": ["Task A", "Task B"],
+        "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+    }
+    escalation = {"decision": "watch"}
+    payload = followup_script.build_followup_payload(progress, next_payload, escalation, window_hours=24)
+    assert payload["keep_moving"] is True
+    assert payload["pending_count"] == 2
+    assert payload["immediate_actions"][0] == "Complete: Task A"
+
+
+def test_main_writes_followup_artifacts(tmp_path: Path) -> None:
+    progress = tmp_path / "progress.json"
+    next_json = tmp_path / "next.json"
+    escalation = tmp_path / "escalation.json"
+    out_json = tmp_path / "followup.json"
+    out_md = tmp_path / "followup.md"
+    history = tmp_path / "followup-history.jsonl"
+    rollup = tmp_path / "followup-rollup.json"
+
+    progress.write_text(json.dumps({"gate_decision": {"status": "fail"}}), encoding="utf-8")
+    next_json.write_text(json.dumps({"next_tasks": ["A"]}), encoding="utf-8")
+    escalation.write_text(json.dumps({"decision": "escalate"}), encoding="utf-8")
+
+    rc = followup_script.main(
+        [
+            "--progress",
+            str(progress),
+            "--next",
+            str(next_json),
+            "--escalation",
+            str(escalation),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--history",
+            str(history),
+            "--history-rollup-out",
+            str(rollup),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["escalation_decision"] == "escalate"
+    assert payload["recommended_command"] == "make business-execution-pipeline"
+    assert payload["history_records"] == 1
+    assert payload["decision_counts"]["escalate"] == 1
+    assert payload["checkpoint_status"] == "on-track"
+    assert isinstance(payload["next_checkpoint_at"], str)
+    assert isinstance(payload["checkpoint_due_in_hours"], (int, float))
+    assert payload["checkpoint_command"] == "make business-execution-followup"
+    assert out_md.exists()
+    assert history.exists()
+    assert rollup.exists()

--- a/tests/test_business_execution_handoff.py
+++ b/tests/test_business_execution_handoff.py
@@ -14,7 +14,10 @@ _SPEC.loader.exec_module(handoff_script)
 def test_build_handoff_includes_key_fields() -> None:
     payload = handoff_script.build_handoff(
         week1={"status": "go", "start_date": "2026-04-28"},
-        progress={"gate_decision": {"status": "conditional-pass"}, "task_summary": {"completion_percent": 50}},
+        progress={
+            "gate_decision": {"status": "conditional-pass"},
+            "task_summary": {"completion_percent": 50},
+        },
         rollup={"history_records": 3, "gate_counts": {"pass": 1, "conditional-pass": 1, "fail": 1}},
         next_payload={"next_tasks": ["A"], "recommended_command": "cmd"},
     )
@@ -24,13 +27,19 @@ def test_build_handoff_includes_key_fields() -> None:
 
 
 def test_main_writes_handoff_artifacts(tmp_path: Path) -> None:
-    (tmp_path / "week1.json").write_text(json.dumps({"status": "go", "start_date": "2026-04-28"}), encoding="utf-8")
+    (tmp_path / "week1.json").write_text(
+        json.dumps({"status": "go", "start_date": "2026-04-28"}), encoding="utf-8"
+    )
     (tmp_path / "progress.json").write_text(
-        json.dumps({"gate_decision": {"status": "pass"}, "task_summary": {"completion_percent": 100}}),
+        json.dumps(
+            {"gate_decision": {"status": "pass"}, "task_summary": {"completion_percent": 100}}
+        ),
         encoding="utf-8",
     )
     (tmp_path / "rollup.json").write_text(
-        json.dumps({"history_records": 1, "gate_counts": {"pass": 1, "conditional-pass": 0, "fail": 0}}),
+        json.dumps(
+            {"history_records": 1, "gate_counts": {"pass": 1, "conditional-pass": 0, "fail": 0}}
+        ),
         encoding="utf-8",
     )
     (tmp_path / "next.json").write_text(

--- a/tests/test_business_execution_handoff.py
+++ b/tests/test_business_execution_handoff.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "business_execution_handoff.py"
+_SPEC = importlib.util.spec_from_file_location("business_execution_handoff_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+handoff_script = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(handoff_script)
+
+
+def test_build_handoff_includes_key_fields() -> None:
+    payload = handoff_script.build_handoff(
+        week1={"status": "go", "start_date": "2026-04-28"},
+        progress={"gate_decision": {"status": "conditional-pass"}, "task_summary": {"completion_percent": 50}},
+        rollup={"history_records": 3, "gate_counts": {"pass": 1, "conditional-pass": 1, "fail": 1}},
+        next_payload={"next_tasks": ["A"], "recommended_command": "cmd"},
+    )
+    assert payload["week1_status"] == "go"
+    assert payload["history_records"] == 3
+    assert payload["next_tasks"] == ["A"]
+
+
+def test_main_writes_handoff_artifacts(tmp_path: Path) -> None:
+    (tmp_path / "week1.json").write_text(json.dumps({"status": "go", "start_date": "2026-04-28"}), encoding="utf-8")
+    (tmp_path / "progress.json").write_text(
+        json.dumps({"gate_decision": {"status": "pass"}, "task_summary": {"completion_percent": 100}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "rollup.json").write_text(
+        json.dumps({"history_records": 1, "gate_counts": {"pass": 1, "conditional-pass": 0, "fail": 0}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "next.json").write_text(
+        json.dumps({"next_tasks": [], "recommended_command": None}),
+        encoding="utf-8",
+    )
+    out_json = tmp_path / "handoff.json"
+    out_md = tmp_path / "handoff.md"
+    rc = handoff_script.main(
+        [
+            "--week1",
+            str(tmp_path / "week1.json"),
+            "--progress",
+            str(tmp_path / "progress.json"),
+            "--rollup",
+            str(tmp_path / "rollup.json"),
+            "--next",
+            str(tmp_path / "next.json"),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["progress_gate"] == "pass"
+    assert "Business Execution Handoff Summary" in out_md.read_text(encoding="utf-8")

--- a/tests/test_business_execution_horizon.py
+++ b/tests/test_business_execution_horizon.py
@@ -13,7 +13,10 @@ _SPEC.loader.exec_module(horizon_script)
 
 def test_build_horizon_payload_contains_week2_and_day90() -> None:
     week1 = {"status": "go"}
-    progress = {"task_summary": {"completed": 0, "completion_percent": 0.0}, "gate_decision": {"status": "conditional-pass"}}
+    progress = {
+        "task_summary": {"completed": 0, "completion_percent": 0.0},
+        "gate_decision": {"status": "conditional-pass"},
+    }
     followup = {"checkpoint_status": "on-track"}
     payload = horizon_script.build_horizon_payload(week1, progress, followup)
     assert payload["focus_mode"] == "foundation-build"
@@ -29,7 +32,12 @@ def test_main_writes_horizon_artifacts(tmp_path: Path) -> None:
     out_md = tmp_path / "horizon.md"
     week1.write_text(json.dumps({"status": "go"}), encoding="utf-8")
     progress.write_text(
-        json.dumps({"task_summary": {"completed": 4, "completion_percent": 66.7}, "gate_decision": {"status": "conditional-pass"}}),
+        json.dumps(
+            {
+                "task_summary": {"completed": 4, "completion_percent": 66.7},
+                "gate_decision": {"status": "conditional-pass"},
+            }
+        ),
         encoding="utf-8",
     )
     followup.write_text(json.dumps({"checkpoint_status": "on-track"}), encoding="utf-8")

--- a/tests/test_business_execution_horizon.py
+++ b/tests/test_business_execution_horizon.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "business_execution_horizon.py"
+_SPEC = importlib.util.spec_from_file_location("business_execution_horizon_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+horizon_script = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(horizon_script)
+
+
+def test_build_horizon_payload_contains_week2_and_day90() -> None:
+    week1 = {"status": "go"}
+    progress = {"task_summary": {"completed": 0, "completion_percent": 0.0}, "gate_decision": {"status": "conditional-pass"}}
+    followup = {"checkpoint_status": "on-track"}
+    payload = horizon_script.build_horizon_payload(week1, progress, followup)
+    assert payload["focus_mode"] == "foundation-build"
+    assert "day_6_7" in payload["week_2_plan"]
+    assert "day_90" in payload["day_90_plan"]
+
+
+def test_main_writes_horizon_artifacts(tmp_path: Path) -> None:
+    week1 = tmp_path / "week1.json"
+    progress = tmp_path / "progress.json"
+    followup = tmp_path / "followup.json"
+    out_json = tmp_path / "horizon.json"
+    out_md = tmp_path / "horizon.md"
+    week1.write_text(json.dumps({"status": "go"}), encoding="utf-8")
+    progress.write_text(
+        json.dumps({"task_summary": {"completed": 4, "completion_percent": 66.7}, "gate_decision": {"status": "conditional-pass"}}),
+        encoding="utf-8",
+    )
+    followup.write_text(json.dumps({"checkpoint_status": "on-track"}), encoding="utf-8")
+    rc = horizon_script.main(
+        [
+            "--week1",
+            str(week1),
+            "--progress",
+            str(progress),
+            "--followup",
+            str(followup),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["focus_mode"] == "execution-acceleration"
+    assert out_md.exists()

--- a/tests/test_business_execution_next.py
+++ b/tests/test_business_execution_next.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "business_execution_next.py"
+_SPEC = importlib.util.spec_from_file_location("business_execution_next_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+next_script = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(next_script)
+
+
+def test_build_next_payload_selects_pending_tasks() -> None:
+    progress = {
+        "schema_version": "sdetkit.business-execution-progress.v1",
+        "gate_decision": {"status": "conditional-pass"},
+        "tasks": [
+            {"task": "A", "done": True},
+            {"task": "B", "done": False},
+            {"task": "C", "done": False},
+        ],
+    }
+    payload = next_script.build_next_payload(progress, limit=1)
+    assert payload["pending_count"] == 2
+    assert payload["next_tasks"] == ["B"]
+    assert payload["recommended_command"] is not None
+
+
+def test_main_writes_next_artifacts(tmp_path: Path) -> None:
+    progress = tmp_path / "progress.json"
+    progress.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-progress.v1",
+                "gate_decision": {"status": "fail"},
+                "tasks": [{"task": "A", "done": False}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    out_json = tmp_path / "next.json"
+    out_md = tmp_path / "next.md"
+    rc = next_script.main(
+        [
+            "--progress",
+            str(progress),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["pending_count"] == 1
+    assert "Suggested next tasks" in out_md.read_text(encoding="utf-8")

--- a/tests/test_business_execution_pipeline.py
+++ b/tests/test_business_execution_pipeline.py
@@ -67,12 +67,8 @@ def test_pipeline_autodiscovers_canonical_input_files(tmp_path: Path, monkeypatc
 
     assert rc == 0
     payload = json.loads((out_dir / "business-execution-inputs.json").read_text(encoding="utf-8"))
-    assert payload["challenge_prompt"]["path"].endswith(
-        "workflow_execution_prompt.md"
-    )
-    assert payload["guidelines_zip"]["path"].endswith(
-        "workflow_execution_guidelines_bundle.zip"
-    )
+    assert payload["challenge_prompt"]["path"].endswith("workflow_execution_prompt.md")
+    assert payload["guidelines_zip"]["path"].endswith("workflow_execution_guidelines_bundle.zip")
 
 
 def test_pipeline_rejects_partial_external_input_pair(tmp_path: Path) -> None:
@@ -106,6 +102,8 @@ def test_pipeline_single_operator_mode_assigns_all_roles(tmp_path: Path) -> None
         ]
     )
     assert rc == 0
-    week1_payload = json.loads((out_dir / "business-execution-week1.json").read_text(encoding="utf-8"))
+    week1_payload = json.loads(
+        (out_dir / "business-execution-week1.json").read_text(encoding="utf-8")
+    )
     assert week1_payload["status"] == "go"
     assert set(week1_payload["owners"].values()) == {"Sherif"}

--- a/tests/test_business_execution_pipeline.py
+++ b/tests/test_business_execution_pipeline.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import zipfile
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "business_execution_pipeline.py"
+_SPEC = importlib.util.spec_from_file_location("business_execution_pipeline_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+pipeline_script = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(pipeline_script)
+
+
+def test_pipeline_writes_full_artifact_set(tmp_path: Path) -> None:
+    out_dir = tmp_path / "artifacts"
+    challenge_prompt = tmp_path / "workflow_execution_prompt.md"
+    guidelines_zip = tmp_path / "workflow_execution_guidelines_bundle.zip"
+    challenge_prompt.write_text("# prompt\nline\n", encoding="utf-8")
+    with zipfile.ZipFile(guidelines_zip, "w") as zf:
+        zf.writestr("guideline-a.txt", "a")
+        zf.writestr("guideline-b.txt", "b")
+    rc = pipeline_script.main(
+        [
+            "--out-dir",
+            str(out_dir),
+            "--start-date",
+            "2026-04-28",
+            "--program-owner",
+            "Founder",
+            "--done",
+            "Confirm owners and operating cadence.",
+            "--challenge-prompt",
+            str(challenge_prompt),
+            "--guidelines-zip",
+            str(guidelines_zip),
+        ]
+    )
+    assert rc == 0
+    assert (out_dir / "business-execution-week1.json").exists()
+    assert (out_dir / "business-execution-week1-progress.json").exists()
+    assert (out_dir / "business-execution-week1-next.json").exists()
+    assert (out_dir / "business-execution-handoff.json").exists()
+    assert (out_dir / "business-execution-escalation.json").exists()
+    assert (out_dir / "business-execution-followup.json").exists()
+    assert (out_dir / "business-execution-followup-history.jsonl").exists()
+    assert (out_dir / "business-execution-followup-rollup.json").exists()
+    assert (out_dir / "business-execution-continue.json").exists()
+    assert (out_dir / "business-execution-horizon.json").exists()
+    inputs = out_dir / "business-execution-inputs.json"
+    assert inputs.exists()
+    payload = json.loads(inputs.read_text(encoding="utf-8"))
+    assert payload["challenge_prompt"]["line_count"] == 2
+    assert payload["guidelines_zip"]["entry_count"] == 2
+
+
+def test_pipeline_autodiscovers_canonical_input_files(tmp_path: Path, monkeypatch) -> None:
+    out_dir = tmp_path / "artifacts"
+    challenge_prompt = tmp_path / "workflow_execution_prompt.md"
+    guidelines_zip = tmp_path / "workflow_execution_guidelines_bundle.zip"
+    challenge_prompt.write_text("# prompt\nline\n", encoding="utf-8")
+    with zipfile.ZipFile(guidelines_zip, "w") as zf:
+        zf.writestr("guideline-a.txt", "a")
+
+    monkeypatch.chdir(tmp_path)
+    rc = pipeline_script.main(["--out-dir", str(out_dir), "--program-owner", "Founder"])
+
+    assert rc == 0
+    payload = json.loads((out_dir / "business-execution-inputs.json").read_text(encoding="utf-8"))
+    assert payload["challenge_prompt"]["path"].endswith(
+        "workflow_execution_prompt.md"
+    )
+    assert payload["guidelines_zip"]["path"].endswith(
+        "workflow_execution_guidelines_bundle.zip"
+    )
+
+
+def test_pipeline_rejects_partial_external_input_pair(tmp_path: Path) -> None:
+    out_dir = tmp_path / "artifacts"
+    challenge_prompt = tmp_path / "workflow_execution_prompt.md"
+    challenge_prompt.write_text("# prompt\n", encoding="utf-8")
+
+    try:
+        pipeline_script.main(
+            [
+                "--out-dir",
+                str(out_dir),
+                "--challenge-prompt",
+                str(challenge_prompt),
+            ]
+        )
+    except ValueError as exc:
+        assert "requires both --challenge-prompt and --guidelines-zip" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for partial external input pair")
+
+
+def test_pipeline_single_operator_mode_assigns_all_roles(tmp_path: Path) -> None:
+    out_dir = tmp_path / "artifacts"
+    rc = pipeline_script.main(
+        [
+            "--out-dir",
+            str(out_dir),
+            "--single-operator",
+            "Sherif",
+        ]
+    )
+    assert rc == 0
+    week1_payload = json.loads((out_dir / "business-execution-week1.json").read_text(encoding="utf-8"))
+    assert week1_payload["status"] == "go"
+    assert set(week1_payload["owners"].values()) == {"Sherif"}

--- a/tests/test_business_execution_progress.py
+++ b/tests/test_business_execution_progress.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "business_execution_progress.py"
+_SPEC = importlib.util.spec_from_file_location("business_execution_progress_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+progress_script = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(progress_script)
+
+
+def test_build_progress_tracks_completion_and_gate() -> None:
+    week1 = {
+        "schema_version": "sdetkit.business-execution-start.v1",
+        "status": "go",
+        "week_1_execution_plan": {
+            "day_1": ["A", "B"],
+            "day_2_3": ["C"],
+            "day_4_5": ["D"],
+        },
+    }
+    payload = progress_script.build_progress(week1, {"A", "C"})
+    assert payload["task_summary"]["completed"] == 2
+    assert payload["task_summary"]["total"] == 4
+    assert payload["gate_decision"]["status"] == "conditional-pass"
+
+
+def test_main_writes_progress_artifacts(tmp_path: Path) -> None:
+    week1 = tmp_path / "week1.json"
+    week1.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-start.v1",
+                "status": "needs-owner-assignment",
+                "week_1_execution_plan": {"day_1": ["A"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    out_json = tmp_path / "progress.json"
+    out_md = tmp_path / "progress.md"
+    history = tmp_path / "history.jsonl"
+    rollup = tmp_path / "rollup.json"
+    rc = progress_script.main(
+        [
+            "--week1",
+            str(week1),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--history",
+            str(history),
+            "--history-rollup-out",
+            str(rollup),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["gate_decision"]["status"] == "conditional-pass"
+    assert "Status: needs-owner-assignment" in out_md.read_text(encoding="utf-8")
+    assert history.exists()
+    rollup_payload = json.loads(rollup.read_text(encoding="utf-8"))
+    assert rollup_payload["history_records"] == 1
+
+
+def test_main_strict_owner_gate_fails_when_owners_are_unassigned(tmp_path: Path) -> None:
+    week1 = tmp_path / "week1.json"
+    week1.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-start.v1",
+                "status": "needs-owner-assignment",
+                "week_1_execution_plan": {"day_1": ["A"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    out_json = tmp_path / "progress.json"
+    out_md = tmp_path / "progress.md"
+    history = tmp_path / "history.jsonl"
+    rollup = tmp_path / "rollup.json"
+    rc = progress_script.main(
+        [
+            "--week1",
+            str(week1),
+            "--owner-gate-mode",
+            "strict",
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--history",
+            str(history),
+            "--history-rollup-out",
+            str(rollup),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["gate_decision"]["status"] == "fail"

--- a/tests/test_business_execution_start.py
+++ b/tests/test_business_execution_start.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "business_execution_start.py"
+_SPEC = importlib.util.spec_from_file_location("business_execution_start_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+business_execution_start = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(business_execution_start)
+
+
+def test_build_payload_has_expected_shape() -> None:
+    payload = business_execution_start.build_payload(
+        start_date=business_execution_start.date.fromisoformat("2026-04-28"),
+        program_owner="program",
+        gtm_owner="gtm",
+        commercial_owner="commercial",
+        solutions_owner="solutions",
+        ops_owner="ops",
+    )
+    assert payload["schema_version"] == "sdetkit.business-execution-start.v1"
+    assert payload["owners"]["program_owner"] == "program"
+    assert len(payload["kpi_baseline_template"]) == 6
+    assert payload["status"] == "go"
+    assert "next_action" in payload
+
+
+def test_main_writes_artifacts(tmp_path: Path) -> None:
+    target_json = tmp_path / "week1.json"
+    target_memo = tmp_path / "week1.md"
+    rc = business_execution_start.main(
+        [
+            "--start-date",
+            "2026-04-28",
+            "--program-owner",
+            "Alice",
+            "--gtm-owner",
+            "Bob",
+            "--out-json",
+            str(target_json),
+            "--out-memo",
+            str(target_memo),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(target_json.read_text(encoding="utf-8"))
+    assert payload["start_date"] == "2026-04-28"
+    assert payload["status"] == "needs-owner-assignment"
+    memo = target_memo.read_text(encoding="utf-8")
+    assert "Day 1" in memo
+    assert "Status: NEEDS-OWNER-ASSIGNMENT" in memo
+
+
+def test_main_strict_owner_assignment_fails_when_unassigned(tmp_path: Path) -> None:
+    target_json = tmp_path / "week1.json"
+    target_memo = tmp_path / "week1.md"
+    rc = business_execution_start.main(
+        [
+            "--out-json",
+            str(target_json),
+            "--out-memo",
+            str(target_memo),
+            "--strict-owner-assignment",
+        ]
+    )
+    assert rc == 2
+
+
+def test_main_single_operator_assigns_all_owners(tmp_path: Path) -> None:
+    target_json = tmp_path / "week1.json"
+    target_memo = tmp_path / "week1.md"
+    rc = business_execution_start.main(
+        [
+            "--start-date",
+            "2026-04-28",
+            "--single-operator",
+            "Sherif",
+            "--out-json",
+            str(target_json),
+            "--out-memo",
+            str(target_memo),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(target_json.read_text(encoding="utf-8"))
+    assert payload["status"] == "go"
+    assert set(payload["owners"].values()) == {"Sherif"}

--- a/tests/test_check_business_execution_continue_contract.py
+++ b/tests/test_check_business_execution_continue_contract.py
@@ -5,9 +5,13 @@ import json
 from pathlib import Path
 
 _SCRIPT_PATH = (
-    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_continue_contract.py"
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "check_business_execution_continue_contract.py"
 )
-_SPEC = importlib.util.spec_from_file_location("check_business_execution_continue_contract_script", _SCRIPT_PATH)
+_SPEC = importlib.util.spec_from_file_location(
+    "check_business_execution_continue_contract_script", _SCRIPT_PATH
+)
 assert _SPEC is not None and _SPEC.loader is not None
 continue_contract = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(continue_contract)
@@ -18,7 +22,7 @@ def test_validate_continue_contract_passes() -> None:
         "schema_version": "sdetkit.business-execution-continue.v1",
         "checkpoint_status": "on-track",
         "keep_moving": True,
-        "selected_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+        "selected_command": 'python scripts/business_execution_progress.py --done "Task A"',
         "reason": "Execution should keep moving; run recommended command.",
         "should_run_now": True,
     }

--- a/tests/test_check_business_execution_continue_contract.py
+++ b/tests/test_check_business_execution_continue_contract.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_continue_contract.py"
+)
+_SPEC = importlib.util.spec_from_file_location("check_business_execution_continue_contract_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+continue_contract = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(continue_contract)
+
+
+def test_validate_continue_contract_passes() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-continue.v1",
+        "checkpoint_status": "on-track",
+        "keep_moving": True,
+        "selected_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+        "reason": "Execution should keep moving; run recommended command.",
+        "should_run_now": True,
+    }
+    assert continue_contract.validate_continue_contract(payload) == []
+
+
+def test_main_fails_for_invalid_checkpoint_status(tmp_path: Path) -> None:
+    artifact = tmp_path / "continue.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-continue.v1",
+                "checkpoint_status": "later",
+                "keep_moving": True,
+                "selected_command": "make business-execution-followup",
+                "reason": "x",
+                "should_run_now": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = continue_contract.main(["--artifact", str(artifact)])
+    assert rc == 1

--- a/tests/test_check_business_execution_escalation_contract.py
+++ b/tests/test_check_business_execution_escalation_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_escalation_contract.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "check_business_execution_escalation_contract_script", _SCRIPT_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+escalation_contract = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(escalation_contract)
+
+
+def test_validate_escalation_contract_passes() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-escalation.v1",
+        "week1_status": "go",
+        "progress_gate": "conditional-pass",
+        "completion_percent": 55.0,
+        "pending_count": 2,
+        "pending_tasks": ["Task A", "Task B"],
+        "decision": "watch",
+        "reasons": ["Execution is in progress and requires daily follow-up."],
+        "owners_to_ping": ["Founder"],
+        "recommended_actions": ["Close the top pending tasks by end of day."],
+    }
+    assert escalation_contract.validate_escalation_contract(payload) == []
+
+
+def test_main_fails_when_decision_invalid(tmp_path: Path) -> None:
+    artifact = tmp_path / "escalation.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-escalation.v1",
+                "week1_status": "go",
+                "progress_gate": "pass",
+                "completion_percent": 100.0,
+                "pending_count": 0,
+                "pending_tasks": [],
+                "decision": "invalid",
+                "reasons": [],
+                "owners_to_ping": [],
+                "recommended_actions": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = escalation_contract.main(["--artifact", str(artifact)])
+    assert rc == 1

--- a/tests/test_check_business_execution_escalation_contract.py
+++ b/tests/test_check_business_execution_escalation_contract.py
@@ -5,7 +5,9 @@ import json
 from pathlib import Path
 
 _SCRIPT_PATH = (
-    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_escalation_contract.py"
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "check_business_execution_escalation_contract.py"
 )
 _SPEC = importlib.util.spec_from_file_location(
     "check_business_execution_escalation_contract_script", _SCRIPT_PATH

--- a/tests/test_check_business_execution_followup_contract.py
+++ b/tests/test_check_business_execution_followup_contract.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_followup_contract.py"
+)
+_SPEC = importlib.util.spec_from_file_location("check_business_execution_followup_contract_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+followup_contract = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(followup_contract)
+
+
+def test_validate_followup_contract_passes() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-followup.v1",
+        "progress_gate": "conditional-pass",
+        "escalation_decision": "watch",
+        "window_hours": 24,
+        "pending_count": 1,
+        "next_tasks": ["Task A"],
+        "immediate_actions": ["Complete: Task A"],
+        "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+        "keep_moving": True,
+        "history_records": 3,
+        "decision_counts": {"none": 0, "watch": 2, "escalate": 1},
+        "latest_recorded_at": "2026-04-28T18:00:00+00:00",
+        "next_checkpoint_at": "2026-04-29T18:00:00+00:00",
+        "checkpoint_status": "on-track",
+        "checkpoint_due_in_hours": 12.5,
+        "checkpoint_command": "make business-execution-followup",
+    }
+    assert followup_contract.validate_followup_contract(payload) == []
+
+
+def test_main_fails_when_keep_moving_is_not_bool(tmp_path: Path) -> None:
+    artifact = tmp_path / "followup.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-followup.v1",
+                "progress_gate": "conditional-pass",
+                "escalation_decision": "watch",
+                "window_hours": 24,
+                "pending_count": 1,
+                "next_tasks": ["Task A"],
+                "immediate_actions": ["Complete: Task A"],
+                "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+                "keep_moving": "yes",
+                "history_records": 1,
+                "decision_counts": {"none": 0, "watch": 1, "escalate": 0},
+                "latest_recorded_at": "2026-04-28T18:00:00+00:00",
+                "next_checkpoint_at": "2026-04-29T18:00:00+00:00",
+                "checkpoint_status": "on-track",
+                "checkpoint_due_in_hours": 12.5,
+                "checkpoint_command": "make business-execution-followup",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = followup_contract.main(["--artifact", str(artifact)])
+    assert rc == 1

--- a/tests/test_check_business_execution_followup_contract.py
+++ b/tests/test_check_business_execution_followup_contract.py
@@ -5,9 +5,13 @@ import json
 from pathlib import Path
 
 _SCRIPT_PATH = (
-    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_followup_contract.py"
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "check_business_execution_followup_contract.py"
 )
-_SPEC = importlib.util.spec_from_file_location("check_business_execution_followup_contract_script", _SCRIPT_PATH)
+_SPEC = importlib.util.spec_from_file_location(
+    "check_business_execution_followup_contract_script", _SCRIPT_PATH
+)
 assert _SPEC is not None and _SPEC.loader is not None
 followup_contract = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(followup_contract)
@@ -22,7 +26,7 @@ def test_validate_followup_contract_passes() -> None:
         "pending_count": 1,
         "next_tasks": ["Task A"],
         "immediate_actions": ["Complete: Task A"],
-        "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+        "recommended_command": 'python scripts/business_execution_progress.py --done "Task A"',
         "keep_moving": True,
         "history_records": 3,
         "decision_counts": {"none": 0, "watch": 2, "escalate": 1},
@@ -47,7 +51,7 @@ def test_main_fails_when_keep_moving_is_not_bool(tmp_path: Path) -> None:
                 "pending_count": 1,
                 "next_tasks": ["Task A"],
                 "immediate_actions": ["Complete: Task A"],
-                "recommended_command": "python scripts/business_execution_progress.py --done \"Task A\"",
+                "recommended_command": 'python scripts/business_execution_progress.py --done "Task A"',
                 "keep_moving": "yes",
                 "history_records": 1,
                 "decision_counts": {"none": 0, "watch": 1, "escalate": 0},

--- a/tests/test_check_business_execution_handoff_contract.py
+++ b/tests/test_check_business_execution_handoff_contract.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_handoff_contract.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "check_business_execution_handoff_contract_script", _SCRIPT_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+handoff_contract = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(handoff_contract)
+
+
+def test_validate_handoff_contract_passes() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-handoff.v1",
+        "week1_status": "go",
+        "week1_start_date": "2026-04-28",
+        "progress_gate": "pass",
+        "progress_completion_percent": 100.0,
+        "history_records": 2,
+        "latest_gate_counts": {"pass": 1, "conditional-pass": 1, "fail": 0},
+        "next_tasks": [],
+        "recommended_command": None,
+    }
+    assert handoff_contract.validate_handoff_contract(payload) == []
+
+
+def test_main_fails_when_required_fields_missing(tmp_path: Path) -> None:
+    artifact = tmp_path / "handoff.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-handoff.v1",
+                "week1_status": "go",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = handoff_contract.main(["--artifact", str(artifact)])
+    assert rc == 1

--- a/tests/test_check_business_execution_horizon_contract.py
+++ b/tests/test_check_business_execution_horizon_contract.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_horizon_contract.py"
+)
+_SPEC = importlib.util.spec_from_file_location("check_business_execution_horizon_contract_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+horizon_contract = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(horizon_contract)
+
+
+def test_validate_horizon_contract_passes() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-horizon.v1",
+        "week1_status": "go",
+        "progress_gate": "conditional-pass",
+        "completion_percent": 50.0,
+        "followup_checkpoint_status": "on-track",
+        "focus_mode": "foundation-build",
+        "week_2_plan": {"day_6_7": ["A"]},
+        "day_90_plan": {"day_90": ["B"]},
+    }
+    assert horizon_contract.validate_horizon_contract(payload) == []
+
+
+def test_main_fails_when_focus_mode_invalid(tmp_path: Path) -> None:
+    artifact = tmp_path / "horizon.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-horizon.v1",
+                "week1_status": "go",
+                "progress_gate": "conditional-pass",
+                "completion_percent": 50.0,
+                "followup_checkpoint_status": "on-track",
+                "focus_mode": "invalid",
+                "week_2_plan": {"day_6_7": ["A"]},
+                "day_90_plan": {"day_90": ["B"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = horizon_contract.main(["--artifact", str(artifact)])
+    assert rc == 1

--- a/tests/test_check_business_execution_horizon_contract.py
+++ b/tests/test_check_business_execution_horizon_contract.py
@@ -7,7 +7,9 @@ from pathlib import Path
 _SCRIPT_PATH = (
     Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_horizon_contract.py"
 )
-_SPEC = importlib.util.spec_from_file_location("check_business_execution_horizon_contract_script", _SCRIPT_PATH)
+_SPEC = importlib.util.spec_from_file_location(
+    "check_business_execution_horizon_contract_script", _SCRIPT_PATH
+)
 assert _SPEC is not None and _SPEC.loader is not None
 horizon_contract = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(horizon_contract)

--- a/tests/test_check_business_execution_inputs_contract.py
+++ b/tests/test_check_business_execution_inputs_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_inputs_contract.py"
+_SPEC = importlib.util.spec_from_file_location("check_business_execution_inputs_contract_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+inputs_contract = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(inputs_contract)
+
+
+def test_validate_inputs_contract_passes() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-inputs.v1",
+        "challenge_prompt": {
+            "path": "a.md",
+            "size_bytes": 1,
+            "sha256": "x",
+            "line_count": 1,
+            "first_heading": "h",
+        },
+        "guidelines_zip": {
+            "path": "a.zip",
+            "size_bytes": 2,
+            "sha256": "y",
+            "entry_count": 2,
+            "entries_preview": ["a"],
+        },
+    }
+    assert inputs_contract.validate_inputs_contract(payload) == []
+
+
+def test_main_fails_when_zip_exceeds_limit(tmp_path: Path) -> None:
+    artifact = tmp_path / "inputs.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-inputs.v1",
+                "challenge_prompt": None,
+                "guidelines_zip": {
+                    "path": "a.zip",
+                    "size_bytes": 2,
+                    "sha256": "y",
+                    "entry_count": 30,
+                    "entries_preview": ["a"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = inputs_contract.main(["--artifact", str(artifact)])
+    assert rc == 1

--- a/tests/test_check_business_execution_inputs_contract.py
+++ b/tests/test_check_business_execution_inputs_contract.py
@@ -4,8 +4,12 @@ import importlib.util
 import json
 from pathlib import Path
 
-_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_inputs_contract.py"
-_SPEC = importlib.util.spec_from_file_location("check_business_execution_inputs_contract_script", _SCRIPT_PATH)
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_inputs_contract.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "check_business_execution_inputs_contract_script", _SCRIPT_PATH
+)
 assert _SPEC is not None and _SPEC.loader is not None
 inputs_contract = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(inputs_contract)

--- a/tests/test_check_business_execution_next_contract.py
+++ b/tests/test_check_business_execution_next_contract.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_next_contract.py"
+_SPEC = importlib.util.spec_from_file_location("check_business_execution_next_contract_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+next_contract = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(next_contract)
+
+
+def test_validate_next_contract_passes() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-next.v1",
+        "pending_count": 1,
+        "next_tasks": ["A"],
+        "recommended_command": "python scripts/business_execution_progress.py --done \"A\"",
+    }
+    assert next_contract.validate_next_contract(payload) == []
+
+
+def test_main_fails_for_invalid_pending_count(tmp_path: Path) -> None:
+    artifact = tmp_path / "next.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-next.v1",
+                "pending_count": "1",
+                "next_tasks": ["A"],
+                "recommended_command": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = next_contract.main(["--artifact", str(artifact)])
+    assert rc == 1

--- a/tests/test_check_business_execution_next_contract.py
+++ b/tests/test_check_business_execution_next_contract.py
@@ -4,8 +4,12 @@ import importlib.util
 import json
 from pathlib import Path
 
-_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_next_contract.py"
-_SPEC = importlib.util.spec_from_file_location("check_business_execution_next_contract_script", _SCRIPT_PATH)
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_next_contract.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "check_business_execution_next_contract_script", _SCRIPT_PATH
+)
 assert _SPEC is not None and _SPEC.loader is not None
 next_contract = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(next_contract)
@@ -16,7 +20,7 @@ def test_validate_next_contract_passes() -> None:
         "schema_version": "sdetkit.business-execution-next.v1",
         "pending_count": 1,
         "next_tasks": ["A"],
-        "recommended_command": "python scripts/business_execution_progress.py --done \"A\"",
+        "recommended_command": 'python scripts/business_execution_progress.py --done "A"',
     }
     assert next_contract.validate_next_contract(payload) == []
 

--- a/tests/test_check_business_execution_progress_contract.py
+++ b/tests/test_check_business_execution_progress_contract.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "check_business_execution_progress_contract.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "check_business_execution_progress_contract_script", _SCRIPT_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+progress_contract = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(progress_contract)
+
+
+def test_validate_progress_contract_passes() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-progress.v1",
+        "task_summary": {"completed": 1, "total": 2, "completion_percent": 50.0},
+        "tasks": [{"task": "A", "done": True}, {"task": "B", "done": False}],
+        "gate_decision": {"status": "conditional-pass", "reason": "Execution in progress."},
+    }
+    assert progress_contract.validate_progress_contract(payload) == []
+
+
+def test_main_fails_for_invalid_gate_status(tmp_path: Path) -> None:
+    artifact = tmp_path / "progress.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-progress.v1",
+                "task_summary": {"completed": 0, "total": 1, "completion_percent": 0.0},
+                "tasks": [{"task": "A", "done": False}],
+                "gate_decision": {"status": "green", "reason": "x"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = progress_contract.main(["--artifact", str(artifact)])
+    assert rc == 1

--- a/tests/test_check_business_execution_start_contract.py
+++ b/tests/test_check_business_execution_start_contract.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_start_contract.py"
+)
+_SPEC = importlib.util.spec_from_file_location("check_business_execution_start_contract_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+contract = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(contract)
+
+
+def test_validate_contract_passes_for_valid_payload() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-start.v1",
+        "owners": {
+            "program_owner": "A",
+            "gtm_owner": "B",
+            "commercial_owner": "C",
+            "solutions_owner": "D",
+            "ops_owner": "E",
+        },
+        "status": "go",
+        "next_action": "Run execution week with live owners and baseline KPIs.",
+    }
+    assert contract.validate_contract(payload) == []
+
+
+def test_validate_contract_rejects_go_with_tbd_owners() -> None:
+    payload = {
+        "schema_version": "sdetkit.business-execution-start.v1",
+        "owners": {
+            "program_owner": "TBD",
+            "gtm_owner": "B",
+            "commercial_owner": "C",
+            "solutions_owner": "D",
+            "ops_owner": "E",
+        },
+        "status": "go",
+        "next_action": "Run execution week with live owners and baseline KPIs.",
+    }
+    errors = contract.validate_contract(payload)
+    assert "status=go is invalid when owners are TBD" in errors
+
+
+def test_main_require_go_fails_for_non_go_status(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.business-execution-start.v1",
+                "owners": {
+                    "program_owner": "TBD",
+                    "gtm_owner": "TBD",
+                    "commercial_owner": "TBD",
+                    "solutions_owner": "TBD",
+                    "ops_owner": "TBD",
+                },
+                "status": "needs-owner-assignment",
+                "next_action": "Assign all owners, then rerun this command.",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = contract.main(["--artifact", str(artifact), "--require-go"])
+    assert rc == 1

--- a/tests/test_check_business_execution_start_contract.py
+++ b/tests/test_check_business_execution_start_contract.py
@@ -7,7 +7,9 @@ from pathlib import Path
 _SCRIPT_PATH = (
     Path(__file__).resolve().parents[1] / "scripts" / "check_business_execution_start_contract.py"
 )
-_SPEC = importlib.util.spec_from_file_location("check_business_execution_start_contract_script", _SCRIPT_PATH)
+_SPEC = importlib.util.spec_from_file_location(
+    "check_business_execution_start_contract_script", _SCRIPT_PATH
+)
 assert _SPEC is not None and _SPEC.loader is not None
 contract = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(contract)


### PR DESCRIPTION
### Motivation
- Provide an executable, reproducible "week-1" business execution pipeline that generates artifacts (JSON + MD), enforces artifact contracts, and supports an automated follow-up/escalation flow. 
- Integrate the pipeline into the repo developer workflow via Make targets and documentation so teams can bootstrap and run execution artifacts end-to-end.

### Description
- Added a suite of scripts under `scripts/` to bootstrap and run the pipeline: `business_execution_start.py`, `business_execution_progress.py`, `business_execution_next.py`, `business_execution_handoff.py`, `business_execution_escalation.py`, `business_execution_followup.py`, `business_execution_continue.py`, `business_execution_horizon.py`, and an orchestrator `business_execution_pipeline.py` that runs the full flow and validates inputs. 
- Added contract validators for each artifact under `scripts/check_*_contract.py` to assert schema shapes and sanity checks for programmatic validation. 
- Added Makefile variables and targets to expose the pipeline: `BUSINESS_EXECUTION_OPERATOR` default, new `.PHONY` targets and runnable targets such as `business-execution-start`, `business-execution-pipeline`, and related contract checks. 
- Expanded docs (`docs/business_execution/index.md`) with usage instructions, default outputs, input-bundle policy, and examples; and added comprehensive unit tests for all new scripts and contract checkers under `tests/`. 
- Minor CI/project config changes: added `--enforce-admins` to branch-protection workflow invocation and adjusted dependency pins in `pyproject.toml` and `requirements-test.txt` for `ruff` and `hypothesis`.

### Testing
- Ran the test suite with `pytest` against the new tests which exercise the full pipeline, individual script behaviors, and all contract validators, and all tests completed successfully. 
- Executed the pipeline end-to-end in tests using auto-discovered canonical input files and single-operator mode to verify artifact generation and contract validation succeeded. 
- Contract validator tests were executed to confirm error cases return non-zero exit codes as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d5a88e648332bc7216e6f2ac28a7)