### PR TITLE
Docs: switch CLI examples to `release gate` and add "Choose your path" navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ DevS69 SDETKit is a release-confidence CLI for deterministic ship/no-ship decisi
 
 **Primary outcome:** know if a change is ready to ship.
 
-Canonical first path: `python -m sdetkit release gate fast` -> `python -m sdetkit release gate release` -> `python -m sdetkit release doctor`.
+Canonical first path: `python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor`.
 
 Guided alias for first-time users: `python -m sdetkit start --journey fast-start --format markdown`.
 
@@ -25,9 +25,9 @@ This page is the product homepage/router for first-time adoption.
 ## Fast start
 
 ```bash
-python -m sdetkit release gate fast --format json --stable-json --out build/gate-fast.json
-python -m sdetkit release gate release --format json --out build/release-preflight.json
-python -m sdetkit release doctor
+python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit gate release --format json --out build/release-preflight.json
+python -m sdetkit doctor
 ```
 
 New teams should stop here first, then inspect artifacts before exploring advanced commands.
@@ -44,7 +44,7 @@ build/release-preflight.json
 ## Pick your path first
 
 - [Choose your path (30-second router)](choose-your-path.md)
-- Command alias: `python -m sdetkit release gate fast --format json --stable-json --out build/gate-fast.json`
+- Equivalent namespace form: `python -m sdetkit release gate fast --format json --stable-json --out build/gate-fast.json`
 - Full release path: `python -m sdetkit release gate fast` -> `python -m sdetkit release gate release` -> `python -m sdetkit release doctor`
 
 ## Try it quickly
@@ -57,7 +57,7 @@ build/release-preflight.json
 
 ## Keep first adoption simple
 
-1. Start with the canonical path (`release gate fast` -> `release gate release` -> `release doctor`).
+1. Start with the canonical path (`gate fast` -> `gate release` -> `doctor`).
 2. Optional guided onboarding prompt: `python -m sdetkit start --journey fast-start --format markdown`.
 3. For reviewer handoff + adoption planning, prefer the one-command bundle:
    - `make adoption-control-loop-full`

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ DevS69 SDETKit is a release-confidence CLI for deterministic ship/no-ship decisi
 
 **Primary outcome:** know if a change is ready to ship.
 
-Canonical first path: `python -m sdetkit gate fast` -> `python -m sdetkit gate release` -> `python -m sdetkit doctor`.
+Canonical first path: `python -m sdetkit release gate fast` -> `python -m sdetkit release gate release` -> `python -m sdetkit release doctor`.
 
 Guided alias for first-time users: `python -m sdetkit start --journey fast-start --format markdown`.
 
@@ -12,7 +12,7 @@ This page is the product homepage/router for first-time adoption.
 
 <div class="quick-jump" markdown>
 
-[⚡ Fast start](#fast-start) · [🧭 Repo tour](repo-tour.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-reports)
+[⚡ Fast start](#fast-start) · [🧭 Choose your path](choose-your-path.md) · [🧭 Repo tour](repo-tour.md) · [🛠 CLI commands](cli.md) · [🩺 Doctor checks](doctor.md) · [🤝 Contribute](contributing.md) · [📦 Legacy reports](#legacy-reports)
 
 </div>
 
@@ -25,12 +25,14 @@ This page is the product homepage/router for first-time adoption.
 ## Fast start
 
 ```bash
-python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json
-python -m sdetkit gate release --format json --out build/release-preflight.json
-python -m sdetkit doctor
+python -m sdetkit release gate fast --format json --stable-json --out build/gate-fast.json
+python -m sdetkit release gate release --format json --out build/release-preflight.json
+python -m sdetkit release doctor
 ```
 
 New teams should stop here first, then inspect artifacts before exploring advanced commands.
+
+Compatibility aliases still supported: `python -m sdetkit gate fast`, `python -m sdetkit gate release`, and `python -m sdetkit doctor`.
 
 ## What you get
 
@@ -38,6 +40,12 @@ New teams should stop here first, then inspect artifacts before exploring advanc
 build/gate-fast.json
 build/release-preflight.json
 ```
+
+## Pick your path first
+
+- [Choose your path (30-second router)](choose-your-path.md)
+- Command alias: `python -m sdetkit release gate fast --format json --stable-json --out build/gate-fast.json`
+- Full release path: `python -m sdetkit release gate fast` -> `python -m sdetkit release gate release` -> `python -m sdetkit release doctor`
 
 ## Try it quickly
 
@@ -49,7 +57,7 @@ build/release-preflight.json
 
 ## Keep first adoption simple
 
-1. Start with the canonical path (`gate fast` -> `gate release` -> `doctor`).
+1. Start with the canonical path (`release gate fast` -> `release gate release` -> `release doctor`).
 2. Optional guided onboarding prompt: `python -m sdetkit start --journey fast-start --format markdown`.
 3. For reviewer handoff + adoption planning, prefer the one-command bundle:
    - `make adoption-control-loop-full`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,12 +85,14 @@ extra_javascript:
 
 nav:
   - Start here: index.md
+  - Choose your path: choose-your-path.md
   - Canonical first-proof path (primary):
       - Install: install.md
       - Quickstart (copy-paste): quickstart-copy-paste.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
       - Guided first run: ready-to-use.md
       - Team adoption checklist: team-adoption-checklist.md
+      - Choose your path (30-second router): choose-your-path.md
       - Adopt in your repository: adoption.md
       - Team rollout playbook: team-rollout-playbook.md
       - Team rollout scenario: team-rollout-scenario.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,6 @@ extra_javascript:
 
 nav:
   - Start here: index.md
-  - Choose your path: choose-your-path.md
   - Canonical first-proof path (primary):
       - Install: install.md
       - Quickstart (copy-paste): quickstart-copy-paste.md


### PR DESCRIPTION
### Motivation

- Update documentation to reflect the new CLI invocation namespace that nests gate commands under `release` for clearer command hierarchy.
- Surface a short router/choice page to help first-time users pick the appropriate journey quickly.
- Preserve compatibility guidance so existing users can still run previous aliases while migrating.

### Description

- Updated `docs/index.md` to replace `python -m sdetkit gate ...` examples with the new `python -m sdetkit release gate ...` and adjusted quickstart snippets accordingly.
- Added a quick-jump link and a new "Pick your path first" section in `docs/index.md` that links to `choose-your-path.md` and documents the new canonical path and compatibility aliases.
- Updated `mkdocs.yml` to include `choose-your-path.md` in the site navigation so the router page is discoverable from the top-level nav.
- Made small copy edits to canonical path wording across the index to keep examples consistent.

### Testing

- Ran `mkdocs build` to validate that the documentation builds and the updated pages render, and the build completed successfully.
- Verified that the updated `index.md` contains the new links and command examples, and that `choose-your-path.md` appears in the generated navigation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12e00aad883329eb7fb2a709be022)