### PR TITLE
Add failure remediation workflow (action plan builder, autofix runner, docs, and tests)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,3 +537,13 @@ phase6-status: phase6-metrics-contract
 phase6-progress: phase6-metrics-contract
 
 phase6-complete: phase6-metrics-contract
+
+.PHONY: failure-plan failure-autofix failure-workflow
+failure-plan:
+	python scripts/build_failure_action_plan.py
+
+failure-autofix:
+	python scripts/failure_autofix_workflow.py --max-actions 5
+
+failure-workflow: failure-plan failure-autofix
+	@echo "failure workflow complete: see examples/kits/intelligence/failure-autofix-report.json"

--- a/README.md
+++ b/README.md
@@ -195,3 +195,18 @@ python tools/maintenance_command_center.py \
 - Policy baselines: [policy baselines](docs/policy-and-baselines.md)
 - Quality playbook: [QUALITY_PLAYBOOK.md](QUALITY_PLAYBOOK.md)
 - Release notes: [CHANGELOG.md](CHANGELOG.md)
+
+## Failure remediation workflow (rank-1 SDET lane)
+Use these commands to run the full intelligence loop:
+
+```bash
+make failure-workflow
+```
+
+This will:
+1. Build a prioritized action plan from `examples/kits/intelligence/failures.json`.
+2. Execute reproduce commands and generate autofix recommendations.
+3. Emit a combined report at `examples/kits/intelligence/failure-autofix-report.json`.
+
+Manual steps are documented in:
+- `examples/kits/intelligence/failure-fix-playbook.md`

--- a/examples/kits/intelligence/failure-action-plan.json
+++ b/examples/kits/intelligence/failure-action-plan.json
@@ -1,0 +1,34 @@
+{
+  "source": "examples/kits/intelligence/failures.json",
+  "total_actions": 2,
+  "actions": [
+    {
+      "rank": 1,
+      "issue_id": "ISSUE-001",
+      "priority": "P1",
+      "owner": "sre-team",
+      "status": "planned",
+      "category": "reliability",
+      "test_id": "tests/api/test_orders.py::test_retry_on_timeout",
+      "security_impact": "low",
+      "next_step": "Increase timeout budget, add bounded exponential backoff retries, and emit timeout telemetry for alerting.",
+      "reproduce_command": "pytest -q tests/api/test_orders.py::test_retry_on_timeout",
+      "verify_command": "pytest -q tests/api/test_orders.py::test_retry_on_timeout --maxfail=1",
+      "definition_of_done": "Failing test passes consistently for 3 consecutive runs."
+    },
+    {
+      "rank": 2,
+      "issue_id": "ISSUE-002",
+      "priority": "P2",
+      "owner": "platform-network",
+      "status": "planned",
+      "category": "network-stability",
+      "test_id": "tests/integration/test_checkout.py::test_payment_capture",
+      "security_impact": "medium",
+      "next_step": "Enforce idempotency keys for payment capture and add safe retry guards around transient connection resets.",
+      "reproduce_command": "pytest -q tests/integration/test_checkout.py::test_payment_capture",
+      "verify_command": "pytest -q tests/integration/test_checkout.py::test_payment_capture --maxfail=1",
+      "definition_of_done": "Failing test passes consistently for 3 consecutive runs."
+    }
+  ]
+}

--- a/examples/kits/intelligence/failure-autofix-report.json
+++ b/examples/kits/intelligence/failure-autofix-report.json
@@ -2,6 +2,8 @@
   "source_plan": "examples/kits/intelligence/failure-action-plan.json",
   "executed_actions": 2,
   "failed_actions": 2,
+  "passed_actions": 0,
+  "skipped_actions": 0,
   "results": [
     {
       "issue_id": "ISSUE-001",
@@ -38,7 +40,7 @@
         "Add circuit-breaker guardrail to prevent retry storms.",
         "Run security.sh after fix and block merge on new warnings/errors."
       ],
-      "output_preview": "ERROR: file or directory not found: tests/integration/test_checkout.py::test_payment_capture\n\n\nno tests ran in 0.22s"
+      "output_preview": "ERROR: file or directory not found: tests/integration/test_checkout.py::test_payment_capture\n\n\nno tests ran in 0.24s"
     }
   ]
 }

--- a/examples/kits/intelligence/failure-autofix-report.json
+++ b/examples/kits/intelligence/failure-autofix-report.json
@@ -1,0 +1,44 @@
+{
+  "source_plan": "examples/kits/intelligence/failure-action-plan.json",
+  "executed_actions": 2,
+  "failed_actions": 2,
+  "results": [
+    {
+      "issue_id": "ISSUE-001",
+      "priority": "P1",
+      "owner": "sre-team",
+      "status": "failed",
+      "exit_code": 4,
+      "reproduce_command": "pytest -q tests/api/test_orders.py::test_retry_on_timeout",
+      "candidate_code_areas": [
+        "src/**/orders*.py",
+        "scripts/**/orders*.py"
+      ],
+      "auto_fix_suggestions": [
+        "Tune timeout thresholds for upstream dependency boundaries.",
+        "Implement bounded exponential backoff for transient timeouts.",
+        "Add telemetry: timeout rate, retry count, and p95 latency."
+      ],
+      "output_preview": "ERROR: file or directory not found: tests/api/test_orders.py::test_retry_on_timeout\n\n\nno tests ran in 0.23s"
+    },
+    {
+      "issue_id": "ISSUE-002",
+      "priority": "P2",
+      "owner": "platform-network",
+      "status": "failed",
+      "exit_code": 4,
+      "reproduce_command": "pytest -q tests/integration/test_checkout.py::test_payment_capture",
+      "candidate_code_areas": [
+        "src/**/checkout*.py",
+        "scripts/**/checkout*.py"
+      ],
+      "auto_fix_suggestions": [
+        "Enforce idempotency keys for side-effecting operations.",
+        "Retry only safe/transient socket reset errors.",
+        "Add circuit-breaker guardrail to prevent retry storms.",
+        "Run security.sh after fix and block merge on new warnings/errors."
+      ],
+      "output_preview": "ERROR: file or directory not found: tests/integration/test_checkout.py::test_payment_capture\n\n\nno tests ran in 0.22s"
+    }
+  ]
+}

--- a/examples/kits/intelligence/failure-fix-playbook.md
+++ b/examples/kits/intelligence/failure-fix-playbook.md
@@ -1,0 +1,44 @@
+# Failure Fix Playbook
+
+Use this flow to start fixing failures from `failure-action-plan.json`.
+
+## 1) Pick the top-ranked issue
+- Open `examples/kits/intelligence/failure-action-plan.json`.
+- Start with the lowest `rank` value (highest priority).
+
+## 2) Reproduce the issue
+- Run the `reproduce_command` for the selected action.
+- Capture logs and any stack traces.
+
+## 3) Implement fix safely
+- Keep changes scoped to the component mapped by the failing test.
+- Add/adjust test coverage for the identified bug path.
+- For payment/network issues, enforce idempotency and bounded retries.
+
+## 4) Verify resolution
+- Run `verify_command` at least 3 times.
+- Mark item complete only when all runs pass and no new regressions appear.
+
+## 5) Update status
+- Change `status` in the action item (`planned` -> `in_progress` -> `blocked`/`done`).
+- Add short notes in commit message referencing `issue_id`.
+
+## Suggested immediate order
+1. `ISSUE-001` (`P1`) - API retry timeout stabilization.
+2. `ISSUE-002` (`P2`) - checkout connection reset hardening.
+
+## 6) Run the unified autofix workflow
+Use the automation script to execute all planned failure reproductions and emit one combined report:
+
+```bash
+python scripts/failure_autofix_workflow.py --max-actions 5
+```
+
+The report is written to:
+- `examples/kits/intelligence/failure-autofix-report.json`
+
+Use this report to:
+- identify failing reproductions quickly,
+- map each issue to likely code areas,
+- apply targeted autofix suggestions,
+- and re-run security/verification gates before merge.

--- a/examples/kits/intelligence/failures.json
+++ b/examples/kits/intelligence/failures.json
@@ -1,13 +1,34 @@
 {
+  "generated_at": "2026-04-29T00:00:00Z",
+  "summary": {
+    "total_failures": 2,
+    "by_priority": {
+      "P1": 1,
+      "P2": 1
+    },
+    "security_related": 1
+  },
   "failures": [
     {
+      "id": "ISSUE-001",
+      "priority": "P1",
       "test_id": "tests/api/test_orders.py::test_retry_on_timeout",
       "message": "request timed out after 2.0s while waiting for upstream",
+      "category": "reliability",
+      "security_impact": "low",
+      "issue": "Request retries are timing out under upstream delay, which can hide traffic spikes and degrade API reliability.",
+      "fix_recommendation": "Increase timeout budget, add bounded exponential backoff retries, and emit timeout telemetry for alerting.",
       "fixture_scope": "session"
     },
     {
+      "id": "ISSUE-002",
+      "priority": "P2",
       "test_id": "tests/integration/test_checkout.py::test_payment_capture",
       "message": "connection reset by peer during network call",
+      "category": "network-stability",
+      "security_impact": "medium",
+      "issue": "Unstable checkout network sessions may cause duplicate submission risk if retry/idempotency controls are weak.",
+      "fix_recommendation": "Enforce idempotency keys for payment capture and add safe retry guards around transient connection resets.",
       "fixture_scope": "module"
     }
   ]

--- a/scripts/build_failure_action_plan.py
+++ b/scripts/build_failure_action_plan.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Generate a prioritized remediation plan from failure intelligence JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+PRIORITY_RANK = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+SECURITY_WEIGHT = {"critical": 0, "high": 1, "medium": 2, "low": 3, "none": 4}
+
+
+def _load_failures(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("failures payload must be a JSON object")
+    return payload
+
+
+def _sort_key(item: dict) -> tuple[int, int, str]:
+    priority = str(item.get("priority", "P3")).upper()
+    security = str(item.get("security_impact", "none")).lower()
+    return (
+        PRIORITY_RANK.get(priority, 99),
+        SECURITY_WEIGHT.get(security, 99),
+        str(item.get("id", "")),
+    )
+
+
+def _owner_for_category(category: str) -> str:
+    mapping = {
+        "reliability": "sre-team",
+        "network-stability": "platform-network",
+        "security": "appsec",
+    }
+    return mapping.get(category, "qa-lead")
+
+
+def _build_actions(failures: Iterable[dict]) -> list[dict]:
+    actions: list[dict] = []
+    for rank, failure in enumerate(sorted(failures, key=_sort_key), start=1):
+        category = str(failure.get("category", "unknown"))
+        actions.append(
+            {
+                "rank": rank,
+                "issue_id": failure.get("id", "UNKNOWN"),
+                "priority": failure.get("priority", "P3"),
+                "owner": _owner_for_category(category),
+                "status": "planned",
+                "category": category,
+                "test_id": failure.get("test_id", ""),
+                "security_impact": failure.get("security_impact", "none"),
+                "next_step": failure.get("fix_recommendation", "Define remediation."),
+                "reproduce_command": f"pytest -q {failure.get('test_id', '')}",
+                "verify_command": f"pytest -q {failure.get('test_id', '')} --maxfail=1",
+                "definition_of_done": "Failing test passes consistently for 3 consecutive runs.",
+            }
+        )
+    return actions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default="examples/kits/intelligence/failures.json")
+    parser.add_argument("--output", default="examples/kits/intelligence/failure-action-plan.json")
+    args = parser.parse_args()
+
+    payload = _load_failures(Path(args.input))
+    failures = payload.get("failures", [])
+    if not isinstance(failures, list):
+        raise ValueError("`failures` must be a list")
+
+    actions = _build_actions(failures)
+    output = {
+        "source": args.input,
+        "total_actions": len(actions),
+        "actions": actions,
+    }
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(f"{json.dumps(output, indent=2)}\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/failure_autofix_workflow.py
+++ b/scripts/failure_autofix_workflow.py
@@ -69,7 +69,9 @@ def _ripgrep_candidates(test_id: str) -> list[str]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--plan", default="examples/kits/intelligence/failure-action-plan.json")
-    parser.add_argument("--report", default="examples/kits/intelligence/failure-autofix-report.json")
+    parser.add_argument(
+        "--report", default="examples/kits/intelligence/failure-autofix-report.json"
+    )
     parser.add_argument("--max-actions", type=int, default=5)
     parser.add_argument("--timeout-seconds", type=int, default=90)
     args = parser.parse_args()
@@ -81,7 +83,9 @@ def main() -> int:
     for action in actions:
         cmd = str(action.get("reproduce_command", "")).strip()
         if not cmd:
-            results.append({"issue_id": action.get("issue_id"), "status": "skipped", "reason": "no command"})
+            results.append(
+                {"issue_id": action.get("issue_id"), "status": "skipped", "reason": "no command"}
+            )
             continue
 
         code, output = _run(cmd, args.timeout_seconds)

--- a/scripts/failure_autofix_workflow.py
+++ b/scripts/failure_autofix_workflow.py
@@ -14,13 +14,14 @@ def _load_plan(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _run(command: str) -> tuple[int, str]:
+def _run(command: str, timeout_seconds: int) -> tuple[int, str]:
     proc = subprocess.run(
         shlex.split(command),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
         check=False,
+        timeout=timeout_seconds,
     )
     return proc.returncode, proc.stdout
 
@@ -70,6 +71,7 @@ def main() -> int:
     parser.add_argument("--plan", default="examples/kits/intelligence/failure-action-plan.json")
     parser.add_argument("--report", default="examples/kits/intelligence/failure-autofix-report.json")
     parser.add_argument("--max-actions", type=int, default=5)
+    parser.add_argument("--timeout-seconds", type=int, default=90)
     args = parser.parse_args()
 
     plan = _load_plan(Path(args.plan))
@@ -82,7 +84,7 @@ def main() -> int:
             results.append({"issue_id": action.get("issue_id"), "status": "skipped", "reason": "no command"})
             continue
 
-        code, output = _run(cmd)
+        code, output = _run(cmd, args.timeout_seconds)
         results.append(
             {
                 "issue_id": action.get("issue_id"),
@@ -97,10 +99,15 @@ def main() -> int:
             }
         )
 
+    failed = sum(1 for item in results if item.get("status") == "failed")
+    passed = sum(1 for item in results if item.get("status") == "passed")
+    skipped = sum(1 for item in results if item.get("status") == "skipped")
     report = {
         "source_plan": args.plan,
         "executed_actions": len(results),
-        "failed_actions": sum(1 for item in results if item.get("status") == "failed"),
+        "failed_actions": failed,
+        "passed_actions": passed,
+        "skipped_actions": skipped,
         "results": results,
     }
     out_path = Path(args.report)

--- a/scripts/failure_autofix_workflow.py
+++ b/scripts/failure_autofix_workflow.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Run a full failure triage + auto-fix suggestion workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from pathlib import Path
+
+
+def _load_plan(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _run(command: str) -> tuple[int, str]:
+    proc = subprocess.run(
+        shlex.split(command),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    return proc.returncode, proc.stdout
+
+
+def _suggestions_for(action: dict) -> list[str]:
+    category = str(action.get("category", "")).lower()
+    security_impact = str(action.get("security_impact", "none")).lower()
+    suggestions: list[str] = []
+
+    if "reliability" in category:
+        suggestions.extend(
+            [
+                "Tune timeout thresholds for upstream dependency boundaries.",
+                "Implement bounded exponential backoff for transient timeouts.",
+                "Add telemetry: timeout rate, retry count, and p95 latency.",
+            ]
+        )
+
+    if "network" in category:
+        suggestions.extend(
+            [
+                "Enforce idempotency keys for side-effecting operations.",
+                "Retry only safe/transient socket reset errors.",
+                "Add circuit-breaker guardrail to prevent retry storms.",
+            ]
+        )
+
+    if security_impact in {"high", "critical", "medium"}:
+        suggestions.append("Run security.sh after fix and block merge on new warnings/errors.")
+
+    if not suggestions:
+        suggestions.append("Review failing path and add targeted regression test before fix.")
+
+    return suggestions
+
+
+def _ripgrep_candidates(test_id: str) -> list[str]:
+    if "::" not in test_id:
+        return []
+    test_file = test_id.split("::", 1)[0]
+    stem = Path(test_file).stem.replace("test_", "")
+    return [f"src/**/{stem}*.py", f"scripts/**/{stem}*.py"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", default="examples/kits/intelligence/failure-action-plan.json")
+    parser.add_argument("--report", default="examples/kits/intelligence/failure-autofix-report.json")
+    parser.add_argument("--max-actions", type=int, default=5)
+    args = parser.parse_args()
+
+    plan = _load_plan(Path(args.plan))
+    actions = plan.get("actions", [])[: args.max_actions]
+
+    results: list[dict] = []
+    for action in actions:
+        cmd = str(action.get("reproduce_command", "")).strip()
+        if not cmd:
+            results.append({"issue_id": action.get("issue_id"), "status": "skipped", "reason": "no command"})
+            continue
+
+        code, output = _run(cmd)
+        results.append(
+            {
+                "issue_id": action.get("issue_id"),
+                "priority": action.get("priority"),
+                "owner": action.get("owner"),
+                "status": "failed" if code != 0 else "passed",
+                "exit_code": code,
+                "reproduce_command": cmd,
+                "candidate_code_areas": _ripgrep_candidates(str(action.get("test_id", ""))),
+                "auto_fix_suggestions": _suggestions_for(action),
+                "output_preview": "\n".join(output.splitlines()[:25]),
+            }
+        )
+
+    report = {
+        "source_plan": args.plan,
+        "executed_actions": len(results),
+        "failed_actions": sum(1 for item in results if item.get("status") == "failed"),
+        "results": results,
+    }
+    out_path = Path(args.report)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(f"{json.dumps(report, indent=2)}\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_failure_workflows.py
+++ b/tests/test_failure_workflows.py
@@ -98,6 +98,8 @@ def test_failure_autofix_workflow_generates_report(tmp_path: Path) -> None:
 
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["executed_actions"] == 1
+    assert report["passed_actions"] == 1
+    assert report["failed_actions"] == 0
     assert report["results"][0]["status"] == "passed"
     assert report["results"][0]["issue_id"] == "ISSUE-01"
     assert report["results"][0]["auto_fix_suggestions"]

--- a/tests/test_failure_workflows.py
+++ b/tests/test_failure_workflows.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def test_build_failure_action_plan_generates_expected_fields(tmp_path: Path) -> None:
+    input_path = tmp_path / "failures.json"
+    output_path = tmp_path / "plan.json"
+    input_path.write_text(
+        json.dumps(
+            {
+                "failures": [
+                    {
+                        "id": "ISSUE-10",
+                        "priority": "P2",
+                        "test_id": "tests/test_api.py::test_timeout",
+                        "category": "reliability",
+                        "security_impact": "low",
+                        "fix_recommendation": "Tune timeout",
+                    },
+                    {
+                        "id": "ISSUE-01",
+                        "priority": "P1",
+                        "test_id": "tests/test_payment.py::test_capture",
+                        "category": "network-stability",
+                        "security_impact": "medium",
+                        "fix_recommendation": "Add idempotency",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run(
+        [
+            sys.executable,
+            "scripts/build_failure_action_plan.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=Path.cwd(),
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["total_actions"] == 2
+    assert payload["actions"][0]["issue_id"] == "ISSUE-01"
+    assert "reproduce_command" in payload["actions"][0]
+    assert "verify_command" in payload["actions"][0]
+
+
+def test_failure_autofix_workflow_generates_report(tmp_path: Path) -> None:
+    plan_path = tmp_path / "plan.json"
+    report_path = tmp_path / "report.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "actions": [
+                    {
+                        "issue_id": "ISSUE-01",
+                        "priority": "P1",
+                        "owner": "qa",
+                        "category": "reliability",
+                        "security_impact": "medium",
+                        "test_id": "tests/test_api.py::test_timeout",
+                        "reproduce_command": f"{sys.executable} -c \"print(\'ok\')\"",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run(
+        [
+            sys.executable,
+            "scripts/failure_autofix_workflow.py",
+            "--plan",
+            str(plan_path),
+            "--report",
+            str(report_path),
+            "--max-actions",
+            "1",
+        ],
+        cwd=Path.cwd(),
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["executed_actions"] == 1
+    assert report["results"][0]["status"] == "passed"
+    assert report["results"][0]["issue_id"] == "ISSUE-01"
+    assert report["results"][0]["auto_fix_suggestions"]

--- a/tests/test_failure_workflows.py
+++ b/tests/test_failure_workflows.py
@@ -73,7 +73,7 @@ def test_failure_autofix_workflow_generates_report(tmp_path: Path) -> None:
                         "category": "reliability",
                         "security_impact": "medium",
                         "test_id": "tests/test_api.py::test_timeout",
-                        "reproduce_command": f"{sys.executable} -c \"print(\'ok\')\"",
+                        "reproduce_command": f"{sys.executable} -c \"print('ok')\"",
                     }
                 ]
             }


### PR DESCRIPTION
### Motivation

- Provide an automated loop to triage failing tests into a prioritized action plan and generate autofix recommendations for SDET/intelligence workflows.

### Description

- Add `scripts/build_failure_action_plan.py` to ingest `examples/kits/intelligence/failures.json` and emit a ranked action plan at `examples/kits/intelligence/failure-action-plan.json` with reproduce/verify commands and owners.
- Add `scripts/failure_autofix_workflow.py` to execute reproduce commands from a plan, collect outputs, infer candidate code areas, and write a combined report to `examples/kits/intelligence/failure-autofix-report.json` with suggestions.
- Update `Makefile` with `failure-plan`, `failure-autofix`, and `failure-workflow` targets and add README documentation and a `failure-fix-playbook.md` under `examples/kits/intelligence` describing usage and expected artifacts.
- Add example fixtures (`examples/kits/intelligence/*.json` and `*.md`) and unit tests in `tests/test_failure_workflows.py` that validate plan generation and the autofix workflow report format.

### Testing

- Ran the new unit tests via `pytest -q tests/test_failure_workflows.py` which executed the plan builder and autofix scripts and completed successfully (exit 0).
- The tests assert that `failure-action-plan.json` contains expected fields and that `failure-autofix-report.json` records executed actions and `auto_fix_suggestions` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1aee879a483328d4ec36c315aa1f9)