### PR TITLE
docs: add dependency snapshot submission troubleshooting guidance

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -67,3 +67,23 @@ See also:
 For private inquiries (including commercial licensing permissions), use one of the channels below:
 - LinkedIn: https://www.linkedin.com/in/sherif-atef-b1077a124/
 - Email: sherif.atef6300@gmail.com
+
+## GitHub dependency snapshot submission failures
+
+If your workflow uses `actions/component-detection-dependency-submission-action` and fails with:
+
+- `HttpError: An error occurred while processing your request. Please try again later.`
+- `Failed to submit snapshot`
+
+this is usually a transient GitHub Dependency Graph API-side failure (the component scan can still succeed).
+
+Recommended mitigations:
+
+1. Ensure job permissions include:
+   - `contents: read`
+   - `dependency-graph: write`
+2. Add an exponential-backoff retry around the submission step.
+3. Keep the detector category/filter constrained (for Python: `detectorsCategories: Python`, `detectorsFilter: PipReport`) to reduce payload size and execution time.
+4. Keep `snapshot-sha` and `snapshot-ref` aligned to the triggering commit/ref.
+
+If the failure is intermittent, re-running the workflow usually succeeds once GitHub API capacity recovers.


### PR DESCRIPTION
### Motivation
- Add troubleshooting guidance for transient GitHub Dependency Graph API failures observed during dependency snapshot submission by `actions/component-detection-dependency-submission-action` so maintainers can quickly diagnose and recover when submission fails while component detection succeeds.

### Description
- Added a new `## GitHub dependency snapshot submission failures` section to `SUPPORT.md` that documents the common error signatures (`HttpError: An error occurred while processing your request. Please try again later.` / `Failed to submit snapshot`) and recommends mitigations including required job permissions (`contents: read`, `dependency-graph: write`), adding an exponential-backoff retry, scoping detectors (`detectorsCategories: Python`, `detectorsFilter: PipReport`), and keeping `snapshot-sha`/`snapshot-ref` aligned to the triggering commit/ref.

### Testing
- No automated tests were added because this is a documentation-only change; the change is minimal and will be validated by the repository's existing CI and linters during regular workflow runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f224024240833284afbbee3c5bf780)