### PR TITLE
Add external adoption gate profile

### DIFF
--- a/src/sdetkit/gates/gate.py
+++ b/src/sdetkit/gates/gate.py
@@ -280,6 +280,15 @@ def _run_fast(ns: argparse.Namespace) -> int:
     root = Path(ns.root).resolve()
     only = _parse_step_filter(ns.only)
     skip = _parse_step_filter(ns.skip)
+    gate_profile = str(getattr(ns, "profile", "strict") or "strict")
+
+    # External adoption must prove SDETKit can install, run, and emit evidence
+    # before enforcing repo-specific quality policy. Keep strict as the default.
+    if gate_profile == "adoption" and not only:
+        ns.no_ci_templates = True
+        ns.no_ruff = True
+        ns.no_mypy = True
+        ns.no_pytest = True
 
     unknown = sorted((only | skip) - set(AVAILABLE_STEPS))
     if unknown:
@@ -350,30 +359,33 @@ def _run_fast(ns: argparse.Namespace) -> int:
             ns.no_pytest = True
 
     if not ns.no_doctor and should_run("doctor"):
-        fail_on = "medium" if ns.strict else "high"
-        steps.append(
-            {
-                "id": "doctor",
-                **_run(
-                    [
-                        sys.executable,
-                        "-m",
-                        "sdetkit",
-                        "doctor",
-                        "--dev",
-                        "--ci",
-                        "--deps",
-                        "--clean-tree",
-                        "--repo",
-                        "--fail-on",
-                        fail_on,
-                        "--format",
-                        "json",
-                    ],
-                    cwd=root,
-                ),
-            }
-        )
+        if gate_profile == "adoption":
+            doctor_cmd = [
+                sys.executable,
+                "-m",
+                "sdetkit",
+                "doctor",
+                "--format",
+                "json",
+            ]
+        else:
+            fail_on = "medium" if ns.strict else "high"
+            doctor_cmd = [
+                sys.executable,
+                "-m",
+                "sdetkit",
+                "doctor",
+                "--dev",
+                "--ci",
+                "--deps",
+                "--clean-tree",
+                "--repo",
+                "--fail-on",
+                fail_on,
+                "--format",
+                "json",
+            ]
+        steps.append({"id": "doctor", **_run(doctor_cmd, cwd=root)})
 
     if not ns.no_ci_templates and should_run("ci_templates"):
         steps.append(
@@ -447,6 +459,7 @@ def _run_fast(ns: argparse.Namespace) -> int:
     failed = [s["id"] for s in steps if not s.get("ok", False)]
     gate_payload: dict[str, Any] = {
         "profile": "fast",
+        "gate_profile": gate_profile,
         "root": str(root),
         "request_context": request_context,
         "ok": not bool(failed),
@@ -553,6 +566,7 @@ def _normalize_release_steps(steps: list[dict[str, Any]], root: Path) -> list[di
 
 def _release_commands(ns: argparse.Namespace, root: Path) -> list[tuple[str, list[str]]]:
     code_scan_out = str(Path(getattr(ns, "code_scan_out", "build/code-scanning.sarif")))
+    gate_profile = str(getattr(ns, "profile", "strict") or "strict")
     doctor_cmd = [sys.executable, "-m", "sdetkit", "doctor", "--release", "--format", "json"]
     if ns.release_full:
         doctor_cmd = [
@@ -563,6 +577,30 @@ def _release_commands(ns: argparse.Namespace, root: Path) -> list[tuple[str, lis
             "--release-full",
             "--format",
             "json",
+        ]
+
+    if gate_profile == "adoption":
+        return [
+            (
+                "doctor_release",
+                [sys.executable, "-m", "sdetkit", "doctor", "--format", "json"],
+            ),
+            (
+                "gate_fast",
+                [
+                    sys.executable,
+                    "-m",
+                    "sdetkit",
+                    "gate",
+                    "fast",
+                    "--root",
+                    str(root),
+                    "--profile",
+                    "adoption",
+                    "--format",
+                    "json",
+                ],
+            ),
         ]
 
     return [
@@ -656,6 +694,7 @@ def _run_release(ns: argparse.Namespace) -> int:
 
     payload = {
         "profile": "release",
+        "gate_profile": str(getattr(ns, "profile", "strict") or "strict"),
         "root": "<repo>",
         "request_context": request_context,
         "dry_run": bool(ns.dry_run),
@@ -794,6 +833,7 @@ def main(argv: list[str] | None = None) -> int:
     fast.add_argument("--format", choices=["text", "json", "md"], default="text")
     fast.add_argument("--out", "--output", default=None)
     fast.add_argument("--stable-json", action="store_true")
+    fast.add_argument("--profile", choices=["strict", "adoption"], default="strict")
     fast.add_argument("--strict", action="store_true")
     fast.add_argument("--list-steps", action="store_true")
     fast.add_argument("--only", default=None)
@@ -817,6 +857,7 @@ def main(argv: list[str] | None = None) -> int:
     release.add_argument("--format", choices=["text", "json"], default="text")
     release.add_argument("--out", "--output", default=None)
     release.add_argument("--dry-run", action="store_true")
+    release.add_argument("--profile", choices=["strict", "adoption"], default="strict")
     release.add_argument("--release-full", action="store_true")
     playbook_group = release.add_mutually_exclusive_group()
     playbook_group.add_argument("--playbooks-all", action="store_true")

--- a/tests/test_gate_adoption_profile.py
+++ b/tests/test_gate_adoption_profile.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from sdetkit import gate
+
+
+def test_gate_fast_adoption_profile_runs_basic_doctor_only(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], cwd: Path) -> dict[str, object]:
+        calls.append(cmd)
+        return {
+            "cmd": cmd,
+            "rc": 0,
+            "ok": True,
+            "duration_ms": 1,
+            "stdout": "{}",
+            "stderr": "",
+        }
+
+    monkeypatch.setattr(gate, "_run", fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    rc = gate.main(["fast", "--profile", "adoption", "--format", "json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["profile"] == "fast"
+    assert payload["gate_profile"] == "adoption"
+    assert payload["failed_steps"] == []
+    assert [step["id"] for step in payload["steps"]] == ["doctor"]
+    assert calls == [[sys.executable, "-m", "sdetkit", "doctor", "--format", "json"]]
+
+
+def test_gate_release_adoption_profile_runs_doctor_and_adoption_fast(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], cwd: Path) -> dict[str, object]:
+        calls.append(cmd)
+        return {
+            "cmd": cmd,
+            "rc": 0,
+            "ok": True,
+            "duration_ms": 1,
+            "stdout": "{}",
+            "stderr": "",
+        }
+
+    monkeypatch.setattr(gate, "_run", fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    rc = gate.main(["release", "--profile", "adoption", "--format", "json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["profile"] == "release"
+    assert payload["gate_profile"] == "adoption"
+    assert payload["failed_steps"] == []
+    assert [step["id"] for step in payload["steps"]] == [
+        "doctor_release",
+        "gate_fast",
+    ]
+    assert calls == [
+        [sys.executable, "-m", "sdetkit", "doctor", "--format", "json"],
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "gate",
+            "fast",
+            "--root",
+            str(tmp_path.resolve()),
+            "--profile",
+            "adoption",
+            "--format",
+            "json",
+        ],
+    ]
+
+
+def test_gate_fast_strict_default_is_unchanged(monkeypatch, tmp_path: Path, capsys) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], cwd: Path) -> dict[str, object]:
+        calls.append(cmd)
+        return {
+            "cmd": cmd,
+            "rc": 0,
+            "ok": True,
+            "duration_ms": 1,
+            "stdout": "{}",
+            "stderr": "",
+        }
+
+    monkeypatch.setattr(gate, "_run", fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    rc = gate.main(["fast", "--format", "json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["gate_profile"] == "strict"
+    assert [step["id"] for step in payload["steps"]] == [
+        "doctor",
+        "ci_templates",
+        "ruff",
+        "ruff_format",
+        "mypy",
+        "pytest",
+    ]


### PR DESCRIPTION
## Summary

Adds an explicit external adoption gate profile:

- `python -m sdetkit gate fast --profile adoption`
- `python -m sdetkit gate release --profile adoption`

This keeps the existing strict/default gate behavior unchanged while giving external repos a first-adoption path that proves installability, CLI execution, and JSON artifact generation before enforcing SDETKit’s own repo policy.

## Evidence

### Own repo Phase A

- Decision: SHIP
- `gate-fast.json`: ok, no failed steps
- `release-preflight.json`: ok, no failed steps
- `doctor.json`: ok, no failed steps

### External repo Phase B

Tested against:

- `pypa/sampleproject`
- `pytest-dev/pluggy`

Result:

- Decision: SHIP
- repeated failure patterns: none
- remediation priority: NONE
- code change now: false

## Why

Before this change, external repos repeatedly failed the strict default gate on SDETKit-specific checks such as CI templates, mypy, ruff, and SDETKit internal pytest paths. The adoption profile resolves that without weakening strict defaults.
