### PR TITLE
Refresh dependency floors from upgrade audit

### DIFF
--- a/constraints-ci.txt
+++ b/constraints-ci.txt
@@ -3,7 +3,7 @@
 httpx==0.28.1
 build==1.4.4
 check-wheel-contents==0.6.3
-hypothesis==6.152.2
+hypothesis==6.152.4
 mkdocs==1.6.1
 mkdocs-material==9.7.6
 mypy==1.20.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
   "twine==6.2.0"
 ]
 test = [
-  "hypothesis==6.152.2",
+  "hypothesis==6.152.4",
   "PyYAML",
   "pytest",
   "pytest-asyncio",
@@ -70,7 +70,7 @@ telegram = [
   "python-telegram-bot>=22.7,<23"
 ]
 whatsapp = [
-  "twilio>=9.10.4,<10"
+  "twilio>=9.10.5,<10"
 ]
 
 [tool.setuptools]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ pygments==2.20.0
 pytest-cov==7.1.0
 pytest-asyncio==1.3.0
 pytest-xdist[psutil]==3.8.0
-hypothesis==6.152.2
+hypothesis==6.152.4
 PyYAML==6.0.3
 httpx==0.28.1
 ruff==0.15.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pytest==9.0.3
 pygments==2.20.0
 pytest-cov==7.1.0
 pytest-asyncio==1.3.0
-hypothesis==6.152.3
+hypothesis==6.152.4
 mutmut==3.5.0
 build==1.4.4
 twine==6.2.0

--- a/tests/test_notify_plugins.py
+++ b/tests/test_notify_plugins.py
@@ -15,7 +15,7 @@ class _EP:
 
 
 class _EPs:
-    def init_(self, items: list[_EP]) -> None:
+    def __init__(self, items: list[_EP]) -> None:
         self._items = items
 
     def select(self, *, group: str):


### PR DESCRIPTION
## Summary

Refreshes dependency floors based on `sdetkit intelligence upgrade-audit`.

Changes:

- `hypothesis` -> `6.152.4`
- `twilio` floor -> `9.10.5`
- fixes a notify plugin test helper typo exposed by the targeted validation lane

## Evidence

Validated in a clean venv:

- installed `sdetkit` editable with dev/test/packaging/telegram/whatsapp extras
- verified installed versions:
  - `hypothesis=6.152.4`
  - `twilio=9.10.5`
  - `sdetkit=1.0.3`
- upgrade-audit after change:
  - actionable upgrade candidates: 0
- `bash quality.sh ci`
- `bash quality.sh cov`
- `bash ci.sh quick --skip-docs --artifact-dir build`
- `python -m pytest -q tests/test_notify_plugins.py tests/test_notify_plugins_extra.py`
- `python -m sdetkit gate fast --format json --stable-json`
- `python -m sdetkit doctor --release --format json`

## Reason

Upgrade audit identified two actionable maintenance items:

- `hypothesis`: stage-upgrade
- `twilio`: raise-floor

`ruff`, `httpx`, and `pytest` remain unchanged.
