### PR TITLE
Add explicit Telegram real-send notify path

### DIFF
--- a/src/sdetkit/notify.py
+++ b/src/sdetkit/notify.py
@@ -54,6 +54,12 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("adapter", nargs="?", help="Adapter name (stdout, telegram, whatsapp, etc.)")
     p.add_argument("--message", default="", help="Message payload")
     p.add_argument("--dry-run", action="store_true", help="Print only; do not send")
+    p.add_argument(
+        "--real-send", action="store_true", help="Send through the live adapter when configured"
+    )
+    p.add_argument(
+        "--timeout", type=float, default=10.0, help="Network timeout for live adapter sends"
+    )
     p.add_argument("--list", action="store_true", help="List discovered adapters")
     return p
 

--- a/src/sdetkit/notify_plugins.py
+++ b/src/sdetkit/notify_plugins.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
+from urllib import parse, request
 
 
 class StdoutAdapter:
@@ -13,31 +15,83 @@ class StdoutAdapter:
         return 0
 
 
+def _post_form_json(url: str, data: dict[str, str], *, timeout: float) -> dict[str, object]:
+    encoded = parse.urlencode(data).encode("utf-8")
+    req = request.Request(
+        url,
+        data=encoded,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+
+    with request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - explicit user-provided bot API URL
+        raw = resp.read().decode("utf-8", errors="replace")
+
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("telegram response was not a JSON object")
+    return payload
+
+
 class TelegramAdapter:
     name = "telegram"
 
     def send(self, args: argparse.Namespace) -> int:
-        # Optional runtime dependency may be required by downstream implementation.
         token = os.environ.get("SDETKIT_TELEGRAM_TOKEN")
         chat_id = os.environ.get("SDETKIT_TELEGRAM_CHAT_ID")
+
         if not token or not chat_id:
             sys.stdout.write(
                 "telegram adapter not configured: set SDETKIT_TELEGRAM_TOKEN and SDETKIT_TELEGRAM_CHAT_ID.\n"
             )
             return 2
-        sys.stdout.write("telegram adapter configured; use --dry-run in offline mode.\n")
-        return 0
+
+        if not getattr(args, "real_send", False):
+            sys.stdout.write(
+                "telegram adapter configured; use --real-send to send a live message.\n"
+            )
+            return 0
+
+        message = str(getattr(args, "message", "") or "").strip()
+        if not message:
+            sys.stdout.write("telegram real-send requires --message.\n")
+            return 2
+
+        timeout = float(getattr(args, "timeout", 10.0) or 10.0)
+        url = f"https://api.telegram.org/bot{token}/sendMessage"
+
+        try:
+            payload = _post_form_json(
+                url,
+                {"chat_id": chat_id, "text": message},
+                timeout=timeout,
+            )
+        except Exception as exc:
+            sys.stdout.write(f"telegram send failed: {type(exc).__name__}: {exc}\n")
+            return 2
+
+        if payload.get("ok") is True:
+            sys.stdout.write("telegram message sent.\n")
+            return 0
+
+        description = payload.get("description", "unknown telegram error")
+        sys.stdout.write(f"telegram send failed: {description}\n")
+        return 2
 
 
 class WhatsAppAdapter:
     name = "whatsapp"
 
     def send(self, args: argparse.Namespace) -> int:
-        # Optional runtime dependency may be required by downstream implementation.
         api_key = os.environ.get("SDETKIT_WHATSAPP_API_KEY")
         if not api_key:
             sys.stdout.write("whatsapp adapter not configured: set SDETKIT_WHATSAPP_API_KEY.\n")
             return 2
+
+        if getattr(args, "real_send", False):
+            sys.stdout.write("whatsapp real-send is not implemented yet.\n")
+            return 2
+
         sys.stdout.write("whatsapp adapter configured; use --dry-run in offline mode.\n")
         return 0
 

--- a/tests/test_notify_telegram_real_send.py
+++ b/tests/test_notify_telegram_real_send.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+
+from sdetkit import cli, notify_plugins
+
+
+class _Response:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_telegram_configured_default_stays_offline(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("SDETKIT_TELEGRAM_TOKEN", "token")
+    monkeypatch.setenv("SDETKIT_TELEGRAM_CHAT_ID", "123")
+
+    rc = cli.main(["notify", "telegram", "--message", "hello"])
+
+    assert rc == 0
+    assert "use --real-send" in capsys.readouterr().out
+
+
+def test_telegram_real_send_posts_message(monkeypatch, capsys) -> None:
+    calls: list[tuple[str, bytes | None]] = []
+
+    def fake_urlopen(req, timeout):  # noqa: ANN001
+        calls.append((req.full_url, req.data))
+        assert timeout == 10.0
+        return _Response({"ok": True, "result": {"message_id": 1}})
+
+    monkeypatch.setenv("SDETKIT_TELEGRAM_TOKEN", "token")
+    monkeypatch.setenv("SDETKIT_TELEGRAM_CHAT_ID", "123")
+    monkeypatch.setattr(notify_plugins.request, "urlopen", fake_urlopen)
+
+    rc = cli.main(["notify", "telegram", "--message", "hello", "--real-send"])
+
+    assert rc == 0
+    assert "telegram message sent" in capsys.readouterr().out
+    assert calls
+    url, data = calls[0]
+    assert url == "https://api.telegram.org/bottoken/sendMessage"
+    assert data is not None
+    assert b"chat_id=123" in data
+    assert b"text=hello" in data
+
+
+def test_telegram_real_send_requires_message(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("SDETKIT_TELEGRAM_TOKEN", "token")
+    monkeypatch.setenv("SDETKIT_TELEGRAM_CHAT_ID", "123")
+
+    rc = cli.main(["notify", "telegram", "--real-send"])
+
+    assert rc == 2
+    assert "requires --message" in capsys.readouterr().out
+
+
+def test_telegram_real_send_handles_api_failure(monkeypatch, capsys) -> None:
+    def fake_urlopen(req, timeout):  # noqa: ANN001
+        return _Response({"ok": False, "description": "chat not found"})
+
+    monkeypatch.setenv("SDETKIT_TELEGRAM_TOKEN", "token")
+    monkeypatch.setenv("SDETKIT_TELEGRAM_CHAT_ID", "123")
+    monkeypatch.setattr(notify_plugins.request, "urlopen", fake_urlopen)
+
+    rc = cli.main(["notify", "telegram", "--message", "hello", "--real-send"])
+
+    assert rc == 2
+    assert "chat not found" in capsys.readouterr().out
+
+
+def test_whatsapp_real_send_is_explicitly_not_implemented(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("SDETKIT_WHATSAPP_API_KEY", "key")
+
+    rc = cli.main(["notify", "whatsapp", "--message", "hello", "--real-send"])
+
+    assert rc == 2
+    assert "not implemented" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Adds an explicit `--real-send` path for the Telegram notify adapter.

Default behavior remains offline-safe:

- `sdetkit notify telegram --message ...` validates configuration only
- `sdetkit notify telegram --message ... --dry-run` remains dry-run
- `sdetkit notify telegram --message ... --real-send` sends through Telegram Bot API

## Evidence

- focused notify tests: 12 passed
- `notify telegram --help` includes `--real-send` and `--timeout`
- live Telegram send tested with sandbox bot credentials
- `gate fast` passed

## Safety

- secrets are read only from environment variables
- token is not printed
- live network send requires explicit `--real-send`
- WhatsApp real-send remains explicitly not implemented
