### PR TITLE
Fix kits list top-level CLI output

### DIFF
--- a/src/sdetkit/kits.py
+++ b/src/sdetkit/kits.py
@@ -7,8 +7,11 @@ from pathlib import Path
 from typing import Any
 
 
-def _stdout(message: str) -> None:
-    sys.stdout.write(message + "\n")
+def _stdout(message: object) -> None:
+    if isinstance(message, str):
+        sys.stdout.write(message + "\n")
+    else:
+        sys.stdout.write(json.dumps(message) + "\n")
 
 
 SCHEMA_VERSION = "sdetkit.kits.catalog.v1"

--- a/tests/test_kits_umbrella_cli.py
+++ b/tests/test_kits_umbrella_cli.py
@@ -159,3 +159,25 @@ def test_kits_radar_emits_dependency_dashboard_json() -> None:
     assert payload["headline_metrics"]["packages_audited"] >= 1
     assert payload["dashboard_cards"]
     assert payload["maintenance_lanes"]
+
+
+def test_top_level_kits_list_returns_catalog(capsys) -> None:
+    from sdetkit import cli
+
+    rc = cli.main(["kits", "list"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "sdetkit.kits.catalog.v1" in out
+    assert "release-confidence" in out
+
+
+def test_top_level_kits_list_json_returns_catalog(capsys) -> None:
+    from sdetkit import cli
+
+    rc = cli.main(["kits", "list", "--format", "json"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "sdetkit.kits.catalog.v1" in out
+    assert "release-confidence" in out


### PR DESCRIPTION
## Summary

Fixes `python -m sdetkit kits list` so the top-level CLI route no longer crashes when text mode receives a structured catalog payload.

## Evidence

- `python -m ruff check src/sdetkit/kits.py tests/test_kits_umbrella_cli.py`
- `python -m pytest -q tests/test_kits_blueprint.py tests/test_kits_umbrella_cli.py tests/test_kits_intelligence_integration_forensics.py`
- `python -m sdetkit kits list`
- `python -m sdetkit kits list --format json`
- `.sdetkit/live-audit/run_repo_full_analysis.sh`

## Notes

Generated evidence under `build/live-adoption` is local only and is not included in this PR.
