### PR TITLE
Install test deps before first-proof local lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ premerge-finalize: install
 first-proof: first-proof-install
 	@bash -lc '. .venv/bin/activate && PYTHONPATH=src python scripts/first_proof.py $(if $(filter true,$(FIRST_PROOF_STRICT)),--strict,) $(if $(filter true,$(FIRST_PROOF_RELEASE_DRY_RUN)),--release-dry-run,) --format json --out-dir build/first-proof'
 
-first-proof-local: venv
+first-proof-local: install
 	@bash -lc '. .venv/bin/activate && PYTHONPATH=src python scripts/first_proof.py $(if $(filter true,$(FIRST_PROOF_STRICT)),--strict,) $(if $(filter true,$(FIRST_PROOF_RELEASE_DRY_RUN)),--release-dry-run,) --format json --out-dir build/first-proof'
 
 first-proof-contract: venv
@@ -85,7 +85,7 @@ first-proof-trend-threshold: venv
 first-proof-tests: install
 	@bash -lc '. .venv/bin/activate && python -m pytest -q tests/test_first_proof_script.py tests/test_first_proof_contract.py tests/test_first_proof_learning_db.py tests/test_first_proof_weekly_trend.py tests/test_first_proof_control_tower.py tests/test_first_proof_trend_threshold.py tests/test_build_owner_escalation_payload.py'
 
-first-proof-tests-local: venv
+first-proof-tests-local: install
 	@bash -lc '. .venv/bin/activate && python -m pytest -q tests/test_first_proof_script.py tests/test_first_proof_contract.py tests/test_first_proof_learning_db.py tests/test_first_proof_weekly_trend.py tests/test_first_proof_control_tower.py tests/test_first_proof_trend_threshold.py tests/test_build_owner_escalation_payload.py'
 
 first-proof-verify: first-proof


### PR DESCRIPTION
## Summary

Fixes `make first-proof-verify-local` so the Makefile-owned `.venv` has test/dev dependencies before running the first-proof local lane.

## Root cause

The workflow installed `requirements-test.txt` into the runner Python, but `make first-proof-verify-local` creates/uses `.venv`. `first-proof-local` depended only on `venv`, so `gate fast` ran before pytest/ruff/mypy were installed into `.venv`.

`first-proof-tests-local` also needs the same install dependency before invoking pytest.

## Fix

- Change `first-proof-local: venv` to `first-proof-local: install`
- Change `first-proof-tests-local: venv` to `first-proof-tests-local: install`

## Evidence

- `rm -rf .venv && python3.11 -m venv .venv`
- `make install`
- `python --version`
- `python -m pytest --version`
- `python - <<'PY'
from datetime import UTC
print("datetime_UTC_ok=True")
PY`
- `make first-proof-verify-local`

Observed locally:

- `FIRST_PROOF_DECISION=SHIP`
- `health_score=100`
- `UPGRADE_STATUS decision=SHIP health=100 contract_ok=True onboarding=ADVANCE`
- `27 passed`
