### PR TITLE
Skip invalid JSON files during review inspect

### DIFF
--- a/src/sdetkit/inspect_data.py
+++ b/src/sdetkit/inspect_data.py
@@ -57,7 +57,13 @@ def _safe_slug(value: str) -> str:
 
 def _read_json_records(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
     notes: list[str] = []
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        return [], [f"{path}: empty JSON file skipped"]
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return [], [f"{path}: invalid JSON skipped ({exc.msg})"]
     if isinstance(payload, list):
         rows = [row for row in payload if isinstance(row, dict)]
         dropped = len(payload) - len(rows)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -841,3 +841,36 @@ def test_review_recovers_from_corrupt_probe_memory(tmp_path: Path) -> None:
         == "sdetkit.review.probe-memory.v1"
     )
     assert isinstance(payload["adaptive_review"]["probe_memory"]["normalized_outcomes"], list)
+
+
+def test_cli_review_repo_skips_empty_json_file(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        "[project]\nname='empty-json-fixture'\nversion='0.1.0'\n",
+        encoding="utf-8",
+    )
+    (repo / "empty.json").write_text("", encoding="utf-8")
+
+    run = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "review",
+            str(repo),
+            "--workspace-root",
+            str(tmp_path / "workspace"),
+            "--format",
+            "json",
+            "--no-workspace",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert run.returncode in {0, 2}
+    assert run.stderr == ""
+    payload = json.loads(run.stdout)
+    assert payload["workflow"] == "review"
+    assert payload["path"].endswith("repo")


### PR DESCRIPTION
## Summary

Fixes documented front-door review commands so repo-level review does not crash when inspect encounters an empty or malformed JSON file.

## Root cause

`python -m sdetkit review . --no-workspace --format json` calls `run_inspect()`, which scans repo files. `inspect_data._read_json_records()` parsed JSON files directly and allowed an empty file to raise `JSONDecodeError`, aborting review before JSON output.

## Fix

- Skip empty JSON files during inspect with a note.
- Skip invalid JSON files during inspect with a note.
- Add a CLI regression test for repo review with an empty JSON file.

## Evidence

- `python -m ruff check src/sdetkit/inspect_data.py tests/test_review.py`
- `python -m ruff format --check src/sdetkit/inspect_data.py tests/test_review.py`
- `python -m pytest -q tests/test_review.py`
- `python -m sdetkit review . --no-workspace --format json` emits valid JSON with acceptable findings rc
- `python -m sdetkit review . --no-workspace --format operator-json` emits valid JSON with acceptable findings rc
- curated docs-core proof passes with review rc `0/2` policy
