### PR TITLE
Improve legacy namespace help behavior

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -753,6 +753,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         argv = sys.argv[1:]
 
     argv, no_legacy_hint = extract_global_flag(argv, "--no-legacy-hint")
+    argv, show_hidden_commands = extract_global_flag(argv, "--show-hidden")
 
     if argv:
         argv = list(argv)
@@ -778,7 +779,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     if preparse_result is not None:
         return preparse_result
 
-    show_hidden_commands = "--show-hidden" in argv
     p, sub = _build_root_parser(show_hidden_commands=show_hidden_commands)
 
     if not show_hidden_commands:

--- a/src/sdetkit/legacy_namespace.py
+++ b/src/sdetkit/legacy_namespace.py
@@ -7,12 +7,31 @@ from .legacy_cli import run_legacy_migrate_hint
 from .legacy_commands import LEGACY_NAMESPACE_COMMANDS
 
 
+def _write_legacy_help() -> None:
+    sys.stdout.write(
+        "usage: sdetkit legacy [-h] {list,migrate-hint,<legacy-command>} ...\n"
+        "\n"
+        "Access historical and closeout compatibility lanes.\n"
+        "\n"
+        "positional arguments:\n"
+        "  list              list contained legacy commands\n"
+        "  migrate-hint      show migration guidance for a legacy command\n"
+        "  <legacy-command>  run a contained legacy command\n"
+        "\n"
+        "options:\n"
+        "  -h, --help        show this help message and exit\n"
+    )
+
+
 def handle_legacy_namespace(argv: Sequence[str]) -> int | None:
     if not argv or argv[0] != "legacy":
         return None
     if len(argv) == 1:
-        sys.stderr.write("legacy error: expected a legacy command name\n")
-        return 2
+        _write_legacy_help()
+        return 0
+    if argv[1] in {"-h", "--help"}:
+        _write_legacy_help()
+        return 0
     if argv[1] == "list":
         sys.stdout.write("\n".join(LEGACY_NAMESPACE_COMMANDS) + "\n")
         return 0

--- a/tests/test_legacy_namespace.py
+++ b/tests/test_legacy_namespace.py
@@ -46,6 +46,7 @@ def test_cli_main_unknown_legacy_subcommand_fails_fast(capsys) -> None:
     err = capsys.readouterr().err
     assert "legacy error: unknown subcommand 'unknown-subcmd'" in err
 
+
 def test_handle_legacy_namespace_help_shows_help(capsys) -> None:
     rc = legacy_namespace.handle_legacy_namespace(["legacy", "--help"])
     assert rc == 0
@@ -73,4 +74,3 @@ def test_cli_main_show_hidden_legacy_help_shows_help(capsys) -> None:
     assert rc == 0
     out = capsys.readouterr().out
     assert "usage: sdetkit legacy" in out
-

--- a/tests/test_legacy_namespace.py
+++ b/tests/test_legacy_namespace.py
@@ -14,11 +14,12 @@ def test_handle_legacy_namespace_lists_commands(capsys) -> None:
     assert "weekly-review-lane" in out
 
 
-def test_handle_legacy_namespace_requires_subcommand(capsys) -> None:
+def test_handle_legacy_namespace_noargs_shows_help(capsys) -> None:
     rc = legacy_namespace.handle_legacy_namespace(["legacy"])
-    assert rc == 2
-    err = capsys.readouterr().err
-    assert "expected a legacy command name" in err
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "usage: sdetkit legacy" in out
+    assert "migrate-hint" in out
 
 
 def test_handle_legacy_namespace_routes_migrate_hint(monkeypatch) -> None:
@@ -44,3 +45,32 @@ def test_cli_main_unknown_legacy_subcommand_fails_fast(capsys) -> None:
     assert rc == 2
     err = capsys.readouterr().err
     assert "legacy error: unknown subcommand 'unknown-subcmd'" in err
+
+def test_handle_legacy_namespace_help_shows_help(capsys) -> None:
+    rc = legacy_namespace.handle_legacy_namespace(["legacy", "--help"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "usage: sdetkit legacy" in out
+    assert "list" in out
+
+
+def test_cli_main_legacy_help_without_show_hidden(capsys) -> None:
+    rc = cli.main(["legacy", "--help"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "usage: sdetkit legacy" in out
+
+
+def test_cli_main_show_hidden_legacy_noargs_shows_help(capsys) -> None:
+    rc = cli.main(["--show-hidden", "legacy"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "usage: sdetkit legacy" in out
+
+
+def test_cli_main_show_hidden_legacy_help_shows_help(capsys) -> None:
+    rc = cli.main(["--show-hidden", "legacy", "--help"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "usage: sdetkit legacy" in out
+


### PR DESCRIPTION
Makes the advanced legacy namespace behave consistently for no-args and help invocations. The legacy namespace now renders help for `sdetkit legacy`, `sdetkit legacy --help`, and the same forms with `--show-hidden`. Unknown legacy subcommands still fail fast. Adds focused tests and no broader product surface is changed.