### PR TITLE
Clarify WhatsApp notify adapter posture

### DIFF
--- a/docs/plugins-and-fix.md
+++ b/docs/plugins-and-fix.md
@@ -113,3 +113,8 @@ Optional extras:
 pip install sdetkit[telegram]
 pip install sdetkit[whatsapp]
 ```
+
+Posture by adapter:
+
+- `telegram` is the live-send adapter. It stays offline unless credentials are configured and `--real-send` is passed.
+- `whatsapp` is incubator/config-probe only. The extra keeps the dependency boundary testable, but WhatsApp live-send is intentionally not implemented yet.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -11,4 +11,8 @@ my_task = "my_pkg.ops:task_factory"
 ```
 
 Built-in notifier: `sdetkit notify stdout --message "hello"`.
-Optional adapters (`telegram`, `whatsapp`) are soft dependencies with friendly configuration errors.
+
+Optional adapters are soft dependencies with friendly configuration errors:
+
+- `telegram`: gated live-send support is available only with explicit credentials and `--real-send`.
+- `whatsapp`: incubator/config-probe only; the optional extra installs the dependency boundary, but live real-send is not implemented.

--- a/src/sdetkit/notify_plugins.py
+++ b/src/sdetkit/notify_plugins.py
@@ -85,14 +85,23 @@ class WhatsAppAdapter:
     def send(self, args: argparse.Namespace) -> int:
         api_key = os.environ.get("SDETKIT_WHATSAPP_API_KEY")
         if not api_key:
-            sys.stdout.write("whatsapp adapter not configured: set SDETKIT_WHATSAPP_API_KEY.\n")
+            sys.stdout.write(
+                "whatsapp adapter is incubator/config-probe only: "
+                "set SDETKIT_WHATSAPP_API_KEY only for configuration checks; "
+                "real-send is not implemented.\n"
+            )
             return 2
 
         if getattr(args, "real_send", False):
-            sys.stdout.write("whatsapp real-send is not implemented yet.\n")
+            sys.stdout.write(
+                "whatsapp real-send is not implemented; use --dry-run or config-probe mode only.\n"
+            )
             return 2
 
-        sys.stdout.write("whatsapp adapter configured; use --dry-run in offline mode.\n")
+        sys.stdout.write(
+            "whatsapp adapter configured for incubator/config-probe mode; "
+            "use --dry-run for offline message preview.\n"
+        )
         return 0
 
 

--- a/tests/test_notify_plugins_extra.py
+++ b/tests/test_notify_plugins_extra.py
@@ -21,15 +21,27 @@ def test_telegram_adapter_configured_path(monkeypatch, capsys) -> None:
     assert "configured" in capsys.readouterr().out
 
 
-def test_whatsapp_adapter_configured_path(monkeypatch, capsys) -> None:
+def test_whatsapp_adapter_configured_path_is_config_probe_only(monkeypatch, capsys) -> None:
     monkeypatch.setenv("SDETKIT_WHATSAPP_API_KEY", "k")
-    args = argparse.Namespace(message="ignored")
+    args = argparse.Namespace(message="ignored", real_send=False)
     rc = notify_plugins.WhatsAppAdapter().send(args)
     assert rc == 0
-    assert "configured" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "configured" in out
+    assert "incubator/config-probe" in out
 
 
 def test_adapter_factory_helpers_return_expected_types() -> None:
     assert isinstance(notify_plugins.stdout_adapter(), notify_plugins.StdoutAdapter)
     assert isinstance(notify_plugins.telegram_adapter(), notify_plugins.TelegramAdapter)
     assert isinstance(notify_plugins.whatsapp_adapter(), notify_plugins.WhatsAppAdapter)
+
+
+def test_whatsapp_adapter_unconfigured_explains_incubator_posture(monkeypatch, capsys) -> None:
+    monkeypatch.delenv("SDETKIT_WHATSAPP_API_KEY", raising=False)
+    args = argparse.Namespace(message="ignored", real_send=False)
+    rc = notify_plugins.WhatsAppAdapter().send(args)
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "incubator/config-probe" in out
+    assert "real-send is not implemented" in out

--- a/tests/test_notify_telegram_real_send.py
+++ b/tests/test_notify_telegram_real_send.py
@@ -83,4 +83,6 @@ def test_whatsapp_real_send_is_explicitly_not_implemented(monkeypatch, capsys) -
     rc = cli.main(["notify", "whatsapp", "--message", "hello", "--real-send"])
 
     assert rc == 2
-    assert "not implemented" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "not implemented" in out
+    assert "config-probe" in out


### PR DESCRIPTION
Clarifies that the WhatsApp notify adapter is incubator/config-probe only and that live real-send is intentionally not implemented. Keeps Telegram as the explicit live-send path, adds focused tests, updates docs, and does not call external services.