### PR TITLE
Add live-adoption proof page to docs nav

### DIFF
--- a/docs/live-adoption-product-proof.md
+++ b/docs/live-adoption-product-proof.md
@@ -2,6 +2,10 @@
 
 SDETKit is backed by committed UTF-8 live-adoption product proof evidence.
 
+!!! note "Snapshot record"
+    This page records the post-#1072 live-adoption proof snapshot. Follow-up productization work has since closed the `legacy-noargs` help/UX finding and clarified WhatsApp as incubator/config-probe only.
+
+
 ## Proof identity
 
 | Field | Value |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - CI contract: ci-contract.md
       - Before/after evidence example: before-after-evidence-example.md
       - Evidence showcase: evidence-showcase.md
+      - Live-adoption product proof: live-adoption-product-proof.md
       - Reporting and trends: reporting-and-trends.md
       - Release confidence ROI: release-confidence-roi.md
       - Adoption proof examples: adoption-proof-examples.md


### PR DESCRIPTION
Adds the live-adoption product proof page to the public docs navigation and marks it as a post-#1072 snapshot record. This keeps the proof discoverable while clarifying that follow-up productization work has closed the legacy-noargs UX finding and clarified WhatsApp posture.