### PR TITLE
Document five-head contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ To keep recurring bot-generated maintenance issues actionable, enable the rollin
 
 It keeps only the top priority maintenance trackers open, consolidates lower-priority bot trackers into one rolling issue (`🧠 Maintenance command center (rolling)`), and appends each run's problems into `.sdetkit/maintenance/issue-learning-db.jsonl` with a rollup in `.sdetkit/maintenance/issue-learning-rollup.json`.
 
-The workflow also refreshes `doctor` + adaptive `review` signals (including five-head status/confidence) before updating the command center so remediation priorities learn over time.
+The workflow also refreshes `doctor` + adaptive `review` signals, including the deterministic five-head contract (`quality`, `reliability`, `security`, `evidence`, `delivery`), before updating the command center so remediation priorities learn over time.
 
 Dry-run test against the live issue queue (without closing/updating issues):
 

--- a/docs/premium-quality-gate.md
+++ b/docs/premium-quality-gate.md
@@ -58,6 +58,21 @@ Use these commands to quickly diagnose PR quality issues and unblock reviews.
 
 Use `bash premium-gate.sh` locally and in CI. The gate is now a self-contained **five-head engine** with explicit phases and runtime telemetry:
 
+### Five-head contract
+
+The five-head engine is a deterministic product signal, not an external AI call. It summarizes release posture across five named heads:
+
+| Head | Meaning |
+|---|---|
+| `quality` | test, lint, doctor, and validation pressure |
+| `reliability` | repeatability, workflow health, and runtime confidence |
+| `security` | security/audit posture and policy gate pressure |
+| `evidence` | supporting versus conflicting evidence quality |
+| `delivery` | priority queue heat and release-readiness pressure |
+
+`review --format operator-json` emits the same contract under top-level `five_heads` with schema version `sdetkit.review.five-heads.v1`. The premium gate renders the same posture for operator-facing markdown and step-index outputs. Status values are intended for deterministic triage and should be treated as release signals, not as a replacement for the underlying evidence artifacts.
+
+
 1. **Head-1 Foundation & Quality** (`bash quality.sh`)
 2. **Head-2 Source Truth & Style** (ruff format/lint)
 3. **Head-3 Operational Confidence** (CI + doctor + maintenance + integration topology contract + ops profile)


### PR DESCRIPTION
Clarifies the deterministic five-head contract used by review operator JSON and premium gate outputs. Documents the five heads, schema version, and intended status/confidence posture without changing engine behavior.