### PR TITLE
Start Adaptive Power Engine v2 — Wave 1: Deep Repo Index Engine

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,7 @@ build/release-preflight.json
 - [Use cases](use-cases.md)
 - [Release confidence ROI](release-confidence-roi.md)
 - [Repo health dashboard](repo-health-dashboard.md)
+- [Deep Repo Index Engine (Wave 1)](repo-index-engine.md)
 - [Business execution hub](business_execution/index.md)
 - [Merge readiness and execution checklist](business_execution/08-merge-readiness-checklist.md)
 

--- a/docs/repo-index-engine.md
+++ b/docs/repo-index-engine.md
@@ -1,0 +1,35 @@
+# Deep Repo Index Engine (Wave 1)
+
+The repo index engine builds deterministic local evidence for Adaptive Power Engine v2.
+
+## What it does
+
+- Crawls a local repository without network calls.
+- Skips ignored directories (`.git`, `.venv`, `site`, caches, `node_modules`, `htmlcov`).
+- Produces machine-readable evidence files for future boost scan v2, adaptive review, and patch planning.
+
+## Commands
+
+```bash
+python -m sdetkit index build PATH --out build/sdetkit-index
+python -m sdetkit index inspect build/sdetkit-index --format text
+python -m sdetkit index inspect build/sdetkit-index --format operator-json
+```
+
+## Evidence files
+
+- `build/sdetkit-index/index.json`
+- `build/sdetkit-index/files.jsonl`
+- `build/sdetkit-index/symbols.jsonl`
+- `build/sdetkit-index/hotspots.jsonl`
+
+Schema version: `sdetkit.index.v1`.
+
+## Future feed-in
+
+Wave 1 index evidence is the substrate for:
+
+- boost scan v2 prioritization
+- adaptive review planning
+- deterministic operator reports
+- source-to-test pairing hints and risk hotspot surfacing

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -314,6 +314,19 @@ Then use stability-aware command discovery:
     boost_scan.add_argument("--minutes", type=int, default=5)
     boost_scan.add_argument("--max-lines", type=int, default=100)
     boost_scan.add_argument("--format", choices=["text", "operator-json"], default="text")
+    index = sub.add_parser(
+        "index",
+        help="[Advanced but supported] Build and inspect deterministic deep repo index evidence",
+    )
+    index_sub = index.add_subparsers(dest="index_cmd", required=False)
+    index_build = index_sub.add_parser(
+        "build", help="Build deterministic local repo index evidence"
+    )
+    index_build.add_argument("path")
+    index_build.add_argument("--out", default="build/sdetkit-index")
+    index_inspect = index_sub.add_parser("inspect", help="Inspect local repo index evidence")
+    index_inspect.add_argument("path")
+    index_inspect.add_argument("--format", choices=["text", "operator-json"], default="text")
 
     rpt = sub.add_parser("report", help="Reporting workflows and output packs")
     rpt.add_argument("args", nargs=argparse.REMAINDER)
@@ -887,6 +900,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             ]
             return _run_module_main("sdetkit.boost", forwarded)
         return _run_module_main("sdetkit.boost", [])
+    if ns.cmd == "index":
+        if getattr(ns, "index_cmd", None) == "build":
+            return _run_module_main("sdetkit.index", ["build", str(ns.path), "--out", str(ns.out)])
+        if getattr(ns, "index_cmd", None) == "inspect":
+            return _run_module_main(
+                "sdetkit.index",
+                ["inspect", str(ns.path), "--format", str(ns.format)],
+            )
+        return _run_module_main("sdetkit.index", [])
 
     if ns.cmd == "fit":
         forwarded = [

--- a/src/sdetkit/index.py
+++ b/src/sdetkit/index.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+SCHEMA_VERSION = "sdetkit.index.v1"
+IGNORED_DIRS = {
+    ".git",
+    ".venv",
+    "venv",
+    "site",
+    "htmlcov",
+    ".mypy_cache",
+    ".pytest_cache",
+    "node_modules",
+    "__pycache__",
+    "build",
+}
+TEXT_EXTS = {".py", ".md", ".txt", ".rst", ".json", ".yml", ".yaml", ".toml", ".ini", ".cfg"}
+
+
+@dataclass(frozen=True)
+class ScanFile:
+    path: str
+    ext: str
+    kind: str
+    lines: int
+    bytes: int
+
+
+def _iter_files(root: Path) -> list[Path]:
+    out: list[Path] = []
+    for base, dirs, files in __import__("os").walk(root):
+        dirs[:] = sorted(d for d in dirs if d not in IGNORED_DIRS)
+        pbase = Path(base)
+        if any(part in IGNORED_DIRS for part in pbase.parts):
+            continue
+        for name in sorted(files):
+            out.append(pbase / name)
+    return out
+
+
+def _kind_for(path: Path) -> str:
+    rel = path.as_posix().lower()
+    if "/tests/" in rel or path.name.startswith("test_"):
+        return "test"
+    if path.suffix.lower() in {".md", ".rst"}:
+        return "docs"
+    if ".github/workflows/" in rel:
+        return "workflow"
+    if path.suffix.lower() in {".toml", ".ini", ".cfg", ".yml", ".yaml", ".json"}:
+        return "config"
+    if path.suffix.lower() in {".py", ".js", ".ts", ".java", ".go", ".rs"}:
+        return "source"
+    return "other"
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _extract_symbols(rel: str, path: Path, text: str) -> list[dict[str, object]]:
+    symbols: list[dict[str, object]] = []
+    if path.suffix.lower() == ".py":
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            return symbols
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                symbols.append(
+                    {"file": rel, "name": node.name, "type": "function", "line": node.lineno}
+                )
+            elif isinstance(node, ast.ClassDef):
+                symbols.append(
+                    {"file": rel, "name": node.name, "type": "class", "line": node.lineno}
+                )
+    elif path.suffix.lower() == ".md":
+        for i, line in enumerate(text.splitlines(), start=1):
+            if line.lstrip().startswith("#"):
+                symbols.append(
+                    {
+                        "file": rel,
+                        "name": line.strip().lstrip("#").strip(),
+                        "type": "markdown_heading",
+                        "line": i,
+                    }
+                )
+    elif path.suffix.lower() == ".json":
+        try:
+            obj = json.loads(text)
+        except json.JSONDecodeError:
+            return symbols
+        if isinstance(obj, dict):
+            for key in sorted(obj.keys()):
+                symbols.append({"file": rel, "name": str(key), "type": "json_key", "line": 1})
+    return symbols
+
+
+def build_index(root: Path, out_dir: Path) -> dict[str, object]:
+    files: list[dict[str, object]] = []
+    symbols: list[dict[str, object]] = []
+    hotspots: list[dict[str, object]] = []
+    counts = Counter()
+    lang_counts = Counter()
+    total_lines = 0
+
+    for path in _iter_files(root):
+        rel = path.relative_to(root).as_posix()
+        ext = path.suffix.lower() or "<none>"
+        kind = _kind_for(path)
+        size = path.stat().st_size
+        text = ""
+        lines = 0
+        if ext in TEXT_EXTS:
+            text = _read_text(path)
+            lines = text.count("\n") + (1 if text else 0)
+        total_lines += lines
+        lang_counts[ext] += 1
+        counts[kind] += 1
+        files.append({"path": rel, "ext": ext, "kind": kind, "lines": lines, "bytes": size})
+        if size > 200_000 or lines > 1500:
+            hotspots.append(
+                {
+                    "file": rel,
+                    "type": "large_file",
+                    "severity": "moderate",
+                    "signal": f"lines={lines} bytes={size}",
+                }
+            )
+        low = text.lower()
+        todo_hits = low.count("todo") + low.count("fixme") + low.count("xxx")
+        if todo_hits:
+            hotspots.append(
+                {
+                    "file": rel,
+                    "type": "todo_marker",
+                    "severity": "minor",
+                    "signal": f"marker_hits={todo_hits}",
+                }
+            )
+        symbols.extend(_extract_symbols(rel, path, text) if text else [])
+
+    hotspots = sorted(hotspots, key=lambda x: (str(x["file"]), str(x["type"])))
+    symbols = sorted(
+        symbols, key=lambda x: (str(x["file"]), str(x["type"]), str(x["name"]), int(x["line"]))
+    )
+    files = sorted(files, key=lambda x: str(x["path"]))
+
+    high_signal = [f["path"] for f in files if f["kind"] in {"source", "test", "workflow"}][:10]
+    index = {
+        "schema_version": SCHEMA_VERSION,
+        "tool": "sdetkit index",
+        "root": root.resolve().as_posix(),
+        "summary": "Deterministic local repository index for adaptive power engine wave 1.",
+        "counts": {
+            "scanned_files": len(files),
+            "scanned_lines": total_lines,
+            "source_files": counts["source"],
+            "test_files": counts["test"],
+            "docs_files": counts["docs"],
+            "workflow_files": counts["workflow"],
+            "config_files": counts["config"],
+        },
+        "languages": [
+            {"ext": k, "files": v}
+            for k, v in sorted(lang_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+        ],
+        "files": files[:20],
+        "symbols": symbols[:20],
+        "hotspots": hotspots[:20],
+        "high_signal_files": high_signal,
+        "risk_markers": {
+            "todo_hotspots": sum(1 for h in hotspots if h["type"] == "todo_marker"),
+            "large_files": sum(1 for h in hotspots if h["type"] == "large_file"),
+        },
+        "evidence_files": {
+            "index_json": (out_dir / "index.json").as_posix(),
+            "files_jsonl": (out_dir / "files.jsonl").as_posix(),
+            "symbols_jsonl": (out_dir / "symbols.jsonl").as_posix(),
+            "hotspots_jsonl": (out_dir / "hotspots.jsonl").as_posix(),
+        },
+    }
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "index.json").write_text(
+        json.dumps(index, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    for name, rows in (
+        ("files.jsonl", files),
+        ("symbols.jsonl", symbols),
+        ("hotspots.jsonl", hotspots),
+    ):
+        with (out_dir / name).open("w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row, sort_keys=True) + "\n")
+    return index
+
+
+def inspect_index(path: Path) -> dict[str, object]:
+    out_dir = path
+    idx = json.loads((out_dir / "index.json").read_text(encoding="utf-8"))
+    if idx.get("schema_version") != SCHEMA_VERSION:
+        raise SystemExit("invalid index schema")
+    return idx
+
+
+def _text_summary(payload: dict[str, object]) -> str:
+    counts = payload["counts"]
+    langs = payload["languages"][:5]
+    hotspots = payload["hotspots"][:5]
+    lines = [
+        "Decision: index evidence ready for adaptive power engine wave 1.",
+        f"Scanned files: {counts['scanned_files']}",
+        f"Scanned lines: {counts['scanned_lines']}",
+        "Top languages: " + ", ".join(f"{x['ext']}({x['files']})" for x in langs),
+        "Top hotspots: " + ", ".join(f"{x['type']}:{x['file']}" for x in hotspots)
+        if hotspots
+        else "Top hotspots: none",
+        "High-signal files: " + ", ".join(payload["high_signal_files"][:5]),
+        "Evidence files: " + ", ".join(payload["evidence_files"].values()),
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="sdetkit index")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    b = sub.add_parser("build", help="Build deterministic repo index evidence")
+    b.add_argument("path")
+    b.add_argument("--out", default="build/sdetkit-index")
+    i = sub.add_parser("inspect", help="Inspect existing index evidence")
+    i.add_argument("path")
+    i.add_argument("--format", choices=["text", "operator-json"], default="text")
+
+    ns = p.parse_args(argv)
+    if ns.cmd == "build":
+        build_index(Path(ns.path).resolve(), Path(ns.out))
+        return 0
+    payload = inspect_index(Path(ns.path))
+    if ns.format == "operator-json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_text_summary(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_discoverability_contract.py
+++ b/tests/test_cli_help_discoverability_contract.py
@@ -149,3 +149,10 @@ def test_boost_scan_help_discoverability() -> None:
     assert proc.returncode == 0
     assert "--minutes" in proc.stdout
     assert "--max-lines" in proc.stdout
+
+
+def test_index_help_discoverability() -> None:
+    proc = _run("index", "--help")
+    assert proc.returncode == 0
+    assert "build" in proc.stdout
+    assert "inspect" in proc.stdout

--- a/tests/test_index_engine.py
+++ b/tests/test_index_engine.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "-m", "sdetkit", *args], text=True, capture_output=True)
+
+
+def test_index_build_creates_evidence_files(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src.py").write_text("def alpha():\n    return 1\n", encoding="utf-8")
+    out = tmp_path / "build" / "sdetkit-index"
+    proc = _run("index", "build", str(repo), "--out", str(out))
+    assert proc.returncode == 0
+    for name in ("index.json", "files.jsonl", "symbols.jsonl", "hotspots.jsonl"):
+        assert (out / name).exists()
+
+
+def test_index_inspect_operator_json_schema(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("class A:\n    pass\n", encoding="utf-8")
+    out = tmp_path / "idx"
+    assert _run("index", "build", str(repo), "--out", str(out)).returncode == 0
+    proc = _run("index", "inspect", str(out), "--format", "operator-json")
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "sdetkit.index.v1"
+
+
+def test_python_ast_symbol_extraction(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pkg.py").write_text(
+        "class Engine:\n    pass\n\ndef run():\n    return 7\n", encoding="utf-8"
+    )
+    out = tmp_path / "idx"
+    _run("index", "build", str(repo), "--out", str(out))
+    rows = [
+        (json.loads(line))
+        for line in (out / "symbols.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    names = {r["name"] for r in rows}
+    assert "Engine" in names
+    assert "run" in names
+
+
+def test_markdown_heading_extraction(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Title\n## Scope\n", encoding="utf-8")
+    out = tmp_path / "idx"
+    _run("index", "build", str(repo), "--out", str(out))
+    rows = [
+        json.loads(line)
+        for line in (out / "symbols.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    headings = [r["name"] for r in rows if r["type"] == "markdown_heading"]
+    assert "Title" in headings
+    assert "Scope" in headings
+
+
+def test_todo_fixme_hotspot_detection(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("# TODO: repair\n# FIXME: later\n", encoding="utf-8")
+    out = tmp_path / "idx"
+    _run("index", "build", str(repo), "--out", str(out))
+    rows = [
+        json.loads(line)
+        for line in (out / "hotspots.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert any(r["type"] == "todo_marker" for r in rows)
+
+
+def test_ignored_directories_are_skipped(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / ".git" / "hidden.py").write_text("def nope():\n    pass\n", encoding="utf-8")
+    (repo / "node_modules").mkdir()
+    (repo / "node_modules" / "pkg.js").write_text("console.log('x')\n", encoding="utf-8")
+    (repo / "ok.py").write_text("def yes():\n    return 1\n", encoding="utf-8")
+    out = tmp_path / "idx"
+    _run("index", "build", str(repo), "--out", str(out))
+    files = [
+        json.loads(line)["path"]
+        for line in (out / "files.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert "ok.py" in files
+    assert ".git/hidden.py" not in files
+    assert "node_modules/pkg.js" not in files


### PR DESCRIPTION
### Motivation
- Provide a deterministic, local, machine-readable repository index as the foundational evidence layer for future Boost Scan v2, adaptive review, patch planning, and operator reports.
- Offer a stable operator-facing schema and concise inspection output so downstream systems can reliably consume index evidence without network calls or secrets leakage.

### Description
- Added a new `sdetkit.index` module implementing Wave 1 indexing with schema `sdetkit.index.v1` and evidence writers for `index.json`, `files.jsonl`, `symbols.jsonl`, and `hotspots.jsonl` (`src/sdetkit/index.py`).
- Implemented deterministic repo traversal with ignored-directory filtering and classification of files into `source`, `test`, `docs`, `workflow`, `config`, and `other`, plus language/extension counts, scanned file/line totals, large-file hotspots, and TODO/FIXME/XXX markers.
- Extracted Python symbols via AST, markdown headings, and JSON top-level keys into `symbols.jsonl`, and produced concise text inspection and stable `operator-json` output paths.
- Wired CLI commands `python -m sdetkit index build PATH --out build/sdetkit-index` and `python -m sdetkit index inspect PATH --format text|operator-json` into the root CLI (`src/sdetkit/cli.py`) and added focused tests (`tests/test_index_engine.py`) plus CLI help discoverability test updates.
- Added documentation `docs/repo-index-engine.md` and linked it from `docs/index.md` describing purpose, commands, evidence files, and deterministic posture.

### Testing
- Ran `python -m pytest -q -p no:cacheprovider tests/test_index_engine.py tests/test_cli_help_discoverability_contract.py` and received `21 passed` (all tests passed).
- Ran `python -m ruff check src tests` and `python -m ruff format --check src tests` and both checks passed with no formatting or lint failures.
- Ran `python -m sdetkit repo check --format json --out build/repo-check-index-engine.json --force` and the repo check reported `findings: []` and `score: 100`.
- Built docs with `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict` and the documentation build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45a3d9a9c8332ba48cd2c6665e6f8)