### PR TITLE
Fix index inspect repo-path contract

### DIFF
--- a/docs/repo-index-engine.md
+++ b/docs/repo-index-engine.md
@@ -12,9 +12,12 @@ The repo index engine builds deterministic local evidence for Adaptive Power Eng
 
 ```bash
 python -m sdetkit index build PATH --out build/sdetkit-index
-python -m sdetkit index inspect build/sdetkit-index --format text
-python -m sdetkit index inspect build/sdetkit-index --format operator-json
+python -m sdetkit index inspect PATH --format text
+python -m sdetkit index inspect PATH --format operator-json
 ```
+
+Inspect accepts either a repo path or an index evidence directory.
+When given a repo path, evidence is (re)built under `PATH/build/sdetkit-index`.
 
 ## Evidence files
 

--- a/src/sdetkit/index.py
+++ b/src/sdetkit/index.py
@@ -202,7 +202,14 @@ def build_index(root: Path, out_dir: Path) -> dict[str, object]:
 
 
 def inspect_index(path: Path) -> dict[str, object]:
-    out_dir = path
+    resolved = path.resolve()
+    candidate = resolved / "index.json"
+    if candidate.exists():
+        out_dir = resolved
+    else:
+        out_dir = resolved / "build" / "sdetkit-index"
+        build_index(resolved, out_dir)
+
     idx = json.loads((out_dir / "index.json").read_text(encoding="utf-8"))
     if idx.get("schema_version") != SCHEMA_VERSION:
         raise SystemExit("invalid index schema")

--- a/tests/test_index_engine.py
+++ b/tests/test_index_engine.py
@@ -94,3 +94,37 @@ def test_ignored_directories_are_skipped(tmp_path: Path) -> None:
     assert "ok.py" in files
     assert ".git/hidden.py" not in files
     assert "node_modules/pkg.js" not in files
+
+
+def test_index_inspect_accepts_repo_root_operator_json(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+
+    proc = _run("index", "inspect", str(repo), "--format", "operator-json")
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "sdetkit.index.v1"
+
+
+def test_index_inspect_accepts_evidence_directory(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+    out = tmp_path / "idx"
+    assert _run("index", "build", str(repo), "--out", str(out)).returncode == 0
+
+    proc = _run("index", "inspect", str(out), "--format", "text")
+    assert proc.returncode == 0
+    assert "Scanned files:" in proc.stdout
+
+
+def test_index_inspect_repo_root_text_includes_scanned_and_evidence(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+
+    proc = _run("index", "inspect", str(repo), "--format", "text")
+    assert proc.returncode == 0
+    assert "Scanned files:" in proc.stdout
+    assert "Evidence files:" in proc.stdout


### PR DESCRIPTION
### Motivation
- `index inspect` crashed with `FileNotFoundError: index.json` when users passed a repository root instead of an evidence directory because `inspect_index` assumed `PATH` was already an index evidence dir.
- The command surface documented/expected is `python -m sdetkit index inspect PATH` where `PATH` may be a repo root, so `inspect` must accept both repo roots and evidence directories.
- The change must preserve `schema_version = sdetkit.index.v1` and must not modify `index build` behavior or introduce network calls.

### Description
- Updated `inspect_index(path: Path)` to treat `path` as an evidence dir when `PATH/index.json` exists, otherwise treat `path` as a repo root and build deterministic evidence into `PATH/build/sdetkit-index` before inspecting. (`src/sdetkit/index.py`).
- The code still validates `schema_version` and returns the same payload shape, preserving `sdetkit.index.v1`.
- Added focused tests to `tests/test_index_engine.py` exercising `inspect` for a repo root with `--format operator-json`, `inspect` for an evidence directory with `--format text`, and repo-root text output containing scanned and evidence file lines.
- Updated docs `docs/repo-index-engine.md` to clarify that `inspect` accepts either a repo path or an evidence directory and that repo-path inspection (re)builds evidence under `PATH/build/sdetkit-index`.

### Testing
- Ran unit tests with `python -m pytest -q -p no:cacheprovider tests/test_index_engine.py tests/test_cli_help_discoverability_contract.py` and all tests passed (`24 passed`).
- Ran static checks with `python -m ruff check src tests` and formatting check with `python -m ruff format --check src tests`, both succeeded.
- Ran repository verification with `python -m sdetkit repo check --format json --out build/repo-check-index-inspect-fix.json --force` which returned no findings.
- Built docs with `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f463af8e848332b592ee183263b3cd)