### PR TITLE
Add Wave 2 adaptive SQLite memory foundation

### DIFF
--- a/docs/adaptive-memory.md
+++ b/docs/adaptive-memory.md
@@ -1,0 +1,49 @@
+# Adaptive SQLite memory (Wave 2 foundation)
+
+SDETKit Adaptive Power Engine v2 Wave 2 adds a local SQLite memory layer that stores deterministic index intelligence across runs.
+
+## Purpose
+
+- Persist local repo scan history so recurring risks can be ranked over time.
+- Store file/symbol/hotspot snapshots and derived risk events.
+- Provide explainable history for future Boost Scan v2 and Adaptive Review v2.
+
+## Safety and posture
+
+- Local-only SQLite database.
+- No network calls.
+- No external services.
+- No secrets required or transmitted.
+
+## Commands
+
+```bash
+python -m sdetkit adaptive init --db .sdetkit/adaptive.db
+python -m sdetkit adaptive ingest build/sdetkit-index/index.json --db .sdetkit/adaptive.db
+python -m sdetkit adaptive history --db .sdetkit/adaptive.db --format text
+python -m sdetkit adaptive history --db .sdetkit/adaptive.db --format operator-json
+python -m sdetkit adaptive explain PATH --db .sdetkit/adaptive.db --format text
+python -m sdetkit adaptive explain PATH --db .sdetkit/adaptive.db --format operator-json
+```
+
+Schema version: `sdetkit.adaptive.memory.v1`.
+
+## Tables
+
+- `schema_meta`: schema version metadata.
+- `runs`: ingest run summary (root, scanned file/line counts, source path).
+- `files`: indexed file rollup per run.
+- `symbols`: extracted symbol rollup per run.
+- `hotspots`: hotspot rollup per run.
+- `risk_events`: derived recurring risk keys from hotspots.
+- `recommendations`: derived prioritized follow-up actions.
+
+## Output contract notes
+
+- `operator-json` is stable and machine-readable.
+- `history` includes run counts, latest run, totals, top risk files, and recommendations.
+- `explain` includes recurring hotspot evidence scoped to a target path and recommended next actions.
+
+## Git hygiene
+
+Adaptive DB files are generated local artifacts. Do not commit `.db` outputs or build evidence.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,6 +182,7 @@ nav:
           - Evidence Pack: evidence.md
           - Ops Control Plane: ops.md
           - Tool server: tool-server.md
+          - Adaptive SQLite memory: adaptive-memory.md
           - IDE + pre-commit integration: ide-and-precommit.md
           - Omnichannel + MCP bridge: omnichannel-mcp-bridge.md
           - Plugins: plugins.md

--- a/src/sdetkit/adaptive.py
+++ b/src/sdetkit/adaptive.py
@@ -1,0 +1,4 @@
+from .adaptive_memory import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_memory.py
+++ b/src/sdetkit/adaptive_memory.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+SCHEMA_VERSION = "sdetkit.adaptive.memory.v1"
+INDEX_SCHEMA_VERSION = "sdetkit.index.v1"
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with _connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS schema_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS runs (
+                run_id TEXT PRIMARY KEY,
+                created_at_utc TEXT NOT NULL,
+                root TEXT NOT NULL,
+                source_schema TEXT NOT NULL,
+                scanned_files INTEGER NOT NULL,
+                scanned_lines INTEGER NOT NULL,
+                source_index_path TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS files (
+                run_id TEXT NOT NULL,
+                path TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                ext TEXT NOT NULL,
+                lines INTEGER NOT NULL,
+                bytes INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS symbols (
+                run_id TEXT NOT NULL,
+                file TEXT NOT NULL,
+                name TEXT NOT NULL,
+                type TEXT NOT NULL,
+                line INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS hotspots (
+                run_id TEXT NOT NULL,
+                file TEXT NOT NULL,
+                type TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                signal TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS risk_events (
+                run_id TEXT NOT NULL,
+                risk_key TEXT NOT NULL,
+                file TEXT NOT NULL,
+                type TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                occurrence_count INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS recommendations (
+                run_id TEXT NOT NULL,
+                title TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                file TEXT NOT NULL,
+                priority INTEGER NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO schema_meta(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            ("schema_version", SCHEMA_VERSION),
+        )
+
+
+def _run_id(payload: dict[str, object]) -> str:
+    canon = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()[:16]
+
+
+def ingest_index(db_path: Path, index_path: Path) -> str:
+    init_db(db_path)
+    payload = json.loads(index_path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != INDEX_SCHEMA_VERSION:
+        raise SystemExit("invalid index schema")
+    run_id = _run_id(payload)
+    with _connect(db_path) as conn:
+        exists = conn.execute("SELECT 1 FROM runs WHERE run_id = ?", (run_id,)).fetchone()
+        if exists:
+            return run_id
+        counts = payload.get("counts", {})
+        conn.execute(
+            "INSERT INTO runs(run_id, created_at_utc, root, source_schema, scanned_files, scanned_lines, source_index_path) VALUES(?, ?, ?, ?, ?, ?, ?)",
+            (
+                run_id,
+                datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                str(payload.get("root", "")),
+                str(payload.get("schema_version", "")),
+                int(counts.get("scanned_files", 0)),
+                int(counts.get("scanned_lines", 0)),
+                index_path.as_posix(),
+            ),
+        )
+        conn.executemany(
+            "INSERT INTO files(run_id, path, kind, ext, lines, bytes) VALUES(?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    run_id,
+                    str(r.get("path", "")),
+                    str(r.get("kind", "other")),
+                    str(r.get("ext", "<none>")),
+                    int(r.get("lines", 0)),
+                    int(r.get("bytes", 0)),
+                )
+                for r in payload.get("files", [])
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO symbols(run_id, file, name, type, line) VALUES(?, ?, ?, ?, ?)",
+            [
+                (
+                    run_id,
+                    str(r.get("file", "")),
+                    str(r.get("name", "")),
+                    str(r.get("type", "unknown")),
+                    int(r.get("line", 0)),
+                )
+                for r in payload.get("symbols", [])
+            ],
+        )
+        hotspot_rows = [
+            (
+                run_id,
+                str(r.get("file", "")),
+                str(r.get("type", "unknown")),
+                str(r.get("severity", "minor")),
+                str(r.get("signal", "")),
+            )
+            for r in payload.get("hotspots", [])
+        ]
+        conn.executemany(
+            "INSERT INTO hotspots(run_id, file, type, severity, signal) VALUES(?, ?, ?, ?, ?)",
+            hotspot_rows,
+        )
+
+        risk_counts: dict[tuple[str, str, str], int] = {}
+        for _, file, kind, severity, _ in hotspot_rows:
+            key = (file, kind, severity)
+            risk_counts[key] = risk_counts.get(key, 0) + 1
+        conn.executemany(
+            "INSERT INTO risk_events(run_id, risk_key, file, type, severity, occurrence_count) VALUES(?, ?, ?, ?, ?, ?)",
+            [
+                (run_id, f"{file}:{kind}:{severity}", file, kind, severity, count)
+                for (file, kind, severity), count in sorted(risk_counts.items())
+            ],
+        )
+
+        recs = []
+        for (file, kind, severity), count in sorted(risk_counts.items()):
+            priority = 1 if severity == "severe" else 2 if severity == "moderate" else 3
+            if severity in {"severe", "moderate"} or count > 1:
+                recs.append(
+                    (
+                        run_id,
+                        f"Address {kind} hotspot",
+                        f"{severity} hotspot seen {count} time(s)",
+                        file,
+                        priority,
+                    )
+                )
+        conn.executemany(
+            "INSERT INTO recommendations(run_id, title, reason, file, priority) VALUES(?, ?, ?, ?, ?)",
+            recs,
+        )
+    return run_id
+
+
+def _history_payload(db_path: Path) -> dict[str, object]:
+    with _connect(db_path) as conn:
+        run_count = int(conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0])
+        latest = conn.execute(
+            "SELECT run_id, created_at_utc, root FROM runs ORDER BY created_at_utc DESC, run_id DESC LIMIT 1"
+        ).fetchone()
+        totals = conn.execute(
+            "SELECT COALESCE(SUM(scanned_files),0), (SELECT COUNT(*) FROM hotspots) FROM runs"
+        ).fetchone()
+        top_files = conn.execute(
+            "SELECT file, COUNT(*) AS count FROM risk_events GROUP BY file ORDER BY count DESC, file ASC LIMIT 5"
+        ).fetchall()
+        recs = conn.execute(
+            "SELECT title, reason, file, priority FROM recommendations ORDER BY priority ASC, file ASC, title ASC LIMIT 5"
+        ).fetchall()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": "sdetkit adaptive history",
+        "db": db_path.as_posix(),
+        "run_count": run_count,
+        "latest_run": dict(latest) if latest else None,
+        "totals": {"files_indexed": int(totals[0]), "hotspots": int(totals[1])},
+        "top_risk_files": [{"file": r[0], "count": int(r[1])} for r in top_files],
+        "recommendations": [dict(r) for r in recs],
+    }
+
+
+def explain_path(db_path: Path, path: str) -> dict[str, object]:
+    history = _history_payload(db_path)
+    with _connect(db_path) as conn:
+        hot = conn.execute(
+            "SELECT file, type, severity, COUNT(*) AS count FROM hotspots WHERE file LIKE ? GROUP BY file, type, severity ORDER BY count DESC, file ASC LIMIT 5",
+            (f"%{path}%",),
+        ).fetchall()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": "sdetkit adaptive explain",
+        "db": db_path.as_posix(),
+        "path": path,
+        "run_count": history["run_count"],
+        "recurring_hotspots": [dict(r) for r in hot],
+        "recommendations": history["recommendations"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="sdetkit adaptive")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    ip = sub.add_parser("init")
+    ip.add_argument("--db", default=".sdetkit/adaptive.db")
+    ing = sub.add_parser("ingest")
+    ing.add_argument("index_json")
+    ing.add_argument("--db", default=".sdetkit/adaptive.db")
+    hist = sub.add_parser("history")
+    hist.add_argument("--db", default=".sdetkit/adaptive.db")
+    hist.add_argument("--format", choices=["text", "operator-json"], default="text")
+    exp = sub.add_parser("explain")
+    exp.add_argument("path")
+    exp.add_argument("--db", default=".sdetkit/adaptive.db")
+    exp.add_argument("--format", choices=["text", "operator-json"], default="text")
+
+    ns = p.parse_args(argv)
+    db_path = Path(ns.db)
+    if ns.cmd == "init":
+        init_db(db_path)
+        return 0
+    if ns.cmd == "ingest":
+        ingest_index(db_path, Path(ns.index_json))
+        return 0
+    if ns.cmd == "history":
+        init_db(db_path)
+        payload = _history_payload(db_path)
+        if ns.format == "operator-json":
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            latest = payload["latest_run"]
+            print(f"Runs: {payload['run_count']}")
+            print(f"Latest: {latest['run_id']}" if latest else "Latest: none")
+            print(
+                f"Totals: files={payload['totals']['files_indexed']} hotspots={payload['totals']['hotspots']}"
+            )
+        return 0
+    init_db(db_path)
+    payload = explain_path(db_path, str(ns.path))
+    if ns.format == "operator-json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"Path: {payload['path']}")
+        print(f"Runs: {payload['run_count']}")
+        print(f"Recurring hotspots: {len(payload['recurring_hotspots'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -318,6 +318,31 @@ Then use stability-aware command discovery:
         "index",
         help="[Advanced but supported] Build and inspect deterministic deep repo index evidence",
     )
+    adaptive = sub.add_parser(
+        "adaptive",
+        help="[Advanced but supported] Local SQLite adaptive memory for cross-run repo intelligence",
+    )
+    adaptive_sub = adaptive.add_subparsers(dest="adaptive_cmd", required=False)
+    adaptive_init = adaptive_sub.add_parser(
+        "init", help="Initialize local adaptive memory database"
+    )
+    adaptive_init.add_argument("--db", default=".sdetkit/adaptive.db")
+    adaptive_ingest = adaptive_sub.add_parser(
+        "ingest", help="Ingest sdetkit index evidence into adaptive memory"
+    )
+    adaptive_ingest.add_argument("index_json")
+    adaptive_ingest.add_argument("--db", default=".sdetkit/adaptive.db")
+    adaptive_history = adaptive_sub.add_parser(
+        "history", help="Summarize adaptive memory run history"
+    )
+    adaptive_history.add_argument("--db", default=".sdetkit/adaptive.db")
+    adaptive_history.add_argument("--format", choices=["text", "operator-json"], default="text")
+    adaptive_explain = adaptive_sub.add_parser(
+        "explain", help="Explain adaptive memory signals for a path"
+    )
+    adaptive_explain.add_argument("path")
+    adaptive_explain.add_argument("--db", default=".sdetkit/adaptive.db")
+    adaptive_explain.add_argument("--format", choices=["text", "operator-json"], default="text")
     index_sub = index.add_subparsers(dest="index_cmd", required=False)
     index_build = index_sub.add_parser(
         "build", help="Build deterministic local repo index evidence"
@@ -900,6 +925,25 @@ def main(argv: Sequence[str] | None = None) -> int:
             ]
             return _run_module_main("sdetkit.boost", forwarded)
         return _run_module_main("sdetkit.boost", [])
+
+    if ns.cmd == "adaptive":
+        if getattr(ns, "adaptive_cmd", None) == "init":
+            return _run_module_main("sdetkit.adaptive", ["init", "--db", str(ns.db)])
+        if getattr(ns, "adaptive_cmd", None) == "ingest":
+            return _run_module_main(
+                "sdetkit.adaptive", ["ingest", str(ns.index_json), "--db", str(ns.db)]
+            )
+        if getattr(ns, "adaptive_cmd", None) == "history":
+            return _run_module_main(
+                "sdetkit.adaptive", ["history", "--db", str(ns.db), "--format", str(ns.format)]
+            )
+        if getattr(ns, "adaptive_cmd", None) == "explain":
+            return _run_module_main(
+                "sdetkit.adaptive",
+                ["explain", str(ns.path), "--db", str(ns.db), "--format", str(ns.format)],
+            )
+        return _run_module_main("sdetkit.adaptive", [])
+
     if ns.cmd == "index":
         if getattr(ns, "index_cmd", None) == "build":
             return _run_module_main("sdetkit.index", ["build", str(ns.path), "--out", str(ns.out)])

--- a/tests/test_adaptive_memory.py
+++ b/tests/test_adaptive_memory.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "-m", "sdetkit", *args], text=True, capture_output=True)
+
+
+def _build_index(tmp_path: Path) -> Path:
+    proc = _run("index", "inspect", str(tmp_path), "--format", "operator-json")
+    assert proc.returncode == 0
+    out = tmp_path / "index.json"
+    out.write_text(proc.stdout, encoding="utf-8")
+    return out
+
+
+def test_adaptive_init_creates_schema_and_is_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / ".sdetkit" / "adaptive.db"
+    p1 = _run("adaptive", "init", "--db", str(db))
+    p2 = _run("adaptive", "init", "--db", str(db))
+    assert p1.returncode == 0
+    assert p2.returncode == 0
+    with sqlite3.connect(db) as conn:
+        got = conn.execute("SELECT value FROM schema_meta WHERE key='schema_version'").fetchone()
+    assert got and got[0] == "sdetkit.adaptive.memory.v1"
+
+
+def test_adaptive_ingest_store_and_schema_reject(tmp_path: Path) -> None:
+    db = tmp_path / "adaptive.db"
+    good = _build_index(tmp_path)
+    init = _run("adaptive", "init", "--db", str(db))
+    assert init.returncode == 0
+    ing = _run("adaptive", "ingest", str(good), "--db", str(db))
+    assert ing.returncode == 0
+    with sqlite3.connect(db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM files").fetchone()[0] >= 0
+        assert conn.execute("SELECT COUNT(*) FROM symbols").fetchone()[0] >= 0
+        assert conn.execute("SELECT COUNT(*) FROM hotspots").fetchone()[0] >= 0
+
+    bad = tmp_path / "bad.json"
+    payload = json.loads(good.read_text(encoding="utf-8"))
+    payload["schema_version"] = "wrong"
+    bad.write_text(json.dumps(payload), encoding="utf-8")
+    bad_proc = _run("adaptive", "ingest", str(bad), "--db", str(db))
+    assert bad_proc.returncode != 0
+
+
+def test_adaptive_history_and_explain_contracts(tmp_path: Path) -> None:
+    db = tmp_path / "adaptive.db"
+    _run("adaptive", "init", "--db", str(db))
+
+    empty = _run("adaptive", "explain", ".", "--db", str(db), "--format", "text")
+    assert empty.returncode == 0
+    assert "Runs: 0" in empty.stdout
+
+    good = _build_index(tmp_path)
+    _run("adaptive", "ingest", str(good), "--db", str(db))
+
+    htxt = _run("adaptive", "history", "--db", str(db), "--format", "text")
+    assert htxt.returncode == 0
+    assert "Runs:" in htxt.stdout
+
+    hjson = _run("adaptive", "history", "--db", str(db), "--format", "operator-json")
+    payload = json.loads(hjson.stdout)
+    assert payload["schema_version"] == "sdetkit.adaptive.memory.v1"
+
+    ejson = _run("adaptive", "explain", ".", "--db", str(db), "--format", "operator-json")
+    ep = json.loads(ejson.stdout)
+    assert "recurring_hotspots" in ep
+    assert "recommendations" in ep
+
+
+def test_adaptive_cli_help_discoverability() -> None:
+    proc = _run("adaptive", "--help")
+    assert proc.returncode == 0
+    assert "init" in proc.stdout
+    assert "ingest" in proc.stdout
+    assert "history" in proc.stdout
+    assert "explain" in proc.stdout
+
+    assert _run("adaptive", "init", "--help").returncode == 0
+    assert _run("adaptive", "ingest", "--help").returncode == 0
+    assert _run("adaptive", "history", "--help").returncode == 0
+    assert _run("adaptive", "explain", "--help").returncode == 0


### PR DESCRIPTION
### Motivation
- Provide a deterministic, local SQLite memory layer so SDETKit can remember repo index intelligence across runs and surface recurring risks and evolution for future Boost Scan v2 / Adaptive Review v2.
- Keep the feature local-only with no network, no secrets, and a stable schema `sdetkit.adaptive.memory.v1` suitable for operator integrations.

### Description
- Add `src/sdetkit/adaptive_memory.py` implementing the SQLite schema (`schema_meta`, `runs`, `files`, `symbols`, `hotspots`, `risk_events`, `recommendations`), idempotent `init_db`, deterministic `run_id` hashing, ingest from `sdetkit.index.v1`, and derived `risk_events`/`recommendations` logic.
- Expose a CLI surface via `python -m sdetkit adaptive` (subcommands `init`, `ingest`, `history`, `explain`) by adding `src/sdetkit/adaptive.py` and wiring subparsers in `src/sdetkit/cli.py` to forward calls to the module.
- Add tests in `tests/test_adaptive_memory.py` covering init idempotency, ingest success/rejection, persistence of runs/files/symbols/hotspots, `history`/`explain` (text and `operator-json`), and CLI help discoverability.
- Document the feature in `docs/adaptive-memory.md` and add a navigation entry to `mkdocs.yml`; the docs note that generated `.db` files must not be committed.

### Testing
- Ran unit/integration tests with `python -m pytest -q -p no:cacheprovider tests/test_adaptive_memory.py tests/test_index_engine.py tests/test_cli_help_discoverability_contract.py` and all tests passed (`28 passed`).
- Ran style/format checks with `python -m ruff check src tests` and `python -m ruff format --check src tests` (reformatted as needed) and checks passed after formatting.
- Exercised the CLI flow end-to-end with `python -m sdetkit index inspect . --format operator-json`, `python -m sdetkit adaptive init --db build/adaptive-memory/adaptive.db`, `python -m sdetkit adaptive ingest build/index-inspect-adaptive-memory.json --db build/adaptive-memory/adaptive.db`, and validated outputs with `python -m json.tool` which succeeded.
- Ran `python -m sdetkit repo check --format json --out build/repo-check-adaptive-memory.json --force` which returned zero findings and `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f471f8b410833286cf10e92545dd34)