### PR TITLE
Harden adaptive review signal integration

### DIFF
--- a/docs/adaptive-review.md
+++ b/docs/adaptive-review.md
@@ -18,3 +18,7 @@ It is local-only: no network calls, no external services, and no secrets require
 - Adaptive payload schema: `sdetkit.review.adaptive.v1` in `operator-json` under `adaptive_review`.
 - Existing non-adaptive review output remains unchanged.
 - Do not commit `.db` files or generated evidence artifacts.
+
+- `--deep` runs the local repo index helper via `python -m sdetkit index inspect PATH --format operator-json`.
+- `--learn` uses adaptive memory plus boost scan v2 via `python -m sdetkit boost scan PATH --deep --learn --db DB --format operator-json`.
+- Review may return exit code `2` when findings/non-ship signals exist while still emitting valid `operator-json`.

--- a/src/sdetkit/intelligence/review.py
+++ b/src/sdetkit/intelligence/review.py
@@ -2297,14 +2297,32 @@ def _render_release_readiness_markdown(contract: dict[str, Any]) -> str:
 
 
 def _run_json_cmd(args: list[str]) -> dict[str, Any]:
-    proc = subprocess.run(args, check=False, capture_output=True, text=True)
+    proc = subprocess.run(
+        args,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    diagnostics = {
+        "command": args,
+        "rc": int(proc.returncode),
+        "stderr": (proc.stderr or "").strip()[:500],
+        "stdout_present": bool((proc.stdout or "").strip()),
+    }
     if proc.returncode != 0:
-        return {}
+        return {"_diagnostics": diagnostics}
     try:
         loaded = json.loads(proc.stdout or "{}")
     except json.JSONDecodeError:
-        return {}
-    return loaded if isinstance(loaded, dict) else {}
+        diagnostics["parse_error"] = "invalid json"
+        return {"_diagnostics": diagnostics}
+    if not isinstance(loaded, dict):
+        diagnostics["parse_error"] = "json root not object"
+        return {"_diagnostics": diagnostics}
+    loaded.setdefault("_diagnostics", diagnostics)
+    return loaded
 
 
 def _build_adaptive_review_v2(
@@ -2318,7 +2336,16 @@ def _build_adaptive_review_v2(
 ) -> dict[str, Any]:
     index_payload = (
         _run_json_cmd(
-            ["python", "-m", "sdetkit", "index", str(target), "--format", "operator-json"]
+            [
+                "python",
+                "-m",
+                "sdetkit",
+                "index",
+                "inspect",
+                str(target),
+                "--format",
+                "operator-json",
+            ]
         )
         if deep
         else {}
@@ -2353,42 +2380,72 @@ def _build_adaptive_review_v2(
             "operator-json",
         ]
     )
-    boost_payload = _run_json_cmd(
-        [
-            "python",
-            "-m",
-            "sdetkit",
-            "boost-scan",
-            str(target),
-            "--format",
-            "operator-json",
-            "--db",
-            str(db_path),
-        ]
-    )
+    boost_args = [
+        "python",
+        "-m",
+        "sdetkit",
+        "boost",
+        "scan",
+        str(target),
+        "--deep",
+        "--learn",
+        "--db",
+        str(db_path),
+        "--format",
+        "operator-json",
+    ]
+    if evidence_dir:
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        boost_evidence_dir = safe_path(evidence_dir, "boost", allow_absolute=False)
+        boost_evidence_dir.mkdir(parents=True, exist_ok=True)
+        boost_args.extend(["--evidence-dir", str(boost_evidence_dir)])
+    boost_payload = _run_json_cmd(boost_args)
     findings = [row for row in payload.get("top_matters", []) if isinstance(row, dict)]
     recommendations = list(
         dict.fromkeys(
             [str(row.get("next_action", "")) for row in findings if row.get("next_action")]
         )
     )
-    recurring = boost_payload.get("recurring_risks", []) if isinstance(boost_payload, dict) else []
+    recurring = []
+    if isinstance(boost_payload, dict):
+        recurring = boost_payload.get("recurring_risks", [])
+    if (not isinstance(recurring, list) or not recurring) and isinstance(explain_payload, dict):
+        recurring = explain_payload.get("recurring_risks", [])
     five_heads = (
         payload.get("five_heads", {}) if isinstance(payload.get("five_heads", {}), dict) else {}
     )
     heads = five_heads.get("heads", {}) if isinstance(five_heads.get("heads", {}), dict) else {}
+    index_ok = (
+        isinstance(index_payload, dict)
+        and "missing_signal" not in index_payload
+        and "_diagnostics" in index_payload
+        and int(index_payload.get("_diagnostics", {}).get("rc", 1)) == 0
+    )
+    boost_ok = (
+        isinstance(boost_payload, dict)
+        and "missing_signal" not in boost_payload
+        and "_diagnostics" in boost_payload
+        and int(boost_payload.get("_diagnostics", {}).get("rc", 1)) == 0
+    )
+    memory_ok = (
+        isinstance(history_payload, dict)
+        and "_diagnostics" in history_payload
+        and int(history_payload.get("_diagnostics", {}).get("rc", 1)) == 0
+    )
     out = {
         "schema_version": "sdetkit.review.adaptive.v1",
         "enabled": True,
         "root": str(target),
         "decision": str(payload.get("status", "attention")),
-        "confidence": "medium" if recurring else "degraded",
+        "confidence": "normal" if (index_ok and boost_ok and memory_ok) else "degraded",
         "summary": "Adaptive review combined review, index, memory, and boost-scan signals.",
         "adaptive_findings": findings[:8],
         "recurring_risks": recurring if isinstance(recurring, list) else [],
-        "memory_summary": history_payload or {"missing_signal": "history unavailable"},
-        "boost_summary": boost_payload or {"missing_signal": "boost unavailable"},
-        "index_summary": index_payload or {"missing_signal": "index unavailable"},
+        "memory_summary": history_payload
+        if memory_ok
+        else {"missing_signal": "history unavailable"},
+        "boost_summary": boost_payload if boost_ok else {"missing_signal": "boost unavailable"},
+        "index_summary": index_payload if index_ok else {"missing_signal": "index unavailable"},
         "five_head_alignment": {
             "schema_version_observed": five_heads.get("schema_version", ""),
             "heads_present": sorted(heads.keys()),
@@ -2398,12 +2455,33 @@ def _build_adaptive_review_v2(
             "quality_signal": heads.get("quality", {}),
             "security_signal": heads.get("security", {}),
         },
-        "recommended_fixes": recommendations[:10],
+        "recommended_fixes": (
+            boost_payload.get("recommended_fixes")
+            if isinstance(boost_payload, dict)
+            and isinstance(boost_payload.get("recommended_fixes"), list)
+            else recommendations
+        )[:10],
         "patch_candidates": boost_payload.get("patch_candidates", [])
         if isinstance(boost_payload, dict)
         else [],
         "evidence_files": [],
-        "signals": {"deep": deep, "learn": learn, "db": str(db_path), "explain": explain_payload},
+        "signals": {
+            "deep": deep,
+            "learn": learn,
+            "db": str(db_path),
+            "explain": explain_payload,
+            "helpers": {
+                "index": index_payload.get("_diagnostics", {})
+                if isinstance(index_payload, dict)
+                else {},
+                "boost": boost_payload.get("_diagnostics", {})
+                if isinstance(boost_payload, dict)
+                else {},
+                "history": history_payload.get("_diagnostics", {})
+                if isinstance(history_payload, dict)
+                else {},
+            },
+        },
     }
     if evidence_dir:
         evidence_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_review_adaptive_v2.py
+++ b/tests/test_review_adaptive_v2.py
@@ -5,6 +5,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from sdetkit.intelligence import review as review_mod
+
 
 def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -52,9 +56,13 @@ def test_review_adaptive_operator_json_and_evidence(tmp_path: Path) -> None:
     assert "memory_summary" in adaptive
     assert "index_summary" in adaptive
     assert "boost_summary" in adaptive
+    assert adaptive.get("boost_summary", {}).get("missing_signal") is None
+    assert adaptive.get("index_summary", {}).get("missing_signal") is None
+    assert adaptive.get("confidence") != "degraded"
     for name in [
         "adaptive-review.json",
         "boost-v2.json",
+        "index.json",
         "memory-history.json",
         "memory-explain.json",
     ]:
@@ -93,3 +101,50 @@ def test_review_adaptive_idempotent_learn(tmp_path: Path) -> None:
     hist = _run("adaptive", "history", "--db", str(db), "--format", "operator-json")
     payload = json.loads(hist.stdout)
     assert int(payload.get("run_count", 0)) >= 0
+
+
+def test_review_adaptive_patch_candidates_populated(tmp_path: Path) -> None:
+    repo = tmp_path / "tmprepo"
+    repo.mkdir()
+    (repo / "c.py").write_text("print(1)\n", encoding="utf-8")
+    run = _run(
+        "review",
+        str(repo),
+        "--adaptive",
+        "--deep",
+        "--learn",
+        "--db",
+        str(tmp_path / "adaptive.db"),
+        "--format",
+        "operator-json",
+    )
+    assert run.returncode in (0, 2)
+    payload = json.loads(run.stdout)
+    assert isinstance(payload["adaptive_review"].get("patch_candidates"), list)
+
+
+def test_adaptive_helper_failure_degrades_with_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def _fake_run(args, **kwargs):
+        cmd = " ".join(args)
+        if "index inspect" in cmd:
+            return subprocess.CompletedProcess(args, 7, stdout="", stderr="index failed")
+        if "boost scan" in cmd:
+            return subprocess.CompletedProcess(args, 8, stdout="", stderr="boost failed")
+        return subprocess.CompletedProcess(args, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(review_mod.subprocess, "run", _fake_run)
+    out = review_mod._build_adaptive_review_v2(
+        target=tmp_path,
+        payload={"status": "attention", "top_matters": [], "five_heads": {"heads": {}}},
+        deep=True,
+        learn=True,
+        db_path=tmp_path / "adaptive.db",
+        evidence_dir=None,
+    )
+    assert out["confidence"] == "degraded"
+    assert out["boost_summary"]["missing_signal"] == "boost unavailable"
+    assert out["index_summary"]["missing_signal"] == "index unavailable"
+    assert out["signals"]["helpers"]["boost"]["rc"] == 8
+    assert out["signals"]["helpers"]["index"]["rc"] == 7


### PR DESCRIPTION
### Motivation
- Adaptive Review v2 emitted degraded confidence when local `index` and `boost` helper signals were available but not correctly consumed by the adaptive reviewer.
- The goal is to make `--adaptive --deep --learn` reliably consume local `index` and `boost` outputs while degrading gracefully on helper failures and emitting deterministic diagnostics.

### Description
- Rewired helper invocation to use the correct local entrypoints: `python -m sdetkit index inspect PATH --format operator-json` and `python -m sdetkit boost scan PATH --deep --learn --db DB --format operator-json`, and added evidence subdir handling when `--evidence-dir` is present.
- Replaced the simple `_run_json_cmd` with deterministic subprocess capture (`encoding="utf-8"`, `errors="replace"`, bounded `stderr`) that returns structured `_diagnostics` instead of silently failing on RC/parse errors.
- Improved adaptive payload population so `index_summary`, `boost_summary`, `memory_summary`, `patch_candidates`, `recommended_fixes`, and `recurring_risks` are populated from helper outputs when available and fallback to clear `missing_signal` entries when not.
- Deterministic confidence logic now sets `confidence` to `normal` when index, boost, and memory helpers succeeded, otherwise `degraded`, and helper diagnostics are surfaced under `adaptive_review.signals.helpers`.
- Evidence writing now uses `safe_path` and creates the required artifacts: `adaptive-review.json`, `boost-v2.json`, `index.json`, `memory-history.json`, and `memory-explain.json` when `--evidence-dir` is provided.
- Tests were extended in `tests/test_review_adaptive_v2.py` to assert no `missing_signal` for successful helpers, presence of `patch_candidates`, graceful degradation with diagnostics on helper failure, and non-adaptive compatibility.
- Docs updated (`docs/adaptive-review.md`) to clarify that `--deep` runs `index inspect` and `--learn` runs `boost scan` + adaptive memory and to note RC=2 semantics.

### Testing
- Ran unit tests with `python -m pytest -q -p no:cacheprovider tests/test_review.py tests/test_review_adaptive_v2.py tests/test_boost_scan_v2.py tests/test_index_engine.py tests/test_adaptive_memory.py tests/test_cli_help_discoverability_contract.py` which completed with `63 passed`.
- Ran static checks with `python -m ruff check src tests` and formatting checks with `python -m ruff format --check src tests`, and reformatted two files to satisfy style rules, after which `ruff` reported all checks passed.
- Performed an end-to-end verification by running `python -m sdetkit review . --adaptive --deep --learn --db build/adaptive-review-signal/adaptive.db --evidence-dir build/adaptive-review-signal --format operator-json` and validated the adaptive payload assertions (schema, no `missing_signal` for index/boost, and `patch_candidates`), printing `adaptive_review_signal_integration=PASS`; also ran `mkdocs` build successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b70733f8833286f59043478f5a17)