### PR TITLE
Fix release-room operator JSON contract

### DIFF
--- a/src/sdetkit/release_room.py
+++ b/src/sdetkit/release_room.py
@@ -182,6 +182,18 @@ def build_plan(
             if x
         ],
     }
+    payload["repo_path"] = str(root)
+    payload["source_status"] = {
+        name: {
+            "available": isinstance(signal.get("payload"), dict) and bool(signal.get("payload")),
+            "rc": signal.get("rc"),
+        }
+        for name, signal in payload.get("signals", {}).items()
+        if isinstance(signal, dict)
+    }
+    payload["validation_commands"] = list(payload.get("validation_plan", []))
+    payload["evidence_paths"] = list(payload.get("evidence_files", []))
+    payload["next_pr_recommendation"] = payload.get("next_pr", {})
     payload["operator_brief"] = render_text(payload, max_lines=max_lines)
     return payload
 
@@ -271,6 +283,7 @@ def main(argv: list[str] | None = None) -> int:
             out = safe_path(ed, name, allow_absolute=False)
             out.write_text(body, encoding="utf-8")
             payload["evidence_files"].append(out.as_posix())
+    payload["evidence_paths"] = list(payload.get("evidence_files", []))
     if ns.format == "operator-json":
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:

--- a/tests/test_release_room_plan.py
+++ b/tests/test_release_room_plan.py
@@ -24,6 +24,24 @@ def test_operator_json_contract(tmp_path):
     assert proc.returncode == 0
     payload = json.loads(proc.stdout)
     assert payload["schema_version"] == "sdetkit.release_room.plan.v1"
+    required = {
+        "schema_version",
+        "repo_path",
+        "decision",
+        "confidence",
+        "source_status",
+        "top_risks",
+        "patch_candidates",
+        "recommended_fixes",
+        "validation_commands",
+        "evidence_paths",
+        "next_pr_recommendation",
+    }
+    assert required <= set(payload)
+    assert isinstance(payload["source_status"], dict)
+    assert isinstance(payload["validation_commands"], list)
+    assert isinstance(payload["evidence_paths"], list)
+    assert payload["next_pr_recommendation"]
     assert payload["decision"] in {"SHIP", "REVIEW", "NO-SHIP", "UNKNOWN"}
     assert isinstance(payload.get("patch_candidates"), list)
     assert isinstance(payload.get("signals"), dict)
@@ -83,7 +101,7 @@ def test_validation_plan_contains_required_commands(tmp_path):
         "operator-json",
     )
     payload = json.loads(proc.stdout)
-    joined = "\n".join(payload["validation_plan"])
+    joined = "\n".join(payload["validation_commands"])
     assert "pytest" in joined
     assert "ruff check" in joined
     assert "ruff format --check" in joined


### PR DESCRIPTION
## Summary
- Exposes release-room operator contract fields as top-level JSON keys.
- Keeps evidence_paths synchronized after evidence files are written.
- Strengthens release-room tests so missing top-level operator keys fail before merge.

## Validation
- .venv/bin/python -m pytest -q -p no:cacheprovider tests/test_release_room_plan.py tests/test_cli_help_discoverability_contract.py
- .venv/bin/python -m pytest -q -p no:cacheprovider tests/test_release_room_plan.py tests/test_review_adaptive_v2.py tests/test_boost_scan_v2.py tests/test_index_engine.py tests/test_adaptive_memory.py tests/test_cli_help_discoverability_contract.py
- .venv/bin/python -m ruff check src tests
- .venv/bin/python -m ruff format --check src tests
- .venv/bin/python -m sdetkit release-room plan . --deep --learn --db build/hotfix-release-room-operator-json-contract/release-room/adaptive.db --evidence-dir build/hotfix-release-room-operator-json-contract/release-room --max-lines 100 --format text
- .venv/bin/python -m sdetkit release-room plan . --deep --learn --db build/hotfix-release-room-operator-json-contract/release-room/adaptive.db --evidence-dir build/hotfix-release-room-operator-json-contract/release-room --format operator-json
- release_room_contract=PASS
- .venv/bin/python -m sdetkit repo check --format json --out build/hotfix-release-room-operator-json-contract/repo-check.json --force
- NO_MKDOCS_2_WARNING=1 .venv/bin/python -m mkdocs build --strict