### PR TITLE
Add guided `upgrade-next` lane and `operator-onramp` Makefile targets with docs and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ FIRST_PROOF_READINESS_PROFILE ?= lenient
 PHASE2_BASELINE_PRE_EXTRACTION ?= docs/artifacts/phase2-hotspot-baseline-pre-extraction-$(DATE_TAG).json
 BUSINESS_EXECUTION_OPERATOR ?= sherif69-sa
 
-.PHONY: bootstrap max brutal venv runtime-install first-proof-install install ci-deps-sync test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry upgrade-next onboarding-next doctor-remediate first-proof-freshness first-proof-ops-bundle-contract first-proof-ops-bundle-trend first-proof-ops-bundle-trend-report first-proof-execution-report first-proof-execution-contract first-proof-schema-contract upgrade-status-line first-proof-followup-ready followup-ready-metrics first-proof-dashboard first-proof-readiness-threshold followup-changelog plan-next-10 cleanup-first-proof-artifacts golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-fast ship-readiness-contract release-room release-room-fast portfolio-readiness premerge-release-room premerge-release-room-fast adaptive-scenario-db adaptive-postcheck owner-escalation-payload adaptive-premerge adaptive-ops-bundle repo-alignment-check test-bootstrap test-bootstrap-contract merge-ready premerge-finalize first-proof first-proof-local first-proof-contract first-proof-health-score first-proof-learn first-proof-control-tower first-proof-weekly-trend first-proof-trend-threshold first-proof-tests first-proof-tests-local first-proof-verify first-proof-verify-local gate-decision-summary gate-decision-summary-contract fit-check adoption-followup adoption-followup-contract adoption-control-loop adoption-control-loop-contract adoption-posture adoption-validate adoption-control-loop-full ops-followup ops-followup-contract ops-now ops-now-lite ops-next ops-premerge-next ops-premerge-next-fast phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-execution-core phase1-workflow phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-start phase2-workflow phase2-status phase2-start-contract phase2-seed phase2-hotspot-baseline phase2-hotspot-delta phase2-complete phase2-progress phase2-surface-clarity phase3-dependency-radar phase3-quality-contract phase3-quality-report phase3-do-it phase4-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract plan-status phase1-execute phase2-execute phase3-governance phase4-credibility real-workflow-daily real-workflow-daily-fast real-workflow-weekly real-workflow-premerge real-workflow-premerge-fast real-workflow ops-daily ops-daily-fast ops-weekly ops-premerge ops-premerge-fast ops-workflow
+.PHONY: bootstrap max brutal venv runtime-install first-proof-install install ci-deps-sync test cov lint fmt type docs-serve docs-build package-validate release-preflight release-verify-plan upgrade-audit upgrade-audit-ci registry upgrade-next operator-onramp operator-onramp-dry-run operator-onramp-verify onboarding-next doctor-remediate first-proof-freshness first-proof-ops-bundle-contract first-proof-ops-bundle-trend first-proof-ops-bundle-trend-report first-proof-execution-report first-proof-execution-contract first-proof-schema-contract upgrade-status-line first-proof-followup-ready followup-ready-metrics first-proof-dashboard first-proof-readiness-threshold followup-changelog plan-next-10 cleanup-first-proof-artifacts golden-path-health canonical-path-drift legacy-command-analyzer legacy-burndown adoption-scorecard adoption-scorecard-contract observability-contract operator-onboarding-wizard primary-docs-map top-tier-reporting enterprise-contracts-check enterprise-assessment enterprise-assessment-contract ship-readiness ship-readiness-fast ship-readiness-contract release-room release-room-fast portfolio-readiness premerge-release-room premerge-release-room-fast adaptive-scenario-db adaptive-postcheck owner-escalation-payload adaptive-premerge adaptive-ops-bundle repo-alignment-check test-bootstrap test-bootstrap-contract merge-ready premerge-finalize first-proof first-proof-local first-proof-contract first-proof-health-score first-proof-learn first-proof-control-tower first-proof-weekly-trend first-proof-trend-threshold first-proof-tests first-proof-tests-local first-proof-verify first-proof-verify-local gate-decision-summary gate-decision-summary-contract fit-check adoption-followup adoption-followup-contract adoption-control-loop adoption-control-loop-contract adoption-posture adoption-validate adoption-control-loop-full ops-followup ops-followup-contract ops-now ops-now-lite ops-next ops-premerge-next ops-premerge-next-fast phase1-baseline phase1-status phase1-next phase1-ops-snapshot phase1-dashboard phase1-weekly-pack phase1-control-loop phase1-run-all phase1-artifact-set phase1-telemetry phase1-finish-signal phase1-next-pass phase1-blocker-register phase1-do-it phase1-execution-core phase1-workflow phase1-flow-contract phase1-gate-phase2 phase1-executive-report phase1-retire-plan phase1-complete phase1-closeout phase-current phase-current-json phase2-start phase2-workflow phase2-status phase2-start-contract phase2-seed phase2-hotspot-baseline phase2-hotspot-delta phase2-complete phase2-progress phase2-surface-clarity phase3-dependency-radar phase3-quality-contract phase3-quality-report phase3-do-it phase4-governance-contract phase5-ecosystem-contract phase6-start phase6-status phase6-progress phase6-complete phase6-metrics-contract plan-status phase1-execute phase2-execute phase3-governance phase4-credibility real-workflow-daily real-workflow-daily-fast real-workflow-weekly real-workflow-premerge real-workflow-premerge-fast real-workflow ops-daily ops-daily-fast ops-weekly ops-premerge ops-premerge-fast ops-workflow
 .PHONY: business-execution-start business-execution-start-contract business-execution-go-gate business-execution-progress business-execution-progress-contract business-execution-next business-execution-next-contract business-execution-handoff business-execution-handoff-contract business-execution-escalation business-execution-escalation-contract business-execution-followup business-execution-followup-contract business-execution-continue business-execution-continue-contract business-execution-horizon business-execution-horizon-contract business-execution-inputs-contract business-execution-pipeline business-execution-week1-pipeline
 
 bootstrap: venv
@@ -194,12 +194,43 @@ ops-workflow: real-workflow
 
 upgrade-next:
 	@bash -lc 'echo "=== SDETKit Upgrade Next (Guided Path) ==="'
-	@bash -lc 'echo "1) make first-proof"'
-	@bash -lc 'echo "2) make first-proof-verify"'
-	@bash -lc 'echo "3) make ops-now-lite"'
-	@bash -lc 'echo "4) make ops-next"'
-	@bash -lc 'echo "5) make plan-status"'
+	@bash -lc 'echo "1) make first-proof            # establish deterministic SHIP/NO-SHIP baseline"'
+	@bash -lc 'echo "2) make first-proof-health-score # compute executive 0-100 readiness score"'
+	@bash -lc 'echo "3) make first-proof-verify     # run CI-equivalent verification lane"'
+	@bash -lc 'echo "4) make first-proof-freshness  # enforce evidence freshness/retention signal"'
+	@bash -lc 'echo "5) make doctor-remediate       # emit top blocker remediation hints"'
+	@bash -lc 'echo ""'
+	@bash -lc 'echo "Set UPGRADE_NEXT_RUN=1 to run commands 1-5 automatically."'
+	@bash -lc 'echo "Set UPGRADE_NEXT_DRY_RUN=1 to print commands only (no execution)."'
 	@bash -lc 'echo "Docs: docs/upgrade-next-commands.md"'
+	@bash -lc 'if [ "$${UPGRADE_NEXT_RUN:-0}" = "1" ]; then \
+		echo "Running guided path..."; \
+		if [ "$${UPGRADE_NEXT_DRY_RUN:-0}" = "1" ]; then \
+			echo "DRY RUN: make first-proof"; \
+			echo "DRY RUN: make first-proof-health-score"; \
+			echo "DRY RUN: make first-proof-verify"; \
+			echo "DRY RUN: make first-proof-freshness"; \
+			echo "DRY RUN: make doctor-remediate"; \
+		else \
+			$(MAKE) first-proof; \
+			$(MAKE) first-proof-health-score; \
+			$(MAKE) first-proof-verify; \
+			$(MAKE) first-proof-freshness; \
+			$(MAKE) doctor-remediate; \
+		fi; \
+		fi'
+
+operator-onramp: upgrade-next onboarding-next first-proof-dashboard
+	@bash -lc 'echo "operator-onramp completed: upgrade-next + onboarding-next + first-proof-dashboard"'
+	@bash -lc 'echo "Next docs: docs/operator-onboarding-7-day.md and docs/upgrade-next-commands.md"'
+
+operator-onramp-dry-run:
+	@bash -lc 'echo "DRY RUN: make upgrade-next"'
+	@bash -lc 'echo "DRY RUN: make onboarding-next"'
+	@bash -lc 'echo "DRY RUN: make first-proof-dashboard"'
+
+operator-onramp-verify: operator-onramp first-proof-schema-contract first-proof-execution-contract first-proof-followup-ready
+	@bash -lc 'echo "operator-onramp-verify completed: contracts + followup-ready passed"'
 
 business-execution-start: venv
 	@bash -lc '. .venv/bin/activate && python scripts/business_execution_start.py --single-operator "$(BUSINESS_EXECUTION_OPERATOR)"'

--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ Related docs:
 - [Portfolio reporting recipe](docs/portfolio-reporting-recipe.md)
 - [KPI schema](docs/kpi-schema.md)
 
+## Upgrade next (intent router)
+
+For first-time operators who want a single guided lane, use:
+
+```bash
+make upgrade-next
+```
+
+This prints a deterministic "next 5 commands" path and links to:
+- [`docs/upgrade-next-commands.md`](docs/upgrade-next-commands.md)
+
 
 ## Maintenance command center (issue noise control)
 

--- a/docs/upgrade-next-commands.md
+++ b/docs/upgrade-next-commands.md
@@ -1,4 +1,4 @@
-# Upgrade Next Commands (Intent → Command)
+# Upgrade Next Commands (Intent -> Command)
 
 Use this page when you know the goal but not the exact command.
 
@@ -51,6 +51,34 @@ make upgrade-next
 ```
 
 This prints the recommended "next 5 commands" sequence.
+
+To run those five commands automatically:
+
+```bash
+UPGRADE_NEXT_RUN=1 make upgrade-next
+```
+
+The guided five-command lane includes:
+- `first-proof-health-score` for an executive readiness score artifact (`build/first-proof/health-score.json`).
+- `first-proof-freshness` to confirm first-proof artifacts remain current and auditable.
+- `doctor-remediate` so the lane ends with top blocker fixes, not only status output.
+
+To preview the exact sequence without executing:
+
+```bash
+UPGRADE_NEXT_RUN=1 UPGRADE_NEXT_DRY_RUN=1 make upgrade-next
+```
+
+## I need one-command onboarding-by-default
+
+```bash
+make operator-onramp
+make operator-onramp-dry-run
+make operator-onramp-verify
+```
+
+This runs `upgrade-next`, builds `onboarding-next` artifacts, and renders the first-proof dashboard.
+`operator-onramp-verify` adds schema/execution/followup-ready contract checks.
 
 ## Notes
 

--- a/tests/test_upgrade_next_onramp.py
+++ b/tests/test_upgrade_next_onramp.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_makefile_upgrade_next_exposes_guided_five_step_path() -> None:
+    makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    assert "upgrade-next:" in makefile
+    assert "operator-onramp: upgrade-next onboarding-next first-proof-dashboard" in makefile
+    assert "operator-onramp-dry-run:" in makefile
+    assert (
+        "operator-onramp-verify: operator-onramp first-proof-schema-contract "
+        "first-proof-execution-contract first-proof-followup-ready" in makefile
+    )
+    assert "make first-proof" in makefile
+    assert "make first-proof-health-score" in makefile
+    assert "make first-proof-verify" in makefile
+    assert "make first-proof-freshness" in makefile
+    assert "make doctor-remediate" in makefile
+    assert "UPGRADE_NEXT_RUN=1" in makefile
+    assert "UPGRADE_NEXT_DRY_RUN=1" in makefile
+
+
+def test_upgrade_next_doc_includes_auto_run_flag() -> None:
+    docs_page = (REPO_ROOT / "docs" / "upgrade-next-commands.md").read_text(encoding="utf-8")
+    assert "make upgrade-next" in docs_page
+    assert "make operator-onramp" in docs_page
+    assert "make operator-onramp-dry-run" in docs_page
+    assert "make operator-onramp-verify" in docs_page
+    assert "UPGRADE_NEXT_RUN=1 make upgrade-next" in docs_page
+    assert "UPGRADE_NEXT_DRY_RUN=1 make upgrade-next" in docs_page
+
+
+def test_readme_links_upgrade_next_intent_router() -> None:
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "## Upgrade next (intent router)" in readme
+    assert "docs/upgrade-next-commands.md" in readme
+
+
+def test_upgrade_next_dry_run_prints_all_commands_without_execution() -> None:
+    proc = subprocess.run(
+        ["make", "upgrade-next"],
+        cwd=REPO_ROOT,
+        env={**os.environ, "UPGRADE_NEXT_RUN": "1", "UPGRADE_NEXT_DRY_RUN": "1"},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = proc.stdout
+    assert "Running guided path..." in out
+    assert "DRY RUN: make first-proof" in out
+    assert "DRY RUN: make first-proof-health-score" in out
+    assert "DRY RUN: make first-proof-verify" in out
+    assert "DRY RUN: make first-proof-freshness" in out
+    assert "DRY RUN: make doctor-remediate" in out
+
+
+def test_operator_onramp_dry_run_prints_sequence() -> None:
+    proc = subprocess.run(
+        ["make", "operator-onramp-dry-run"],
+        cwd=REPO_ROOT,
+        env={**os.environ},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = proc.stdout
+    assert "DRY RUN: make upgrade-next" in out
+    assert "DRY RUN: make onboarding-next" in out
+    assert "DRY RUN: make first-proof-dashboard" in out


### PR DESCRIPTION
### Motivation

- Provide a single, opinionated guided lane for first-time operators to run the next best steps toward a deterministic release baseline.
- Make it easy to preview or automatically execute a recommended five-step sequence and expose an onramp composed of upgrade + onboarding + dashboard targets.

### Description

- Enhance `Makefile` to expand the `upgrade-next` output with five recommended commands, add `UPGRADE_NEXT_RUN` and `UPGRADE_NEXT_DRY_RUN` flags, and implement optional automatic execution of the guided path.
- Add new Makefile targets `operator-onramp`, `operator-onramp-dry-run`, and `operator-onramp-verify` that compose `upgrade-next`, `onboarding-next`, and `first-proof-dashboard` and include verification contracts.
- Update the `.PHONY` list to include the new operator onramp targets and add explanatory messaging for the guided path steps within `upgrade-next`.
- Add a README section `## Upgrade next (intent router)` and extend `docs/upgrade-next-commands.md` with instructions for auto-run and dry-run behavior and details about the included sub-commands.
- Add `tests/test_upgrade_next_onramp.py` which asserts the Makefile and docs contain the new lanes/flags and exercises `make upgrade-next` (dry-run) and `make operator-onramp-dry-run` to validate printed output.

### Testing

- Added `tests/test_upgrade_next_onramp.py` and ran the test suite with `pytest -q`, which executed the new assertions and command invocations successfully.
- Verified the Makefile dry-run behavior by running `UPGRADE_NEXT_RUN=1 UPGRADE_NEXT_DRY_RUN=1 make upgrade-next` in tests to ensure it prints the expected DRY RUN lines.
- Executed `make operator-onramp-dry-run` via the test harness to confirm the expected sequence is printed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f4a65b9c83329d50be5b6a87b077)