### PR TITLE
Add portfolio-orchestrate multi-repo orchestrator, CLI integration, adapters, schemas, docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ python -m sdetkit portfolio-orchestrate execute \
   --plan build/portfolio-execution-plan.json \
   --max-workers 8 \
   --run \
+  --transport ssh \
   --timeout-seconds 120 \
   --out build/portfolio-execution-results.json
 
@@ -144,6 +145,7 @@ python -m sdetkit portfolio-orchestrate run-pipeline \
   --adapters config/portfolio_adapters.json \
   --max-workers 8 \
   --run \
+  --transport ssh \
   --timeout-seconds 120 \
   --retries 1 \
   --max-failures 3 \
@@ -174,6 +176,11 @@ python -m sdetkit portfolio-orchestrate batch-run \
   --manifest examples/topology/portfolio-batch.sample.json \
   --max-parallel 4 \
   --out-dir build/portfolio-batch
+
+# policy_overrides in batch manifests can be either an object:
+# "policy_overrides": {"max_risk_score": 25}
+# or a JSON string:
+# "policy_overrides": "{\"max_risk_score\": 25}"
 
 python -m sdetkit portfolio-orchestrate impact-plan \
   --repo-graph examples/topology/enterprise-repo-graph.sample.json \

--- a/README.md
+++ b/README.md
@@ -76,6 +76,125 @@ Real workflow operations: [`docs/real-workflow-operations.md`](docs/real-workflo
 Quick ops aliases: `make ops-daily` / `make ops-daily-fast` / `make ops-weekly` / `make ops-premerge` / `make ops-premerge-fast` / `make ops-premerge-next` / `make ops-premerge-next-fast` / `make ops-followup` / `make ops-now` / `make ops-now-lite` / `make ops-next`
 Rollback/remediation examples: [`docs/integrations/rollback-remediation-examples.md`](docs/integrations/rollback-remediation-examples.md)
 
+## Multi-repo execution (new)
+
+You can now generate a deterministic multi-repo execution plan and portfolio risk report:
+
+```bash
+python -m sdetkit portfolio-orchestrate orchestrate \
+  --repo-graph examples/topology/enterprise-repo-graph.sample.json \
+  --schema schemas/repo-graph.schema.json \
+  --max-workers 4 \
+  --out build/portfolio-execution-plan.json
+
+python -m sdetkit portfolio-orchestrate validate-graph \
+  --repo-graph examples/topology/enterprise-repo-graph.sample.json \
+  --schema schemas/repo-graph.schema.json
+
+python -m sdetkit portfolio-orchestrate risk-report \
+  --plan build/portfolio-execution-plan.json \
+  --out build/portfolio-risk-report.json
+
+python -m sdetkit portfolio-orchestrate execute \
+  --plan build/portfolio-execution-plan.json \
+  --max-workers 8 \
+  --transport local \
+  --adapters config/portfolio_adapters.json \
+  --artifact-dir build/portfolio-workers \
+  --retries 1 \
+  --max-failures 3 \
+  --cancel-file .sdetkit/portfolio-cancel-targets.txt \
+  --out build/portfolio-execution-intents.json
+
+# Optional: execute adapter commands (not only dry-run intents)
+python -m sdetkit portfolio-orchestrate execute \
+  --plan build/portfolio-execution-plan.json \
+  --max-workers 8 \
+  --run \
+  --timeout-seconds 120 \
+  --out build/portfolio-execution-results.json
+
+python -m sdetkit portfolio-orchestrate score-execution \
+  --results build/portfolio-execution-results.json \
+  --out build/portfolio-execution-scorecard.json
+
+python -m sdetkit portfolio-orchestrate report \
+  --plan build/portfolio-execution-plan.json \
+  --risk build/portfolio-risk-report.json \
+  --score build/portfolio-execution-scorecard.json \
+  --out build/portfolio-report.md
+
+python -m sdetkit portfolio-orchestrate analyze-plan \
+  --plan build/portfolio-execution-plan.json \
+  --out build/portfolio-plan-analysis.json
+
+python -m sdetkit portfolio-orchestrate run-pipeline \
+  --repo-graph examples/topology/enterprise-repo-graph.sample.json \
+  --schema schemas/repo-graph.schema.json \
+  --adapters config/portfolio_adapters.json \
+  --max-workers 8 \
+  --policy config/portfolio_policy.default.json \
+  --history .sdetkit/portfolio-history.jsonl \
+  --out-dir build/portfolio-pipeline
+
+# Optional: run real adapter commands in the pipeline
+python -m sdetkit portfolio-orchestrate run-pipeline \
+  --repo-graph examples/topology/enterprise-repo-graph.sample.json \
+  --schema schemas/repo-graph.schema.json \
+  --adapters config/portfolio_adapters.json \
+  --max-workers 8 \
+  --run \
+  --timeout-seconds 120 \
+  --retries 1 \
+  --max-failures 3 \
+  --policy config/portfolio_policy.default.json \
+  --history .sdetkit/portfolio-history.jsonl \
+  --out-dir build/portfolio-pipeline-run
+
+python -m sdetkit portfolio-orchestrate evaluate-policy \
+  --risk build/portfolio-risk-report.json \
+  --score build/portfolio-execution-scorecard.json \
+  --execution build/portfolio-execution-results.json \
+  --policy config/portfolio_policy.default.json \
+  --out build/portfolio-policy-decision.json
+
+python -m sdetkit portfolio-orchestrate history-trend \
+  --history .sdetkit/portfolio-history.jsonl \
+  --out build/portfolio-history-trend.json
+
+python -m sdetkit portfolio-orchestrate dashboard \
+  --plan build/portfolio-execution-plan.json \
+  --risk build/portfolio-risk-report.json \
+  --score build/portfolio-execution-scorecard.json \
+  --execution build/portfolio-execution-results.json \
+  --policy build/portfolio-policy-decision.json \
+  --out build/portfolio-dashboard.html
+
+python -m sdetkit portfolio-orchestrate batch-run \
+  --manifest examples/topology/portfolio-batch.sample.json \
+  --max-parallel 4 \
+  --out-dir build/portfolio-batch
+
+python -m sdetkit portfolio-orchestrate impact-plan \
+  --repo-graph examples/topology/enterprise-repo-graph.sample.json \
+  --changed-files examples/kits/intelligence/changed-files.txt \
+  --out build/portfolio-impact-plan.json
+
+python -m sdetkit portfolio-orchestrate batch-control-tower \
+  --history build/portfolio-batch/batch-history.jsonl \
+  --out build/portfolio-batch/control-tower.json
+
+python -m sdetkit portfolio-orchestrate cancel-worker \
+  --target api \
+  --cancel-file .sdetkit/portfolio-cancel-targets.txt
+```
+
+Execution rows now include Worker Contract-style fields (`worker`, `run_id`, `started_at`, `finished_at`, `inputs`, `result`, `escalation`) for consistent downstream automation.
+
+Reference contracts:
+- Worker contract: [`docs/contracts/worker-contract-v1.md`](docs/contracts/worker-contract-v1.md)
+- Repo graph schema: [`schemas/repo-graph.schema.json`](schemas/repo-graph.schema.json)
+
 Release preflight now expects `build/first-proof/first-proof-summary.json` to exist and pass
 `check_first_proof_summary_contract.py`.
 

--- a/adapters/go/README.md
+++ b/adapters/go/README.md
@@ -1,0 +1,9 @@
+# Go adapter (initial)
+
+This adapter will map Go quality/release checks to Worker Contract v1 output.
+
+Initial parity target:
+- gofmt/go vet
+- go test
+- build
+- dependency vulnerability scan

--- a/adapters/node/README.md
+++ b/adapters/node/README.md
@@ -1,0 +1,9 @@
+# Node adapter (initial)
+
+This adapter will map Node/TypeScript quality/release checks to Worker Contract v1 output.
+
+Initial parity target:
+- lint
+- test
+- build
+- package audit

--- a/config/portfolio_adapters.json
+++ b/config/portfolio_adapters.json
@@ -1,0 +1,5 @@
+{
+  "python": ["python", "-m", "sdetkit", "gate", "fast", "--repo", "{repo_path}"],
+  "node": ["npm", "test", "--prefix", "{repo_path}"],
+  "go": ["go", "test", "./...", "{repo_path}"]
+}

--- a/config/portfolio_policy.default.json
+++ b/config/portfolio_policy.default.json
@@ -1,0 +1,7 @@
+{
+  "name": "default-enterprise",
+  "max_risk_score": 35,
+  "min_execution_reliability": 80,
+  "max_failures": 0,
+  "allow_stopped_early": false
+}

--- a/config/portfolio_policy.packs.json
+++ b/config/portfolio_policy.packs.json
@@ -1,0 +1,26 @@
+{
+  "default_profile": "standard",
+  "profiles": {
+    "standard": {
+      "name": "standard",
+      "max_risk_score": 35,
+      "min_execution_reliability": 80,
+      "max_failures": 0,
+      "allow_stopped_early": false
+    },
+    "regulated": {
+      "name": "regulated",
+      "max_risk_score": 25,
+      "min_execution_reliability": 90,
+      "max_failures": 0,
+      "allow_stopped_early": false
+    },
+    "critical-release": {
+      "name": "critical-release",
+      "max_risk_score": 15,
+      "min_execution_reliability": 95,
+      "max_failures": 0,
+      "allow_stopped_early": false
+    }
+  }
+}

--- a/docs/contracts/worker-contract-v1.md
+++ b/docs/contracts/worker-contract-v1.md
@@ -1,0 +1,27 @@
+# Worker Contract v1
+
+Every worker must emit deterministic JSON with this shape:
+
+```json
+{
+  "worker": "string",
+  "run_id": "string",
+  "started_at": "ISO-8601",
+  "finished_at": "ISO-8601",
+  "status": "ok|fail|error",
+  "inputs": {},
+  "evidence": [],
+  "result": {},
+  "escalation": {
+    "required": false,
+    "reason": "string"
+  }
+}
+```
+
+## Required guarantees
+
+- Idempotent for same inputs.
+- Emits machine-readable evidence pointers.
+- Emits explicit escalation signal.
+- Never returns ambiguous final status.

--- a/docs/top-tier-upgrade-cycle-plan.md
+++ b/docs/top-tier-upgrade-cycle-plan.md
@@ -1,0 +1,127 @@
+# Top-tier upgrade cycle plan (multi-repo, multi-language, multi-worker)
+
+## 1) What is already proven strongly in this repository
+
+Based on the current repository state and front-door documentation, the platform already demonstrates strong proof in the following areas:
+
+- Deterministic **SHIP / NO-SHIP** release gates with machine-readable artifacts.
+- A committed **live-adoption product proof** flow with explicit outcomes and known-finding accounting.
+- Multiple operational lanes (release gate, review, quality, CI-ready, reporting).
+- Strong artifact-first governance across docs/artifacts and plans/ for auditable execution history.
+- Extensive contract-check scripts that enforce consistency across releases, governance phases, and closeout packs.
+
+In short: this repo is already beyond a simple test toolkit; it behaves like an operating system for release confidence.
+
+## 2) Current strategic gaps to close for global top-tier scale
+
+To support huge enterprise portfolios (many repos, many languages, many teams), the biggest gaps are now platform-level, not feature-level.
+
+### Gap A: Polyglot-first execution model
+
+Today, many workflows are Python-centric. To become default for mixed stacks, the platform needs first-class adapters for:
+
+- Node/TypeScript
+- Java/Kotlin
+- Go
+- .NET
+- Rust
+- Infrastructure repos (Terraform/Helm)
+
+### Gap B: Cross-repo orchestration and dependency awareness
+
+Large organizations ship from interconnected repositories. The platform needs explicit support for:
+
+- dependency graph ingestion
+- change impact propagation across repos
+- coordinated gate decisions for release trains
+
+### Gap C: Multi-worker control plane
+
+The repo has many scripts (worker-like capabilities), but needs a clearer unified worker model with:
+
+- standardized worker lifecycle
+- queueing/prioritization
+- parallel execution governance
+- retry/escalation policies
+
+### Gap D: Enterprise observability and cost-performance controls
+
+At scale, teams need strict cost and throughput visibility:
+
+- time-to-signal SLOs
+- artifact freshness SLOs
+- worker CPU/minute budgets
+- false-positive / false-negative tracking by lane
+
+## 3) Next continuous upgrade cycle (10-direction execution)
+
+Run the next cycle as ten parallel streams with one ownership board.
+
+1. **Polyglot adapters**: implement language adapters with common contract output.
+2. **Cross-repo graph**: add manifest format for upstream/downstream repo relationships.
+3. **Worker runtime**: define worker protocol (`input`, `evidence`, `result`, `escalation`).
+4. **Scheduler**: add priority queue with weighted fairness and max-concurrency controls.
+5. **Unified evidence schema v2**: normalize artifact fields across all workers.
+6. **Risk scoring engine**: portfolio-level risk from per-repo gate evidence.
+7. **Auto-remediation lane**: safe fixers for common failures with rollback proofs.
+8. **Executive control tower**: organization-level dashboards + trend alerts.
+9. **Governance pack templates**: standard closeout packs for any language/repo type.
+10. **Integration marketplace**: plug-ins for CI providers, SCMs, test frameworks, and package ecosystems.
+
+## 4) Architecture target for "interact with all repos"
+
+Adopt a layered architecture:
+
+- **Layer 1: Adapters** (language/repo specific)
+- **Layer 2: Worker contracts** (common run model)
+- **Layer 3: Orchestrator** (multi-worker scheduling + retries)
+- **Layer 4: Evidence lake** (immutable run artifacts)
+- **Layer 5: Decision engine** (SHIP/NO-SHIP + portfolio risk)
+- **Layer 6: Consumption APIs** (CLI, CI, dashboards, bots)
+
+This preserves deterministic behavior while enabling heterogenous stacks.
+
+## 5) 90-day implementation roadmap
+
+### Days 1-30 (Foundation)
+
+- Freeze and publish **worker contract v1**.
+- Add two non-Python adapters (recommend Node + Go first).
+- Add cross-repo manifest and parser.
+- Emit unified evidence schema v2 in parallel with existing outputs.
+
+### Days 31-60 (Scale)
+
+- Introduce scheduler with bounded concurrency and queue metrics.
+- Add portfolio risk scoring from repo-level artifacts.
+- Add baseline auto-remediation worker for top recurring failures.
+- Add SLO dashboards (time-to-signal, queue latency, pass-rate drift).
+
+### Days 61-90 (Enterprise hardening)
+
+- Add enterprise policy packs (regulated vs standard modes).
+- Add release-train coordination across dependency-linked repos.
+- Add signed evidence bundles and tamper checks.
+- Publish global operator handbook + reference architecture.
+
+## 6) KPI system for world-class status
+
+Track these KPIs weekly and quarterly:
+
+- Gate decision latency p50/p95
+- Cross-repo impact detection precision
+- Automated remediation success rate
+- Evidence completeness ratio
+- Regression escape rate after SHIP
+- Cost per evaluated change-set
+- Worker utilization and queue starvation rate
+
+## 7) Immediate next actions (starting now)
+
+1. Create `worker-contract-v1.md` with strict JSON schema examples.
+2. Add `repo-graph.schema.json` and one enterprise sample topology.
+3. Stand up `adapters/node/` and `adapters/go/` with minimal parity commands.
+4. Add a single orchestration command for multi-repo execution.
+5. Add `portfolio-risk-report.json` generation from existing artifacts.
+
+If these five are delivered first, this repo moves from strong single-repo excellence to true enterprise multi-repo operating capability.

--- a/examples/topology/enterprise-repo-graph.sample.json
+++ b/examples/topology/enterprise-repo-graph.sample.json
@@ -1,0 +1,7 @@
+{
+  "repos": [
+    {"name": "platform-api", "path": "repos/platform-api", "language": "python", "priority": 10, "depends_on": ["contracts"]},
+    {"name": "contracts", "path": "repos/contracts", "language": "go", "priority": 15},
+    {"name": "web-app", "path": "repos/web-app", "language": "node", "priority": 40, "depends_on": ["platform-api"]}
+  ]
+}

--- a/examples/topology/portfolio-batch.sample.json
+++ b/examples/topology/portfolio-batch.sample.json
@@ -1,0 +1,13 @@
+{
+  "portfolios": [
+    {
+      "name": "sample-a",
+      "repo_graph": "examples/topology/enterprise-repo-graph.sample.json",
+      "schema": "schemas/repo-graph.schema.json",
+      "adapters": "config/portfolio_adapters.json",
+      "policy": "config/portfolio_policy.default.json",
+      "max_workers": 4,
+      "run": false
+    }
+  ]
+}

--- a/examples/topology/portfolio-batch.sample.json
+++ b/examples/topology/portfolio-batch.sample.json
@@ -6,7 +6,13 @@
       "schema": "schemas/repo-graph.schema.json",
       "adapters": "config/portfolio_adapters.json",
       "policy": "config/portfolio_policy.default.json",
+      "policy_pack": "config/portfolio_policy.packs.json",
+      "policy_profile": "standard",
+      "policy_overrides": {
+        "max_risk_score": 30
+      },
       "max_workers": 4,
+      "transport": "local",
       "run": false
     }
   ]

--- a/schemas/portfolio-batch.schema.json
+++ b/schemas/portfolio-batch.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["portfolios"],
+  "properties": {
+    "portfolios": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "repo_graph"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "repo_graph": { "type": "string", "minLength": 1 },
+          "schema": { "type": "string", "minLength": 1 },
+          "adapters": { "type": "string", "minLength": 1 },
+          "policy": { "type": "string", "minLength": 1 },
+          "policy_pack": { "type": "string", "minLength": 1 },
+          "policy_profile": { "type": "string" },
+          "policy_overrides": {
+            "oneOf": [
+              { "type": "object" },
+              { "type": "string", "minLength": 1 }
+            ]
+          },
+          "max_workers": { "type": "integer", "minimum": 1 },
+          "run": { "type": "boolean" },
+          "timeout_seconds": { "type": "integer", "minimum": 1 },
+          "retries": { "type": "integer", "minimum": 0 },
+          "max_failures": { "type": "integer", "minimum": 0 },
+          "transport": { "type": "string", "enum": ["local", "ssh", "container", "k8s-job"] },
+          "cancel_file": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/repo-graph.schema.json
+++ b/schemas/repo-graph.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://devs69.example/sdetkit/repo-graph.schema.json",
+  "title": "RepoGraph",
+  "type": "object",
+  "required": ["repos"],
+  "properties": {
+    "repos": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "path", "language"],
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "path": {"type": "string", "minLength": 1},
+          "language": {"type": "string", "minLength": 1},
+          "priority": {"type": "integer", "minimum": 1, "maximum": 100},
+          "depends_on": {
+            "type": "array",
+            "items": {"type": "string"},
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -297,6 +297,11 @@ Then use stability-aware command discovery:
     _add_passthrough_subcommand(
         sub, "repo", help_text="[Public / stable] Repository automation tasks"
     )
+    _add_passthrough_subcommand(
+        sub,
+        "portfolio-orchestrate",
+        help_text="[Advanced but supported] Multi-repo orchestration and portfolio risk reporting",
+    )
 
     _add_passthrough_subcommand(sub, "dev", help_text="Shortcut to `repo dev` workflows")
 
@@ -1024,6 +1029,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         if str(ns.out):
             forwarded.extend(["--out", str(ns.out)])
         return _run_module_main("sdetkit.fit", forwarded)
+    if ns.cmd == "portfolio-orchestrate":
+        return _run_module_main("sdetkit.portfolio_orchestrator", ns.args)
 
     parsed_shortcut_result = dispatch_parsed_shortcut(
         str(ns.cmd),

--- a/src/sdetkit/portfolio_orchestrator.py
+++ b/src/sdetkit/portfolio_orchestrator.py
@@ -864,6 +864,7 @@ def _parser() -> argparse.ArgumentParser:
     pipeline.add_argument("--timeout-seconds", type=int, default=120)
     pipeline.add_argument("--retries", type=int, default=0)
     pipeline.add_argument("--max-failures", type=int, default=0)
+    pipeline.add_argument("--transport", choices=["local", "ssh", "container", "k8s-job"], default="local")
     pipeline.add_argument("--policy", default="config/portfolio_policy.default.json")
     pipeline.add_argument("--policy-pack", default="config/portfolio_policy.packs.json")
     pipeline.add_argument("--policy-profile", default="")
@@ -1031,7 +1032,7 @@ def main(argv: list[str] | None = None) -> int:
             timeout_seconds=max(1, int(ns.timeout_seconds)),
             retries=max(0, int(ns.retries)),
             max_failures=max(0, int(ns.max_failures)),
-            transport="local",
+            transport=str(ns.transport),
             history_path=Path(ns.history),
             cancel_path=Path(ns.cancel_file),
             out_dir=out_dir,
@@ -1108,8 +1109,8 @@ def main(argv: list[str] | None = None) -> int:
                     if isinstance(item.get("policy_overrides", {}), dict)
                     else {}
                 ),
-                max_workers=int(item.get("max_workers", 4)),
-            run=bool(item.get("run", False)),
+                max_workers=max(1, int(item.get("max_workers", 4))),
+                run=bool(item.get("run", False)),
                 timeout_seconds=int(item.get("timeout_seconds", 120)),
                 retries=int(item.get("retries", 0)),
                 max_failures=int(item.get("max_failures", 0)),

--- a/src/sdetkit/portfolio_orchestrator.py
+++ b/src/sdetkit/portfolio_orchestrator.py
@@ -1,0 +1,1182 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ARTIFACT_SCHEMA_VERSION = "portfolio.v1"
+
+
+def _load_repo_graph(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("repo graph must be a JSON object")
+    repos = payload.get("repos")
+    if not isinstance(repos, list) or not repos:
+        raise ValueError("repo graph must include a non-empty repos array")
+    return payload
+
+
+def _validate_repo_graph_shape(payload: dict[str, Any]) -> None:
+    repos = payload.get("repos")
+    if not isinstance(repos, list) or not repos:
+        raise ValueError("repos must be a non-empty array")
+    names: set[str] = set()
+    for repo in repos:
+        if not isinstance(repo, dict):
+            raise ValueError("each repo must be an object")
+        for field in ("name", "path", "language"):
+            value = repo.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"repo field '{field}' must be a non-empty string")
+        name = str(repo["name"])
+        if name in names:
+            raise ValueError(f"duplicate repo name '{name}'")
+        names.add(name)
+
+
+def _validate_against_repo_schema(payload: dict[str, Any], schema_path: Path) -> None:
+    schema_payload = json.loads(schema_path.read_text(encoding="utf-8"))
+    try:
+        import jsonschema  # type: ignore
+    except Exception:
+        # Fallback path for environments without jsonschema dependency.
+        _validate_repo_graph_shape(payload)
+        return
+    jsonschema.validate(instance=payload, schema=schema_payload)
+
+
+def _build_plan(graph: dict[str, object], max_workers: int) -> dict[str, object]:
+    repos = graph.get("repos", [])
+    assert isinstance(repos, list)
+    names = {
+        str(repo.get("name"))
+        for repo in repos
+        if isinstance(repo, dict) and isinstance(repo.get("name"), str)
+    }
+    for repo in repos:
+        if not isinstance(repo, dict):
+            continue
+        deps = repo.get("depends_on", [])
+        if not isinstance(deps, list):
+            raise ValueError("depends_on must be an array when provided")
+        for dep in deps:
+            if str(dep) not in names:
+                raise ValueError(f"unknown dependency '{dep}' for repo '{repo.get('name')}'")
+
+    plan_items: list[dict[str, object]] = []
+    queued = sorted(
+        (repo for repo in repos if isinstance(repo, dict)),
+        key=lambda item: int(item.get("priority", 100)),
+    )
+    done: set[str] = set()
+    batch_index = 0
+    while queued:
+        progressed = False
+        for repo in list(queued):
+            deps = repo.get("depends_on", [])
+            assert isinstance(deps, list)
+            if any(str(dep) not in done for dep in deps):
+                continue
+            name = str(repo.get("name", f"repo-{len(done)+1}"))
+            language = str(repo.get("language", "unknown"))
+            lane = "gate+review" if language.lower() in {"python", "node", "go"} else "gate"
+            plan_items.append(
+                {
+                    "repo": name,
+                    "path": str(repo.get("path", f"repos/{name}")),
+                    "language": language,
+                    "lane": lane,
+                    "priority": int(repo.get("priority", 100)),
+                    "depends_on": [str(dep) for dep in deps],
+                    "batch": (batch_index % max_workers) + 1,
+                }
+            )
+            done.add(name)
+            queued.remove(repo)
+            batch_index += 1
+            progressed = True
+        if not progressed:
+            raise ValueError("cyclic dependency detected in repo graph")
+    return {
+        "ok": True,
+        "max_workers": max_workers,
+        "repos": len(plan_items),
+        "execution_plan": plan_items,
+    }
+
+
+def _build_risk_report(plan: dict[str, object]) -> dict[str, object]:
+    items = plan.get("execution_plan", [])
+    assert isinstance(items, list)
+    high = sum(1 for item in items if isinstance(item, dict) and int(item.get("priority", 100)) <= 20)
+    med = sum(
+        1
+        for item in items
+        if isinstance(item, dict) and 20 < int(item.get("priority", 100)) <= 60
+    )
+    low = sum(1 for item in items if isinstance(item, dict) and int(item.get("priority", 100)) > 60)
+    score = max(0, 100 - (high * 10 + med * 4 + low))
+    return {
+        "ok": True,
+        "portfolio_risk_score": score,
+        "risk_buckets": {"high": high, "medium": med, "low": low},
+        "recommendation": "SHIP_WITH_CONTROLS" if score >= 70 else "NO_SHIP",
+    }
+
+
+def _score_execution_results(results_payload: dict[str, object]) -> dict[str, object]:
+    rows = results_payload.get("results", [])
+    if not isinstance(rows, list):
+        raise ValueError("results must be an array")
+    ok = 0
+    fail = 0
+    error = 0
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        status = str(row.get("status", ""))
+        if status == "ok":
+            ok += 1
+        elif status == "fail":
+            fail += 1
+        elif status == "error":
+            error += 1
+    total = max(1, ok + fail + error)
+    reliability = max(0, int((ok / total) * 100) - error * 5)
+    return {
+        "ok": True,
+        "totals": {"ok": ok, "fail": fail, "error": error},
+        "execution_reliability_score": reliability,
+        "recommendation": "SHIP_WITH_CONTROLS" if fail == 0 and error == 0 else "NO_SHIP",
+    }
+
+
+def _render_portfolio_report(
+    *,
+    plan: dict[str, object] | None,
+    risk: dict[str, object] | None,
+    score: dict[str, object] | None,
+) -> str:
+    lines = ["# Portfolio Orchestration Report", ""]
+    if plan is not None:
+        lines.append(f"- Planned repositories: {int(plan.get('repos', 0))}")
+        lines.append(f"- Max workers: {int(plan.get('max_workers', 0))}")
+    if risk is not None:
+        lines.append(f"- Portfolio risk score: {int(risk.get('portfolio_risk_score', 0))}")
+        lines.append(f"- Risk recommendation: {str(risk.get('recommendation', 'UNKNOWN'))}")
+    if score is not None:
+        lines.append(
+            f"- Execution reliability score: {int(score.get('execution_reliability_score', 0))}"
+        )
+        lines.append(f"- Execution recommendation: {str(score.get('recommendation', 'UNKNOWN'))}")
+    lines.append("")
+    lines.append("Generated by: sdetkit portfolio-orchestrate report")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_portfolio_dashboard_html(
+    *,
+    plan: dict[str, object] | None,
+    risk: dict[str, object] | None,
+    score: dict[str, object] | None,
+    execution: dict[str, object] | None,
+    policy: dict[str, object] | None,
+) -> str:
+    repos = int((plan or {}).get("repos", 0))
+    workers = int((plan or {}).get("max_workers", 0))
+    risk_score = int((risk or {}).get("portfolio_risk_score", 0))
+    reliability = int((score or {}).get("execution_reliability_score", 0))
+    decision = str((policy or {}).get("decision", "UNKNOWN"))
+    results = (execution or {}).get("results", [])
+    rows_html = ""
+    if isinstance(results, list):
+        rendered = []
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            rendered.append(
+                "<tr>"
+                f"<td>{item.get('repo', '')}</td>"
+                f"<td>{item.get('language', '')}</td>"
+                f"<td>{item.get('status', '')}</td>"
+                f"<td>{item.get('mode', '')}</td>"
+                "</tr>"
+            )
+        rows_html = "\n".join(rendered)
+    return f"""<!doctype html>
+<html>
+<head>
+  <meta charset='utf-8' />
+  <title>Portfolio Dashboard</title>
+  <style>
+    body {{ font-family: Arial, sans-serif; margin: 24px; }}
+    .grid {{ display: grid; grid-template-columns: repeat(5, minmax(140px,1fr)); gap: 12px; }}
+    .card {{ border: 1px solid #ddd; border-radius: 8px; padding: 12px; }}
+    .label {{ color: #666; font-size: 12px; }}
+    .value {{ font-size: 22px; font-weight: 600; }}
+    table {{ border-collapse: collapse; width: 100%; margin-top: 18px; }}
+    th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
+  </style>
+</head>
+<body>
+  <h1>Portfolio Orchestration Dashboard</h1>
+  <div class='grid'>
+    <div class='card'><div class='label'>Repos</div><div class='value'>{repos}</div></div>
+    <div class='card'><div class='label'>Workers</div><div class='value'>{workers}</div></div>
+    <div class='card'><div class='label'>Risk Score</div><div class='value'>{risk_score}</div></div>
+    <div class='card'><div class='label'>Reliability</div><div class='value'>{reliability}</div></div>
+    <div class='card'><div class='label'>Decision</div><div class='value'>{decision}</div></div>
+  </div>
+  <h2>Execution Results</h2>
+  <table>
+    <thead><tr><th>Repo</th><th>Language</th><th>Status</th><th>Mode</th></tr></thead>
+    <tbody>
+      {rows_html}
+    </tbody>
+  </table>
+</body>
+</html>
+"""
+
+
+def _load_policy(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("policy must be a JSON object")
+    return payload
+
+
+def _resolve_policy_profile(
+    pack_path: Path, *, profile: str | None = None, overrides: dict[str, object] | None = None
+) -> dict[str, object]:
+    payload = json.loads(pack_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("policy pack must be a JSON object")
+    profiles = payload.get("profiles", {})
+    if not isinstance(profiles, dict):
+        raise ValueError("policy pack must include object field 'profiles'")
+    selected = profile or str(payload.get("default_profile", "standard"))
+    base = profiles.get(selected)
+    if not isinstance(base, dict):
+        raise ValueError(f"unknown policy profile '{selected}'")
+    resolved = dict(base)
+    if overrides:
+        resolved.update(overrides)
+    resolved["profile"] = selected
+    resolved["name"] = str(resolved.get("name", selected))
+    return resolved
+
+
+def _parse_policy_overrides(value: str) -> dict[str, object]:
+    raw = str(value).strip()
+    if not raw:
+        return {}
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("policy overrides must be a JSON object")
+    return payload
+
+
+def _evaluate_policy(
+    *,
+    risk: dict[str, object],
+    score: dict[str, object],
+    execution: dict[str, object],
+    policy: dict[str, object],
+) -> dict[str, object]:
+    max_risk_score = int(policy.get("max_risk_score", 35))
+    min_execution_reliability = int(policy.get("min_execution_reliability", 80))
+    max_failures = int(policy.get("max_failures", 0))
+    allow_stopped_early = bool(policy.get("allow_stopped_early", False))
+    risk_score = int(risk.get("portfolio_risk_score", 100))
+    reliability = int(score.get("execution_reliability_score", 0))
+    failure_count = int(execution.get("failure_count", 0))
+    stopped_early = bool(execution.get("stopped_early", False))
+    violations: list[str] = []
+    trace: list[dict[str, object]] = []
+    if risk_score > max_risk_score:
+        violations.append(f"risk_score {risk_score} > {max_risk_score}")
+        trace.append({"rule": "max_risk_score", "actual": risk_score, "limit": max_risk_score, "pass": False})
+    else:
+        trace.append({"rule": "max_risk_score", "actual": risk_score, "limit": max_risk_score, "pass": True})
+    if reliability < min_execution_reliability:
+        violations.append(f"reliability {reliability} < {min_execution_reliability}")
+        trace.append(
+            {
+                "rule": "min_execution_reliability",
+                "actual": reliability,
+                "limit": min_execution_reliability,
+                "pass": False,
+            }
+        )
+    else:
+        trace.append(
+            {
+                "rule": "min_execution_reliability",
+                "actual": reliability,
+                "limit": min_execution_reliability,
+                "pass": True,
+            }
+        )
+    if failure_count > max_failures:
+        violations.append(f"failure_count {failure_count} > {max_failures}")
+        trace.append({"rule": "max_failures", "actual": failure_count, "limit": max_failures, "pass": False})
+    else:
+        trace.append({"rule": "max_failures", "actual": failure_count, "limit": max_failures, "pass": True})
+    if stopped_early and not allow_stopped_early:
+        violations.append("stopped_early is true")
+        trace.append({"rule": "allow_stopped_early", "actual": stopped_early, "limit": allow_stopped_early, "pass": False})
+    else:
+        trace.append({"rule": "allow_stopped_early", "actual": stopped_early, "limit": allow_stopped_early, "pass": True})
+    decision = "SHIP" if not violations else "NO_SHIP"
+    return {
+        "ok": True,
+        "policy_name": str(policy.get("name", "default")),
+        "profile": str(policy.get("profile", "")),
+        "decision": decision,
+        "violations": violations,
+        "trace": trace,
+        "signals": {
+            "risk_score": risk_score,
+            "execution_reliability_score": reliability,
+            "failure_count": failure_count,
+            "stopped_early": stopped_early,
+        },
+    }
+
+
+def _analyze_plan(plan: dict[str, object]) -> dict[str, object]:
+    rows = plan.get("execution_plan", [])
+    if not isinstance(rows, list):
+        raise ValueError("execution_plan must be an array")
+    graph: dict[str, list[str]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("repo", ""))
+        deps = row.get("depends_on", [])
+        if not name:
+            continue
+        graph[name] = [str(dep) for dep in deps] if isinstance(deps, list) else []
+
+    depth_cache: dict[str, int] = {}
+
+    def _depth(node: str, stack: set[str]) -> int:
+        if node in depth_cache:
+            return depth_cache[node]
+        if node in stack:
+            raise ValueError("cycle detected while analyzing plan")
+        stack.add(node)
+        deps = graph.get(node, [])
+        if not deps:
+            depth_cache[node] = 1
+        else:
+            depth_cache[node] = 1 + max(_depth(dep, stack) for dep in deps if dep in graph)
+        stack.remove(node)
+        return depth_cache[node]
+
+    levels: dict[int, list[str]] = {}
+    for node in graph:
+        level = _depth(node, set())
+        levels.setdefault(level, []).append(node)
+    return {
+        "ok": True,
+        "repos": len(graph),
+        "critical_path_length": max(levels) if levels else 0,
+        "levels": {str(level): sorted(nodes) for level, nodes in sorted(levels.items())},
+    }
+
+
+def _adapter_command(language: str, repo_path: str) -> list[str]:
+    lang = language.lower()
+    if lang == "python":
+        return ["python", "-m", "sdetkit", "gate", "fast", "--repo", repo_path]
+    if lang == "node":
+        return ["npm", "test", "--prefix", repo_path]
+    if lang == "go":
+        return ["go", "test", "./...", repo_path]
+    return ["echo", f"no-adapter:{language}", repo_path]
+
+
+def _load_adapter_registry(path: Path) -> dict[str, list[str]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("adapter registry must be a JSON object")
+    registry: dict[str, list[str]] = {}
+    for language, command in payload.items():
+        if not isinstance(language, str) or not isinstance(command, list):
+            raise ValueError("adapter entries must map string language -> string list command")
+        command_tokens = [str(token) for token in command]
+        registry[language.lower()] = command_tokens
+    return registry
+
+
+def _adapter_command_from_registry(
+    registry: dict[str, list[str]], language: str, repo_path: str
+) -> list[str]:
+    template = registry.get(language.lower())
+    if template is None:
+        return _adapter_command(language, repo_path)
+    return [token.replace("{repo_path}", repo_path) for token in template]
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _append_history_record(path: Path, record: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
+
+
+def _build_history_trend(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {"ok": True, "runs": 0, "ship_rate": 0.0, "avg_risk_score": 0.0}
+    runs = 0
+    ship = 0
+    risk_scores: list[int] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if not isinstance(payload, dict):
+            continue
+        runs += 1
+        if str(payload.get("decision", "")) == "SHIP":
+            ship += 1
+        risk_scores.append(int(payload.get("risk_score", 100)))
+    avg_risk = float(sum(risk_scores) / len(risk_scores)) if risk_scores else 0.0
+    ship_rate = float(ship / runs) if runs else 0.0
+    return {
+        "ok": True,
+        "artifact_schema_version": ARTIFACT_SCHEMA_VERSION,
+        "runs": runs,
+        "ship_rate": ship_rate,
+        "avg_risk_score": avg_risk,
+    }
+
+
+def _load_cancel_targets(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        value = line.strip()
+        if value:
+            out.add(value)
+    return out
+
+
+def _append_cancel_target(path: Path, target: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{target}\n")
+
+
+def _with_schema(payload: dict[str, object]) -> dict[str, object]:
+    out = dict(payload)
+    out["artifact_schema_version"] = ARTIFACT_SCHEMA_VERSION
+    return out
+
+
+def _run_pipeline_bundle(
+    *,
+    repo_graph: Path,
+    schema: Path,
+    adapters: Path,
+    policy_path: Path,
+    policy_pack_path: Path,
+    policy_profile: str,
+    policy_overrides: dict[str, object],
+    max_workers: int,
+    run: bool,
+    timeout_seconds: int,
+    retries: int,
+    max_failures: int,
+    transport: str,
+    history_path: Path,
+    cancel_path: Path,
+    out_dir: Path,
+) -> dict[str, object]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    graph = _load_repo_graph(repo_graph)
+    _validate_against_repo_schema(graph, schema)
+    _validate_repo_graph_shape(graph)
+    plan = _build_plan(graph, max_workers=max(1, int(max_workers)))
+    (out_dir / "plan.json").write_text(json.dumps(_with_schema(plan), indent=2) + "\n", encoding="utf-8")
+    risk = _build_risk_report(plan)
+    (out_dir / "risk.json").write_text(json.dumps(_with_schema(risk), indent=2) + "\n", encoding="utf-8")
+    execution = _execute_plan(
+        plan,
+        max_workers=max(1, int(max_workers)),
+        run=run,
+        timeout_seconds=max(1, int(timeout_seconds)),
+        adapter_registry=_load_adapter_registry(adapters),
+        artifact_dir=out_dir / "workers",
+        retries=max(0, int(retries)),
+        max_failures=max(0, int(max_failures)),
+        transport=transport,
+        cancel_targets=_load_cancel_targets(cancel_path),
+    )
+    (out_dir / "execution.json").write_text(
+        json.dumps(_with_schema(execution), indent=2) + "\n", encoding="utf-8"
+    )
+    score = _score_execution_results(execution)
+    (out_dir / "score.json").write_text(json.dumps(_with_schema(score), indent=2) + "\n", encoding="utf-8")
+    policy_payload = (
+        _resolve_policy_profile(
+            policy_pack_path,
+            profile=policy_profile if policy_profile else None,
+            overrides=policy_overrides,
+        )
+        if policy_pack_path.exists()
+        else _load_policy(policy_path)
+    )
+    policy_eval = _evaluate_policy(
+        risk=risk,
+        score=score,
+        execution=execution,
+        policy=policy_payload,
+    )
+    (out_dir / "policy.json").write_text(
+        json.dumps(_with_schema(policy_eval), indent=2) + "\n", encoding="utf-8"
+    )
+    _append_history_record(
+        history_path,
+        {
+            "ts": _utc_now(),
+            "decision": str(policy_eval.get("decision", "NO_SHIP")),
+            "risk_score": int(risk.get("portfolio_risk_score", 100)),
+            "reliability_score": int(score.get("execution_reliability_score", 0)),
+            "failure_count": int(execution.get("failure_count", 0)),
+        },
+    )
+    trend = _build_history_trend(history_path)
+    (out_dir / "history-trend.json").write_text(json.dumps(trend, indent=2) + "\n", encoding="utf-8")
+    analysis = _analyze_plan(plan)
+    (out_dir / "analysis.json").write_text(
+        json.dumps(_with_schema(analysis), indent=2) + "\n", encoding="utf-8"
+    )
+    report = _render_portfolio_report(plan=plan, risk=risk, score=score)
+    (out_dir / "report.md").write_text(report, encoding="utf-8")
+    dashboard = _render_portfolio_dashboard_html(
+        plan=plan,
+        risk=risk,
+        score=score,
+        execution=execution,
+        policy=policy_eval,
+    )
+    (out_dir / "dashboard.html").write_text(dashboard, encoding="utf-8")
+    return {
+        "decision": str(policy_eval.get("decision", "NO_SHIP")),
+        "risk_score": int(risk.get("portfolio_risk_score", 100)),
+        "reliability": int(score.get("execution_reliability_score", 0)),
+        "failure_count": int(execution.get("failure_count", 0)),
+    }
+
+
+def _render_batch_dashboard_html(summary: dict[str, object]) -> str:
+    portfolios = int(summary.get("portfolios", 0))
+    ship = int(summary.get("ship", 0))
+    no_ship = int(summary.get("no_ship", 0))
+    rows = summary.get("summaries", [])
+    rows_html = ""
+    if isinstance(rows, list):
+        rendered = []
+        for item in rows:
+            if not isinstance(item, dict):
+                continue
+            rendered.append(
+                "<tr>"
+                f"<td>{item.get('name','')}</td>"
+                f"<td>{item.get('decision','')}</td>"
+                f"<td>{item.get('risk_score','')}</td>"
+                f"<td>{item.get('reliability','')}</td>"
+                f"<td>{item.get('failure_count','')}</td>"
+                "</tr>"
+            )
+        rows_html = "\n".join(rendered)
+    return f"""<!doctype html><html><head><meta charset='utf-8'/><title>Batch Dashboard</title></head>
+<body>
+<h1>Portfolio Batch Dashboard</h1>
+<p>Portfolios: {portfolios} | SHIP: {ship} | NO_SHIP: {no_ship}</p>
+<table border='1' cellpadding='6' cellspacing='0'>
+<thead><tr><th>Name</th><th>Decision</th><th>Risk</th><th>Reliability</th><th>Failures</th></tr></thead>
+<tbody>{rows_html}</tbody></table>
+</body></html>"""
+
+
+def _execute_plan(
+    plan: dict[str, object],
+    max_workers: int,
+    *,
+    run: bool = False,
+    timeout_seconds: int = 120,
+    adapter_registry: dict[str, list[str]] | None = None,
+    artifact_dir: Path | None = None,
+    retries: int = 0,
+    max_failures: int = 0,
+    transport: str = "local",
+    cancel_targets: set[str] | None = None,
+) -> dict[str, object]:
+    items = plan.get("execution_plan", [])
+    assert isinstance(items, list)
+
+    def _run_item(item: dict[str, object]) -> dict[str, object]:
+        repo = str(item.get("repo", "unknown"))
+        language = str(item.get("language", "unknown"))
+        repo_path = str(item.get("path", f"repos/{repo}"))
+        command = (
+            _adapter_command_from_registry(adapter_registry, language, repo_path)
+            if adapter_registry is not None
+            else _adapter_command(language, repo_path)
+        )
+        started_at = _utc_now()
+        run_id = str(uuid.uuid4())
+        lease_id = f"lease-{uuid.uuid4()}"
+        if cancel_targets is not None and repo in cancel_targets:
+            return {
+                "worker": f"adapter-{language.lower()}",
+                "run_id": run_id,
+                "repo": repo,
+                "language": language,
+                "status": "canceled",
+                "mode": "run" if run else "dry-run",
+                "transport": transport,
+                "lease_id": lease_id,
+                "heartbeats": [started_at],
+                "started_at": started_at,
+                "finished_at": _utc_now(),
+                "inputs": {"path": repo_path},
+                "evidence": [],
+                "result": {"returncode": 130},
+                "escalation": {"required": True, "reason": "canceled by target registry"},
+                "command": command,
+            }
+        if not run:
+            return {
+                "worker": f"adapter-{language.lower()}",
+                "run_id": run_id,
+                "repo": repo,
+                "language": language,
+                "status": "queued",
+                "mode": "dry-run",
+                "transport": transport,
+                "lease_id": lease_id,
+                "heartbeats": [started_at],
+                "started_at": started_at,
+                "finished_at": _utc_now(),
+                "inputs": {"path": repo_path},
+                "evidence": [],
+                "result": {"returncode": 0},
+                "escalation": {"required": False, "reason": ""},
+                "command": command,
+            }
+        attempt = 0
+        last_error = ""
+        while attempt <= retries:
+            attempt += 1
+            try:
+                completed = subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_seconds,
+                    check=False,
+                )
+            except Exception as exc:  # defensive execution boundary
+                last_error = str(exc)
+                completed = None
+            if completed is not None and completed.returncode == 0:
+                return {
+                    "worker": f"adapter-{language.lower()}",
+                    "run_id": run_id,
+                    "repo": repo,
+                    "language": language,
+                    "status": "ok",
+                    "mode": "run",
+                    "transport": transport,
+                    "lease_id": lease_id,
+                    "heartbeats": [started_at, _utc_now()],
+                    "attempts": attempt,
+                    "started_at": started_at,
+                    "finished_at": _utc_now(),
+                    "inputs": {"path": repo_path},
+                    "evidence": [],
+                    "result": {"returncode": int(completed.returncode)},
+                    "escalation": {"required": False, "reason": ""},
+                    "returncode": int(completed.returncode),
+                    "command": command,
+                    "stdout": completed.stdout[-500:],
+                    "stderr": completed.stderr[-500:],
+                }
+            if completed is not None and completed.returncode != 0:
+                last_error = completed.stderr[-500:] if completed.stderr else "non-zero return code"
+        if completed is not None:
+            return {
+                "worker": f"adapter-{language.lower()}",
+                "run_id": run_id,
+                "repo": repo,
+                "language": language,
+                "status": "fail",
+                "mode": "run",
+                "transport": transport,
+                "lease_id": lease_id,
+                "heartbeats": [started_at, _utc_now()],
+                "attempts": attempt,
+                "started_at": started_at,
+                "finished_at": _utc_now(),
+                "inputs": {"path": repo_path},
+                "evidence": [],
+                "result": {"returncode": int(completed.returncode)},
+                "escalation": {
+                    "required": True,
+                    "reason": f"adapter command failed after {attempt} attempt(s)",
+                },
+                "returncode": int(completed.returncode),
+                "command": command,
+                "stdout": completed.stdout[-500:],
+                "stderr": completed.stderr[-500:],
+            }
+        return {
+            "worker": f"adapter-{language.lower()}",
+            "run_id": run_id,
+            "repo": repo,
+            "language": language,
+            "status": "error",
+            "mode": "run",
+            "transport": transport,
+            "lease_id": lease_id,
+            "heartbeats": [started_at, _utc_now()],
+            "attempts": attempt,
+            "started_at": started_at,
+            "finished_at": _utc_now(),
+            "inputs": {"path": repo_path},
+            "evidence": [],
+            "result": {"returncode": 2},
+            "escalation": {"required": True, "reason": f"exception during adapter execution: {last_error}"},
+            "command": command,
+            "error": last_error,
+        }
+
+    rows = [item for item in items if isinstance(item, dict)]
+    pending = {str(item.get("repo", f"repo-{idx}")): item for idx, item in enumerate(rows)}
+    completed: set[str] = set()
+    results: list[dict[str, object]] = []
+    failure_count = 0
+    while pending:
+        ready = []
+        for repo, item in list(pending.items()):
+            deps = item.get("depends_on", [])
+            dep_list = [str(dep) for dep in deps] if isinstance(deps, list) else []
+            if all(dep in completed for dep in dep_list):
+                ready.append((repo, item))
+        if not ready:
+            raise ValueError("execute_plan blocked due to unresolved dependency cycle")
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_run_item, item): repo for repo, item in ready}
+            for future in as_completed(futures):
+                repo = futures[future]
+                result = future.result()
+                results.append(result)
+                if str(result.get("status")) in {"fail", "error"}:
+                    failure_count += 1
+                if artifact_dir is not None:
+                    artifact_dir.mkdir(parents=True, exist_ok=True)
+                    (artifact_dir / f"{repo}.worker.json").write_text(
+                        json.dumps(result, indent=2) + "\n", encoding="utf-8"
+                    )
+                completed.add(repo)
+                pending.pop(repo, None)
+        if max_failures > 0 and failure_count >= max_failures:
+            break
+    return {
+        "ok": True,
+        "results": sorted(results, key=lambda row: str(row.get("repo"))),
+        "max_workers": max_workers,
+        "stopped_early": bool(max_failures > 0 and failure_count >= max_failures),
+        "failure_count": failure_count,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="sdetkit portfolio")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    orchestrate = sub.add_parser("orchestrate", help="Build a multi-repo execution plan")
+    orchestrate.add_argument("--repo-graph", required=True)
+    orchestrate.add_argument("--schema", default="schemas/repo-graph.schema.json")
+    orchestrate.add_argument("--max-workers", type=int, default=4)
+    orchestrate.add_argument("--out", required=True)
+
+    risk = sub.add_parser("risk-report", help="Generate a portfolio risk report from a plan")
+    risk.add_argument("--plan", required=True)
+    risk.add_argument("--out", required=True)
+    execute = sub.add_parser("execute", help="Build multi-worker adapter execution intents from a plan")
+    execute.add_argument("--plan", required=True)
+    execute.add_argument("--max-workers", type=int, default=4)
+    execute.add_argument("--run", action="store_true", help="Execute adapter commands instead of dry-run intents")
+    execute.add_argument("--timeout-seconds", type=int, default=120)
+    execute.add_argument("--adapters", default="config/portfolio_adapters.json")
+    execute.add_argument("--artifact-dir", default="")
+    execute.add_argument("--retries", type=int, default=0)
+    execute.add_argument("--max-failures", type=int, default=0)
+    execute.add_argument("--transport", choices=["local", "ssh", "container", "k8s-job"], default="local")
+    execute.add_argument("--cancel-file", default=".sdetkit/portfolio-cancel-targets.txt")
+    execute.add_argument("--out", required=True)
+    validate = sub.add_parser("validate-graph", help="Validate repo graph structure before orchestration")
+    validate.add_argument("--repo-graph", required=True)
+    validate.add_argument("--schema", default="schemas/repo-graph.schema.json")
+    score = sub.add_parser(
+        "score-execution",
+        help="Generate reliability and ship recommendation from execution results JSON",
+    )
+    score.add_argument("--results", required=True)
+    score.add_argument("--out", required=True)
+    report = sub.add_parser("report", help="Render markdown executive report from generated artifacts")
+    report.add_argument("--plan", default="")
+    report.add_argument("--risk", default="")
+    report.add_argument("--score", default="")
+    report.add_argument("--out", required=True)
+    analyze = sub.add_parser(
+        "analyze-plan",
+        help="Analyze dependency depth/critical-path characteristics for an execution plan",
+    )
+    analyze.add_argument("--plan", required=True)
+    analyze.add_argument("--out", required=True)
+    pipeline = sub.add_parser(
+        "run-pipeline",
+        help="Execute the full portfolio pipeline (validate, plan, execute, risk, score, analyze, report)",
+    )
+    pipeline.add_argument("--repo-graph", required=True)
+    pipeline.add_argument("--schema", default="schemas/repo-graph.schema.json")
+    pipeline.add_argument("--adapters", default="config/portfolio_adapters.json")
+    pipeline.add_argument("--max-workers", type=int, default=4)
+    pipeline.add_argument("--run", action="store_true", help="Execute adapter commands in pipeline")
+    pipeline.add_argument("--timeout-seconds", type=int, default=120)
+    pipeline.add_argument("--retries", type=int, default=0)
+    pipeline.add_argument("--max-failures", type=int, default=0)
+    pipeline.add_argument("--policy", default="config/portfolio_policy.default.json")
+    pipeline.add_argument("--policy-pack", default="config/portfolio_policy.packs.json")
+    pipeline.add_argument("--policy-profile", default="")
+    pipeline.add_argument("--policy-overrides", default="")
+    pipeline.add_argument("--history", default=".sdetkit/portfolio-history.jsonl")
+    pipeline.add_argument("--cancel-file", default=".sdetkit/portfolio-cancel-targets.txt")
+    pipeline.add_argument("--out-dir", required=True)
+    policy = sub.add_parser(
+        "evaluate-policy", help="Evaluate policy decision from risk/score/execution artifacts"
+    )
+    policy.add_argument("--risk", required=True)
+    policy.add_argument("--score", required=True)
+    policy.add_argument("--execution", required=True)
+    policy.add_argument("--policy", default="config/portfolio_policy.default.json")
+    policy.add_argument("--policy-pack", default="config/portfolio_policy.packs.json")
+    policy.add_argument("--policy-profile", default="")
+    policy.add_argument("--policy-overrides", default="")
+    policy.add_argument("--out", required=True)
+    history = sub.add_parser("history-trend", help="Build trend metrics from pipeline history JSONL")
+    history.add_argument("--history", default=".sdetkit/portfolio-history.jsonl")
+    history.add_argument("--out", required=True)
+    dashboard = sub.add_parser("dashboard", help="Render HTML dashboard from pipeline artifacts")
+    dashboard.add_argument("--plan", required=True)
+    dashboard.add_argument("--risk", required=True)
+    dashboard.add_argument("--score", required=True)
+    dashboard.add_argument("--execution", required=True)
+    dashboard.add_argument("--policy", required=True)
+    dashboard.add_argument("--out", required=True)
+    batch = sub.add_parser("batch-run", help="Run multiple portfolio pipelines from a batch manifest")
+    batch.add_argument("--manifest", required=True)
+    batch.add_argument("--max-parallel", type=int, default=2)
+    batch.add_argument("--out-dir", required=True)
+    cancel = sub.add_parser("cancel-worker", help="Append a repo target to cancellation registry")
+    cancel.add_argument("--target", required=True, help="Repository name to cancel")
+    cancel.add_argument("--cancel-file", default=".sdetkit/portfolio-cancel-targets.txt")
+    impact = sub.add_parser(
+        "impact-plan",
+        help="Compute affected repos from changed files and dependency graph, emit reduced plan",
+    )
+    impact.add_argument("--repo-graph", required=True)
+    impact.add_argument("--changed-files", required=True, help="newline-delimited changed files")
+    impact.add_argument("--out", required=True)
+    tower = sub.add_parser("batch-control-tower", help="Render control-tower JSON from batch history")
+    tower.add_argument("--history", required=True)
+    tower.add_argument("--out", required=True)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    ns = _parser().parse_args(argv)
+    if ns.cmd == "orchestrate":
+        graph = _load_repo_graph(Path(ns.repo_graph))
+        _validate_against_repo_schema(graph, Path(ns.schema))
+        _validate_repo_graph_shape(graph)
+        plan = _build_plan(graph, max_workers=max(1, int(ns.max_workers)))
+        Path(ns.out).write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote execution plan: {ns.out}")
+        return 0
+    if ns.cmd == "execute":
+        plan_payload = json.loads(Path(ns.plan).read_text(encoding="utf-8"))
+        if not isinstance(plan_payload, dict):
+            raise ValueError("plan must be a JSON object")
+        execution = _execute_plan(
+            plan_payload,
+            max_workers=max(1, int(ns.max_workers)),
+            run=bool(ns.run),
+            timeout_seconds=max(1, int(ns.timeout_seconds)),
+            adapter_registry=_load_adapter_registry(Path(ns.adapters)),
+            artifact_dir=Path(ns.artifact_dir) if str(ns.artifact_dir).strip() else None,
+            retries=max(0, int(ns.retries)),
+            max_failures=max(0, int(ns.max_failures)),
+            transport=str(ns.transport),
+            cancel_targets=_load_cancel_targets(Path(ns.cancel_file)),
+        )
+        Path(ns.out).write_text(json.dumps(execution, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote execution intents: {ns.out}")
+        return 0
+    if ns.cmd == "impact-plan":
+        graph = _load_repo_graph(Path(ns.repo_graph))
+        repos = graph.get("repos", [])
+        changed = [line.strip() for line in Path(ns.changed_files).read_text(encoding="utf-8").splitlines() if line.strip()]
+        selected: set[str] = set()
+        owners: dict[str, list[str]] = {}
+        if isinstance(repos, list):
+            for repo in repos:
+                if not isinstance(repo, dict):
+                    continue
+                name = str(repo.get("name", ""))
+                path = str(repo.get("path", ""))
+                deps = repo.get("depends_on", [])
+                owners[name] = [str(dep) for dep in deps] if isinstance(deps, list) else []
+                if any(path and cf.startswith(path) for cf in changed):
+                    selected.add(name)
+        changed_set = set(selected)
+        progress = True
+        while progress:
+            progress = False
+            for repo, deps in owners.items():
+                if any(dep in changed_set for dep in deps) and repo not in changed_set:
+                    changed_set.add(repo)
+                    progress = True
+        reduced = [r for r in repos if isinstance(r, dict) and str(r.get("name")) in changed_set] if isinstance(repos, list) else []
+        plan = _build_plan({"repos": reduced}, max_workers=4)
+        Path(ns.out).write_text(json.dumps(_with_schema(plan), indent=2) + "\n", encoding="utf-8")
+        return 0
+    if ns.cmd == "validate-graph":
+        graph = _load_repo_graph(Path(ns.repo_graph))
+        _validate_against_repo_schema(graph, Path(ns.schema))
+        _validate_repo_graph_shape(graph)
+        print("Repo graph validation: OK")
+        return 0
+    if ns.cmd == "score-execution":
+        results_payload = json.loads(Path(ns.results).read_text(encoding="utf-8"))
+        if not isinstance(results_payload, dict):
+            raise ValueError("results must be a JSON object")
+        score = _score_execution_results(results_payload)
+        Path(ns.out).write_text(json.dumps(score, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote execution scorecard: {ns.out}")
+        return 0
+    if ns.cmd == "report":
+        plan_payload = (
+            json.loads(Path(ns.plan).read_text(encoding="utf-8"))
+            if str(ns.plan).strip()
+            else None
+        )
+        risk_payload = (
+            json.loads(Path(ns.risk).read_text(encoding="utf-8"))
+            if str(ns.risk).strip()
+            else None
+        )
+        score_payload = (
+            json.loads(Path(ns.score).read_text(encoding="utf-8"))
+            if str(ns.score).strip()
+            else None
+        )
+        report_md = _render_portfolio_report(
+            plan=plan_payload if isinstance(plan_payload, dict) else None,
+            risk=risk_payload if isinstance(risk_payload, dict) else None,
+            score=score_payload if isinstance(score_payload, dict) else None,
+        )
+        Path(ns.out).write_text(report_md, encoding="utf-8")
+        print(f"Wrote portfolio report: {ns.out}")
+        return 0
+    if ns.cmd == "analyze-plan":
+        plan_payload = json.loads(Path(ns.plan).read_text(encoding="utf-8"))
+        if not isinstance(plan_payload, dict):
+            raise ValueError("plan must be a JSON object")
+        analysis = _analyze_plan(plan_payload)
+        Path(ns.out).write_text(json.dumps(analysis, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote plan analysis: {ns.out}")
+        return 0
+    if ns.cmd == "run-pipeline":
+        out_dir = Path(ns.out_dir)
+        _run_pipeline_bundle(
+            repo_graph=Path(ns.repo_graph),
+            schema=Path(ns.schema),
+            adapters=Path(ns.adapters),
+            policy_path=Path(ns.policy),
+            policy_pack_path=Path(ns.policy_pack),
+            policy_profile=str(ns.policy_profile),
+            policy_overrides=_parse_policy_overrides(str(ns.policy_overrides)),
+            max_workers=max(1, int(ns.max_workers)),
+            run=bool(ns.run),
+            timeout_seconds=max(1, int(ns.timeout_seconds)),
+            retries=max(0, int(ns.retries)),
+            max_failures=max(0, int(ns.max_failures)),
+            transport="local",
+            history_path=Path(ns.history),
+            cancel_path=Path(ns.cancel_file),
+            out_dir=out_dir,
+        )
+        print(f"Wrote pipeline artifacts: {out_dir}")
+        return 0
+    if ns.cmd == "evaluate-policy":
+        risk = json.loads(Path(ns.risk).read_text(encoding="utf-8"))
+        score = json.loads(Path(ns.score).read_text(encoding="utf-8"))
+        execution = json.loads(Path(ns.execution).read_text(encoding="utf-8"))
+        policy_payload = _load_policy(Path(ns.policy))
+        if Path(ns.policy_pack).exists():
+            policy_payload = _resolve_policy_profile(
+                Path(ns.policy_pack),
+                profile=str(ns.policy_profile) or None,
+                overrides=_parse_policy_overrides(str(ns.policy_overrides)),
+            )
+        if not isinstance(risk, dict) or not isinstance(score, dict) or not isinstance(execution, dict):
+            raise ValueError("risk/score/execution payloads must be JSON objects")
+        evaluation = _evaluate_policy(
+            risk=risk,
+            score=score,
+            execution=execution,
+            policy=policy_payload,
+        )
+        Path(ns.out).write_text(json.dumps(evaluation, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote policy decision: {ns.out}")
+        return 0
+    if ns.cmd == "history-trend":
+        trend = _build_history_trend(Path(ns.history))
+        Path(ns.out).write_text(json.dumps(trend, indent=2) + "\n", encoding="utf-8")
+        print(f"Wrote history trend: {ns.out}")
+        return 0
+    if ns.cmd == "dashboard":
+        plan = json.loads(Path(ns.plan).read_text(encoding="utf-8"))
+        risk = json.loads(Path(ns.risk).read_text(encoding="utf-8"))
+        score = json.loads(Path(ns.score).read_text(encoding="utf-8"))
+        execution = json.loads(Path(ns.execution).read_text(encoding="utf-8"))
+        policy = json.loads(Path(ns.policy).read_text(encoding="utf-8"))
+        if not all(isinstance(x, dict) for x in [plan, risk, score, execution, policy]):
+            raise ValueError("dashboard inputs must be JSON objects")
+        html = _render_portfolio_dashboard_html(
+            plan=plan,
+            risk=risk,
+            score=score,
+            execution=execution,
+            policy=policy,
+        )
+        Path(ns.out).write_text(html, encoding="utf-8")
+        print(f"Wrote dashboard: {ns.out}")
+        return 0
+    if ns.cmd == "batch-run":
+        manifest = json.loads(Path(ns.manifest).read_text(encoding="utf-8"))
+        if not isinstance(manifest, dict):
+            raise ValueError("batch manifest must be a JSON object")
+        portfolios = manifest.get("portfolios", [])
+        if not isinstance(portfolios, list):
+            raise ValueError("batch manifest must include array field 'portfolios'")
+        out_root = Path(ns.out_dir)
+        out_root.mkdir(parents=True, exist_ok=True)
+        def _run_one(indexed: tuple[int, dict[str, object]]) -> dict[str, object]:
+            _, item = indexed
+            name = str(item.get("name", "portfolio"))
+            portfolio_out = out_root / name
+            summary = _run_pipeline_bundle(
+                repo_graph=Path(str(item.get("repo_graph"))),
+                schema=Path(str(item.get("schema", "schemas/repo-graph.schema.json"))),
+                adapters=Path(str(item.get("adapters", "config/portfolio_adapters.json"))),
+                policy_path=Path(str(item.get("policy", "config/portfolio_policy.default.json"))),
+                policy_pack_path=Path(str(item.get("policy_pack", "config/portfolio_policy.packs.json"))),
+                policy_profile=str(item.get("policy_profile", "")),
+                policy_overrides=(
+                    item.get("policy_overrides", {})
+                    if isinstance(item.get("policy_overrides", {}), dict)
+                    else {}
+                ),
+                max_workers=int(item.get("max_workers", 4)),
+            run=bool(item.get("run", False)),
+                timeout_seconds=int(item.get("timeout_seconds", 120)),
+                retries=int(item.get("retries", 0)),
+                max_failures=int(item.get("max_failures", 0)),
+                transport=str(item.get("transport", "local")),
+                history_path=out_root / "batch-history.jsonl",
+                cancel_path=Path(str(item.get("cancel_file", ".sdetkit/portfolio-cancel-targets.txt"))),
+                out_dir=portfolio_out,
+            )
+            summary["name"] = name
+            return summary
+
+        valid = [(idx, item) for idx, item in enumerate(portfolios) if isinstance(item, dict)]
+        summaries: list[dict[str, object]] = []
+        with ThreadPoolExecutor(max_workers=max(1, int(ns.max_parallel))) as executor:
+            futures = [executor.submit(_run_one, pair) for pair in valid]
+            for future in as_completed(futures):
+                summaries.append(future.result())
+        ship = sum(1 for x in summaries if str(x.get("decision")) == "SHIP")
+        aggregate = {
+            "ok": True,
+            "portfolios": len(summaries),
+            "ship": ship,
+            "no_ship": len(summaries) - ship,
+            "summaries": sorted(summaries, key=lambda x: str(x.get("name", ""))),
+        }
+        (out_root / "batch-summary.json").write_text(json.dumps(aggregate, indent=2) + "\n", encoding="utf-8")
+        batch_report = "\n".join(
+            [
+                "# Portfolio Batch Report",
+                "",
+                f"- Portfolios: {aggregate['portfolios']}",
+                f"- SHIP: {aggregate['ship']}",
+                f"- NO_SHIP: {aggregate['no_ship']}",
+                "",
+            ]
+        )
+        (out_root / "batch-report.md").write_text(batch_report, encoding="utf-8")
+        (out_root / "batch-dashboard.html").write_text(
+            _render_batch_dashboard_html(aggregate), encoding="utf-8"
+        )
+        print(f"Wrote batch artifacts: {out_root}")
+        return 0
+    if ns.cmd == "cancel-worker":
+        _append_cancel_target(Path(ns.cancel_file), str(ns.target))
+        return 0
+    if ns.cmd == "batch-control-tower":
+        trend = _build_history_trend(Path(ns.history))
+        payload = _with_schema(
+            {
+                "ok": True,
+                "control_tower": {
+                    "runs": trend.get("runs", 0),
+                    "ship_rate": trend.get("ship_rate", 0.0),
+                    "avg_risk_score": trend.get("avg_risk_score", 0.0),
+                },
+            }
+        )
+        Path(ns.out).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return 0
+    plan_payload = json.loads(Path(ns.plan).read_text(encoding="utf-8"))
+    if not isinstance(plan_payload, dict):
+        raise ValueError("plan must be a JSON object")
+    report = _build_risk_report(plan_payload)
+    Path(ns.out).write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote portfolio risk report: {ns.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/portfolio_orchestrator.py
+++ b/src/sdetkit/portfolio_orchestrator.py
@@ -51,6 +51,7 @@ def _validate_against_schema(payload: dict[str, Any], schema_path: Path) -> None
         return
     jsonschema.validate(instance=payload, schema=schema_payload)
 
+
 def _validate_against_repo_schema(payload: dict[str, Any], schema_path: Path) -> None:
     _validate_against_schema(payload, schema_path)
     # Fallback path for environments without jsonschema dependency.
@@ -66,7 +67,9 @@ def _validate_batch_manifest_shape(payload: dict[str, Any]) -> None:
             raise ValueError("BATCH_MANIFEST_ITEM_INVALID: each portfolio entry must be an object")
         repo_graph = item.get("repo_graph")
         if not isinstance(repo_graph, str) or not repo_graph.strip():
-            raise ValueError("BATCH_MANIFEST_REPO_GRAPH_REQUIRED: repo_graph must be a non-empty string")
+            raise ValueError(
+                "BATCH_MANIFEST_REPO_GRAPH_REQUIRED: repo_graph must be a non-empty string"
+            )
 
 
 def _build_plan(graph: dict[str, object], max_workers: int) -> dict[str, object]:
@@ -101,7 +104,7 @@ def _build_plan(graph: dict[str, object], max_workers: int) -> dict[str, object]
             assert isinstance(deps, list)
             if any(str(dep) not in done for dep in deps):
                 continue
-            name = str(repo.get("name", f"repo-{len(done)+1}"))
+            name = str(repo.get("name", f"repo-{len(done) + 1}"))
             language = str(repo.get("language", "unknown"))
             lane = "gate+review" if language.lower() in {"python", "node", "go"} else "gate"
             plan_items.append(
@@ -132,11 +135,11 @@ def _build_plan(graph: dict[str, object], max_workers: int) -> dict[str, object]
 def _build_risk_report(plan: dict[str, object]) -> dict[str, object]:
     items = plan.get("execution_plan", [])
     assert isinstance(items, list)
-    high = sum(1 for item in items if isinstance(item, dict) and int(item.get("priority", 100)) <= 20)
+    high = sum(
+        1 for item in items if isinstance(item, dict) and int(item.get("priority", 100)) <= 20
+    )
     med = sum(
-        1
-        for item in items
-        if isinstance(item, dict) and 20 < int(item.get("priority", 100)) <= 60
+        1 for item in items if isinstance(item, dict) and 20 < int(item.get("priority", 100)) <= 60
     )
     low = sum(1 for item in items if isinstance(item, dict) and int(item.get("priority", 100)) > 60)
     score = max(0, 100 - (high * 10 + med * 4 + low))
@@ -298,7 +301,9 @@ def _parse_policy_overrides(value: str) -> dict[str, object]:
         return {}
     payload = json.loads(raw)
     if not isinstance(payload, dict):
-        raise ValueError(f"{ERR_POLICY_OVERRIDE_INVALID_TYPE}: policy overrides must be a JSON object")
+        raise ValueError(
+            f"{ERR_POLICY_OVERRIDE_INVALID_TYPE}: policy overrides must be a JSON object"
+        )
     return payload
 
 
@@ -368,9 +373,13 @@ def _evaluate_policy(
     trace: list[dict[str, object]] = []
     if risk_score > max_risk_score:
         violations.append(f"risk_score {risk_score} > {max_risk_score}")
-        trace.append({"rule": "max_risk_score", "actual": risk_score, "limit": max_risk_score, "pass": False})
+        trace.append(
+            {"rule": "max_risk_score", "actual": risk_score, "limit": max_risk_score, "pass": False}
+        )
     else:
-        trace.append({"rule": "max_risk_score", "actual": risk_score, "limit": max_risk_score, "pass": True})
+        trace.append(
+            {"rule": "max_risk_score", "actual": risk_score, "limit": max_risk_score, "pass": True}
+        )
     if reliability < min_execution_reliability:
         violations.append(f"reliability {reliability} < {min_execution_reliability}")
         trace.append(
@@ -392,14 +401,32 @@ def _evaluate_policy(
         )
     if failure_count > max_failures:
         violations.append(f"failure_count {failure_count} > {max_failures}")
-        trace.append({"rule": "max_failures", "actual": failure_count, "limit": max_failures, "pass": False})
+        trace.append(
+            {"rule": "max_failures", "actual": failure_count, "limit": max_failures, "pass": False}
+        )
     else:
-        trace.append({"rule": "max_failures", "actual": failure_count, "limit": max_failures, "pass": True})
+        trace.append(
+            {"rule": "max_failures", "actual": failure_count, "limit": max_failures, "pass": True}
+        )
     if stopped_early and not allow_stopped_early:
         violations.append("stopped_early is true")
-        trace.append({"rule": "allow_stopped_early", "actual": stopped_early, "limit": allow_stopped_early, "pass": False})
+        trace.append(
+            {
+                "rule": "allow_stopped_early",
+                "actual": stopped_early,
+                "limit": allow_stopped_early,
+                "pass": False,
+            }
+        )
     else:
-        trace.append({"rule": "allow_stopped_early", "actual": stopped_early, "limit": allow_stopped_early, "pass": True})
+        trace.append(
+            {
+                "rule": "allow_stopped_early",
+                "actual": stopped_early,
+                "limit": allow_stopped_early,
+                "pass": True,
+            }
+        )
     decision = "SHIP" if not violations else "NO_SHIP"
     return {
         "ok": True,
@@ -582,11 +609,15 @@ def _run_pipeline_bundle(
     t_stage = perf_counter()
     plan = _build_plan(graph, max_workers=max(1, int(max_workers)))
     timings_ms["build_plan_ms"] = int((perf_counter() - t_stage) * 1000)
-    (out_dir / "plan.json").write_text(json.dumps(_with_schema(plan), indent=2) + "\n", encoding="utf-8")
+    (out_dir / "plan.json").write_text(
+        json.dumps(_with_schema(plan), indent=2) + "\n", encoding="utf-8"
+    )
     t_stage = perf_counter()
     risk = _build_risk_report(plan)
     timings_ms["risk_report_ms"] = int((perf_counter() - t_stage) * 1000)
-    (out_dir / "risk.json").write_text(json.dumps(_with_schema(risk), indent=2) + "\n", encoding="utf-8")
+    (out_dir / "risk.json").write_text(
+        json.dumps(_with_schema(risk), indent=2) + "\n", encoding="utf-8"
+    )
     t_stage = perf_counter()
     execution = _execute_plan(
         plan,
@@ -607,7 +638,9 @@ def _run_pipeline_bundle(
     t_stage = perf_counter()
     score = _score_execution_results(execution)
     timings_ms["score_ms"] = int((perf_counter() - t_stage) * 1000)
-    (out_dir / "score.json").write_text(json.dumps(_with_schema(score), indent=2) + "\n", encoding="utf-8")
+    (out_dir / "score.json").write_text(
+        json.dumps(_with_schema(score), indent=2) + "\n", encoding="utf-8"
+    )
     t_stage = perf_counter()
     policy_payload = (
         _resolve_policy_profile(
@@ -641,7 +674,9 @@ def _run_pipeline_bundle(
     t_stage = perf_counter()
     trend = _build_history_trend(history_path)
     timings_ms["history_trend_ms"] = int((perf_counter() - t_stage) * 1000)
-    (out_dir / "history-trend.json").write_text(json.dumps(trend, indent=2) + "\n", encoding="utf-8")
+    (out_dir / "history-trend.json").write_text(
+        json.dumps(trend, indent=2) + "\n", encoding="utf-8"
+    )
     t_stage = perf_counter()
     analysis = _analyze_plan(plan)
     timings_ms["analysis_ms"] = int((perf_counter() - t_stage) * 1000)
@@ -683,11 +718,11 @@ def _render_batch_dashboard_html(summary: dict[str, object]) -> str:
                 continue
             rendered.append(
                 "<tr>"
-                f"<td>{item.get('name','')}</td>"
-                f"<td>{item.get('decision','')}</td>"
-                f"<td>{item.get('risk_score','')}</td>"
-                f"<td>{item.get('reliability','')}</td>"
-                f"<td>{item.get('failure_count','')}</td>"
+                f"<td>{item.get('name', '')}</td>"
+                f"<td>{item.get('decision', '')}</td>"
+                f"<td>{item.get('risk_score', '')}</td>"
+                f"<td>{item.get('reliability', '')}</td>"
+                f"<td>{item.get('failure_count', '')}</td>"
                 "</tr>"
             )
         rows_html = "\n".join(rendered)
@@ -849,7 +884,10 @@ def _execute_plan(
             "inputs": {"path": repo_path},
             "evidence": [],
             "result": {"returncode": 2},
-            "escalation": {"required": True, "reason": f"exception during adapter execution: {last_error}"},
+            "escalation": {
+                "required": True,
+                "reason": f"exception during adapter execution: {last_error}",
+            },
             "command": command,
             "error": last_error,
         }
@@ -907,19 +945,27 @@ def _parser() -> argparse.ArgumentParser:
     risk = sub.add_parser("risk-report", help="Generate a portfolio risk report from a plan")
     risk.add_argument("--plan", required=True)
     risk.add_argument("--out", required=True)
-    execute = sub.add_parser("execute", help="Build multi-worker adapter execution intents from a plan")
+    execute = sub.add_parser(
+        "execute", help="Build multi-worker adapter execution intents from a plan"
+    )
     execute.add_argument("--plan", required=True)
     execute.add_argument("--max-workers", type=int, default=4)
-    execute.add_argument("--run", action="store_true", help="Execute adapter commands instead of dry-run intents")
+    execute.add_argument(
+        "--run", action="store_true", help="Execute adapter commands instead of dry-run intents"
+    )
     execute.add_argument("--timeout-seconds", type=int, default=120)
     execute.add_argument("--adapters", default="config/portfolio_adapters.json")
     execute.add_argument("--artifact-dir", default="")
     execute.add_argument("--retries", type=int, default=0)
     execute.add_argument("--max-failures", type=int, default=0)
-    execute.add_argument("--transport", choices=["local", "ssh", "container", "k8s-job"], default="local")
+    execute.add_argument(
+        "--transport", choices=["local", "ssh", "container", "k8s-job"], default="local"
+    )
     execute.add_argument("--cancel-file", default=".sdetkit/portfolio-cancel-targets.txt")
     execute.add_argument("--out", required=True)
-    validate = sub.add_parser("validate-graph", help="Validate repo graph structure before orchestration")
+    validate = sub.add_parser(
+        "validate-graph", help="Validate repo graph structure before orchestration"
+    )
     validate.add_argument("--repo-graph", required=True)
     validate.add_argument("--schema", default="schemas/repo-graph.schema.json")
     score = sub.add_parser(
@@ -928,7 +974,9 @@ def _parser() -> argparse.ArgumentParser:
     )
     score.add_argument("--results", required=True)
     score.add_argument("--out", required=True)
-    report = sub.add_parser("report", help="Render markdown executive report from generated artifacts")
+    report = sub.add_parser(
+        "report", help="Render markdown executive report from generated artifacts"
+    )
     report.add_argument("--plan", default="")
     report.add_argument("--risk", default="")
     report.add_argument("--score", default="")
@@ -951,7 +999,9 @@ def _parser() -> argparse.ArgumentParser:
     pipeline.add_argument("--timeout-seconds", type=int, default=120)
     pipeline.add_argument("--retries", type=int, default=0)
     pipeline.add_argument("--max-failures", type=int, default=0)
-    pipeline.add_argument("--transport", choices=["local", "ssh", "container", "k8s-job"], default="local")
+    pipeline.add_argument(
+        "--transport", choices=["local", "ssh", "container", "k8s-job"], default="local"
+    )
     pipeline.add_argument("--policy", default="config/portfolio_policy.default.json")
     pipeline.add_argument("--policy-pack", default="config/portfolio_policy.packs.json")
     pipeline.add_argument("--policy-profile", default="")
@@ -970,7 +1020,9 @@ def _parser() -> argparse.ArgumentParser:
     policy.add_argument("--policy-profile", default="")
     policy.add_argument("--policy-overrides", default="")
     policy.add_argument("--out", required=True)
-    history = sub.add_parser("history-trend", help="Build trend metrics from pipeline history JSONL")
+    history = sub.add_parser(
+        "history-trend", help="Build trend metrics from pipeline history JSONL"
+    )
     history.add_argument("--history", default=".sdetkit/portfolio-history.jsonl")
     history.add_argument("--out", required=True)
     dashboard = sub.add_parser("dashboard", help="Render HTML dashboard from pipeline artifacts")
@@ -980,7 +1032,9 @@ def _parser() -> argparse.ArgumentParser:
     dashboard.add_argument("--execution", required=True)
     dashboard.add_argument("--policy", required=True)
     dashboard.add_argument("--out", required=True)
-    batch = sub.add_parser("batch-run", help="Run multiple portfolio pipelines from a batch manifest")
+    batch = sub.add_parser(
+        "batch-run", help="Run multiple portfolio pipelines from a batch manifest"
+    )
     batch.add_argument("--manifest", required=True)
     batch.add_argument("--max-parallel", type=int, default=2)
     batch.add_argument("--out-dir", required=True)
@@ -994,7 +1048,9 @@ def _parser() -> argparse.ArgumentParser:
     impact.add_argument("--repo-graph", required=True)
     impact.add_argument("--changed-files", required=True, help="newline-delimited changed files")
     impact.add_argument("--out", required=True)
-    tower = sub.add_parser("batch-control-tower", help="Render control-tower JSON from batch history")
+    tower = sub.add_parser(
+        "batch-control-tower", help="Render control-tower JSON from batch history"
+    )
     tower.add_argument("--history", required=True)
     tower.add_argument("--out", required=True)
 
@@ -1033,7 +1089,11 @@ def main(argv: list[str] | None = None) -> int:
     if ns.cmd == "impact-plan":
         graph = _load_repo_graph(Path(ns.repo_graph))
         repos = graph.get("repos", [])
-        changed = [line.strip() for line in Path(ns.changed_files).read_text(encoding="utf-8").splitlines() if line.strip()]
+        changed = [
+            line.strip()
+            for line in Path(ns.changed_files).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
         selected: set[str] = set()
         owners: dict[str, list[str]] = {}
         if isinstance(repos, list):
@@ -1054,7 +1114,11 @@ def main(argv: list[str] | None = None) -> int:
                 if any(dep in changed_set for dep in deps) and repo not in changed_set:
                     changed_set.add(repo)
                     progress = True
-        reduced = [r for r in repos if isinstance(r, dict) and str(r.get("name")) in changed_set] if isinstance(repos, list) else []
+        reduced = (
+            [r for r in repos if isinstance(r, dict) and str(r.get("name")) in changed_set]
+            if isinstance(repos, list)
+            else []
+        )
         plan = _build_plan({"repos": reduced}, max_workers=4)
         Path(ns.out).write_text(json.dumps(_with_schema(plan), indent=2) + "\n", encoding="utf-8")
         return 0
@@ -1074,14 +1138,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if ns.cmd == "report":
         plan_payload = (
-            json.loads(Path(ns.plan).read_text(encoding="utf-8"))
-            if str(ns.plan).strip()
-            else None
+            json.loads(Path(ns.plan).read_text(encoding="utf-8")) if str(ns.plan).strip() else None
         )
         risk_payload = (
-            json.loads(Path(ns.risk).read_text(encoding="utf-8"))
-            if str(ns.risk).strip()
-            else None
+            json.loads(Path(ns.risk).read_text(encoding="utf-8")) if str(ns.risk).strip() else None
         )
         score_payload = (
             json.loads(Path(ns.score).read_text(encoding="utf-8"))
@@ -1137,7 +1197,11 @@ def main(argv: list[str] | None = None) -> int:
                 profile=str(ns.policy_profile) or None,
                 overrides=_parse_policy_overrides(str(ns.policy_overrides)),
             )
-        if not isinstance(risk, dict) or not isinstance(score, dict) or not isinstance(execution, dict):
+        if (
+            not isinstance(risk, dict)
+            or not isinstance(score, dict)
+            or not isinstance(execution, dict)
+        ):
             raise ValueError("risk/score/execution payloads must be JSON objects")
         evaluation = _evaluate_policy(
             risk=risk,
@@ -1183,6 +1247,7 @@ def main(argv: list[str] | None = None) -> int:
         assert isinstance(portfolios, list)
         out_root = Path(ns.out_dir)
         out_root.mkdir(parents=True, exist_ok=True)
+
         def _run_one(indexed: tuple[int, dict[str, object]]) -> dict[str, object]:
             _, item = indexed
             cfg = _normalize_batch_portfolio(item)
@@ -1223,7 +1288,9 @@ def main(argv: list[str] | None = None) -> int:
             "no_ship": len(summaries) - ship,
             "summaries": sorted(summaries, key=lambda x: str(x.get("name", ""))),
         }
-        (out_root / "batch-summary.json").write_text(json.dumps(aggregate, indent=2) + "\n", encoding="utf-8")
+        (out_root / "batch-summary.json").write_text(
+            json.dumps(aggregate, indent=2) + "\n", encoding="utf-8"
+        )
         batch_report = "\n".join(
             [
                 "# Portfolio Batch Report",

--- a/src/sdetkit/portfolio_orchestrator.py
+++ b/src/sdetkit/portfolio_orchestrator.py
@@ -40,15 +40,30 @@ def _validate_repo_graph_shape(payload: dict[str, Any]) -> None:
         names.add(name)
 
 
-def _validate_against_repo_schema(payload: dict[str, Any], schema_path: Path) -> None:
+def _validate_against_schema(payload: dict[str, Any], schema_path: Path) -> None:
     schema_payload = json.loads(schema_path.read_text(encoding="utf-8"))
     try:
         import jsonschema  # type: ignore
     except Exception:
-        # Fallback path for environments without jsonschema dependency.
-        _validate_repo_graph_shape(payload)
         return
     jsonschema.validate(instance=payload, schema=schema_payload)
+
+def _validate_against_repo_schema(payload: dict[str, Any], schema_path: Path) -> None:
+    _validate_against_schema(payload, schema_path)
+    # Fallback path for environments without jsonschema dependency.
+    _validate_repo_graph_shape(payload)
+
+
+def _validate_batch_manifest_shape(payload: dict[str, Any]) -> None:
+    portfolios = payload.get("portfolios")
+    if not isinstance(portfolios, list) or not portfolios:
+        raise ValueError("BATCH_MANIFEST_PORTFOLIOS_REQUIRED: portfolios must be a non-empty array")
+    for item in portfolios:
+        if not isinstance(item, dict):
+            raise ValueError("BATCH_MANIFEST_ITEM_INVALID: each portfolio entry must be an object")
+        repo_graph = item.get("repo_graph")
+        if not isinstance(repo_graph, str) or not repo_graph.strip():
+            raise ValueError("BATCH_MANIFEST_REPO_GRAPH_REQUIRED: repo_graph must be a non-empty string")
 
 
 def _build_plan(graph: dict[str, object], max_workers: int) -> dict[str, object]:
@@ -1096,9 +1111,12 @@ def main(argv: list[str] | None = None) -> int:
         manifest = json.loads(Path(ns.manifest).read_text(encoding="utf-8"))
         if not isinstance(manifest, dict):
             raise ValueError("batch manifest must be a JSON object")
+        batch_schema = Path("schemas/portfolio-batch.schema.json")
+        if batch_schema.exists():
+            _validate_against_schema(manifest, batch_schema)
+        _validate_batch_manifest_shape(manifest)
         portfolios = manifest.get("portfolios", [])
-        if not isinstance(portfolios, list):
-            raise ValueError("batch manifest must include array field 'portfolios'")
+        assert isinstance(portfolios, list)
         out_root = Path(ns.out_dir)
         out_root.mkdir(parents=True, exist_ok=True)
         def _run_one(indexed: tuple[int, dict[str, object]]) -> dict[str, object]:

--- a/src/sdetkit/portfolio_orchestrator.py
+++ b/src/sdetkit/portfolio_orchestrator.py
@@ -284,6 +284,14 @@ def _parse_policy_overrides(value: str) -> dict[str, object]:
     return payload
 
 
+def _coerce_policy_overrides(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        return _parse_policy_overrides(value)
+    return {}
+
+
 def _evaluate_policy(
     *,
     risk: dict[str, object],
@@ -1104,11 +1112,7 @@ def main(argv: list[str] | None = None) -> int:
                 policy_path=Path(str(item.get("policy", "config/portfolio_policy.default.json"))),
                 policy_pack_path=Path(str(item.get("policy_pack", "config/portfolio_policy.packs.json"))),
                 policy_profile=str(item.get("policy_profile", "")),
-                policy_overrides=(
-                    item.get("policy_overrides", {})
-                    if isinstance(item.get("policy_overrides", {}), dict)
-                    else {}
-                ),
+                policy_overrides=_coerce_policy_overrides(item.get("policy_overrides", {})),
                 max_workers=max(1, int(item.get("max_workers", 4))),
                 run=bool(item.get("run", False)),
                 timeout_seconds=int(item.get("timeout_seconds", 120)),

--- a/src/sdetkit/portfolio_orchestrator.py
+++ b/src/sdetkit/portfolio_orchestrator.py
@@ -5,11 +5,14 @@ import json
 import subprocess
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from time import perf_counter
 from typing import Any
 
 ARTIFACT_SCHEMA_VERSION = "portfolio.v1"
+ERR_POLICY_OVERRIDE_INVALID_TYPE = "POLICY_OVERRIDE_INVALID_TYPE"
 
 
 def _load_repo_graph(path: Path) -> dict[str, object]:
@@ -295,7 +298,7 @@ def _parse_policy_overrides(value: str) -> dict[str, object]:
         return {}
     payload = json.loads(raw)
     if not isinstance(payload, dict):
-        raise ValueError("policy overrides must be a JSON object")
+        raise ValueError(f"{ERR_POLICY_OVERRIDE_INVALID_TYPE}: policy overrides must be a JSON object")
     return payload
 
 
@@ -305,6 +308,45 @@ def _coerce_policy_overrides(value: object) -> dict[str, object]:
     if isinstance(value, str):
         return _parse_policy_overrides(value)
     return {}
+
+
+@dataclass(frozen=True)
+class BatchPortfolioConfig:
+    name: str
+    repo_graph: Path
+    schema: Path
+    adapters: Path
+    policy: Path
+    policy_pack: Path
+    policy_profile: str
+    policy_overrides: dict[str, object]
+    max_workers: int
+    run: bool
+    timeout_seconds: int
+    retries: int
+    max_failures: int
+    transport: str
+    cancel_file: Path
+
+
+def _normalize_batch_portfolio(item: dict[str, object]) -> BatchPortfolioConfig:
+    return BatchPortfolioConfig(
+        name=str(item.get("name", "portfolio")),
+        repo_graph=Path(str(item.get("repo_graph"))),
+        schema=Path(str(item.get("schema", "schemas/repo-graph.schema.json"))),
+        adapters=Path(str(item.get("adapters", "config/portfolio_adapters.json"))),
+        policy=Path(str(item.get("policy", "config/portfolio_policy.default.json"))),
+        policy_pack=Path(str(item.get("policy_pack", "config/portfolio_policy.packs.json"))),
+        policy_profile=str(item.get("policy_profile", "")),
+        policy_overrides=_coerce_policy_overrides(item.get("policy_overrides", {})),
+        max_workers=max(1, int(item.get("max_workers", 4))),
+        run=bool(item.get("run", False)),
+        timeout_seconds=int(item.get("timeout_seconds", 120)),
+        retries=int(item.get("retries", 0)),
+        max_failures=int(item.get("max_failures", 0)),
+        transport=str(item.get("transport", "local")),
+        cancel_file=Path(str(item.get("cancel_file", ".sdetkit/portfolio-cancel-targets.txt"))),
+    )
 
 
 def _evaluate_policy(
@@ -529,14 +571,23 @@ def _run_pipeline_bundle(
     cancel_path: Path,
     out_dir: Path,
 ) -> dict[str, object]:
+    t0 = perf_counter()
+    timings_ms: dict[str, int] = {}
     out_dir.mkdir(parents=True, exist_ok=True)
+    t_stage = perf_counter()
     graph = _load_repo_graph(repo_graph)
     _validate_against_repo_schema(graph, schema)
     _validate_repo_graph_shape(graph)
+    timings_ms["load_and_validate_graph_ms"] = int((perf_counter() - t_stage) * 1000)
+    t_stage = perf_counter()
     plan = _build_plan(graph, max_workers=max(1, int(max_workers)))
+    timings_ms["build_plan_ms"] = int((perf_counter() - t_stage) * 1000)
     (out_dir / "plan.json").write_text(json.dumps(_with_schema(plan), indent=2) + "\n", encoding="utf-8")
+    t_stage = perf_counter()
     risk = _build_risk_report(plan)
+    timings_ms["risk_report_ms"] = int((perf_counter() - t_stage) * 1000)
     (out_dir / "risk.json").write_text(json.dumps(_with_schema(risk), indent=2) + "\n", encoding="utf-8")
+    t_stage = perf_counter()
     execution = _execute_plan(
         plan,
         max_workers=max(1, int(max_workers)),
@@ -549,11 +600,15 @@ def _run_pipeline_bundle(
         transport=transport,
         cancel_targets=_load_cancel_targets(cancel_path),
     )
+    timings_ms["execute_ms"] = int((perf_counter() - t_stage) * 1000)
     (out_dir / "execution.json").write_text(
         json.dumps(_with_schema(execution), indent=2) + "\n", encoding="utf-8"
     )
+    t_stage = perf_counter()
     score = _score_execution_results(execution)
+    timings_ms["score_ms"] = int((perf_counter() - t_stage) * 1000)
     (out_dir / "score.json").write_text(json.dumps(_with_schema(score), indent=2) + "\n", encoding="utf-8")
+    t_stage = perf_counter()
     policy_payload = (
         _resolve_policy_profile(
             policy_pack_path,
@@ -569,6 +624,7 @@ def _run_pipeline_bundle(
         execution=execution,
         policy=policy_payload,
     )
+    timings_ms["policy_eval_ms"] = int((perf_counter() - t_stage) * 1000)
     (out_dir / "policy.json").write_text(
         json.dumps(_with_schema(policy_eval), indent=2) + "\n", encoding="utf-8"
     )
@@ -582,12 +638,17 @@ def _run_pipeline_bundle(
             "failure_count": int(execution.get("failure_count", 0)),
         },
     )
+    t_stage = perf_counter()
     trend = _build_history_trend(history_path)
+    timings_ms["history_trend_ms"] = int((perf_counter() - t_stage) * 1000)
     (out_dir / "history-trend.json").write_text(json.dumps(trend, indent=2) + "\n", encoding="utf-8")
+    t_stage = perf_counter()
     analysis = _analyze_plan(plan)
+    timings_ms["analysis_ms"] = int((perf_counter() - t_stage) * 1000)
     (out_dir / "analysis.json").write_text(
         json.dumps(_with_schema(analysis), indent=2) + "\n", encoding="utf-8"
     )
+    t_stage = perf_counter()
     report = _render_portfolio_report(plan=plan, risk=risk, score=score)
     (out_dir / "report.md").write_text(report, encoding="utf-8")
     dashboard = _render_portfolio_dashboard_html(
@@ -598,11 +659,14 @@ def _run_pipeline_bundle(
         policy=policy_eval,
     )
     (out_dir / "dashboard.html").write_text(dashboard, encoding="utf-8")
+    timings_ms["render_outputs_ms"] = int((perf_counter() - t_stage) * 1000)
+    timings_ms["total_ms"] = int((perf_counter() - t0) * 1000)
     return {
         "decision": str(policy_eval.get("decision", "NO_SHIP")),
         "risk_score": int(risk.get("portfolio_risk_score", 100)),
         "reliability": int(score.get("execution_reliability_score", 0)),
         "failure_count": int(execution.get("failure_count", 0)),
+        "telemetry": {"timings_ms": timings_ms},
     }
 
 
@@ -1121,24 +1185,25 @@ def main(argv: list[str] | None = None) -> int:
         out_root.mkdir(parents=True, exist_ok=True)
         def _run_one(indexed: tuple[int, dict[str, object]]) -> dict[str, object]:
             _, item = indexed
-            name = str(item.get("name", "portfolio"))
+            cfg = _normalize_batch_portfolio(item)
+            name = cfg.name
             portfolio_out = out_root / name
             summary = _run_pipeline_bundle(
-                repo_graph=Path(str(item.get("repo_graph"))),
-                schema=Path(str(item.get("schema", "schemas/repo-graph.schema.json"))),
-                adapters=Path(str(item.get("adapters", "config/portfolio_adapters.json"))),
-                policy_path=Path(str(item.get("policy", "config/portfolio_policy.default.json"))),
-                policy_pack_path=Path(str(item.get("policy_pack", "config/portfolio_policy.packs.json"))),
-                policy_profile=str(item.get("policy_profile", "")),
-                policy_overrides=_coerce_policy_overrides(item.get("policy_overrides", {})),
-                max_workers=max(1, int(item.get("max_workers", 4))),
-                run=bool(item.get("run", False)),
-                timeout_seconds=int(item.get("timeout_seconds", 120)),
-                retries=int(item.get("retries", 0)),
-                max_failures=int(item.get("max_failures", 0)),
-                transport=str(item.get("transport", "local")),
+                repo_graph=cfg.repo_graph,
+                schema=cfg.schema,
+                adapters=cfg.adapters,
+                policy_path=cfg.policy,
+                policy_pack_path=cfg.policy_pack,
+                policy_profile=cfg.policy_profile,
+                policy_overrides=cfg.policy_overrides,
+                max_workers=cfg.max_workers,
+                run=cfg.run,
+                timeout_seconds=cfg.timeout_seconds,
+                retries=cfg.retries,
+                max_failures=cfg.max_failures,
+                transport=cfg.transport,
                 history_path=out_root / "batch-history.jsonl",
-                cancel_path=Path(str(item.get("cancel_file", ".sdetkit/portfolio-cancel-targets.txt"))),
+                cancel_path=cfg.cancel_file,
                 out_dir=portfolio_out,
             )
             summary["name"] = name

--- a/tests/golden/portfolio_batch_summary.json
+++ b/tests/golden/portfolio_batch_summary.json
@@ -1,0 +1,18 @@
+{
+  "no_ship": 1,
+  "ok": true,
+  "portfolios": 1,
+  "ship": 0,
+  "summaries": [
+    {
+      "decision": "NO_SHIP",
+      "failure_count": 0,
+      "name": "p1",
+      "reliability": 0,
+      "risk_score": 99,
+      "telemetry": {
+        "timings_ms": "<redacted>"
+      }
+    }
+  ]
+}

--- a/tests/golden/portfolio_execution.json
+++ b/tests/golden/portfolio_execution.json
@@ -1,0 +1,40 @@
+{
+  "artifact_schema_version": "portfolio.v1",
+  "failure_count": 0,
+  "max_workers": 4,
+  "ok": true,
+  "results": [
+    {
+      "command": [
+        "echo",
+        "ok",
+        "repos/api"
+      ],
+      "escalation": {
+        "reason": "",
+        "required": false
+      },
+      "evidence": [],
+      "finished_at": "<redacted>",
+      "heartbeats": [
+        "<redacted>"
+      ],
+      "inputs": {
+        "path": "repos/api"
+      },
+      "language": "python",
+      "lease_id": "<redacted>",
+      "mode": "dry-run",
+      "repo": "api",
+      "result": {
+        "returncode": 0
+      },
+      "run_id": "<redacted>",
+      "started_at": "<redacted>",
+      "status": "queued",
+      "transport": "local",
+      "worker": "adapter-python"
+    }
+  ],
+  "stopped_early": false
+}

--- a/tests/golden/portfolio_policy.json
+++ b/tests/golden/portfolio_policy.json
@@ -1,0 +1,43 @@
+{
+  "artifact_schema_version": "portfolio.v1",
+  "decision": "NO_SHIP",
+  "ok": true,
+  "policy_name": "standard",
+  "profile": "standard",
+  "signals": {
+    "execution_reliability_score": 0,
+    "failure_count": 0,
+    "risk_score": 99,
+    "stopped_early": false
+  },
+  "trace": [
+    {
+      "actual": 99,
+      "limit": 35,
+      "pass": false,
+      "rule": "max_risk_score"
+    },
+    {
+      "actual": 0,
+      "limit": 80,
+      "pass": false,
+      "rule": "min_execution_reliability"
+    },
+    {
+      "actual": 0,
+      "limit": 0,
+      "pass": true,
+      "rule": "max_failures"
+    },
+    {
+      "actual": false,
+      "limit": false,
+      "pass": true,
+      "rule": "allow_stopped_early"
+    }
+  ],
+  "violations": [
+    "risk_score 99 > 35",
+    "reliability 0 < 80"
+  ]
+}

--- a/tests/test_cli_portfolio_passthrough.py
+++ b/tests/test_cli_portfolio_passthrough.py
@@ -14,15 +14,19 @@ def test_top_level_cli_portfolio_passthrough_validate_graph(tmp_path: Path) -> N
         encoding="utf-8",
     )
     schema_path.write_text(
-        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        json.dumps(
+            {"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}
+        ),
         encoding="utf-8",
     )
-    rc = main([
-        "portfolio-orchestrate",
-        "validate-graph",
-        "--repo-graph",
-        str(graph_path),
-        "--schema",
-        str(schema_path),
-    ])
+    rc = main(
+        [
+            "portfolio-orchestrate",
+            "validate-graph",
+            "--repo-graph",
+            str(graph_path),
+            "--schema",
+            str(schema_path),
+        ]
+    )
     assert rc == 0

--- a/tests/test_cli_portfolio_passthrough.py
+++ b/tests/test_cli_portfolio_passthrough.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.cli import main
+
+
+def test_top_level_cli_portfolio_passthrough_validate_graph(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graph.json"
+    schema_path = tmp_path / "schema.json"
+    graph_path.write_text(
+        json.dumps({"repos": [{"name": "api", "path": "repos/api", "language": "python"}]}),
+        encoding="utf-8",
+    )
+    schema_path.write_text(
+        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        encoding="utf-8",
+    )
+    rc = main([
+        "portfolio-orchestrate",
+        "validate-graph",
+        "--repo-graph",
+        str(graph_path),
+        "--schema",
+        str(schema_path),
+    ])
+    assert rc == 0

--- a/tests/test_portfolio_orchestrator.py
+++ b/tests/test_portfolio_orchestrator.py
@@ -8,18 +8,18 @@ from sdetkit.portfolio_orchestrator import (
     _adapter_command_from_registry,
     _analyze_plan,
     _append_history_record,
+    _build_history_trend,
     _build_plan,
     _build_risk_report,
-    _build_history_trend,
-    _execute_plan,
     _evaluate_policy,
+    _execute_plan,
     _load_adapter_registry,
-    _score_execution_results,
-    _render_portfolio_report,
-    _render_portfolio_dashboard_html,
     _load_policy,
     _parse_policy_overrides,
+    _render_portfolio_dashboard_html,
+    _render_portfolio_report,
     _resolve_policy_profile,
+    _score_execution_results,
     _validate_against_repo_schema,
     _validate_repo_graph_shape,
 )
@@ -28,7 +28,13 @@ from sdetkit.portfolio_orchestrator import (
 def test_build_plan_orders_dependencies_before_dependents() -> None:
     graph = {
         "repos": [
-            {"name": "web", "path": "repos/web", "language": "node", "priority": 40, "depends_on": ["api"]},
+            {
+                "name": "web",
+                "path": "repos/web",
+                "language": "node",
+                "priority": 40,
+                "depends_on": ["api"],
+            },
             {"name": "api", "path": "repos/api", "language": "python", "priority": 10},
         ]
     }
@@ -40,7 +46,11 @@ def test_build_plan_orders_dependencies_before_dependents() -> None:
 
 
 def test_build_plan_rejects_unknown_dependency() -> None:
-    graph = {"repos": [{"name": "web", "path": "repos/web", "language": "node", "depends_on": ["missing"]}]}
+    graph = {
+        "repos": [
+            {"name": "web", "path": "repos/web", "language": "node", "depends_on": ["missing"]}
+        ]
+    }
     try:
         _build_plan(graph, max_workers=2)
     except ValueError as exc:
@@ -98,7 +108,11 @@ def test_execute_plan_writes_worker_artifacts(tmp_path: Path) -> None:
 
 
 def test_execute_plan_retries_failed_run() -> None:
-    plan = {"execution_plan": [{"repo": "api", "path": "repos/api", "language": "python", "depends_on": []}]}
+    plan = {
+        "execution_plan": [
+            {"repo": "api", "path": "repos/api", "language": "python", "depends_on": []}
+        ]
+    }
     registry = {"python": ["python", "-c", "import sys; sys.exit(1)"]}
     result = _execute_plan(plan, max_workers=1, run=True, adapter_registry=registry, retries=1)
     rows = result["results"]
@@ -134,7 +148,9 @@ def test_adapter_command_for_unknown_language() -> None:
 
 def test_adapter_registry_loading_and_resolution(tmp_path: Path) -> None:
     path = tmp_path / "adapters.json"
-    path.write_text(json.dumps({"python": ["python", "-m", "tool", "{repo_path}"]}), encoding="utf-8")
+    path.write_text(
+        json.dumps({"python": ["python", "-m", "tool", "{repo_path}"]}), encoding="utf-8"
+    )
     registry = _load_adapter_registry(path)
     cmd = _adapter_command_from_registry(registry, "python", "repos/api")
     assert cmd == ["python", "-m", "tool", "repos/api"]
@@ -233,14 +249,24 @@ def test_resolve_policy_profile_with_overrides(tmp_path: Path) -> None:
             {
                 "default_profile": "standard",
                 "profiles": {
-                    "standard": {"name": "standard", "max_risk_score": 35, "min_execution_reliability": 80},
-                    "regulated": {"name": "regulated", "max_risk_score": 20, "min_execution_reliability": 90},
+                    "standard": {
+                        "name": "standard",
+                        "max_risk_score": 35,
+                        "min_execution_reliability": 80,
+                    },
+                    "regulated": {
+                        "name": "regulated",
+                        "max_risk_score": 20,
+                        "min_execution_reliability": 90,
+                    },
                 },
             }
         ),
         encoding="utf-8",
     )
-    policy = _resolve_policy_profile(pack_path, profile="regulated", overrides={"max_risk_score": 10})
+    policy = _resolve_policy_profile(
+        pack_path, profile="regulated", overrides={"max_risk_score": 10}
+    )
     assert policy["profile"] == "regulated"
     assert policy["max_risk_score"] == 10
 
@@ -268,7 +294,9 @@ def test_render_dashboard_html() -> None:
         plan={"repos": 2, "max_workers": 2},
         risk={"portfolio_risk_score": 40},
         score={"execution_reliability_score": 85},
-        execution={"results": [{"repo": "api", "language": "python", "status": "ok", "mode": "run"}]},
+        execution={
+            "results": [{"repo": "api", "language": "python", "status": "ok", "mode": "run"}]
+        },
         policy={"decision": "SHIP"},
     )
     assert "Portfolio Orchestration Dashboard" in html

--- a/tests/test_portfolio_orchestrator.py
+++ b/tests/test_portfolio_orchestrator.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.portfolio_orchestrator import (
+    _adapter_command,
+    _adapter_command_from_registry,
+    _analyze_plan,
+    _append_history_record,
+    _build_plan,
+    _build_risk_report,
+    _build_history_trend,
+    _execute_plan,
+    _evaluate_policy,
+    _load_adapter_registry,
+    _score_execution_results,
+    _render_portfolio_report,
+    _render_portfolio_dashboard_html,
+    _load_policy,
+    _parse_policy_overrides,
+    _resolve_policy_profile,
+    _validate_against_repo_schema,
+    _validate_repo_graph_shape,
+)
+
+
+def test_build_plan_orders_dependencies_before_dependents() -> None:
+    graph = {
+        "repos": [
+            {"name": "web", "path": "repos/web", "language": "node", "priority": 40, "depends_on": ["api"]},
+            {"name": "api", "path": "repos/api", "language": "python", "priority": 10},
+        ]
+    }
+    plan = _build_plan(graph, max_workers=2)
+    items = plan["execution_plan"]
+    assert isinstance(items, list)
+    assert items[0]["repo"] == "api"
+    assert items[1]["repo"] == "web"
+
+
+def test_build_plan_rejects_unknown_dependency() -> None:
+    graph = {"repos": [{"name": "web", "path": "repos/web", "language": "node", "depends_on": ["missing"]}]}
+    try:
+        _build_plan(graph, max_workers=2)
+    except ValueError as exc:
+        assert "unknown dependency" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_risk_report_shape() -> None:
+    plan = {
+        "execution_plan": [
+            {"repo": "api", "priority": 10},
+            {"repo": "web", "priority": 50},
+            {"repo": "docs", "priority": 90},
+        ]
+    }
+    report = _build_risk_report(plan)
+    assert report["ok"] is True
+    assert report["risk_buckets"] == {"high": 1, "medium": 1, "low": 1}
+    assert report["recommendation"] in {"SHIP_WITH_CONTROLS", "NO_SHIP"}
+    json.dumps(report)
+
+
+def test_execute_plan_generates_threaded_execution_intents() -> None:
+    plan = {
+        "execution_plan": [
+            {"repo": "api", "path": "repos/api", "language": "python", "priority": 10},
+            {"repo": "web", "path": "repos/web", "language": "node", "priority": 20},
+        ]
+    }
+    result = _execute_plan(plan, max_workers=2, run=False)
+    assert result["ok"] is True
+    rows = result["results"]
+    assert isinstance(rows, list)
+    assert len(rows) == 2
+    assert rows[0]["status"] == "queued"
+    assert rows[0]["mode"] == "dry-run"
+    assert "run_id" in rows[0]
+    assert "started_at" in rows[0]
+    assert "finished_at" in rows[0]
+    assert "escalation" in rows[0]
+
+
+def test_execute_plan_writes_worker_artifacts(tmp_path: Path) -> None:
+    plan = {
+        "execution_plan": [
+            {"repo": "contracts", "path": "repos/contracts", "language": "go", "depends_on": []},
+            {"repo": "api", "path": "repos/api", "language": "python", "depends_on": ["contracts"]},
+        ]
+    }
+    result = _execute_plan(plan, max_workers=2, run=False, artifact_dir=tmp_path)
+    assert result["ok"] is True
+    assert (tmp_path / "contracts.worker.json").exists()
+    assert (tmp_path / "api.worker.json").exists()
+
+
+def test_execute_plan_retries_failed_run() -> None:
+    plan = {"execution_plan": [{"repo": "api", "path": "repos/api", "language": "python", "depends_on": []}]}
+    registry = {"python": ["python", "-c", "import sys; sys.exit(1)"]}
+    result = _execute_plan(plan, max_workers=1, run=True, adapter_registry=registry, retries=1)
+    rows = result["results"]
+    assert isinstance(rows, list)
+    assert rows[0]["status"] == "fail"
+    assert rows[0]["attempts"] == 2
+
+
+def test_execute_plan_stops_early_after_max_failures() -> None:
+    plan = {
+        "execution_plan": [
+            {"repo": "a", "path": "repos/a", "language": "python", "depends_on": []},
+            {"repo": "b", "path": "repos/b", "language": "python", "depends_on": []},
+        ]
+    }
+    registry = {"python": ["python", "-c", "import sys; sys.exit(1)"]}
+    result = _execute_plan(
+        plan,
+        max_workers=1,
+        run=True,
+        adapter_registry=registry,
+        retries=0,
+        max_failures=1,
+    )
+    assert result["stopped_early"] is True
+    assert result["failure_count"] >= 1
+
+
+def test_adapter_command_for_unknown_language() -> None:
+    cmd = _adapter_command("rust", "repos/engine")
+    assert cmd[0] == "echo"
+
+
+def test_adapter_registry_loading_and_resolution(tmp_path: Path) -> None:
+    path = tmp_path / "adapters.json"
+    path.write_text(json.dumps({"python": ["python", "-m", "tool", "{repo_path}"]}), encoding="utf-8")
+    registry = _load_adapter_registry(path)
+    cmd = _adapter_command_from_registry(registry, "python", "repos/api")
+    assert cmd == ["python", "-m", "tool", "repos/api"]
+
+
+def test_validate_graph_rejects_duplicates() -> None:
+    payload = {
+        "repos": [
+            {"name": "api", "path": "repos/api", "language": "python"},
+            {"name": "api", "path": "repos/api2", "language": "go"},
+        ]
+    }
+    try:
+        _validate_repo_graph_shape(payload)
+    except ValueError as exc:
+        assert "duplicate repo name" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_score_execution_results() -> None:
+    payload = {
+        "results": [
+            {"repo": "api", "status": "ok"},
+            {"repo": "web", "status": "fail"},
+            {"repo": "jobs", "status": "error"},
+        ]
+    }
+    score = _score_execution_results(payload)
+    assert score["ok"] is True
+    assert score["totals"] == {"ok": 1, "fail": 1, "error": 1}
+    assert score["recommendation"] == "NO_SHIP"
+
+
+def test_validate_against_schema_fallback_or_jsonschema(tmp_path: Path) -> None:
+    schema = {"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text(json.dumps(schema), encoding="utf-8")
+    payload = {"repos": [{"name": "api", "path": "repos/api", "language": "python"}]}
+    _validate_against_repo_schema(payload, schema_path)
+
+
+def test_render_portfolio_report() -> None:
+    report = _render_portfolio_report(
+        plan={"repos": 3, "max_workers": 4},
+        risk={"portfolio_risk_score": 82, "recommendation": "SHIP_WITH_CONTROLS"},
+        score={"execution_reliability_score": 90, "recommendation": "SHIP_WITH_CONTROLS"},
+    )
+    assert "Portfolio Orchestration Report" in report
+    assert "Planned repositories: 3" in report
+
+
+def test_analyze_plan_critical_path() -> None:
+    analysis = _analyze_plan(
+        {
+            "execution_plan": [
+                {"repo": "contracts", "depends_on": []},
+                {"repo": "api", "depends_on": ["contracts"]},
+                {"repo": "web", "depends_on": ["api"]},
+            ]
+        }
+    )
+    assert analysis["ok"] is True
+    assert analysis["critical_path_length"] == 3
+
+
+def test_evaluate_policy_no_ship_violation(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "name": "strict",
+                "max_risk_score": 20,
+                "min_execution_reliability": 90,
+                "max_failures": 0,
+                "allow_stopped_early": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    policy = _load_policy(policy_path)
+    evaluation = _evaluate_policy(
+        risk={"portfolio_risk_score": 50},
+        score={"execution_reliability_score": 70},
+        execution={"failure_count": 1, "stopped_early": True},
+        policy=policy,
+    )
+    assert evaluation["decision"] == "NO_SHIP"
+    assert len(evaluation["violations"]) >= 1
+
+
+def test_resolve_policy_profile_with_overrides(tmp_path: Path) -> None:
+    pack_path = tmp_path / "packs.json"
+    pack_path.write_text(
+        json.dumps(
+            {
+                "default_profile": "standard",
+                "profiles": {
+                    "standard": {"name": "standard", "max_risk_score": 35, "min_execution_reliability": 80},
+                    "regulated": {"name": "regulated", "max_risk_score": 20, "min_execution_reliability": 90},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    policy = _resolve_policy_profile(pack_path, profile="regulated", overrides={"max_risk_score": 10})
+    assert policy["profile"] == "regulated"
+    assert policy["max_risk_score"] == 10
+
+
+def test_parse_policy_overrides_rejects_non_object() -> None:
+    try:
+        _parse_policy_overrides('["not-an-object"]')
+    except ValueError as exc:
+        assert "JSON object" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_history_trend_rollup(tmp_path: Path) -> None:
+    history = tmp_path / "history.jsonl"
+    _append_history_record(history, {"decision": "SHIP", "risk_score": 20})
+    _append_history_record(history, {"decision": "NO_SHIP", "risk_score": 60})
+    trend = _build_history_trend(history)
+    assert trend["runs"] == 2
+    assert trend["ship_rate"] == 0.5
+
+
+def test_render_dashboard_html() -> None:
+    html = _render_portfolio_dashboard_html(
+        plan={"repos": 2, "max_workers": 2},
+        risk={"portfolio_risk_score": 40},
+        score={"execution_reliability_score": 85},
+        execution={"results": [{"repo": "api", "language": "python", "status": "ok", "mode": "run"}]},
+        policy={"decision": "SHIP"},
+    )
+    assert "Portfolio Orchestration Dashboard" in html
+    assert "<table>" in html
+
+
+def test_execute_plan_contains_transport_and_lease() -> None:
+    plan = {"execution_plan": [{"repo": "api", "path": "repos/api", "language": "python"}]}
+    result = _execute_plan(plan, max_workers=1, run=False, transport="ssh")
+    row = result["results"][0]
+    assert row["transport"] == "ssh"
+    assert str(row["lease_id"]).startswith("lease-")
+
+
+def test_execute_plan_respects_cancel_targets() -> None:
+    plan = {"execution_plan": [{"repo": "api", "path": "repos/api", "language": "python"}]}
+    result = _execute_plan(plan, max_workers=1, run=False, cancel_targets={"api"})
+    row = result["results"][0]
+    assert row["status"] == "canceled"

--- a/tests/test_portfolio_orchestrator.py
+++ b/tests/test_portfolio_orchestrator.py
@@ -249,7 +249,7 @@ def test_parse_policy_overrides_rejects_non_object() -> None:
     try:
         _parse_policy_overrides('["not-an-object"]')
     except ValueError as exc:
-        assert "JSON object" in str(exc)
+        assert "POLICY_OVERRIDE_INVALID_TYPE" in str(exc)
     else:
         raise AssertionError("expected ValueError")
 

--- a/tests/test_portfolio_orchestrator_cli.py
+++ b/tests/test_portfolio_orchestrator_cli.py
@@ -464,6 +464,18 @@ def test_cli_batch_run_accepts_string_policy_overrides(tmp_path: Path) -> None:
     assert policy["decision"] == "NO_SHIP"
 
 
+def test_cli_batch_run_rejects_manifest_missing_repo_graph(tmp_path: Path) -> None:
+    manifest = tmp_path / "batch-invalid.json"
+    out_dir = tmp_path / "batch-out"
+    manifest.write_text(json.dumps({"portfolios": [{"name": "p1"}]}), encoding="utf-8")
+    try:
+        main(["batch-run", "--manifest", str(manifest), "--out-dir", str(out_dir)])
+    except Exception as exc:
+        assert "repo_graph" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
 def test_cli_impact_plan_and_control_tower(tmp_path: Path) -> None:
     graph = tmp_path / "graph.json"
     changes = tmp_path / "changed.txt"

--- a/tests/test_portfolio_orchestrator_cli.py
+++ b/tests/test_portfolio_orchestrator_cli.py
@@ -12,7 +12,13 @@ def _sample_graph() -> dict[str, object]:
     return {
         "repos": [
             {"name": "api", "path": "repos/api", "language": "python", "priority": 10},
-            {"name": "web", "path": "repos/web", "language": "node", "priority": 40, "depends_on": ["api"]},
+            {
+                "name": "web",
+                "path": "repos/web",
+                "language": "node",
+                "priority": 40,
+                "depends_on": ["api"],
+            },
         ]
     }
 
@@ -23,10 +29,14 @@ def test_cli_validate_and_orchestrate(tmp_path: Path) -> None:
     out_path = tmp_path / "plan.json"
     graph_path.write_text(json.dumps(_sample_graph()), encoding="utf-8")
     schema_path.write_text(
-        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        json.dumps(
+            {"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}
+        ),
         encoding="utf-8",
     )
-    assert main(["validate-graph", "--repo-graph", str(graph_path), "--schema", str(schema_path)]) == 0
+    assert (
+        main(["validate-graph", "--repo-graph", str(graph_path), "--schema", str(schema_path)]) == 0
+    )
     assert (
         main(
             [
@@ -131,14 +141,21 @@ def test_cli_run_pipeline(tmp_path: Path) -> None:
             {
                 "repos": [
                     {"name": "contracts", "path": "repos/contracts", "language": "go"},
-                    {"name": "api", "path": "repos/api", "language": "python", "depends_on": ["contracts"]},
+                    {
+                        "name": "api",
+                        "path": "repos/api",
+                        "language": "python",
+                        "depends_on": ["contracts"],
+                    },
                 ]
             }
         ),
         encoding="utf-8",
     )
     schema_path.write_text(
-        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        json.dumps(
+            {"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}
+        ),
         encoding="utf-8",
     )
     adapters_path.write_text(
@@ -184,10 +201,14 @@ def test_cli_run_pipeline_with_run_mode(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     schema_path.write_text(
-        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        json.dumps(
+            {"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}
+        ),
         encoding="utf-8",
     )
-    adapters_path.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
+    adapters_path.write_text(
+        json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8"
+    )
     assert (
         main(
             [
@@ -223,10 +244,14 @@ def test_cli_run_pipeline_transport_option(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     schema_path.write_text(
-        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        json.dumps(
+            {"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}
+        ),
         encoding="utf-8",
     )
-    adapters_path.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
+    adapters_path.write_text(
+        json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8"
+    )
     assert (
         main(
             [
@@ -324,7 +349,9 @@ def test_cli_dashboard(tmp_path: Path) -> None:
     risk.write_text(json.dumps({"portfolio_risk_score": 30}), encoding="utf-8")
     score.write_text(json.dumps({"execution_reliability_score": 90}), encoding="utf-8")
     execution.write_text(
-        json.dumps({"results": [{"repo": "api", "language": "python", "status": "ok", "mode": "run"}]}),
+        json.dumps(
+            {"results": [{"repo": "api", "language": "python", "status": "ok", "mode": "run"}]}
+        ),
         encoding="utf-8",
     )
     policy.write_text(json.dumps({"decision": "SHIP"}), encoding="utf-8")
@@ -364,7 +391,9 @@ def test_cli_batch_run(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     schema.write_text(
-        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        json.dumps(
+            {"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}
+        ),
         encoding="utf-8",
     )
     adapters.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
@@ -441,7 +470,9 @@ def test_cli_batch_run_accepts_string_policy_overrides(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     schema.write_text(
-        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        json.dumps(
+            {"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}
+        ),
         encoding="utf-8",
     )
     adapters.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
@@ -455,7 +486,7 @@ def test_cli_batch_run_accepts_string_policy_overrides(tmp_path: Path) -> None:
                         "schema": str(schema),
                         "adapters": str(adapters),
                         "run": False,
-                        "policy_overrides": "{\"max_risk_score\": 0}",
+                        "policy_overrides": '{"max_risk_score": 0}',
                     }
                 ]
             }
@@ -490,7 +521,12 @@ def test_cli_impact_plan_and_control_tower(tmp_path: Path) -> None:
             {
                 "repos": [
                     {"name": "contracts", "path": "repos/contracts", "language": "go"},
-                    {"name": "api", "path": "repos/api", "language": "python", "depends_on": ["contracts"]},
+                    {
+                        "name": "api",
+                        "path": "repos/api",
+                        "language": "python",
+                        "depends_on": ["contracts"],
+                    },
                 ]
             }
         ),
@@ -533,10 +569,33 @@ def test_portfolio_outputs_match_committed_goldens(tmp_path: Path) -> None:
     schema = tmp_path / "schema.json"
     adapters = tmp_path / "adapters.json"
     out_dir = tmp_path / "pipeline-out"
-    graph.write_text(json.dumps({"repos": [{"name": "api", "path": "repos/api", "language": "python"}]}), encoding="utf-8")
-    schema.write_text(json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}), encoding="utf-8")
+    graph.write_text(
+        json.dumps({"repos": [{"name": "api", "path": "repos/api", "language": "python"}]}),
+        encoding="utf-8",
+    )
+    schema.write_text(
+        json.dumps(
+            {"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}
+        ),
+        encoding="utf-8",
+    )
     adapters.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
-    assert main(["run-pipeline", "--repo-graph", str(graph), "--schema", str(schema), "--adapters", str(adapters), "--out-dir", str(out_dir)]) == 0
+    assert (
+        main(
+            [
+                "run-pipeline",
+                "--repo-graph",
+                str(graph),
+                "--schema",
+                str(schema),
+                "--adapters",
+                str(adapters),
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        == 0
+    )
 
     execution = json.loads((out_dir / "execution.json").read_text(encoding="utf-8"))
     for row in execution.get("results", []):
@@ -546,7 +605,9 @@ def test_portfolio_outputs_match_committed_goldens(tmp_path: Path) -> None:
                     row[key] = "<redacted>"
             if isinstance(row.get("heartbeats"), list):
                 row["heartbeats"] = ["<redacted>"]
-    assert execution == json.loads((GOLDEN_DIR / "portfolio_execution.json").read_text(encoding="utf-8"))
+    assert execution == json.loads(
+        (GOLDEN_DIR / "portfolio_execution.json").read_text(encoding="utf-8")
+    )
 
     policy = json.loads((out_dir / "policy.json").read_text(encoding="utf-8"))
     assert policy == json.loads((GOLDEN_DIR / "portfolio_policy.json").read_text(encoding="utf-8"))
@@ -554,7 +615,19 @@ def test_portfolio_outputs_match_committed_goldens(tmp_path: Path) -> None:
     manifest = tmp_path / "batch.json"
     batch_out = tmp_path / "batch-out"
     manifest.write_text(
-        json.dumps({"portfolios": [{"name": "p1", "repo_graph": str(graph), "schema": str(schema), "adapters": str(adapters), "run": False}]}),
+        json.dumps(
+            {
+                "portfolios": [
+                    {
+                        "name": "p1",
+                        "repo_graph": str(graph),
+                        "schema": str(schema),
+                        "adapters": str(adapters),
+                        "run": False,
+                    }
+                ]
+            }
+        ),
         encoding="utf-8",
     )
     assert main(["batch-run", "--manifest", str(manifest), "--out-dir", str(batch_out)]) == 0
@@ -563,4 +636,6 @@ def test_portfolio_outputs_match_committed_goldens(tmp_path: Path) -> None:
         for item in summary["summaries"]:
             if isinstance(item, dict):
                 item["telemetry"] = {"timings_ms": "<redacted>"}
-    assert summary == json.loads((GOLDEN_DIR / "portfolio_batch_summary.json").read_text(encoding="utf-8"))
+    assert summary == json.loads(
+        (GOLDEN_DIR / "portfolio_batch_summary.json").read_text(encoding="utf-8")
+    )

--- a/tests/test_portfolio_orchestrator_cli.py
+++ b/tests/test_portfolio_orchestrator_cli.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from sdetkit.portfolio_orchestrator import main
 
+GOLDEN_DIR = Path(__file__).with_name("golden")
+
 
 def _sample_graph() -> dict[str, object]:
     return {
@@ -524,3 +526,41 @@ def test_cli_cancel_worker_registry(tmp_path: Path) -> None:
     cancel_file = tmp_path / "cancel.txt"
     assert main(["cancel-worker", "--target", "api", "--cancel-file", str(cancel_file)]) == 0
     assert "api" in cancel_file.read_text(encoding="utf-8")
+
+
+def test_portfolio_outputs_match_committed_goldens(tmp_path: Path) -> None:
+    graph = tmp_path / "graph.json"
+    schema = tmp_path / "schema.json"
+    adapters = tmp_path / "adapters.json"
+    out_dir = tmp_path / "pipeline-out"
+    graph.write_text(json.dumps({"repos": [{"name": "api", "path": "repos/api", "language": "python"}]}), encoding="utf-8")
+    schema.write_text(json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}), encoding="utf-8")
+    adapters.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
+    assert main(["run-pipeline", "--repo-graph", str(graph), "--schema", str(schema), "--adapters", str(adapters), "--out-dir", str(out_dir)]) == 0
+
+    execution = json.loads((out_dir / "execution.json").read_text(encoding="utf-8"))
+    for row in execution.get("results", []):
+        if isinstance(row, dict):
+            for key in ("run_id", "started_at", "finished_at", "lease_id"):
+                if key in row:
+                    row[key] = "<redacted>"
+            if isinstance(row.get("heartbeats"), list):
+                row["heartbeats"] = ["<redacted>"]
+    assert execution == json.loads((GOLDEN_DIR / "portfolio_execution.json").read_text(encoding="utf-8"))
+
+    policy = json.loads((out_dir / "policy.json").read_text(encoding="utf-8"))
+    assert policy == json.loads((GOLDEN_DIR / "portfolio_policy.json").read_text(encoding="utf-8"))
+
+    manifest = tmp_path / "batch.json"
+    batch_out = tmp_path / "batch-out"
+    manifest.write_text(
+        json.dumps({"portfolios": [{"name": "p1", "repo_graph": str(graph), "schema": str(schema), "adapters": str(adapters), "run": False}]}),
+        encoding="utf-8",
+    )
+    assert main(["batch-run", "--manifest", str(manifest), "--out-dir", str(batch_out)]) == 0
+    summary = json.loads((batch_out / "batch-summary.json").read_text(encoding="utf-8"))
+    if isinstance(summary.get("summaries"), list):
+        for item in summary["summaries"]:
+            if isinstance(item, dict):
+                item["telemetry"] = {"timings_ms": "<redacted>"}
+    assert summary == json.loads((GOLDEN_DIR / "portfolio_batch_summary.json").read_text(encoding="utf-8"))

--- a/tests/test_portfolio_orchestrator_cli.py
+++ b/tests/test_portfolio_orchestrator_cli.py
@@ -427,6 +427,43 @@ def test_cli_batch_run(tmp_path: Path) -> None:
     assert (out_dir / "batch-dashboard.html").exists()
 
 
+def test_cli_batch_run_accepts_string_policy_overrides(tmp_path: Path) -> None:
+    graph = tmp_path / "graph.json"
+    schema = tmp_path / "schema.json"
+    adapters = tmp_path / "adapters.json"
+    manifest = tmp_path / "batch.json"
+    out_dir = tmp_path / "batch-out"
+    graph.write_text(
+        json.dumps({"repos": [{"name": "api", "path": "repos/api", "language": "python"}]}),
+        encoding="utf-8",
+    )
+    schema.write_text(
+        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        encoding="utf-8",
+    )
+    adapters.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
+    manifest.write_text(
+        json.dumps(
+            {
+                "portfolios": [
+                    {
+                        "name": "p1",
+                        "repo_graph": str(graph),
+                        "schema": str(schema),
+                        "adapters": str(adapters),
+                        "run": False,
+                        "policy_overrides": "{\"max_risk_score\": 0}",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert main(["batch-run", "--manifest", str(manifest), "--out-dir", str(out_dir)]) == 0
+    policy = json.loads((out_dir / "p1" / "policy.json").read_text(encoding="utf-8"))
+    assert policy["decision"] == "NO_SHIP"
+
+
 def test_cli_impact_plan_and_control_tower(tmp_path: Path) -> None:
     graph = tmp_path / "graph.json"
     changes = tmp_path / "changed.txt"

--- a/tests/test_portfolio_orchestrator_cli.py
+++ b/tests/test_portfolio_orchestrator_cli.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.portfolio_orchestrator import main
+
+
+def _sample_graph() -> dict[str, object]:
+    return {
+        "repos": [
+            {"name": "api", "path": "repos/api", "language": "python", "priority": 10},
+            {"name": "web", "path": "repos/web", "language": "node", "priority": 40, "depends_on": ["api"]},
+        ]
+    }
+
+
+def test_cli_validate_and_orchestrate(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graph.json"
+    schema_path = tmp_path / "schema.json"
+    out_path = tmp_path / "plan.json"
+    graph_path.write_text(json.dumps(_sample_graph()), encoding="utf-8")
+    schema_path.write_text(
+        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        encoding="utf-8",
+    )
+    assert main(["validate-graph", "--repo-graph", str(graph_path), "--schema", str(schema_path)]) == 0
+    assert (
+        main(
+            [
+                "orchestrate",
+                "--repo-graph",
+                str(graph_path),
+                "--schema",
+                str(schema_path),
+                "--max-workers",
+                "2",
+                "--out",
+                str(out_path),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+    assert payload["repos"] == 2
+
+
+def test_cli_score_execution(tmp_path: Path) -> None:
+    results_path = tmp_path / "results.json"
+    out_path = tmp_path / "score.json"
+    results_path.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {"repo": "api", "status": "ok"},
+                    {"repo": "web", "status": "fail"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert main(["score-execution", "--results", str(results_path), "--out", str(out_path)]) == 0
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["recommendation"] == "NO_SHIP"
+
+
+def test_cli_report_generation(tmp_path: Path) -> None:
+    plan_path = tmp_path / "plan.json"
+    risk_path = tmp_path / "risk.json"
+    score_path = tmp_path / "score.json"
+    out_path = tmp_path / "report.md"
+    plan_path.write_text(json.dumps({"repos": 2, "max_workers": 2}), encoding="utf-8")
+    risk_path.write_text(
+        json.dumps({"portfolio_risk_score": 80, "recommendation": "SHIP_WITH_CONTROLS"}),
+        encoding="utf-8",
+    )
+    score_path.write_text(
+        json.dumps({"execution_reliability_score": 95, "recommendation": "SHIP_WITH_CONTROLS"}),
+        encoding="utf-8",
+    )
+    assert (
+        main(
+            [
+                "report",
+                "--plan",
+                str(plan_path),
+                "--risk",
+                str(risk_path),
+                "--score",
+                str(score_path),
+                "--out",
+                str(out_path),
+            ]
+        )
+        == 0
+    )
+    report = out_path.read_text(encoding="utf-8")
+    assert "Portfolio Orchestration Report" in report
+
+
+def test_cli_analyze_plan(tmp_path: Path) -> None:
+    plan_path = tmp_path / "plan.json"
+    out_path = tmp_path / "analysis.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "execution_plan": [
+                    {"repo": "contracts", "depends_on": []},
+                    {"repo": "api", "depends_on": ["contracts"]},
+                    {"repo": "web", "depends_on": ["api"]},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert main(["analyze-plan", "--plan", str(plan_path), "--out", str(out_path)]) == 0
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["critical_path_length"] == 3
+
+
+def test_cli_run_pipeline(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graph.json"
+    schema_path = tmp_path / "schema.json"
+    adapters_path = tmp_path / "adapters.json"
+    out_dir = tmp_path / "pipeline"
+    graph_path.write_text(
+        json.dumps(
+            {
+                "repos": [
+                    {"name": "contracts", "path": "repos/contracts", "language": "go"},
+                    {"name": "api", "path": "repos/api", "language": "python", "depends_on": ["contracts"]},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    schema_path.write_text(
+        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        encoding="utf-8",
+    )
+    adapters_path.write_text(
+        json.dumps({"python": ["echo", "py", "{repo_path}"], "go": ["echo", "go", "{repo_path}"]}),
+        encoding="utf-8",
+    )
+    assert (
+        main(
+            [
+                "run-pipeline",
+                "--repo-graph",
+                str(graph_path),
+                "--schema",
+                str(schema_path),
+                "--adapters",
+                str(adapters_path),
+                "--max-workers",
+                "2",
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        == 0
+    )
+    assert (out_dir / "plan.json").exists()
+    assert (out_dir / "risk.json").exists()
+    assert (out_dir / "execution.json").exists()
+    assert (out_dir / "score.json").exists()
+    assert (out_dir / "analysis.json").exists()
+    assert (out_dir / "report.md").exists()
+    assert (out_dir / "policy.json").exists()
+    assert (out_dir / "history-trend.json").exists()
+    assert (out_dir / "dashboard.html").exists()
+
+
+def test_cli_run_pipeline_with_run_mode(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graph.json"
+    schema_path = tmp_path / "schema.json"
+    adapters_path = tmp_path / "adapters.json"
+    out_dir = tmp_path / "pipeline-run"
+    graph_path.write_text(
+        json.dumps({"repos": [{"name": "api", "path": "repos/api", "language": "python"}]}),
+        encoding="utf-8",
+    )
+    schema_path.write_text(
+        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        encoding="utf-8",
+    )
+    adapters_path.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
+    assert (
+        main(
+            [
+                "run-pipeline",
+                "--repo-graph",
+                str(graph_path),
+                "--schema",
+                str(schema_path),
+                "--adapters",
+                str(adapters_path),
+                "--max-workers",
+                "1",
+                "--run",
+                "--timeout-seconds",
+                "30",
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        == 0
+    )
+    execution = json.loads((out_dir / "execution.json").read_text(encoding="utf-8"))
+    assert execution["ok"] is True
+
+
+def test_cli_evaluate_policy(tmp_path: Path) -> None:
+    risk_path = tmp_path / "risk.json"
+    score_path = tmp_path / "score.json"
+    execution_path = tmp_path / "execution.json"
+    policy_path = tmp_path / "policy.json"
+    out_path = tmp_path / "decision.json"
+    risk_path.write_text(json.dumps({"portfolio_risk_score": 90}), encoding="utf-8")
+    score_path.write_text(json.dumps({"execution_reliability_score": 60}), encoding="utf-8")
+    execution_path.write_text(
+        json.dumps({"failure_count": 2, "stopped_early": True}),
+        encoding="utf-8",
+    )
+    policy_path.write_text(
+        json.dumps(
+            {
+                "name": "strict",
+                "max_risk_score": 30,
+                "min_execution_reliability": 90,
+                "max_failures": 0,
+                "allow_stopped_early": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert (
+        main(
+            [
+                "evaluate-policy",
+                "--risk",
+                str(risk_path),
+                "--score",
+                str(score_path),
+                "--execution",
+                str(execution_path),
+                "--policy",
+                str(policy_path),
+                "--out",
+                str(out_path),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["decision"] == "NO_SHIP"
+
+
+def test_cli_history_trend(tmp_path: Path) -> None:
+    history = tmp_path / "history.jsonl"
+    history.write_text(
+        "\n".join(
+            [
+                json.dumps({"decision": "SHIP", "risk_score": 20}),
+                json.dumps({"decision": "NO_SHIP", "risk_score": 50}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "trend.json"
+    assert main(["history-trend", "--history", str(history), "--out", str(out)]) == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["runs"] == 2
+
+
+def test_cli_dashboard(tmp_path: Path) -> None:
+    plan = tmp_path / "plan.json"
+    risk = tmp_path / "risk.json"
+    score = tmp_path / "score.json"
+    execution = tmp_path / "execution.json"
+    policy = tmp_path / "policy.json"
+    out = tmp_path / "dashboard.html"
+    plan.write_text(json.dumps({"repos": 2, "max_workers": 2}), encoding="utf-8")
+    risk.write_text(json.dumps({"portfolio_risk_score": 30}), encoding="utf-8")
+    score.write_text(json.dumps({"execution_reliability_score": 90}), encoding="utf-8")
+    execution.write_text(
+        json.dumps({"results": [{"repo": "api", "language": "python", "status": "ok", "mode": "run"}]}),
+        encoding="utf-8",
+    )
+    policy.write_text(json.dumps({"decision": "SHIP"}), encoding="utf-8")
+    assert (
+        main(
+            [
+                "dashboard",
+                "--plan",
+                str(plan),
+                "--risk",
+                str(risk),
+                "--score",
+                str(score),
+                "--execution",
+                str(execution),
+                "--policy",
+                str(policy),
+                "--out",
+                str(out),
+            ]
+        )
+        == 0
+    )
+    html = out.read_text(encoding="utf-8")
+    assert "Portfolio Orchestration Dashboard" in html
+
+
+def test_cli_batch_run(tmp_path: Path) -> None:
+    manifest = tmp_path / "batch.json"
+    out_dir = tmp_path / "batch-out"
+    graph = tmp_path / "graph.json"
+    schema = tmp_path / "schema.json"
+    adapters = tmp_path / "adapters.json"
+    policy = tmp_path / "policy.json"
+    graph.write_text(
+        json.dumps({"repos": [{"name": "api", "path": "repos/api", "language": "python"}]}),
+        encoding="utf-8",
+    )
+    schema.write_text(
+        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        encoding="utf-8",
+    )
+    adapters.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
+    policy.write_text(
+        json.dumps(
+            {
+                "name": "default-enterprise",
+                "max_risk_score": 100,
+                "min_execution_reliability": 0,
+                "max_failures": 10,
+                "allow_stopped_early": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest.write_text(
+        json.dumps(
+            {
+                "portfolios": [
+                    {
+                        "name": "p1",
+                        "repo_graph": str(graph),
+                        "schema": str(schema),
+                        "adapters": str(adapters),
+                        "policy": str(policy),
+                        "max_workers": 1,
+                        "run": False,
+                    },
+                    {
+                        "name": "p2",
+                        "repo_graph": str(graph),
+                        "schema": str(schema),
+                        "adapters": str(adapters),
+                        "policy": str(policy),
+                        "max_workers": 1,
+                        "run": False,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert (
+        main(
+            [
+                "batch-run",
+                "--manifest",
+                str(manifest),
+                "--max-parallel",
+                "2",
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        == 0
+    )
+    summary = json.loads((out_dir / "batch-summary.json").read_text(encoding="utf-8"))
+    assert summary["portfolios"] == 2
+    assert (out_dir / "p1" / "dashboard.html").exists()
+    assert (out_dir / "p2" / "dashboard.html").exists()
+    assert (out_dir / "batch-report.md").exists()
+    assert (out_dir / "batch-dashboard.html").exists()
+
+
+def test_cli_impact_plan_and_control_tower(tmp_path: Path) -> None:
+    graph = tmp_path / "graph.json"
+    changes = tmp_path / "changed.txt"
+    out = tmp_path / "impact-plan.json"
+    history = tmp_path / "batch-history.jsonl"
+    tower = tmp_path / "tower.json"
+    graph.write_text(
+        json.dumps(
+            {
+                "repos": [
+                    {"name": "contracts", "path": "repos/contracts", "language": "go"},
+                    {"name": "api", "path": "repos/api", "language": "python", "depends_on": ["contracts"]},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    changes.write_text("repos/contracts/schema.proto\n", encoding="utf-8")
+    assert (
+        main(
+            [
+                "impact-plan",
+                "--repo-graph",
+                str(graph),
+                "--changed-files",
+                str(changes),
+                "--out",
+                str(out),
+            ]
+        )
+        == 0
+    )
+    impact = json.loads(out.read_text(encoding="utf-8"))
+    assert impact["repos"] == 2
+    history.write_text(
+        json.dumps({"decision": "SHIP", "risk_score": 20}) + "\n",
+        encoding="utf-8",
+    )
+    assert main(["batch-control-tower", "--history", str(history), "--out", str(tower)]) == 0
+    tower_payload = json.loads(tower.read_text(encoding="utf-8"))
+    assert tower_payload["control_tower"]["runs"] == 1
+
+
+def test_cli_cancel_worker_registry(tmp_path: Path) -> None:
+    cancel_file = tmp_path / "cancel.txt"
+    assert main(["cancel-worker", "--target", "api", "--cancel-file", str(cancel_file)]) == 0
+    assert "api" in cancel_file.read_text(encoding="utf-8")

--- a/tests/test_portfolio_orchestrator_cli.py
+++ b/tests/test_portfolio_orchestrator_cli.py
@@ -421,6 +421,7 @@ def test_cli_batch_run(tmp_path: Path) -> None:
     )
     summary = json.loads((out_dir / "batch-summary.json").read_text(encoding="utf-8"))
     assert summary["portfolios"] == 2
+    assert "timings_ms" in summary["summaries"][0]["telemetry"]
     assert (out_dir / "p1" / "dashboard.html").exists()
     assert (out_dir / "p2" / "dashboard.html").exists()
     assert (out_dir / "batch-report.md").exists()

--- a/tests/test_portfolio_orchestrator_cli.py
+++ b/tests/test_portfolio_orchestrator_cli.py
@@ -211,6 +211,42 @@ def test_cli_run_pipeline_with_run_mode(tmp_path: Path) -> None:
     assert execution["ok"] is True
 
 
+def test_cli_run_pipeline_transport_option(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graph.json"
+    schema_path = tmp_path / "schema.json"
+    adapters_path = tmp_path / "adapters.json"
+    out_dir = tmp_path / "pipeline-transport"
+    graph_path.write_text(
+        json.dumps({"repos": [{"name": "api", "path": "repos/api", "language": "python"}]}),
+        encoding="utf-8",
+    )
+    schema_path.write_text(
+        json.dumps({"type": "object", "required": ["repos"], "properties": {"repos": {"type": "array"}}}),
+        encoding="utf-8",
+    )
+    adapters_path.write_text(json.dumps({"python": ["echo", "ok", "{repo_path}"]}), encoding="utf-8")
+    assert (
+        main(
+            [
+                "run-pipeline",
+                "--repo-graph",
+                str(graph_path),
+                "--schema",
+                str(schema_path),
+                "--adapters",
+                str(adapters_path),
+                "--transport",
+                "ssh",
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        == 0
+    )
+    execution = json.loads((out_dir / "execution.json").read_text(encoding="utf-8"))
+    assert execution["results"][0]["transport"] == "ssh"
+
+
 def test_cli_evaluate_policy(tmp_path: Path) -> None:
     risk_path = tmp_path / "risk.json"
     score_path = tmp_path / "score.json"


### PR DESCRIPTION
### Motivation

- Provide deterministic multi-repo orchestration and portfolio-level risk/reporting for enterprise portfolios. 
- Standardize a Worker Contract (v1) for adapters so polyglot repos can emit consistent run artifacts. 
- Offer policy profiles and batch/pipeline flows to evaluate and automate cross-repo decisions. 

### Description

- Add a new orchestrator CLI module at `src/sdetkit/portfolio_orchestrator.py` that supports `orchestrate`, `validate-graph`, `risk-report`, `execute`, `score-execution`, `report`, `analyze-plan`, `run-pipeline`, `evaluate-policy`, `history-trend`, `dashboard`, `batch-run`, `impact-plan`, `batch-control-tower`, and `cancel-worker` operations. 
- Wire CLI passthrough in `src/sdetkit/cli.py` with the top-level `portfolio-orchestrate` entry and new `main` dispatch for the orchestrator. 
- Add repository graph schema `schemas/repo-graph.schema.json`, example topology `examples/topology/enterprise-repo-graph.sample.json`, batch manifest sample, adapter registry `config/portfolio_adapters.json`, policy defaults `config/portfolio_policy.default.json` and `config/portfolio_policy.packs.json`. 
- Add docs and reference material: `docs/contracts/worker-contract-v1.md`, `docs/top-tier-upgrade-cycle-plan.md`, and README updates showing sample portfolio orchestrate commands and Worker Contract-style execution rows. 
- Add adapter README stubs for Node and Go in `adapters/node/README.md` and `adapters/go/README.md`. 
- Implement artifact/history helpers, risk scoring, execution scoring, policy resolution/evaluation, plan analysis, dashboard/report rendering, cancel registry, and plan impact calculation in the orchestrator. 
- Add comprehensive unit and CLI tests under `tests/` to cover plan building, execution flows, adapter registry resolution, policy evaluation, pipeline run, batch runs, impact analysis, dashboard/report generation, and CLI passthrough. 

### Testing

- Ran the added test suite using the new tests under `tests/` including `tests/test_portfolio_orchestrator.py`, `tests/test_portfolio_orchestrator_cli.py`, and `tests/test_cli_portfolio_passthrough.py` with `pytest`; all new tests completed successfully. 
- Exercised pipeline flows via tests that run `main()` entrypoints for `orchestrate`, `validate-graph`, `run-pipeline`, `score-execution`, `report`, `analyze-plan`, `evaluate-policy`, `history-trend`, `dashboard`, `batch-run`, `impact-plan`, and `cancel-worker`; artifacts were generated as expected and assertions passed. 
- Verified adapter registry loading and template substitution via unit tests and confirmed dry-run vs run behaviors, retry semantics, cancel targets, and early-stop (`max_failures`) logic succeeded in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67a1c8c1c8332a0e9fc61e36a0c0d)