### PR TITLE
Add mission-control evidence bundle

### DIFF
--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -1,0 +1,34 @@
+# Mission Control
+
+Mission Control is the canonical release-confidence evidence bundle for SDETKit.
+
+Use it when you want one deterministic operator-facing starting point before running the deeper gates, diagnostics, review, and readiness commands.
+
+```bash
+python -m sdetkit mission-control run --out-dir build/mission-control
+```
+
+The command writes:
+
+```text
+build/mission-control/mission-control.json
+build/mission-control/mission-control.md
+```
+
+The JSON bundle contains the schema version, repository identity, decision, risk band, workflow steps, findings, artifact index, and recommended next actions.
+
+```bash
+python -m sdetkit mission-control summarize --bundle build/mission-control/mission-control.json
+```
+
+The first Mission Control release is intentionally lightweight. It creates a stable evidence contract and points operators to the existing public release-confidence surfaces:
+
+```text
+gate fast
+gate release
+doctor
+review
+readiness
+```
+
+The release-room step is listed as a planned future public surface so the bundle can represent the full operator path before that command is promoted.

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -261,6 +261,19 @@ Then use stability-aware command discovery:
         help_text="[Public / stable] Deterministic repo and release-readiness checks",
     )
 
+    mission_control_parser = sub.add_parser(
+        "mission-control",
+        help="[Public / stable] Unified release-confidence evidence bundle",
+        add_help=False,
+    )
+    mission_control_parser.add_argument(
+        "-h",
+        "--help",
+        action="store_true",
+        dest="mission_control_help",
+    )
+    mission_control_parser.add_argument("args", nargs=argparse.REMAINDER)
+
     _add_passthrough_subcommand(
         sub,
         "gate",
@@ -878,6 +891,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if ns.cmd == "release":
         return dispatch_release_subcommand(ns.args, run_module_main=_run_module_main)
+
+    if ns.cmd == "mission-control":
+        forwarded = list(ns.args)
+        if bool(getattr(ns, "mission_control_help", False)):
+            forwarded.insert(0, "--help")
+        return _run_module_main("sdetkit.mission_control", forwarded)
 
     if ns.cmd == "inspect":
         return _run_module_main("sdetkit.inspect_data", build_inspect_forwarded_args(ns, ns.args))

--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -4,10 +4,10 @@ import argparse
 import json
 import subprocess
 import sys
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Sequence
-
+from typing import Any
 
 SCHEMA_VERSION = "1"
 
@@ -23,8 +23,7 @@ def _run_text(args: Sequence[str], *, cwd: Path) -> tuple[int, str]:
             cwd=str(cwd),
             check=False,
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
         )
     except OSError as exc:
         return 127, str(exc)

--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+
+SCHEMA_VERSION = "1"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _run_text(args: Sequence[str], *, cwd: Path) -> tuple[int, str]:
+    try:
+        completed = subprocess.run(
+            list(args),
+            cwd=str(cwd),
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as exc:
+        return 127, str(exc)
+    output = completed.stdout.strip() or completed.stderr.strip()
+    return completed.returncode, output
+
+
+def _git_value(repo: Path, args: Sequence[str], fallback: str) -> str:
+    rc, output = _run_text(["git", *args], cwd=repo)
+    if rc != 0 or not output:
+        return fallback
+    return output.splitlines()[0].strip() or fallback
+
+
+def _git_dirty(repo: Path) -> bool:
+    rc, output = _run_text(["git", "status", "--short"], cwd=repo)
+    return rc == 0 and bool(output.strip())
+
+
+def _command_steps() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "gate_fast",
+            "label": "Fast release confidence gate",
+            "command": "python -m sdetkit gate fast",
+            "status": "ready",
+            "tier": "public_stable",
+        },
+        {
+            "id": "gate_release",
+            "label": "Strict release confidence gate",
+            "command": "python -m sdetkit gate release",
+            "status": "ready",
+            "tier": "public_stable",
+        },
+        {
+            "id": "doctor",
+            "label": "Repository and release-readiness diagnostics",
+            "command": "python -m sdetkit doctor",
+            "status": "ready",
+            "tier": "public_stable",
+        },
+        {
+            "id": "review",
+            "label": "Operator review workflow",
+            "command": "python -m sdetkit review . --profile release --format operator-json",
+            "status": "ready",
+            "tier": "public_stable",
+        },
+        {
+            "id": "readiness",
+            "label": "Production readiness scorecard",
+            "command": "python -m sdetkit readiness",
+            "status": "ready",
+            "tier": "public_stable",
+        },
+        {
+            "id": "release_room",
+            "label": "Release-room plan",
+            "command": "python -m sdetkit release-room",
+            "status": "planned",
+            "tier": "future_public_surface",
+        },
+    ]
+
+
+def _artifact(path: Path, label: str, kind: str) -> dict[str, str]:
+    return {
+        "label": label,
+        "kind": kind,
+        "path": path.as_posix(),
+    }
+
+
+def build_bundle(repo: Path, out_dir: Path) -> dict[str, Any]:
+    repo = repo.resolve()
+    out_dir = out_dir.resolve()
+    generated_at = _utc_now()
+    branch = _git_value(repo, ["branch", "--show-current"], "unknown")
+    commit = _git_value(repo, ["rev-parse", "HEAD"], "unknown")
+    dirty = _git_dirty(repo)
+
+    steps = _command_steps()
+    findings = []
+    if dirty:
+        findings.append(
+            {
+                "severity": "warning",
+                "code": "WORKTREE_DIRTY",
+                "message": "Working tree has uncommitted changes.",
+            }
+        )
+
+    next_actions = [
+        {
+            "id": "run_fast_gate",
+            "command": "python -m sdetkit gate fast",
+            "reason": "Check fast release-confidence feedback first.",
+        },
+        {
+            "id": "run_release_gate",
+            "command": "python -m sdetkit gate release",
+            "reason": "Run strict release gate before operator signoff.",
+        },
+        {
+            "id": "run_doctor",
+            "command": "python -m sdetkit doctor",
+            "reason": "Collect deterministic repository diagnostics.",
+        },
+    ]
+
+    decision = "SHIP_WITH_FINDINGS" if findings else "SHIP"
+    risk_band = "medium" if findings else "low"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": generated_at,
+        "ok": True,
+        "decision": decision,
+        "risk_band": risk_band,
+        "repo": {
+            "path": repo.as_posix(),
+            "branch": branch,
+            "commit": commit,
+            "dirty": dirty,
+        },
+        "steps": steps,
+        "findings": findings,
+        "artifacts": [
+            _artifact(out_dir / "mission-control.json", "Mission Control JSON bundle", "json"),
+            _artifact(out_dir / "mission-control.md", "Mission Control operator brief", "markdown"),
+        ],
+        "next_actions": next_actions,
+    }
+
+
+def render_markdown(bundle: dict[str, Any]) -> str:
+    repo = bundle["repo"]
+    lines = [
+        "# Mission Control",
+        "",
+        f"Generated: {bundle['generated_at_utc']}",
+        f"Decision: {bundle['decision']}",
+        f"Risk band: {bundle['risk_band']}",
+        f"Repository: {repo['path']}",
+        f"Branch: {repo['branch']}",
+        f"Commit: {repo['commit']}",
+        f"Dirty: {str(repo['dirty']).lower()}",
+        "",
+        "## Steps",
+        "",
+    ]
+
+    for step in bundle["steps"]:
+        lines.append(f"- {step['id']}: {step['status']} - `{step['command']}`")
+
+    lines.extend(["", "## Findings", ""])
+
+    if bundle["findings"]:
+        for finding in bundle["findings"]:
+            lines.append(f"- {finding['severity']}: {finding['code']} - {finding['message']}")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Next actions", ""])
+
+    for action in bundle["next_actions"]:
+        lines.append(f"- {action['id']}: `{action['command']}`")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_bundle(bundle: dict[str, Any], out_dir: Path) -> tuple[Path, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "mission-control.json"
+    md_path = out_dir / "mission-control.md"
+    json_path.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_path.write_text(render_markdown(bundle), encoding="utf-8")
+    return json_path, md_path
+
+
+def _run(args: argparse.Namespace) -> int:
+    repo = Path(args.repo)
+    out_dir = Path(args.out_dir)
+    bundle = build_bundle(repo, out_dir)
+    json_path, md_path = write_bundle(bundle, out_dir)
+    print(f"wrote {json_path}")
+    print(f"wrote {md_path}")
+    print(f"decision={bundle['decision']} risk_band={bundle['risk_band']}")
+    return 0
+
+
+def _summarize(args: argparse.Namespace) -> int:
+    path = Path(args.bundle)
+    bundle = json.loads(path.read_text(encoding="utf-8"))
+    print(f"decision={bundle['decision']}")
+    print(f"risk_band={bundle['risk_band']}")
+    print(f"repo={bundle['repo']['path']}")
+    print(f"steps={len(bundle['steps'])}")
+    print(f"findings={len(bundle['findings'])}")
+    return 0
+
+
+def _schema(_: argparse.Namespace) -> int:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "required_top_level_keys": [
+            "schema_version",
+            "generated_at_utc",
+            "ok",
+            "decision",
+            "risk_band",
+            "repo",
+            "steps",
+            "findings",
+            "artifacts",
+            "next_actions",
+        ],
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit mission-control",
+        description="Create a deterministic release-confidence evidence bundle.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    run = sub.add_parser("run", help="Write mission-control.json and mission-control.md")
+    run.add_argument("--repo", default=".")
+    run.add_argument("--out-dir", default="build/mission-control")
+    run.set_defaults(func=_run)
+
+    summarize = sub.add_parser("summarize", help="Summarize a mission-control.json bundle")
+    summarize.add_argument("--bundle", required=True)
+    summarize.set_defaults(func=_summarize)
+
+    schema = sub.add_parser("schema", help="Print the Mission Control bundle schema summary")
+    schema.set_defaults(func=_schema)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    ns = parser.parse_args(list(sys.argv[1:] if argv is None else argv))
+    return int(ns.func(ns))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mission_control.py
+++ b/tests/test_mission_control.py
@@ -1,8 +1,8 @@
 import json
 
 import pytest
-from sdetkit import cli
-from sdetkit import mission_control
+
+from sdetkit import cli, mission_control
 
 
 def test_mission_control_run_writes_json_and_markdown(tmp_path):

--- a/tests/test_mission_control.py
+++ b/tests/test_mission_control.py
@@ -1,0 +1,107 @@
+import json
+
+import pytest
+from sdetkit import cli
+from sdetkit import mission_control
+
+
+def test_mission_control_run_writes_json_and_markdown(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+
+    rc = mission_control.main(["run", "--repo", str(repo), "--out-dir", str(out_dir)])
+
+    assert rc == 0
+
+    bundle_path = out_dir / "mission-control.json"
+    brief_path = out_dir / "mission-control.md"
+
+    assert bundle_path.exists()
+    assert brief_path.exists()
+
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+
+    assert bundle["schema_version"] == "1"
+    assert bundle["ok"] is True
+    assert bundle["decision"] == "SHIP"
+    assert bundle["risk_band"] == "low"
+    assert bundle["repo"]["path"] == repo.resolve().as_posix()
+    assert bundle["repo"]["branch"] == "unknown"
+    assert bundle["repo"]["commit"] == "unknown"
+    assert bundle["repo"]["dirty"] is False
+    assert [step["id"] for step in bundle["steps"]] == [
+        "gate_fast",
+        "gate_release",
+        "doctor",
+        "review",
+        "readiness",
+        "release_room",
+    ]
+    assert bundle["steps"][-1]["status"] == "planned"
+    assert bundle["findings"] == []
+    assert [artifact["path"] for artifact in bundle["artifacts"]] == [
+        (out_dir.resolve() / "mission-control.json").as_posix(),
+        (out_dir.resolve() / "mission-control.md").as_posix(),
+    ]
+
+    brief = brief_path.read_text(encoding="utf-8")
+    assert "# Mission Control" in brief
+    assert "Decision: SHIP" in brief
+    assert "gate_fast" in brief
+    assert "release_room" in brief
+
+
+def test_mission_control_summarize_prints_stable_counts(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+
+    assert mission_control.main(["run", "--repo", str(repo), "--out-dir", str(out_dir)]) == 0
+
+    capsys.readouterr()
+
+    rc = mission_control.main(["summarize", "--bundle", str(out_dir / "mission-control.json")])
+
+    assert rc == 0
+
+    output = capsys.readouterr().out
+    assert "decision=SHIP" in output
+    assert "risk_band=low" in output
+    assert "steps=6" in output
+    assert "findings=0" in output
+
+
+def test_mission_control_schema_lists_required_top_level_keys(capsys):
+    rc = mission_control.main(["schema"])
+
+    assert rc == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "1"
+    assert "decision" in payload["required_top_level_keys"]
+    assert "next_actions" in payload["required_top_level_keys"]
+
+
+def test_root_cli_dispatches_mission_control(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+
+    rc = cli.main(["mission-control", "run", "--repo", str(repo), "--out-dir", str(out_dir)])
+
+    assert rc == 0
+    assert (out_dir / "mission-control.json").exists()
+    assert (out_dir / "mission-control.md").exists()
+
+def test_root_cli_forwards_mission_control_help(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["mission-control", "--help"])
+
+    assert exc.value.code == 0
+
+    output = capsys.readouterr().out
+    assert "sdetkit mission-control" in output
+    assert "run" in output
+    assert "summarize" in output
+    assert "schema" in output

--- a/tests/test_mission_control.py
+++ b/tests/test_mission_control.py
@@ -94,6 +94,7 @@ def test_root_cli_dispatches_mission_control(tmp_path):
     assert (out_dir / "mission-control.json").exists()
     assert (out_dir / "mission-control.md").exists()
 
+
 def test_root_cli_forwards_mission_control_help(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["mission-control", "--help"])


### PR DESCRIPTION
Adds a public mission-control command that writes a deterministic release-confidence evidence bundle.

Includes:
- mission-control run
- mission-control summarize
- mission-control schema
- JSON and Markdown evidence outputs
- root CLI forwarding and help behavior
- targeted regression tests
- Mission Control docs

Validation:
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control --help
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control run --out-dir build/mission-control-smoke
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control summarize --bundle build/mission-control-smoke/mission-control.json
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control schema
- python3 -S -m py_compile src/sdetkit/mission_control.py src/sdetkit/cli.py