### PR TITLE
Add executable mission-control mode

### DIFF
--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -32,3 +32,27 @@ readiness
 ```
 
 The release-room step is listed as a planned future public surface so the bundle can represent the full operator path before that command is promoted.
+
+## Executable mode
+
+Use `--execute` when you want Mission Control to run the lightweight public gates and capture their stdout/stderr as bundle artifacts.
+
+```bash
+python -m sdetkit mission-control run --execute --out-dir build/mission-control
+```
+
+By default executable mode runs:
+
+```text
+gate fast
+doctor
+readiness
+```
+
+Use `--include-release` when the stricter release gate should also be executed and archived:
+
+```bash
+python -m sdetkit mission-control run --execute --include-release --out-dir build/mission-control
+```
+
+When an executed step fails, the bundle records the failing return code, keeps the step output files, sets `ok` to false, and returns `NO_SHIP`.

--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import subprocess
 import sys
+import time
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -51,6 +52,7 @@ def _command_steps() -> list[dict[str, Any]]:
             "command": "python -m sdetkit gate fast",
             "status": "ready",
             "tier": "public_stable",
+            "executable": True,
         },
         {
             "id": "gate_release",
@@ -58,6 +60,7 @@ def _command_steps() -> list[dict[str, Any]]:
             "command": "python -m sdetkit gate release",
             "status": "ready",
             "tier": "public_stable",
+            "executable": True,
         },
         {
             "id": "doctor",
@@ -65,6 +68,7 @@ def _command_steps() -> list[dict[str, Any]]:
             "command": "python -m sdetkit doctor",
             "status": "ready",
             "tier": "public_stable",
+            "executable": True,
         },
         {
             "id": "review",
@@ -72,6 +76,7 @@ def _command_steps() -> list[dict[str, Any]]:
             "command": "python -m sdetkit review . --profile release --format operator-json",
             "status": "ready",
             "tier": "public_stable",
+            "executable": False,
         },
         {
             "id": "readiness",
@@ -79,6 +84,7 @@ def _command_steps() -> list[dict[str, Any]]:
             "command": "python -m sdetkit readiness",
             "status": "ready",
             "tier": "public_stable",
+            "executable": True,
         },
         {
             "id": "release_room",
@@ -86,8 +92,115 @@ def _command_steps() -> list[dict[str, Any]]:
             "command": "python -m sdetkit release-room",
             "status": "planned",
             "tier": "future_public_surface",
+            "executable": False,
         },
     ]
+
+
+def _execution_args(step_id: str) -> list[str]:
+    commands = {
+        "gate_fast": [sys.executable, "-m", "sdetkit", "gate", "fast"],
+        "gate_release": [sys.executable, "-m", "sdetkit", "gate", "release"],
+        "doctor": [sys.executable, "-m", "sdetkit", "doctor"],
+        "readiness": [sys.executable, "-m", "sdetkit", "readiness"],
+    }
+    return commands[step_id]
+
+
+def _selected_execute_ids(*, include_release: bool) -> set[str]:
+    selected = {"gate_fast", "doctor", "readiness"}
+    if include_release:
+        selected.add("gate_release")
+    return selected
+
+
+def _run_step_process(
+    args: Sequence[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int,
+) -> tuple[int, str, str, int]:
+    started = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            list(args),
+            cwd=str(cwd),
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        return completed.returncode, completed.stdout, completed.stderr, elapsed_ms
+    except subprocess.TimeoutExpired as exc:
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        stderr = stderr or f"timed out after {timeout_seconds}s"
+        return 124, stdout, stderr, elapsed_ms
+    except OSError as exc:
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+        return 127, "", str(exc), elapsed_ms
+
+
+def _write_step_outputs(
+    *,
+    out_dir: Path,
+    step_id: str,
+    stdout: str,
+    stderr: str,
+) -> tuple[Path, Path]:
+    step_dir = out_dir / "steps"
+    step_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = step_dir / f"{step_id}.stdout"
+    stderr_path = step_dir / f"{step_id}.stderr"
+    stdout_path.write_text(stdout, encoding="utf-8")
+    stderr_path.write_text(stderr, encoding="utf-8")
+    return stdout_path, stderr_path
+
+
+def _execute_steps(
+    *,
+    steps: list[dict[str, Any]],
+    repo: Path,
+    out_dir: Path,
+    include_release: bool,
+    timeout_seconds: int,
+) -> list[dict[str, Any]]:
+    selected = _selected_execute_ids(include_release=include_release)
+    executed_steps = []
+
+    for step in steps:
+        updated = dict(step)
+        step_id = str(step["id"])
+
+        if step_id not in selected:
+            updated["executed"] = False
+            executed_steps.append(updated)
+            continue
+
+        args = _execution_args(step_id)
+        rc, stdout, stderr, elapsed_ms = _run_step_process(
+            args,
+            cwd=repo,
+            timeout_seconds=timeout_seconds,
+        )
+        stdout_path, stderr_path = _write_step_outputs(
+            out_dir=out_dir,
+            step_id=step_id,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        updated["executed"] = True
+        updated["status"] = "passed" if rc == 0 else "failed"
+        updated["rc"] = rc
+        updated["elapsed_ms"] = elapsed_ms
+        updated["stdout_path"] = stdout_path.resolve().as_posix()
+        updated["stderr_path"] = stderr_path.resolve().as_posix()
+        executed_steps.append(updated)
+
+    return executed_steps
 
 
 def _artifact(path: Path, label: str, kind: str) -> dict[str, str]:
@@ -98,7 +211,60 @@ def _artifact(path: Path, label: str, kind: str) -> dict[str, str]:
     }
 
 
-def build_bundle(repo: Path, out_dir: Path) -> dict[str, Any]:
+def _step_artifacts(steps: Sequence[dict[str, Any]]) -> list[dict[str, str]]:
+    artifacts = []
+    for step in steps:
+        step_id = str(step["id"])
+        stdout_path = step.get("stdout_path")
+        stderr_path = step.get("stderr_path")
+        if isinstance(stdout_path, str):
+            artifacts.append(
+                {
+                    "label": f"{step_id} stdout",
+                    "kind": "stdout",
+                    "path": stdout_path,
+                }
+            )
+        if isinstance(stderr_path, str):
+            artifacts.append(
+                {
+                    "label": f"{step_id} stderr",
+                    "kind": "stderr",
+                    "path": stderr_path,
+                }
+            )
+    return artifacts
+
+
+def _execution_counts(steps: Sequence[dict[str, Any]]) -> tuple[int, int, int]:
+    executed = [step for step in steps if step.get("executed") is True]
+    passed = [step for step in executed if step.get("status") == "passed"]
+    failed = [step for step in executed if step.get("status") == "failed"]
+    return len(executed), len(passed), len(failed)
+
+
+def _execution_findings(steps: Sequence[dict[str, Any]]) -> list[dict[str, str]]:
+    findings = []
+    for step in steps:
+        if step.get("executed") is True and step.get("status") == "failed":
+            findings.append(
+                {
+                    "severity": "error",
+                    "code": "STEP_FAILED",
+                    "message": f"{step['id']} failed with rc={step.get('rc')}.",
+                }
+            )
+    return findings
+
+
+def build_bundle(
+    repo: Path,
+    out_dir: Path,
+    *,
+    execute: bool = False,
+    include_release: bool = False,
+    timeout_seconds: int = 60,
+) -> dict[str, Any]:
     repo = repo.resolve()
     out_dir = out_dir.resolve()
     generated_at = _utc_now()
@@ -107,7 +273,20 @@ def build_bundle(repo: Path, out_dir: Path) -> dict[str, Any]:
     dirty = _git_dirty(repo)
 
     steps = _command_steps()
-    findings = []
+    if execute:
+        steps = _execute_steps(
+            steps=steps,
+            repo=repo,
+            out_dir=out_dir,
+            include_release=include_release,
+            timeout_seconds=timeout_seconds,
+        )
+    else:
+        steps = [dict(step, executed=False) for step in steps]
+
+    executed_count, passed_count, failed_count = _execution_counts(steps)
+
+    findings = _execution_findings(steps)
     if dirty:
         findings.append(
             {
@@ -135,13 +314,27 @@ def build_bundle(repo: Path, out_dir: Path) -> dict[str, Any]:
         },
     ]
 
-    decision = "SHIP_WITH_FINDINGS" if findings else "SHIP"
-    risk_band = "medium" if findings else "low"
+    if failed_count:
+        decision = "NO_SHIP"
+        risk_band = "high"
+    elif findings:
+        decision = "SHIP_WITH_FINDINGS"
+        risk_band = "medium"
+    else:
+        decision = "SHIP"
+        risk_band = "low"
+
+    artifacts = [
+        _artifact(out_dir / "mission-control.json", "Mission Control JSON bundle", "json"),
+        _artifact(out_dir / "mission-control.md", "Mission Control operator brief", "markdown"),
+    ]
+    artifacts.extend(_step_artifacts(steps))
 
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at_utc": generated_at,
-        "ok": True,
+        "ok": failed_count == 0,
+        "mode": "execute" if execute else "plan",
         "decision": decision,
         "risk_band": risk_band,
         "repo": {
@@ -150,12 +343,12 @@ def build_bundle(repo: Path, out_dir: Path) -> dict[str, Any]:
             "commit": commit,
             "dirty": dirty,
         },
+        "executed_step_count": executed_count,
+        "passed_step_count": passed_count,
+        "failed_step_count": failed_count,
         "steps": steps,
         "findings": findings,
-        "artifacts": [
-            _artifact(out_dir / "mission-control.json", "Mission Control JSON bundle", "json"),
-            _artifact(out_dir / "mission-control.md", "Mission Control operator brief", "markdown"),
-        ],
+        "artifacts": artifacts,
         "next_actions": next_actions,
     }
 
@@ -166,19 +359,26 @@ def render_markdown(bundle: dict[str, Any]) -> str:
         "# Mission Control",
         "",
         f"Generated: {bundle['generated_at_utc']}",
+        f"Mode: {bundle['mode']}",
         f"Decision: {bundle['decision']}",
         f"Risk band: {bundle['risk_band']}",
         f"Repository: {repo['path']}",
         f"Branch: {repo['branch']}",
         f"Commit: {repo['commit']}",
         f"Dirty: {str(repo['dirty']).lower()}",
+        f"Executed steps: {bundle['executed_step_count']}",
+        f"Passed steps: {bundle['passed_step_count']}",
+        f"Failed steps: {bundle['failed_step_count']}",
         "",
         "## Steps",
         "",
     ]
 
     for step in bundle["steps"]:
-        lines.append(f"- {step['id']}: {step['status']} - `{step['command']}`")
+        line = f"- {step['id']}: {step['status']} - `{step['command']}`"
+        if step.get("executed") is True:
+            line += f" rc={step.get('rc')} elapsed_ms={step.get('elapsed_ms')}"
+        lines.append(line)
 
     lines.extend(["", "## Findings", ""])
 
@@ -209,12 +409,18 @@ def write_bundle(bundle: dict[str, Any], out_dir: Path) -> tuple[Path, Path]:
 def _run(args: argparse.Namespace) -> int:
     repo = Path(args.repo)
     out_dir = Path(args.out_dir)
-    bundle = build_bundle(repo, out_dir)
+    bundle = build_bundle(
+        repo,
+        out_dir,
+        execute=bool(args.execute),
+        include_release=bool(args.include_release),
+        timeout_seconds=int(args.timeout_seconds),
+    )
     json_path, md_path = write_bundle(bundle, out_dir)
     print(f"wrote {json_path}")
     print(f"wrote {md_path}")
     print(f"decision={bundle['decision']} risk_band={bundle['risk_band']}")
-    return 0
+    return 0 if bundle["ok"] else 2
 
 
 def _summarize(args: argparse.Namespace) -> int:
@@ -223,7 +429,10 @@ def _summarize(args: argparse.Namespace) -> int:
     print(f"decision={bundle['decision']}")
     print(f"risk_band={bundle['risk_band']}")
     print(f"repo={bundle['repo']['path']}")
+    print(f"mode={bundle.get('mode', 'plan')}")
     print(f"steps={len(bundle['steps'])}")
+    print(f"executed_steps={bundle.get('executed_step_count', 0)}")
+    print(f"failed_steps={bundle.get('failed_step_count', 0)}")
     print(f"findings={len(bundle['findings'])}")
     return 0
 
@@ -235,9 +444,13 @@ def _schema(_: argparse.Namespace) -> int:
             "schema_version",
             "generated_at_utc",
             "ok",
+            "mode",
             "decision",
             "risk_band",
             "repo",
+            "executed_step_count",
+            "passed_step_count",
+            "failed_step_count",
             "steps",
             "findings",
             "artifacts",
@@ -258,6 +471,9 @@ def build_parser() -> argparse.ArgumentParser:
     run = sub.add_parser("run", help="Write mission-control.json and mission-control.md")
     run.add_argument("--repo", default=".")
     run.add_argument("--out-dir", default="build/mission-control")
+    run.add_argument("--execute", action="store_true")
+    run.add_argument("--include-release", action="store_true")
+    run.add_argument("--timeout-seconds", type=int, default=60)
     run.set_defaults(func=_run)
 
     summarize = sub.add_parser("summarize", help="Summarize a mission-control.json bundle")

--- a/tests/test_mission_control.py
+++ b/tests/test_mission_control.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -24,12 +25,14 @@ def test_mission_control_run_writes_json_and_markdown(tmp_path):
 
     assert bundle["schema_version"] == "1"
     assert bundle["ok"] is True
+    assert bundle["mode"] == "plan"
     assert bundle["decision"] == "SHIP"
     assert bundle["risk_band"] == "low"
     assert bundle["repo"]["path"] == repo.resolve().as_posix()
     assert bundle["repo"]["branch"] == "unknown"
     assert bundle["repo"]["commit"] == "unknown"
     assert bundle["repo"]["dirty"] is False
+    assert bundle["executed_step_count"] == 0
     assert [step["id"] for step in bundle["steps"]] == [
         "gate_fast",
         "gate_release",
@@ -47,9 +50,120 @@ def test_mission_control_run_writes_json_and_markdown(tmp_path):
 
     brief = brief_path.read_text(encoding="utf-8")
     assert "# Mission Control" in brief
+    assert "Mode: plan" in brief
     assert "Decision: SHIP" in brief
     assert "gate_fast" in brief
     assert "release_room" in brief
+
+
+def test_mission_control_execute_writes_step_outputs(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+    calls = []
+
+    def fake_run_step_process(args, *, cwd, timeout_seconds):
+        calls.append((list(args), cwd, timeout_seconds))
+        return 0, "step stdout\n", "", 17
+
+    monkeypatch.setattr(mission_control, "_run_step_process", fake_run_step_process)
+
+    rc = mission_control.main(
+        [
+            "run",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--execute",
+        ]
+    )
+
+    assert rc == 0
+
+    bundle = json.loads((out_dir / "mission-control.json").read_text(encoding="utf-8"))
+    executed = [step for step in bundle["steps"] if step["executed"] is True]
+
+    assert bundle["mode"] == "execute"
+    assert bundle["ok"] is True
+    assert bundle["executed_step_count"] == 3
+    assert bundle["passed_step_count"] == 3
+    assert bundle["failed_step_count"] == 0
+    assert [step["id"] for step in executed] == ["gate_fast", "doctor", "readiness"]
+    assert all(step["status"] == "passed" for step in executed)
+    assert all(step["rc"] == 0 for step in executed)
+    assert len(calls) == 3
+
+    for step in executed:
+        stdout_path = Path(step["stdout_path"])
+        stderr_path = Path(step["stderr_path"])
+        assert stdout_path.read_text(encoding="utf-8") == "step stdout\n"
+        assert stderr_path.read_text(encoding="utf-8") == ""
+
+
+def test_mission_control_execute_include_release_adds_release_gate(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+
+    def fake_run_step_process(args, *, cwd, timeout_seconds):
+        return 0, "ok\n", "", 5
+
+    monkeypatch.setattr(mission_control, "_run_step_process", fake_run_step_process)
+
+    rc = mission_control.main(
+        [
+            "run",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--execute",
+            "--include-release",
+        ]
+    )
+
+    assert rc == 0
+
+    bundle = json.loads((out_dir / "mission-control.json").read_text(encoding="utf-8"))
+    executed_ids = [step["id"] for step in bundle["steps"] if step["executed"] is True]
+
+    assert executed_ids == ["gate_fast", "gate_release", "doctor", "readiness"]
+    assert bundle["executed_step_count"] == 4
+
+
+def test_mission_control_execute_failed_step_sets_no_ship(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+
+    def fake_run_step_process(args, *, cwd, timeout_seconds):
+        if "doctor" in args:
+            return 1, "", "doctor failed\n", 9
+        return 0, "ok\n", "", 5
+
+    monkeypatch.setattr(mission_control, "_run_step_process", fake_run_step_process)
+
+    rc = mission_control.main(
+        [
+            "run",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--execute",
+        ]
+    )
+
+    assert rc == 2
+
+    bundle = json.loads((out_dir / "mission-control.json").read_text(encoding="utf-8"))
+
+    assert bundle["ok"] is False
+    assert bundle["decision"] == "NO_SHIP"
+    assert bundle["risk_band"] == "high"
+    assert bundle["failed_step_count"] == 1
+    assert bundle["findings"][0]["code"] == "STEP_FAILED"
 
 
 def test_mission_control_summarize_prints_stable_counts(tmp_path, capsys):
@@ -68,7 +182,10 @@ def test_mission_control_summarize_prints_stable_counts(tmp_path, capsys):
     output = capsys.readouterr().out
     assert "decision=SHIP" in output
     assert "risk_band=low" in output
+    assert "mode=plan" in output
     assert "steps=6" in output
+    assert "executed_steps=0" in output
+    assert "failed_steps=0" in output
     assert "findings=0" in output
 
 
@@ -80,6 +197,8 @@ def test_mission_control_schema_lists_required_top_level_keys(capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["schema_version"] == "1"
     assert "decision" in payload["required_top_level_keys"]
+    assert "mode" in payload["required_top_level_keys"]
+    assert "executed_step_count" in payload["required_top_level_keys"]
     assert "next_actions" in payload["required_top_level_keys"]
 
 


### PR DESCRIPTION
Extends Mission Control with executable run mode.

Includes:
- mission-control run --execute
- mission-control run --execute --include-release
- per-step stdout/stderr artifacts
- executed/passed/failed counts in the JSON bundle
- NO_SHIP decision when an executed step fails
- updated summary/schema output
- regression tests and docs

Validation:
- PYTHONPATH=src .venv/bin/python -m ruff check src/sdetkit/mission_control.py tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m ruff format --check src/sdetkit/mission_control.py tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m sdetkit gate fast
- PYTHONPATH=src .venv/bin/python -m sdetkit gate release
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control run --execute --out-dir build/mission-control-v2-execute-smoke
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control run --execute --include-release --out-dir build/mission-control-v2-release-smoke-clean