### PR TITLE
Add mission-control run ledger

### DIFF
--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -56,3 +56,25 @@ python -m sdetkit mission-control run --execute --include-release --out-dir buil
 ```
 
 When an executed step fails, the bundle records the failing return code, keeps the step output files, sets `ok` to false, and returns `NO_SHIP`.
+
+## Run ledger
+
+Each run appends a compact JSONL record to the local Mission Control ledger:
+
+```text
+.sdetkit/runs/mission-control-runs.jsonl
+```
+
+The ledger keeps the run id, timestamp, repository, branch, commit, mode, decision, risk band, step counts, and artifact directory. Use it to track release-confidence history without needing a remote service.
+
+Use `--ledger-path` when you want the ledger somewhere else:
+
+```bash
+python -m sdetkit mission-control run --ledger-path build/mission-control-runs.jsonl
+```
+
+Use `--no-ledger` for one-off smoke runs that should not append history:
+
+```bash
+python -m sdetkit mission-control run --execute --no-ledger
+```

--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -5,6 +5,7 @@ import json
 import subprocess
 import sys
 import time
+import uuid
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,6 +16,11 @@ SCHEMA_VERSION = "1"
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _run_id(generated_at: str) -> str:
+    stamp = generated_at.replace("-", "").replace(":", "").replace("Z", "")
+    return f"mc-{stamp}-{uuid.uuid4().hex[:12]}"
 
 
 def _run_text(args: Sequence[str], *, cwd: Path) -> tuple[int, str]:
@@ -42,6 +48,10 @@ def _git_value(repo: Path, args: Sequence[str], fallback: str) -> str:
 def _git_dirty(repo: Path) -> bool:
     rc, output = _run_text(["git", "status", "--short"], cwd=repo)
     return rc == 0 and bool(output.strip())
+
+
+def _default_ledger_path(repo: Path) -> Path:
+    return repo / ".sdetkit" / "runs" / "mission-control-runs.jsonl"
 
 
 def _command_steps() -> list[dict[str, Any]]:
@@ -264,6 +274,7 @@ def build_bundle(
     execute: bool = False,
     include_release: bool = False,
     timeout_seconds: int = 60,
+    ledger_path: Path | None = None,
 ) -> dict[str, Any]:
     repo = repo.resolve()
     out_dir = out_dir.resolve()
@@ -329,9 +340,18 @@ def build_bundle(
         _artifact(out_dir / "mission-control.md", "Mission Control operator brief", "markdown"),
     ]
     artifacts.extend(_step_artifacts(steps))
+    if ledger_path is not None:
+        artifacts.append(
+            _artifact(
+                ledger_path.resolve(),
+                "Mission Control run ledger",
+                "jsonl",
+            )
+        )
 
     return {
         "schema_version": SCHEMA_VERSION,
+        "run_id": _run_id(generated_at),
         "generated_at_utc": generated_at,
         "ok": failed_count == 0,
         "mode": "execute" if execute else "plan",
@@ -358,6 +378,7 @@ def render_markdown(bundle: dict[str, Any]) -> str:
     lines = [
         "# Mission Control",
         "",
+        f"Run ID: {bundle['run_id']}",
         f"Generated: {bundle['generated_at_utc']}",
         f"Mode: {bundle['mode']}",
         f"Decision: {bundle['decision']}",
@@ -406,19 +427,57 @@ def write_bundle(bundle: dict[str, Any], out_dir: Path) -> tuple[Path, Path]:
     return json_path, md_path
 
 
+def _ledger_record(bundle: dict[str, Any], out_dir: Path) -> dict[str, Any]:
+    repo = bundle["repo"]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": bundle["run_id"],
+        "timestamp": bundle["generated_at_utc"],
+        "repo": repo["path"],
+        "branch": repo["branch"],
+        "commit": repo["commit"],
+        "mode": bundle["mode"],
+        "decision": bundle["decision"],
+        "risk_band": bundle["risk_band"],
+        "ok": bundle["ok"],
+        "executed_step_count": bundle["executed_step_count"],
+        "failed_step_count": bundle["failed_step_count"],
+        "artifact_dir": out_dir.resolve().as_posix(),
+    }
+
+
+def append_ledger(bundle: dict[str, Any], ledger_path: Path, out_dir: Path) -> Path:
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    record = _ledger_record(bundle, out_dir)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+    return ledger_path
+
+
 def _run(args: argparse.Namespace) -> int:
-    repo = Path(args.repo)
-    out_dir = Path(args.out_dir)
+    repo = Path(args.repo).resolve()
+    out_dir = Path(args.out_dir).resolve()
+    ledger_path = None
+    if not bool(args.no_ledger):
+        if args.ledger_path:
+            ledger_path = Path(args.ledger_path).resolve()
+        else:
+            ledger_path = _default_ledger_path(repo).resolve()
+
     bundle = build_bundle(
         repo,
         out_dir,
         execute=bool(args.execute),
         include_release=bool(args.include_release),
         timeout_seconds=int(args.timeout_seconds),
+        ledger_path=ledger_path,
     )
     json_path, md_path = write_bundle(bundle, out_dir)
     print(f"wrote {json_path}")
     print(f"wrote {md_path}")
+    if ledger_path is not None:
+        ledger_written = append_ledger(bundle, ledger_path, out_dir)
+        print(f"wrote {ledger_written}")
     print(f"decision={bundle['decision']} risk_band={bundle['risk_band']}")
     return 0 if bundle["ok"] else 2
 
@@ -426,6 +485,7 @@ def _run(args: argparse.Namespace) -> int:
 def _summarize(args: argparse.Namespace) -> int:
     path = Path(args.bundle)
     bundle = json.loads(path.read_text(encoding="utf-8"))
+    print(f"run_id={bundle.get('run_id', 'unknown')}")
     print(f"decision={bundle['decision']}")
     print(f"risk_band={bundle['risk_band']}")
     print(f"repo={bundle['repo']['path']}")
@@ -442,6 +502,7 @@ def _schema(_: argparse.Namespace) -> int:
         "schema_version": SCHEMA_VERSION,
         "required_top_level_keys": [
             "schema_version",
+            "run_id",
             "generated_at_utc",
             "ok",
             "mode",
@@ -455,6 +516,21 @@ def _schema(_: argparse.Namespace) -> int:
             "findings",
             "artifacts",
             "next_actions",
+        ],
+        "ledger_record_keys": [
+            "schema_version",
+            "run_id",
+            "timestamp",
+            "repo",
+            "branch",
+            "commit",
+            "mode",
+            "decision",
+            "risk_band",
+            "ok",
+            "executed_step_count",
+            "failed_step_count",
+            "artifact_dir",
         ],
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
@@ -474,6 +550,8 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--execute", action="store_true")
     run.add_argument("--include-release", action="store_true")
     run.add_argument("--timeout-seconds", type=int, default=60)
+    run.add_argument("--ledger-path", default="")
+    run.add_argument("--no-ledger", action="store_true")
     run.set_defaults(func=_run)
 
     summarize = sub.add_parser("summarize", help="Summarize a mission-control.json bundle")

--- a/tests/test_mission_control.py
+++ b/tests/test_mission_control.py
@@ -6,7 +6,13 @@ import pytest
 from sdetkit import cli, mission_control
 
 
-def test_mission_control_run_writes_json_and_markdown(tmp_path):
+def _jsonl_records(path: Path):
+    return [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+def test_mission_control_run_writes_json_markdown_and_ledger(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     out_dir = tmp_path / "out"
@@ -17,13 +23,17 @@ def test_mission_control_run_writes_json_and_markdown(tmp_path):
 
     bundle_path = out_dir / "mission-control.json"
     brief_path = out_dir / "mission-control.md"
+    ledger_path = repo / ".sdetkit" / "runs" / "mission-control-runs.jsonl"
 
     assert bundle_path.exists()
     assert brief_path.exists()
+    assert ledger_path.exists()
 
     bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    records = _jsonl_records(ledger_path)
 
     assert bundle["schema_version"] == "1"
+    assert bundle["run_id"].startswith("mc-")
     assert bundle["ok"] is True
     assert bundle["mode"] == "plan"
     assert bundle["decision"] == "SHIP"
@@ -43,17 +53,82 @@ def test_mission_control_run_writes_json_and_markdown(tmp_path):
     ]
     assert bundle["steps"][-1]["status"] == "planned"
     assert bundle["findings"] == []
-    assert [artifact["path"] for artifact in bundle["artifacts"]] == [
-        (out_dir.resolve() / "mission-control.json").as_posix(),
-        (out_dir.resolve() / "mission-control.md").as_posix(),
-    ]
+    assert [artifact["kind"] for artifact in bundle["artifacts"]] == ["json", "markdown", "jsonl"]
+
+    assert len(records) == 1
+    assert records[0]["run_id"] == bundle["run_id"]
+    assert records[0]["mode"] == "plan"
+    assert records[0]["decision"] == "SHIP"
+    assert records[0]["artifact_dir"] == out_dir.resolve().as_posix()
 
     brief = brief_path.read_text(encoding="utf-8")
     assert "# Mission Control" in brief
+    assert f"Run ID: {bundle['run_id']}" in brief
     assert "Mode: plan" in brief
     assert "Decision: SHIP" in brief
     assert "gate_fast" in brief
     assert "release_room" in brief
+
+
+def test_mission_control_no_ledger_suppresses_ledger_artifact(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+
+    rc = mission_control.main(
+        ["run", "--repo", str(repo), "--out-dir", str(out_dir), "--no-ledger"]
+    )
+
+    assert rc == 0
+
+    bundle = json.loads((out_dir / "mission-control.json").read_text(encoding="utf-8"))
+
+    assert not (repo / ".sdetkit").exists()
+    assert [artifact["kind"] for artifact in bundle["artifacts"]] == ["json", "markdown"]
+
+
+def test_mission_control_custom_ledger_path_appends_runs(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir_1 = tmp_path / "out1"
+    out_dir_2 = tmp_path / "out2"
+    ledger_path = tmp_path / "runs" / "mission-control.jsonl"
+
+    assert (
+        mission_control.main(
+            [
+                "run",
+                "--repo",
+                str(repo),
+                "--out-dir",
+                str(out_dir_1),
+                "--ledger-path",
+                str(ledger_path),
+            ]
+        )
+        == 0
+    )
+    assert (
+        mission_control.main(
+            [
+                "run",
+                "--repo",
+                str(repo),
+                "--out-dir",
+                str(out_dir_2),
+                "--ledger-path",
+                str(ledger_path),
+            ]
+        )
+        == 0
+    )
+
+    records = _jsonl_records(ledger_path)
+
+    assert len(records) == 2
+    assert records[0]["run_id"] != records[1]["run_id"]
+    assert records[0]["artifact_dir"] == out_dir_1.resolve().as_posix()
+    assert records[1]["artifact_dir"] == out_dir_2.resolve().as_posix()
 
 
 def test_mission_control_execute_writes_step_outputs(tmp_path, monkeypatch):
@@ -76,6 +151,7 @@ def test_mission_control_execute_writes_step_outputs(tmp_path, monkeypatch):
             "--out-dir",
             str(out_dir),
             "--execute",
+            "--no-ledger",
         ]
     )
 
@@ -120,6 +196,7 @@ def test_mission_control_execute_include_release_adds_release_gate(tmp_path, mon
             str(out_dir),
             "--execute",
             "--include-release",
+            "--no-ledger",
         ]
     )
 
@@ -152,6 +229,7 @@ def test_mission_control_execute_failed_step_sets_no_ship(tmp_path, monkeypatch)
             "--out-dir",
             str(out_dir),
             "--execute",
+            "--no-ledger",
         ]
     )
 
@@ -171,7 +249,10 @@ def test_mission_control_summarize_prints_stable_counts(tmp_path, capsys):
     repo.mkdir()
     out_dir = tmp_path / "out"
 
-    assert mission_control.main(["run", "--repo", str(repo), "--out-dir", str(out_dir)]) == 0
+    assert (
+        mission_control.main(["run", "--repo", str(repo), "--out-dir", str(out_dir), "--no-ledger"])
+        == 0
+    )
 
     capsys.readouterr()
 
@@ -180,6 +261,7 @@ def test_mission_control_summarize_prints_stable_counts(tmp_path, capsys):
     assert rc == 0
 
     output = capsys.readouterr().out
+    assert "run_id=mc-" in output
     assert "decision=SHIP" in output
     assert "risk_band=low" in output
     assert "mode=plan" in output
@@ -189,17 +271,19 @@ def test_mission_control_summarize_prints_stable_counts(tmp_path, capsys):
     assert "findings=0" in output
 
 
-def test_mission_control_schema_lists_required_top_level_keys(capsys):
+def test_mission_control_schema_lists_required_top_level_and_ledger_keys(capsys):
     rc = mission_control.main(["schema"])
 
     assert rc == 0
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["schema_version"] == "1"
+    assert "run_id" in payload["required_top_level_keys"]
     assert "decision" in payload["required_top_level_keys"]
     assert "mode" in payload["required_top_level_keys"]
     assert "executed_step_count" in payload["required_top_level_keys"]
     assert "next_actions" in payload["required_top_level_keys"]
+    assert "artifact_dir" in payload["ledger_record_keys"]
 
 
 def test_root_cli_dispatches_mission_control(tmp_path):
@@ -207,7 +291,17 @@ def test_root_cli_dispatches_mission_control(tmp_path):
     repo.mkdir()
     out_dir = tmp_path / "out"
 
-    rc = cli.main(["mission-control", "run", "--repo", str(repo), "--out-dir", str(out_dir)])
+    rc = cli.main(
+        [
+            "mission-control",
+            "run",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--no-ledger",
+        ]
+    )
 
     assert rc == 0
     assert (out_dir / "mission-control.json").exists()


### PR DESCRIPTION
Adds append-only local Mission Control run ledger support.

Includes:
- default local JSONL ledger at .sdetkit/runs/mission-control-runs.jsonl
- run_id in Mission Control bundles and Markdown
- --ledger-path for custom ledger storage
- --no-ledger for smoke/one-off runs
- compact ledger records with repo, branch, commit, mode, decision, risk band, counts, and artifact directory
- schema output for ledger record keys
- regression tests and docs

Validation:
- PYTHONPATH=src .venv/bin/python -m ruff check src/sdetkit/mission_control.py tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m ruff format --check src/sdetkit/mission_control.py tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m sdetkit gate fast
- PYTHONPATH=src .venv/bin/python -m sdetkit gate release
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control run --execute --include-release --no-ledger --out-dir build/mission-control-ledger-no-ledger-smoke