### PR TITLE
Add mission-control history summary

### DIFF
--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -78,3 +78,19 @@ Use `--no-ledger` for one-off smoke runs that should not append history:
 ```bash
 python -m sdetkit mission-control run --execute --no-ledger
 ```
+
+## History summary
+
+Use `history` to summarize a Mission Control JSONL run ledger without starting a server or database.
+
+```bash
+python -m sdetkit mission-control history --ledger .sdetkit/runs/mission-control-runs.jsonl
+```
+
+The text summary reports run counts, decision counts, the latest decision and risk band, failed-run rate, and the most common failed step when matching bundle artifacts are still available.
+
+Use JSON output for automation:
+
+```bash
+python -m sdetkit mission-control history --ledger .sdetkit/runs/mission-control-runs.jsonl --format json
+```

--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import time
 import uuid
+from collections import Counter
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -454,6 +455,129 @@ def append_ledger(bundle: dict[str, Any], ledger_path: Path, out_dir: Path) -> P
     return ledger_path
 
 
+def _load_ledger_records(ledger_path: Path) -> list[dict[str, Any]]:
+    if not ledger_path.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(
+        ledger_path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            record = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSONL record at line {line_number}: {exc}") from exc
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def _int_record_value(record: dict[str, Any], key: str) -> int:
+    value = record.get(key, 0)
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return 0
+
+
+def _failed_step_ids_from_record(record: dict[str, Any]) -> list[str]:
+    artifact_dir = record.get("artifact_dir")
+    if not isinstance(artifact_dir, str) or not artifact_dir:
+        return ["unknown"] if _int_record_value(record, "failed_step_count") > 0 else []
+
+    bundle_path = Path(artifact_dir) / "mission-control.json"
+    if not bundle_path.exists():
+        return ["unknown"] if _int_record_value(record, "failed_step_count") > 0 else []
+
+    try:
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ["unknown"] if _int_record_value(record, "failed_step_count") > 0 else []
+
+    failed_steps = []
+    for step in bundle.get("steps", []):
+        if (
+            isinstance(step, dict)
+            and step.get("executed") is True
+            and step.get("status") == "failed"
+        ):
+            failed_steps.append(str(step.get("id", "unknown")))
+
+    if failed_steps:
+        return failed_steps
+    return ["unknown"] if _int_record_value(record, "failed_step_count") > 0 else []
+
+
+def build_history_summary(ledger_path: Path) -> dict[str, Any]:
+    ledger_path = ledger_path.resolve()
+    records = _load_ledger_records(ledger_path)
+    decision_counts = Counter(str(record.get("decision", "UNKNOWN")) for record in records)
+    failed_runs = sum(1 for record in records if _int_record_value(record, "failed_step_count") > 0)
+
+    failed_step_counts: Counter[str] = Counter()
+    for record in records:
+        failed_step_counts.update(_failed_step_ids_from_record(record))
+
+    latest = records[-1] if records else {}
+    runs = len(records)
+    known_decisions = {
+        "SHIP",
+        "SHIP_WITH_FINDINGS",
+        "NO_SHIP",
+    }
+    other_decisions = sum(
+        count for decision, count in decision_counts.items() if decision not in known_decisions
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ledger_path": ledger_path.as_posix(),
+        "runs": runs,
+        "ship": decision_counts.get("SHIP", 0),
+        "ship_with_findings": decision_counts.get("SHIP_WITH_FINDINGS", 0),
+        "no_ship": decision_counts.get("NO_SHIP", 0),
+        "other_decisions": other_decisions,
+        "latest_run_id": latest.get("run_id", "none"),
+        "latest_timestamp": latest.get("timestamp", "none"),
+        "latest_decision": latest.get("decision", "none"),
+        "latest_risk_band": latest.get("risk_band", "none"),
+        "latest_mode": latest.get("mode", "none"),
+        "latest_artifact_dir": latest.get("artifact_dir", "none"),
+        "failed_runs": failed_runs,
+        "failure_rate": round(failed_runs / runs, 4) if runs else 0.0,
+        "most_common_failed_step": failed_step_counts.most_common(1)[0][0]
+        if failed_step_counts
+        else "none",
+    }
+
+
+def render_history_text(summary: dict[str, Any]) -> str:
+    keys = [
+        "ledger_path",
+        "runs",
+        "ship",
+        "ship_with_findings",
+        "no_ship",
+        "other_decisions",
+        "latest_run_id",
+        "latest_timestamp",
+        "latest_decision",
+        "latest_risk_band",
+        "latest_mode",
+        "latest_artifact_dir",
+        "failed_runs",
+        "failure_rate",
+        "most_common_failed_step",
+    ]
+    return "\n".join(f"{key}={summary[key]}" for key in keys)
+
+
 def _run(args: argparse.Namespace) -> int:
     repo = Path(args.repo).resolve()
     out_dir = Path(args.out_dir).resolve()
@@ -532,8 +656,44 @@ def _schema(_: argparse.Namespace) -> int:
             "failed_step_count",
             "artifact_dir",
         ],
+        "history_summary_keys": [
+            "schema_version",
+            "ledger_path",
+            "runs",
+            "ship",
+            "ship_with_findings",
+            "no_ship",
+            "other_decisions",
+            "latest_run_id",
+            "latest_timestamp",
+            "latest_decision",
+            "latest_risk_band",
+            "latest_mode",
+            "latest_artifact_dir",
+            "failed_runs",
+            "failure_rate",
+            "most_common_failed_step",
+        ],
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def _history(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    ledger_path = (
+        Path(args.ledger).resolve() if args.ledger else _default_ledger_path(repo).resolve()
+    )
+    try:
+        summary = build_history_summary(ledger_path)
+    except ValueError as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(render_history_text(summary))
     return 0
 
 
@@ -560,6 +720,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     schema = sub.add_parser("schema", help="Print the Mission Control bundle schema summary")
     schema.set_defaults(func=_schema)
+
+    history = sub.add_parser("history", help="Summarize a Mission Control JSONL run ledger")
+    history.add_argument("--repo", default=".")
+    history.add_argument("--ledger", default="")
+    history.add_argument("--format", choices=["text", "json"], default="text")
+    history.set_defaults(func=_history)
 
     return parser
 

--- a/tests/test_mission_control.py
+++ b/tests/test_mission_control.py
@@ -284,6 +284,7 @@ def test_mission_control_schema_lists_required_top_level_and_ledger_keys(capsys)
     assert "executed_step_count" in payload["required_top_level_keys"]
     assert "next_actions" in payload["required_top_level_keys"]
     assert "artifact_dir" in payload["ledger_record_keys"]
+    assert "failure_rate" in payload["history_summary_keys"]
 
 
 def test_root_cli_dispatches_mission_control(tmp_path):
@@ -319,3 +320,113 @@ def test_root_cli_forwards_mission_control_help(capsys):
     assert "run" in output
     assert "summarize" in output
     assert "schema" in output
+    assert "history" in output
+
+
+def test_mission_control_history_summarizes_text_ledger(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    ledger_path = tmp_path / "runs" / "mission-control.jsonl"
+
+    assert (
+        mission_control.main(
+            [
+                "run",
+                "--repo",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "one"),
+                "--ledger-path",
+                str(ledger_path),
+            ]
+        )
+        == 0
+    )
+    assert (
+        mission_control.main(
+            [
+                "run",
+                "--repo",
+                str(repo),
+                "--out-dir",
+                str(tmp_path / "two"),
+                "--ledger-path",
+                str(ledger_path),
+            ]
+        )
+        == 0
+    )
+
+    capsys.readouterr()
+
+    rc = mission_control.main(["history", "--ledger", str(ledger_path)])
+
+    assert rc == 0
+
+    output = capsys.readouterr().out
+    assert "runs=2" in output
+    assert "ship=2" in output
+    assert "ship_with_findings=0" in output
+    assert "no_ship=0" in output
+    assert "latest_decision=SHIP" in output
+    assert "latest_risk_band=low" in output
+    assert "failure_rate=0.0" in output
+    assert "most_common_failed_step=none" in output
+
+
+def test_mission_control_history_json_reports_failed_step(tmp_path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "failed"
+    ledger_path = tmp_path / "runs" / "mission-control.jsonl"
+
+    def fake_run_step_process(args, *, cwd, timeout_seconds):
+        if "doctor" in args:
+            return 1, "", "doctor failed\n", 9
+        return 0, "ok\n", "", 5
+
+    monkeypatch.setattr(mission_control, "_run_step_process", fake_run_step_process)
+
+    assert (
+        mission_control.main(
+            [
+                "run",
+                "--repo",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--execute",
+                "--ledger-path",
+                str(ledger_path),
+            ]
+        )
+        == 2
+    )
+
+    capsys.readouterr()
+
+    rc = mission_control.main(["history", "--ledger", str(ledger_path), "--format", "json"])
+
+    assert rc == 0
+
+    summary = json.loads(capsys.readouterr().out)
+
+    assert summary["runs"] == 1
+    assert summary["no_ship"] == 1
+    assert summary["failed_runs"] == 1
+    assert summary["failure_rate"] == 1.0
+    assert summary["latest_decision"] == "NO_SHIP"
+    assert summary["most_common_failed_step"] == "doctor"
+
+
+def test_mission_control_history_missing_ledger_is_empty(tmp_path, capsys):
+    ledger_path = tmp_path / "missing.jsonl"
+
+    rc = mission_control.main(["history", "--ledger", str(ledger_path)])
+
+    assert rc == 0
+
+    output = capsys.readouterr().out
+    assert "runs=0" in output
+    assert "latest_decision=none" in output
+    assert "failure_rate=0.0" in output


### PR DESCRIPTION
Adds Mission Control ledger history summaries.

Includes:
- mission-control history
- text and JSON history output
- decision counts across ledger records
- latest run metadata
- failed-run rate
- most common failed step when bundle artifacts are available
- schema output for history summary keys
- regression tests and docs

Validation:
- PYTHONPATH=src .venv/bin/python -m ruff check src/sdetkit/mission_control.py tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m ruff format --check src/sdetkit/mission_control.py tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m sdetkit gate fast
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control history --ledger build/mission-control-history-smoke-clean/runs.jsonl
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control history --ledger build/mission-control-history-smoke-clean/runs.jsonl --format json