### PR TITLE
Add mission-control report brief

### DIFF
--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -94,3 +94,19 @@ Use JSON output for automation:
 ```bash
 python -m sdetkit mission-control history --ledger .sdetkit/runs/mission-control-runs.jsonl --format json
 ```
+
+## Report brief
+
+Use `report` to turn a Mission Control bundle into a Markdown release brief.
+
+```bash
+python -m sdetkit mission-control report   --bundle build/mission-control/mission-control.json   --out build/mission-control/report.md
+```
+
+Add `--history` to include ledger trend context in the same brief:
+
+```bash
+python -m sdetkit mission-control report   --bundle build/mission-control/mission-control.json   --history .sdetkit/runs/mission-control-runs.jsonl   --out build/mission-control/report.md
+```
+
+The report includes the executive decision, risk band, execution counts, step outcomes, findings, history summary, next actions, and artifact paths.

--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -578,6 +578,162 @@ def render_history_text(summary: dict[str, Any]) -> str:
     return "\n".join(f"{key}={summary[key]}" for key in keys)
 
 
+def _format_report_findings(bundle: dict[str, Any]) -> list[str]:
+    findings = bundle.get("findings", [])
+    if not isinstance(findings, list) or not findings:
+        return ["- none"]
+
+    lines = []
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        severity = finding.get("severity", "unknown")
+        code = finding.get("code", "UNKNOWN")
+        message = finding.get("message", "")
+        lines.append(f"- {severity}: {code} - {message}")
+    return lines or ["- none"]
+
+
+def _format_report_steps(bundle: dict[str, Any]) -> list[str]:
+    steps = bundle.get("steps", [])
+    if not isinstance(steps, list) or not steps:
+        return ["- none"]
+
+    lines = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        line = f"- {step.get('id', 'unknown')}: {step.get('status', 'unknown')}"
+        command = step.get("command")
+        if command:
+            line += f" - `{command}`"
+        if step.get("executed") is True:
+            line += (
+                f" (rc={step.get('rc', 'unknown')}, elapsed_ms={step.get('elapsed_ms', 'unknown')})"
+            )
+        lines.append(line)
+    return lines or ["- none"]
+
+
+def _format_report_next_actions(bundle: dict[str, Any]) -> list[str]:
+    actions = bundle.get("next_actions", [])
+    if not isinstance(actions, list) or not actions:
+        return ["- none"]
+
+    lines = []
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        action_id = action.get("id", "unknown")
+        command = action.get("command", "")
+        reason = action.get("reason", "")
+        if command:
+            lines.append(f"- {action_id}: `{command}` — {reason}")
+        else:
+            lines.append(f"- {action_id}: {reason}")
+    return lines or ["- none"]
+
+
+def _format_report_artifacts(bundle: dict[str, Any]) -> list[str]:
+    artifacts = bundle.get("artifacts", [])
+    if not isinstance(artifacts, list) or not artifacts:
+        return ["- none"]
+
+    lines = []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        label = artifact.get("label", "artifact")
+        kind = artifact.get("kind", "file")
+        artifact_path = artifact.get("path", "")
+        lines.append(f"- {label} ({kind}): `{artifact_path}`")
+    return lines or ["- none"]
+
+
+def render_report_markdown(
+    bundle: dict[str, Any],
+    history_summary: dict[str, Any] | None = None,
+) -> str:
+    repo = bundle.get("repo", {})
+    if not isinstance(repo, dict):
+        repo = {}
+
+    lines = [
+        "# Mission Control Report",
+        "",
+        "## Executive summary",
+        "",
+        f"- Run ID: {bundle.get('run_id', 'unknown')}",
+        f"- Decision: {bundle.get('decision', 'unknown')}",
+        f"- Risk band: {bundle.get('risk_band', 'unknown')}",
+        f"- Mode: {bundle.get('mode', 'unknown')}",
+        f"- Generated: {bundle.get('generated_at_utc', 'unknown')}",
+        f"- Repository: {repo.get('path', 'unknown')}",
+        f"- Branch: {repo.get('branch', 'unknown')}",
+        f"- Commit: {repo.get('commit', 'unknown')}",
+        f"- Dirty: {str(repo.get('dirty', 'unknown')).lower()}",
+        "",
+        "## Execution",
+        "",
+        f"- Executed steps: {bundle.get('executed_step_count', 0)}",
+        f"- Passed steps: {bundle.get('passed_step_count', 0)}",
+        f"- Failed steps: {bundle.get('failed_step_count', 0)}",
+        "",
+        "## Steps",
+        "",
+        *_format_report_steps(bundle),
+        "",
+        "## Findings",
+        "",
+        *_format_report_findings(bundle),
+        "",
+        "## History summary",
+        "",
+    ]
+
+    if history_summary is None:
+        lines.append("- not provided")
+    else:
+        lines.extend(
+            [
+                f"- Ledger: `{history_summary.get('ledger_path', 'unknown')}`",
+                f"- Runs: {history_summary.get('runs', 0)}",
+                f"- Ship: {history_summary.get('ship', 0)}",
+                f"- Ship with findings: {history_summary.get('ship_with_findings', 0)}",
+                f"- No ship: {history_summary.get('no_ship', 0)}",
+                f"- Latest decision: {history_summary.get('latest_decision', 'none')}",
+                f"- Latest risk band: {history_summary.get('latest_risk_band', 'none')}",
+                f"- Failure rate: {history_summary.get('failure_rate', 0.0)}",
+                f"- Most common failed step: {history_summary.get('most_common_failed_step', 'none')}",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Next actions",
+            "",
+            *_format_report_next_actions(bundle),
+            "",
+            "## Artifacts",
+            "",
+            *_format_report_artifacts(bundle),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_report(
+    bundle: dict[str, Any],
+    out_path: Path,
+    history_summary: dict[str, Any] | None = None,
+) -> Path:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(render_report_markdown(bundle, history_summary), encoding="utf-8")
+    return out_path
+
+
 def _run(args: argparse.Namespace) -> int:
     repo = Path(args.repo).resolve()
     out_dir = Path(args.out_dir).resolve()
@@ -674,6 +830,15 @@ def _schema(_: argparse.Namespace) -> int:
             "failure_rate",
             "most_common_failed_step",
         ],
+        "report_sections": [
+            "Executive summary",
+            "Execution",
+            "Steps",
+            "Findings",
+            "History summary",
+            "Next actions",
+            "Artifacts",
+        ],
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
@@ -694,6 +859,33 @@ def _history(args: argparse.Namespace) -> int:
         print(json.dumps(summary, indent=2, sort_keys=True))
     else:
         print(render_history_text(summary))
+    return 0
+
+
+def _report(args: argparse.Namespace) -> int:
+    bundle_path = Path(args.bundle)
+    out_path = Path(args.out)
+
+    try:
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error=failed to read bundle: {exc}", file=sys.stderr)
+        return 2
+
+    history_summary = None
+    if args.history:
+        try:
+            history_summary = build_history_summary(Path(args.history))
+        except ValueError as exc:
+            print(f"error={exc}", file=sys.stderr)
+            return 2
+
+    written = write_report(bundle, out_path, history_summary)
+    print(f"wrote {written.resolve()}")
+    print(f"decision={bundle.get('decision', 'unknown')}")
+    print(f"risk_band={bundle.get('risk_band', 'unknown')}")
+    if history_summary is not None:
+        print(f"history_runs={history_summary['runs']}")
     return 0
 
 
@@ -726,6 +918,12 @@ def build_parser() -> argparse.ArgumentParser:
     history.add_argument("--ledger", default="")
     history.add_argument("--format", choices=["text", "json"], default="text")
     history.set_defaults(func=_history)
+
+    report = sub.add_parser("report", help="Write a Markdown release brief from a bundle")
+    report.add_argument("--bundle", required=True)
+    report.add_argument("--history", default="")
+    report.add_argument("--out", default="build/mission-control/report.md")
+    report.set_defaults(func=_report)
 
     return parser
 

--- a/tests/test_mission_control.py
+++ b/tests/test_mission_control.py
@@ -285,6 +285,7 @@ def test_mission_control_schema_lists_required_top_level_and_ledger_keys(capsys)
     assert "next_actions" in payload["required_top_level_keys"]
     assert "artifact_dir" in payload["ledger_record_keys"]
     assert "failure_rate" in payload["history_summary_keys"]
+    assert "Executive summary" in payload["report_sections"]
 
 
 def test_root_cli_dispatches_mission_control(tmp_path):
@@ -321,6 +322,7 @@ def test_root_cli_forwards_mission_control_help(capsys):
     assert "summarize" in output
     assert "schema" in output
     assert "history" in output
+    assert "report" in output
 
 
 def test_mission_control_history_summarizes_text_ledger(tmp_path, capsys):
@@ -430,3 +432,107 @@ def test_mission_control_history_missing_ledger_is_empty(tmp_path, capsys):
     assert "runs=0" in output
     assert "latest_decision=none" in output
     assert "failure_rate=0.0" in output
+
+
+def test_mission_control_report_writes_markdown_without_history(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "bundle"
+    report_path = tmp_path / "report.md"
+
+    assert (
+        mission_control.main(["run", "--repo", str(repo), "--out-dir", str(out_dir), "--no-ledger"])
+        == 0
+    )
+
+    capsys.readouterr()
+
+    rc = mission_control.main(
+        [
+            "report",
+            "--bundle",
+            str(out_dir / "mission-control.json"),
+            "--out",
+            str(report_path),
+        ]
+    )
+
+    assert rc == 0
+
+    output = capsys.readouterr().out
+    report = report_path.read_text(encoding="utf-8")
+
+    assert "wrote " in output
+    assert "decision=SHIP" in output
+    assert "# Mission Control Report" in report
+    assert "## Executive summary" in report
+    assert "- Decision: SHIP" in report
+    assert "- Risk band: low" in report
+    assert "## History summary" in report
+    assert "- not provided" in report
+    assert "## Artifacts" in report
+
+
+def test_mission_control_report_includes_history_summary(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    ledger_path = tmp_path / "runs" / "mission-control.jsonl"
+    out_dir_1 = tmp_path / "one"
+    out_dir_2 = tmp_path / "two"
+    report_path = tmp_path / "report.md"
+
+    assert (
+        mission_control.main(
+            [
+                "run",
+                "--repo",
+                str(repo),
+                "--out-dir",
+                str(out_dir_1),
+                "--ledger-path",
+                str(ledger_path),
+            ]
+        )
+        == 0
+    )
+    assert (
+        mission_control.main(
+            [
+                "run",
+                "--repo",
+                str(repo),
+                "--out-dir",
+                str(out_dir_2),
+                "--ledger-path",
+                str(ledger_path),
+            ]
+        )
+        == 0
+    )
+
+    capsys.readouterr()
+
+    rc = mission_control.main(
+        [
+            "report",
+            "--bundle",
+            str(out_dir_2 / "mission-control.json"),
+            "--history",
+            str(ledger_path),
+            "--out",
+            str(report_path),
+        ]
+    )
+
+    assert rc == 0
+
+    output = capsys.readouterr().out
+    report = report_path.read_text(encoding="utf-8")
+
+    assert "history_runs=2" in output
+    assert "- Runs: 2" in report
+    assert "- Ship: 2" in report
+    assert "- Latest decision: SHIP" in report
+    assert "- Latest risk band: low" in report
+    assert "- Failure rate: 0.0" in report
+    assert "- Most common failed step: none" in report


### PR DESCRIPTION
Adds Mission Control Markdown report briefs from bundles and optional history.

Includes:
- mission-control report
- Markdown release brief generation
- optional ledger history context
- executive summary, execution, steps, findings, history, next actions, and artifacts sections
- schema output for report sections
- regression tests and docs

Validation:
- PYTHONPATH=src .venv/bin/python -m ruff check src/sdetkit/mission_control.py tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m ruff format --check src/sdetkit/mission_control.py tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mission_control.py
- PYTHONPATH=src .venv/bin/python -m sdetkit gate fast
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control report --bundle build/mission-control-report-clean-smoke/two/mission-control.json --history build/mission-control-report-clean-smoke/runs.jsonl --out build/mission-control-report-clean-smoke/report.md