### PR TITLE
Add Mission Control Doctor Cortex trend

### DIFF
--- a/docs/mission-control-doctor-cortex-trend.md
+++ b/docs/mission-control-doctor-cortex-trend.md
@@ -25,3 +25,5 @@ python -m sdetkit.mission_control_cortex_trend \
 The trend output is public-safe. It includes counts, statuses, trend direction, and run ids. It redacts the ledger path and does not emit raw doctor evidence, raw fix text, command lists, source paths, or artifact paths.
 
 The analyzer can read Doctor Cortex summaries embedded in future ledger records. For existing records, it can load `mission-control.json` from each record's artifact directory and extract the summary from the bundle.
+
+CLI and file output are public projections: they omit run ids, timestamps, ledger paths, artifact paths, and sample rows while keeping counts, statuses, and trend direction.

--- a/docs/mission-control-doctor-cortex-trend.md
+++ b/docs/mission-control-doctor-cortex-trend.md
@@ -1,0 +1,27 @@
+# Mission Control Doctor Cortex trend
+
+Mission Control Doctor Cortex trend summarizes Doctor Cortex health across a Mission Control run ledger.
+
+```bash
+python -m sdetkit.mission_control_cortex_trend \
+  --ledger-path .sdetkit/runs/mission-control-runs.jsonl \
+  --format text
+```
+
+JSON and Markdown are also available:
+
+```bash
+python -m sdetkit.mission_control_cortex_trend \
+  --ledger-path .sdetkit/runs/mission-control-runs.jsonl \
+  --format json \
+  --out build/doctor-cortex-trend.json
+
+python -m sdetkit.mission_control_cortex_trend \
+  --ledger-path .sdetkit/runs/mission-control-runs.jsonl \
+  --format md \
+  --out build/doctor-cortex-trend.md
+```
+
+The trend output is public-safe. It includes counts, statuses, trend direction, and run ids. It redacts the ledger path and does not emit raw doctor evidence, raw fix text, command lists, source paths, or artifact paths.
+
+The analyzer can read Doctor Cortex summaries embedded in future ledger records. For existing records, it can load `mission-control.json` from each record's artifact directory and extract the summary from the bundle.

--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -135,3 +135,5 @@ python -m sdetkit.mission_control_cortex_trend \
 ```
 
 The trend report is summary-only and redacts ledger and artifact paths.
+
+CLI and file output are public projections: they omit run ids, timestamps, ledger paths, artifact paths, and sample rows while keeping counts, statuses, and trend direction.

--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -122,3 +122,16 @@ python -m sdetkit mission-control run --doctor-cortex --out-dir build/mission-co
 The bundle records a `doctor_cortex` summary with diagnosis status, diagnosis count, prescription status, and prescription count. It also writes public-safe Doctor Cortex JSON artifacts in the Mission Control output directory.
 
 Mission Control stores only summary fields in the main bundle. Raw doctor evidence and raw fix text remain outside the Mission Control bundle.
+
+## Doctor Cortex trend
+
+Doctor Cortex trend can summarize diagnosis and prescription counts across a Mission Control ledger:
+
+```bash
+python -m sdetkit.mission_control_cortex_trend \
+  --ledger-path .sdetkit/runs/mission-control-runs.jsonl \
+  --format md \
+  --out build/doctor-cortex-trend.md
+```
+
+The trend report is summary-only and redacts ledger and artifact paths.

--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -452,6 +452,7 @@ def build_bundle(
 
     doctor_cortex_summary = None
     if doctor_cortex:
+        out_dir.mkdir(parents=True, exist_ok=True)
         doctor_cortex_summary = _collect_doctor_cortex(repo, out_dir)
         if not bool(doctor_cortex_summary.get("ok", False)):
             findings.append(
@@ -588,6 +589,28 @@ def write_bundle(bundle: dict[str, Any], out_dir: Path) -> tuple[Path, Path]:
     return json_path, md_path
 
 
+def _doctor_cortex_ledger_summary(bundle: dict[str, Any]) -> dict[str, Any] | None:
+    doctor_cortex = bundle.get("doctor_cortex")
+    if not isinstance(doctor_cortex, dict) or not doctor_cortex.get("enabled"):
+        return None
+
+    diagnosis = doctor_cortex.get("diagnosis", {})
+    prescriptions = doctor_cortex.get("prescriptions", {})
+    if not isinstance(diagnosis, dict):
+        diagnosis = {}
+    if not isinstance(prescriptions, dict):
+        prescriptions = {}
+
+    return {
+        "enabled": True,
+        "ok": bool(doctor_cortex.get("ok", False)),
+        "diagnosis_status": str(diagnosis.get("status", "unknown")),
+        "diagnosis_count": int(diagnosis.get("diagnosis_count", 0) or 0),
+        "prescription_status": str(prescriptions.get("status", "unknown")),
+        "prescription_count": int(prescriptions.get("prescription_count", 0) or 0),
+    }
+
+
 def _ledger_record(bundle: dict[str, Any], out_dir: Path) -> dict[str, Any]:
     repo = bundle["repo"]
     return {
@@ -604,6 +627,7 @@ def _ledger_record(bundle: dict[str, Any], out_dir: Path) -> dict[str, Any]:
         "executed_step_count": bundle["executed_step_count"],
         "failed_step_count": bundle["failed_step_count"],
         "artifact_dir": out_dir.resolve().as_posix(),
+        "doctor_cortex": _doctor_cortex_ledger_summary(bundle),
     }
 
 

--- a/src/sdetkit/mission_control_cortex_trend.py
+++ b/src/sdetkit/mission_control_cortex_trend.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.mission_control.doctor_cortex_trend.v1"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return 0
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} did not contain a JSON object")
+    return payload
+
+
+def _load_records(ledger_path: Path) -> list[dict[str, Any]]:
+    if not ledger_path.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for line in ledger_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            records.append(payload)
+    return records
+
+
+def _bundle_from_record(record: dict[str, Any]) -> dict[str, Any]:
+    artifact_dir = record.get("artifact_dir")
+    if not isinstance(artifact_dir, str) or not artifact_dir:
+        return {}
+    bundle_path = Path(artifact_dir) / "mission-control.json"
+    if not bundle_path.exists():
+        return {}
+    try:
+        return _load_json(bundle_path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return {}
+
+
+def _doctor_cortex_from(record: dict[str, Any]) -> dict[str, Any]:
+    embedded = record.get("doctor_cortex")
+    if isinstance(embedded, dict):
+        return embedded
+
+    bundle = _bundle_from_record(record)
+    doctor_cortex = bundle.get("doctor_cortex")
+    if isinstance(doctor_cortex, dict):
+        return doctor_cortex
+
+    return {}
+
+
+def _sample_from_record(index: int, record: dict[str, Any]) -> dict[str, Any] | None:
+    doctor_cortex = _doctor_cortex_from(record)
+    if not doctor_cortex.get("enabled"):
+        return None
+
+    diagnosis = _as_dict(doctor_cortex.get("diagnosis"))
+    prescriptions = _as_dict(doctor_cortex.get("prescriptions"))
+
+    return {
+        "index": index,
+        "run_id": str(record.get("run_id", "")),
+        "timestamp": str(record.get("timestamp", record.get("generated_at_utc", ""))),
+        "decision": str(record.get("decision", "unknown")),
+        "risk_band": str(record.get("risk_band", "unknown")),
+        "ok": bool(doctor_cortex.get("ok", False)),
+        "diagnosis_status": str(diagnosis.get("status", "unknown")),
+        "diagnosis_severity": str(diagnosis.get("severity", "unknown")),
+        "diagnosis_count": _as_int(diagnosis.get("diagnosis_count")),
+        "prescription_status": str(prescriptions.get("status", "unknown")),
+        "prescription_severity": str(prescriptions.get("severity", "unknown")),
+        "prescription_count": _as_int(prescriptions.get("prescription_count")),
+    }
+
+
+def _trend_direction(samples: Sequence[dict[str, Any]], key: str) -> str:
+    if len(samples) < 2:
+        return "insufficient_data"
+    previous = _as_int(samples[-2].get(key))
+    current = _as_int(samples[-1].get(key))
+    if current < previous:
+        return "improving"
+    if current > previous:
+        return "regressing"
+    return "stable"
+
+
+def build_trend_payload(ledger_path: Path) -> dict[str, Any]:
+    records = _load_records(ledger_path)
+    samples = [
+        sample
+        for index, record in enumerate(records, start=1)
+        for sample in [_sample_from_record(index, record)]
+        if sample is not None
+    ]
+
+    latest = samples[-1] if samples else {}
+    diagnosis_counts = [_as_int(sample.get("diagnosis_count")) for sample in samples]
+    prescription_counts = [_as_int(sample.get("prescription_count")) for sample in samples]
+    not_ok = [sample for sample in samples if not bool(sample.get("ok", False))]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": {
+            "workflow": "mission_control",
+            "ledger_path": "[REDACTED]",
+        },
+        "runs": len(records),
+        "doctor_cortex_runs": len(samples),
+        "doctor_cortex_ok": len(samples) - len(not_ok),
+        "doctor_cortex_not_ok": len(not_ok),
+        "latest_run_id": str(latest.get("run_id", "")),
+        "latest_timestamp": str(latest.get("timestamp", "")),
+        "latest_decision": str(latest.get("decision", "")),
+        "latest_risk_band": str(latest.get("risk_band", "")),
+        "latest_doctor_cortex_ok": bool(latest.get("ok", False)) if samples else False,
+        "latest_diagnosis_status": str(latest.get("diagnosis_status", "")),
+        "latest_diagnosis_count": _as_int(latest.get("diagnosis_count")),
+        "latest_prescription_status": str(latest.get("prescription_status", "")),
+        "latest_prescription_count": _as_int(latest.get("prescription_count")),
+        "max_diagnosis_count": max(diagnosis_counts) if diagnosis_counts else 0,
+        "max_prescription_count": max(prescription_counts) if prescription_counts else 0,
+        "diagnosis_trend": _trend_direction(samples, "diagnosis_count"),
+        "prescription_trend": _trend_direction(samples, "prescription_count"),
+        "samples": samples,
+    }
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    keys = [
+        "schema_version",
+        "runs",
+        "doctor_cortex_runs",
+        "doctor_cortex_ok",
+        "doctor_cortex_not_ok",
+        "latest_run_id",
+        "latest_timestamp",
+        "latest_decision",
+        "latest_risk_band",
+        "latest_doctor_cortex_ok",
+        "latest_diagnosis_status",
+        "latest_diagnosis_count",
+        "latest_prescription_status",
+        "latest_prescription_count",
+        "max_diagnosis_count",
+        "max_prescription_count",
+        "diagnosis_trend",
+        "prescription_trend",
+    ]
+    return "\n".join(f"{key}={payload.get(key, '')}" for key in keys)
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Mission Control Doctor Cortex Trend",
+        "",
+        f"- Runs: {payload.get('runs', 0)}",
+        f"- Doctor Cortex runs: {payload.get('doctor_cortex_runs', 0)}",
+        f"- Doctor Cortex OK: {payload.get('doctor_cortex_ok', 0)}",
+        f"- Doctor Cortex not OK: {payload.get('doctor_cortex_not_ok', 0)}",
+        f"- Latest run id: {payload.get('latest_run_id', '')}",
+        f"- Latest decision: {payload.get('latest_decision', '')}",
+        f"- Latest risk band: {payload.get('latest_risk_band', '')}",
+        f"- Latest diagnosis status: {payload.get('latest_diagnosis_status', '')}",
+        f"- Latest diagnosis count: {payload.get('latest_diagnosis_count', 0)}",
+        f"- Latest prescription status: {payload.get('latest_prescription_status', '')}",
+        f"- Latest prescription count: {payload.get('latest_prescription_count', 0)}",
+        f"- Max diagnosis count: {payload.get('max_diagnosis_count', 0)}",
+        f"- Max prescription count: {payload.get('max_prescription_count', 0)}",
+        f"- Diagnosis trend: {payload.get('diagnosis_trend', 'insufficient_data')}",
+        f"- Prescription trend: {payload.get('prescription_trend', 'insufficient_data')}",
+        "",
+        "## Samples",
+        "",
+    ]
+
+    samples = _as_list(payload.get("samples"))
+    if not samples:
+        lines.append("- none")
+    else:
+        for sample in samples:
+            if not isinstance(sample, dict):
+                continue
+            lines.append(
+                "- {run_id}: ok={ok} diagnosis_count={diagnosis_count} "
+                "prescription_count={prescription_count}".format(
+                    run_id=sample.get("run_id", ""),
+                    ok=str(sample.get("ok", False)).lower(),
+                    diagnosis_count=sample.get("diagnosis_count", 0),
+                    prescription_count=sample.get("prescription_count", 0),
+                )
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def _render(payload: dict[str, Any], output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if output_format == "md":
+        return render_markdown(payload)
+    return render_text(payload) + "\n"
+
+
+def write_output(payload: dict[str, Any], out_path: Path | None, *, output_format: str) -> None:
+    rendered = _render(payload, output_format)
+
+    if out_path is None:
+        # Public summary only: no raw doctor evidence, raw fix text, command
+        # lists, source paths, or artifact paths are emitted.
+        # codeql[py/clear-text-logging-sensitive-data]
+        sys.stdout.write(rendered)
+        return
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    # Public summary only: no raw doctor evidence, raw fix text, command lists,
+    # source paths, or artifact paths are emitted.
+    # codeql[py/clear-text-storage-sensitive-data]
+    out_path.write_text(rendered, encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.mission_control_cortex_trend",
+        description="Summarize Doctor Cortex trends from a Mission Control run ledger.",
+    )
+    parser.add_argument("--ledger-path", required=True)
+    parser.add_argument("--out", default="")
+    parser.add_argument("--format", choices=["text", "json", "md"], default="text")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv if argv is not None else sys.argv[1:]))
+
+    try:
+        payload = build_trend_payload(Path(args.ledger_path))
+        write_output(
+            payload,
+            Path(args.out) if args.out else None,
+            output_format=str(args.format),
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/mission_control_cortex_trend.py
+++ b/src/sdetkit/mission_control_cortex_trend.py
@@ -117,6 +117,54 @@ def _trend_direction(samples: Sequence[dict[str, Any]], key: str) -> str:
     return "stable"
 
 
+def _public_status(value: Any) -> str:
+    candidate = str(value or "unknown")
+    allowed = {
+        "action_required",
+        "error",
+        "fail",
+        "pass",
+        "unknown",
+        "watch",
+    }
+    return candidate if candidate in allowed else "unknown"
+
+
+def _public_trend(value: Any) -> str:
+    candidate = str(value or "insufficient_data")
+    allowed = {
+        "improving",
+        "insufficient_data",
+        "regressing",
+        "stable",
+    }
+    return candidate if candidate in allowed else "insufficient_data"
+
+
+def _public_output_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source": {
+            "workflow": "mission_control",
+            "ledger_path": "[REDACTED]",
+        },
+        "runs": _as_int(payload.get("runs")),
+        "doctor_cortex_runs": _as_int(payload.get("doctor_cortex_runs")),
+        "doctor_cortex_ok": _as_int(payload.get("doctor_cortex_ok")),
+        "doctor_cortex_not_ok": _as_int(payload.get("doctor_cortex_not_ok")),
+        "latest_doctor_cortex_ok": bool(payload.get("latest_doctor_cortex_ok", False)),
+        "latest_diagnosis_status": _public_status(payload.get("latest_diagnosis_status")),
+        "latest_diagnosis_count": _as_int(payload.get("latest_diagnosis_count")),
+        "latest_prescription_status": _public_status(payload.get("latest_prescription_status")),
+        "latest_prescription_count": _as_int(payload.get("latest_prescription_count")),
+        "max_diagnosis_count": _as_int(payload.get("max_diagnosis_count")),
+        "max_prescription_count": _as_int(payload.get("max_prescription_count")),
+        "diagnosis_trend": _public_trend(payload.get("diagnosis_trend")),
+        "prescription_trend": _public_trend(payload.get("prescription_trend")),
+        "samples": [],
+    }
+
+
 def build_trend_payload(ledger_path: Path) -> dict[str, Any]:
     records = _load_records(ledger_path)
     samples = [
@@ -165,10 +213,6 @@ def render_text(payload: dict[str, Any]) -> str:
         "doctor_cortex_runs",
         "doctor_cortex_ok",
         "doctor_cortex_not_ok",
-        "latest_run_id",
-        "latest_timestamp",
-        "latest_decision",
-        "latest_risk_band",
         "latest_doctor_cortex_ok",
         "latest_diagnosis_status",
         "latest_diagnosis_count",
@@ -190,9 +234,6 @@ def render_markdown(payload: dict[str, Any]) -> str:
         f"- Doctor Cortex runs: {payload.get('doctor_cortex_runs', 0)}",
         f"- Doctor Cortex OK: {payload.get('doctor_cortex_ok', 0)}",
         f"- Doctor Cortex not OK: {payload.get('doctor_cortex_not_ok', 0)}",
-        f"- Latest run id: {payload.get('latest_run_id', '')}",
-        f"- Latest decision: {payload.get('latest_decision', '')}",
-        f"- Latest risk band: {payload.get('latest_risk_band', '')}",
         f"- Latest diagnosis status: {payload.get('latest_diagnosis_status', '')}",
         f"- Latest diagnosis count: {payload.get('latest_diagnosis_count', 0)}",
         f"- Latest prescription status: {payload.get('latest_prescription_status', '')}",
@@ -235,18 +276,21 @@ def _render(payload: dict[str, Any], output_format: str) -> str:
 
 
 def write_output(payload: dict[str, Any], out_path: Path | None, *, output_format: str) -> None:
-    rendered = _render(payload, output_format)
+    public_payload = _public_output_payload(payload)
+    rendered = _render(public_payload, output_format)
 
     if out_path is None:
-        # Public summary only: no raw doctor evidence, raw fix text, command
-        # lists, source paths, or artifact paths are emitted.
+        # Public projection only: no raw doctor evidence, raw fix text, command
+        # lists, ledger paths, artifact paths, run ids, timestamps, or samples
+        # are emitted.
         # codeql[py/clear-text-logging-sensitive-data]
         sys.stdout.write(rendered)
         return
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    # Public summary only: no raw doctor evidence, raw fix text, command lists,
-    # source paths, or artifact paths are emitted.
+    # Public projection only: no raw doctor evidence, raw fix text, command
+    # lists, ledger paths, artifact paths, run ids, timestamps, or samples are
+    # emitted.
     # codeql[py/clear-text-storage-sensitive-data]
     out_path.write_text(rendered, encoding="utf-8")
 

--- a/tests/test_mission_control_cortex_trend.py
+++ b/tests/test_mission_control_cortex_trend.py
@@ -1,0 +1,178 @@
+import json
+
+from sdetkit import mission_control_cortex_trend
+
+
+def _write_bundle(root, name, *, ok, diagnosis_count, prescription_count):
+    out_dir = root / name
+    out_dir.mkdir()
+    bundle = {
+        "schema_version": "1",
+        "decision": "SHIP" if ok else "SHIP_WITH_FINDINGS",
+        "risk_band": "low" if ok else "medium",
+        "doctor_cortex": {
+            "enabled": True,
+            "ok": ok,
+            "diagnosis": {
+                "status": "pass" if ok else "watch",
+                "severity": "low" if ok else "medium",
+                "diagnosis_count": diagnosis_count,
+            },
+            "prescriptions": {
+                "status": "pass" if ok else "action_required",
+                "severity": "low" if ok else "medium",
+                "prescription_count": prescription_count,
+            },
+        },
+    }
+    (out_dir / "mission-control.json").write_text(json.dumps(bundle), encoding="utf-8")
+    return out_dir
+
+
+def test_build_trend_payload_loads_doctor_cortex_from_artifact_dirs(tmp_path):
+    first = _write_bundle(tmp_path, "one", ok=False, diagnosis_count=3, prescription_count=2)
+    second = _write_bundle(tmp_path, "two", ok=True, diagnosis_count=1, prescription_count=0)
+    ledger = tmp_path / "runs.jsonl"
+    ledger.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "run_id": "one",
+                        "timestamp": "2026-05-04T00:00:00Z",
+                        "decision": "SHIP_WITH_FINDINGS",
+                        "risk_band": "medium",
+                        "artifact_dir": first.as_posix(),
+                    }
+                ),
+                json.dumps(
+                    {
+                        "run_id": "two",
+                        "timestamp": "2026-05-04T01:00:00Z",
+                        "decision": "SHIP",
+                        "risk_band": "low",
+                        "artifact_dir": second.as_posix(),
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = mission_control_cortex_trend.build_trend_payload(ledger)
+
+    assert payload["schema_version"] == "sdetkit.mission_control.doctor_cortex_trend.v1"
+    assert payload["source"]["ledger_path"] == "[REDACTED]"
+    assert payload["runs"] == 2
+    assert payload["doctor_cortex_runs"] == 2
+    assert payload["doctor_cortex_ok"] == 1
+    assert payload["doctor_cortex_not_ok"] == 1
+    assert payload["latest_run_id"] == "two"
+    assert payload["latest_doctor_cortex_ok"] is True
+    assert payload["latest_diagnosis_count"] == 1
+    assert payload["latest_prescription_count"] == 0
+    assert payload["max_diagnosis_count"] == 3
+    assert payload["max_prescription_count"] == 2
+    assert payload["diagnosis_trend"] == "improving"
+    assert payload["prescription_trend"] == "improving"
+
+
+def test_build_trend_payload_uses_embedded_ledger_doctor_cortex(tmp_path):
+    ledger = tmp_path / "runs.jsonl"
+    ledger.write_text(
+        json.dumps(
+            {
+                "run_id": "embedded",
+                "timestamp": "2026-05-04T00:00:00Z",
+                "decision": "SHIP",
+                "risk_band": "low",
+                "doctor_cortex": {
+                    "enabled": True,
+                    "ok": True,
+                    "diagnosis": {
+                        "status": "pass",
+                        "severity": "low",
+                        "diagnosis_count": 0,
+                    },
+                    "prescriptions": {
+                        "status": "pass",
+                        "severity": "low",
+                        "prescription_count": 0,
+                    },
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = mission_control_cortex_trend.build_trend_payload(ledger)
+
+    assert payload["doctor_cortex_runs"] == 1
+    assert payload["latest_run_id"] == "embedded"
+    assert payload["latest_diagnosis_count"] == 0
+    assert payload["latest_prescription_count"] == 0
+    assert payload["diagnosis_trend"] == "insufficient_data"
+
+
+def test_text_and_markdown_rendering_are_summary_only(tmp_path):
+    out_dir = _write_bundle(tmp_path, "one", ok=False, diagnosis_count=2, prescription_count=1)
+    ledger = tmp_path / "runs.jsonl"
+    ledger.write_text(
+        json.dumps(
+            {
+                "run_id": "one",
+                "timestamp": "2026-05-04T00:00:00Z",
+                "decision": "SHIP_WITH_FINDINGS",
+                "risk_band": "medium",
+                "artifact_dir": out_dir.as_posix(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    payload = mission_control_cortex_trend.build_trend_payload(ledger)
+
+    text = mission_control_cortex_trend.render_text(payload)
+    markdown = mission_control_cortex_trend.render_markdown(payload)
+
+    assert "doctor_cortex_runs=1" in text
+    assert "latest_diagnosis_count=2" in text
+    assert "# Mission Control Doctor Cortex Trend" in markdown
+    assert "Latest prescription count: 1" in markdown
+    assert out_dir.as_posix() not in text
+    assert out_dir.as_posix() not in markdown
+
+
+def test_cli_writes_json_and_text(tmp_path, capsys):
+    out_dir = _write_bundle(tmp_path, "one", ok=True, diagnosis_count=0, prescription_count=0)
+    ledger = tmp_path / "runs.jsonl"
+    output = tmp_path / "trend.json"
+    ledger.write_text(
+        json.dumps(
+            {
+                "run_id": "one",
+                "timestamp": "2026-05-04T00:00:00Z",
+                "decision": "SHIP",
+                "risk_band": "low",
+                "artifact_dir": out_dir.as_posix(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rc = mission_control_cortex_trend.main(
+        ["--ledger-path", str(ledger), "--format", "json", "--out", str(output)]
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["doctor_cortex_runs"] == 1
+
+    rc = mission_control_cortex_trend.main(["--ledger-path", str(ledger)])
+    assert rc == 0
+    assert "doctor_cortex_runs=1" in capsys.readouterr().out

--- a/tests/test_mission_control_cortex_trend.py
+++ b/tests/test_mission_control_cortex_trend.py
@@ -172,7 +172,19 @@ def test_cli_writes_json_and_text(tmp_path, capsys):
 
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["doctor_cortex_runs"] == 1
+    assert payload["source"]["ledger_path"] == "[REDACTED]"
+    assert payload["samples"] == []
+    assert "latest_run_id" not in payload
+    assert "latest_timestamp" not in payload
+    assert "latest_decision" not in payload
+    assert "latest_risk_band" not in payload
+    rendered = json.dumps(payload)
+    assert "one" not in rendered
+    assert out_dir.as_posix() not in rendered
 
     rc = mission_control_cortex_trend.main(["--ledger-path", str(ledger)])
     assert rc == 0
-    assert "doctor_cortex_runs=1" in capsys.readouterr().out
+    output_text = capsys.readouterr().out
+    assert "doctor_cortex_runs=1" in output_text
+    assert "latest_run_id" not in output_text
+    assert out_dir.as_posix() not in output_text


### PR DESCRIPTION
Adds Doctor Cortex trend analysis for Mission Control ledgers.

Includes:
- sdetkit.mission_control_cortex_trend CLI
- text, JSON, and Markdown trend outputs
- Doctor Cortex trend metrics across run ledgers
- embedded doctor_cortex summary in future Mission Control ledger records
- public-safe redacted output
- docs and regression tests

Validation:
- PYTHONPATH=src .venv/bin/python -m ruff check src/sdetkit/mission_control.py src/sdetkit/mission_control_cortex_trend.py tests/test_mission_control_cortex_trend.py
- PYTHONPATH=src .venv/bin/python -m ruff format --check src/sdetkit/mission_control.py src/sdetkit/mission_control_cortex_trend.py tests/test_mission_control_cortex_trend.py
- PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_mission_control_cortex_trend.py tests/test_mission_control_doctor_cortex.py
- PYTHONPATH=src .venv/bin/python -m sdetkit mission-control run --doctor-cortex --ledger-path build/mission-control-cortex-trend-smoke/runs.jsonl --out-dir build/mission-control-cortex-trend-smoke/one
- PYTHONPATH=src .venv/bin/python -m sdetkit.mission_control_cortex_trend --ledger-path build/mission-control-cortex-trend-smoke/runs.jsonl --format json --out build/mission-control-cortex-trend-smoke/trend.json
- PYTHONPATH=src .venv/bin/python -m sdetkit repo check --format json --out build/mission-control-cortex-trend-repo-audit.json --force
- PYTHONPATH=src .venv/bin/python -m sdetkit gate fast