### PR TITLE
Write adaptive diagnosis artifacts on autopilot failure

### DIFF
--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from typing import Any
 
 
+_ACTIVE_FAILURE_CONTEXT: dict[str, Any] = {"out_dir": None, "report": None}
+
+
 def _run(
     cmd: list[str], *, allow_fail: bool = False, env: dict[str, str] | None = None
 ) -> dict[str, Any]:
@@ -24,6 +27,7 @@ def _run(
         "ok": proc.returncode == 0,
     }
     if not allow_fail and proc.returncode != 0:
+        _write_adaptive_diagnosis_on_failure(result)
         raise RuntimeError(
             f"command failed ({proc.returncode}): {' '.join(cmd)}\n"
             f"stdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}"
@@ -206,6 +210,9 @@ def main(argv: list[str] | None = None) -> int:
         "repo": args.repo,
         "steps": {},
     }
+
+    _ACTIVE_FAILURE_CONTEXT["out_dir"] = out_dir
+    _ACTIVE_FAILURE_CONTEXT["report"] = report
 
     # 1) Baseline checks
     report["steps"]["baseline_pre_commit"] = _run([sys.executable, "-m", "pre_commit", "run", "-a"])

--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -11,7 +11,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-
 _ACTIVE_FAILURE_CONTEXT: dict[str, Any] = {"out_dir": None, "report": None}
 
 
@@ -71,6 +70,92 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
         if isinstance(item, dict):
             rows.append(item)
     return rows
+
+
+def _failure_key_for_command(cmd: list[str]) -> str:
+    joined = " ".join(cmd)
+    if "pre_commit" in joined:
+        return "baseline_pre_commit"
+    if "pytest" in joined and "test_kpi_audit.py" in joined:
+        return "baseline_kpi_test"
+    if "ruff" in joined:
+        return "baseline_ruff"
+    if "repo check" in joined:
+        return "enterprise_repo_check"
+    if "security check" in joined:
+        return "security_actionable"
+    if "review" in joined:
+        return "review_json"
+    return "runtime_failure"
+
+
+def _write_adaptive_diagnosis_on_failure(failure: dict[str, Any]) -> None:
+    out_dir = _ACTIVE_FAILURE_CONTEXT.get("out_dir")
+    report = _ACTIVE_FAILURE_CONTEXT.get("report")
+    if not isinstance(out_dir, Path) or not isinstance(report, dict):
+        return
+
+    try:
+        from sdetkit import adaptive_diagnosis
+    except Exception as exc:
+        _write_json(
+            out_dir / "adaptive-diagnosis-error.json",
+            {
+                "schema_version": "sdetkit.maintenance.autopilot.adaptive_diagnosis_error.v1",
+                "ok": False,
+                "error": str(exc),
+            },
+        )
+        return
+
+    cmd = [str(part) for part in failure.get("cmd", [])]
+    failure_key = _failure_key_for_command(cmd)
+    steps: list[dict[str, Any]] = []
+
+    for step_name, step_payload in report.get("steps", {}).items():
+        if not isinstance(step_payload, dict):
+            continue
+        if bool(step_payload.get("ok", True)):
+            continue
+        steps.append(
+            {
+                "id": str(step_name),
+                "status": "failed",
+                "rc": step_payload.get("returncode"),
+            }
+        )
+
+    steps.append(
+        {
+            "id": failure_key,
+            "status": "failed",
+            "rc": failure.get("returncode"),
+        }
+    )
+
+    log_text = "\n".join(
+        [
+            "command: " + " ".join(cmd),
+            str(failure.get("stdout", "")),
+            str(failure.get("stderr", "")),
+        ]
+    )
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text=log_text,
+        mission_control={
+            "decision": "NO_SHIP",
+            "failed_step_count": max(1, len(steps)),
+            "steps": steps,
+            "artifacts": ["adaptive-diagnosis.json", "adaptive-diagnosis.md"],
+        },
+        ledger_records=[],
+    )
+
+    _write_json(out_dir / "adaptive-diagnosis.json", payload)
+    (out_dir / "adaptive-diagnosis.md").write_text(
+        adaptive_diagnosis.render_markdown(payload),
+        encoding="utf-8",
+    )
 
 
 POLICY_RULES: dict[str, dict[str, Any]] = {


### PR DESCRIPTION
## Summary
- Wire maintenance autopilot failures into Adaptive Diagnosis.
- Write `adaptive-diagnosis.json` and `adaptive-diagnosis.md` into the autopilot output directory before required-command failures re-raise.
- Keep successful autopilot behavior unchanged.

## Why
- Autopilot currently exits with a raw traceback when a required gate fails.
- This adds operator-facing diagnosis artifacts that explain what failed, why it is easy to miss, suggested fix path, proof commands, and learning signals.

## How
- Add a narrow failure context for the active output directory and partial report.
- Classify the failing command into a stable failure key.
- Call `sdetkit.adaptive_diagnosis.analyze_evidence()` from the required-command failure path.
- Write Markdown and JSON artifacts before raising the original RuntimeError.

## Risk assessment
- Risk level: medium
- Primary risk area: failure-path behavior in `tools/maintenance_autopilot.py`
- Successful autopilot behavior should remain unchanged.

## Test evidence
- WSL2 local checks performed before push:
  - `PYTHONPATH=src python -m ruff check --fix tools/maintenance_autopilot.py`
  - `PYTHONPATH=src python -m ruff format tools/maintenance_autopilot.py`
  - `PYTHONPATH=src python -m ruff format --check tools/maintenance_autopilot.py`
  - `PYTHONPATH=src python -m ruff check tools/maintenance_autopilot.py`
  - `PYTHONPATH=src python -m py_compile tools/maintenance_autopilot.py`
  - adaptive diagnosis artifact smoke test

## Rollback plan
- Revert the autopilot helper commits if the failure-path artifact writer causes CI regressions.

## Checklist
- [x] Runtime code updated
- [x] Failure artifact path added
- [x] No successful-path command order changes intended
- [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`
