### PR TITLE
Add adaptive safe fix planner

### DIFF
--- a/src/sdetkit/adaptive_safe_fix.py
+++ b/src/sdetkit/adaptive_safe_fix.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive_safe_fix.v1"
+SOURCE_SCHEMA_VERSION = "sdetkit.adaptive.diagnosis.v1"
+SAFE_FORMAT_CODE = "PRE_COMMIT_FORMAT_DRIFT"
+ACTIONABLE_STATUSES = {"needs_attention", "needs_fix"}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_text(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").strip()
+
+
+def _load_diagnosis(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    if payload.get("schema_version") != SOURCE_SCHEMA_VERSION:
+        raise ValueError(f"unsupported adaptive diagnosis schema in {path}")
+    return payload
+
+
+def _format_targets(diagnosis: dict[str, Any]) -> str:
+    files = [_safe_text(value) for value in _as_list(diagnosis.get("affected_files"))]
+    files = [value for value in files if value]
+    return " ".join(files) if files else "<touched-python-files>"
+
+
+def _first_diagnosis(payload: dict[str, Any]) -> dict[str, Any]:
+    for item in _as_list(payload.get("diagnoses")):
+        row = _as_dict(item)
+        if row:
+            return row
+    return {}
+
+
+def _is_safe_format_plan(payload: dict[str, Any], diagnosis: dict[str, Any]) -> bool:
+    status = str(payload.get("status", "unknown"))
+    if status not in ACTIONABLE_STATUSES:
+        return False
+    if diagnosis.get("code") != SAFE_FORMAT_CODE:
+        return False
+    if diagnosis.get("severity") not in {"low", "medium"}:
+        return False
+    if diagnosis.get("confidence") != "high":
+        return False
+    return True
+
+
+def build_plan(payload: dict[str, Any]) -> dict[str, Any]:
+    diagnosis = _first_diagnosis(payload)
+    code = str(diagnosis.get("code", "UNKNOWN") or "UNKNOWN")
+    targets = _format_targets(diagnosis)
+    safe = _is_safe_format_plan(payload, diagnosis)
+
+    if safe:
+        commands = [
+            f"PYTHONPATH=src python -m ruff format {targets}",
+            f"PYTHONPATH=src python -m ruff format --check {targets}",
+            f"PYTHONPATH=src python -m ruff check {targets}",
+        ]
+        proof_commands = [
+            f"PYTHONPATH=src python -m ruff format --check {targets}",
+            "PYTHONPATH=src python -m pytest -q <targeted-tests>",
+        ]
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "source_schema_version": str(payload.get("schema_version", "")),
+            "ok": True,
+            "source_status": str(payload.get("status", "unknown")),
+            "source_code": code,
+            "safe_to_auto_fix": True,
+            "fix_type": "format_only",
+            "confidence": "high",
+            "requires_human_review": False,
+            "reason": (
+                "Formatter drift is safe to plan because the primary diagnosis is "
+                "PRE_COMMIT_FORMAT_DRIFT with high confidence and low/medium severity."
+            ),
+            "commands": commands,
+            "proof_commands": proof_commands,
+            "affected_files": _as_list(diagnosis.get("affected_files")),
+        }
+
+    reason = "No diagnosis was available to plan from."
+    if diagnosis:
+        reason = f"{code} requires human review; this planner only auto-plans format-only drift."
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_schema_version": str(payload.get("schema_version", "")),
+        "ok": True,
+        "source_status": str(payload.get("status", "unknown")),
+        "source_code": code,
+        "safe_to_auto_fix": False,
+        "fix_type": "review_required",
+        "confidence": str(diagnosis.get("confidence", payload.get("confidence", "unknown"))),
+        "requires_human_review": True,
+        "reason": reason,
+        "commands": [],
+        "proof_commands": _as_list(diagnosis.get("proof_commands"))[:3],
+        "affected_files": _as_list(diagnosis.get("affected_files")),
+    }
+
+
+def plan_from_file(diagnosis_path: Path, out_path: Path | None = None) -> dict[str, Any]:
+    payload = _load_diagnosis(diagnosis_path)
+    plan = build_plan(payload)
+    plan["source_path"] = diagnosis_path.as_posix()
+    if out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return plan
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_safe_fix")
+    parser.add_argument("diagnosis_json")
+    parser.add_argument("--out", default="")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        plan = plan_from_file(
+            Path(args.diagnosis_json), Path(args.out) if args.out else None
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(json.dumps(plan, indent=2, sort_keys=True))
+    else:
+        print(f"safe_to_auto_fix: {str(plan['safe_to_auto_fix']).lower()}")
+        print(f"fix_type: {plan['fix_type']}")
+        print(f"requires_human_review: {str(plan['requires_human_review']).lower()}")
+        print(f"reason: {plan['reason']}")
+        for command in plan.get("commands", []):
+            print(f"command: {command}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_safe_fix.py
+++ b/src/sdetkit/adaptive_safe_fix.py
@@ -135,9 +135,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
-        plan = plan_from_file(
-            Path(args.diagnosis_json), Path(args.out) if args.out else None
-        )
+        plan = plan_from_file(Path(args.diagnosis_json), Path(args.out) if args.out else None)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"error={exc}")
         return 2

--- a/tests/test_adaptive_safe_fix.py
+++ b/tests/test_adaptive_safe_fix.py
@@ -3,7 +3,9 @@ import json
 from sdetkit import adaptive_safe_fix
 
 
-def _payload(code="PRE_COMMIT_FORMAT_DRIFT", status="needs_fix", severity="medium", confidence="high"):
+def _payload(
+    code="PRE_COMMIT_FORMAT_DRIFT", status="needs_fix", severity="medium", confidence="high"
+):
     return {
         "schema_version": "sdetkit.adaptive.diagnosis.v1",
         "ok": False,
@@ -113,9 +115,7 @@ def test_cli_outputs_json_and_rejects_bad_schema(tmp_path, capsys):
     plan_path = tmp_path / "safe-fix-plan.json"
     diagnosis_path.write_text(json.dumps(_payload()), encoding="utf-8")
 
-    rc = adaptive_safe_fix.main(
-        [str(diagnosis_path), "--out", str(plan_path), "--format", "json"]
-    )
+    rc = adaptive_safe_fix.main([str(diagnosis_path), "--out", str(plan_path), "--format", "json"])
 
     assert rc == 0
     output = json.loads(capsys.readouterr().out)

--- a/tests/test_adaptive_safe_fix.py
+++ b/tests/test_adaptive_safe_fix.py
@@ -1,0 +1,129 @@
+import json
+
+from sdetkit import adaptive_safe_fix
+
+
+def _payload(code="PRE_COMMIT_FORMAT_DRIFT", status="needs_fix", severity="medium", confidence="high"):
+    return {
+        "schema_version": "sdetkit.adaptive.diagnosis.v1",
+        "ok": False,
+        "status": status,
+        "risk_score": 53,
+        "confidence": confidence,
+        "summary": "Primary issue.",
+        "diagnosis_count": 1,
+        "diagnoses": [
+            {
+                "code": code,
+                "severity": severity,
+                "confidence": confidence,
+                "title": "Formatter drift blocked pre-commit",
+                "recommended_fix": ["Run ruff format on touched files."],
+                "proof_commands": ["PYTHONPATH=src python -m pytest -q tests/test_case.py"],
+                "risk_if_ignored": "CI stays red.",
+                "learning_signal": "formatting-drift-after-green-tests",
+                "repeat_count": 1,
+                "affected_files": ["src/sdetkit/example.py", "tests/test_example.py"],
+            }
+        ],
+        "fix_plan": [],
+        "learning_updates": [],
+    }
+
+
+def test_formatter_drift_builds_safe_format_only_plan():
+    plan = adaptive_safe_fix.build_plan(_payload())
+
+    assert plan["schema_version"] == "sdetkit.adaptive_safe_fix.v1"
+    assert plan["safe_to_auto_fix"] is True
+    assert plan["fix_type"] == "format_only"
+    assert plan["requires_human_review"] is False
+    assert plan["confidence"] == "high"
+    assert plan["affected_files"] == ["src/sdetkit/example.py", "tests/test_example.py"]
+    assert plan["commands"] == [
+        "PYTHONPATH=src python -m ruff format src/sdetkit/example.py tests/test_example.py",
+        "PYTHONPATH=src python -m ruff format --check src/sdetkit/example.py tests/test_example.py",
+        "PYTHONPATH=src python -m ruff check src/sdetkit/example.py tests/test_example.py",
+    ]
+    assert plan["proof_commands"][0].endswith(
+        "ruff format --check src/sdetkit/example.py tests/test_example.py"
+    )
+    assert "pytest" in plan["proof_commands"][1]
+
+
+def test_formatter_drift_without_files_uses_placeholder_targets():
+    payload = _payload()
+    payload["diagnoses"][0]["affected_files"] = []
+
+    plan = adaptive_safe_fix.build_plan(payload)
+
+    assert plan["safe_to_auto_fix"] is True
+    assert plan["commands"][0].endswith("ruff format <touched-python-files>")
+
+
+def test_non_formatter_diagnoses_require_human_review():
+    for code in [
+        "PYTEST_ASSERTION_FAILURE",
+        "PYTEST_IMPORT_FAILURE",
+        "MYPY_TYPE_CONTRACT_DRIFT",
+        "MISSION_CONTROL_NO_SHIP",
+        "DOCTOR_CORTEX_DIAGNOSIS_REGRESSION",
+        "RUFF_LINT_FAILURE",
+    ]:
+        plan = adaptive_safe_fix.build_plan(_payload(code=code))
+        assert plan["safe_to_auto_fix"] is False
+        assert plan["requires_human_review"] is True
+        assert plan["fix_type"] == "review_required"
+        assert code in plan["reason"]
+
+
+def test_formatter_drift_requires_actionable_high_confidence_low_or_medium_severity():
+    assert adaptive_safe_fix.build_plan(_payload(status="monitor"))["safe_to_auto_fix"] is False
+    assert adaptive_safe_fix.build_plan(_payload(confidence="medium"))["safe_to_auto_fix"] is False
+    assert adaptive_safe_fix.build_plan(_payload(severity="high"))["safe_to_auto_fix"] is False
+
+
+def test_empty_diagnosis_requires_review():
+    payload = _payload()
+    payload["diagnoses"] = []
+
+    plan = adaptive_safe_fix.build_plan(payload)
+
+    assert plan["safe_to_auto_fix"] is False
+    assert plan["requires_human_review"] is True
+    assert plan["source_code"] == "UNKNOWN"
+    assert plan["commands"] == []
+
+
+def test_plan_from_file_writes_output(tmp_path):
+    diagnosis_path = tmp_path / "adaptive-diagnosis.json"
+    plan_path = tmp_path / "safe-fix-plan.json"
+    diagnosis_path.write_text(json.dumps(_payload()), encoding="utf-8")
+
+    plan = adaptive_safe_fix.plan_from_file(diagnosis_path, plan_path)
+
+    assert plan["safe_to_auto_fix"] is True
+    assert plan["source_path"] == diagnosis_path.as_posix()
+    written = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert written["fix_type"] == "format_only"
+
+
+def test_cli_outputs_json_and_rejects_bad_schema(tmp_path, capsys):
+    diagnosis_path = tmp_path / "adaptive-diagnosis.json"
+    plan_path = tmp_path / "safe-fix-plan.json"
+    diagnosis_path.write_text(json.dumps(_payload()), encoding="utf-8")
+
+    rc = adaptive_safe_fix.main(
+        [str(diagnosis_path), "--out", str(plan_path), "--format", "json"]
+    )
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["safe_to_auto_fix"] is True
+    assert plan_path.exists()
+
+    diagnosis_path.write_text(json.dumps({"schema_version": "bad"}), encoding="utf-8")
+    rc = adaptive_safe_fix.main([str(diagnosis_path)])
+
+    assert rc == 2
+    assert "unsupported adaptive diagnosis schema" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Add `sdetkit.adaptive_safe_fix`, a plan-only safe-fix planner for Adaptive Diagnosis output.
- Add tests that enforce the safety boundary: only high-confidence `PRE_COMMIT_FORMAT_DRIFT` with low/medium severity can produce a safe format-only plan.

## Why
- SDETKit can now diagnose, comment, and remember patterns. The next step is to recommend the smallest safe repair without mutating branches.

## How
- Read `sdetkit.adaptive.diagnosis.v1` JSON.
- Emit `sdetkit.adaptive_safe_fix.v1` plans.
- Return `safe_to_auto_fix=true` only for narrow formatter drift.
- Require human review for pytest, import, mypy, Mission Control, Doctor Cortex, and ruff lint diagnoses.

## Risk assessment
- Risk level: medium
- Primary risk area: new Python module and test formatting
- No commands are executed by the planner.
- No auto-fix or branch mutation behavior is added.

## Test evidence
- CI should run the focused tests:
  - `PYTHONPATH=src python -m pytest -q tests/test_adaptive_safe_fix.py`

## Rollback plan
- Revert the planner module and tests if needed.

## Checklist
- [x] Runtime module added
- [x] Tests added
- [x] Plan-only behavior
- [x] No branch mutation or auto-fix execution
- [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`
