### PR TITLE
Add adaptive safe remediation runner

### DIFF
--- a/src/sdetkit/adaptive_safe_remediation.py
+++ b/src/sdetkit/adaptive_safe_remediation.py
@@ -166,7 +166,9 @@ def render_markdown(result: dict[str, Any]) -> str:
         lines.append("## Commands")
         for item in commands:
             row = _as_dict(item)
-            lines.append(f"- `{row.get('command', '')}` → ok={row.get('ok')} rc={row.get('returncode')}")
+            lines.append(
+                f"- `{row.get('command', '')}` → ok={row.get('ok')} rc={row.get('returncode')}"
+            )
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 

--- a/src/sdetkit/adaptive_safe_remediation.py
+++ b/src/sdetkit/adaptive_safe_remediation.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive_safe_remediation.v1"
+PLAN_SCHEMA_VERSION = "sdetkit.adaptive_safe_fix.v1"
+ALLOWED_PREFIXES = (
+    ("PYTHONPATH=src", "python", "-m", "ruff", "format"),
+    ("PYTHONPATH=src", "python", "-m", "ruff", "check"),
+    ("PYTHONPATH=src", "python", "-m", "pytest", "-q"),
+)
+BLOCKED_TOKENS = {"git", "gh", "hub", "twine"}
+
+CommandRunner = Callable[[list[str], Path], dict[str, Any]]
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _load_plan(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    if payload.get("schema_version") != PLAN_SCHEMA_VERSION:
+        raise ValueError(f"unsupported safe fix plan schema in {path}")
+    return payload
+
+
+def _has_placeholder(command: str) -> bool:
+    return "<" in command or ">" in command
+
+
+def _split_command(command: str) -> list[str]:
+    return shlex.split(command)
+
+
+def _is_allowed_command(command: str) -> tuple[bool, str]:
+    if _has_placeholder(command):
+        return False, "command contains unresolved placeholder"
+    try:
+        parts = _split_command(command)
+    except ValueError as exc:
+        return False, f"command could not be parsed: {exc}"
+    if not parts:
+        return False, "command is empty"
+    if any(part in BLOCKED_TOKENS for part in parts):
+        return False, "command contains blocked mutation token"
+    for prefix in ALLOWED_PREFIXES:
+        if tuple(parts[: len(prefix)]) == prefix:
+            return True, "allowed"
+    return False, "command is outside the safe remediation allowlist"
+
+
+def validate_plan(plan: dict[str, Any]) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    if plan.get("schema_version") != PLAN_SCHEMA_VERSION:
+        reasons.append("unsupported schema_version")
+    if plan.get("safe_to_auto_fix") is not True:
+        reasons.append("safe_to_auto_fix is not true")
+    if plan.get("fix_type") != "format_only":
+        reasons.append("fix_type is not format_only")
+    if plan.get("requires_human_review") is not False:
+        reasons.append("requires_human_review is not false")
+    commands = [str(command) for command in _as_list(plan.get("commands"))]
+    if not commands:
+        reasons.append("no commands to run")
+    for command in commands:
+        ok, reason = _is_allowed_command(command)
+        if not ok:
+            reasons.append(f"unsafe command `{command}`: {reason}")
+    return not reasons, reasons
+
+
+def _default_runner(parts: list[str], cwd: Path) -> dict[str, Any]:
+    env_prefix: dict[str, str] = {}
+    while parts and "=" in parts[0] and not parts[0].startswith("-"):
+        key, value = parts.pop(0).split("=", 1)
+        env_prefix[key] = value
+    import os
+
+    env = {**os.environ, **env_prefix}
+    proc = subprocess.run(parts, cwd=cwd, env=env, capture_output=True, text=True, check=False)
+    return {
+        "cmd": parts,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "ok": proc.returncode == 0,
+    }
+
+
+def _run_commands(
+    commands: Sequence[str], cwd: Path, command_runner: CommandRunner
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for command in commands:
+        parts = _split_command(command)
+        result = command_runner(parts, cwd)
+        result["command"] = command
+        result["ok"] = bool(result.get("ok", False))
+        result["returncode"] = int(result.get("returncode", 1) or 0)
+        results.append(result)
+        if not result["ok"]:
+            break
+    return results
+
+
+def build_result(
+    plan: dict[str, Any], command_results: list[dict[str, Any]], validation_errors: list[str]
+) -> dict[str, Any]:
+    attempted = not validation_errors
+    ok = attempted and all(bool(item.get("ok", False)) for item in command_results)
+    status = "success" if ok else "blocked" if validation_errors else "failed"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": ok,
+        "status": status,
+        "attempted": attempted,
+        "safe_to_auto_fix": bool(plan.get("safe_to_auto_fix", False)),
+        "fix_type": str(plan.get("fix_type", "unknown")),
+        "source_code": str(plan.get("source_code", "UNKNOWN")),
+        "validation_errors": validation_errors,
+        "command_count": len(command_results),
+        "commands": [
+            {
+                "command": str(item.get("command", "")),
+                "returncode": int(item.get("returncode", 1)),
+                "ok": bool(item.get("ok", False)),
+                "stdout": str(item.get("stdout", ""))[-2000:],
+                "stderr": str(item.get("stderr", ""))[-2000:],
+            }
+            for item in command_results
+        ],
+    }
+
+
+def render_markdown(result: dict[str, Any]) -> str:
+    lines = [
+        "# Adaptive Safe Remediation Result",
+        "",
+        f"- Status: `{result.get('status', 'unknown')}`",
+        f"- OK: `{str(result.get('ok', False)).lower()}`",
+        f"- Attempted: `{str(result.get('attempted', False)).lower()}`",
+        f"- Fix type: `{result.get('fix_type', 'unknown')}`",
+        f"- Source code: `{result.get('source_code', 'UNKNOWN')}`",
+        "",
+    ]
+    errors = _as_list(result.get("validation_errors"))
+    if errors:
+        lines.append("## Validation errors")
+        lines.extend(f"- {error}" for error in errors)
+        lines.append("")
+    commands = _as_list(result.get("commands"))
+    if commands:
+        lines.append("## Commands")
+        for item in commands:
+            row = _as_dict(item)
+            lines.append(f"- `{row.get('command', '')}` → ok={row.get('ok')} rc={row.get('returncode')}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def run_plan(
+    plan: dict[str, Any],
+    *,
+    cwd: Path | None = None,
+    command_runner: CommandRunner = _default_runner,
+) -> dict[str, Any]:
+    valid, validation_errors = validate_plan(plan)
+    command_results: list[dict[str, Any]] = []
+    if valid:
+        command_results = _run_commands(
+            [str(command) for command in _as_list(plan.get("commands"))],
+            cwd or Path.cwd(),
+            command_runner,
+        )
+    return build_result(plan, command_results, validation_errors)
+
+
+def run_plan_file(
+    plan_path: Path,
+    *,
+    out_json: Path | None = None,
+    out_md: Path | None = None,
+    cwd: Path | None = None,
+    command_runner: CommandRunner = _default_runner,
+) -> dict[str, Any]:
+    plan = _load_plan(plan_path)
+    result = run_plan(plan, cwd=cwd, command_runner=command_runner)
+    result["plan_path"] = plan_path.as_posix()
+    if out_json is not None:
+        out_json.parent.mkdir(parents=True, exist_ok=True)
+        out_json.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if out_md is not None:
+        out_md.parent.mkdir(parents=True, exist_ok=True)
+        out_md.write_text(render_markdown(result), encoding="utf-8")
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_safe_remediation")
+    parser.add_argument("safe_fix_plan_json")
+    parser.add_argument("--out-json", default="")
+    parser.add_argument("--out-md", default="")
+    parser.add_argument("--cwd", default="")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = run_plan_file(
+            Path(args.safe_fix_plan_json),
+            out_json=Path(args.out_json) if args.out_json else None,
+            out_md=Path(args.out_md) if args.out_md else None,
+            cwd=Path(args.cwd) if args.cwd else None,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"status: {result['status']}")
+        print(f"ok: {str(result['ok']).lower()}")
+        print(f"attempted: {str(result['attempted']).lower()}")
+        for error in result.get("validation_errors", []):
+            print(f"validation_error: {error}")
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adaptive_safe_remediation.py
+++ b/tests/test_adaptive_safe_remediation.py
@@ -1,0 +1,156 @@
+import json
+
+from sdetkit import adaptive_safe_remediation
+
+
+def _plan(commands=None, **overrides):
+    payload = {
+        "schema_version": "sdetkit.adaptive_safe_fix.v1",
+        "source_schema_version": "sdetkit.adaptive.diagnosis.v1",
+        "ok": True,
+        "source_status": "needs_fix",
+        "source_code": "PRE_COMMIT_FORMAT_DRIFT",
+        "safe_to_auto_fix": True,
+        "fix_type": "format_only",
+        "confidence": "high",
+        "requires_human_review": False,
+        "reason": "format-only drift",
+        "commands": commands
+        if commands is not None
+        else [
+            "PYTHONPATH=src python -m ruff format src/sdetkit/example.py",
+            "PYTHONPATH=src python -m ruff format --check src/sdetkit/example.py",
+            "PYTHONPATH=src python -m ruff check src/sdetkit/example.py",
+        ],
+        "proof_commands": [],
+        "affected_files": ["src/sdetkit/example.py"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _runner_factory(results=None):
+    calls = []
+    queued = list(results or [])
+
+    def runner(parts, cwd):
+        calls.append((list(parts), cwd))
+        result = queued.pop(0) if queued else {"ok": True, "returncode": 0, "stdout": "ok", "stderr": ""}
+        return dict(result)
+
+    return calls, runner
+
+
+def test_validate_plan_accepts_format_only_allowlist():
+    ok, errors = adaptive_safe_remediation.validate_plan(_plan())
+
+    assert ok is True
+    assert errors == []
+
+
+def test_validate_plan_rejects_review_required_or_unsafe_commands():
+    for plan in [
+        _plan(safe_to_auto_fix=False),
+        _plan(requires_human_review=True),
+        _plan(fix_type="review_required"),
+        _plan(commands=["git push origin HEAD"]),
+        _plan(commands=["PYTHONPATH=src python -m ruff format <touched-python-files>"]),
+        _plan(commands=["python -m pip install -r requirements.txt"]),
+    ]:
+        ok, errors = adaptive_safe_remediation.validate_plan(plan)
+        assert ok is False
+        assert errors
+
+
+def test_run_plan_executes_commands_in_order_with_fake_runner(tmp_path):
+    calls, runner = _runner_factory()
+
+    result = adaptive_safe_remediation.run_plan(_plan(), cwd=tmp_path, command_runner=runner)
+
+    assert result["ok"] is True
+    assert result["status"] == "success"
+    assert result["attempted"] is True
+    assert result["command_count"] == 3
+    assert [call[0] for call in calls] == [
+        ["PYTHONPATH=src", "python", "-m", "ruff", "format", "src/sdetkit/example.py"],
+        ["PYTHONPATH=src", "python", "-m", "ruff", "format", "--check", "src/sdetkit/example.py"],
+        ["PYTHONPATH=src", "python", "-m", "ruff", "check", "src/sdetkit/example.py"],
+    ]
+    assert all(call[1] == tmp_path for call in calls)
+
+
+def test_run_plan_stops_after_first_failed_command(tmp_path):
+    calls, runner = _runner_factory(
+        [
+            {"ok": True, "returncode": 0, "stdout": "format ok", "stderr": ""},
+            {"ok": False, "returncode": 1, "stdout": "", "stderr": "format check failed"},
+            {"ok": True, "returncode": 0, "stdout": "should not run", "stderr": ""},
+        ]
+    )
+
+    result = adaptive_safe_remediation.run_plan(_plan(), cwd=tmp_path, command_runner=runner)
+
+    assert result["ok"] is False
+    assert result["status"] == "failed"
+    assert result["command_count"] == 2
+    assert len(calls) == 2
+    assert result["commands"][1]["stderr"] == "format check failed"
+
+
+def test_run_plan_blocks_invalid_plan_without_running_commands(tmp_path):
+    calls, runner = _runner_factory()
+
+    result = adaptive_safe_remediation.run_plan(
+        _plan(commands=["git commit -am bad"]), cwd=tmp_path, command_runner=runner
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "blocked"
+    assert result["attempted"] is False
+    assert result["command_count"] == 0
+    assert calls == []
+    assert "blocked mutation token" in result["validation_errors"][0]
+
+
+def test_run_plan_file_writes_json_and_markdown(tmp_path):
+    plan_path = tmp_path / "safe-fix-plan.json"
+    out_json = tmp_path / "result.json"
+    out_md = tmp_path / "result.md"
+    plan_path.write_text(json.dumps(_plan()), encoding="utf-8")
+    calls, runner = _runner_factory()
+
+    result = adaptive_safe_remediation.run_plan_file(
+        plan_path,
+        out_json=out_json,
+        out_md=out_md,
+        cwd=tmp_path,
+        command_runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["plan_path"] == plan_path.as_posix()
+    assert json.loads(out_json.read_text(encoding="utf-8"))["status"] == "success"
+    assert "# Adaptive Safe Remediation Result" in out_md.read_text(encoding="utf-8")
+    assert len(calls) == 3
+
+
+def test_cli_returns_nonzero_for_blocked_plan(tmp_path, capsys):
+    plan_path = tmp_path / "safe-fix-plan.json"
+    plan_path.write_text(json.dumps(_plan(commands=["git status"])), encoding="utf-8")
+
+    rc = adaptive_safe_remediation.main([str(plan_path)])
+
+    assert rc == 1
+    output = capsys.readouterr().out
+    assert "status: blocked" in output
+    assert "validation_error:" in output
+
+
+def test_cli_rejects_bad_schema(tmp_path, capsys):
+    plan_path = tmp_path / "safe-fix-plan.json"
+    plan_path.write_text(json.dumps({"schema_version": "bad"}), encoding="utf-8")
+
+    rc = adaptive_safe_remediation.main([str(plan_path)])
+
+    assert rc == 2
+    assert "unsupported safe fix plan schema" in capsys.readouterr().out

--- a/tests/test_adaptive_safe_remediation.py
+++ b/tests/test_adaptive_safe_remediation.py
@@ -35,7 +35,9 @@ def _runner_factory(results=None):
 
     def runner(parts, cwd):
         calls.append((list(parts), cwd))
-        result = queued.pop(0) if queued else {"ok": True, "returncode": 0, "stdout": "ok", "stderr": ""}
+        result = (
+            queued.pop(0) if queued else {"ok": True, "returncode": 0, "stdout": "ok", "stderr": ""}
+        )
         return dict(result)
 
     return calls, runner


### PR DESCRIPTION
## Summary
- Add `sdetkit.adaptive_safe_remediation`, a runner for approved safe-fix plans.
- Add focused tests for plan validation, command allowlisting, placeholder blocking, deterministic command execution, failure stopping, artifact writing, and CLI behavior.

## Why
- The safe-fix planner can now identify narrow format-only repairs. This PR adds the next layer: execute only approved local commands and write remediation result artifacts.

## How
- Read `sdetkit.adaptive_safe_fix.v1` plans.
- Require `safe_to_auto_fix=true`, `fix_type=format_only`, and `requires_human_review=false`.
- Allow only Ruff format/check and targeted pytest command shapes.
- Block placeholders and mutation commands such as git/gh/twine.
- Write JSON and Markdown result artifacts.

## Safety boundary
- No commits are created.
- No pushes happen.
- No PR branches are mutated.
- Commands stop after the first failure.

## Risk assessment
- Risk level: medium
- Primary risk area: command allowlist correctness and new Python formatting

## Test evidence
- CI should run:
  - `PYTHONPATH=src python -m pytest -q tests/test_adaptive_safe_remediation.py`

## Rollback plan
- Revert the runner module and tests if needed.

## Checklist
- [x] Runtime module added
- [x] Tests added
- [x] Runner-only behavior
- [x] No commit/push behavior
- [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`