### PR TITLE
Run safe format remediation from autopilot

### DIFF
--- a/tests/test_maintenance_autopilot_safe_remediation.py
+++ b/tests/test_maintenance_autopilot_safe_remediation.py
@@ -1,0 +1,98 @@
+import importlib.util
+from pathlib import Path
+
+from sdetkit import adaptive_safe_fix, adaptive_safe_remediation
+
+
+def _load_autopilot():
+    spec = importlib.util.spec_from_file_location(
+        "maintenance_autopilot", "tools/maintenance_autopilot.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_autopilot_writes_safe_fix_plan_and_remediation_artifacts(tmp_path, monkeypatch):
+    autopilot = _load_autopilot()
+    plan = {
+        "schema_version": "sdetkit.adaptive_safe_fix.v1",
+        "safe_to_auto_fix": True,
+        "fix_type": "format_only",
+        "requires_human_review": False,
+        "source_code": "PRE_COMMIT_FORMAT_DRIFT",
+        "commands": ["PYTHONPATH=src python -m ruff format src/sdetkit/example.py"],
+    }
+    result = {
+        "schema_version": "sdetkit.adaptive_safe_remediation.v1",
+        "ok": True,
+        "status": "success",
+        "attempted": True,
+        "safe_to_auto_fix": True,
+        "fix_type": "format_only",
+        "source_code": "PRE_COMMIT_FORMAT_DRIFT",
+        "validation_errors": [],
+        "command_count": 1,
+        "commands": [],
+    }
+
+    monkeypatch.setattr(adaptive_safe_fix, "build_plan", lambda payload: plan)
+    monkeypatch.setattr(adaptive_safe_remediation, "run_plan", lambda payload, cwd: result)
+    monkeypatch.setattr(
+        adaptive_safe_remediation,
+        "render_markdown",
+        lambda payload: "# Adaptive Safe Remediation Result\n",
+    )
+
+    autopilot._write_safe_fix_artifacts_on_failure(
+        tmp_path, {"schema_version": "sdetkit.adaptive.diagnosis.v1"}
+    )
+
+    assert (tmp_path / "safe-fix-plan.json").exists()
+    assert (tmp_path / "adaptive-safe-remediation-result.json").exists()
+    assert (tmp_path / "adaptive-safe-remediation-result.md").exists()
+
+
+def test_autopilot_writes_plan_only_when_human_review_required(tmp_path, monkeypatch):
+    autopilot = _load_autopilot()
+    plan = {
+        "schema_version": "sdetkit.adaptive_safe_fix.v1",
+        "safe_to_auto_fix": False,
+        "fix_type": "review_required",
+        "requires_human_review": True,
+        "source_code": "PYTEST_ASSERTION_FAILURE",
+        "commands": [],
+    }
+
+    monkeypatch.setattr(adaptive_safe_fix, "build_plan", lambda payload: plan)
+
+    def fail_if_called(payload, cwd):
+        raise AssertionError("unsafe plans must not run remediation")
+
+    monkeypatch.setattr(adaptive_safe_remediation, "run_plan", fail_if_called)
+
+    autopilot._write_safe_fix_artifacts_on_failure(
+        tmp_path, {"schema_version": "sdetkit.adaptive.diagnosis.v1"}
+    )
+
+    assert (tmp_path / "safe-fix-plan.json").exists()
+    assert not (tmp_path / "adaptive-safe-remediation-result.json").exists()
+    assert not (tmp_path / "adaptive-safe-remediation-result.md").exists()
+
+
+def test_autopilot_records_safe_remediation_errors(tmp_path, monkeypatch):
+    autopilot = _load_autopilot()
+
+    def raise_build_plan(payload):
+        raise RuntimeError("planner failed")
+
+    monkeypatch.setattr(adaptive_safe_fix, "build_plan", raise_build_plan)
+
+    autopilot._write_safe_fix_artifacts_on_failure(
+        tmp_path, {"schema_version": "sdetkit.adaptive.diagnosis.v1"}
+    )
+
+    error_path = tmp_path / "adaptive-safe-remediation-error.json"
+    assert error_path.exists()
+    assert "planner failed" in error_path.read_text(encoding="utf-8")

--- a/tests/test_maintenance_autopilot_safe_remediation.py
+++ b/tests/test_maintenance_autopilot_safe_remediation.py
@@ -1,5 +1,4 @@
 import importlib.util
-from pathlib import Path
 
 from sdetkit import adaptive_safe_fix, adaptive_safe_remediation
 

--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -156,6 +156,50 @@ def _write_adaptive_diagnosis_on_failure(failure: dict[str, Any]) -> None:
         adaptive_diagnosis.render_markdown(payload),
         encoding="utf-8",
     )
+    _write_safe_fix_artifacts_on_failure(out_dir, payload)
+
+
+def _write_safe_fix_artifacts_on_failure(out_dir: Path, diagnosis_payload: dict[str, Any]) -> None:
+    try:
+        from sdetkit import adaptive_safe_fix, adaptive_safe_remediation
+    except Exception as exc:
+        _write_json(
+            out_dir / "adaptive-safe-remediation-error.json",
+            {
+                "schema_version": "sdetkit.maintenance.autopilot.safe_remediation_error.v1",
+                "ok": False,
+                "error": str(exc),
+            },
+        )
+        return
+
+    try:
+        plan = adaptive_safe_fix.build_plan(diagnosis_payload)
+        _write_json(out_dir / "safe-fix-plan.json", plan)
+
+        if not (
+            plan.get("safe_to_auto_fix") is True
+            and plan.get("fix_type") == "format_only"
+            and plan.get("requires_human_review") is False
+        ):
+            return
+
+        result = adaptive_safe_remediation.run_plan(plan, cwd=Path.cwd())
+        result["plan_path"] = (out_dir / "safe-fix-plan.json").as_posix()
+        _write_json(out_dir / "adaptive-safe-remediation-result.json", result)
+        (out_dir / "adaptive-safe-remediation-result.md").write_text(
+            adaptive_safe_remediation.render_markdown(result),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        _write_json(
+            out_dir / "adaptive-safe-remediation-error.json",
+            {
+                "schema_version": "sdetkit.maintenance.autopilot.safe_remediation_error.v1",
+                "ok": False,
+                "error": str(exc),
+            },
+        )
 
 
 POLICY_RULES: dict[str, dict[str, Any]] = {


### PR DESCRIPTION
## Summary
- Wire maintenance autopilot failure handling into the Adaptive Safe Fix Planner and Adaptive Safe Remediation Runner.
- Write `safe-fix-plan.json` for adaptive diagnosis failures.
- When the plan is explicitly safe format-only, run the safe remediation runner and write JSON/Markdown result artifacts.

## Why
- SDETKit can already diagnose, plan, and run safe format-only remediation locally. This PR connects those layers inside autopilot so format-only failures can produce remediation artifacts automatically.

## How
- After `adaptive-diagnosis.json` and `.md` are written, build a safe-fix plan from the diagnosis payload.
- Always write `safe-fix-plan.json`.
- Only run remediation when:
  - `safe_to_auto_fix=true`
  - `fix_type=format_only`
  - `requires_human_review=false`
- Write:
  - `adaptive-safe-remediation-result.json`
  - `adaptive-safe-remediation-result.md`
  - or `adaptive-safe-remediation-error.json` if the integration fails.

## Safety boundary
- No commits are created.
- No pushes happen.
- No PR branches are mutated.
- Unsafe or review-required plans are not executed.

## Test evidence
- WSL2 local proof before push:
  - Ruff formatted the touched files.
  - Targeted remediation tests passed: `3 passed`.
  - Full pre-commit passed, including Ruff format and mypy.

## Rollback plan
- Revert this autopilot integration commit if safe remediation artifacts cause regressions.

## Checklist
- [x] Autopilot integration added
- [x] Tests added
- [x] No commit/push behavior added
- [x] Unsafe plans are not executed
- [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`