### PR TITLE
Commit safe mechanical fixes from autopilot

### DIFF
--- a/.github/workflows/maintenance-autopilot.yml
+++ b/.github/workflows/maintenance-autopilot.yml
@@ -39,6 +39,7 @@ jobs:
             PYTHONPATH=src python tools/maintenance_autopilot.py \
               --owner "${{ github.repository_owner }}" \
               --repo "${{ github.event.repository.name }}" \
+              --commit-safe-fixes \
               --max-remediation-attempts 3 \
               --remediation-cooldown-runs 2 \
               --out-dir build/maintenance/autopilot

--- a/tests/test_maintenance_autopilot_safe_commit.py
+++ b/tests/test_maintenance_autopilot_safe_commit.py
@@ -1,0 +1,161 @@
+import importlib.util
+import json
+
+
+def _load_autopilot():
+    spec = importlib.util.spec_from_file_location(
+        "maintenance_autopilot", "tools/maintenance_autopilot.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _same_repo_event(path):
+    payload = {
+        "pull_request": {
+            "head": {"repo": {"full_name": "sherif69-sa/DevS69-sdetkit"}},
+            "base": {"repo": {"full_name": "sherif69-sa/DevS69-sdetkit"}},
+        }
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _safe_plan():
+    return {
+        "schema_version": "sdetkit.adaptive_safe_fix.v1",
+        "safe_to_auto_fix": True,
+        "fix_type": "format_only",
+        "requires_human_review": False,
+        "source_code": "PRE_COMMIT_FORMAT_DRIFT",
+        "affected_files": ["src/sdetkit/example.py"],
+    }
+
+
+def _success_result():
+    return {
+        "schema_version": "sdetkit.adaptive_safe_remediation.v1",
+        "ok": True,
+        "status": "success",
+    }
+
+
+def test_commit_safe_fix_changes_pushes_same_repo_branch(tmp_path, monkeypatch):
+    autopilot = _load_autopilot()
+    event_path = tmp_path / "event.json"
+    _same_repo_event(event_path)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_HEAD_REF", "feature/example")
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("GH_TOKEN", "token")
+    autopilot._ACTIVE_FAILURE_CONTEXT.update(
+        {
+            "commit_safe_fixes": True,
+            "token_env": "GH_TOKEN",
+            "owner": "sherif69-sa",
+            "repo": "DevS69-sdetkit",
+        }
+    )
+
+    calls = []
+
+    def runner(cmd):
+        calls.append(cmd)
+        if cmd == ["git", "diff", "--name-only"]:
+            return {"ok": True, "returncode": 0, "stdout": "src/sdetkit/example.py\n", "stderr": ""}
+        return {"ok": True, "returncode": 0, "stdout": "ok", "stderr": ""}
+
+    result = autopilot._commit_safe_fix_changes(
+        tmp_path, _safe_plan(), _success_result(), git_runner=runner
+    )
+
+    assert result["ok"] is True
+    assert result["pushed"] is True
+    assert calls[-1] == ["git", "push", "origin", "HEAD:feature/example"]
+    assert (tmp_path / "adaptive-safe-commit-result.json").exists()
+
+
+def test_commit_safe_fix_changes_rejects_fork_pull_request(tmp_path, monkeypatch):
+    autopilot = _load_autopilot()
+    event_path = tmp_path / "event.json"
+    payload = {
+        "pull_request": {
+            "head": {"repo": {"full_name": "someone/fork"}},
+            "base": {"repo": {"full_name": "sherif69-sa/DevS69-sdetkit"}},
+        }
+    }
+    event_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_HEAD_REF", "feature/example")
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("GH_TOKEN", "token")
+    autopilot._ACTIVE_FAILURE_CONTEXT.update(
+        {
+            "commit_safe_fixes": True,
+            "token_env": "GH_TOKEN",
+            "owner": "sherif69-sa",
+            "repo": "DevS69-sdetkit",
+        }
+    )
+
+    result = autopilot._commit_safe_fix_changes(
+        tmp_path,
+        _safe_plan(),
+        _success_result(),
+        git_runner=lambda cmd: (_ for _ in ()).throw(AssertionError()),
+    )
+
+    assert result["ok"] is False
+    assert result["attempted"] is False
+    assert "same-repository" in result["reason"]
+
+
+def test_commit_safe_fix_changes_rejects_files_outside_plan(tmp_path, monkeypatch):
+    autopilot = _load_autopilot()
+    event_path = tmp_path / "event.json"
+    _same_repo_event(event_path)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_HEAD_REF", "feature/example")
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("GH_TOKEN", "token")
+    autopilot._ACTIVE_FAILURE_CONTEXT.update(
+        {
+            "commit_safe_fixes": True,
+            "token_env": "GH_TOKEN",
+            "owner": "sherif69-sa",
+            "repo": "DevS69-sdetkit",
+        }
+    )
+
+    def runner(cmd):
+        if cmd == ["git", "diff", "--name-only"]:
+            return {"ok": True, "returncode": 0, "stdout": "src/sdetkit/other.py\n", "stderr": ""}
+        raise AssertionError("must stop before git add/commit/push")
+
+    result = autopilot._commit_safe_fix_changes(
+        tmp_path, _safe_plan(), _success_result(), git_runner=runner
+    )
+
+    assert result["ok"] is False
+    assert result["attempted"] is False
+    assert result["outside_plan"] == ["src/sdetkit/other.py"]
+
+
+def test_commit_safe_fix_changes_disabled_by_default(tmp_path):
+    autopilot = _load_autopilot()
+    autopilot._ACTIVE_FAILURE_CONTEXT["commit_safe_fixes"] = False
+
+    result = autopilot._commit_safe_fix_changes(
+        tmp_path,
+        _safe_plan(),
+        _success_result(),
+        git_runner=lambda cmd: (_ for _ in ()).throw(AssertionError()),
+    )
+
+    assert result["ok"] is False
+    assert result["attempted"] is False
+    assert "disabled" in result["reason"]

--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -7,11 +7,19 @@ import shlex
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-_ACTIVE_FAILURE_CONTEXT: dict[str, Any] = {"out_dir": None, "report": None}
+_ACTIVE_FAILURE_CONTEXT: dict[str, Any] = {
+    "out_dir": None,
+    "report": None,
+    "commit_safe_fixes": False,
+    "token_env": "GH_TOKEN",
+    "owner": "",
+    "repo": "",
+}
 
 
 def _run(
@@ -191,6 +199,7 @@ def _write_safe_fix_artifacts_on_failure(out_dir: Path, diagnosis_payload: dict[
             adaptive_safe_remediation.render_markdown(result),
             encoding="utf-8",
         )
+        _commit_safe_fix_changes(out_dir, plan, result)
     except Exception as exc:
         _write_json(
             out_dir / "adaptive-safe-remediation-error.json",
@@ -200,6 +209,176 @@ def _write_safe_fix_artifacts_on_failure(out_dir: Path, diagnosis_payload: dict[
                 "error": str(exc),
             },
         )
+
+
+GitRunner = Callable[[list[str]], dict[str, Any]]
+
+
+def _run_git(cmd: list[str]) -> dict[str, Any]:
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return {
+        "cmd": cmd,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "ok": proc.returncode == 0,
+    }
+
+
+def _safe_pr_push_target() -> tuple[bool, str, str]:
+    if _ACTIVE_FAILURE_CONTEXT.get("commit_safe_fixes") is not True:
+        return False, "commit-safe-fixes flag is disabled", ""
+
+    event_name = os.getenv("GITHUB_EVENT_NAME", "")
+    if event_name != "pull_request":
+        return False, f"event {event_name or '<empty>'} is not pull_request", ""
+
+    head_ref = os.getenv("GITHUB_HEAD_REF", "").strip()
+    base_ref = os.getenv("GITHUB_BASE_REF", "").strip()
+    if not head_ref:
+        return False, "missing GITHUB_HEAD_REF", ""
+    if head_ref in {"main", "master"} or head_ref == base_ref:
+        return False, "ref is protected or same as base", ""
+
+    token_env = str(_ACTIVE_FAILURE_CONTEXT.get("token_env", "GH_TOKEN"))
+    if not os.getenv(token_env, "").strip():
+        return False, f"missing token in {token_env}", ""
+
+    event_path = os.getenv("GITHUB_EVENT_PATH", "").strip()
+    if not event_path:
+        return False, "missing GITHUB_EVENT_PATH", ""
+
+    payload = _load_json(Path(event_path))
+    pull_request = payload.get("pull_request", {})
+    if not isinstance(pull_request, dict):
+        return False, "event payload has no pull_request object", ""
+
+    head = pull_request.get("head", {})
+    base = pull_request.get("base", {})
+    head_repo = head.get("repo", {}) if isinstance(head, dict) else {}
+    base_repo = base.get("repo", {}) if isinstance(base, dict) else {}
+    head_full_name = str(head_repo.get("full_name", "")) if isinstance(head_repo, dict) else ""
+    base_full_name = str(base_repo.get("full_name", "")) if isinstance(base_repo, dict) else ""
+    expected = f"{_ACTIVE_FAILURE_CONTEXT.get('owner')}/{_ACTIVE_FAILURE_CONTEXT.get('repo')}"
+
+    if head_full_name != expected or base_full_name != expected:
+        return False, "pull request is not a same-repository branch", ""
+
+    return True, "ok", head_ref
+
+
+def _allowed_safe_changed_files(plan: dict[str, Any]) -> set[str]:
+    values = plan.get("affected_files", [])
+    if not isinstance(values, list):
+        return set()
+    return {
+        str(value).strip()
+        for value in values
+        if str(value).strip() and "<" not in str(value) and ">" not in str(value)
+    }
+
+
+def _git_stdout_lines(result: dict[str, Any]) -> list[str]:
+    return [line.strip() for line in str(result.get("stdout", "")).splitlines() if line.strip()]
+
+
+def _write_safe_fix_commit_result(out_dir: Path, payload: dict[str, Any]) -> None:
+    _write_json(out_dir / "adaptive-safe-commit-result.json", payload)
+
+
+def _commit_safe_fix_changes(
+    out_dir: Path,
+    plan: dict[str, Any],
+    remediation_result: dict[str, Any],
+    *,
+    git_runner: GitRunner = _run_git,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "schema_version": "sdetkit.maintenance.autopilot.safe_fix_commit.v1",
+        "ok": False,
+        "attempted": False,
+        "pushed": False,
+        "reason": "",
+        "changed_files": [],
+        "head_ref": "",
+    }
+
+    if not bool(remediation_result.get("ok", False)):
+        result["reason"] = "safe remediation did not succeed"
+        _write_safe_fix_commit_result(out_dir, result)
+        return result
+
+    if not (
+        plan.get("safe_to_auto_fix") is True
+        and plan.get("fix_type") == "format_only"
+        and plan.get("requires_human_review") is False
+    ):
+        result["reason"] = "plan is not an approved format-only safe fix"
+        _write_safe_fix_commit_result(out_dir, result)
+        return result
+
+    ok, reason, head_ref = _safe_pr_push_target()
+    result["head_ref"] = head_ref
+    if not ok:
+        result["reason"] = reason
+        _write_safe_fix_commit_result(out_dir, result)
+        return result
+
+    diff = git_runner(["git", "diff", "--name-only"])
+    if not bool(diff.get("ok", False)):
+        result["reason"] = "git diff failed"
+        result["stderr"] = str(diff.get("stderr", ""))[-2000:]
+        _write_safe_fix_commit_result(out_dir, result)
+        return result
+
+    changed_files = _git_stdout_lines(diff)
+    result["changed_files"] = changed_files
+    if not changed_files:
+        result["reason"] = "safe remediation produced no tracked file changes"
+        _write_safe_fix_commit_result(out_dir, result)
+        return result
+
+    allowed_files = _allowed_safe_changed_files(plan)
+    outside = [item for item in changed_files if item not in allowed_files]
+    if outside:
+        result["reason"] = "changed files are outside the safe fix plan"
+        result["outside_plan"] = outside
+        _write_safe_fix_commit_result(out_dir, result)
+        return result
+
+    result["attempted"] = True
+    commands = [
+        ["git", "config", "user.name", "github-actions[bot]"],
+        ["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"],
+        ["git", "add", "--", *changed_files],
+        ["git", "commit", "-m", "chore: apply safe mechanical fixes"],
+        ["git", "push", "origin", f"HEAD:{head_ref}"],
+    ]
+
+    command_results: list[dict[str, Any]] = []
+    for cmd in commands:
+        item = git_runner(cmd)
+        command_results.append(
+            {
+                "cmd": cmd,
+                "ok": bool(item.get("ok", False)),
+                "returncode": item.get("returncode"),
+                "stdout": str(item.get("stdout", ""))[-2000:],
+                "stderr": str(item.get("stderr", ""))[-2000:],
+            }
+        )
+        if not bool(item.get("ok", False)):
+            result["reason"] = f"command failed: {' '.join(cmd[:2])}"
+            result["commands"] = command_results
+            _write_safe_fix_commit_result(out_dir, result)
+            return result
+
+    result["ok"] = True
+    result["pushed"] = True
+    result["reason"] = "safe mechanical fix committed and pushed"
+    result["commands"] = command_results
+    _write_safe_fix_commit_result(out_dir, result)
+    return result
 
 
 POLICY_RULES: dict[str, dict[str, Any]] = {
@@ -326,6 +505,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--token-env", default="GH_TOKEN")
     parser.add_argument("--memory-db", default=".sdetkit/maintenance/failure-memory.jsonl")
     parser.add_argument("--auto-remediate-safe", action="store_true")
+    parser.add_argument("--commit-safe-fixes", action="store_true")
     parser.add_argument("--max-remediation-attempts", type=int, default=3)
     parser.add_argument("--remediation-cooldown-runs", type=int, default=2)
     args = parser.parse_args(argv)
@@ -342,6 +522,10 @@ def main(argv: list[str] | None = None) -> int:
 
     _ACTIVE_FAILURE_CONTEXT["out_dir"] = out_dir
     _ACTIVE_FAILURE_CONTEXT["report"] = report
+    _ACTIVE_FAILURE_CONTEXT["commit_safe_fixes"] = bool(args.commit_safe_fixes)
+    _ACTIVE_FAILURE_CONTEXT["token_env"] = args.token_env
+    _ACTIVE_FAILURE_CONTEXT["owner"] = args.owner
+    _ACTIVE_FAILURE_CONTEXT["repo"] = args.repo
 
     # 1) Baseline checks
     report["steps"]["baseline_pre_commit"] = _run([sys.executable, "-m", "pre_commit", "run", "-a"])


### PR DESCRIPTION
## Summary
- Add guarded same-repository PR push support for successful safe mechanical fixes.
- Add `--commit-safe-fixes` to maintenance autopilot.
- Wire the maintenance-autopilot PR workflow to enable safe commit mode.
- Add tests for same-repo push, fork rejection, outside-plan file rejection, and disabled-by-default behavior.

## Why
- We keep seeing tiny mechanical failures such as Ruff formatting, import ordering, and unused-import fixes that require manual WSL2 cleanup.
- The previous PRs added diagnosis, planning, and safe remediation artifacts. This PR adds the final guarded step: commit and push only after the safe remediation succeeds and only for same-repo PR branches.

## How
- Only runs after `adaptive_safe_remediation` returns `ok=true`.
- Only accepts plans with:
  - `safe_to_auto_fix=true`
  - `fix_type=format_only`
  - `requires_human_review=false`
- Requires pull_request event metadata.
- Rejects fork PRs.
- Rejects main/master or same-as-base refs.
- Requires a token.
- Checks `git diff --name-only` and rejects files outside the safe-fix plan.
- Commits and pushes with `chore: apply safe mechanical fixes` only after all guards pass.

## Safety boundary
- No auto-fix for pytest failures.
- No auto-fix for mypy failures.
- No auto-fix for dependency conflicts.
- No auto-fix for security findings.
- No auto-fix for fork PRs.
- No auto-fix when changed files are outside the plan.

## Test evidence
- WSL2 local proof before push:
  - Ruff formatted touched Python files.
  - Targeted commit/push safety tests passed: `4 passed`.
  - Full pre-commit passed after Ruff import ordering fix.

## Notes
- Ruff does not format workflow YAML; the local `ruff format .github/workflows/maintenance-autopilot.yml` attempt reported a parse error, but YAML was validated by pre-commit `check yaml`.

## Rollback plan
- Revert this workflow/autopilot integration if safe commit behavior causes regressions.

## Checklist
- [x] Same-repo PR branch only
- [x] Fork PRs rejected
- [x] Main/master rejected
- [x] Outside-plan file changes rejected
- [x] Disabled by default in CLI unless `--commit-safe-fixes` is set
- [x] Premium guideline reference reviewed: `docs/premium-quality-gate.md`