### PR TITLE
Plan safe Ruff fixable lint remediation

### DIFF
--- a/src/sdetkit/adaptive_diagnosis.py
+++ b/src/sdetkit/adaptive_diagnosis.py
@@ -13,6 +13,9 @@ SCHEMA_VERSION = "sdetkit.adaptive.diagnosis.v1"
 SEVERITY_SCORE = {"high": 30, "medium": 18, "low": 8, "info": 3}
 SEVERITY_RANK = {"high": 0, "medium": 1, "low": 2, "info": 3}
 CONFIDENCE_RANK = {"high": 0, "medium": 1, "low": 2}
+SAFE_RUFF_FIXABLE_RULES = {"F401", "I001"}
+SAFE_AUTO_FIX_CODES = {"PRE_COMMIT_FORMAT_DRIFT", "RUFF_FIXABLE_LINT"}
+RUFF_RULE_RE = re.compile(r"\b([A-Z]\d{3})\b")
 ABS_PATH_RE = re.compile(r"(?<![A-Za-z0-9_.-])(?:/[A-Za-z0-9_@%+=:,./-]+)+")
 WIN_PATH_RE = re.compile(r"[A-Za-z]:\\\\[^\s`'\"]+")
 
@@ -92,6 +95,60 @@ def _file_mentions(text: str) -> list[str]:
     return _safe_list([path for path in found if not path.startswith(("http/", "https/"))], 8)
 
 
+def _ruff_rule_codes(text: str) -> list[str]:
+    codes: list[str] = []
+    for code in RUFF_RULE_RE.findall(text):
+        if code not in codes:
+            codes.append(code)
+    return codes[:12]
+
+
+def _is_safe_ruff_fixable_lint(text: str, codes: Sequence[str]) -> bool:
+    lower = text.lower()
+    if not codes:
+        return False
+    if any(code not in SAFE_RUFF_FIXABLE_RULES for code in codes):
+        return False
+    return (
+        "fixable" in lower
+        or "[*]" in text
+        or "remove unused import" in lower
+        or "import block is un-sorted" in lower
+    )
+
+
+def _append_ruff_lint(text: str, files: Sequence[str], diagnoses: list[dict[str, Any]]) -> None:
+    codes = _ruff_rule_codes(text)
+    if files and _is_safe_ruff_fixable_lint(text, codes):
+        targets = " ".join(files)
+        rule_text = ", ".join(codes)
+        diagnoses.append(
+            _diag(
+                "RUFF_FIXABLE_LINT",
+                "medium",
+                "high",
+                "Ruff fixable lint can be mechanically remediated",
+                f"Ruff reported fixable mechanical lint ({rule_text}) in known files.",
+                "Developers often fix the visible import by hand and miss that Ruff can apply this narrow class safely.",
+                ["ruff fixable lint", f"ruff_rules={rule_text}", "safe_rules=F401,I001"],
+                [
+                    "Run ruff check --fix on affected files.",
+                    "Run ruff format on affected files.",
+                    "Re-run Ruff check and format check.",
+                ],
+                [
+                    f"PYTHONPATH=src python -m ruff check {targets}",
+                    f"PYTHONPATH=src python -m ruff format --check {targets}",
+                ],
+                "The PR stays red for a mechanical lint issue that the autopilot can safely prove.",
+                "ruff-fixable-lint",
+                files=files,
+            )
+        )
+        return
+    _append_static("RUFF_LINT_FAILURE", "Ruff lint contract failed", files, diagnoses)
+
+
 def _append_log(text: str, diagnoses: list[dict[str, Any]]) -> None:
     lower = text.lower()
     files = _file_mentions(text)
@@ -121,8 +178,8 @@ def _append_log(text: str, diagnoses: list[dict[str, Any]]) -> None:
         )
     if "mypy" in lower and "error:" in lower:
         _append_static("MYPY_TYPE_CONTRACT_DRIFT", "Type contract drift detected", files, diagnoses)
-    if "ruff" in lower and "failed" in lower and not formatted:
-        _append_static("RUFF_LINT_FAILURE", "Ruff lint contract failed", files, diagnoses)
+    if "ruff" in lower and ("failed" in lower or "fixable" in lower) and not formatted:
+        _append_ruff_lint(text, files, diagnoses)
     if "modulenotfounderror" in lower or "importerror while importing" in lower:
         _append_pytest(
             text,
@@ -414,6 +471,8 @@ def analyze_evidence(
 def _status_for(diagnoses: Sequence[dict[str, Any]]) -> str:
     if any(item.get("severity") == "high" for item in diagnoses):
         return "needs_fix"
+    if any(str(item.get("code", "")) in SAFE_AUTO_FIX_CODES for item in diagnoses):
+        return "needs_fix"
     if _risk_score(diagnoses) >= 30:
         return "needs_attention"
     return "monitor" if diagnoses else "clear"
@@ -446,7 +505,7 @@ def _payload(diagnoses: list[dict[str, Any]], status: str) -> dict[str, Any]:
             {
                 "code": item["code"],
                 "title": item["title"],
-                "safe_to_auto_fix": item["code"] == "PRE_COMMIT_FORMAT_DRIFT",
+                "safe_to_auto_fix": item["code"] in SAFE_AUTO_FIX_CODES,
                 "recommended_fix": item["recommended_fix"][:4],
                 "proof_commands": item["proof_commands"][:4],
             }

--- a/src/sdetkit/adaptive_safe_fix.py
+++ b/src/sdetkit/adaptive_safe_fix.py
@@ -8,6 +8,7 @@ from typing import Any
 SCHEMA_VERSION = "sdetkit.adaptive_safe_fix.v1"
 SOURCE_SCHEMA_VERSION = "sdetkit.adaptive.diagnosis.v1"
 SAFE_FORMAT_CODE = "PRE_COMMIT_FORMAT_DRIFT"
+SAFE_RUFF_FIXABLE_CODE = "RUFF_FIXABLE_LINT"
 ACTIONABLE_STATUSES = {"needs_attention", "needs_fix"}
 
 
@@ -32,9 +33,13 @@ def _load_diagnosis(path: Path) -> dict[str, Any]:
     return payload
 
 
-def _format_targets(diagnosis: dict[str, Any]) -> str:
+def _target_files(diagnosis: dict[str, Any]) -> list[str]:
     files = [_safe_text(value) for value in _as_list(diagnosis.get("affected_files"))]
-    files = [value for value in files if value]
+    return [value for value in files if value]
+
+
+def _format_targets(diagnosis: dict[str, Any]) -> str:
+    files = _target_files(diagnosis)
     return " ".join(files) if files else "<touched-python-files>"
 
 
@@ -59,11 +64,25 @@ def _is_safe_format_plan(payload: dict[str, Any], diagnosis: dict[str, Any]) -> 
     return True
 
 
+def _is_safe_ruff_fixable_plan(payload: dict[str, Any], diagnosis: dict[str, Any]) -> bool:
+    status = str(payload.get("status", "unknown"))
+    if status not in ACTIONABLE_STATUSES:
+        return False
+    if diagnosis.get("code") != SAFE_RUFF_FIXABLE_CODE:
+        return False
+    if diagnosis.get("severity") not in {"low", "medium"}:
+        return False
+    if diagnosis.get("confidence") != "high":
+        return False
+    return bool(_target_files(diagnosis))
+
+
 def build_plan(payload: dict[str, Any]) -> dict[str, Any]:
     diagnosis = _first_diagnosis(payload)
     code = str(diagnosis.get("code", "UNKNOWN") or "UNKNOWN")
     targets = _format_targets(diagnosis)
     safe = _is_safe_format_plan(payload, diagnosis)
+    ruff_safe = _is_safe_ruff_fixable_plan(payload, diagnosis)
 
     if safe:
         commands = [
@@ -94,9 +113,40 @@ def build_plan(payload: dict[str, Any]) -> dict[str, Any]:
             "affected_files": _as_list(diagnosis.get("affected_files")),
         }
 
+    if ruff_safe:
+        commands = [
+            f"PYTHONPATH=src python -m ruff check --fix {targets}",
+            f"PYTHONPATH=src python -m ruff format {targets}",
+            f"PYTHONPATH=src python -m ruff check {targets}",
+            f"PYTHONPATH=src python -m ruff format --check {targets}",
+        ]
+        proof_commands = [
+            f"PYTHONPATH=src python -m ruff check {targets}",
+            f"PYTHONPATH=src python -m ruff format --check {targets}",
+            "PYTHONPATH=src python -m pytest -q <targeted-tests>",
+        ]
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "source_schema_version": str(payload.get("schema_version", "")),
+            "ok": True,
+            "source_status": str(payload.get("status", "unknown")),
+            "source_code": code,
+            "safe_to_auto_fix": True,
+            "fix_type": "ruff_fixable_lint",
+            "confidence": "high",
+            "requires_human_review": False,
+            "reason": (
+                "Ruff reported only narrow fixable lint with known affected files; "
+                "F401 and I001 are treated as safe mechanical fixes after proof."
+            ),
+            "commands": commands,
+            "proof_commands": proof_commands,
+            "affected_files": _as_list(diagnosis.get("affected_files")),
+        }
+
     reason = "No diagnosis was available to plan from."
     if diagnosis:
-        reason = f"{code} requires human review; this planner only auto-plans format-only drift."
+        reason = f"{code} requires human review; this planner only auto-plans formatter drift and narrow Ruff fixable lint."
     return {
         "schema_version": SCHEMA_VERSION,
         "source_schema_version": str(payload.get("schema_version", "")),

--- a/src/sdetkit/adaptive_safe_remediation.py
+++ b/src/sdetkit/adaptive_safe_remediation.py
@@ -10,6 +10,7 @@ from typing import Any
 
 SCHEMA_VERSION = "sdetkit.adaptive_safe_remediation.v1"
 PLAN_SCHEMA_VERSION = "sdetkit.adaptive_safe_fix.v1"
+SAFE_FIX_TYPES = {"format_only", "ruff_fixable_lint"}
 ALLOWED_PREFIXES = (
     ("PYTHONPATH=src", "python", "-m", "ruff", "format"),
     ("PYTHONPATH=src", "python", "-m", "ruff", "check"),
@@ -45,7 +46,34 @@ def _split_command(command: str) -> list[str]:
     return shlex.split(command)
 
 
-def _is_allowed_command(command: str) -> tuple[bool, str]:
+def _planned_files(plan: dict[str, Any]) -> set[str]:
+    return {
+        str(value).strip()
+        for value in _as_list(plan.get("affected_files"))
+        if str(value).strip() and "<" not in str(value) and ">" not in str(value)
+    }
+
+
+def _without_env_prefix(parts: Sequence[str]) -> list[str]:
+    remaining = list(parts)
+    while remaining and "=" in remaining[0] and not remaining[0].startswith("-"):
+        remaining.pop(0)
+    return remaining
+
+
+def _ruff_targets(parts: Sequence[str]) -> list[str]:
+    command = _without_env_prefix(parts)
+    if len(command) < 4 or command[:3] != ["python", "-m", "ruff"]:
+        return []
+    targets: list[str] = []
+    for part in command[4:]:
+        if part.startswith("-"):
+            continue
+        targets.append(part)
+    return targets
+
+
+def _is_allowed_command(command: str, fix_type: str, planned_files: set[str]) -> tuple[bool, str]:
     if _has_placeholder(command):
         return False, "command contains unresolved placeholder"
     try:
@@ -54,6 +82,13 @@ def _is_allowed_command(command: str) -> tuple[bool, str]:
         return False, f"command could not be parsed: {exc}"
     if not parts:
         return False, "command is empty"
+    if "--fix" in parts and fix_type != "ruff_fixable_lint":
+        return False, "ruff --fix is only allowed for ruff_fixable_lint plans"
+    targets = _ruff_targets(parts)
+    if targets:
+        outside = [target for target in targets if target not in planned_files]
+        if outside:
+            return False, "ruff command targets are outside affected_files"
     if any(part in BLOCKED_TOKENS for part in parts):
         return False, "command contains blocked mutation token"
     for prefix in ALLOWED_PREFIXES:
@@ -68,15 +103,17 @@ def validate_plan(plan: dict[str, Any]) -> tuple[bool, list[str]]:
         reasons.append("unsupported schema_version")
     if plan.get("safe_to_auto_fix") is not True:
         reasons.append("safe_to_auto_fix is not true")
-    if plan.get("fix_type") != "format_only":
-        reasons.append("fix_type is not format_only")
+    fix_type = str(plan.get("fix_type", ""))
+    if fix_type not in SAFE_FIX_TYPES:
+        reasons.append("fix_type is not an allowed safe mechanical fix")
     if plan.get("requires_human_review") is not False:
         reasons.append("requires_human_review is not false")
+    planned_files = _planned_files(plan)
     commands = [str(command) for command in _as_list(plan.get("commands"))]
     if not commands:
         reasons.append("no commands to run")
     for command in commands:
-        ok, reason = _is_allowed_command(command)
+        ok, reason = _is_allowed_command(command, fix_type, planned_files)
         if not ok:
             reasons.append(f"unsafe command `{command}`: {reason}")
     return not reasons, reasons

--- a/tests/test_adaptive_diagnosis.py
+++ b/tests/test_adaptive_diagnosis.py
@@ -64,6 +64,59 @@ def test_format_drift_comment_is_specific_and_safe():
     assert "secret-project" not in rendered
 
 
+def test_ruff_fixable_lint_comment_is_specific_and_safe():
+    log_text = """
+    ruff check..............................................................Failed
+    tests/test_maintenance_autopilot_safe_remediation.py:2:21: F401 [*] `pathlib.Path` imported but unused
+    help: Remove unused import: `pathlib.Path`
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+    """
+
+    payload = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    diagnosis = payload["diagnoses"][0]
+
+    assert payload["status"] == "needs_fix"
+    assert diagnosis["code"] == "RUFF_FIXABLE_LINT"
+    assert diagnosis["confidence"] == "high"
+    assert diagnosis["affected_files"] == ["tests/test_maintenance_autopilot_safe_remediation.py"]
+    assert "ruff_rules=F401" in diagnosis["evidence"]
+    assert payload["fix_plan"][0]["safe_to_auto_fix"] is True
+    assert "ruff check --fix" in " ".join(diagnosis["recommended_fix"])
+
+
+def test_ruff_import_sorting_is_specific_and_safe():
+    log_text = """
+    ruff check..............................................................Failed
+    src/sdetkit/adaptive_safe_fix.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+    """
+
+    payload = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    diagnosis = payload["diagnoses"][0]
+
+    assert diagnosis["code"] == "RUFF_FIXABLE_LINT"
+    assert diagnosis["affected_files"] == ["src/sdetkit/adaptive_safe_fix.py"]
+    assert "ruff_rules=I001" in diagnosis["evidence"]
+    assert payload["fix_plan"][0]["safe_to_auto_fix"] is True
+
+
+def test_ruff_fixable_lint_keeps_logic_risk_rules_review_required():
+    log_text = """
+    ruff check..............................................................Failed
+    src/sdetkit/example.py:10:5: B006 [*] Do not use mutable data structures for argument defaults
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+    """
+
+    payload = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    diagnosis = payload["diagnoses"][0]
+
+    assert diagnosis["code"] == "RUFF_LINT_FAILURE"
+    assert payload["fix_plan"][0]["safe_to_auto_fix"] is False
+
+
 def test_pytest_assertion_failure_uses_first_test_as_fix_anchor():
     log_text = """
     FAILED tests/test_widget.py::test_widget_contract - AssertionError

--- a/tests/test_adaptive_safe_fix.py
+++ b/tests/test_adaptive_safe_fix.py
@@ -63,6 +63,36 @@ def test_formatter_drift_without_files_uses_placeholder_targets():
     assert plan["commands"][0].endswith("ruff format <touched-python-files>")
 
 
+def test_ruff_fixable_lint_builds_safe_file_scoped_plan():
+    plan = adaptive_safe_fix.build_plan(_payload(code="RUFF_FIXABLE_LINT"))
+
+    assert plan["safe_to_auto_fix"] is True
+    assert plan["fix_type"] == "ruff_fixable_lint"
+    assert plan["requires_human_review"] is False
+    assert plan["source_code"] == "RUFF_FIXABLE_LINT"
+    assert plan["commands"] == [
+        "PYTHONPATH=src python -m ruff check --fix src/sdetkit/example.py tests/test_example.py",
+        "PYTHONPATH=src python -m ruff format src/sdetkit/example.py tests/test_example.py",
+        "PYTHONPATH=src python -m ruff check src/sdetkit/example.py tests/test_example.py",
+        "PYTHONPATH=src python -m ruff format --check src/sdetkit/example.py tests/test_example.py",
+    ]
+    assert plan["proof_commands"][:2] == [
+        "PYTHONPATH=src python -m ruff check src/sdetkit/example.py tests/test_example.py",
+        "PYTHONPATH=src python -m ruff format --check src/sdetkit/example.py tests/test_example.py",
+    ]
+
+
+def test_ruff_fixable_lint_without_known_files_requires_review():
+    payload = _payload(code="RUFF_FIXABLE_LINT")
+    payload["diagnoses"][0]["affected_files"] = []
+
+    plan = adaptive_safe_fix.build_plan(payload)
+
+    assert plan["safe_to_auto_fix"] is False
+    assert plan["requires_human_review"] is True
+    assert plan["fix_type"] == "review_required"
+
+
 def test_non_formatter_diagnoses_require_human_review():
     for code in [
         "PYTEST_ASSERTION_FAILURE",

--- a/tests/test_adaptive_safe_remediation.py
+++ b/tests/test_adaptive_safe_remediation.py
@@ -50,6 +50,48 @@ def test_validate_plan_accepts_format_only_allowlist():
     assert errors == []
 
 
+def test_validate_plan_accepts_ruff_fixable_lint_allowlist():
+    ok, errors = adaptive_safe_remediation.validate_plan(
+        _plan(
+            source_code="RUFF_FIXABLE_LINT",
+            fix_type="ruff_fixable_lint",
+            commands=[
+                "PYTHONPATH=src python -m ruff check --fix src/sdetkit/example.py",
+                "PYTHONPATH=src python -m ruff format src/sdetkit/example.py",
+                "PYTHONPATH=src python -m ruff check src/sdetkit/example.py",
+                "PYTHONPATH=src python -m ruff format --check src/sdetkit/example.py",
+            ],
+        )
+    )
+
+    assert ok is True
+    assert errors == []
+
+
+def test_validate_plan_rejects_ruff_fix_in_format_only_plan():
+    ok, errors = adaptive_safe_remediation.validate_plan(
+        _plan(commands=["PYTHONPATH=src python -m ruff check --fix src/sdetkit/example.py"])
+    )
+
+    assert ok is False
+    assert "ruff --fix is only allowed" in errors[0]
+
+
+def test_validate_plan_rejects_ruff_command_outside_affected_files():
+    ok, errors = adaptive_safe_remediation.validate_plan(
+        _plan(
+            source_code="RUFF_FIXABLE_LINT",
+            fix_type="ruff_fixable_lint",
+            commands=[
+                "PYTHONPATH=src python -m ruff check --fix tests/test_other.py",
+            ],
+        )
+    )
+
+    assert ok is False
+    assert "outside affected_files" in errors[0]
+
+
 def test_validate_plan_rejects_review_required_or_unsafe_commands():
     for plan in [
         _plan(safe_to_auto_fix=False),

--- a/tests/test_maintenance_autopilot_safe_commit.py
+++ b/tests/test_maintenance_autopilot_safe_commit.py
@@ -22,13 +22,13 @@ def _same_repo_event(path):
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _safe_plan():
+def _safe_plan(fix_type="format_only", source_code="PRE_COMMIT_FORMAT_DRIFT"):
     return {
         "schema_version": "sdetkit.adaptive_safe_fix.v1",
         "safe_to_auto_fix": True,
-        "fix_type": "format_only",
+        "fix_type": fix_type,
         "requires_human_review": False,
-        "source_code": "PRE_COMMIT_FORMAT_DRIFT",
+        "source_code": source_code,
         "affected_files": ["src/sdetkit/example.py"],
     }
 
@@ -75,6 +75,44 @@ def test_commit_safe_fix_changes_pushes_same_repo_branch(tmp_path, monkeypatch):
     assert result["pushed"] is True
     assert calls[-1] == ["git", "push", "origin", "HEAD:feature/example"]
     assert (tmp_path / "adaptive-safe-commit-result.json").exists()
+
+
+def test_commit_safe_fix_changes_accepts_ruff_fixable_lint_plan(tmp_path, monkeypatch):
+    autopilot = _load_autopilot()
+    event_path = tmp_path / "event.json"
+    _same_repo_event(event_path)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_HEAD_REF", "feature/example")
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("GH_TOKEN", "token")
+    autopilot._ACTIVE_FAILURE_CONTEXT.update(
+        {
+            "commit_safe_fixes": True,
+            "token_env": "GH_TOKEN",
+            "owner": "sherif69-sa",
+            "repo": "DevS69-sdetkit",
+        }
+    )
+
+    calls = []
+
+    def runner(cmd):
+        calls.append(cmd)
+        if cmd == ["git", "diff", "--name-only"]:
+            return {"ok": True, "returncode": 0, "stdout": "src/sdetkit/example.py\n", "stderr": ""}
+        return {"ok": True, "returncode": 0, "stdout": "ok", "stderr": ""}
+
+    result = autopilot._commit_safe_fix_changes(
+        tmp_path,
+        _safe_plan(fix_type="ruff_fixable_lint", source_code="RUFF_FIXABLE_LINT"),
+        _success_result(),
+        git_runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["pushed"] is True
+    assert calls[-1] == ["git", "push", "origin", "HEAD:feature/example"]
 
 
 def test_commit_safe_fix_changes_rejects_fork_pull_request(tmp_path, monkeypatch):

--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -187,7 +187,7 @@ def _write_safe_fix_artifacts_on_failure(out_dir: Path, diagnosis_payload: dict[
 
         if not (
             plan.get("safe_to_auto_fix") is True
-            and plan.get("fix_type") == "format_only"
+            and plan.get("fix_type") in {"format_only", "ruff_fixable_lint"}
             and plan.get("requires_human_review") is False
         ):
             return
@@ -310,10 +310,10 @@ def _commit_safe_fix_changes(
 
     if not (
         plan.get("safe_to_auto_fix") is True
-        and plan.get("fix_type") == "format_only"
+        and plan.get("fix_type") in {"format_only", "ruff_fixable_lint"}
         and plan.get("requires_human_review") is False
     ):
-        result["reason"] = "plan is not an approved format-only safe fix"
+        result["reason"] = "plan is not an approved safe mechanical fix"
         _write_safe_fix_commit_result(out_dir, result)
         return result
 


### PR DESCRIPTION
## Summary
- Detect narrow Ruff fixable lint as a specific adaptive diagnosis family.
- Plan safe file-scoped remediation for F401 unused imports and I001 import sorting.
- Allow `ruff check --fix` only through the safe `ruff_fixable_lint` remediation path.
- Keep pytest, mypy, dependency, security, Mission Control, and logic-risk Ruff rules review-first.

## Safety
- Only F401 and I001 are auto-fix eligible.
- Ruff fix commands must target files from `affected_files`.
- Plans with placeholders, broad targets, unsafe commands, or review-required diagnoses remain blocked.
- Same-repo PR push safety remains guarded and only accepts approved safe mechanical fix types.

## Test evidence
- Corrected unsafe broad-target audit passed.
- Target-scoping audit confirmed `_planned_files`, `_ruff_targets`, and outside-plan rejection are present.
- `PYTHONPATH=src python -m pytest -q tests/test_adaptive_diagnosis.py tests/test_adaptive_safe_fix.py tests/test_adaptive_safe_remediation.py tests/test_maintenance_autopilot_safe_commit.py` → 36 passed.
- `PYTHONPATH=src python -m ruff format --check <touched files>` → passed.
- `PYTHONPATH=src python -m ruff check <touched files>` → passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.

## Rollback plan
- Revert this PR to return safe remediation to format-only planning.