### PR TITLE
Render adaptive Ruff fixable reviewer comments

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -44,43 +44,9 @@ jobs:
             --log quality.log \
             --format json \
             --out build/pr-quality/adaptive-diagnosis.json
-          python - <<'PY' > build/pr-quality/adaptive-diagnosis-comment.md
-          import json
-          from pathlib import Path
-
-          path = Path("build/pr-quality/adaptive-diagnosis.json")
-          if not path.exists():
-              raise SystemExit(0)
-
-          payload = json.loads(path.read_text(encoding="utf-8"))
-          if payload.get("status") in {"clear", "monitor"}:
-              raise SystemExit(0)
-
-          diagnoses = payload.get("diagnoses") or []
-          if not diagnoses:
-              raise SystemExit(0)
-
-          first = diagnoses[0]
-          fixes = first.get("recommended_fix") or []
-          commands = first.get("proof_commands") or []
-
-          print("### Adaptive Diagnosis")
-          print(f"- status: `{payload.get('status', 'unknown')}`")
-          print(f"- risk score: `{payload.get('risk_score', 'unknown')}`")
-          print(f"- confidence: `{payload.get('confidence', 'unknown')}`")
-          print(f"- primary issue: **{first.get('title', 'Unknown issue')}**")
-          print()
-          print("Why developers miss it:")
-          print(first.get("why_developers_miss_it", "No hidden-risk explanation available."))
-          if fixes:
-              print()
-              print("Recommended fix:")
-              print(f"- {fixes[0]}")
-          if commands:
-              print()
-              print("Proof command:")
-              print(f"- `{commands[0]}`")
-          PY
+          PYTHONPATH=src python -m sdetkit.pr_quality_comment \
+            build/pr-quality/adaptive-diagnosis.json \
+            > build/pr-quality/adaptive-diagnosis-comment.md
 
       - name: Build PR comment body
         run: |

--- a/src/sdetkit/pr_quality_comment.py
+++ b/src/sdetkit/pr_quality_comment.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _first_text(values: list[Any], fallback: str) -> str:
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return fallback
+
+
+def _matching_fix_plan(payload: dict[str, Any], code: str) -> dict[str, Any]:
+    for item in _as_list(payload.get("fix_plan")):
+        row = _as_dict(item)
+        if str(row.get("code", "")) == code:
+            return row
+    return (
+        _as_dict(_as_list(payload.get("fix_plan"))[0]) if _as_list(payload.get("fix_plan")) else {}
+    )
+
+
+def _auto_fix_status(code: str, fix_plan: dict[str, Any]) -> str:
+    if fix_plan.get("safe_to_auto_fix") is not True:
+        return "SDETKit will keep this review-first because the current evidence is not safe for automatic remediation."
+    if code == "RUFF_FIXABLE_LINT":
+        return "SDETKit can auto-fix this only when the safe plan, affected-file scope, remediation proof, and same-repo branch guards all pass."
+    if code == "PRE_COMMIT_FORMAT_DRIFT":
+        return "SDETKit can auto-fix this when the format-only safe plan, remediation proof, and same-repo branch guards all pass."
+    return "SDETKit can auto-fix this only when the safe mechanical plan and proof gates pass."
+
+
+def render_adaptive_diagnosis_comment(payload: dict[str, Any]) -> str:
+    if payload.get("status") in {"clear", "monitor"}:
+        return ""
+
+    diagnoses = _as_list(payload.get("diagnoses"))
+    if not diagnoses:
+        return ""
+
+    first = _as_dict(diagnoses[0])
+    code = str(first.get("code", "UNKNOWN"))
+    fixes = _as_list(first.get("recommended_fix"))
+    commands = _as_list(first.get("proof_commands"))
+    fix_plan = _matching_fix_plan(payload, code)
+
+    lines = [
+        "### Adaptive Diagnosis",
+        f"- status: `{payload.get('status', 'unknown')}`",
+        f"- risk score: `{payload.get('risk_score', 'unknown')}`",
+        f"- confidence: `{payload.get('confidence', 'unknown')}`",
+        f"- primary issue: **{first.get('title', 'Unknown issue')}**",
+        f"- diagnosis code: `{code}`",
+        "",
+        "Why developers miss it:",
+        str(first.get("why_developers_miss_it", "No hidden-risk explanation available.")),
+        "",
+        "Smallest safe fix:",
+        f"- {_first_text(fixes, 'Inspect the first failing evidence item and apply the smallest safe change.')}",
+        "",
+        "Proof command:",
+        f"- `{_first_text(commands, 'PYTHONPATH=src python -m pytest -q <targeted-tests>')}`",
+        "",
+        "Auto-fix status:",
+        f"- {_auto_fix_status(code, fix_plan)}",
+    ]
+
+    if code == "RUFF_FIXABLE_LINT":
+        lines.extend(
+            [
+                "",
+                "Ruff fixable lint route:",
+                "- Applies only to the narrow F401/I001 mechanical allowlist.",
+                "- Runs `ruff check --fix` only on affected files, then proves Ruff check and format check.",
+                "- Logic-risk Ruff findings remain review-first.",
+            ]
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_from_file(path: Path) -> str:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return render_adaptive_diagnosis_comment(payload)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.pr_quality_comment")
+    parser.add_argument("adaptive_diagnosis_json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        rendered = render_from_file(Path(args.adaptive_diagnosis_json))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_quality_comment.py
+++ b/tests/test_pr_quality_comment.py
@@ -1,0 +1,81 @@
+import json
+
+from sdetkit import pr_quality_comment
+
+
+def _payload(code="RUFF_FIXABLE_LINT", safe_to_auto_fix=True):
+    return {
+        "schema_version": "sdetkit.adaptive.diagnosis.v1",
+        "ok": False,
+        "status": "needs_fix",
+        "risk_score": 26,
+        "confidence": "high",
+        "diagnoses": [
+            {
+                "code": code,
+                "title": "Ruff fixable lint can be mechanically remediated",
+                "why_developers_miss_it": "Developers often fix the visible import by hand.",
+                "recommended_fix": ["Run ruff check --fix on affected files."],
+                "proof_commands": ["PYTHONPATH=src python -m ruff check tests/test_example.py"],
+            }
+        ],
+        "fix_plan": [
+            {
+                "code": code,
+                "title": "Ruff fixable lint can be mechanically remediated",
+                "safe_to_auto_fix": safe_to_auto_fix,
+                "recommended_fix": ["Run ruff check --fix on affected files."],
+                "proof_commands": ["PYTHONPATH=src python -m ruff check tests/test_example.py"],
+            }
+        ],
+    }
+
+
+def test_render_ruff_fixable_lint_comment_explains_auto_fix_route():
+    rendered = pr_quality_comment.render_adaptive_diagnosis_comment(_payload())
+
+    assert "### Adaptive Diagnosis" in rendered
+    assert "diagnosis code: `RUFF_FIXABLE_LINT`" in rendered
+    assert "Smallest safe fix:" in rendered
+    assert "Run ruff check --fix on affected files." in rendered
+    assert "Auto-fix status:" in rendered
+    assert "SDETKit can auto-fix this only when" in rendered
+    assert "F401/I001" in rendered
+    assert "Logic-risk Ruff findings remain review-first." in rendered
+
+
+def test_render_review_first_comment_when_fix_plan_is_not_safe():
+    rendered = pr_quality_comment.render_adaptive_diagnosis_comment(
+        _payload(code="PYTEST_ASSERTION_FAILURE", safe_to_auto_fix=False)
+    )
+
+    assert "diagnosis code: `PYTEST_ASSERTION_FAILURE`" in rendered
+    assert "review-first" in rendered
+    assert "Ruff fixable lint route:" not in rendered
+
+
+def test_render_empty_for_green_or_monitor_payloads():
+    payload = _payload()
+    payload["status"] = "monitor"
+
+    assert pr_quality_comment.render_adaptive_diagnosis_comment(payload) == ""
+
+
+def test_cli_renders_comment_from_file(tmp_path, capsys):
+    path = tmp_path / "adaptive-diagnosis.json"
+    path.write_text(json.dumps(_payload()), encoding="utf-8")
+
+    rc = pr_quality_comment.main([str(path)])
+
+    assert rc == 0
+    assert "Ruff fixable lint route:" in capsys.readouterr().out
+
+
+def test_cli_rejects_bad_json(tmp_path, capsys):
+    path = tmp_path / "adaptive-diagnosis.json"
+    path.write_text("not-json", encoding="utf-8")
+
+    rc = pr_quality_comment.main([str(path)])
+
+    assert rc == 2
+    assert "error=" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Move Adaptive Diagnosis PR-comment rendering out of inline workflow Python into a tested module.
- Add richer reviewer wording for safe Ruff fixable lint diagnoses.
- Explain the smallest safe fix, proof command, auto-fix status, and F401/I001 safe route.
- Keep review-first messaging for non-safe or logic-risk failures.

## Why
- PR #1133 taught the diagnosis/planner/remediation loop to safely handle F401 unused imports and I001 import sorting.
- The reviewer comment should now explain that precise path instead of presenting only generic diagnosis details.

## Safety
- The workflow still only comments when adaptive diagnosis is actionable.
- Green or monitor-only states still produce no adaptive diagnosis comment.
- Non-safe fix plans explicitly say SDETKit keeps the failure review-first.
- Ruff fixable lint wording is limited to the narrow F401/I001 route and says logic-risk Ruff findings remain review-first.

## Test evidence
- `PYTHONPATH=src python -m pytest -q tests/test_pr_quality_comment.py` → 5 passed.
- `PYTHONPATH=src python -m ruff format --check src/sdetkit/pr_quality_comment.py tests/test_pr_quality_comment.py` → passed.
- `PYTHONPATH=src python -m ruff check src/sdetkit/pr_quality_comment.py tests/test_pr_quality_comment.py` → passed.
- `PYTHONPATH=src python -m pre_commit run check-yaml --files .github/workflows/pr-quality-comment.yml` → passed.
- `PYTHONPATH=src python -m pre_commit run --files .github/workflows/pr-quality-comment.yml src/sdetkit/pr_quality_comment.py tests/test_pr_quality_comment.py` → passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.

## Rollback plan
- Revert this PR to restore the prior inline workflow comment renderer.