### PR TITLE
Record adaptive safe fix learning outcomes

### DIFF
--- a/src/sdetkit/adaptive_diagnosis_memory.py
+++ b/src/sdetkit/adaptive_diagnosis_memory.py
@@ -57,6 +57,58 @@ def load_diagnosis(path: Path) -> dict[str, Any]:
     return payload
 
 
+def build_safe_fix_learning_record(
+    *,
+    plan: dict[str, Any],
+    remediation_result: dict[str, Any] | None = None,
+    commit_result: dict[str, Any] | None = None,
+    learned_at_utc: str | None = None,
+) -> dict[str, Any]:
+    remediation = _as_dict(remediation_result)
+    commit = _as_dict(commit_result)
+    affected_files = [str(value) for value in _as_list(plan.get("affected_files"))]
+    identity = {
+        "source": "adaptive_safe_fix",
+        "source_code": plan.get("source_code", "UNKNOWN"),
+        "fix_type": plan.get("fix_type", "unknown"),
+        "safe_to_auto_fix": bool(plan.get("safe_to_auto_fix", False)),
+        "remediation_status": remediation.get("status", "not_attempted"),
+        "commit_pushed": bool(commit.get("pushed", False)),
+    }
+    return {
+        "schema_version": RECORD_SCHEMA_VERSION,
+        "record_id": _record_hash(identity),
+        "learned_at_utc": learned_at_utc or _timestamp(),
+        "source": "adaptive_safe_fix",
+        "source_schema_version": str(plan.get("schema_version", "")),
+        "source_status": str(plan.get("source_status", "unknown")),
+        "source_confidence": str(plan.get("confidence", "unknown")),
+        "source_risk_score": 0,
+        "code": str(plan.get("source_code", "UNKNOWN")),
+        "signal": f"safe-fix-{plan.get('fix_type', 'unknown')}",
+        "severity": "info",
+        "confidence": str(plan.get("confidence", "unknown")),
+        "title": f"Safe fix outcome for {plan.get('fix_type', 'unknown')}",
+        "recommended_fix": _first(plan.get("commands")),
+        "proof_command": _first(plan.get("proof_commands")),
+        "risk_if_ignored": str(plan.get("reason", "")),
+        "repeat_count": 0,
+        "affected_files": affected_files,
+        "fix_type": str(plan.get("fix_type", "unknown")),
+        "safe_to_auto_fix": bool(plan.get("safe_to_auto_fix", False)),
+        "requires_human_review": bool(plan.get("requires_human_review", True)),
+        "affected_file_count": len(affected_files),
+        "remediation_attempted": bool(remediation.get("attempted", False)),
+        "remediation_ok": bool(remediation.get("ok", False)),
+        "remediation_status": str(remediation.get("status", "not_attempted")),
+        "remediation_command_count": _as_int(remediation.get("command_count")),
+        "commit_attempted": bool(commit.get("attempted", False)),
+        "commit_ok": bool(commit.get("ok", False)),
+        "commit_pushed": bool(commit.get("pushed", False)),
+        "commit_reason": str(commit.get("reason", "")),
+    }
+
+
 def build_learning_records(
     payload: dict[str, Any],
     *,

--- a/tests/test_adaptive_diagnosis_memory.py
+++ b/tests/test_adaptive_diagnosis_memory.py
@@ -36,6 +36,51 @@ def _diagnosis_payload(status="needs_fix"):
     }
 
 
+def test_build_safe_fix_learning_record_captures_remediation_and_commit_outcome():
+    record = adaptive_diagnosis_memory.build_safe_fix_learning_record(
+        plan={
+            "schema_version": "sdetkit.adaptive_safe_fix.v1",
+            "source_status": "needs_fix",
+            "source_code": "RUFF_FIXABLE_LINT",
+            "safe_to_auto_fix": True,
+            "fix_type": "ruff_fixable_lint",
+            "confidence": "high",
+            "requires_human_review": False,
+            "reason": "safe narrow lint",
+            "commands": ["PYTHONPATH=src python -m ruff check --fix tests/test_case.py"],
+            "proof_commands": ["PYTHONPATH=src python -m ruff check tests/test_case.py"],
+            "affected_files": ["tests/test_case.py"],
+        },
+        remediation_result={
+            "ok": True,
+            "status": "success",
+            "attempted": True,
+            "command_count": 4,
+        },
+        commit_result={
+            "ok": True,
+            "attempted": True,
+            "pushed": True,
+            "reason": "safe mechanical fix committed and pushed",
+        },
+        learned_at_utc="2026-05-05T00:00:00Z",
+    )
+
+    assert record["source"] == "adaptive_safe_fix"
+    assert record["code"] == "RUFF_FIXABLE_LINT"
+    assert record["fix_type"] == "ruff_fixable_lint"
+    assert record["affected_file_count"] == 1
+    assert record["remediation_attempted"] is True
+    assert record["remediation_ok"] is True
+    assert record["remediation_status"] == "success"
+    assert record["remediation_command_count"] == 4
+    assert record["commit_attempted"] is True
+    assert record["commit_ok"] is True
+    assert record["commit_pushed"] is True
+    assert record["learned_at_utc"] == "2026-05-05T00:00:00Z"
+    assert len(record["record_id"]) == 16
+
+
 def test_build_learning_records_from_actionable_diagnosis():
     records = adaptive_diagnosis_memory.build_learning_records(
         _diagnosis_payload(), learned_at_utc="2026-05-05T00:00:00Z"

--- a/tests/test_maintenance_autopilot_safe_remediation.py
+++ b/tests/test_maintenance_autopilot_safe_remediation.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 
 from sdetkit import adaptive_safe_fix, adaptive_safe_remediation
 
@@ -11,6 +12,64 @@ def _load_autopilot():
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def test_write_safe_fix_artifacts_writes_safe_fix_learning_outcome(tmp_path, monkeypatch):
+    autopilot = _load_autopilot()
+    monkeypatch.chdir(tmp_path)
+    plan = {
+        "schema_version": "sdetkit.adaptive_safe_fix.v1",
+        "safe_to_auto_fix": True,
+        "fix_type": "format_only",
+        "requires_human_review": False,
+        "source_code": "PRE_COMMIT_FORMAT_DRIFT",
+        "confidence": "high",
+        "commands": ["PYTHONPATH=src python -m ruff format src/sdetkit/example.py"],
+        "proof_commands": ["PYTHONPATH=src python -m ruff format --check src/sdetkit/example.py"],
+        "affected_files": ["src/sdetkit/example.py"],
+    }
+
+    monkeypatch.setattr(adaptive_safe_fix, "build_plan", lambda payload: plan)
+    monkeypatch.setattr(
+        adaptive_safe_remediation,
+        "run_plan",
+        lambda payload, cwd: {
+            "schema_version": "sdetkit.adaptive_safe_remediation.v1",
+            "ok": True,
+            "status": "success",
+            "attempted": True,
+            "command_count": 3,
+        },
+    )
+    monkeypatch.setattr(
+        adaptive_safe_remediation,
+        "render_markdown",
+        lambda payload: "# Adaptive Safe Remediation Result\n",
+    )
+    monkeypatch.setattr(
+        autopilot,
+        "_commit_safe_fix_changes",
+        lambda out_dir, plan, result: {
+            "schema_version": "sdetkit.maintenance.autopilot.safe_fix_commit.v1",
+            "ok": False,
+            "attempted": False,
+            "pushed": False,
+            "reason": "commit-safe-fixes flag is disabled",
+        },
+    )
+
+    autopilot._write_safe_fix_artifacts_on_failure(
+        tmp_path, {"schema_version": "sdetkit.adaptive.diagnosis.v1"}
+    )
+
+    learning_path = tmp_path / "adaptive-safe-fix-learning-result.json"
+    assert learning_path.exists()
+    payload = json.loads(learning_path.read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+    assert payload["input_records"] == 1
+    assert payload["fix_type"] == "format_only"
+    assert payload["remediation_status"] == "success"
+    assert payload["commit_pushed"] is False
 
 
 def test_autopilot_writes_safe_fix_plan_and_remediation_artifacts(tmp_path, monkeypatch):

--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -190,6 +190,7 @@ def _write_safe_fix_artifacts_on_failure(out_dir: Path, diagnosis_payload: dict[
             and plan.get("fix_type") in {"format_only", "ruff_fixable_lint"}
             and plan.get("requires_human_review") is False
         ):
+            _write_safe_fix_learning_outcome(out_dir, plan)
             return
 
         result = adaptive_safe_remediation.run_plan(plan, cwd=Path.cwd())
@@ -199,7 +200,8 @@ def _write_safe_fix_artifacts_on_failure(out_dir: Path, diagnosis_payload: dict[
             adaptive_safe_remediation.render_markdown(result),
             encoding="utf-8",
         )
-        _commit_safe_fix_changes(out_dir, plan, result)
+        commit_result = _commit_safe_fix_changes(out_dir, plan, result)
+        _write_safe_fix_learning_outcome(out_dir, plan, result, commit_result)
     except Exception as exc:
         _write_json(
             out_dir / "adaptive-safe-remediation-error.json",
@@ -284,6 +286,51 @@ def _git_stdout_lines(result: dict[str, Any]) -> list[str]:
 
 def _write_safe_fix_commit_result(out_dir: Path, payload: dict[str, Any]) -> None:
     _write_json(out_dir / "adaptive-safe-commit-result.json", payload)
+
+
+def _write_safe_fix_learning_outcome(
+    out_dir: Path,
+    plan: dict[str, Any],
+    remediation_result: dict[str, Any] | None = None,
+    commit_result: dict[str, Any] | None = None,
+) -> None:
+    try:
+        from sdetkit import adaptive_diagnosis_memory
+    except Exception as exc:
+        _write_json(
+            out_dir / "adaptive-safe-fix-learning-error.json",
+            {
+                "schema_version": "sdetkit.maintenance.autopilot.safe_fix_learning_error.v1",
+                "ok": False,
+                "error": str(exc),
+            },
+        )
+        return
+
+    try:
+        record = adaptive_diagnosis_memory.build_safe_fix_learning_record(
+            plan=plan,
+            remediation_result=remediation_result,
+            commit_result=commit_result,
+        )
+        summary = adaptive_diagnosis_memory.append_learning_records(
+            Path(".sdetkit/maintenance/adaptive-safe-fix-memory.jsonl"),
+            [record],
+        )
+        summary["record_id"] = record.get("record_id", "")
+        summary["fix_type"] = record.get("fix_type", "unknown")
+        summary["remediation_status"] = record.get("remediation_status", "unknown")
+        summary["commit_pushed"] = record.get("commit_pushed", False)
+        _write_json(out_dir / "adaptive-safe-fix-learning-result.json", summary)
+    except Exception as exc:
+        _write_json(
+            out_dir / "adaptive-safe-fix-learning-error.json",
+            {
+                "schema_version": "sdetkit.maintenance.autopilot.safe_fix_learning_error.v1",
+                "ok": False,
+                "error": str(exc),
+            },
+        )
 
 
 def _commit_safe_fix_changes(


### PR DESCRIPTION
## Summary
- Add compact learning records for adaptive safe-fix outcomes.
- Capture plan metadata, fix type, affected-file count, remediation status, command count, and commit/push outcome.
- Have maintenance autopilot write a safe-fix learning result artifact after review-required plans and after safe remediation/commit handling.
- Add regression coverage for memory record content and autopilot learning artifact emission.

## Why
- PR #1133 added safe automatic remediation for formatter drift plus narrow Ruff F401/I001 fixes.
- PR #1134 made reviewer comments explain that route.
- This PR closes the next loop: safe fix attempts now leave durable learning evidence about whether remediation and commit/push actually worked.

## Safety
- This does not broaden the auto-fix allowlist.
- This does not add new remediation commands.
- Review-required plans are still not remediated, but now record a safe-fix learning outcome.
- Commit/push guards remain unchanged.
- Learning write failures are isolated into `adaptive-safe-fix-learning-error.json` and do not replace remediation artifacts.

## Test evidence
- `PYTHONPATH=src python -m pytest -q tests/test_adaptive_diagnosis_memory.py tests/test_maintenance_autopilot_safe_remediation.py` → 10 passed.
- `PYTHONPATH=src python -m ruff format --check src/sdetkit/adaptive_diagnosis_memory.py tools/maintenance_autopilot.py tests/test_adaptive_diagnosis_memory.py tests/test_maintenance_autopilot_safe_remediation.py` → passed.
- `PYTHONPATH=src python -m ruff check src/sdetkit/adaptive_diagnosis_memory.py tools/maintenance_autopilot.py tests/test_adaptive_diagnosis_memory.py tests/test_maintenance_autopilot_safe_remediation.py` → passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.

## Rollback plan
- Revert this PR to remove safe-fix outcome learning while leaving diagnosis, remediation, and PR comment behavior unchanged.