### PR TITLE
Summarize adaptive safe fix memory rollups

### DIFF
--- a/src/sdetkit/adaptive_diagnosis_memory.py
+++ b/src/sdetkit/adaptive_diagnosis_memory.py
@@ -9,6 +9,7 @@ from typing import Any
 
 SCHEMA_VERSION = "sdetkit.adaptive_diagnosis.memory.v1"
 RECORD_SCHEMA_VERSION = "sdetkit.adaptive_diagnosis.learning_record.v1"
+SAFE_FIX_ROLLUP_SCHEMA_VERSION = "sdetkit.adaptive_safe_fix.rollup.v1"
 SOURCE_SCHEMA_VERSION = "sdetkit.adaptive.diagnosis.v1"
 ACTIONABLE_STATUSES = {"needs_attention", "needs_fix"}
 
@@ -107,6 +108,81 @@ def build_safe_fix_learning_record(
         "commit_pushed": bool(commit.get("pushed", False)),
         "commit_reason": str(commit.get("reason", "")),
     }
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    return round(numerator / denominator, 4) if denominator else 0.0
+
+
+def build_safe_fix_memory_rollup(records: list[dict[str, Any]]) -> dict[str, Any]:
+    groups: dict[tuple[str, str], dict[str, Any]] = {}
+    safe_fix_records = 0
+
+    for record in records:
+        row = _as_dict(record)
+        if row.get("source") != "adaptive_safe_fix":
+            continue
+
+        safe_fix_records += 1
+        fix_type = str(row.get("fix_type", "unknown"))
+        code = str(row.get("code", "UNKNOWN"))
+        key = (fix_type, code)
+        group = groups.setdefault(
+            key,
+            {
+                "fix_type": fix_type,
+                "code": code,
+                "records": 0,
+                "affected_file_count": 0,
+                "remediation_attempts": 0,
+                "remediation_successes": 0,
+                "commit_attempts": 0,
+                "commit_pushes": 0,
+                "latest_record_id": "",
+                "latest_learned_at_utc": "",
+                "latest_remediation_status": "unknown",
+                "latest_commit_reason": "",
+            },
+        )
+
+        group["records"] += 1
+        group["affected_file_count"] += _as_int(row.get("affected_file_count"))
+        if bool(row.get("remediation_attempted", False)):
+            group["remediation_attempts"] += 1
+        if bool(row.get("remediation_ok", False)):
+            group["remediation_successes"] += 1
+        if bool(row.get("commit_attempted", False)):
+            group["commit_attempts"] += 1
+        if bool(row.get("commit_pushed", False)):
+            group["commit_pushes"] += 1
+        group["latest_record_id"] = str(row.get("record_id", ""))
+        group["latest_learned_at_utc"] = str(row.get("learned_at_utc", ""))
+        group["latest_remediation_status"] = str(row.get("remediation_status", "unknown"))
+        group["latest_commit_reason"] = str(row.get("commit_reason", ""))
+
+    ordered_groups = []
+    for group in sorted(groups.values(), key=lambda item: (item["fix_type"], item["code"])):
+        group["remediation_success_rate"] = _rate(
+            _as_int(group["remediation_successes"]), _as_int(group["remediation_attempts"])
+        )
+        group["commit_push_rate"] = _rate(
+            _as_int(group["commit_pushes"]), _as_int(group["commit_attempts"])
+        )
+        ordered_groups.append(group)
+
+    return {
+        "schema_version": SAFE_FIX_ROLLUP_SCHEMA_VERSION,
+        "ok": True,
+        "source": "adaptive_safe_fix_memory",
+        "input_records": len(records),
+        "safe_fix_records": safe_fix_records,
+        "group_count": len(ordered_groups),
+        "groups": ordered_groups,
+    }
+
+
+def safe_fix_rollup_from_db(db_path: Path) -> dict[str, Any]:
+    return build_safe_fix_memory_rollup(_read_jsonl(db_path))
 
 
 def build_learning_records(

--- a/tests/test_adaptive_diagnosis_memory.py
+++ b/tests/test_adaptive_diagnosis_memory.py
@@ -81,6 +81,86 @@ def test_build_safe_fix_learning_record_captures_remediation_and_commit_outcome(
     assert len(record["record_id"]) == 16
 
 
+def test_build_safe_fix_memory_rollup_groups_success_rates():
+    format_record = adaptive_diagnosis_memory.build_safe_fix_learning_record(
+        plan={
+            "schema_version": "sdetkit.adaptive_safe_fix.v1",
+            "source_status": "needs_fix",
+            "source_code": "PRE_COMMIT_FORMAT_DRIFT",
+            "safe_to_auto_fix": True,
+            "fix_type": "format_only",
+            "confidence": "high",
+            "requires_human_review": False,
+            "commands": ["PYTHONPATH=src python -m ruff format tests/test_case.py"],
+            "proof_commands": ["PYTHONPATH=src python -m ruff format --check tests/test_case.py"],
+            "affected_files": ["tests/test_case.py"],
+        },
+        remediation_result={"ok": True, "status": "success", "attempted": True, "command_count": 3},
+        commit_result={"ok": False, "attempted": False, "pushed": False, "reason": "disabled"},
+        learned_at_utc="2026-05-05T00:00:00Z",
+    )
+    ruff_record = adaptive_diagnosis_memory.build_safe_fix_learning_record(
+        plan={
+            "schema_version": "sdetkit.adaptive_safe_fix.v1",
+            "source_status": "needs_fix",
+            "source_code": "RUFF_FIXABLE_LINT",
+            "safe_to_auto_fix": True,
+            "fix_type": "ruff_fixable_lint",
+            "confidence": "high",
+            "requires_human_review": False,
+            "commands": ["PYTHONPATH=src python -m ruff check --fix tests/test_case.py"],
+            "proof_commands": ["PYTHONPATH=src python -m ruff check tests/test_case.py"],
+            "affected_files": ["tests/test_case.py", "src/sdetkit/example.py"],
+        },
+        remediation_result={"ok": True, "status": "success", "attempted": True, "command_count": 4},
+        commit_result={"ok": True, "attempted": True, "pushed": True, "reason": "pushed"},
+        learned_at_utc="2026-05-05T00:01:00Z",
+    )
+
+    rollup = adaptive_diagnosis_memory.build_safe_fix_memory_rollup(
+        [format_record, ruff_record, {"source": "adaptive_diagnosis"}]
+    )
+
+    assert rollup["schema_version"] == "sdetkit.adaptive_safe_fix.rollup.v1"
+    assert rollup["safe_fix_records"] == 2
+    assert rollup["group_count"] == 2
+    by_type = {group["fix_type"]: group for group in rollup["groups"]}
+    assert by_type["format_only"]["remediation_success_rate"] == 1.0
+    assert by_type["format_only"]["commit_push_rate"] == 0.0
+    assert by_type["ruff_fixable_lint"]["affected_file_count"] == 2
+    assert by_type["ruff_fixable_lint"]["commit_push_rate"] == 1.0
+    assert by_type["ruff_fixable_lint"]["latest_remediation_status"] == "success"
+
+
+def test_safe_fix_rollup_from_db_reads_jsonl(tmp_path):
+    db_path = tmp_path / "adaptive-safe-fix-memory.jsonl"
+    record = adaptive_diagnosis_memory.build_safe_fix_learning_record(
+        plan={
+            "schema_version": "sdetkit.adaptive_safe_fix.v1",
+            "source_code": "RUFF_FIXABLE_LINT",
+            "safe_to_auto_fix": True,
+            "fix_type": "ruff_fixable_lint",
+            "requires_human_review": False,
+            "affected_files": ["tests/test_case.py"],
+        },
+        remediation_result={"ok": False, "status": "failed", "attempted": True, "command_count": 2},
+        commit_result={
+            "ok": False,
+            "attempted": False,
+            "pushed": False,
+            "reason": "remediation failed",
+        },
+        learned_at_utc="2026-05-05T00:00:00Z",
+    )
+    adaptive_diagnosis_memory.append_learning_records(db_path, [record])
+
+    rollup = adaptive_diagnosis_memory.safe_fix_rollup_from_db(db_path)
+
+    assert rollup["safe_fix_records"] == 1
+    assert rollup["groups"][0]["remediation_success_rate"] == 0.0
+    assert rollup["groups"][0]["latest_remediation_status"] == "failed"
+
+
 def test_build_learning_records_from_actionable_diagnosis():
     records = adaptive_diagnosis_memory.build_learning_records(
         _diagnosis_payload(), learned_at_utc="2026-05-05T00:00:00Z"

--- a/tests/test_maintenance_autopilot_safe_remediation.py
+++ b/tests/test_maintenance_autopilot_safe_remediation.py
@@ -71,6 +71,14 @@ def test_write_safe_fix_artifacts_writes_safe_fix_learning_outcome(tmp_path, mon
     assert payload["remediation_status"] == "success"
     assert payload["commit_pushed"] is False
 
+    rollup_path = tmp_path / "adaptive-safe-fix-learning-rollup.json"
+    assert rollup_path.exists()
+    rollup = json.loads(rollup_path.read_text(encoding="utf-8"))
+    assert rollup["schema_version"] == "sdetkit.adaptive_safe_fix.rollup.v1"
+    assert rollup["safe_fix_records"] == 1
+    assert rollup["groups"][0]["fix_type"] == "format_only"
+    assert rollup["groups"][0]["remediation_success_rate"] == 1.0
+
 
 def test_autopilot_writes_safe_fix_plan_and_remediation_artifacts(tmp_path, monkeypatch):
     autopilot = _load_autopilot()

--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -313,15 +313,15 @@ def _write_safe_fix_learning_outcome(
             remediation_result=remediation_result,
             commit_result=commit_result,
         )
-        summary = adaptive_diagnosis_memory.append_learning_records(
-            Path(".sdetkit/maintenance/adaptive-safe-fix-memory.jsonl"),
-            [record],
-        )
+        memory_path = Path(".sdetkit/maintenance/adaptive-safe-fix-memory.jsonl")
+        summary = adaptive_diagnosis_memory.append_learning_records(memory_path, [record])
+        rollup = adaptive_diagnosis_memory.build_safe_fix_memory_rollup(_read_jsonl(memory_path))
         summary["record_id"] = record.get("record_id", "")
         summary["fix_type"] = record.get("fix_type", "unknown")
         summary["remediation_status"] = record.get("remediation_status", "unknown")
         summary["commit_pushed"] = record.get("commit_pushed", False)
         _write_json(out_dir / "adaptive-safe-fix-learning-result.json", summary)
+        _write_json(out_dir / "adaptive-safe-fix-learning-rollup.json", rollup)
     except Exception as exc:
         _write_json(
             out_dir / "adaptive-safe-fix-learning-error.json",


### PR DESCRIPTION
## Summary
- Add read-only rollups for adaptive safe-fix memory records.
- Group safe-fix outcomes by `fix_type` and diagnosis `code`.
- Report remediation attempts, remediation successes, commit attempts, commit pushes, rates, affected-file totals, and latest status.
- Have maintenance autopilot write `adaptive-safe-fix-learning-rollup.json` beside the existing safe-fix learning result artifact.

## Why
- PR #1135 made safe-fix attempts durable in memory.
- This PR makes that memory useful by summarizing trust signals for future policy and dashboard work.

## Safety
- This does not broaden the auto-fix allowlist.
- This does not add remediation commands.
- This does not change commit/push guards.
- Rollups are read-only diagnostic summaries derived from existing JSONL memory records.

## Test evidence
- `PYTHONPATH=src python -m pytest -q tests/test_adaptive_diagnosis_memory.py tests/test_maintenance_autopilot_safe_remediation.py` → 12 passed.
- `PYTHONPATH=src python -m ruff format --check src/sdetkit/adaptive_diagnosis_memory.py tools/maintenance_autopilot.py tests/test_adaptive_diagnosis_memory.py tests/test_maintenance_autopilot_safe_remediation.py` → passed.
- `PYTHONPATH=src python -m ruff check src/sdetkit/adaptive_diagnosis_memory.py tools/maintenance_autopilot.py tests/test_adaptive_diagnosis_memory.py tests/test_maintenance_autopilot_safe_remediation.py` → passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.

## Rollback plan
- Revert this PR to stop writing rollup summaries while keeping safe-fix learning records intact.