### PR TITLE
Detect GitHub Actions annotation hygiene risks

### DIFF
--- a/src/sdetkit/github_actions_annotation_hygiene.py
+++ b/src/sdetkit/github_actions_annotation_hygiene.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.github_actions.annotation_hygiene.v1"
+
+_NODE20_ACTION_RE = re.compile(r"(?P<action>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[A-Za-z0-9_.:/-]+)")
+_JOB_RE = re.compile(r"^(?P<job>[A-Za-z0-9_. -]+)$")
+
+
+def _lines(text: str) -> list[str]:
+    return [line.rstrip() for line in text.splitlines()]
+
+
+def _nearest_job(lines: list[str], index: int) -> str:
+    for pos in range(index, -1, -1):
+        candidate = lines[pos].strip()
+        if not candidate:
+            continue
+        if candidate.startswith(("Warning:", "Notice:", "Error:", "Run ", "with:", "env:")):
+            continue
+        if candidate.startswith(("-", "{", "}", '"')):
+            continue
+        match = _JOB_RE.match(candidate)
+        if match:
+            return match.group("job").strip()
+    return "unknown"
+
+
+def _extract_action(line: str) -> str:
+    match = _NODE20_ACTION_RE.search(line)
+    return match.group("action") if match else ""
+
+
+def analyze_annotations(text: str) -> dict[str, Any]:
+    lines = _lines(text)
+    findings: list[dict[str, Any]] = []
+
+    for index, line in enumerate(lines):
+        lower = line.lower()
+
+        if "node.js 20 actions are deprecated" in lower:
+            action = _extract_action(line)
+            findings.append(
+                {
+                    "id": "github_actions_node20_deprecation",
+                    "severity": "warning",
+                    "job": _nearest_job(lines, index),
+                    "action": action,
+                    "title": "GitHub Actions Node.js 20 runtime deprecation",
+                    "evidence": line.strip(),
+                    "recommendation": (
+                        "Update the action to a Node 24-compatible release when available, "
+                        "or test the workflow with FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true."
+                    ),
+                }
+            )
+
+        if "python-version" in lower and "input is not set" in lower:
+            findings.append(
+                {
+                    "id": "github_actions_missing_python_version",
+                    "severity": "notice",
+                    "job": _nearest_job(lines, index),
+                    "action": "",
+                    "title": "GitHub Actions setup-python version is implicit",
+                    "evidence": line.strip(),
+                    "recommendation": (
+                        "Pin an explicit python-version in the workflow when the source "
+                        "workflow is visible; otherwise treat as a generated or managed job."
+                    ),
+                }
+            )
+
+        if (
+            "component-detection-dependency-submission-action" in line
+            or "component-detection scan" in lower
+            or "pipreport" in line
+        ):
+            findings.append(
+                {
+                    "id": "github_actions_dependency_submission_annotation_source",
+                    "severity": "info",
+                    "job": _nearest_job(lines, index),
+                    "action": _extract_action(line),
+                    "title": "Dependency submission annotation came from component detection",
+                    "evidence": line.strip(),
+                    "recommendation": (
+                        "Do not patch product code for this annotation. Inspect workflow "
+                        "ownership first because the job may be GitHub-managed or generated."
+                    ),
+                }
+            )
+
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for finding in findings:
+        key = (
+            str(finding.get("id", "")),
+            str(finding.get("job", "")),
+            str(finding.get("evidence", "")),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(finding)
+
+    warning_count = sum(1 for finding in deduped if finding["severity"] == "warning")
+    notice_count = sum(1 for finding in deduped if finding["severity"] == "notice")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": warning_count == 0,
+        "finding_count": len(deduped),
+        "warning_count": warning_count,
+        "notice_count": notice_count,
+        "findings": deduped,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# GitHub Actions annotation hygiene",
+        "",
+        f"- findings: **{payload.get('finding_count', 0)}**",
+        f"- warnings: **{payload.get('warning_count', 0)}**",
+        f"- notices: **{payload.get('notice_count', 0)}**",
+    ]
+    findings = payload.get("findings", [])
+    if not isinstance(findings, list) or not findings:
+        lines.extend(["", "No GitHub Actions annotation hygiene findings detected."])
+        return "\n".join(lines) + "\n"
+
+    lines.append("")
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        lines.extend(
+            [
+                f"## {finding.get('title', 'Finding')}",
+                "",
+                f"- id: `{finding.get('id', 'unknown')}`",
+                f"- severity: `{finding.get('severity', 'unknown')}`",
+                f"- job: `{finding.get('job', 'unknown')}`",
+            ]
+        )
+        action = str(finding.get("action", ""))
+        if action:
+            lines.append(f"- action: `{action}`")
+        lines.extend(
+            [
+                f"- evidence: {finding.get('evidence', '')}",
+                f"- recommendation: {finding.get('recommendation', '')}",
+                "",
+            ]
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def analyze_file(path: Path) -> dict[str, Any]:
+    return analyze_annotations(path.read_text(encoding="utf-8"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.github_actions_annotation_hygiene")
+    parser.add_argument("annotation_log")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    parser.add_argument("--out")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = analyze_file(Path(args.annotation_log))
+    except OSError as exc:
+        print(f"error={exc}")
+        return 2
+
+    rendered = (
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        if args.format == "json"
+        else render_markdown(payload)
+    )
+
+    if args.out:
+        Path(args.out).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+    return 1 if payload.get("warning_count", 0) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_github_actions_annotation_hygiene.py
+++ b/tests/test_github_actions_annotation_hygiene.py
@@ -1,0 +1,66 @@
+import json
+
+from sdetkit import github_actions_annotation_hygiene as hygiene
+
+ANNOTATIONS = """submit-pypi
+Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/component-detection-dependency-submission-action@374343effede691df3a5ffaf36b4e7acab919590. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
+submit-pypi
+The `python-version` input is not set. The version of Python currently in `PATH` will be used.
+Run actions/component-detection-dependency-submission-action@374343effede691df3a5ffaf36b4e7acab919590
+/home/runner/work/repo/repo/component-detection scan --SourceDirectory . --DetectorsFilter PipReport
+"""
+
+
+def test_analyze_annotations_detects_node20_python_and_dependency_submission_source():
+    payload = hygiene.analyze_annotations(ANNOTATIONS)
+
+    assert payload["schema_version"] == "sdetkit.github_actions.annotation_hygiene.v1"
+    assert payload["ok"] is False
+    assert payload["warning_count"] == 1
+    assert payload["notice_count"] == 1
+    ids = {finding["id"] for finding in payload["findings"]}
+    assert "github_actions_node20_deprecation" in ids
+    assert "github_actions_missing_python_version" in ids
+    assert "github_actions_dependency_submission_annotation_source" in ids
+
+
+def test_node20_finding_extracts_action_and_job():
+    payload = hygiene.analyze_annotations(ANNOTATIONS)
+    finding = next(
+        item for item in payload["findings"] if item["id"] == "github_actions_node20_deprecation"
+    )
+
+    assert finding["job"] == "submit-pypi"
+    assert finding["action"].startswith("actions/component-detection-dependency-submission-action@")
+    assert "Node.js 20" in finding["title"]
+
+
+def test_render_markdown_includes_recommendations():
+    rendered = hygiene.render_markdown(hygiene.analyze_annotations(ANNOTATIONS))
+
+    assert "# GitHub Actions annotation hygiene" in rendered
+    assert "GitHub Actions Node.js 20 runtime deprecation" in rendered
+    assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in rendered
+    assert "Do not patch product code" in rendered
+
+
+def test_cli_writes_json_and_returns_warning_status(tmp_path):
+    log_path = tmp_path / "annotations.txt"
+    out_path = tmp_path / "annotations.json"
+    log_path.write_text(ANNOTATIONS, encoding="utf-8")
+
+    rc = hygiene.main([str(log_path), "--format", "json", "--out", str(out_path)])
+
+    assert rc == 1
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["warning_count"] == 1
+
+
+def test_cli_returns_zero_when_no_warnings(tmp_path, capsys):
+    log_path = tmp_path / "annotations.txt"
+    log_path.write_text("all green\n", encoding="utf-8")
+
+    rc = hygiene.main([str(log_path), "--format", "md"])
+
+    assert rc == 0
+    assert "No GitHub Actions annotation hygiene findings" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Add a GitHub Actions annotation hygiene analyzer for CI/runtime warning text.
- Detect Node.js 20 action deprecation annotations.
- Detect missing `python-version` input notices.
- Detect component-detection/dependency-submission annotation sources so hidden or GitHub-managed jobs can be triaged without guessing at workflow YAML.

## Why
- Recent checks surfaced a Node.js 20 deprecation warning and a missing `python-version` notice under `submit-pypi`, but repository workflow search did not find a visible workflow source to patch directly.
- This PR teaches SDETKit to classify those annotations as workflow hygiene follow-ups instead of changing product code or blindly editing YAML.

## Safety
- Diagnostic-only: no workflow behavior changes.
- No auto-fix allowlist changes.
- No CI command changes.
- The analyzer returns nonzero only when warning-level annotation hygiene findings are detected.

## Test evidence
- `PYTHONPATH=src python -m pytest -q tests/test_github_actions_annotation_hygiene.py` → 5 passed.
- `PYTHONPATH=src python -m ruff format --check src/sdetkit/github_actions_annotation_hygiene.py tests/test_github_actions_annotation_hygiene.py` → passed.
- `PYTHONPATH=src python -m ruff check src/sdetkit/github_actions_annotation_hygiene.py tests/test_github_actions_annotation_hygiene.py` → passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.

## Rollback plan
- Revert this PR to remove the annotation-hygiene analyzer and tests.