### PR TITLE
Add maintenance check for Actions annotation hygiene

### DIFF
--- a/src/sdetkit/maintenance/checks/github_actions_annotation_hygiene_check.py
+++ b/src/sdetkit/maintenance/checks/github_actions_annotation_hygiene_check.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit import github_actions_annotation_hygiene
+
+from ..types import CheckAction, CheckResult, MaintenanceContext
+
+CHECK_NAME = "github_actions_annotation_hygiene"
+CHECK_MODES = {"quick", "full"}
+ENV_LOG_PATH = "SDETKIT_GITHUB_ACTIONS_ANNOTATION_LOG"
+
+
+def _log_path(ctx: MaintenanceContext) -> Path | None:
+    raw = str(ctx.env.get(ENV_LOG_PATH, "")).strip()
+    if not raw:
+        return None
+    path = Path(raw)
+    return path if path.is_absolute() else ctx.repo_root / path
+
+
+def _actions_for_payload(payload: dict) -> list[CheckAction]:
+    actions = [
+        CheckAction(
+            id="annotation-hygiene-input",
+            title="Provide GitHub Actions annotation log",
+            applied=False,
+            notes=f"Set {ENV_LOG_PATH} to a saved annotations log path.",
+        )
+    ]
+    findings = payload.get("findings", [])
+    if not isinstance(findings, list):
+        return actions
+
+    for finding in findings[:5]:
+        if not isinstance(finding, dict):
+            continue
+        finding_id = str(finding.get("id", "annotation-hygiene-follow-up"))
+        title = str(finding.get("recommendation", "")).strip()
+        if not title:
+            title = str(finding.get("title", "Inspect GitHub Actions annotation")).strip()
+        actions.append(
+            CheckAction(
+                id=finding_id,
+                title=title,
+                applied=False,
+                notes=str(finding.get("severity", "info")),
+            )
+        )
+    return actions
+
+
+def run(ctx: MaintenanceContext) -> CheckResult:
+    path = _log_path(ctx)
+    if path is None:
+        return CheckResult(
+            ok=True,
+            summary="GitHub Actions annotation hygiene log not configured",
+            details={
+                "configured": False,
+                "env_var": ENV_LOG_PATH,
+            },
+            actions=[
+                CheckAction(
+                    id="annotation-hygiene-configure",
+                    title="Capture GitHub Actions annotations before running this check",
+                    applied=False,
+                    notes=f"Set {ENV_LOG_PATH} to a saved annotation log file.",
+                )
+            ],
+        )
+
+    if not path.exists():
+        return CheckResult(
+            ok=False,
+            summary="GitHub Actions annotation hygiene log was not found",
+            details={
+                "configured": True,
+                "env_var": ENV_LOG_PATH,
+                "path": path.as_posix(),
+            },
+            actions=[
+                CheckAction(
+                    id="annotation-hygiene-missing-log",
+                    title="Write or download the GitHub Actions annotation log",
+                    applied=False,
+                    notes=path.as_posix(),
+                )
+            ],
+        )
+
+    payload = github_actions_annotation_hygiene.analyze_file(path)
+    findings = int(payload.get("finding_count", 0) or 0)
+    warnings = int(payload.get("warning_count", 0) or 0)
+    notices = int(payload.get("notice_count", 0) or 0)
+    summary = (
+        f"GitHub Actions annotation hygiene: {findings} finding(s), "
+        f"{warnings} warning(s), {notices} notice(s)"
+    )
+
+    return CheckResult(
+        ok=bool(payload.get("ok", False)),
+        summary=summary,
+        details={
+            "configured": True,
+            "env_var": ENV_LOG_PATH,
+            "path": path.as_posix(),
+            "annotation_hygiene": payload,
+        },
+        actions=_actions_for_payload(payload),
+    )
+
+
+__all__ = ["run", "CHECK_NAME", "CHECK_MODES"]

--- a/tests/test_github_actions_annotation_hygiene_check.py
+++ b/tests/test_github_actions_annotation_hygiene_check.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from sdetkit.maintenance.checks import github_actions_annotation_hygiene_check as check
+from sdetkit.maintenance.registry import discover_checks
+from sdetkit.maintenance.types import MaintenanceContext
+
+ANNOTATIONS = """submit-pypi
+Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/component-detection-dependency-submission-action@374343effede691df3a5ffaf36b4e7acab919590.
+submit-pypi
+The `python-version` input is not set. The version of Python currently in `PATH` will be used.
+"""
+
+
+def _ctx(tmp_path: Path, env: dict[str, str] | None = None) -> MaintenanceContext:
+    return MaintenanceContext(
+        repo_root=tmp_path,
+        python_exe="python",
+        mode="quick",
+        fix=False,
+        env=env or {},
+        logger=object(),
+    )
+
+
+def test_annotation_hygiene_check_is_discovered():
+    names = {name for name, _runner, _modes in discover_checks()}
+
+    assert "github_actions_annotation_hygiene" in names
+
+
+def test_annotation_hygiene_check_is_ok_when_log_is_not_configured(tmp_path):
+    result = check.run(_ctx(tmp_path))
+
+    assert result.ok is True
+    assert "not configured" in result.summary
+    assert result.details["env_var"] == "SDETKIT_GITHUB_ACTIONS_ANNOTATION_LOG"
+    assert result.actions[0].id == "annotation-hygiene-configure"
+
+
+def test_annotation_hygiene_check_flags_missing_configured_log(tmp_path):
+    result = check.run(
+        _ctx(tmp_path, {"SDETKIT_GITHUB_ACTIONS_ANNOTATION_LOG": "missing-annotations.txt"})
+    )
+
+    assert result.ok is False
+    assert "not found" in result.summary
+    assert result.details["configured"] is True
+    assert result.actions[0].id == "annotation-hygiene-missing-log"
+
+
+def test_annotation_hygiene_check_reports_warning_findings(tmp_path):
+    log_path = tmp_path / "annotations.txt"
+    log_path.write_text(ANNOTATIONS, encoding="utf-8")
+
+    result = check.run(_ctx(tmp_path, {"SDETKIT_GITHUB_ACTIONS_ANNOTATION_LOG": "annotations.txt"}))
+
+    assert result.ok is False
+    assert "1 warning" in result.summary
+    payload = result.details["annotation_hygiene"]
+    assert payload["warning_count"] == 1
+    assert payload["notice_count"] == 1
+    assert any(action.id == "github_actions_node20_deprecation" for action in result.actions)
+
+
+def test_annotation_hygiene_check_passes_clean_log(tmp_path):
+    log_path = tmp_path / "annotations.txt"
+    log_path.write_text("all green\n", encoding="utf-8")
+
+    result = check.run(_ctx(tmp_path, {"SDETKIT_GITHUB_ACTIONS_ANNOTATION_LOG": str(log_path)}))
+
+    assert result.ok is True
+    assert "0 finding" in result.summary
+    assert result.details["annotation_hygiene"]["findings"] == []


### PR DESCRIPTION
## Summary
- Add a maintenance check wrapper for the GitHub Actions annotation hygiene analyzer.
- Auto-discover the check as `github_actions_annotation_hygiene` through the existing maintenance registry.
- Allow annotation logs to be supplied via `SDETKIT_GITHUB_ACTIONS_ANNOTATION_LOG`.
- Report Node.js 20 deprecation warnings, missing `python-version` notices, and component-detection/dependency-submission annotation sources in maintenance output.

## Why
- PR #1137 added the standalone analyzer.
- This PR wires it into `python -m sdetkit maintenance --include-check github_actions_annotation_hygiene --format json`, making the signal available to SDETKit maintenance/reporting flows.

## Safety
- Diagnostic-only: no workflow behavior changes.
- No auto-fix allowlist changes.
- No CI command changes.
- Missing/unconfigured logs are handled explicitly; configured-but-missing logs fail with a clear action.

## Test evidence
- Maintenance CLI smoke with `SDETKIT_GITHUB_ACTIONS_ANNOTATION_LOG=/tmp/sdetkit-actions-annotations.txt` and `--include-check github_actions_annotation_hygiene --format json` → passed.
- `PYTHONPATH=src python -m pytest -q tests/test_github_actions_annotation_hygiene.py tests/test_github_actions_annotation_hygiene_check.py` → 10 passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.

## Rollback plan
- Revert this PR to remove the maintenance check wrapper while keeping the standalone analyzer from #1137.