### PR TITLE
Report GitHub Actions annotation hygiene findings

### DIFF
--- a/src/sdetkit/github_actions_annotation_hygiene_report.py
+++ b/src/sdetkit/github_actions_annotation_hygiene_report.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from sdetkit import github_actions_annotation_hygiene
+
+SCHEMA_VERSION = "sdetkit.github_actions.annotation_hygiene_report.v1"
+CHECK_NAME = "github_actions_annotation_hygiene"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int_value(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _annotation_payload_from_maintenance_report(report: dict[str, Any]) -> dict[str, Any]:
+    checks = _as_dict(report.get("checks"))
+    check = _as_dict(checks.get(CHECK_NAME))
+    details = _as_dict(check.get("details"))
+    payload = _as_dict(details.get("annotation_hygiene"))
+    if payload:
+        return payload
+    return {
+        "schema_version": github_actions_annotation_hygiene.SCHEMA_VERSION,
+        "ok": True,
+        "finding_count": 0,
+        "warning_count": 0,
+        "notice_count": 0,
+        "findings": [],
+    }
+
+
+def build_report(
+    annotation_payload: dict[str, Any],
+    *,
+    source_type: str,
+    source_path: str = "",
+) -> dict[str, Any]:
+    findings = [
+        item for item in _as_list(annotation_payload.get("findings")) if isinstance(item, dict)
+    ]
+    by_severity: dict[str, int] = {}
+    by_id: dict[str, int] = {}
+    for finding in findings:
+        severity = str(finding.get("severity", "unknown"))
+        finding_id = str(finding.get("id", "unknown"))
+        by_severity[severity] = by_severity.get(severity, 0) + 1
+        by_id[finding_id] = by_id.get(finding_id, 0) + 1
+
+    warning_count = _int_value(annotation_payload.get("warning_count"))
+    notice_count = _int_value(annotation_payload.get("notice_count"))
+    finding_count = _int_value(annotation_payload.get("finding_count", len(findings)))
+    top_actions = []
+    for finding in findings[:5]:
+        recommendation = str(finding.get("recommendation", "")).strip()
+        title = str(finding.get("title", "")).strip()
+        if recommendation:
+            top_actions.append(recommendation)
+        elif title:
+            top_actions.append(title)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": warning_count == 0,
+        "source_type": source_type,
+        "source_path": source_path,
+        "finding_count": finding_count,
+        "warning_count": warning_count,
+        "notice_count": notice_count,
+        "by_severity": dict(sorted(by_severity.items())),
+        "by_id": dict(sorted(by_id.items())),
+        "top_actions": list(dict.fromkeys(top_actions)),
+        "annotation_hygiene": annotation_payload,
+    }
+
+
+def report_from_maintenance_json(path: Path) -> dict[str, Any]:
+    report = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(report, dict):
+        raise ValueError(f"expected maintenance JSON object in {path}")
+    return build_report(
+        _annotation_payload_from_maintenance_report(report),
+        source_type="maintenance_json",
+        source_path=path.as_posix(),
+    )
+
+
+def report_from_annotation_log(path: Path) -> dict[str, Any]:
+    return build_report(
+        github_actions_annotation_hygiene.analyze_file(path),
+        source_type="annotation_log",
+        source_path=path.as_posix(),
+    )
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# GitHub Actions annotation hygiene report",
+        "",
+        f"- source: `{report.get('source_type', 'unknown')}`",
+        f"- findings: **{report.get('finding_count', 0)}**",
+        f"- warnings: **{report.get('warning_count', 0)}**",
+        f"- notices: **{report.get('notice_count', 0)}**",
+    ]
+
+    by_id = _as_dict(report.get("by_id"))
+    if by_id:
+        lines.extend(["", "## Finding types", ""])
+        for finding_id, count in by_id.items():
+            lines.append(f"- `{finding_id}`: {count}")
+
+    findings = _as_list(_as_dict(report.get("annotation_hygiene")).get("findings"))
+    if findings:
+        lines.extend(["", "## Findings", ""])
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            lines.extend(
+                [
+                    f"### {finding.get('title', 'Finding')}",
+                    "",
+                    f"- id: `{finding.get('id', 'unknown')}`",
+                    f"- severity: `{finding.get('severity', 'unknown')}`",
+                    f"- job: `{finding.get('job', 'unknown')}`",
+                ]
+            )
+            action = str(finding.get("action", "")).strip()
+            if action:
+                lines.append(f"- action: `{action}`")
+            lines.extend(
+                [
+                    f"- evidence: {finding.get('evidence', '')}",
+                    f"- recommendation: {finding.get('recommendation', '')}",
+                    "",
+                ]
+            )
+    else:
+        lines.extend(["", "No GitHub Actions annotation hygiene findings detected."])
+
+    top_actions = _as_list(report.get("top_actions"))
+    if top_actions:
+        lines.extend(["", "## Suggested next actions", ""])
+        for action in top_actions:
+            lines.append(f"- {action}")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.github_actions_annotation_hygiene_report"
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--maintenance-json")
+    source.add_argument("--annotation-log")
+    parser.add_argument("--out-json")
+    parser.add_argument("--out-md")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.maintenance_json:
+            report = report_from_maintenance_json(Path(args.maintenance_json))
+        else:
+            report = report_from_annotation_log(Path(args.annotation_log))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    json_text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    md_text = render_markdown(report)
+
+    if args.out_json:
+        Path(args.out_json).write_text(json_text, encoding="utf-8")
+    if args.out_md:
+        Path(args.out_md).write_text(md_text, encoding="utf-8")
+
+    if args.format == "json":
+        print(json_text, end="")
+    else:
+        print(md_text, end="")
+
+    return 1 if report.get("warning_count", 0) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_github_actions_annotation_hygiene_report.py
+++ b/tests/test_github_actions_annotation_hygiene_report.py
@@ -1,0 +1,123 @@
+import json
+
+from sdetkit import github_actions_annotation_hygiene_report as report
+
+ANNOTATIONS = """submit-pypi
+Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/component-detection-dependency-submission-action@374343effede691df3a5ffaf36b4e7acab919590.
+submit-pypi
+The `python-version` input is not set. The version of Python currently in `PATH` will be used.
+"""
+
+
+def _maintenance_payload():
+    return {
+        "ok": False,
+        "checks": {
+            "github_actions_annotation_hygiene": {
+                "ok": False,
+                "summary": "GitHub Actions annotation hygiene: 2 finding(s), 1 warning(s), 1 notice(s)",
+                "details": {
+                    "annotation_hygiene": {
+                        "schema_version": "sdetkit.github_actions.annotation_hygiene.v1",
+                        "ok": False,
+                        "finding_count": 2,
+                        "warning_count": 1,
+                        "notice_count": 1,
+                        "findings": [
+                            {
+                                "id": "github_actions_node20_deprecation",
+                                "severity": "warning",
+                                "job": "submit-pypi",
+                                "action": "actions/component-detection-dependency-submission-action@abc",
+                                "title": "GitHub Actions Node.js 20 runtime deprecation",
+                                "evidence": "Node.js 20 actions are deprecated.",
+                                "recommendation": "Update the action or test Node 24.",
+                            },
+                            {
+                                "id": "github_actions_missing_python_version",
+                                "severity": "notice",
+                                "job": "submit-pypi",
+                                "action": "",
+                                "title": "GitHub Actions setup-python version is implicit",
+                                "evidence": "The `python-version` input is not set.",
+                                "recommendation": "Pin an explicit python-version.",
+                            },
+                        ],
+                    }
+                },
+                "actions": [],
+            }
+        },
+    }
+
+
+def test_report_from_maintenance_json_rolls_up_findings(tmp_path):
+    path = tmp_path / "maintenance.json"
+    path.write_text(json.dumps(_maintenance_payload()), encoding="utf-8")
+
+    payload = report.report_from_maintenance_json(path)
+
+    assert payload["schema_version"] == "sdetkit.github_actions.annotation_hygiene_report.v1"
+    assert payload["ok"] is False
+    assert payload["source_type"] == "maintenance_json"
+    assert payload["warning_count"] == 1
+    assert payload["notice_count"] == 1
+    assert payload["by_id"]["github_actions_node20_deprecation"] == 1
+    assert payload["by_severity"]["warning"] == 1
+    assert "Update the action" in payload["top_actions"][0]
+
+
+def test_report_from_annotation_log_runs_analyzer(tmp_path):
+    path = tmp_path / "annotations.txt"
+    path.write_text(ANNOTATIONS, encoding="utf-8")
+
+    payload = report.report_from_annotation_log(path)
+
+    assert payload["source_type"] == "annotation_log"
+    assert payload["warning_count"] == 1
+    assert payload["notice_count"] == 1
+    assert "github_actions_node20_deprecation" in payload["by_id"]
+
+
+def test_render_markdown_is_comment_ready(tmp_path):
+    path = tmp_path / "maintenance.json"
+    path.write_text(json.dumps(_maintenance_payload()), encoding="utf-8")
+
+    rendered = report.render_markdown(report.report_from_maintenance_json(path))
+
+    assert "# GitHub Actions annotation hygiene report" in rendered
+    assert "GitHub Actions Node.js 20 runtime deprecation" in rendered
+    assert "Suggested next actions" in rendered
+    assert "submit-pypi" in rendered
+
+
+def test_cli_writes_json_and_markdown_from_maintenance_report(tmp_path):
+    input_path = tmp_path / "maintenance.json"
+    out_json = tmp_path / "annotation-hygiene-report.json"
+    out_md = tmp_path / "annotation-hygiene-report.md"
+    input_path.write_text(json.dumps(_maintenance_payload()), encoding="utf-8")
+
+    rc = report.main(
+        [
+            "--maintenance-json",
+            str(input_path),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+
+    assert rc == 1
+    assert json.loads(out_json.read_text(encoding="utf-8"))["warning_count"] == 1
+    assert "GitHub Actions annotation hygiene report" in out_md.read_text(encoding="utf-8")
+
+
+def test_cli_returns_zero_for_clean_annotation_log(tmp_path, capsys):
+    input_path = tmp_path / "annotations.txt"
+    input_path.write_text("all green\n", encoding="utf-8")
+
+    rc = report.main(["--annotation-log", str(input_path), "--format", "md"])
+
+    assert rc == 0
+    assert "No GitHub Actions annotation hygiene findings" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Add a reporter for GitHub Actions annotation hygiene findings.
- Consume maintenance check output for `github_actions_annotation_hygiene`.
- Produce JSON and Markdown artifacts for reporting and review.

## Why
- PR #1138 integrated the annotation hygiene analyzer into maintenance.
- This PR surfaces those results in durable artifacts and Markdown for follow-up and human inspection.

## Safety
- Diagnostic-only: no workflow behavior changes.
- No auto-fix allowlist changes.
- No CI command changes.
- Missing/unconfigured logs are handled explicitly.

## Test evidence
- CLI smoke passed with maintenance JSON input.
- 15 targeted tests passed.
- Ruff format/check passed.
- pre-commit run -a passed.

## Rollback plan
- Revert this PR to remove reporter artifacts while keeping the analyzer and maintenance check from #1138.