### PR TITLE
Build adaptive maintenance priority rollups

### DIFF
--- a/src/sdetkit/maintenance_priority_rollup.py
+++ b/src/sdetkit/maintenance_priority_rollup.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.maintenance.priority_rollup.v1"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _append_item(
+    items: list[dict[str, Any]],
+    *,
+    priority: int,
+    source: str,
+    title: str,
+    reason: str,
+    action: str,
+    severity: str,
+    key: str,
+) -> None:
+    items.append(
+        {
+            "priority": priority,
+            "source": source,
+            "title": title,
+            "reason": reason,
+            "action": action,
+            "severity": severity,
+            "key": key,
+        }
+    )
+
+
+def _maintenance_items(report: dict[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    checks = _as_dict(report.get("checks"))
+    for name in sorted(checks):
+        check = _as_dict(checks.get(name))
+        if check.get("ok") is False:
+            _append_item(
+                items,
+                priority=1,
+                source="maintenance",
+                title=f"Maintenance check failed: {name}",
+                reason=_text(check.get("summary")) or "Maintenance check reported a failure.",
+                action=f"Review maintenance check `{name}` and run its suggested action.",
+                severity="error",
+                key=f"maintenance:{name}",
+            )
+
+        for action in _as_list(check.get("actions"))[:3]:
+            row = _as_dict(action)
+            title = _text(row.get("title"))
+            if not title:
+                continue
+            _append_item(
+                items,
+                priority=3 if check.get("ok") else 2,
+                source="maintenance_action",
+                title=title,
+                reason=f"Suggested by maintenance check `{name}`.",
+                action=title,
+                severity="warning" if not check.get("ok") else "info",
+                key=f"maintenance-action:{name}:{row.get('id', title)}",
+            )
+    return items
+
+
+def _annotation_items(report: dict[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    annotation = _as_dict(report.get("annotation_hygiene"))
+    findings = _as_list(annotation.get("findings"))
+    for finding in findings:
+        row = _as_dict(finding)
+        severity = _text(row.get("severity")) or "info"
+        if severity == "warning":
+            priority = 2
+        elif severity == "notice":
+            priority = 4
+        else:
+            priority = 5
+        title = _text(row.get("title")) or "GitHub Actions annotation hygiene finding"
+        recommendation = _text(row.get("recommendation")) or "Review GitHub Actions annotation."
+        _append_item(
+            items,
+            priority=priority,
+            source="annotation_hygiene",
+            title=title,
+            reason=_text(row.get("evidence")) or "Annotation hygiene finding was reported.",
+            action=recommendation,
+            severity=severity,
+            key=f"annotation:{row.get('id', title)}:{row.get('job', 'unknown')}",
+        )
+    return items
+
+
+def _safe_fix_items(report: dict[str, Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for group in _as_list(report.get("groups")):
+        row = _as_dict(group)
+        fix_type = _text(row.get("fix_type")) or "unknown"
+        code = _text(row.get("code")) or "UNKNOWN"
+        attempts = _as_int(row.get("remediation_attempts"))
+        successes = _as_int(row.get("remediation_successes"))
+        pushes = _as_int(row.get("commit_pushes"))
+        latest_status = _text(row.get("latest_remediation_status")) or "unknown"
+
+        if attempts and successes < attempts:
+            _append_item(
+                items,
+                priority=2,
+                source="safe_fix_rollup",
+                title=f"Safe fix needs review: {fix_type}",
+                reason=(
+                    f"{successes}/{attempts} remediation attempts succeeded for {code}; "
+                    f"latest status is {latest_status}."
+                ),
+                action=f"Review safe-fix outcomes for `{fix_type}` before widening automation policy.",
+                severity="warning",
+                key=f"safe-fix:{fix_type}:{code}:remediation",
+            )
+        elif attempts and pushes == 0:
+            _append_item(
+                items,
+                priority=5,
+                source="safe_fix_rollup",
+                title=f"Safe fix has no commit pushes yet: {fix_type}",
+                reason=f"{successes}/{attempts} remediations succeeded for {code}, but no pushes were recorded.",
+                action="Keep observing safe-fix outcomes before using them for commit/push policy.",
+                severity="info",
+                key=f"safe-fix:{fix_type}:{code}:pushes",
+            )
+    return items
+
+
+def _dedupe_rank(items: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    ordered: list[dict[str, Any]] = []
+    for item in sorted(
+        items,
+        key=lambda row: (
+            _as_int(row.get("priority")),
+            _text(row.get("source")),
+            _text(row.get("title")),
+            _text(row.get("key")),
+        ),
+    ):
+        key = _text(item.get("key")) or f"{item.get('source')}:{item.get('title')}"
+        if key in seen:
+            continue
+        seen.add(key)
+        item["rank"] = len(ordered) + 1
+        ordered.append(item)
+        if len(ordered) >= limit:
+            break
+    return ordered
+
+
+def build_priority_rollup(
+    *,
+    maintenance_report: dict[str, Any] | None = None,
+    annotation_report: dict[str, Any] | None = None,
+    safe_fix_rollup: dict[str, Any] | None = None,
+    limit: int = 20,
+) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    if maintenance_report:
+        items.extend(_maintenance_items(maintenance_report))
+    if annotation_report:
+        items.extend(_annotation_items(annotation_report))
+    if safe_fix_rollup:
+        items.extend(_safe_fix_items(safe_fix_rollup))
+
+    priority_queue = _dedupe_rank(items, limit)
+    counts_by_priority: dict[str, int] = {}
+    counts_by_source: dict[str, int] = {}
+    for item in priority_queue:
+        priority = str(item.get("priority", "unknown"))
+        source = _text(item.get("source")) or "unknown"
+        counts_by_priority[priority] = counts_by_priority.get(priority, 0) + 1
+        counts_by_source[source] = counts_by_source.get(source, 0) + 1
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": not any(_as_int(item.get("priority")) <= 2 for item in priority_queue),
+        "queue_count": len(priority_queue),
+        "counts_by_priority": dict(sorted(counts_by_priority.items())),
+        "counts_by_source": dict(sorted(counts_by_source.items())),
+        "top_action": _text(priority_queue[0].get("action")) if priority_queue else "",
+        "priority_queue": priority_queue,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Maintenance priority rollup",
+        "",
+        f"- queue items: **{payload.get('queue_count', 0)}**",
+        f"- top action: {payload.get('top_action') or 'No action required.'}",
+    ]
+
+    queue = _as_list(payload.get("priority_queue"))
+    if not queue:
+        lines.extend(["", "No prioritized maintenance follow-ups detected."])
+        return "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            "",
+            "| Rank | P | Source | Severity | Title | Action |",
+            "|---:|---:|---|---|---|---|",
+        ]
+    )
+    for item in queue:
+        row = _as_dict(item)
+        lines.append(
+            "| {rank} | {priority} | {source} | {severity} | {title} | {action} |".format(
+                rank=row.get("rank", ""),
+                priority=row.get("priority", ""),
+                source=_text(row.get("source")).replace("|", "\\|"),
+                severity=_text(row.get("severity")).replace("|", "\\|"),
+                title=_text(row.get("title")).replace("|", "\\|"),
+                action=_text(row.get("action")).replace("|", "\\|"),
+            )
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _read_json(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.maintenance_priority_rollup")
+    parser.add_argument("--maintenance-json")
+    parser.add_argument("--annotation-report-json")
+    parser.add_argument("--safe-fix-rollup-json")
+    parser.add_argument("--out-json")
+    parser.add_argument("--out-md")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    parser.add_argument("--limit", type=int, default=20)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_priority_rollup(
+            maintenance_report=_read_json(args.maintenance_json),
+            annotation_report=_read_json(args.annotation_report_json),
+            safe_fix_rollup=_read_json(args.safe_fix_rollup_json),
+            limit=max(1, args.limit),
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    md_text = render_markdown(payload)
+
+    if args.out_json:
+        Path(args.out_json).write_text(json_text, encoding="utf-8")
+    if args.out_md:
+        Path(args.out_md).write_text(md_text, encoding="utf-8")
+
+    print(json_text if args.format == "json" else md_text, end="")
+    return 1 if not payload.get("ok", False) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_maintenance_priority_rollup.py
+++ b/tests/test_maintenance_priority_rollup.py
@@ -1,0 +1,156 @@
+import json
+
+from sdetkit import maintenance_priority_rollup as rollup
+
+
+def _maintenance_report():
+    return {
+        "checks": {
+            "lint_check": {
+                "ok": False,
+                "summary": "ruff failed",
+                "actions": [{"id": "lint-fix", "title": "Run ruff check --fix"}],
+            },
+            "doctor_check": {
+                "ok": True,
+                "summary": "doctor score 95%",
+                "actions": [{"id": "doctor-review", "title": "Review doctor hints"}],
+            },
+        }
+    }
+
+
+def _annotation_report():
+    return {
+        "annotation_hygiene": {
+            "findings": [
+                {
+                    "id": "github_actions_node20_deprecation",
+                    "severity": "warning",
+                    "job": "submit-pypi",
+                    "title": "GitHub Actions Node.js 20 runtime deprecation",
+                    "evidence": "Node.js 20 actions are deprecated.",
+                    "recommendation": "Update the action or test Node 24.",
+                },
+                {
+                    "id": "github_actions_missing_python_version",
+                    "severity": "notice",
+                    "job": "submit-pypi",
+                    "title": "GitHub Actions setup-python version is implicit",
+                    "evidence": "The python-version input is not set.",
+                    "recommendation": "Pin an explicit python-version.",
+                },
+            ]
+        }
+    }
+
+
+def _safe_fix_rollup():
+    return {
+        "groups": [
+            {
+                "fix_type": "ruff_fixable_lint",
+                "code": "RUFF_FIXABLE_LINT",
+                "remediation_attempts": 2,
+                "remediation_successes": 1,
+                "commit_pushes": 1,
+                "latest_remediation_status": "failed",
+            },
+            {
+                "fix_type": "format_only",
+                "code": "PRE_COMMIT_FORMAT_DRIFT",
+                "remediation_attempts": 3,
+                "remediation_successes": 3,
+                "commit_pushes": 0,
+                "latest_remediation_status": "success",
+            },
+        ]
+    }
+
+
+def test_build_priority_rollup_ranks_maintenance_failures_first():
+    payload = rollup.build_priority_rollup(
+        maintenance_report=_maintenance_report(),
+        annotation_report=_annotation_report(),
+        safe_fix_rollup=_safe_fix_rollup(),
+    )
+
+    assert payload["schema_version"] == "sdetkit.maintenance.priority_rollup.v1"
+    assert payload["ok"] is False
+    assert payload["priority_queue"][0]["priority"] == 1
+    assert payload["priority_queue"][0]["source"] == "maintenance"
+    assert "lint_check" in payload["priority_queue"][0]["title"]
+    assert payload["counts_by_source"]["annotation_hygiene"] == 2
+    assert payload["counts_by_source"]["safe_fix_rollup"] == 2
+
+
+def test_build_priority_rollup_includes_top_action_and_limits_queue():
+    payload = rollup.build_priority_rollup(
+        maintenance_report=_maintenance_report(),
+        annotation_report=_annotation_report(),
+        safe_fix_rollup=_safe_fix_rollup(),
+        limit=3,
+    )
+
+    assert payload["queue_count"] == 3
+    assert (
+        payload["top_action"]
+        == "Review maintenance check `lint_check` and run its suggested action."
+    )
+    assert [item["rank"] for item in payload["priority_queue"]] == [1, 2, 3]
+
+
+def test_render_markdown_outputs_comment_ready_table():
+    payload = rollup.build_priority_rollup(
+        maintenance_report=_maintenance_report(),
+        annotation_report=_annotation_report(),
+    )
+
+    rendered = rollup.render_markdown(payload)
+
+    assert "# Maintenance priority rollup" in rendered
+    assert "| Rank | P | Source | Severity | Title | Action |" in rendered
+    assert "GitHub Actions Node.js 20 runtime deprecation" in rendered
+
+
+def test_cli_writes_json_and_markdown(tmp_path):
+    maintenance_path = tmp_path / "maintenance.json"
+    annotation_path = tmp_path / "annotation.json"
+    safe_fix_path = tmp_path / "safe-fix.json"
+    out_json = tmp_path / "priority.json"
+    out_md = tmp_path / "priority.md"
+
+    maintenance_path.write_text(json.dumps(_maintenance_report()), encoding="utf-8")
+    annotation_path.write_text(json.dumps(_annotation_report()), encoding="utf-8")
+    safe_fix_path.write_text(json.dumps(_safe_fix_rollup()), encoding="utf-8")
+
+    rc = rollup.main(
+        [
+            "--maintenance-json",
+            str(maintenance_path),
+            "--annotation-report-json",
+            str(annotation_path),
+            "--safe-fix-rollup-json",
+            str(safe_fix_path),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--limit",
+            "5",
+        ]
+    )
+
+    assert rc == 1
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["queue_count"] == 5
+    assert "Maintenance priority rollup" in out_md.read_text(encoding="utf-8")
+
+
+def test_empty_rollup_is_ok_and_has_no_actions():
+    payload = rollup.build_priority_rollup()
+
+    assert payload["ok"] is True
+    assert payload["queue_count"] == 0
+    assert payload["top_action"] == ""
+    assert "No prioritized maintenance follow-ups" in rollup.render_markdown(payload)


### PR DESCRIPTION
## Summary
- Add a maintenance priority rollup module that combines maintenance report failures, annotation hygiene findings, and adaptive safe-fix rollups.
- Rank follow-ups into a deterministic priority queue with source, severity, reason, action, and rank.
- Emit JSON and Markdown outputs for command-center/reporting workflows.

## Why
- SDETKit now has multiple loops: safe-fix learning/rollups and GitHub Actions annotation hygiene reporting.
- This PR adds the first command-center primitive that answers: what should a maintainer look at next?

## Safety
- Diagnostic-only: no workflow behavior changes.
- No auto-fix allowlist changes.
- No CI gate behavior changes.
- This only reads existing JSON reports and writes priority rollup artifacts when invoked.

## Test evidence
- CLI smoke with maintenance JSON + annotation report JSON + safe-fix rollup JSON → passed.
- `PYTHONPATH=src python -m pytest -q tests/test_maintenance_priority_rollup.py tests/test_github_actions_annotation_hygiene.py tests/test_github_actions_annotation_hygiene_check.py tests/test_github_actions_annotation_hygiene_report.py` → 20 passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.

## Rollback plan
- Revert this PR to remove the priority-rollup module and tests while leaving the underlying maintenance, annotation hygiene, and safe-fix reports intact.