### PR TITLE
Publish maintenance priority rollup artifacts

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -65,6 +65,25 @@ jobs:
               --format md || true
           fi
 
+      - name: Build maintenance priority rollup
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance.json ]; then
+            args=(--maintenance-json artifacts/maintenance.json)
+            if [ -f artifacts/annotation-hygiene-report.json ]; then
+              args+=(--annotation-report-json artifacts/annotation-hygiene-report.json)
+            fi
+            if [ -f artifacts/adaptive-safe-fix-learning-rollup.json ]; then
+              args+=(--safe-fix-rollup-json artifacts/adaptive-safe-fix-learning-rollup.json)
+            fi
+            python -m sdetkit.maintenance_priority_rollup \
+              "${args[@]}" \
+              --out-json artifacts/maintenance-priority-rollup.json \
+              --out-md artifacts/maintenance-priority-rollup.md \
+              --format md || true
+          fi
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -76,6 +95,8 @@ jobs:
             artifacts/maintenance_fixed.md
             artifacts/annotation-hygiene-report.json
             artifacts/annotation-hygiene-report.md
+            artifacts/maintenance-priority-rollup.json
+            artifacts/maintenance-priority-rollup.md
           if-no-files-found: ignore
 
       - name: Detect diff
@@ -147,6 +168,9 @@ jobs:
             const annotationMd = fs.existsSync('artifacts/annotation-hygiene-report.md')
               ? fs.readFileSync('artifacts/annotation-hygiene-report.md', 'utf8')
               : '';
+            const priorityMd = fs.existsSync('artifacts/maintenance-priority-rollup.md')
+              ? fs.readFileSync('artifacts/maintenance-priority-rollup.md', 'utf8')
+              : '';
 
             const rows = Object.entries(report.checks || {})
               .map(([name, item]) => `| ${name} | ${item.ok ? 'PASS' : 'FAIL'} | ${item.summary} |`)
@@ -163,6 +187,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              priorityMd
+                ? '### Maintenance priority rollup'
+                : '',
+              priorityMd
+                ? (priorityMd.length > 3000 ? `${priorityMd.slice(0, 3000)}\n\n... (truncated)` : priorityMd)
+                : '',
               '',
               annotationMd
                 ? '### GitHub Actions annotation hygiene'

--- a/tests/test_maintenance_on_demand_priority_rollup_workflow.py
+++ b/tests/test_maintenance_on_demand_priority_rollup_workflow.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_builds_priority_rollup_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Build maintenance priority rollup" in text
+    assert "python -m sdetkit.maintenance_priority_rollup" in text
+    assert "--maintenance-json artifacts/maintenance.json" in text
+    assert "--annotation-report-json artifacts/annotation-hygiene-report.json" in text
+    assert "--safe-fix-rollup-json artifacts/adaptive-safe-fix-learning-rollup.json" in text
+    assert "--out-json artifacts/maintenance-priority-rollup.json" in text
+    assert "--out-md artifacts/maintenance-priority-rollup.md" in text
+
+
+def test_maintenance_on_demand_uploads_priority_rollup_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-priority-rollup.json" in text
+    assert "artifacts/maintenance-priority-rollup.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_priority_rollup_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "const priorityMd = fs.existsSync('artifacts/maintenance-priority-rollup.md')" in text
+    assert "### Maintenance priority rollup" in text
+    assert "priorityMd.length > 3000" in text


### PR DESCRIPTION
## Summary
- Wire the maintenance priority rollup into `maintenance-on-demand.yml`.
- Build `artifacts/maintenance-priority-rollup.json` and `artifacts/maintenance-priority-rollup.md` from maintenance output when available.
- Include annotation hygiene report JSON and adaptive safe-fix rollup JSON when present.
- Upload priority rollup artifacts and include the Markdown in maintenance issue comments.

## Why
- PR #1141 added the command-center priority queue primitive.
- This PR publishes that queue through the on-demand maintenance workflow so maintainers get visible ranked next actions.

## Safety
- Diagnostic/reporting-only.
- No workflow auto-fix behavior changes.
- No CI gate behavior changes.
- The priority rollup step uses `if: always()` and `|| true`, so reporting cannot create or mask maintenance failures.

## Test evidence
- `PYTHONPATH=src python -m pytest -q tests/test_maintenance_priority_rollup.py tests/test_maintenance_on_demand_priority_rollup_workflow.py tests/test_maintenance_on_demand_annotation_hygiene_workflow.py` → 11 passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.
- `PYTHONPATH=src python -m pre_commit run check-yaml --files .github/workflows/maintenance-on-demand.yml` → passed.

## Rollback plan
- Revert this PR to stop publishing priority rollup artifacts while keeping the standalone priority rollup module available.