### PR TITLE
Build adaptive maintenance policy decisions

### DIFF
--- a/src/sdetkit/maintenance_policy_decisions.py
+++ b/src/sdetkit/maintenance_policy_decisions.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.maintenance.policy_decisions.v1"
+
+BLOCK_RELEASE = "BLOCK_RELEASE"
+REVIEW_REQUIRED = "REVIEW_REQUIRED"
+TRACK_ONLY = "TRACK_ONLY"
+NO_ACTION = "NO_ACTION"
+
+_DECISION_ORDER = {
+    BLOCK_RELEASE: 0,
+    REVIEW_REQUIRED: 1,
+    TRACK_ONLY: 2,
+    NO_ACTION: 3,
+}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _cell(value: Any) -> str:
+    return _text(value).replace("|", "\\|")
+
+
+def _source_location(source_key: str) -> str:
+    parts = [part for part in source_key.split(":") if part]
+    return parts[-1] if parts else "unknown"
+
+
+def _policy_basis(item: dict[str, Any]) -> list[str]:
+    basis = [
+        f"source={_text(item.get('source')) or 'unknown'}",
+        f"priority={_as_int(item.get('priority'))}",
+        f"severity={_text(item.get('severity')) or 'unknown'}",
+    ]
+    source_key = _text(item.get("key"))
+    if source_key:
+        basis.append(f"key={source_key}")
+    title = _text(item.get("title"))
+    if title:
+        basis.append(f"title={title}")
+    action = _text(item.get("action"))
+    if action:
+        basis.append(f"action={action}")
+    return basis
+
+
+def _risk_profile(
+    *,
+    decision: str,
+    source: str,
+    priority: int,
+    severity: str,
+) -> dict[str, str]:
+    if decision == BLOCK_RELEASE:
+        return {
+            "confidence": "high",
+            "automation_risk": "high",
+            "review_risk": "high",
+            "release_risk": "high",
+        }
+
+    if source == "safe_fix_rollup":
+        return {
+            "confidence": "high",
+            "automation_risk": "high",
+            "review_risk": "medium",
+            "release_risk": "medium" if priority <= 2 else "low",
+        }
+
+    if source == "annotation_hygiene":
+        return {
+            "confidence": "medium",
+            "automation_risk": "high",
+            "review_risk": "low",
+            "release_risk": "low" if severity in {"warning", "notice", "info"} else "medium",
+        }
+
+    if decision == REVIEW_REQUIRED:
+        return {
+            "confidence": "medium",
+            "automation_risk": "medium",
+            "review_risk": "medium",
+            "release_risk": "medium" if priority <= 2 else "low",
+        }
+
+    return {
+        "confidence": "medium",
+        "automation_risk": "low",
+        "review_risk": "low",
+        "release_risk": "low",
+    }
+
+
+def _decision_for_item(item: dict[str, Any]) -> dict[str, str]:
+    priority = _as_int(item.get("priority"))
+    source = _text(item.get("source"))
+    severity = _text(item.get("severity")).lower()
+    title = _text(item.get("title"))
+    action = _text(item.get("action"))
+    reason = _text(item.get("reason"))
+    source_key = _text(item.get("key"))
+    location = _source_location(source_key)
+
+    if priority <= 1 and source == "maintenance":
+        return {
+            "decision": BLOCK_RELEASE,
+            "reason": reason or "Priority-1 maintenance failure was reported.",
+            "adaptive_context": (
+                f"`{title or source}` is a priority-1 maintenance signal. "
+                "Treat it as release-blocking until the failing check is reviewed or fixed."
+            ),
+        }
+
+    if source == "safe_fix_rollup" and priority <= 2:
+        return {
+            "decision": REVIEW_REQUIRED,
+            "reason": reason or "Safe-fix learning shows a failed or incomplete remediation path.",
+            "adaptive_context": (
+                f"`{title or source}` came from safe-fix outcome history. "
+                "Keep this review-first and do not widen automation policy until the recorded "
+                "remediation pattern is consistently successful."
+            ),
+        }
+
+    if source == "annotation_hygiene" and severity == "warning":
+        return {
+            "decision": TRACK_ONLY,
+            "reason": reason or "Workflow annotation hygiene warning was reported.",
+            "adaptive_context": (
+                f"`{title or source}` appeared for `{location}`. Track it as CI/workflow hygiene "
+                "and preserve product-code behavior; this signal does not justify expanding auto-fix policy."
+            ),
+        }
+
+    if source == "maintenance_action":
+        return {
+            "decision": REVIEW_REQUIRED,
+            "reason": reason or "Maintenance suggested an explicit follow-up action.",
+            "adaptive_context": (
+                f"The maintenance queue suggested `{action or title}`. "
+                "Route it to maintainer review before making automation or release-policy changes."
+            ),
+        }
+
+    if priority <= 2:
+        return {
+            "decision": REVIEW_REQUIRED,
+            "reason": reason or f"Priority-{priority} maintenance signal was reported.",
+            "adaptive_context": (
+                f"`{title or source or 'maintenance signal'}` is high-priority. "
+                "Require maintainer review before policy or automation changes."
+            ),
+        }
+
+    if severity in {"notice", "info"} or priority >= 3:
+        return {
+            "decision": TRACK_ONLY,
+            "reason": reason or "Lower-priority or informational maintenance signal was reported.",
+            "adaptive_context": (
+                f"`{title or source or 'maintenance signal'}` is lower-priority. "
+                "Track it for trend/history and avoid turning it into a release block."
+            ),
+        }
+
+    return {
+        "decision": REVIEW_REQUIRED,
+        "reason": reason or f"Maintenance signal `{title or source or 'unknown'}` needs review.",
+        "adaptive_context": (
+            f"`{title or source or 'unknown'}` did not match a narrower policy lane. "
+            "Default to human review instead of fixed automation."
+        ),
+    }
+
+
+def _overall_decision(decisions: list[dict[str, Any]]) -> str:
+    if not decisions:
+        return NO_ACTION
+    return min(
+        (_text(item.get("decision")) or TRACK_ONLY for item in decisions),
+        key=lambda decision: _DECISION_ORDER.get(decision, 99),
+    )
+
+
+def build_policy_decisions(priority_rollup: dict[str, Any]) -> dict[str, Any]:
+    decisions: list[dict[str, Any]] = []
+
+    for item in _as_list(priority_rollup.get("priority_queue")):
+        row = _as_dict(item)
+        if not row:
+            continue
+
+        policy = _decision_for_item(row)
+        decision = _text(policy.get("decision")) or REVIEW_REQUIRED
+        priority = _as_int(row.get("priority"))
+        source = _text(row.get("source")) or "unknown"
+        severity = _text(row.get("severity")) or "unknown"
+        risks = _risk_profile(
+            decision=decision,
+            source=source,
+            priority=priority,
+            severity=severity.lower(),
+        )
+        source_key = _text(row.get("key"))
+
+        decisions.append(
+            {
+                "rank": _as_int(row.get("rank")) or len(decisions) + 1,
+                "decision": decision,
+                "priority": priority,
+                "source": source,
+                "severity": severity,
+                "title": _text(row.get("title")) or "Untitled maintenance signal",
+                "action": _text(row.get("action")),
+                "reason": _text(policy.get("reason")),
+                "adaptive_context": _text(policy.get("adaptive_context")),
+                "policy_basis": _policy_basis(row),
+                "source_key": source_key,
+                "memory_lookup_key": source_key or f"{source}:{_text(row.get('title'))}",
+                "observed_priority": priority,
+                "observed_source": source,
+                "observed_severity": severity,
+                "observed_title": _text(row.get("title")),
+                "observed_action": _text(row.get("action")),
+                "observed_reason": _text(row.get("reason")),
+                "automation_allowed": False,
+                **risks,
+            }
+        )
+
+    counts_by_decision: dict[str, int] = {}
+    counts_by_source: dict[str, int] = {}
+    for item in decisions:
+        decision = _text(item.get("decision")) or TRACK_ONLY
+        source = _text(item.get("source")) or "unknown"
+        counts_by_decision[decision] = counts_by_decision.get(decision, 0) + 1
+        counts_by_source[source] = counts_by_source.get(source, 0) + 1
+
+    overall = _overall_decision(decisions)
+    top = decisions[0] if decisions else {}
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": overall != BLOCK_RELEASE,
+        "decision": overall,
+        "release_blocking": overall == BLOCK_RELEASE,
+        "automation_allowed": False,
+        "adaptive_ready": True,
+        "decision_count": len(decisions),
+        "counts_by_decision": dict(sorted(counts_by_decision.items())),
+        "counts_by_source": dict(sorted(counts_by_source.items())),
+        "top_action": _text(top.get("action")) if top else "",
+        "top_reason": _text(top.get("reason")) if top else "",
+        "top_adaptive_context": _text(top.get("adaptive_context")) if top else "",
+        "decisions": decisions,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Maintenance policy decisions",
+        "",
+        f"- overall decision: **{payload.get('decision', NO_ACTION)}**",
+        f"- release blocking: **{payload.get('release_blocking', False)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- adaptive ready: **{payload.get('adaptive_ready', False)}**",
+        f"- decision items: **{payload.get('decision_count', 0)}**",
+        f"- top action: {payload.get('top_action') or 'No action required.'}",
+    ]
+
+    top_context = _text(payload.get("top_adaptive_context"))
+    if top_context:
+        lines.append(f"- top context: {top_context}")
+
+    decisions = _as_list(payload.get("decisions"))
+    if not decisions:
+        lines.extend(["", "No maintenance policy action is required."])
+        return "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            "",
+            "| Rank | Decision | P | Source | Confidence | Risk | Title | Action |",
+            "|---:|---|---:|---|---|---|---|---|",
+        ]
+    )
+    for item in decisions:
+        row = _as_dict(item)
+        risk = (
+            f"auto={_text(row.get('automation_risk'))}; "
+            f"review={_text(row.get('review_risk'))}; "
+            f"release={_text(row.get('release_risk'))}"
+        )
+        lines.append(
+            f"| {row.get('rank', '')} | {_cell(row.get('decision'))} | "
+            f"{row.get('priority', '')} | {_cell(row.get('source'))} | "
+            f"{_cell(row.get('confidence'))} | {_cell(risk)} | "
+            f"{_cell(row.get('title'))} | {_cell(row.get('action') or 'Review item.')} |"
+        )
+
+    lines.extend(["", "## Adaptive context", ""])
+    for item in decisions[:5]:
+        row = _as_dict(item)
+        lines.append(
+            f"- **{_cell(row.get('decision'))}** `{_cell(row.get('source_key'))}`: {_cell(row.get('adaptive_context'))}"
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def policy_decisions_from_priority_rollup(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return build_policy_decisions(payload)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.maintenance_policy_decisions")
+    parser.add_argument("--priority-rollup-json", required=True)
+    parser.add_argument("--out-json")
+    parser.add_argument("--out-md")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = policy_decisions_from_priority_rollup(Path(args.priority_rollup_json))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    md_text = render_markdown(payload)
+
+    if args.out_json:
+        Path(args.out_json).write_text(json_text, encoding="utf-8")
+    if args.out_md:
+        Path(args.out_md).write_text(md_text, encoding="utf-8")
+
+    print(json_text if args.format == "json" else md_text, end="")
+    return 1 if payload.get("release_blocking", False) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_maintenance_policy_decisions.py
+++ b/tests/test_maintenance_policy_decisions.py
@@ -1,0 +1,160 @@
+import json
+
+from sdetkit import maintenance_policy_decisions as policy
+
+
+def _priority_rollup():
+    return {
+        "schema_version": "sdetkit.maintenance.priority_rollup.v1",
+        "ok": False,
+        "priority_queue": [
+            {
+                "rank": 1,
+                "priority": 1,
+                "source": "maintenance",
+                "severity": "error",
+                "title": "Maintenance check failed: lint_check",
+                "action": "Review maintenance check `lint_check` and run its suggested action.",
+                "key": "maintenance:lint_check",
+            },
+            {
+                "rank": 2,
+                "priority": 2,
+                "source": "annotation_hygiene",
+                "severity": "warning",
+                "title": "GitHub Actions Node.js 20 runtime deprecation",
+                "action": "Update the action or test Node 24.",
+                "key": "annotation:node20:submit-pypi",
+            },
+            {
+                "rank": 3,
+                "priority": 2,
+                "source": "safe_fix_rollup",
+                "severity": "warning",
+                "title": "Safe fix needs review: ruff_fixable_lint",
+                "action": "Review safe-fix outcomes before widening automation policy.",
+                "key": "safe-fix:ruff_fixable_lint:RUFF_FIXABLE_LINT",
+            },
+            {
+                "rank": 4,
+                "priority": 4,
+                "source": "annotation_hygiene",
+                "severity": "notice",
+                "title": "GitHub Actions setup-python version is implicit",
+                "action": "Pin an explicit python-version.",
+                "key": "annotation:python-version:submit-pypi",
+            },
+        ],
+    }
+
+
+def test_build_policy_decisions_blocks_release_for_priority_one_maintenance_failure():
+    payload = policy.build_policy_decisions(_priority_rollup())
+
+    assert payload["schema_version"] == "sdetkit.maintenance.policy_decisions.v1"
+    assert payload["ok"] is False
+    assert payload["decision"] == "BLOCK_RELEASE"
+    assert payload["release_blocking"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["adaptive_ready"] is True
+    assert payload["decisions"][0]["decision"] == "BLOCK_RELEASE"
+    assert payload["decisions"][0]["confidence"] == "high"
+    assert payload["decisions"][0]["release_risk"] == "high"
+    assert payload["decisions"][0]["observed_source"] == "maintenance"
+    assert "source=maintenance" in payload["decisions"][0]["policy_basis"]
+    assert payload["counts_by_decision"]["BLOCK_RELEASE"] == 1
+
+
+def test_build_policy_decisions_maps_warning_and_safe_fix_policies():
+    payload = policy.build_policy_decisions(_priority_rollup())
+    by_title = {item["title"]: item for item in payload["decisions"]}
+
+    node20 = by_title["GitHub Actions Node.js 20 runtime deprecation"]
+    safe_fix = by_title["Safe fix needs review: ruff_fixable_lint"]
+    python_version = by_title["GitHub Actions setup-python version is implicit"]
+
+    assert node20["decision"] == "TRACK_ONLY"
+    assert node20["automation_risk"] == "high"
+    assert node20["release_risk"] == "low"
+    assert "submit-pypi" in node20["adaptive_context"]
+    assert "key=annotation:node20:submit-pypi" in node20["policy_basis"]
+
+    assert safe_fix["decision"] == "REVIEW_REQUIRED"
+    assert safe_fix["automation_risk"] == "high"
+    assert "safe-fix outcome history" in safe_fix["adaptive_context"]
+
+    assert python_version["decision"] == "TRACK_ONLY"
+
+
+def test_build_policy_decisions_no_action_for_empty_rollup():
+    payload = policy.build_policy_decisions({"priority_queue": []})
+
+    assert payload["ok"] is True
+    assert payload["decision"] == "NO_ACTION"
+    assert payload["release_blocking"] is False
+    assert payload["top_action"] == ""
+    assert payload["top_adaptive_context"] == ""
+    assert payload["adaptive_ready"] is True
+    assert payload["decisions"] == []
+
+
+def test_render_markdown_is_comment_ready():
+    payload = policy.build_policy_decisions(_priority_rollup())
+
+    rendered = policy.render_markdown(payload)
+
+    assert "# Maintenance policy decisions" in rendered
+    assert "overall decision: **BLOCK_RELEASE**" in rendered
+    assert "| Rank | Decision | P | Source | Confidence | Risk | Title | Action |" in rendered
+    assert "Adaptive context" in rendered
+    assert "Safe fix needs review: ruff_fixable_lint" in rendered
+
+
+def test_cli_writes_json_and_markdown(tmp_path):
+    input_path = tmp_path / "priority.json"
+    out_json = tmp_path / "policy.json"
+    out_md = tmp_path / "policy.md"
+    input_path.write_text(json.dumps(_priority_rollup()), encoding="utf-8")
+
+    rc = policy.main(
+        [
+            "--priority-rollup-json",
+            str(input_path),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "md",
+        ]
+    )
+
+    assert rc == 1
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["decision"] == "BLOCK_RELEASE"
+    assert "Maintenance policy decisions" in out_md.read_text(encoding="utf-8")
+
+
+def test_cli_returns_zero_for_track_only_rollup(tmp_path):
+    input_path = tmp_path / "priority.json"
+    input_path.write_text(
+        json.dumps(
+            {
+                "priority_queue": [
+                    {
+                        "rank": 1,
+                        "priority": 4,
+                        "source": "annotation_hygiene",
+                        "severity": "notice",
+                        "title": "GitHub Actions setup-python version is implicit",
+                        "action": "Pin an explicit python-version.",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = policy.main(["--priority-rollup-json", str(input_path)])
+
+    assert rc == 0


### PR DESCRIPTION
## Summary
- Add adaptive-ready maintenance policy decisions from `maintenance-priority-rollup.json`.
- Keep fixed safety rails: `BLOCK_RELEASE`, `REVIEW_REQUIRED`, `TRACK_ONLY`, and `NO_ACTION`.
- Add evidence-rich fields for every decision: `adaptive_context`, `policy_basis`, `memory_lookup_key`, observed signal fields, confidence, automation risk, review risk, and release risk.
- Emit JSON and Markdown outputs for command-center/reporting workflows.

## Why
- PR #1141 introduced the maintenance priority queue.
- PR #1142 published the priority queue through maintenance-on-demand artifacts and comments.
- This PR adds the next layer: turn ranked signals into explicit policy decisions while preserving future memory-aware/adaptive behavior.

## Adaptive design note
- This is not intended to be a canned comment bot.
- Decision classes remain fixed for safety, but explanations and policy basis are derived from the observed signal.
- `memory_lookup_key` and observed fields are included so future PRs can join against safe-fix memory, annotation history, repeated failures, and repo-specific outcomes.

## Safety
- Diagnostic-only: no workflow behavior changes.
- No auto-fix allowlist changes.
- No CI gate behavior changes.
- `automation_allowed` is always false in this first version.
- Release blocking is reported only as a policy decision artifact; it does not yet gate workflows.

## Test evidence
- Adaptive-ready CLI smoke with maintenance priority rollup JSON → passed.
- `PYTHONPATH=src python -m pytest -q tests/test_maintenance_policy_decisions.py tests/test_maintenance_priority_rollup.py` → 11 passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.

## Rollback plan
- Revert this PR to remove the policy-decision module and tests while leaving maintenance priority rollups intact.