### PR TITLE
Publish maintenance policy decision artifacts

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -84,6 +84,18 @@ jobs:
               --format md || true
           fi
 
+      - name: Build maintenance policy decisions
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-priority-rollup.json ]; then
+            python -m sdetkit.maintenance_policy_decisions \
+              --priority-rollup-json artifacts/maintenance-priority-rollup.json \
+              --out-json artifacts/maintenance-policy-decisions.json \
+              --out-md artifacts/maintenance-policy-decisions.md \
+              --format md || true
+          fi
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -97,6 +109,8 @@ jobs:
             artifacts/annotation-hygiene-report.md
             artifacts/maintenance-priority-rollup.json
             artifacts/maintenance-priority-rollup.md
+            artifacts/maintenance-policy-decisions.json
+            artifacts/maintenance-policy-decisions.md
           if-no-files-found: ignore
 
       - name: Detect diff
@@ -171,6 +185,9 @@ jobs:
             const priorityMd = fs.existsSync('artifacts/maintenance-priority-rollup.md')
               ? fs.readFileSync('artifacts/maintenance-priority-rollup.md', 'utf8')
               : '';
+            const policyMd = fs.existsSync('artifacts/maintenance-policy-decisions.md')
+              ? fs.readFileSync('artifacts/maintenance-policy-decisions.md', 'utf8')
+              : '';
 
             const rows = Object.entries(report.checks || {})
               .map(([name, item]) => `| ${name} | ${item.ok ? 'PASS' : 'FAIL'} | ${item.summary} |`)
@@ -187,6 +204,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              policyMd
+                ? '### Maintenance policy decisions'
+                : '',
+              policyMd
+                ? (policyMd.length > 3000 ? `${policyMd.slice(0, 3000)}\n\n... (truncated)` : policyMd)
+                : '',
               '',
               priorityMd
                 ? '### Maintenance priority rollup'

--- a/tests/test_maintenance_on_demand_policy_decisions_workflow.py
+++ b/tests/test_maintenance_on_demand_policy_decisions_workflow.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_builds_policy_decision_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Build maintenance policy decisions" in text
+    assert "python -m sdetkit.maintenance_policy_decisions" in text
+    assert "--priority-rollup-json artifacts/maintenance-priority-rollup.json" in text
+    assert "--out-json artifacts/maintenance-policy-decisions.json" in text
+    assert "--out-md artifacts/maintenance-policy-decisions.md" in text
+
+
+def test_maintenance_on_demand_uploads_policy_decision_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-policy-decisions.json" in text
+    assert "artifacts/maintenance-policy-decisions.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_policy_decisions_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "const policyMd = fs.existsSync('artifacts/maintenance-policy-decisions.md')" in text
+    assert "### Maintenance policy decisions" in text
+    assert "policyMd.length > 3000" in text
+
+
+def test_policy_decisions_appear_before_priority_rollup_in_issue_comment():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.index("### Maintenance policy decisions") < text.index(
+        "### Maintenance priority rollup"
+    )


### PR DESCRIPTION
## Summary
- Wire adaptive-ready maintenance policy decisions into `maintenance-on-demand.yml`.
- Build `artifacts/maintenance-policy-decisions.json` and `artifacts/maintenance-policy-decisions.md` from `artifacts/maintenance-priority-rollup.json` when available.
- Upload policy decision artifacts with the existing maintenance artifact bundle.
- Include policy decisions Markdown in the maintenance issue comment before the priority rollup.

## Why
- PR #1143 added adaptive-ready maintenance policy decisions with fixed safety rails and evidence-rich context.
- This PR publishes those decisions through the on-demand maintenance workflow so maintainers can see the action class before reviewing the detailed priority queue.

## Safety
- Diagnostic/reporting-only.
- No auto-fix allowlist changes.
- No CI gate behavior changes.
- The policy decision step uses `if: always()` and `|| true`, so reporting cannot create or mask maintenance failures.
- Policy output is visible but does not yet enforce workflow gates.

## Test evidence
- `PYTHONPATH=src python -m pytest -q tests/test_maintenance_policy_decisions.py tests/test_maintenance_priority_rollup.py tests/test_maintenance_on_demand_policy_decisions_workflow.py tests/test_maintenance_on_demand_priority_rollup_workflow.py` → 18 passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.
- `PYTHONPATH=src python -m pre_commit run check-yaml --files .github/workflows/maintenance-on-demand.yml` → passed.

## Rollback plan
- Revert this PR to stop publishing policy decision artifacts while keeping the standalone policy-decision module available.