### PR TITLE
Publish maintenance policy memory context artifacts

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -96,6 +96,28 @@ jobs:
               --format md || true
           fi
 
+      - name: Build maintenance policy memory context
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-policy-decisions.json ]; then
+            args=(--policy-decisions-json artifacts/maintenance-policy-decisions.json)
+            if [ -f artifacts/adaptive-safe-fix-learning-rollup.json ]; then
+              args+=(--safe-fix-rollup-json artifacts/adaptive-safe-fix-learning-rollup.json)
+            fi
+            if [ -f artifacts/annotation-hygiene-report.json ]; then
+              args+=(--annotation-report-json artifacts/annotation-hygiene-report.json)
+            fi
+            if [ -f artifacts/maintenance-policy-decisions-history.jsonl ]; then
+              args+=(--history-jsonl artifacts/maintenance-policy-decisions-history.jsonl)
+            fi
+            python -m sdetkit.maintenance_policy_memory_context \
+              "${args[@]}" \
+              --out-json artifacts/maintenance-policy-memory-context.json \
+              --out-md artifacts/maintenance-policy-memory-context.md \
+              --format md || true
+          fi
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -111,6 +133,8 @@ jobs:
             artifacts/maintenance-priority-rollup.md
             artifacts/maintenance-policy-decisions.json
             artifacts/maintenance-policy-decisions.md
+            artifacts/maintenance-policy-memory-context.json
+            artifacts/maintenance-policy-memory-context.md
           if-no-files-found: ignore
 
       - name: Detect diff
@@ -188,6 +212,9 @@ jobs:
             const policyMd = fs.existsSync('artifacts/maintenance-policy-decisions.md')
               ? fs.readFileSync('artifacts/maintenance-policy-decisions.md', 'utf8')
               : '';
+            const memoryContextMd = fs.existsSync('artifacts/maintenance-policy-memory-context.md')
+              ? fs.readFileSync('artifacts/maintenance-policy-memory-context.md', 'utf8')
+              : '';
 
             const rows = Object.entries(report.checks || {})
               .map(([name, item]) => `| ${name} | ${item.ok ? 'PASS' : 'FAIL'} | ${item.summary} |`)
@@ -204,6 +231,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              memoryContextMd
+                ? '### Maintenance policy memory context'
+                : '',
+              memoryContextMd
+                ? (memoryContextMd.length > 3000 ? `${memoryContextMd.slice(0, 3000)}\n\n... (truncated)` : memoryContextMd)
+                : '',
               '',
               policyMd
                 ? '### Maintenance policy decisions'

--- a/tests/test_maintenance_on_demand_policy_memory_context_workflow.py
+++ b/tests/test_maintenance_on_demand_policy_memory_context_workflow.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_builds_policy_memory_context_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Build maintenance policy memory context" in text
+    assert "python -m sdetkit.maintenance_policy_memory_context" in text
+    assert "--policy-decisions-json artifacts/maintenance-policy-decisions.json" in text
+    assert "--safe-fix-rollup-json artifacts/adaptive-safe-fix-learning-rollup.json" in text
+    assert "--annotation-report-json artifacts/annotation-hygiene-report.json" in text
+    assert "--history-jsonl artifacts/maintenance-policy-decisions-history.jsonl" in text
+    assert "--out-json artifacts/maintenance-policy-memory-context.json" in text
+    assert "--out-md artifacts/maintenance-policy-memory-context.md" in text
+
+
+def test_maintenance_on_demand_uploads_policy_memory_context_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-policy-memory-context.json" in text
+    assert "artifacts/maintenance-policy-memory-context.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_policy_memory_context_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert (
+        "const memoryContextMd = fs.existsSync('artifacts/maintenance-policy-memory-context.md')"
+        in text
+    )
+    assert "### Maintenance policy memory context" in text
+    assert "memoryContextMd.length > 3000" in text
+
+
+def test_policy_memory_context_appears_before_policy_decisions_in_issue_comment():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.index("### Maintenance policy memory context") < text.index(
+        "### Maintenance policy decisions"
+    )


### PR DESCRIPTION
## Summary
- Wire maintenance policy memory context into `maintenance-on-demand.yml`.
- Build `artifacts/maintenance-policy-memory-context.json` and `artifacts/maintenance-policy-memory-context.md` from policy decisions when available.
- Include optional safe-fix rollup, annotation hygiene report, and policy-decision history JSONL inputs when present.
- Upload memory-context artifacts and include the Markdown in maintenance issue comments before policy decisions.

## Why
- PR #1145 added the memory-aware context layer for policy decisions.
- This PR publishes that context through the on-demand maintenance workflow so maintainers can see repeated-signal and outcome-history context before reading the policy decision table.

## Safety
- Diagnostic/reporting-only.
- No auto-fix allowlist changes.
- No CI gate behavior changes.
- The memory-context step uses `if: always()` and `|| true`, so reporting cannot create or mask maintenance failures.
- Memory context enriches decisions but does not change enforcement or `automation_allowed`.

## Test evidence
- `PYTHONPATH=src python -m pytest -q tests/test_maintenance_policy_memory_context.py tests/test_maintenance_policy_decisions.py tests/test_maintenance_on_demand_policy_memory_context_workflow.py tests/test_maintenance_on_demand_policy_decisions_workflow.py` → 19 passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.
- `PYTHONPATH=src python -m pre_commit run check-yaml --files .github/workflows/maintenance-on-demand.yml` → passed.

## Rollback plan
- Revert this PR to stop publishing policy memory-context artifacts while keeping the standalone memory-context module available.