### PR TITLE
Record maintenance policy decision history

### DIFF
--- a/src/sdetkit/maintenance_policy_decision_history.py
+++ b/src/sdetkit/maintenance_policy_decision_history.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.maintenance.policy_decision_history.v1"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _read_json(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        item = json.loads(raw)
+        if isinstance(item, dict):
+            records.append(item)
+    return records
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _decision_key(item: dict[str, Any]) -> str:
+    return (
+        _text(item.get("memory_lookup_key"))
+        or _text(item.get("source_key"))
+        or f"{_text(item.get('source'))}:{_text(item.get('title'))}"
+    )
+
+
+def _memory_rows_by_key(memory_context: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    rows: dict[str, dict[str, Any]] = {}
+    if not memory_context:
+        return rows
+    for item in _as_list(memory_context.get("decisions")):
+        row = _as_dict(item)
+        key = _decision_key(row)
+        if key:
+            rows[key] = row
+    return rows
+
+
+def _compact_context(row: dict[str, Any], name: str) -> dict[str, Any]:
+    context = _as_dict(row.get(name))
+    if not context:
+        return {}
+    return {
+        key: context[key]
+        for key in sorted(context)
+        if key
+        in {
+            "matched",
+            "context_type",
+            "seen_count",
+            "decisions_by_type",
+            "job",
+            "severity",
+            "finding_id",
+            "fix_type",
+            "code",
+            "remediation_attempts",
+            "remediation_successes",
+            "commit_pushes",
+            "latest_remediation_status",
+            "summary",
+            "policy_hint",
+        }
+    }
+
+
+def _compact_decision(
+    decision: dict[str, Any],
+    *,
+    memory_row: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    memory = memory_row or {}
+    key = _decision_key(decision)
+    return {
+        "rank": _as_int(decision.get("rank")),
+        "decision": _text(decision.get("decision")),
+        "priority": _as_int(decision.get("priority")),
+        "source": _text(decision.get("source")),
+        "severity": _text(decision.get("severity")),
+        "title": _text(decision.get("title")),
+        "action": _text(decision.get("action")),
+        "reason": _text(decision.get("reason")),
+        "adaptive_context": _text(decision.get("adaptive_context")),
+        "source_key": _text(decision.get("source_key")) or key,
+        "memory_lookup_key": key,
+        "confidence": _text(decision.get("confidence")),
+        "automation_risk": _text(decision.get("automation_risk")),
+        "review_risk": _text(decision.get("review_risk")),
+        "release_risk": _text(decision.get("release_risk")),
+        "policy_basis": list(_as_list(decision.get("policy_basis"))),
+        "memory_enriched": bool(memory.get("memory_enriched", False)),
+        "history_context": _compact_context(memory, "history_context"),
+        "safe_fix_context": _compact_context(memory, "safe_fix_context"),
+        "annotation_context": _compact_context(memory, "annotation_context"),
+    }
+
+
+def _record_hash(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def build_history_record(
+    policy_decisions: dict[str, Any],
+    *,
+    memory_context: dict[str, Any] | None = None,
+    recorded_at_utc: str | None = None,
+    run_id: str = "",
+) -> dict[str, Any]:
+    memory_by_key = _memory_rows_by_key(memory_context)
+    decisions = [
+        _compact_decision(row, memory_row=memory_by_key.get(_decision_key(row)))
+        for row in _as_list(policy_decisions.get("decisions"))
+        if _as_dict(row)
+    ]
+
+    stable = {
+        "run_id": _text(run_id),
+        "decision": _text(policy_decisions.get("decision")) or "NO_ACTION",
+        "release_blocking": bool(policy_decisions.get("release_blocking", False)),
+        "top_action": _text(policy_decisions.get("top_action")),
+        "decisions": decisions,
+        "memory_enriched_count": _as_int((memory_context or {}).get("memory_enriched_count")),
+        "repeated_signal_count": _as_int((memory_context or {}).get("repeated_signal_count")),
+    }
+
+    record_id = _record_hash(stable)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "record_id": record_id,
+        "recorded_at_utc": recorded_at_utc or _utc_now(),
+        "run_id": _text(run_id),
+        "decision": stable["decision"],
+        "ok": bool(policy_decisions.get("ok", True)),
+        "release_blocking": stable["release_blocking"],
+        "automation_allowed": bool(policy_decisions.get("automation_allowed", False)),
+        "decision_count": len(decisions),
+        "memory_aware": bool((memory_context or {}).get("memory_aware", False)),
+        "memory_enriched_count": stable["memory_enriched_count"],
+        "repeated_signal_count": stable["repeated_signal_count"],
+        "top_action": stable["top_action"],
+        "top_reason": _text(policy_decisions.get("top_reason")),
+        "top_adaptive_context": _text(policy_decisions.get("top_adaptive_context")),
+        "top_memory_context": _text((memory_context or {}).get("top_memory_context")),
+        "decisions": decisions,
+    }
+
+
+def append_history_record(path: Path, record: dict[str, Any]) -> dict[str, Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _read_jsonl(path)
+    record_id = _text(record.get("record_id"))
+    existing_ids = {_text(item.get("record_id")) for item in existing}
+
+    appended = False
+    if record_id not in existing_ids:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+        appended = True
+        existing.append(record)
+
+    return {
+        "schema_version": "sdetkit.maintenance.policy_decision_history_append.v1",
+        "ok": True,
+        "path": path.as_posix(),
+        "record_id": record_id,
+        "appended": appended,
+        "history_count": len(existing),
+        "decision": _text(record.get("decision")) or "NO_ACTION",
+        "release_blocking": bool(record.get("release_blocking", False)),
+        "decision_count": _as_int(record.get("decision_count")),
+        "memory_enriched_count": _as_int(record.get("memory_enriched_count")),
+        "repeated_signal_count": _as_int(record.get("repeated_signal_count")),
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# Maintenance policy decision history",
+        "",
+        f"- appended: **{summary.get('appended', False)}**",
+        f"- history records: **{summary.get('history_count', 0)}**",
+        f"- decision: **{summary.get('decision', 'NO_ACTION')}**",
+        f"- release blocking: **{summary.get('release_blocking', False)}**",
+        f"- decision items: **{summary.get('decision_count', 0)}**",
+        f"- memory enriched: **{summary.get('memory_enriched_count', 0)}**",
+        f"- repeated signals: **{summary.get('repeated_signal_count', 0)}**",
+        f"- record id: `{summary.get('record_id', '')}`",
+        f"- path: `{summary.get('path', '')}`",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.maintenance_policy_decision_history")
+    parser.add_argument("--policy-decisions-json", required=True)
+    parser.add_argument("--memory-context-json")
+    parser.add_argument("--history-jsonl", required=True)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--out-json")
+    parser.add_argument("--out-md")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        record = build_history_record(
+            _read_json(args.policy_decisions_json) or {},
+            memory_context=_read_json(args.memory_context_json),
+            run_id=args.run_id,
+        )
+        summary = append_history_record(Path(args.history_jsonl), record)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    json_text = json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    md_text = render_markdown(summary)
+
+    if args.out_json:
+        Path(args.out_json).write_text(json_text, encoding="utf-8")
+    if args.out_md:
+        Path(args.out_md).write_text(md_text, encoding="utf-8")
+
+    print(json_text if args.format == "json" else md_text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_maintenance_policy_decision_history.py
+++ b/tests/test_maintenance_policy_decision_history.py
@@ -1,0 +1,209 @@
+import json
+
+from sdetkit import maintenance_policy_decision_history as history
+
+
+def _policy_decisions():
+    return {
+        "decision": "BLOCK_RELEASE",
+        "ok": False,
+        "release_blocking": True,
+        "automation_allowed": False,
+        "top_action": "Review maintenance check `lint_check`.",
+        "top_reason": "Priority-1 maintenance failure was reported.",
+        "top_adaptive_context": "Treat it as release-blocking.",
+        "decisions": [
+            {
+                "rank": 1,
+                "decision": "BLOCK_RELEASE",
+                "priority": 1,
+                "source": "maintenance",
+                "severity": "error",
+                "title": "Maintenance check failed: lint_check",
+                "action": "Review maintenance check `lint_check`.",
+                "reason": "Priority-1 maintenance failure was reported.",
+                "adaptive_context": "Treat it as release-blocking.",
+                "source_key": "maintenance:lint_check",
+                "memory_lookup_key": "maintenance:lint_check",
+                "confidence": "high",
+                "automation_risk": "high",
+                "review_risk": "high",
+                "release_risk": "high",
+                "policy_basis": ["source=maintenance", "priority=1"],
+            },
+            {
+                "rank": 2,
+                "decision": "TRACK_ONLY",
+                "priority": 2,
+                "source": "annotation_hygiene",
+                "severity": "warning",
+                "title": "GitHub Actions Node.js 20 runtime deprecation",
+                "action": "Update the action or test Node 24.",
+                "source_key": "annotation:node20:submit-pypi",
+                "memory_lookup_key": "annotation:node20:submit-pypi",
+                "confidence": "medium",
+                "automation_risk": "high",
+                "review_risk": "low",
+                "release_risk": "low",
+                "policy_basis": ["source=annotation_hygiene", "priority=2"],
+            },
+        ],
+    }
+
+
+def _memory_context():
+    return {
+        "memory_aware": True,
+        "memory_enriched_count": 1,
+        "repeated_signal_count": 1,
+        "top_memory_context": "This signal has appeared 3 time(s).",
+        "decisions": [
+            {
+                "memory_lookup_key": "annotation:node20:submit-pypi",
+                "memory_enriched": True,
+                "history_context": {
+                    "matched": True,
+                    "context_type": "history",
+                    "seen_count": 3,
+                    "decisions_by_type": {"TRACK_ONLY": 3},
+                    "summary": "This signal has appeared 3 time(s).",
+                    "policy_hint": "Escalate recurrence review if the same non-green decision keeps appearing.",
+                },
+                "annotation_context": {
+                    "matched": True,
+                    "context_type": "annotation_hygiene",
+                    "finding_id": "github_actions_node20_deprecation",
+                    "job": "submit-pypi",
+                    "severity": "warning",
+                    "summary": "Annotation memory matched node20.",
+                    "policy_hint": "Track as workflow hygiene.",
+                },
+            }
+        ],
+    }
+
+
+def test_build_history_record_compacts_policy_and_memory_context():
+    record = history.build_history_record(
+        _policy_decisions(),
+        memory_context=_memory_context(),
+        recorded_at_utc="2026-05-05T00:00:00Z",
+        run_id="12345",
+    )
+
+    assert record["schema_version"] == "sdetkit.maintenance.policy_decision_history.v1"
+    assert record["recorded_at_utc"] == "2026-05-05T00:00:00Z"
+    assert record["run_id"] == "12345"
+    assert record["decision"] == "BLOCK_RELEASE"
+    assert record["release_blocking"] is True
+    assert record["decision_count"] == 2
+    assert record["memory_aware"] is True
+    assert record["memory_enriched_count"] == 1
+    assert record["repeated_signal_count"] == 1
+    assert len(record["record_id"]) == 24
+
+    by_key = {item["memory_lookup_key"]: item for item in record["decisions"]}
+    node20 = by_key["annotation:node20:submit-pypi"]
+    assert node20["memory_enriched"] is True
+    assert node20["history_context"]["seen_count"] == 3
+    assert node20["annotation_context"]["job"] == "submit-pypi"
+
+
+def test_append_history_record_dedupes_by_record_id(tmp_path):
+    path = tmp_path / "history" / "policy.jsonl"
+    record = history.build_history_record(
+        _policy_decisions(),
+        recorded_at_utc="2026-05-05T00:00:00Z",
+        run_id="run-1",
+    )
+
+    first = history.append_history_record(path, record)
+    second = history.append_history_record(path, record)
+
+    assert first["appended"] is True
+    assert first["history_count"] == 1
+    assert second["appended"] is False
+    assert second["history_count"] == 1
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_render_markdown_summarizes_append_result(tmp_path):
+    path = tmp_path / "policy-history.jsonl"
+    record = history.build_history_record(_policy_decisions(), run_id="run-1")
+    summary = history.append_history_record(path, record)
+
+    rendered = history.render_markdown(summary)
+
+    assert "# Maintenance policy decision history" in rendered
+    assert "appended: **True**" in rendered
+    assert "decision: **BLOCK_RELEASE**" in rendered
+    assert "record id:" in rendered
+
+
+def test_cli_appends_history_and_writes_outputs(tmp_path):
+    policy_path = tmp_path / "policy.json"
+    memory_path = tmp_path / "memory.json"
+    history_path = tmp_path / "history.jsonl"
+    out_json = tmp_path / "history-summary.json"
+    out_md = tmp_path / "history-summary.md"
+
+    policy_path.write_text(json.dumps(_policy_decisions()), encoding="utf-8")
+    memory_path.write_text(json.dumps(_memory_context()), encoding="utf-8")
+
+    rc = history.main(
+        [
+            "--policy-decisions-json",
+            str(policy_path),
+            "--memory-context-json",
+            str(memory_path),
+            "--history-jsonl",
+            str(history_path),
+            "--run-id",
+            "run-1",
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "md",
+        ]
+    )
+
+    assert rc == 0
+    summary = json.loads(out_json.read_text(encoding="utf-8"))
+    records = [
+        json.loads(line)
+        for line in history_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    assert summary["appended"] is True
+    assert summary["history_count"] == 1
+    assert records[0]["memory_enriched_count"] == 1
+    assert records[0]["decisions"][1]["history_context"]["seen_count"] == 3
+    assert "Maintenance policy decision history" in out_md.read_text(encoding="utf-8")
+
+
+def test_cli_allows_policy_decisions_without_memory_context(tmp_path):
+    policy_path = tmp_path / "policy.json"
+    history_path = tmp_path / "history.jsonl"
+
+    policy_path.write_text(json.dumps(_policy_decisions()), encoding="utf-8")
+
+    rc = history.main(
+        [
+            "--policy-decisions-json",
+            str(policy_path),
+            "--history-jsonl",
+            str(history_path),
+        ]
+    )
+
+    assert rc == 0
+    records = [
+        json.loads(line)
+        for line in history_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert records[0]["memory_aware"] is False
+    assert records[0]["memory_enriched_count"] == 0


### PR DESCRIPTION
## Summary
- Add a policy-decision history writer that appends compact JSONL records from `maintenance-policy-decisions.json`.
- Optionally joins `maintenance-policy-memory-context.json` so history records preserve memory enrichment, repeated-signal context, safe-fix context, and annotation context.
- Deduplicate appended records by stable `record_id` and emit JSON/Markdown append summaries.

## Why
- PR #1145 added memory-aware policy context that can read prior policy-decision history.
- PR #1146 published memory context through maintenance-on-demand.
- This PR closes the loop by creating durable policy-decision history records for future memory-aware decisions.

## Adaptive design note
- This turns policy output into reusable memory instead of one-off comments.
- Records preserve `memory_lookup_key`, observed decision fields, risk fields, policy basis, and compact memory context.
- Future runs can use this JSONL to identify repeated signals and make case-specific recommendations.

## Safety
- Diagnostic/history-only.
- No auto-fix allowlist changes.
- No CI gate behavior changes.
- No enforcement changes.
- Append is idempotent by stable `record_id`.

## Test evidence
- CLI smoke with policy decisions + memory context + history JSONL → passed.
- `PYTHONPATH=src python -m pytest -q tests/test_maintenance_policy_decision_history.py tests/test_maintenance_policy_memory_context.py tests/test_maintenance_policy_decisions.py` → 16 passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.

## Rollback plan
- Revert this PR to remove the history writer while keeping policy decisions and memory-context readers intact.