### PR TITLE
Publish maintenance policy decision history artifacts

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -118,6 +118,26 @@ jobs:
               --format md || true
           fi
 
+      - name: Record maintenance policy decision history
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-policy-decisions.json ]; then
+            args=(
+              --policy-decisions-json artifacts/maintenance-policy-decisions.json
+              --history-jsonl artifacts/maintenance-policy-decisions-history.jsonl
+              --run-id "${GITHUB_RUN_ID}"
+            )
+            if [ -f artifacts/maintenance-policy-memory-context.json ]; then
+              args+=(--memory-context-json artifacts/maintenance-policy-memory-context.json)
+            fi
+            python -m sdetkit.maintenance_policy_decision_history \
+              "${args[@]}" \
+              --out-json artifacts/maintenance-policy-decision-history-summary.json \
+              --out-md artifacts/maintenance-policy-decision-history-summary.md \
+              --format md || true
+          fi
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -135,6 +155,9 @@ jobs:
             artifacts/maintenance-policy-decisions.md
             artifacts/maintenance-policy-memory-context.json
             artifacts/maintenance-policy-memory-context.md
+            artifacts/maintenance-policy-decisions-history.jsonl
+            artifacts/maintenance-policy-decision-history-summary.json
+            artifacts/maintenance-policy-decision-history-summary.md
           if-no-files-found: ignore
 
       - name: Detect diff
@@ -215,6 +238,9 @@ jobs:
             const memoryContextMd = fs.existsSync('artifacts/maintenance-policy-memory-context.md')
               ? fs.readFileSync('artifacts/maintenance-policy-memory-context.md', 'utf8')
               : '';
+            const historyMd = fs.existsSync('artifacts/maintenance-policy-decision-history-summary.md')
+              ? fs.readFileSync('artifacts/maintenance-policy-decision-history-summary.md', 'utf8')
+              : '';
 
             const rows = Object.entries(report.checks || {})
               .map(([name, item]) => `| ${name} | ${item.ok ? 'PASS' : 'FAIL'} | ${item.summary} |`)
@@ -231,6 +257,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              historyMd
+                ? '### Maintenance policy decision history'
+                : '',
+              historyMd
+                ? (historyMd.length > 3000 ? `${historyMd.slice(0, 3000)}\n\n... (truncated)` : historyMd)
+                : '',
               '',
               memoryContextMd
                 ? '### Maintenance policy memory context'

--- a/tests/test_maintenance_on_demand_policy_history_workflow.py
+++ b/tests/test_maintenance_on_demand_policy_history_workflow.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_records_policy_decision_history():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Record maintenance policy decision history" in text
+    assert "python -m sdetkit.maintenance_policy_decision_history" in text
+    assert "--policy-decisions-json artifacts/maintenance-policy-decisions.json" in text
+    assert "--memory-context-json artifacts/maintenance-policy-memory-context.json" in text
+    assert "--history-jsonl artifacts/maintenance-policy-decisions-history.jsonl" in text
+    assert '--run-id "${GITHUB_RUN_ID}"' in text
+    assert "--out-json artifacts/maintenance-policy-decision-history-summary.json" in text
+    assert "--out-md artifacts/maintenance-policy-decision-history-summary.md" in text
+
+
+def test_maintenance_on_demand_uploads_policy_history_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-policy-decisions-history.jsonl" in text
+    assert "artifacts/maintenance-policy-decision-history-summary.json" in text
+    assert "artifacts/maintenance-policy-decision-history-summary.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_policy_history_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert (
+        "const historyMd = fs.existsSync('artifacts/maintenance-policy-decision-history-summary.md')"
+        in text
+    )
+    assert "### Maintenance policy decision history" in text
+    assert "historyMd.length > 3000" in text
+
+
+def test_policy_history_appears_before_memory_context_in_issue_comment():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.index("### Maintenance policy decision history") < text.index(
+        "### Maintenance policy memory context"
+    )


### PR DESCRIPTION
## Summary
- Wire the policy-decision history writer into `maintenance-on-demand.yml`.
- Append `artifacts/maintenance-policy-decisions-history.jsonl` from policy decisions and optional memory context.
- Upload the history JSONL plus JSON/Markdown append summaries.
- Include the history summary in the maintenance issue comment before memory context.

## Why
- PR #1147 added the policy decision history writer.
- This PR makes the history writer part of the on-demand maintenance workflow so future runs can read prior policy decisions and detect repeated signals.

## Adaptive design note
- This closes the loop: policy decisions become durable memory, and future memory context can reuse that history.
- The history record preserves `memory_lookup_key`, risk fields, policy basis, adaptive context, and compact memory context.
- This moves SDETKit further from fixed comments toward case-specific, history-aware recommendations.

## Safety
- Diagnostic/history-only.
- No auto-fix allowlist changes.
- No CI gate behavior changes.
- No enforcement changes.
- The history step uses `if: always()` and `|| true`, so recording cannot create or mask maintenance failures.

## Test evidence
- `PYTHONPATH=src python -m pytest -q tests/test_maintenance_policy_decision_history.py tests/test_maintenance_policy_memory_context.py tests/test_maintenance_on_demand_policy_history_workflow.py tests/test_maintenance_on_demand_policy_memory_context_workflow.py` → 18 passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.
- `PYTHONPATH=src python -m pre_commit run check-yaml --files .github/workflows/maintenance-on-demand.yml` → passed.

## Rollback plan
- Revert this PR to stop writing/uploading policy decision history artifacts while keeping the standalone history writer available.