### PR TITLE
Persist maintenance policy decision history

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -96,6 +96,17 @@ jobs:
               --format md || true
           fi
 
+      - name: Restore maintenance policy decision history
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p artifacts .sdetkit/maintenance
+          if [ -f .sdetkit/maintenance/policy-decisions-history.jsonl ]; then
+            cp .sdetkit/maintenance/policy-decisions-history.jsonl artifacts/maintenance-policy-decisions-history.jsonl
+          else
+            : > artifacts/maintenance-policy-decisions-history.jsonl
+          fi
+
       - name: Build maintenance policy memory context
         if: always()
         shell: bash
@@ -138,6 +149,15 @@ jobs:
               --format md || true
           fi
 
+      - name: Persist maintenance policy decision history
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-policy-decisions-history.jsonl ]; then
+            mkdir -p .sdetkit/maintenance
+            cp artifacts/maintenance-policy-decisions-history.jsonl .sdetkit/maintenance/policy-decisions-history.jsonl
+          fi
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -158,6 +178,7 @@ jobs:
             artifacts/maintenance-policy-decisions-history.jsonl
             artifacts/maintenance-policy-decision-history-summary.json
             artifacts/maintenance-policy-decision-history-summary.md
+            .sdetkit/maintenance/policy-decisions-history.jsonl
           if-no-files-found: ignore
 
       - name: Detect diff
@@ -193,6 +214,9 @@ jobs:
               "",
               "### Applied actions",
               *(applied or ["- none"]),
+              "",
+              "### Policy memory",
+              "- `.sdetkit/maintenance/policy-decisions-history.jsonl` is included when policy history changes during PR-mode maintenance.",
             ]) + "\n",
             encoding='utf-8',
           )

--- a/tests/test_maintenance_on_demand_policy_history_store_workflow.py
+++ b/tests/test_maintenance_on_demand_policy_history_store_workflow.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_restores_policy_history_before_memory_context():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Restore maintenance policy decision history" in text
+    assert ".sdetkit/maintenance/policy-decisions-history.jsonl" in text
+    assert "artifacts/maintenance-policy-decisions-history.jsonl" in text
+    assert text.index("Restore maintenance policy decision history") < text.index(
+        "Build maintenance policy memory context"
+    )
+
+
+def test_maintenance_on_demand_persists_policy_history_after_recording():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Persist maintenance policy decision history" in text
+    assert (
+        "cp artifacts/maintenance-policy-decisions-history.jsonl "
+        ".sdetkit/maintenance/policy-decisions-history.jsonl"
+    ) in text
+    assert text.index("Record maintenance policy decision history") < text.index(
+        "Persist maintenance policy decision history"
+    )
+    assert text.index("Persist maintenance policy decision history") < text.index(
+        "Upload artifacts"
+    )
+
+
+def test_maintenance_on_demand_uploads_policy_history_store_artifact():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert ".sdetkit/maintenance/policy-decisions-history.jsonl" in text
+    assert "artifacts/maintenance-policy-decisions-history.jsonl" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_pr_summary_mentions_policy_memory_persistence():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "### Policy memory" in text
+    assert "policy-decisions-history.jsonl` is included when policy history changes" in text


### PR DESCRIPTION
## Summary
- Restore persisted policy-decision history from `.sdetkit/maintenance/policy-decisions-history.jsonl` into maintenance artifacts before memory context runs.
- Append the current policy decision run into `artifacts/maintenance-policy-decisions-history.jsonl`.
- Copy the updated artifact back to `.sdetkit/maintenance/policy-decisions-history.jsonl` so maintenance PR mode can persist durable memory.
- Upload both artifact history and repo-store history, and mention policy memory persistence in the maintenance PR summary.

## Why
- PR #1147 added the history writer.
- PR #1148 wired per-run history artifacts into maintenance-on-demand.
- This PR makes history survive across runs through a repo-local store, so future memory context can detect repeated signals from prior maintenance runs.

## Adaptive design note
- This is the bridge from per-run memory to long-lived adaptive memory.
- Future runs can restore prior policy decisions before memory context is built, then append the current run and persist the updated JSONL through the controlled maintenance PR path.
- This keeps SDETKit moving toward case-specific, history-aware recommendations instead of fixed comments.

## Safety
- Diagnostic/history-only.
- No auto-fix allowlist changes.
- No CI gate behavior changes.
- No enforcement changes.
- Persistence still flows through the existing `inputs.pr` maintenance PR path when changes are committed.

## Test evidence
- `PYTHONPATH=src python -m pytest -q tests/test_maintenance_policy_decision_history.py tests/test_maintenance_policy_memory_context.py tests/test_maintenance_on_demand_policy_history_workflow.py tests/test_maintenance_on_demand_policy_history_store_workflow.py` → 18 passed.
- `PYTHONPATH=src python -m pre_commit run -a` → passed.
- `PYTHONPATH=src python -m pre_commit run check-yaml --files .github/workflows/maintenance-on-demand.yml` → passed.

## Rollback plan
- Revert this PR to stop restoring/persisting repo-local policy history while keeping per-run history artifacts intact.