### PR TITLE
ci: publish adaptive maintenance recommendation artifacts

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -129,6 +129,18 @@ jobs:
               --format md || true
           fi
 
+      - name: Build adaptive maintenance recommendations
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-policy-memory-context.json ]; then
+            python -m sdetkit.maintenance_recommendations \
+              --memory-context-json artifacts/maintenance-policy-memory-context.json \
+              --out-json artifacts/maintenance-recommendations.json \
+              --out-md artifacts/maintenance-recommendations.md \
+              --format md || true
+          fi
+
       - name: Record maintenance policy decision history
         if: always()
         shell: bash
@@ -175,6 +187,8 @@ jobs:
             artifacts/maintenance-policy-decisions.md
             artifacts/maintenance-policy-memory-context.json
             artifacts/maintenance-policy-memory-context.md
+            artifacts/maintenance-recommendations.json
+            artifacts/maintenance-recommendations.md
             artifacts/maintenance-policy-decisions-history.jsonl
             artifacts/maintenance-policy-decision-history-summary.json
             artifacts/maintenance-policy-decision-history-summary.md
@@ -262,6 +276,9 @@ jobs:
             const memoryContextMd = fs.existsSync('artifacts/maintenance-policy-memory-context.md')
               ? fs.readFileSync('artifacts/maintenance-policy-memory-context.md', 'utf8')
               : '';
+            const recommendationsMd = fs.existsSync('artifacts/maintenance-recommendations.md')
+              ? fs.readFileSync('artifacts/maintenance-recommendations.md', 'utf8')
+              : '';
             const historyMd = fs.existsSync('artifacts/maintenance-policy-decision-history-summary.md')
               ? fs.readFileSync('artifacts/maintenance-policy-decision-history-summary.md', 'utf8')
               : '';
@@ -281,6 +298,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              recommendationsMd
+                ? '### Adaptive maintenance recommendations'
+                : '',
+              recommendationsMd
+                ? (recommendationsMd.length > 3000 ? `${recommendationsMd.slice(0, 3000)}\n\n... (truncated)` : recommendationsMd)
+                : '',
               '',
               historyMd
                 ? '### Maintenance policy decision history'

--- a/tests/test_maintenance_on_demand_recommendations_workflow.py
+++ b/tests/test_maintenance_on_demand_recommendations_workflow.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_builds_recommendation_artifacts_after_memory_context():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Build adaptive maintenance recommendations" in text
+    assert "python -m sdetkit.maintenance_recommendations" in text
+    assert "if [ -f artifacts/maintenance-policy-memory-context.json ]; then" in text
+    assert "--memory-context-json artifacts/maintenance-policy-memory-context.json" in text
+    assert "--out-json artifacts/maintenance-recommendations.json" in text
+    assert "--out-md artifacts/maintenance-recommendations.md" in text
+    assert text.index("Build maintenance policy memory context") < text.index(
+        "Build adaptive maintenance recommendations"
+    )
+    assert text.index("Build adaptive maintenance recommendations") < text.index(
+        "Record maintenance policy decision history"
+    )
+
+
+def test_maintenance_on_demand_uploads_recommendation_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-recommendations.json" in text
+    assert "artifacts/maintenance-recommendations.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_recommendations_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "const recommendationsMd = fs.existsSync('artifacts/maintenance-recommendations.md')" in text
+    assert "### Adaptive maintenance recommendations" in text
+    assert "recommendationsMd.length > 3000" in text
+
+
+def test_recommendations_appear_before_policy_history_in_issue_comment():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.index("### Adaptive maintenance recommendations") < text.index(
+        "### Maintenance policy decision history"
+    )

--- a/tests/test_maintenance_on_demand_recommendations_workflow.py
+++ b/tests/test_maintenance_on_demand_recommendations_workflow.py
@@ -9,9 +9,7 @@ def test_maintenance_on_demand_builds_recommendation_artifacts_after_memory_cont
     assert "Build adaptive maintenance recommendations" in text
     assert "python -m sdetkit.maintenance_recommendations" in text
     assert "if [ -f artifacts/maintenance-policy-memory-context.json ]; then" in text
-    assert (
-        "--memory-context-json artifacts/maintenance-policy-memory-context.json" in text
-    )
+    assert "--memory-context-json artifacts/maintenance-policy-memory-context.json" in text
     assert "--out-json artifacts/maintenance-recommendations.json" in text
     assert "--out-md artifacts/maintenance-recommendations.md" in text
     assert text.index("Build maintenance policy memory context") < text.index(

--- a/tests/test_maintenance_on_demand_recommendations_workflow.py
+++ b/tests/test_maintenance_on_demand_recommendations_workflow.py
@@ -9,7 +9,9 @@ def test_maintenance_on_demand_builds_recommendation_artifacts_after_memory_cont
     assert "Build adaptive maintenance recommendations" in text
     assert "python -m sdetkit.maintenance_recommendations" in text
     assert "if [ -f artifacts/maintenance-policy-memory-context.json ]; then" in text
-    assert "--memory-context-json artifacts/maintenance-policy-memory-context.json" in text
+    assert (
+        "--memory-context-json artifacts/maintenance-policy-memory-context.json" in text
+    )
     assert "--out-json artifacts/maintenance-recommendations.json" in text
     assert "--out-md artifacts/maintenance-recommendations.md" in text
     assert text.index("Build maintenance policy memory context") < text.index(
@@ -31,7 +33,10 @@ def test_maintenance_on_demand_uploads_recommendation_artifacts():
 def test_maintenance_issue_comment_includes_recommendations_when_present():
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert "const recommendationsMd = fs.existsSync('artifacts/maintenance-recommendations.md')" in text
+    assert (
+        "const recommendationsMd = fs.existsSync('artifacts/maintenance-recommendations.md')"
+        in text
+    )
     assert "### Adaptive maintenance recommendations" in text
     assert "recommendationsMd.length > 3000" in text
 


### PR DESCRIPTION
## Summary
- run adaptive maintenance recommendations after policy memory context exists
- upload maintenance recommendation JSON and Markdown artifacts
- include recommendations in the maintenance issue comment before policy history

## Safety
- diagnostic-only workflow surface
- no auto-fix allowlist changes
- no CI gate behavior changes
- no enforcement changes
- automation_allowed remains false

## Tests
- python -m pytest tests/test_maintenance_on_demand_policy_decisions_workflow.py tests/test_maintenance_on_demand_policy_memory_context_workflow.py tests/test_maintenance_on_demand_policy_history_workflow.py tests/test_maintenance_on_demand_policy_history_store_workflow.py tests/test_maintenance_on_demand_recommendations_workflow.py
- YAML parse/order check
- python -m ruff check tests/test_maintenance_on_demand_recommendations_workflow.py
- git diff --check