### PR TITLE
ci: publish maintenance recommendation eligibility diagnostics

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -141,6 +141,18 @@ jobs:
               --format md || true
           fi
 
+      - name: Build maintenance recommendation eligibility
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-recommendations.json ]; then
+            python -m sdetkit.maintenance_recommendation_eligibility \
+              --recommendations-json artifacts/maintenance-recommendations.json \
+              --out-json artifacts/maintenance-recommendation-eligibility.json \
+              --out-md artifacts/maintenance-recommendation-eligibility.md \
+              --format md || true
+          fi
+
       - name: Record maintenance policy decision history
         if: always()
         shell: bash
@@ -189,6 +201,8 @@ jobs:
             artifacts/maintenance-policy-memory-context.md
             artifacts/maintenance-recommendations.json
             artifacts/maintenance-recommendations.md
+            artifacts/maintenance-recommendation-eligibility.json
+            artifacts/maintenance-recommendation-eligibility.md
             artifacts/maintenance-policy-decisions-history.jsonl
             artifacts/maintenance-policy-decision-history-summary.json
             artifacts/maintenance-policy-decision-history-summary.md
@@ -279,6 +293,9 @@ jobs:
             const recommendationsMd = fs.existsSync('artifacts/maintenance-recommendations.md')
               ? fs.readFileSync('artifacts/maintenance-recommendations.md', 'utf8')
               : '';
+            const recommendationEligibilityMd = fs.existsSync('artifacts/maintenance-recommendation-eligibility.md')
+              ? fs.readFileSync('artifacts/maintenance-recommendation-eligibility.md', 'utf8')
+              : '';
             const historyMd = fs.existsSync('artifacts/maintenance-policy-decision-history-summary.md')
               ? fs.readFileSync('artifacts/maintenance-policy-decision-history-summary.md', 'utf8')
               : '';
@@ -298,6 +315,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              recommendationEligibilityMd
+                ? '### Maintenance recommendation eligibility'
+                : '',
+              recommendationEligibilityMd
+                ? (recommendationEligibilityMd.length > 3000 ? `${recommendationEligibilityMd.slice(0, 3000)}\n\n... (truncated)` : recommendationEligibilityMd)
+                : '',
               '',
               recommendationsMd
                 ? '### Adaptive maintenance recommendations'

--- a/scripts/pr_preflight.sh
+++ b/scripts/pr_preflight.sh
@@ -8,7 +8,9 @@ python -m pytest \
   tests/test_maintenance_on_demand_policy_memory_context_workflow.py \
   tests/test_maintenance_on_demand_policy_history_workflow.py \
   tests/test_maintenance_on_demand_policy_history_store_workflow.py \
-  tests/test_maintenance_on_demand_recommendations_workflow.py
+  tests/test_maintenance_on_demand_recommendations_workflow.py \
+  tests/test_maintenance_recommendation_eligibility.py \
+  tests/test_maintenance_on_demand_recommendation_eligibility_workflow.py
 
 python - <<'PY'
 from pathlib import Path

--- a/src/sdetkit/maintenance_recommendation_eligibility.py
+++ b/src/sdetkit/maintenance_recommendation_eligibility.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.maintenance.recommendation_eligibility.v1"
+
+BLOCKED = "BLOCKED"
+REVIEW_REQUIRED = "REVIEW_REQUIRED"
+DEFERRED = "DEFERRED"
+ELIGIBLE_PENDING_POLICY = "ELIGIBLE_PENDING_POLICY"
+
+BLOCK_RELEASE = "BLOCK_RELEASE"
+BLOCK_RELEASE_REVIEW = "BLOCK_RELEASE_REVIEW"
+NOT_ELIGIBLE = "NOT_ELIGIBLE"
+REVIEW_FIRST = "REVIEW_FIRST"
+OBSERVE_ONLY = "OBSERVE_ONLY"
+CANDIDATE_LATER = "CANDIDATE_LATER"
+AUTOMATION_READY = "AUTOMATION_READY"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _cell(value: Any) -> str:
+    return _text(value).replace("|", "\\|")
+
+
+def _read_json(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _eligibility_for_item(item: dict[str, Any], release_blocking: bool) -> dict[str, Any]:
+    recommendation = _text(item.get("recommendation"))
+    decision = _text(item.get("decision"))
+    readiness = _text(item.get("automation_readiness"))
+    row_allowed = bool(item.get("automation_allowed", False))
+    row_eligible = bool(item.get("automation_eligible", False))
+
+    if release_blocking or decision == BLOCK_RELEASE or recommendation == BLOCK_RELEASE_REVIEW:
+        eligibility = BLOCKED
+        reason = "Release-blocking or release-review recommendations cannot enter automation."
+        gate = "Resolve or explicitly review the release-blocking signal first."
+    elif readiness == NOT_ELIGIBLE:
+        eligibility = BLOCKED
+        reason = "The recommendation is explicitly marked not eligible for automation."
+        gate = "Keep this item out of automation policy."
+    elif decision == REVIEW_REQUIRED or readiness == REVIEW_FIRST:
+        eligibility = REVIEW_REQUIRED
+        reason = "The recommendation requires maintainer review before any policy change."
+        gate = "Attach review proof before considering automation policy changes."
+    elif readiness in {OBSERVE_ONLY, CANDIDATE_LATER}:
+        eligibility = DEFERRED
+        reason = "The recommendation needs more history before automation can be considered."
+        gate = "Continue observing repeated successful evidence."
+    elif row_allowed and row_eligible and readiness == AUTOMATION_READY:
+        eligibility = ELIGIBLE_PENDING_POLICY
+        reason = "The recommendation reports automation-ready signals, but this report is diagnostic only."
+        gate = "Require an explicit policy PR before enabling automation."
+    else:
+        eligibility = REVIEW_REQUIRED
+        reason = "The recommendation does not carry enough evidence for automation."
+        gate = "Review the policy basis and attach proof."
+
+    return {
+        "rank": item.get("rank", ""),
+        "recommendation": recommendation,
+        "decision": decision,
+        "source": _text(item.get("source")),
+        "title": _text(item.get("title")),
+        "memory_lookup_key": _text(item.get("memory_lookup_key")),
+        "automation_readiness": readiness,
+        "automation_allowed": row_allowed,
+        "automation_eligible": row_eligible,
+        "eligibility": eligibility,
+        "reason": reason,
+        "required_gate": gate,
+        "proof_needed": _text(item.get("proof_needed")),
+    }
+
+
+def build_eligibility_report(recommendations_payload: dict[str, Any]) -> dict[str, Any]:
+    release_blocking = bool(recommendations_payload.get("release_blocking", False))
+    items = [
+        _eligibility_for_item(_as_dict(item), release_blocking)
+        for item in _as_list(recommendations_payload.get("recommendations"))
+        if _as_dict(item)
+    ]
+
+    counts: dict[str, int] = {}
+    for item in items:
+        eligibility = _text(item.get("eligibility")) or REVIEW_REQUIRED
+        counts[eligibility] = counts.get(eligibility, 0) + 1
+
+    if counts.get(BLOCKED, 0):
+        next_gate = "BLOCKED_REVIEW"
+    elif counts.get(REVIEW_REQUIRED, 0):
+        next_gate = "MAINTAINER_REVIEW"
+    elif counts.get(ELIGIBLE_PENDING_POLICY, 0):
+        next_gate = "POLICY_PR_REQUIRED"
+    else:
+        next_gate = "OBSERVE"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": bool(recommendations_payload.get("ok", True)),
+        "source_schema_version": _text(recommendations_payload.get("schema_version")),
+        "source_decision": _text(recommendations_payload.get("decision")),
+        "release_blocking": release_blocking,
+        "automation_allowed": False,
+        "diagnostic_only": True,
+        "recommendation_count": len(items),
+        "counts_by_eligibility": dict(sorted(counts.items())),
+        "next_gate": next_gate,
+        "items": items,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Maintenance recommendation eligibility",
+        "",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- source decision: **{payload.get('source_decision') or 'UNKNOWN'}**",
+        f"- release blocking: **{payload.get('release_blocking', False)}**",
+        f"- recommendations checked: **{payload.get('recommendation_count', 0)}**",
+        f"- next gate: **{payload.get('next_gate') or 'OBSERVE'}**",
+    ]
+
+    counts = _as_dict(payload.get("counts_by_eligibility"))
+    if counts:
+        lines.extend(["", "## Counts", ""])
+        for name, count in sorted(counts.items()):
+            lines.append(f"- **{_cell(name)}**: {count}")
+
+    items = _as_list(payload.get("items"))
+    if not items:
+        lines.extend(["", "No recommendation eligibility items were produced."])
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines.extend(
+        [
+            "",
+            "## Eligibility details",
+            "",
+            "| Rank | Eligibility | Recommendation | Readiness | Source | Required gate |",
+            "|---:|---|---|---|---|---|",
+        ]
+    )
+
+    for item in items:
+        row = _as_dict(item)
+        lines.append(
+            f"| {row.get('rank', '')} | {_cell(row.get('eligibility'))} | "
+            f"{_cell(row.get('recommendation'))} | "
+            f"{_cell(row.get('automation_readiness'))} | "
+            f"{_cell(row.get('source'))} | {_cell(row.get('required_gate'))} |"
+        )
+
+    lines.extend(["", "## Why blocked, deferred, or review-first", ""])
+    for item in items[:8]:
+        row = _as_dict(item)
+        lines.append(
+            f"- **{_cell(row.get('eligibility'))}** `{_cell(row.get('memory_lookup_key'))}`: "
+            f"{_cell(row.get('reason'))} Proof: {_cell(row.get('proof_needed')) or 'None.'}"
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.maintenance_recommendation_eligibility"
+    )
+    parser.add_argument("--recommendations-json", required=True)
+    parser.add_argument("--out-json")
+    parser.add_argument("--out-md")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_eligibility_report(_read_json(args.recommendations_json) or {})
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    md_text = render_markdown(payload)
+
+    if args.out_json:
+        Path(args.out_json).write_text(json_text, encoding="utf-8")
+    if args.out_md:
+        Path(args.out_md).write_text(md_text, encoding="utf-8")
+
+    print(json_text if args.format == "json" else md_text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_maintenance_on_demand_recommendation_eligibility_workflow.py
+++ b/tests/test_maintenance_on_demand_recommendation_eligibility_workflow.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_builds_recommendation_eligibility_after_recommendations():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Build maintenance recommendation eligibility" in text
+    assert "python -m sdetkit.maintenance_recommendation_eligibility" in text
+    assert "if [ -f artifacts/maintenance-recommendations.json ]; then" in text
+    assert "--recommendations-json artifacts/maintenance-recommendations.json" in text
+    assert "--out-json artifacts/maintenance-recommendation-eligibility.json" in text
+    assert "--out-md artifacts/maintenance-recommendation-eligibility.md" in text
+    assert text.index("Build adaptive maintenance recommendations") < text.index(
+        "Build maintenance recommendation eligibility"
+    )
+    assert text.index("Build maintenance recommendation eligibility") < text.index(
+        "Record maintenance policy decision history"
+    )
+
+
+def test_maintenance_on_demand_uploads_recommendation_eligibility_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-recommendation-eligibility.json" in text
+    assert "artifacts/maintenance-recommendation-eligibility.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_recommendation_eligibility_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert (
+        "const recommendationEligibilityMd = fs.existsSync"
+        "('artifacts/maintenance-recommendation-eligibility.md')"
+    ) in text
+    assert "### Maintenance recommendation eligibility" in text
+    assert "recommendationEligibilityMd.length > 3000" in text
+
+
+def test_recommendation_eligibility_appears_before_recommendations_in_issue_comment():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.index("### Maintenance recommendation eligibility") < text.index(
+        "### Adaptive maintenance recommendations"
+    )

--- a/tests/test_maintenance_recommendation_eligibility.py
+++ b/tests/test_maintenance_recommendation_eligibility.py
@@ -1,0 +1,141 @@
+import json
+
+from sdetkit import maintenance_recommendation_eligibility as eligibility
+
+
+def _recommendations_payload():
+    return {
+        "schema_version": "sdetkit.maintenance.recommendations.v1",
+        "ok": True,
+        "decision": "REVIEW_REQUIRED",
+        "release_blocking": False,
+        "automation_allowed": False,
+        "recommendations": [
+            {
+                "rank": 1,
+                "recommendation": "MANUAL_REVIEW_REQUIRED",
+                "decision": "REVIEW_REQUIRED",
+                "source": "maintenance_action",
+                "title": "Run pytest -q",
+                "memory_lookup_key": "maintenance-action:tests_check:run-tests",
+                "automation_readiness": "REVIEW_FIRST",
+                "automation_allowed": False,
+                "automation_eligible": False,
+                "proof_needed": "Attach passing test output.",
+            },
+            {
+                "rank": 2,
+                "recommendation": "OBSERVE_SAFE_FIX_STABILITY",
+                "decision": "TRACK_ONLY",
+                "source": "safe_fix_rollup",
+                "title": "Observe safe fix stability",
+                "memory_lookup_key": "safe-fix:ruff",
+                "automation_readiness": "CANDIDATE_LATER",
+                "automation_allowed": False,
+                "automation_eligible": False,
+                "proof_needed": "Require repeated successful runs.",
+            },
+        ],
+    }
+
+
+def test_build_eligibility_report_classifies_review_and_deferred_items():
+    payload = eligibility.build_eligibility_report(_recommendations_payload())
+
+    assert payload["schema_version"] == "sdetkit.maintenance.recommendation_eligibility.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["next_gate"] == "MAINTAINER_REVIEW"
+    assert payload["counts_by_eligibility"] == {"DEFERRED": 1, "REVIEW_REQUIRED": 1}
+
+    by_key = {item["memory_lookup_key"]: item for item in payload["items"]}
+    assert by_key["maintenance-action:tests_check:run-tests"]["eligibility"] == "REVIEW_REQUIRED"
+    assert by_key["safe-fix:ruff"]["eligibility"] == "DEFERRED"
+
+
+def test_build_eligibility_report_blocks_release_review_items():
+    payload = eligibility.build_eligibility_report(
+        {
+            "decision": "BLOCK_RELEASE",
+            "release_blocking": True,
+            "recommendations": [
+                {
+                    "rank": 1,
+                    "recommendation": "BLOCK_RELEASE_REVIEW",
+                    "decision": "BLOCK_RELEASE",
+                    "source": "maintenance",
+                    "memory_lookup_key": "maintenance:lint",
+                    "automation_readiness": "NOT_ELIGIBLE",
+                }
+            ],
+        }
+    )
+
+    assert payload["next_gate"] == "BLOCKED_REVIEW"
+    assert payload["counts_by_eligibility"] == {"BLOCKED": 1}
+    assert payload["items"][0]["required_gate"] == (
+        "Resolve or explicitly review the release-blocking signal first."
+    )
+
+
+def test_ready_signals_still_require_policy_pr_and_do_not_enable_automation():
+    payload = eligibility.build_eligibility_report(
+        {
+            "decision": "TRACK_ONLY",
+            "release_blocking": False,
+            "automation_allowed": True,
+            "recommendations": [
+                {
+                    "rank": 1,
+                    "recommendation": "OBSERVE_SAFE_FIX_STABILITY",
+                    "decision": "TRACK_ONLY",
+                    "source": "safe_fix_rollup",
+                    "memory_lookup_key": "safe-fix:ready",
+                    "automation_readiness": "AUTOMATION_READY",
+                    "automation_allowed": True,
+                    "automation_eligible": True,
+                }
+            ],
+        }
+    )
+
+    assert payload["automation_allowed"] is False
+    assert payload["diagnostic_only"] is True
+    assert payload["next_gate"] == "POLICY_PR_REQUIRED"
+    assert payload["items"][0]["eligibility"] == "ELIGIBLE_PENDING_POLICY"
+
+
+def test_render_markdown_is_comment_ready():
+    payload = eligibility.build_eligibility_report(_recommendations_payload())
+
+    rendered = eligibility.render_markdown(payload)
+
+    assert "# Maintenance recommendation eligibility" in rendered
+    assert "diagnostic only" in rendered
+    assert "MAINTAINER_REVIEW" in rendered
+    assert "Why blocked, deferred, or review-first" in rendered
+
+
+def test_cli_writes_json_and_markdown(tmp_path):
+    source = tmp_path / "recommendations.json"
+    out_json = tmp_path / "eligibility.json"
+    out_md = tmp_path / "eligibility.md"
+    source.write_text(json.dumps(_recommendations_payload()), encoding="utf-8")
+
+    rc = eligibility.main(
+        [
+            "--recommendations-json",
+            str(source),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "md",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["next_gate"] == "MAINTAINER_REVIEW"
+    assert "Maintenance recommendation eligibility" in out_md.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add diagnostic-only eligibility reporting for adaptive maintenance recommendations
- publish maintenance-recommendation-eligibility JSON and Markdown artifacts
- include the eligibility section in the maintenance issue comment before recommendation details
- extend local PR preflight coverage for the new diagnostics

## Safety
- diagnostic-only report
- automation_allowed remains false
- no auto-fix allowlist changes
- no enforcement changes
- no automated remediation changes

## Tests
- ./scripts/pr_preflight.sh
- python -m pytest tests/test_maintenance_recommendation_eligibility.py tests/test_maintenance_on_demand_recommendation_eligibility_workflow.py
- PYTHONPATH=src python -m sdetkit.maintenance_recommendation_eligibility --recommendations-json /tmp/maintenance-on-demand-artifacts/artifacts/maintenance-recommendations.json --out-json /tmp/maintenance-recommendation-eligibility.json --out-md /tmp/maintenance-recommendation-eligibility.md --format md
- git diff --check