### PR TITLE
ci: publish maintenance action plan

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -153,6 +153,18 @@ jobs:
               --format md || true
           fi
 
+      - name: Build maintenance action plan
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-recommendation-eligibility.json ]; then
+            python -m sdetkit.maintenance_action_plan \
+              --eligibility-json artifacts/maintenance-recommendation-eligibility.json \
+              --out-json artifacts/maintenance-action-plan.json \
+              --out-md artifacts/maintenance-action-plan.md \
+              --format md || true
+          fi
+
       - name: Record maintenance policy decision history
         if: always()
         shell: bash
@@ -203,6 +215,8 @@ jobs:
             artifacts/maintenance-recommendations.md
             artifacts/maintenance-recommendation-eligibility.json
             artifacts/maintenance-recommendation-eligibility.md
+            artifacts/maintenance-action-plan.json
+            artifacts/maintenance-action-plan.md
             artifacts/maintenance-policy-decisions-history.jsonl
             artifacts/maintenance-policy-decision-history-summary.json
             artifacts/maintenance-policy-decision-history-summary.md
@@ -296,6 +310,9 @@ jobs:
             const recommendationEligibilityMd = fs.existsSync('artifacts/maintenance-recommendation-eligibility.md')
               ? fs.readFileSync('artifacts/maintenance-recommendation-eligibility.md', 'utf8')
               : '';
+            const actionPlanMd = fs.existsSync('artifacts/maintenance-action-plan.md')
+              ? fs.readFileSync('artifacts/maintenance-action-plan.md', 'utf8')
+              : '';
             const historyMd = fs.existsSync('artifacts/maintenance-policy-decision-history-summary.md')
               ? fs.readFileSync('artifacts/maintenance-policy-decision-history-summary.md', 'utf8')
               : '';
@@ -315,6 +332,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              actionPlanMd
+                ? '### Maintenance action plan'
+                : '',
+              actionPlanMd
+                ? (actionPlanMd.length > 3000 ? `${actionPlanMd.slice(0, 3000)}\n\n... (truncated)` : actionPlanMd)
+                : '',
               '',
               recommendationEligibilityMd
                 ? '### Maintenance recommendation eligibility'

--- a/scripts/pr_preflight.sh
+++ b/scripts/pr_preflight.sh
@@ -10,7 +10,9 @@ python -m pytest \
   tests/test_maintenance_on_demand_policy_history_store_workflow.py \
   tests/test_maintenance_on_demand_recommendations_workflow.py \
   tests/test_maintenance_recommendation_eligibility.py \
-  tests/test_maintenance_on_demand_recommendation_eligibility_workflow.py
+  tests/test_maintenance_on_demand_recommendation_eligibility_workflow.py \
+  tests/test_maintenance_action_plan.py \
+  tests/test_maintenance_on_demand_action_plan_workflow.py
 
 python - <<'PY'
 from pathlib import Path

--- a/src/sdetkit/maintenance_action_plan.py
+++ b/src/sdetkit/maintenance_action_plan.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.maintenance.action_plan.v1"
+
+BLOCKED = "BLOCKED"
+REVIEW_REQUIRED = "REVIEW_REQUIRED"
+DEFERRED = "DEFERRED"
+ELIGIBLE_PENDING_POLICY = "ELIGIBLE_PENDING_POLICY"
+
+REVIEW_FIRST = "REVIEW_FIRST"
+CANDIDATE_LATER = "CANDIDATE_LATER"
+AUTOMATION_READY = "AUTOMATION_READY"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _cell(value: Any) -> str:
+    return _text(value).replace("|", "\\|")
+
+
+def _read_json(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _future_auto_fix_candidate(item: dict[str, Any]) -> bool:
+    eligibility = _text(item.get("eligibility"))
+    readiness = _text(item.get("automation_readiness"))
+    if eligibility == ELIGIBLE_PENDING_POLICY and readiness == AUTOMATION_READY:
+        return True
+    return eligibility == DEFERRED and readiness == CANDIDATE_LATER
+
+
+def _action_for_item(item: dict[str, Any]) -> tuple[str, str]:
+    eligibility = _text(item.get("eligibility"))
+    required_gate = _text(item.get("required_gate"))
+
+    if eligibility == BLOCKED:
+        return (
+            "Resolve the blocking condition before any maintenance automation is considered.",
+            required_gate or "Resolve the blocker and rerun maintenance.",
+        )
+    if eligibility == REVIEW_REQUIRED:
+        return (
+            "Review this signal, attach the required proof, and keep automation disabled.",
+            required_gate or "Attach review proof before considering automation policy changes.",
+        )
+    if eligibility == DEFERRED:
+        return (
+            "Keep observing this signal until repeated successful evidence exists.",
+            required_gate or "Continue collecting history before automation policy changes.",
+        )
+    if eligibility == ELIGIBLE_PENDING_POLICY:
+        return (
+            "Prepare an explicit policy PR before enabling any auto-fix behavior.",
+            required_gate or "Require a policy PR before enabling automation.",
+        )
+    return (
+        "Review this signal before taking action.",
+        required_gate or "Review the policy basis and attach proof.",
+    )
+
+
+def _auto_fix_blocker(item: dict[str, Any]) -> str:
+    eligibility = _text(item.get("eligibility"))
+    if eligibility == BLOCKED:
+        return "Blocked by release or explicit non-eligibility gate."
+    if eligibility == REVIEW_REQUIRED:
+        return "Maintainer review proof is required before auto-fix."
+    if eligibility == DEFERRED:
+        return "More repeated successful evidence is required before auto-fix."
+    if eligibility == ELIGIBLE_PENDING_POLICY:
+        return "An explicit policy PR is required before auto-fix."
+    return "Automation is disabled until the policy basis is reviewed."
+
+
+def _plan_item(item: dict[str, Any]) -> dict[str, Any]:
+    recommended_action, next_gate = _action_for_item(item)
+    future_candidate = _future_auto_fix_candidate(item)
+    return {
+        "rank": item.get("rank", ""),
+        "signal": _text(item.get("title")) or _text(item.get("memory_lookup_key")),
+        "source": _text(item.get("source")),
+        "memory_lookup_key": _text(item.get("memory_lookup_key")),
+        "eligibility": _text(item.get("eligibility")) or REVIEW_REQUIRED,
+        "automation_readiness": _text(item.get("automation_readiness")),
+        "recommended_action": recommended_action,
+        "proof_needed": _text(item.get("proof_needed")),
+        "next_gate": next_gate,
+        "future_auto_fix_candidate": future_candidate,
+        "auto_fix_blocker": _auto_fix_blocker(item),
+    }
+
+
+def build_action_plan(eligibility_payload: dict[str, Any]) -> dict[str, Any]:
+    items = [
+        _plan_item(_as_dict(item))
+        for item in _as_list(eligibility_payload.get("items"))
+        if _as_dict(item)
+    ]
+
+    counts: dict[str, int] = {}
+    for item in items:
+        key = _text(item.get("eligibility")) or REVIEW_REQUIRED
+        counts[key] = counts.get(key, 0) + 1
+
+    candidate_count = sum(1 for item in items if bool(item.get("future_auto_fix_candidate")))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": bool(eligibility_payload.get("ok", True)),
+        "source_schema_version": _text(eligibility_payload.get("schema_version")),
+        "source_next_gate": _text(eligibility_payload.get("next_gate")),
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "auto_fix_enabled": False,
+        "action_count": len(items),
+        "future_auto_fix_candidate_count": candidate_count,
+        "counts_by_eligibility": dict(sorted(counts.items())),
+        "actions": items,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Maintenance action plan",
+        "",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- auto-fix enabled: **{payload.get('auto_fix_enabled', False)}**",
+        f"- source next gate: **{payload.get('source_next_gate') or 'UNKNOWN'}**",
+        f"- actions: **{payload.get('action_count', 0)}**",
+        f"- future auto-fix candidates: **{payload.get('future_auto_fix_candidate_count', 0)}**",
+    ]
+
+    counts = _as_dict(payload.get("counts_by_eligibility"))
+    if counts:
+        lines.extend(["", "## Eligibility mix", ""])
+        for name, count in sorted(counts.items()):
+            lines.append(f"- **{_cell(name)}**: {count}")
+
+    actions = _as_list(payload.get("actions"))
+    if not actions:
+        lines.extend(["", "No maintenance actions were planned."])
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines.extend(
+        [
+            "",
+            "## Action plan",
+            "",
+            "| Rank | Eligibility | Future auto-fix | Source | Signal | Next gate |",
+            "|---:|---|---|---|---|---|",
+        ]
+    )
+    for item in actions:
+        row = _as_dict(item)
+        lines.append(
+            f"| {row.get('rank', '')} | {_cell(row.get('eligibility'))} | "
+            f"{bool(row.get('future_auto_fix_candidate'))} | {_cell(row.get('source'))} | "
+            f"{_cell(row.get('signal'))} | {_cell(row.get('next_gate'))} |"
+        )
+
+    lines.extend(["", "## What to do next", ""])
+    for item in actions[:8]:
+        row = _as_dict(item)
+        lines.append(
+            f"- **{_cell(row.get('signal'))}**: {_cell(row.get('recommended_action'))} "
+            f"Proof: {_cell(row.get('proof_needed')) or 'None.'} "
+            f"Auto-fix blocker: {_cell(row.get('auto_fix_blocker'))}"
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.maintenance_action_plan")
+    parser.add_argument("--eligibility-json", required=True)
+    parser.add_argument("--out-json")
+    parser.add_argument("--out-md")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_action_plan(_read_json(args.eligibility_json) or {})
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    md_text = render_markdown(payload)
+
+    if args.out_json:
+        Path(args.out_json).write_text(json_text, encoding="utf-8")
+    if args.out_md:
+        Path(args.out_md).write_text(md_text, encoding="utf-8")
+
+    print(json_text if args.format == "json" else md_text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_maintenance_action_plan.py
+++ b/tests/test_maintenance_action_plan.py
@@ -1,0 +1,122 @@
+import json
+
+from sdetkit import maintenance_action_plan as plan
+
+
+def _eligibility_payload():
+    return {
+        "schema_version": "sdetkit.maintenance.recommendation_eligibility.v1",
+        "ok": True,
+        "next_gate": "MAINTAINER_REVIEW",
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "items": [
+            {
+                "rank": 1,
+                "eligibility": "REVIEW_REQUIRED",
+                "automation_readiness": "REVIEW_FIRST",
+                "source": "maintenance_action",
+                "title": "Run pytest -q",
+                "memory_lookup_key": "maintenance-action:tests_check:run-tests",
+                "proof_needed": "Attach passing test output.",
+                "required_gate": "Attach review proof before considering automation policy changes.",
+            },
+            {
+                "rank": 2,
+                "eligibility": "DEFERRED",
+                "automation_readiness": "CANDIDATE_LATER",
+                "source": "safe_fix_rollup",
+                "title": "Observe ruff safe-fix stability",
+                "memory_lookup_key": "safe-fix:ruff",
+                "proof_needed": "Require repeated successful runs.",
+                "required_gate": "Continue observing repeated successful evidence.",
+            },
+            {
+                "rank": 3,
+                "eligibility": "ELIGIBLE_PENDING_POLICY",
+                "automation_readiness": "AUTOMATION_READY",
+                "source": "safe_fix_rollup",
+                "title": "Safe fix appears stable",
+                "memory_lookup_key": "safe-fix:ready",
+                "proof_needed": "Open policy PR.",
+                "required_gate": "Require an explicit policy PR before enabling automation.",
+            },
+        ],
+    }
+
+
+def test_build_action_plan_keeps_automation_off_and_marks_future_candidates():
+    payload = plan.build_action_plan(_eligibility_payload())
+
+    assert payload["schema_version"] == "sdetkit.maintenance.action_plan.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["auto_fix_enabled"] is False
+    assert payload["source_next_gate"] == "MAINTAINER_REVIEW"
+    assert payload["action_count"] == 3
+    assert payload["future_auto_fix_candidate_count"] == 2
+
+    by_key = {item["memory_lookup_key"]: item for item in payload["actions"]}
+    assert by_key["maintenance-action:tests_check:run-tests"]["future_auto_fix_candidate"] is False
+    assert by_key["safe-fix:ruff"]["future_auto_fix_candidate"] is True
+    assert by_key["safe-fix:ready"]["future_auto_fix_candidate"] is True
+
+
+def test_blocked_item_has_blocked_auto_fix_reason():
+    payload = plan.build_action_plan(
+        {
+            "next_gate": "BLOCKED_REVIEW",
+            "items": [
+                {
+                    "rank": 1,
+                    "eligibility": "BLOCKED",
+                    "automation_readiness": "NOT_ELIGIBLE",
+                    "title": "Release blocker",
+                    "source": "maintenance",
+                    "memory_lookup_key": "maintenance:lint",
+                    "required_gate": "Resolve the release blocker.",
+                }
+            ],
+        }
+    )
+
+    item = payload["actions"][0]
+    assert payload["future_auto_fix_candidate_count"] == 0
+    assert item["future_auto_fix_candidate"] is False
+    assert item["auto_fix_blocker"] == "Blocked by release or explicit non-eligibility gate."
+
+
+def test_render_markdown_is_comment_ready():
+    payload = plan.build_action_plan(_eligibility_payload())
+
+    rendered = plan.render_markdown(payload)
+
+    assert "# Maintenance action plan" in rendered
+    assert "auto-fix enabled: **False**" in rendered
+    assert "future auto-fix candidates: **2**" in rendered
+    assert "What to do next" in rendered
+
+
+def test_cli_writes_json_and_markdown(tmp_path):
+    source = tmp_path / "eligibility.json"
+    out_json = tmp_path / "action-plan.json"
+    out_md = tmp_path / "action-plan.md"
+    source.write_text(json.dumps(_eligibility_payload()), encoding="utf-8")
+
+    rc = plan.main(
+        [
+            "--eligibility-json",
+            str(source),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "md",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["future_auto_fix_candidate_count"] == 2
+    assert "Maintenance action plan" in out_md.read_text(encoding="utf-8")

--- a/tests/test_maintenance_on_demand_action_plan_workflow.py
+++ b/tests/test_maintenance_on_demand_action_plan_workflow.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_builds_action_plan_after_eligibility():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Build maintenance action plan" in text
+    assert "python -m sdetkit.maintenance_action_plan" in text
+    assert "if [ -f artifacts/maintenance-recommendation-eligibility.json ]; then" in text
+    assert "--eligibility-json artifacts/maintenance-recommendation-eligibility.json" in text
+    assert "--out-json artifacts/maintenance-action-plan.json" in text
+    assert "--out-md artifacts/maintenance-action-plan.md" in text
+    assert text.index("Build maintenance recommendation eligibility") < text.index(
+        "Build maintenance action plan"
+    )
+    assert text.index("Build maintenance action plan") < text.index(
+        "Record maintenance policy decision history"
+    )
+
+
+def test_maintenance_on_demand_uploads_action_plan_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-action-plan.json" in text
+    assert "artifacts/maintenance-action-plan.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_action_plan_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "const actionPlanMd = fs.existsSync('artifacts/maintenance-action-plan.md')" in text
+    assert "### Maintenance action plan" in text
+    assert "actionPlanMd.length > 3000" in text
+
+
+def test_action_plan_appears_before_eligibility_in_issue_comment():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.index("### Maintenance action plan") < text.index(
+        "### Maintenance recommendation eligibility"
+    )


### PR DESCRIPTION
## Summary
- add a diagnostic-only maintenance action plan from recommendation eligibility output
- publish maintenance-action-plan JSON and Markdown artifacts
- include the action plan in the maintenance issue comment before eligibility and recommendation details
- extend local PR preflight coverage for action-plan diagnostics

## Roadmap
- keeps the detect -> recommend -> eligibility -> action-plan path intact
- makes future auto-fix candidacy visible without enabling auto-fix
- leaves guarded auto-fix for a later policy-gated PR

## Safety
- diagnostic-only report
- automation_allowed remains false
- auto_fix_enabled remains false
- no auto-fix allowlist changes
- no enforcement changes
- no automated remediation changes

## Tests
- ./scripts/pr_preflight.sh
- PYTHONPATH=src python -m sdetkit.maintenance_action_plan --eligibility-json /tmp/maintenance-on-demand-artifacts/artifacts/maintenance-recommendation-eligibility.json --out-json /tmp/maintenance-action-plan.json --out-md /tmp/maintenance-action-plan.md --format md
- git diff --check