### PR TITLE
Add async envelope pagination parity

### DIFF
--- a/src/sdetkit/apiclient.py
+++ b/src/sdetkit/apiclient.py
@@ -612,3 +612,135 @@ async def fetch_json_list_paginated_async(
         url = nxt
 
     raise RuntimeError("pagination limit exceeded")
+
+def fetch_json_list_paginated_envelope(
+    client: httpx.Client,
+    path: str,
+    retries: int = 1,
+    *,
+    timeout: float | httpx.Timeout | None = None,
+    headers: dict[str, str] | None = None,
+    trace_header: str | None = None,
+    request_id: str | None = None,
+    retry_on_429: bool = False,
+    backoff_base: float = 0.0,
+    backoff_factor: float = 2.0,
+    backoff_jitter: float = 0.0,
+    sleep: Callable[[float], None] | None = None,
+    items_key: str = "items",
+    next_key: str = "next",
+    max_pages: int = 100,
+) -> list:
+    if max_pages < 1:
+        raise ValueError("max_pages must be >= 1")
+    if not str(items_key).strip():
+        raise ValueError("items_key must not be empty")
+    if not str(next_key).strip():
+        raise ValueError("next_key must not be empty")
+
+    out = []
+    seen: set[str] = {str(path)}
+    nxt: str | None = path
+
+    for _ in range(max_pages):
+        if nxt is None:
+            return out
+
+        data = fetch_json_dict(
+            client,
+            nxt,
+            retries=retries,
+            timeout=timeout,
+            headers=headers,
+            trace_header=trace_header,
+            request_id=request_id,
+            retry_on_429=retry_on_429,
+            backoff_base=backoff_base,
+            backoff_factor=backoff_factor,
+            backoff_jitter=backoff_jitter,
+            sleep=sleep,
+        )
+        page_items = data.get(items_key)
+        if not isinstance(page_items, list):
+            raise ValueError(f"expected json array at key '{items_key}'")
+        out.extend(page_items)
+
+        nxt_raw = data.get(next_key)
+        if nxt_raw is None:
+            return out
+        if not isinstance(nxt_raw, str):
+            raise ValueError(f"expected string or null at key '{next_key}'")
+
+        nxt = nxt_raw
+        if nxt in seen:
+            raise RuntimeError("pagination cycle detected")
+        seen.add(nxt)
+
+    raise RuntimeError("pagination limit exceeded")
+
+
+async def fetch_json_list_paginated_envelope_async(
+    client: httpx.AsyncClient,
+    path: str,
+    retries: int = 1,
+    *,
+    timeout: float | httpx.Timeout | None = None,
+    headers: dict[str, str] | None = None,
+    trace_header: str | None = None,
+    request_id: str | None = None,
+    retry_on_429: bool = False,
+    backoff_base: float = 0.0,
+    backoff_factor: float = 2.0,
+    backoff_jitter: float = 0.0,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+    items_key: str = "items",
+    next_key: str = "next",
+    max_pages: int = 100,
+) -> list:
+    if max_pages < 1:
+        raise ValueError("max_pages must be >= 1")
+    if not str(items_key).strip():
+        raise ValueError("items_key must not be empty")
+    if not str(next_key).strip():
+        raise ValueError("next_key must not be empty")
+
+    out = []
+    seen: set[str] = {str(path)}
+    nxt: str | None = path
+
+    for _ in range(max_pages):
+        if nxt is None:
+            return out
+
+        data = await fetch_json_dict_async(
+            client,
+            nxt,
+            retries=retries,
+            timeout=timeout,
+            headers=headers,
+            trace_header=trace_header,
+            request_id=request_id,
+            retry_on_429=retry_on_429,
+            backoff_base=backoff_base,
+            backoff_factor=backoff_factor,
+            backoff_jitter=backoff_jitter,
+            sleep=sleep,
+        )
+        page_items = data.get(items_key)
+        if not isinstance(page_items, list):
+            raise ValueError(f"expected json array at key '{items_key}'")
+        out.extend(page_items)
+
+        nxt_raw = data.get(next_key)
+        if nxt_raw is None:
+            return out
+        if not isinstance(nxt_raw, str):
+            raise ValueError(f"expected string or null at key '{next_key}'")
+
+        nxt = nxt_raw
+        if nxt in seen:
+            raise RuntimeError("pagination cycle detected")
+        seen.add(nxt)
+
+    raise RuntimeError("pagination limit exceeded")
+

--- a/src/sdetkit/apiclient.py
+++ b/src/sdetkit/apiclient.py
@@ -613,6 +613,7 @@ async def fetch_json_list_paginated_async(
 
     raise RuntimeError("pagination limit exceeded")
 
+
 def fetch_json_list_paginated_envelope(
     client: httpx.Client,
     path: str,
@@ -743,4 +744,3 @@ async def fetch_json_list_paginated_envelope_async(
         seen.add(nxt)
 
     raise RuntimeError("pagination limit exceeded")
-

--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -873,6 +873,54 @@ class SdetAsyncHttpClient:
 
         raise RuntimeError("pagination limit exceeded")
 
+    async def get_json_list_paginated_envelope(
+        self,
+        url: str,
+        *,
+        items_key: str = "items",
+        next_key: str = "next",
+        max_pages: int = 100,
+        timeout: float | httpx.Timeout | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> list:
+        if max_pages < 1:
+            raise ValueError("max_pages must be >= 1")
+        if not str(items_key).strip():
+            raise ValueError("items_key must not be empty")
+        if not str(next_key).strip():
+            raise ValueError("next_key must not be empty")
+
+        out = []
+        seen: set[str] = {str(url)}
+        nxt: str | None = url
+
+        for _ in range(max_pages):
+            if nxt is None:
+                return out
+
+            data = await self.get_json_dict(
+                nxt,
+                timeout=timeout,
+                headers=headers,
+            )
+            page_items = data.get(items_key)
+            if not isinstance(page_items, list):
+                raise ValueError(f"expected json array at key '{items_key}'")
+            out.extend(page_items)
+
+            nxt_raw = data.get(next_key)
+            if nxt_raw is None:
+                return out
+            if not isinstance(nxt_raw, str):
+                raise ValueError(f"expected string or null at key '{next_key}'")
+
+            nxt = nxt_raw
+            if nxt in seen:
+                raise RuntimeError("pagination cycle detected")
+            seen.add(nxt)
+
+        raise RuntimeError("pagination limit exceeded")
+
     async def _request_json(
         self,
         url: str,

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -109,7 +109,7 @@ def test_fetch_json_dict_status_code_edges_mutmut():
     from sdetkit.apiclient import fetch_json_dict
 
     class Resp:
-        def init_(self, status_code, payload):
+        def __init__(self, status_code, payload):
             self.status_code = status_code
             self._payload = payload
             self.json_calls = 0
@@ -119,7 +119,7 @@ def test_fetch_json_dict_status_code_edges_mutmut():
             return self._payload
 
     class Client:
-        def init_(self, resp):
+        def __init__(self, resp):
             self.resp = resp
             self.calls = 0
 
@@ -149,7 +149,7 @@ def test_fetch_json_dict_retries_stop_after_success_mutmut():
     from sdetkit.apiclient import fetch_json_dict
 
     class Resp:
-        def init_(self, status_code, payload):
+        def __init__(self, status_code, payload):
             self.status_code = status_code
             self._payload = payload
 
@@ -157,7 +157,7 @@ def test_fetch_json_dict_retries_stop_after_success_mutmut():
             return self._payload
 
     class Client:
-        def init_(self, actions):
+        def __init__(self, actions):
             self.actions = list(actions)
             self.calls = 0
 
@@ -182,7 +182,7 @@ def test_fetch_json_dict_retries_exhausted_call_count_mutmut():
     from sdetkit.apiclient import fetch_json_dict
 
     class Client:
-        def init_(self, exc):
+        def __init__(self, exc):
             self.exc = exc
             self.calls = 0
 
@@ -205,7 +205,7 @@ def test_fetch_json_dict_timeout_is_timeout_error_mutmut():
     from sdetkit.apiclient import fetch_json_dict
 
     class Client:
-        def init_(self, exc):
+        def __init__(self, exc):
             self.exc = exc
             self.calls = 0
 

--- a/tests/test_apiclient_async.py
+++ b/tests/test_apiclient_async.py
@@ -172,7 +172,7 @@ def test_fetch_json_dict_async_status_code_edges_mutmut():
     from sdetkit.apiclient import fetch_json_dict_async
 
     class Resp:
-        def init_(self, status_code, payload):
+        def __init__(self, status_code, payload):
             self.status_code = status_code
             self._payload = payload
             self.json_calls = 0
@@ -182,7 +182,7 @@ def test_fetch_json_dict_async_status_code_edges_mutmut():
             return self._payload
 
     class Client:
-        def init_(self, resp):
+        def __init__(self, resp):
             self.resp = resp
             self.calls = 0
 
@@ -226,7 +226,7 @@ def test_fetch_json_dict_async_retries_stop_after_success_mutmut():
     from sdetkit.apiclient import fetch_json_dict_async
 
     class Resp:
-        def init_(self, status_code, payload):
+        def __init__(self, status_code, payload):
             self.status_code = status_code
             self._payload = payload
 
@@ -234,7 +234,7 @@ def test_fetch_json_dict_async_retries_stop_after_success_mutmut():
             return self._payload
 
     class Client:
-        def init_(self, actions):
+        def __init__(self, actions):
             self.actions = list(actions)
             self.calls = 0
 
@@ -263,7 +263,7 @@ def test_fetch_json_dict_async_retries_exhausted_call_count_mutmut():
     from sdetkit.apiclient import fetch_json_dict_async
 
     class Client:
-        def init_(self, exc):
+        def __init__(self, exc):
             self.exc = exc
             self.calls = 0
 
@@ -288,7 +288,7 @@ def test_fetch_json_dict_async_timeout_is_timeout_error_mutmut():
     from sdetkit.apiclient import fetch_json_dict_async
 
     class Client:
-        def init_(self, exc):
+        def __init__(self, exc):
             self.exc = exc
             self.calls = 0
 

--- a/tests/test_netclient_envelope_parity.py
+++ b/tests/test_netclient_envelope_parity.py
@@ -1,0 +1,105 @@
+import asyncio
+
+import httpx
+import pytest
+
+from sdetkit.netclient import SdetAsyncHttpClient, SdetHttpClient
+from sdetkit import apiclient
+
+
+def test_async_client_envelope_pagination_matches_sync_result():
+    sync_calls = []
+
+    def sync_handler(request):
+        sync_calls.append(str(request.url))
+        if len(sync_calls) == 1:
+            return httpx.Response(200, json={"items": [{"id": 1}], "next": "/p2"}, request=request)
+        return httpx.Response(200, json={"items": [{"id": 2}], "next": None}, request=request)
+
+    async_calls = []
+
+    async def async_handler(request):
+        async_calls.append(str(request.url))
+        if len(async_calls) == 1:
+            return httpx.Response(200, json={"items": [{"id": 1}], "next": "/p2"}, request=request)
+        return httpx.Response(200, json={"items": [{"id": 2}], "next": None}, request=request)
+
+    with httpx.Client(transport=httpx.MockTransport(sync_handler), base_url="https://example.test") as raw:
+        sync_client = SdetHttpClient(raw)
+        sync_result = sync_client.get_json_list_paginated_envelope("/p1")
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(async_handler), base_url="https://example.test") as raw:
+            async_client = SdetAsyncHttpClient(raw)
+            return await async_client.get_json_list_paginated_envelope("/p1")
+
+    assert asyncio.run(run()) == sync_result == [{"id": 1}, {"id": 2}]
+    assert sync_calls == async_calls == ["https://example.test/p1", "https://example.test/p2"]
+
+
+def test_async_client_envelope_pagination_validates_shape_and_cycle():
+    async def run_bad_page():
+        async def handler(request):
+            return httpx.Response(200, json=[{"id": 1}], request=request)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://example.test") as raw:
+            client = SdetAsyncHttpClient(raw)
+            return await client.get_json_list_paginated_envelope("/p1")
+
+    with pytest.raises(ValueError, match="expected json object"):
+        asyncio.run(run_bad_page())
+
+    async def run_bad_items():
+        async def handler(request):
+            return httpx.Response(200, json={"items": {"id": 1}, "next": None}, request=request)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://example.test") as raw:
+            client = SdetAsyncHttpClient(raw)
+            return await client.get_json_list_paginated_envelope("/p1")
+
+    with pytest.raises(ValueError, match="expected json array at key 'items'"):
+        asyncio.run(run_bad_items())
+
+    async def run_cycle():
+        async def handler(request):
+            return httpx.Response(200, json={"items": [1], "next": "/p1"}, request=request)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://example.test") as raw:
+            client = SdetAsyncHttpClient(raw)
+            return await client.get_json_list_paginated_envelope("/p1")
+
+    with pytest.raises(RuntimeError, match="pagination cycle detected"):
+        asyncio.run(run_cycle())
+
+
+def test_apiclient_exposes_sync_and_async_envelope_helpers():
+    assert hasattr(apiclient, "fetch_json_list_paginated_envelope")
+    assert hasattr(apiclient, "fetch_json_list_paginated_envelope_async")
+
+
+def test_apiclient_envelope_helpers_follow_pages():
+    sync_calls = []
+
+    def sync_handler(request):
+        sync_calls.append(str(request.url))
+        if len(sync_calls) == 1:
+            return httpx.Response(200, json={"items": ["a"], "next": "/p2"}, request=request)
+        return httpx.Response(200, json={"items": ["b"], "next": None}, request=request)
+
+    with httpx.Client(transport=httpx.MockTransport(sync_handler), base_url="https://example.test") as raw:
+        assert apiclient.fetch_json_list_paginated_envelope(raw, "/p1") == ["a", "b"]
+
+    async_calls = []
+
+    async def async_handler(request):
+        async_calls.append(str(request.url))
+        if len(async_calls) == 1:
+            return httpx.Response(200, json={"items": ["a"], "next": "/p2"}, request=request)
+        return httpx.Response(200, json={"items": ["b"], "next": None}, request=request)
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(async_handler), base_url="https://example.test") as raw:
+            return await apiclient.fetch_json_list_paginated_envelope_async(raw, "/p1")
+
+    assert asyncio.run(run()) == ["a", "b"]
+    assert sync_calls == async_calls == ["https://example.test/p1", "https://example.test/p2"]

--- a/tests/test_netclient_envelope_parity.py
+++ b/tests/test_netclient_envelope_parity.py
@@ -3,8 +3,8 @@ import asyncio
 import httpx
 import pytest
 
-from sdetkit.netclient import SdetAsyncHttpClient, SdetHttpClient
 from sdetkit import apiclient
+from sdetkit.netclient import SdetAsyncHttpClient, SdetHttpClient
 
 
 def test_async_client_envelope_pagination_matches_sync_result():
@@ -24,12 +24,16 @@ def test_async_client_envelope_pagination_matches_sync_result():
             return httpx.Response(200, json={"items": [{"id": 1}], "next": "/p2"}, request=request)
         return httpx.Response(200, json={"items": [{"id": 2}], "next": None}, request=request)
 
-    with httpx.Client(transport=httpx.MockTransport(sync_handler), base_url="https://example.test") as raw:
+    with httpx.Client(
+        transport=httpx.MockTransport(sync_handler), base_url="https://example.test"
+    ) as raw:
         sync_client = SdetHttpClient(raw)
         sync_result = sync_client.get_json_list_paginated_envelope("/p1")
 
     async def run():
-        async with httpx.AsyncClient(transport=httpx.MockTransport(async_handler), base_url="https://example.test") as raw:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(async_handler), base_url="https://example.test"
+        ) as raw:
             async_client = SdetAsyncHttpClient(raw)
             return await async_client.get_json_list_paginated_envelope("/p1")
 
@@ -42,7 +46,9 @@ def test_async_client_envelope_pagination_validates_shape_and_cycle():
         async def handler(request):
             return httpx.Response(200, json=[{"id": 1}], request=request)
 
-        async with httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://example.test") as raw:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), base_url="https://example.test"
+        ) as raw:
             client = SdetAsyncHttpClient(raw)
             return await client.get_json_list_paginated_envelope("/p1")
 
@@ -53,7 +59,9 @@ def test_async_client_envelope_pagination_validates_shape_and_cycle():
         async def handler(request):
             return httpx.Response(200, json={"items": {"id": 1}, "next": None}, request=request)
 
-        async with httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://example.test") as raw:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), base_url="https://example.test"
+        ) as raw:
             client = SdetAsyncHttpClient(raw)
             return await client.get_json_list_paginated_envelope("/p1")
 
@@ -64,7 +72,9 @@ def test_async_client_envelope_pagination_validates_shape_and_cycle():
         async def handler(request):
             return httpx.Response(200, json={"items": [1], "next": "/p1"}, request=request)
 
-        async with httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://example.test") as raw:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), base_url="https://example.test"
+        ) as raw:
             client = SdetAsyncHttpClient(raw)
             return await client.get_json_list_paginated_envelope("/p1")
 
@@ -86,7 +96,9 @@ def test_apiclient_envelope_helpers_follow_pages():
             return httpx.Response(200, json={"items": ["a"], "next": "/p2"}, request=request)
         return httpx.Response(200, json={"items": ["b"], "next": None}, request=request)
 
-    with httpx.Client(transport=httpx.MockTransport(sync_handler), base_url="https://example.test") as raw:
+    with httpx.Client(
+        transport=httpx.MockTransport(sync_handler), base_url="https://example.test"
+    ) as raw:
         assert apiclient.fetch_json_list_paginated_envelope(raw, "/p1") == ["a", "b"]
 
     async_calls = []
@@ -98,7 +110,9 @@ def test_apiclient_envelope_helpers_follow_pages():
         return httpx.Response(200, json={"items": ["b"], "next": None}, request=request)
 
     async def run():
-        async with httpx.AsyncClient(transport=httpx.MockTransport(async_handler), base_url="https://example.test") as raw:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(async_handler), base_url="https://example.test"
+        ) as raw:
             return await apiclient.fetch_json_list_paginated_envelope_async(raw, "/p1")
 
     assert asyncio.run(run()) == ["a", "b"]


### PR DESCRIPTION
## Summary

- Add `SdetAsyncHttpClient.get_json_list_paginated_envelope`.
- Add sync and async `apiclient` envelope pagination helpers.
- Add regression coverage for async/client/helper envelope pagination parity.
- Fix existing apiclient mutmut test doubles that used `init_` instead of `__init__`.

## Verification

- `tests/test_netclient_envelope_parity.py`: 4 passed
- bounded netclient/apiclient regression slice: expected 60 passed