### PR TITLE
Classify maintenance actions with adaptive diagnosis classes

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -165,6 +165,18 @@ jobs:
               --format md || true
           fi
 
+      - name: Build maintenance action categories
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-action-plan.json ]; then
+            python -m sdetkit.maintenance_action_categories \
+              --action-plan-json artifacts/maintenance-action-plan.json \
+              --out-json artifacts/maintenance-action-categories.json \
+              --out-md artifacts/maintenance-action-categories.md \
+              --format md || true
+          fi
+
       - name: Record maintenance policy decision history
         if: always()
         shell: bash
@@ -313,6 +325,9 @@ jobs:
             const actionPlanMd = fs.existsSync('artifacts/maintenance-action-plan.md')
               ? fs.readFileSync('artifacts/maintenance-action-plan.md', 'utf8')
               : '';
+            const actionCategoriesMd = fs.existsSync('artifacts/maintenance-action-categories.md')
+              ? fs.readFileSync('artifacts/maintenance-action-categories.md', 'utf8')
+              : '';
             const historyMd = fs.existsSync('artifacts/maintenance-policy-decision-history-summary.md')
               ? fs.readFileSync('artifacts/maintenance-policy-decision-history-summary.md', 'utf8')
               : '';
@@ -332,6 +347,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              actionCategoriesMd
+                ? '### Maintenance action categories'
+                : '',
+              actionCategoriesMd
+                ? (actionCategoriesMd.length > 3000 ? `${actionCategoriesMd.slice(0, 3000)}\n\n... (truncated)` : actionCategoriesMd)
+                : '',
               '',
               actionPlanMd
                 ? '### Maintenance action plan'

--- a/src/sdetkit/maintenance_action_categories.py
+++ b/src/sdetkit/maintenance_action_categories.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.maintenance.action_categories.v1"
+
+DIAGNOSTIC_ONLY = True
+AUTOMATION_ALLOWED = False
+
+REVIEW_FIRST = "review_first"
+CANDIDATE_LATER = "candidate_later"
+COMMAND_GUIDANCE = "command_guidance"
+POLICY_REQUIRED = "policy_required"
+
+CATEGORY_BY_DIAGNOSIS = {
+    "PRE_COMMIT_FORMAT_DRIFT": ("formatting", "low", CANDIDATE_LATER),
+    "RUFF_FIXABLE_LINT": ("lint", "low", CANDIDATE_LATER),
+    "MISSING_TEST_DEPENDENCY": ("dependency", "medium", REVIEW_FIRST),
+    "PYTHON_RUNTIME_COMPATIBILITY": ("runtime", "high", REVIEW_FIRST),
+    "LOCAL_ENVIRONMENT_FRICTION": ("environment", "medium", COMMAND_GUIDANCE),
+    "BROKEN_TEST_DOUBLE": ("tests", "medium", REVIEW_FIRST),
+    "MISSING_PUBLIC_API_PARITY": ("product_api", "high", REVIEW_FIRST),
+    "GIT_BRANCH_DIVERGED": ("git_workflow", "medium", COMMAND_GUIDANCE),
+    "REMOTE_BRANCH_DRIFT": ("git_workflow", "medium", COMMAND_GUIDANCE),
+    "PRODUCT_LOGIC_FAILURE": ("product_logic", "high", REVIEW_FIRST),
+    "PYTEST_ASSERTION_FAILURE": ("tests", "high", REVIEW_FIRST),
+    "PYTEST_IMPORT_FAILURE": ("tests", "high", REVIEW_FIRST),
+    "RUFF_LINT_FAILURE": ("lint", "medium", REVIEW_FIRST),
+    "MYPY_TYPE_CONTRACT_DRIFT": ("typing", "medium", REVIEW_FIRST),
+    "UNKNOWN_REVIEW_REQUIRED": ("unknown", "medium", REVIEW_FIRST),
+}
+
+DIAGNOSIS_HINTS = {
+    "ruff": "RUFF_FIXABLE_LINT",
+    "format": "PRE_COMMIT_FORMAT_DRIFT",
+    "pre-commit": "PRE_COMMIT_FORMAT_DRIFT",
+    "pytest": "PRODUCT_LOGIC_FAILURE",
+    "test": "PRODUCT_LOGIC_FAILURE",
+    "dependency": "MISSING_TEST_DEPENDENCY",
+    "python-version": "PYTHON_RUNTIME_COMPATIBILITY",
+    "runtime": "PYTHON_RUNTIME_COMPATIBILITY",
+    "annotation": "UNKNOWN_REVIEW_REQUIRED",
+    "workflow": "UNKNOWN_REVIEW_REQUIRED",
+    "security": "UNKNOWN_REVIEW_REQUIRED",
+}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _cell(value: Any) -> str:
+    return _text(value).replace("|", "\\|")
+
+
+def _read_json(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _item_text(item: dict[str, Any]) -> str:
+    parts = [
+        item.get("diagnosis_class"),
+        item.get("diagnosis_code"),
+        item.get("code"),
+        item.get("source_code"),
+        item.get("memory_lookup_key"),
+        item.get("signal"),
+        item.get("title"),
+        item.get("source"),
+        item.get("proof_needed"),
+        item.get("recommended_action"),
+    ]
+    return " ".join(_text(part) for part in parts).lower()
+
+
+def infer_diagnosis_class(item: dict[str, Any]) -> str:
+    for key in ("diagnosis_class", "diagnosis_code", "code", "source_code"):
+        value = _text(item.get(key))
+        if value in CATEGORY_BY_DIAGNOSIS:
+            return value
+
+    text = _item_text(item)
+    for hint, diagnosis in DIAGNOSIS_HINTS.items():
+        if hint in text:
+            return diagnosis
+
+    return "UNKNOWN_REVIEW_REQUIRED"
+
+
+def _route_for_item(item: dict[str, Any], diagnosis_class: str, default_route: str) -> str:
+    eligibility = _text(item.get("eligibility"))
+    readiness = _text(item.get("automation_readiness"))
+
+    if default_route == CANDIDATE_LATER:
+        if eligibility == "ELIGIBLE_PENDING_POLICY" and readiness == "AUTOMATION_READY":
+            return POLICY_REQUIRED
+        return CANDIDATE_LATER
+
+    if default_route == COMMAND_GUIDANCE:
+        return COMMAND_GUIDANCE
+
+    return REVIEW_FIRST
+
+
+def _reason(diagnosis_class: str, category: str, route: str) -> str:
+    if route == CANDIDATE_LATER:
+        return (
+            f"{diagnosis_class} is a narrow mechanical class, but it still needs "
+            "proof, trend history, and policy gates before automation."
+        )
+    if route == POLICY_REQUIRED:
+        return (
+            f"{diagnosis_class} has enough readiness signal to require an explicit "
+            "policy PR before any auto-fix behavior."
+        )
+    if route == COMMAND_GUIDANCE:
+        return (
+            f"{diagnosis_class} is {category} guidance. It should explain the next "
+            "operator command but must not mutate files."
+        )
+    return f"{diagnosis_class} is review-first and must not be auto-fixed."
+
+
+def _category_item(item: dict[str, Any]) -> dict[str, Any]:
+    diagnosis_class = infer_diagnosis_class(item)
+    category, risk_level, default_route = CATEGORY_BY_DIAGNOSIS.get(
+        diagnosis_class,
+        CATEGORY_BY_DIAGNOSIS["UNKNOWN_REVIEW_REQUIRED"],
+    )
+    safe_fix_route = _route_for_item(item, diagnosis_class, default_route)
+    review_required = safe_fix_route not in {CANDIDATE_LATER, POLICY_REQUIRED}
+
+    return {
+        "rank": item.get("rank", ""),
+        "signal": _text(item.get("signal")) or _text(item.get("title")) or _text(item.get("memory_lookup_key")),
+        "source": _text(item.get("source")),
+        "memory_lookup_key": _text(item.get("memory_lookup_key")),
+        "diagnosis_class": diagnosis_class,
+        "category": category,
+        "risk_level": risk_level,
+        "safe_fix_route": safe_fix_route,
+        "review_required": review_required,
+        "reason": _reason(diagnosis_class, category, safe_fix_route),
+    }
+
+
+def build_action_categories(action_plan_payload: dict[str, Any]) -> dict[str, Any]:
+    source_actions = _as_list(action_plan_payload.get("actions"))
+    items = [_category_item(_as_dict(item)) for item in source_actions if _as_dict(item)]
+
+    counts_by_category: dict[str, int] = {}
+    counts_by_diagnosis: dict[str, int] = {}
+    counts_by_route: dict[str, int] = {}
+    for item in items:
+        category = _text(item.get("category")) or "unknown"
+        diagnosis = _text(item.get("diagnosis_class")) or "UNKNOWN_REVIEW_REQUIRED"
+        route = _text(item.get("safe_fix_route")) or REVIEW_FIRST
+        counts_by_category[category] = counts_by_category.get(category, 0) + 1
+        counts_by_diagnosis[diagnosis] = counts_by_diagnosis.get(diagnosis, 0) + 1
+        counts_by_route[route] = counts_by_route.get(route, 0) + 1
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": bool(action_plan_payload.get("ok", True)),
+        "source_schema_version": _text(action_plan_payload.get("schema_version")),
+        "diagnostic_only": DIAGNOSTIC_ONLY,
+        "automation_allowed": AUTOMATION_ALLOWED,
+        "category_count": len(counts_by_category),
+        "item_count": len(items),
+        "counts_by_category": dict(sorted(counts_by_category.items())),
+        "counts_by_diagnosis": dict(sorted(counts_by_diagnosis.items())),
+        "counts_by_route": dict(sorted(counts_by_route.items())),
+        "items": items,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Maintenance action categories",
+        "",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- categories: **{payload.get('category_count', 0)}**",
+        f"- items: **{payload.get('item_count', 0)}**",
+    ]
+
+    categories = _as_dict(payload.get("counts_by_category"))
+    if categories:
+        lines.extend(
+            [
+                "",
+                "## Category mix",
+                "",
+                "| Category | Count |",
+                "|---|---:|",
+            ]
+        )
+        for category, count in sorted(categories.items()):
+            lines.append(f"| {_cell(category)} | {count} |")
+
+    routes = _as_dict(payload.get("counts_by_route"))
+    if routes:
+        lines.extend(
+            [
+                "",
+                "## Safe-fix route mix",
+                "",
+                "| Route | Count |",
+                "|---|---:|",
+            ]
+        )
+        for route, count in sorted(routes.items()):
+            lines.append(f"| {_cell(route)} | {count} |")
+
+    items = _as_list(payload.get("items"))
+    if not items:
+        lines.extend(["", "No maintenance actions were categorized."])
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines.extend(
+        [
+            "",
+            "## Classified actions",
+            "",
+            "| Rank | Category | Diagnosis | Risk | Route | Signal |",
+            "|---:|---|---|---|---|---|",
+        ]
+    )
+    for item in items:
+        row = _as_dict(item)
+        lines.append(
+            f"| {row.get('rank', '')} | {_cell(row.get('category'))} | "
+            f"{_cell(row.get('diagnosis_class'))} | {_cell(row.get('risk_level'))} | "
+            f"{_cell(row.get('safe_fix_route'))} | {_cell(row.get('signal'))} |"
+        )
+
+    lines.extend(["", "## Review notes", ""])
+    for item in items[:8]:
+        row = _as_dict(item)
+        lines.append(f"- **{_cell(row.get('signal'))}**: {_cell(row.get('reason'))}")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.maintenance_action_categories")
+    parser.add_argument("--action-plan-json", required=True)
+    parser.add_argument("--out-json")
+    parser.add_argument("--out-md")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_action_categories(_read_json(args.action_plan_json) or {})
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    md_text = render_markdown(payload)
+
+    if args.out_json:
+        Path(args.out_json).write_text(json_text, encoding="utf-8")
+    if args.out_md:
+        Path(args.out_md).write_text(md_text, encoding="utf-8")
+
+    print(json_text if args.format == "json" else md_text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/maintenance_action_categories.py
+++ b/src/sdetkit/maintenance_action_categories.py
@@ -148,7 +148,9 @@ def _category_item(item: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "rank": item.get("rank", ""),
-        "signal": _text(item.get("signal")) or _text(item.get("title")) or _text(item.get("memory_lookup_key")),
+        "signal": _text(item.get("signal"))
+        or _text(item.get("title"))
+        or _text(item.get("memory_lookup_key")),
         "source": _text(item.get("source")),
         "memory_lookup_key": _text(item.get("memory_lookup_key")),
         "diagnosis_class": diagnosis_class,

--- a/tests/test_maintenance_action_categories.py
+++ b/tests/test_maintenance_action_categories.py
@@ -1,0 +1,171 @@
+import json
+
+from sdetkit import maintenance_action_categories as categories
+
+
+def _action_plan_payload():
+    return {
+        "schema_version": "sdetkit.maintenance.action_plan.v1",
+        "ok": True,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "actions": [
+            {
+                "rank": 1,
+                "signal": "Run ruff check",
+                "source": "safe_fix_rollup",
+                "memory_lookup_key": "safe-fix:ruff",
+                "eligibility": "DEFERRED",
+                "automation_readiness": "CANDIDATE_LATER",
+                "proof_needed": "Require repeated successful runs.",
+            },
+            {
+                "rank": 2,
+                "signal": "Run pytest -q",
+                "source": "maintenance_action",
+                "memory_lookup_key": "maintenance-action:tests_check:run-tests",
+                "eligibility": "REVIEW_REQUIRED",
+                "automation_readiness": "REVIEW_FIRST",
+                "proof_needed": "Attach passing test output.",
+            },
+            {
+                "rank": 3,
+                "signal": "Fix Python runtime compatibility",
+                "source": "maintenance_action",
+                "memory_lookup_key": "diagnosis:PYTHON_RUNTIME_COMPATIBILITY:runtime",
+                "diagnosis_class": "PYTHON_RUNTIME_COMPATIBILITY",
+                "eligibility": "REVIEW_REQUIRED",
+                "automation_readiness": "REVIEW_FIRST",
+            },
+            {
+                "rank": 4,
+                "signal": "Sync branch before push",
+                "source": "git",
+                "memory_lookup_key": "diagnosis:GIT_BRANCH_DIVERGED:git",
+                "diagnosis_class": "GIT_BRANCH_DIVERGED",
+                "eligibility": "REVIEW_REQUIRED",
+                "automation_readiness": "REVIEW_FIRST",
+            },
+            {
+                "rank": 5,
+                "signal": "Safe format drift appears stable",
+                "source": "safe_fix_rollup",
+                "memory_lookup_key": "diagnosis:PRE_COMMIT_FORMAT_DRIFT:formatting",
+                "diagnosis_class": "PRE_COMMIT_FORMAT_DRIFT",
+                "eligibility": "ELIGIBLE_PENDING_POLICY",
+                "automation_readiness": "AUTOMATION_READY",
+            },
+        ],
+    }
+
+
+def test_build_action_categories_keeps_diagnostic_only_and_maps_classes():
+    payload = categories.build_action_categories(_action_plan_payload())
+
+    assert payload["schema_version"] == "sdetkit.maintenance.action_categories.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["item_count"] == 5
+
+    by_key = {item["memory_lookup_key"]: item for item in payload["items"]}
+
+    ruff = by_key["safe-fix:ruff"]
+    assert ruff["diagnosis_class"] == "RUFF_FIXABLE_LINT"
+    assert ruff["category"] == "lint"
+    assert ruff["risk_level"] == "low"
+    assert ruff["safe_fix_route"] == "candidate_later"
+    assert ruff["review_required"] is False
+
+    tests = by_key["maintenance-action:tests_check:run-tests"]
+    assert tests["diagnosis_class"] == "PRODUCT_LOGIC_FAILURE"
+    assert tests["category"] == "product_logic"
+    assert tests["safe_fix_route"] == "review_first"
+    assert tests["review_required"] is True
+
+    runtime = by_key["diagnosis:PYTHON_RUNTIME_COMPATIBILITY:runtime"]
+    assert runtime["category"] == "runtime"
+    assert runtime["risk_level"] == "high"
+    assert runtime["review_required"] is True
+
+    git = by_key["diagnosis:GIT_BRANCH_DIVERGED:git"]
+    assert git["safe_fix_route"] == "command_guidance"
+    assert git["review_required"] is True
+
+    policy = by_key["diagnosis:PRE_COMMIT_FORMAT_DRIFT:formatting"]
+    assert policy["safe_fix_route"] == "policy_required"
+    assert policy["review_required"] is False
+
+
+def test_counts_are_deterministic():
+    payload = categories.build_action_categories(_action_plan_payload())
+
+    assert payload["counts_by_category"] == {
+        "formatting": 1,
+        "git_workflow": 1,
+        "lint": 1,
+        "product_logic": 1,
+        "runtime": 1,
+    }
+    assert payload["counts_by_route"] == {
+        "candidate_later": 1,
+        "command_guidance": 1,
+        "policy_required": 1,
+        "review_first": 2,
+    }
+
+
+def test_unknown_action_is_review_first():
+    payload = categories.build_action_categories(
+        {
+            "actions": [
+                {
+                    "rank": 1,
+                    "signal": "Unexpected maintenance signal",
+                    "memory_lookup_key": "unknown:signal",
+                }
+            ]
+        }
+    )
+
+    item = payload["items"][0]
+    assert item["diagnosis_class"] == "UNKNOWN_REVIEW_REQUIRED"
+    assert item["category"] == "unknown"
+    assert item["safe_fix_route"] == "review_first"
+    assert item["review_required"] is True
+
+
+def test_render_markdown_is_comment_ready():
+    payload = categories.build_action_categories(_action_plan_payload())
+    rendered = categories.render_markdown(payload)
+
+    assert "# Maintenance action categories" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "Category mix" in rendered
+    assert "Classified actions" in rendered
+    assert "PYTHON_RUNTIME_COMPATIBILITY" in rendered
+
+
+def test_cli_writes_json_and_markdown(tmp_path):
+    source = tmp_path / "action-plan.json"
+    out_json = tmp_path / "categories.json"
+    out_md = tmp_path / "categories.md"
+    source.write_text(json.dumps(_action_plan_payload()), encoding="utf-8")
+
+    rc = categories.main(
+        [
+            "--action-plan-json",
+            str(source),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "md",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.maintenance.action_categories.v1"
+    assert payload["automation_allowed"] is False
+    assert "Maintenance action categories" in out_md.read_text(encoding="utf-8")

--- a/tests/test_maintenance_on_demand_action_categories_workflow.py
+++ b/tests/test_maintenance_on_demand_action_categories_workflow.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_builds_action_categories_after_action_plan():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Build maintenance action categories" in text
+    assert "python -m sdetkit.maintenance_action_categories" in text
+    assert "if [ -f artifacts/maintenance-action-plan.json ]; then" in text
+    assert "--action-plan-json artifacts/maintenance-action-plan.json" in text
+    assert "--out-json artifacts/maintenance-action-categories.json" in text
+    assert "--out-md artifacts/maintenance-action-categories.md" in text
+    assert text.index("Build maintenance action plan") < text.index(
+        "Build maintenance action categories"
+    )
+    assert text.index("Build maintenance action categories") < text.index(
+        "Record maintenance policy decision history"
+    )
+
+
+def test_maintenance_on_demand_uploads_action_category_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-action-categories.json" in text
+    assert "artifacts/maintenance-action-categories.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_action_categories_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "const actionCategoriesMd = fs.existsSync('artifacts/maintenance-action-categories.md')" in text
+    assert "### Maintenance action categories" in text
+    assert "actionCategoriesMd.length > 3000" in text
+
+
+def test_action_categories_appear_before_action_plan_in_issue_comment():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.index("### Maintenance action categories") < text.index(
+        "### Maintenance action plan"
+    )

--- a/tests/test_maintenance_on_demand_action_categories_workflow.py
+++ b/tests/test_maintenance_on_demand_action_categories_workflow.py
@@ -31,7 +31,10 @@ def test_maintenance_on_demand_uploads_action_category_artifacts():
 def test_maintenance_issue_comment_includes_action_categories_when_present():
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert "const actionCategoriesMd = fs.existsSync('artifacts/maintenance-action-categories.md')" in text
+    assert (
+        "const actionCategoriesMd = fs.existsSync('artifacts/maintenance-action-categories.md')"
+        in text
+    )
     assert "### Maintenance action categories" in text
     assert "actionCategoriesMd.length > 3000" in text
 


### PR DESCRIPTION
Closes #1158

## Summary

- Add diagnostic-only maintenance action categories derived from adaptive diagnosis classes.
- Emit maintenance-action-categories JSON and Markdown artifacts.
- Publish action categories in maintenance-on-demand artifacts and issue comments before the action plan.
- Keep auto-fix behavior disabled.

## Safety

- Diagnostic-only.
- automation_allowed remains false.
- No auto-fix allowlist changes.
- No remediation or branch mutation behavior changes.

## Verification

- PYTHONPATH=src .venv311/bin/python -m pytest -q tests/test_maintenance_action_categories.py tests/test_maintenance_on_demand_action_categories_workflow.py tests/test_maintenance_action_plan.py tests/test_maintenance_on_demand_action_plan_workflow.py
- ./scripts/pr_preflight.sh