### PR TITLE
Publish maintenance proof checklist

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -177,6 +177,18 @@ jobs:
               --format md || true
           fi
 
+      - name: Build maintenance proof checklist
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-action-categories.json ]; then
+            python -m sdetkit.maintenance_proof_checklist \
+              --action-categories-json artifacts/maintenance-action-categories.json \
+              --out-json artifacts/maintenance-proof-checklist.json \
+              --out-md artifacts/maintenance-proof-checklist.md \
+              --format md || true
+          fi
+
       - name: Record maintenance policy decision history
         if: always()
         shell: bash
@@ -328,6 +340,9 @@ jobs:
             const actionCategoriesMd = fs.existsSync('artifacts/maintenance-action-categories.md')
               ? fs.readFileSync('artifacts/maintenance-action-categories.md', 'utf8')
               : '';
+            const proofChecklistMd = fs.existsSync('artifacts/maintenance-proof-checklist.md')
+              ? fs.readFileSync('artifacts/maintenance-proof-checklist.md', 'utf8')
+              : '';
             const historyMd = fs.existsSync('artifacts/maintenance-policy-decision-history-summary.md')
               ? fs.readFileSync('artifacts/maintenance-policy-decision-history-summary.md', 'utf8')
               : '';
@@ -347,6 +362,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              proofChecklistMd
+                ? '### Maintenance proof checklist'
+                : '',
+              proofChecklistMd
+                ? (proofChecklistMd.length > 3000 ? `${proofChecklistMd.slice(0, 3000)}\n\n... (truncated)` : proofChecklistMd)
+                : '',
               '',
               actionCategoriesMd
                 ? '### Maintenance action categories'

--- a/src/sdetkit/maintenance_proof_checklist.py
+++ b/src/sdetkit/maintenance_proof_checklist.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.maintenance.proof_checklist.v1"
+
+DIAGNOSTIC_ONLY = True
+AUTOMATION_ALLOWED = False
+
+PROOF_BY_DIAGNOSIS = {
+    "PRE_COMMIT_FORMAT_DRIFT": {
+        "required_proof": "Attach clean pre-commit output after formatter changes.",
+        "proof_commands": ["python -m pre_commit run -a"],
+        "required_artifacts": ["pre-commit output", "git diff/stat"],
+    },
+    "RUFF_FIXABLE_LINT": {
+        "required_proof": "Attach clean Ruff check and format output after the fix.",
+        "proof_commands": [
+            "python -m ruff check src tests",
+            "python -m ruff format --check src tests",
+        ],
+        "required_artifacts": ["ruff check output", "ruff format output"],
+    },
+    "MISSING_TEST_DEPENDENCY": {
+        "required_proof": "Attach dependency installation output and rerun the failed test command.",
+        "proof_commands": ["python -m pip install -r requirements-test.txt", "python -m pytest -q"],
+        "required_artifacts": ["install output", "pytest output"],
+    },
+    "PYTHON_RUNTIME_COMPATIBILITY": {
+        "required_proof": "Attach supported Python version output and focused compatibility test results.",
+        "proof_commands": ["python --version", "python -m pytest -q"],
+        "required_artifacts": ["python version", "pytest output"],
+    },
+    "LOCAL_ENVIRONMENT_FRICTION": {
+        "required_proof": "Attach rerun evidence from a native filesystem or clean environment.",
+        "proof_commands": ["python -m venv .venv", "python -m pytest -q"],
+        "required_artifacts": ["environment note", "rerun output"],
+    },
+    "BROKEN_TEST_DOUBLE": {
+        "required_proof": "Attach focused test output proving the test harness fix.",
+        "proof_commands": ["python -m pytest -q <focused-test>"],
+        "required_artifacts": ["focused pytest output"],
+    },
+    "MISSING_PUBLIC_API_PARITY": {
+        "required_proof": "Attach focused parity tests for the missing public surface.",
+        "proof_commands": ["python -m pytest -q <focused-parity-test>"],
+        "required_artifacts": ["parity test output"],
+    },
+    "GIT_BRANCH_DIVERGED": {
+        "required_proof": "Attach fetch/rebase proof and rerun checks after the branch is synchronized.",
+        "proof_commands": ["git fetch origin <branch>", "git rebase origin/<branch>", "python -m pre_commit run -a"],
+        "required_artifacts": ["git rebase output", "pre-commit output"],
+    },
+    "REMOTE_BRANCH_DRIFT": {
+        "required_proof": "Attach proof rerun after rebasing on the updated remote branch.",
+        "proof_commands": ["git rebase origin/<branch>", "python -m pre_commit run -a"],
+        "required_artifacts": ["git rebase output", "pre-commit output"],
+    },
+    "PRODUCT_LOGIC_FAILURE": {
+        "required_proof": "Attach the focused failing test before the fix and passing output after the fix.",
+        "proof_commands": ["python -m pytest -q <focused-test>"],
+        "required_artifacts": ["before/after focused pytest output"],
+    },
+    "UNKNOWN_REVIEW_REQUIRED": {
+        "required_proof": "Attach the first actionable traceback or command log before progressing.",
+        "proof_commands": ["python -m pre_commit run -a"],
+        "required_artifacts": ["failure log", "review note"],
+    },
+}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _cell(value: Any) -> str:
+    return _text(value).replace("|", "\\|")
+
+
+def _read_json(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _proof_for_diagnosis(diagnosis_class: str) -> dict[str, Any]:
+    return PROOF_BY_DIAGNOSIS.get(diagnosis_class, PROOF_BY_DIAGNOSIS["UNKNOWN_REVIEW_REQUIRED"])
+
+
+def _proof_status(item: dict[str, Any]) -> str:
+    explicit = _text(item.get("proof_status"))
+    if explicit:
+        return explicit
+    evidence = _as_list(item.get("proof_evidence")) or _as_list(item.get("attached_proof"))
+    return "complete" if evidence else "missing"
+
+
+def _checklist_item(item: dict[str, Any]) -> dict[str, Any]:
+    diagnosis_class = _text(item.get("diagnosis_class")) or "UNKNOWN_REVIEW_REQUIRED"
+    proof = _proof_for_diagnosis(diagnosis_class)
+    status = _proof_status(item)
+    can_progress = status == "complete"
+
+    return {
+        "rank": item.get("rank", ""),
+        "signal": _text(item.get("signal")) or _text(item.get("memory_lookup_key")),
+        "memory_lookup_key": _text(item.get("memory_lookup_key")),
+        "diagnosis_class": diagnosis_class,
+        "category": _text(item.get("category")),
+        "risk_level": _text(item.get("risk_level")),
+        "safe_fix_route": _text(item.get("safe_fix_route")),
+        "required_proof": proof["required_proof"],
+        "proof_status": status,
+        "proof_commands": list(proof["proof_commands"]),
+        "required_artifacts": list(proof["required_artifacts"]),
+        "can_progress_to_candidate": can_progress,
+        "blocking_reason": "" if can_progress else "Required proof has not been attached.",
+    }
+
+
+def build_proof_checklist(action_categories_payload: dict[str, Any]) -> dict[str, Any]:
+    items = [
+        _checklist_item(_as_dict(item))
+        for item in _as_list(action_categories_payload.get("items"))
+        if _as_dict(item)
+    ]
+    complete_count = sum(1 for item in items if item["proof_status"] == "complete")
+    missing_count = sum(1 for item in items if item["proof_status"] != "complete")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": bool(action_categories_payload.get("ok", True)),
+        "source_schema_version": _text(action_categories_payload.get("schema_version")),
+        "diagnostic_only": DIAGNOSTIC_ONLY,
+        "automation_allowed": AUTOMATION_ALLOWED,
+        "proof_item_count": len(items),
+        "complete_count": complete_count,
+        "missing_count": missing_count,
+        "items": items,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Maintenance proof checklist",
+        "",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- proof items: **{payload.get('proof_item_count', 0)}**",
+        f"- complete proof: **{payload.get('complete_count', 0)}**",
+        f"- missing proof: **{payload.get('missing_count', 0)}**",
+    ]
+
+    items = _as_list(payload.get("items"))
+    if not items:
+        lines.extend(["", "No maintenance proof items were generated."])
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines.extend(
+        [
+            "",
+            "## Proof checklist",
+            "",
+            "| Rank | Signal | Diagnosis | Proof status | Required proof | Can progress |",
+            "|---:|---|---|---|---|---|",
+        ]
+    )
+    for item in items:
+        row = _as_dict(item)
+        lines.append(
+            f"| {row.get('rank', '')} | {_cell(row.get('signal'))} | "
+            f"{_cell(row.get('diagnosis_class'))} | {_cell(row.get('proof_status'))} | "
+            f"{_cell(row.get('required_proof'))} | {bool(row.get('can_progress_to_candidate'))} |"
+        )
+
+    lines.extend(["", "## Proof commands", ""])
+    for item in items[:8]:
+        row = _as_dict(item)
+        commands = ", ".join(f"`{cmd}`" for cmd in _as_list(row.get("proof_commands")))
+        lines.append(f"- **{_cell(row.get('signal'))}**: {commands}")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.maintenance_proof_checklist")
+    parser.add_argument("--action-categories-json", required=True)
+    parser.add_argument("--out-json")
+    parser.add_argument("--out-md")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_proof_checklist(_read_json(args.action_categories_json) or {})
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    md_text = render_markdown(payload)
+
+    if args.out_json:
+        Path(args.out_json).write_text(json_text, encoding="utf-8")
+    if args.out_md:
+        Path(args.out_md).write_text(md_text, encoding="utf-8")
+
+    print(json_text if args.format == "json" else md_text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/maintenance_proof_checklist.py
+++ b/src/sdetkit/maintenance_proof_checklist.py
@@ -51,7 +51,11 @@ PROOF_BY_DIAGNOSIS = {
     },
     "GIT_BRANCH_DIVERGED": {
         "required_proof": "Attach fetch/rebase proof and rerun checks after the branch is synchronized.",
-        "proof_commands": ["git fetch origin <branch>", "git rebase origin/<branch>", "python -m pre_commit run -a"],
+        "proof_commands": [
+            "git fetch origin <branch>",
+            "git rebase origin/<branch>",
+            "python -m pre_commit run -a",
+        ],
         "required_artifacts": ["git rebase output", "pre-commit output"],
     },
     "REMOTE_BRANCH_DRIFT": {

--- a/tests/test_maintenance_on_demand_proof_checklist_workflow.py
+++ b/tests/test_maintenance_on_demand_proof_checklist_workflow.py
@@ -31,7 +31,9 @@ def test_maintenance_on_demand_uploads_proof_checklist_artifacts():
 def test_maintenance_issue_comment_includes_proof_checklist_when_present():
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert "const proofChecklistMd = fs.existsSync('artifacts/maintenance-proof-checklist.md')" in text
+    assert (
+        "const proofChecklistMd = fs.existsSync('artifacts/maintenance-proof-checklist.md')" in text
+    )
     assert "### Maintenance proof checklist" in text
     assert "proofChecklistMd.length > 3000" in text
 

--- a/tests/test_maintenance_on_demand_proof_checklist_workflow.py
+++ b/tests/test_maintenance_on_demand_proof_checklist_workflow.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_builds_proof_checklist_after_action_categories():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Build maintenance proof checklist" in text
+    assert "python -m sdetkit.maintenance_proof_checklist" in text
+    assert "if [ -f artifacts/maintenance-action-categories.json ]; then" in text
+    assert "--action-categories-json artifacts/maintenance-action-categories.json" in text
+    assert "--out-json artifacts/maintenance-proof-checklist.json" in text
+    assert "--out-md artifacts/maintenance-proof-checklist.md" in text
+    assert text.index("Build maintenance action categories") < text.index(
+        "Build maintenance proof checklist"
+    )
+    assert text.index("Build maintenance proof checklist") < text.index(
+        "Record maintenance policy decision history"
+    )
+
+
+def test_maintenance_on_demand_uploads_proof_checklist_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-proof-checklist.json" in text
+    assert "artifacts/maintenance-proof-checklist.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_proof_checklist_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "const proofChecklistMd = fs.existsSync('artifacts/maintenance-proof-checklist.md')" in text
+    assert "### Maintenance proof checklist" in text
+    assert "proofChecklistMd.length > 3000" in text
+
+
+def test_proof_checklist_appears_before_action_categories_in_issue_comment():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.index("### Maintenance proof checklist") < text.index(
+        "### Maintenance action categories"
+    )

--- a/tests/test_maintenance_proof_checklist.py
+++ b/tests/test_maintenance_proof_checklist.py
@@ -1,0 +1,139 @@
+import json
+
+from sdetkit import maintenance_proof_checklist as checklist
+
+
+def _categories_payload():
+    return {
+        "schema_version": "sdetkit.maintenance.action_categories.v1",
+        "ok": True,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "items": [
+            {
+                "rank": 1,
+                "signal": "Run ruff check",
+                "memory_lookup_key": "diagnosis:RUFF_FIXABLE_LINT:lint",
+                "diagnosis_class": "RUFF_FIXABLE_LINT",
+                "category": "lint",
+                "risk_level": "low",
+                "safe_fix_route": "candidate_later",
+            },
+            {
+                "rank": 2,
+                "signal": "Run pytest -q",
+                "memory_lookup_key": "diagnosis:PRODUCT_LOGIC_FAILURE:tests",
+                "diagnosis_class": "PRODUCT_LOGIC_FAILURE",
+                "category": "product_logic",
+                "risk_level": "high",
+                "safe_fix_route": "review_first",
+            },
+            {
+                "rank": 3,
+                "signal": "Sync branch before push",
+                "memory_lookup_key": "diagnosis:GIT_BRANCH_DIVERGED:git",
+                "diagnosis_class": "GIT_BRANCH_DIVERGED",
+                "category": "git_workflow",
+                "risk_level": "medium",
+                "safe_fix_route": "command_guidance",
+                "proof_status": "complete",
+                "proof_evidence": ["rebased and preflight passed"],
+            },
+            {
+                "rank": 4,
+                "signal": "Unknown maintenance signal",
+                "memory_lookup_key": "diagnosis:UNKNOWN_REVIEW_REQUIRED:unknown",
+                "diagnosis_class": "UNKNOWN_REVIEW_REQUIRED",
+                "category": "unknown",
+                "risk_level": "medium",
+                "safe_fix_route": "review_first",
+            },
+        ],
+    }
+
+
+def test_build_proof_checklist_blocks_missing_proof_and_keeps_diagnostic_only():
+    payload = checklist.build_proof_checklist(_categories_payload())
+
+    assert payload["schema_version"] == "sdetkit.maintenance.proof_checklist.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["proof_item_count"] == 4
+    assert payload["complete_count"] == 1
+    assert payload["missing_count"] == 3
+
+    by_key = {item["memory_lookup_key"]: item for item in payload["items"]}
+
+    ruff = by_key["diagnosis:RUFF_FIXABLE_LINT:lint"]
+    assert ruff["proof_status"] == "missing"
+    assert ruff["can_progress_to_candidate"] is False
+    assert ruff["blocking_reason"] == "Required proof has not been attached."
+    assert "ruff check" in " ".join(ruff["proof_commands"]).lower()
+
+    product = by_key["diagnosis:PRODUCT_LOGIC_FAILURE:tests"]
+    assert product["required_artifacts"] == ["before/after focused pytest output"]
+    assert product["can_progress_to_candidate"] is False
+
+    git = by_key["diagnosis:GIT_BRANCH_DIVERGED:git"]
+    assert git["proof_status"] == "complete"
+    assert git["can_progress_to_candidate"] is True
+    assert git["blocking_reason"] == ""
+
+
+def test_unknown_diagnosis_gets_review_required_proof():
+    payload = checklist.build_proof_checklist(
+        {
+            "items": [
+                {
+                    "rank": 1,
+                    "signal": "Unclassified thing",
+                    "memory_lookup_key": "unknown:signal",
+                    "diagnosis_class": "NOT_A_REAL_CLASS",
+                }
+            ]
+        }
+    )
+
+    item = payload["items"][0]
+    assert item["diagnosis_class"] == "NOT_A_REAL_CLASS"
+    assert item["required_artifacts"] == ["failure log", "review note"]
+    assert item["proof_status"] == "missing"
+    assert item["can_progress_to_candidate"] is False
+
+
+def test_render_markdown_is_comment_ready():
+    payload = checklist.build_proof_checklist(_categories_payload())
+    rendered = checklist.render_markdown(payload)
+
+    assert "# Maintenance proof checklist" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "missing proof: **3**" in rendered
+    assert "Proof checklist" in rendered
+    assert "Proof commands" in rendered
+    assert "RUFF_FIXABLE_LINT" in rendered
+
+
+def test_cli_writes_json_and_markdown(tmp_path):
+    source = tmp_path / "categories.json"
+    out_json = tmp_path / "proof-checklist.json"
+    out_md = tmp_path / "proof-checklist.md"
+    source.write_text(json.dumps(_categories_payload()), encoding="utf-8")
+
+    rc = checklist.main(
+        [
+            "--action-categories-json",
+            str(source),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "md",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.maintenance.proof_checklist.v1"
+    assert payload["missing_count"] == 3
+    assert "Maintenance proof checklist" in out_md.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #1159

## Summary

- Add diagnostic-only maintenance proof checklist artifacts.
- Convert maintenance action categories into explicit proof requirements.
- Block candidate progression when proof is missing.
- Publish maintenance-proof-checklist JSON/Markdown artifacts in maintenance-on-demand.
- Add the proof checklist to maintenance issue comments before action categories.

## Safety

- Diagnostic-only.
- automation_allowed remains false.
- No auto-fix behavior added.
- Missing proof blocks candidate/probation progression.

## Verification

- PYTHONPATH=src .venv311/bin/python -m pytest -q tests/test_maintenance_proof_checklist.py tests/test_maintenance_on_demand_proof_checklist_workflow.py tests/test_maintenance_action_categories.py tests/test_maintenance_on_demand_action_categories_workflow.py
- ./scripts/pr_preflight.sh