### PR TITLE
Publish maintenance signal trend summary

### DIFF
--- a/.github/workflows/maintenance-on-demand.yml
+++ b/.github/workflows/maintenance-on-demand.yml
@@ -189,6 +189,27 @@ jobs:
               --format md || true
           fi
 
+      - name: Build maintenance signal trends
+        if: always()
+        shell: bash
+        run: |
+          if [ -f artifacts/maintenance-proof-checklist.json ]; then
+            args=(
+              --proof-checklist-json artifacts/maintenance-proof-checklist.json
+              --out-json artifacts/maintenance-signal-trends.json
+              --out-md artifacts/maintenance-signal-trends.md
+            )
+            if [ -f artifacts/maintenance-policy-decisions-history.jsonl ]; then
+              args+=(--history-jsonl artifacts/maintenance-policy-decisions-history.jsonl)
+            fi
+            if [ -f artifacts/adaptive-safe-fix-learning-rollup.json ]; then
+              args+=(--safe-fix-rollup-json artifacts/adaptive-safe-fix-learning-rollup.json)
+            fi
+            python -m sdetkit.maintenance_signal_trends \
+              "${args[@]}" \
+              --format md || true
+          fi
+
       - name: Record maintenance policy decision history
         if: always()
         shell: bash
@@ -343,6 +364,9 @@ jobs:
             const proofChecklistMd = fs.existsSync('artifacts/maintenance-proof-checklist.md')
               ? fs.readFileSync('artifacts/maintenance-proof-checklist.md', 'utf8')
               : '';
+            const signalTrendsMd = fs.existsSync('artifacts/maintenance-signal-trends.md')
+              ? fs.readFileSync('artifacts/maintenance-signal-trends.md', 'utf8')
+              : '';
             const historyMd = fs.existsSync('artifacts/maintenance-policy-decision-history-summary.md')
               ? fs.readFileSync('artifacts/maintenance-policy-decision-history-summary.md', 'utf8')
               : '';
@@ -362,6 +386,13 @@ jobs:
               rows || '| n/a | n/a | n/a |',
               '',
               md.length > 5000 ? `${md.slice(0, 5000)}\n\n... (truncated)` : md,
+              '',
+              signalTrendsMd
+                ? '### Maintenance signal trends'
+                : '',
+              signalTrendsMd
+                ? (signalTrendsMd.length > 3000 ? `${signalTrendsMd.slice(0, 3000)}\n\n... (truncated)` : signalTrendsMd)
+                : '',
               '',
               proofChecklistMd
                 ? '### Maintenance proof checklist'

--- a/src/sdetkit/maintenance_signal_trends.py
+++ b/src/sdetkit/maintenance_signal_trends.py
@@ -160,7 +160,9 @@ def _matching_safe_context(
     return {}
 
 
-def _trend(seen_count: int, recent_count: int, safe_fix_attempts: int, safe_fix_successes: int) -> str:
+def _trend(
+    seen_count: int, recent_count: int, safe_fix_attempts: int, safe_fix_successes: int
+) -> str:
     if safe_fix_attempts and safe_fix_successes >= safe_fix_attempts:
         return "previously_fixed"
     if seen_count >= 3 and recent_count >= 1:

--- a/src/sdetkit/maintenance_signal_trends.py
+++ b/src/sdetkit/maintenance_signal_trends.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.maintenance.signal_trends.v1"
+
+DIAGNOSTIC_ONLY = True
+AUTOMATION_ALLOWED = False
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _cell(value: Any) -> str:
+    return _text(value).replace("|", "\\|")
+
+
+def _read_json(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _read_jsonl(path: str | None) -> list[dict[str, Any]]:
+    if not path:
+        return []
+    p = Path(path)
+    if not p.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for raw in p.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        item = json.loads(raw)
+        if isinstance(item, dict):
+            rows.append(item)
+    return rows
+
+
+def _history_key(item: dict[str, Any]) -> str:
+    return (
+        _text(item.get("memory_lookup_key"))
+        or _text(item.get("source_key"))
+        or f"{_text(item.get('source'))}:{_text(item.get('title'))}"
+    )
+
+
+def _history_counts(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    by_key: dict[str, dict[str, Any]] = {}
+    recent_records = records[-5:]
+    recent_keys: set[str] = set()
+
+    for record in recent_records:
+        payload = _as_dict(record)
+        for decision in _as_list(payload.get("decisions")):
+            key = _history_key(_as_dict(decision))
+            if key:
+                recent_keys.add(key)
+
+    for record in records:
+        payload = _as_dict(record)
+        for decision in _as_list(payload.get("decisions")):
+            row = _as_dict(decision)
+            key = _history_key(row)
+            if not key:
+                continue
+            bucket = by_key.setdefault(
+                key,
+                {
+                    "seen_count": 0,
+                    "decision_counts": {},
+                    "latest_decision": "",
+                    "latest_title": "",
+                    "recent_count": 0,
+                },
+            )
+            bucket["seen_count"] = _as_int(bucket.get("seen_count")) + 1
+            decision_name = _text(row.get("decision")) or "UNKNOWN"
+            counts = _as_dict(bucket.get("decision_counts"))
+            counts[decision_name] = _as_int(counts.get(decision_name)) + 1
+            bucket["decision_counts"] = counts
+            bucket["latest_decision"] = decision_name
+            bucket["latest_title"] = _text(row.get("title"))
+
+    for key in recent_keys:
+        if key in by_key:
+            by_key[key]["recent_count"] = _as_int(by_key[key].get("recent_count")) + 1
+
+    return by_key
+
+
+def _safe_fix_group_key(group: dict[str, Any]) -> str:
+    fix_type = _text(group.get("fix_type"))
+    code = _text(group.get("code"))
+    if fix_type and code:
+        return f"safe-fix:{fix_type}:{code}"
+    if code:
+        return f"diagnosis:{code}"
+    return ""
+
+
+def _safe_fix_context(safe_fix_rollup: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    if not safe_fix_rollup:
+        return result
+
+    for group in _as_list(safe_fix_rollup.get("groups")):
+        row = _as_dict(group)
+        keys = {_safe_fix_group_key(row)}
+        code = _text(row.get("code"))
+        if code:
+            keys.add(f"diagnosis:{code}")
+
+        context = {
+            "safe_fix_attempts": _as_int(row.get("remediation_attempts")),
+            "safe_fix_successes": _as_int(row.get("remediation_successes")),
+            "safe_fix_pushes": _as_int(row.get("commit_pushes")),
+            "latest_safe_fix_status": _text(row.get("latest_remediation_status")) or "unknown",
+        }
+        for key in keys:
+            if key:
+                result[key] = context
+
+    return result
+
+
+def _matching_safe_context(
+    memory_lookup_key: str, diagnosis_class: str, contexts: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    candidates = [
+        memory_lookup_key,
+        f"diagnosis:{diagnosis_class}",
+    ]
+    for candidate in candidates:
+        for key, context in contexts.items():
+            if candidate.startswith(key) or key.startswith(candidate):
+                return context
+    return {}
+
+
+def _trend(seen_count: int, recent_count: int, safe_fix_attempts: int, safe_fix_successes: int) -> str:
+    if safe_fix_attempts and safe_fix_successes >= safe_fix_attempts:
+        return "previously_fixed"
+    if seen_count >= 3 and recent_count >= 1:
+        return "recurring"
+    if seen_count >= 3:
+        return "repeated"
+    if recent_count >= 2:
+        return "worsening"
+    return "new"
+
+
+def _trend_confidence(seen_count: int, safe_fix_attempts: int) -> str:
+    if safe_fix_attempts or seen_count >= 3:
+        return "high"
+    if seen_count >= 1:
+        return "medium"
+    return "low"
+
+
+def _recommendation_impact(trend: str, safe_fix_route: str) -> str:
+    if trend == "previously_fixed" and safe_fix_route in {"candidate_later", "policy_required"}:
+        return "candidate_later"
+    if trend in {"recurring", "repeated", "worsening"}:
+        return "prioritize_review"
+    return "observe"
+
+
+def _trend_item(
+    item: dict[str, Any],
+    history: dict[str, dict[str, Any]],
+    safe_contexts: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    memory_key = _text(item.get("memory_lookup_key"))
+    diagnosis_class = _text(item.get("diagnosis_class")) or "UNKNOWN_REVIEW_REQUIRED"
+    history_row = _as_dict(history.get(memory_key))
+    safe_row = _matching_safe_context(memory_key, diagnosis_class, safe_contexts)
+
+    seen_count = _as_int(history_row.get("seen_count"))
+    recent_count = _as_int(history_row.get("recent_count"))
+    safe_fix_attempts = _as_int(safe_row.get("safe_fix_attempts"))
+    safe_fix_successes = _as_int(safe_row.get("safe_fix_successes"))
+    trend = _trend(seen_count, recent_count, safe_fix_attempts, safe_fix_successes)
+
+    return {
+        "rank": item.get("rank", ""),
+        "signal": _text(item.get("signal")) or memory_key,
+        "memory_lookup_key": memory_key,
+        "diagnosis_class": diagnosis_class,
+        "category": _text(item.get("category")),
+        "risk_level": _text(item.get("risk_level")),
+        "safe_fix_route": _text(item.get("safe_fix_route")),
+        "proof_status": _text(item.get("proof_status")),
+        "seen_count": seen_count,
+        "recent_count": recent_count,
+        "safe_fix_attempts": safe_fix_attempts,
+        "safe_fix_successes": safe_fix_successes,
+        "safe_fix_pushes": _as_int(safe_row.get("safe_fix_pushes")),
+        "latest_safe_fix_status": _text(safe_row.get("latest_safe_fix_status")) or "none",
+        "trend": trend,
+        "trend_confidence": _trend_confidence(seen_count, safe_fix_attempts),
+        "recommendation_impact": _recommendation_impact(trend, _text(item.get("safe_fix_route"))),
+    }
+
+
+def build_signal_trends(
+    proof_checklist_payload: dict[str, Any],
+    *,
+    history_records: list[dict[str, Any]] | None = None,
+    safe_fix_rollup: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    history = _history_counts(history_records or [])
+    safe_contexts = _safe_fix_context(safe_fix_rollup)
+    signals = [
+        _trend_item(_as_dict(item), history, safe_contexts)
+        for item in _as_list(proof_checklist_payload.get("items"))
+        if _as_dict(item)
+    ]
+
+    counts_by_trend: dict[str, int] = {}
+    counts_by_impact: dict[str, int] = {}
+    for item in signals:
+        trend = _text(item.get("trend")) or "unknown"
+        impact = _text(item.get("recommendation_impact")) or "observe"
+        counts_by_trend[trend] = counts_by_trend.get(trend, 0) + 1
+        counts_by_impact[impact] = counts_by_impact.get(impact, 0) + 1
+
+    repeated_count = sum(
+        1 for item in signals if _text(item.get("trend")) in {"recurring", "repeated", "worsening"}
+    )
+    prior_success_count = sum(1 for item in signals if _as_int(item.get("safe_fix_successes")) > 0)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": bool(proof_checklist_payload.get("ok", True)),
+        "source_schema_version": _text(proof_checklist_payload.get("schema_version")),
+        "diagnostic_only": DIAGNOSTIC_ONLY,
+        "automation_allowed": AUTOMATION_ALLOWED,
+        "signal_count": len(signals),
+        "repeated_signal_count": repeated_count,
+        "prior_safe_fix_success_count": prior_success_count,
+        "counts_by_trend": dict(sorted(counts_by_trend.items())),
+        "counts_by_recommendation_impact": dict(sorted(counts_by_impact.items())),
+        "signals": signals,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Maintenance signal trends",
+        "",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- signals: **{payload.get('signal_count', 0)}**",
+        f"- repeated signals: **{payload.get('repeated_signal_count', 0)}**",
+        f"- prior safe-fix successes: **{payload.get('prior_safe_fix_success_count', 0)}**",
+    ]
+
+    trends = _as_dict(payload.get("counts_by_trend"))
+    if trends:
+        lines.extend(["", "## Trend mix", "", "| Trend | Count |", "|---|---:|"])
+        for name, count in sorted(trends.items()):
+            lines.append(f"| {_cell(name)} | {count} |")
+
+    signals = _as_list(payload.get("signals"))
+    if not signals:
+        lines.extend(["", "No maintenance signals were available for trend analysis."])
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines.extend(
+        [
+            "",
+            "## Signal trends",
+            "",
+            "| Rank | Signal | Diagnosis | Trend | Seen | Recent | Safe-fix success | Impact |",
+            "|---:|---|---|---|---:|---:|---:|---|",
+        ]
+    )
+    for item in signals:
+        row = _as_dict(item)
+        lines.append(
+            f"| {row.get('rank', '')} | {_cell(row.get('signal'))} | "
+            f"{_cell(row.get('diagnosis_class'))} | {_cell(row.get('trend'))} | "
+            f"{_as_int(row.get('seen_count'))} | {_as_int(row.get('recent_count'))} | "
+            f"{_as_int(row.get('safe_fix_successes'))} | "
+            f"{_cell(row.get('recommendation_impact'))} |"
+        )
+
+    lines.extend(["", "## What this means", ""])
+    for item in signals[:8]:
+        row = _as_dict(item)
+        lines.append(
+            f"- **{_cell(row.get('signal'))}** is `{_cell(row.get('trend'))}` "
+            f"with `{_cell(row.get('recommendation_impact'))}` impact."
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.maintenance_signal_trends")
+    parser.add_argument("--proof-checklist-json", required=True)
+    parser.add_argument("--history-jsonl")
+    parser.add_argument("--safe-fix-rollup-json")
+    parser.add_argument("--out-json")
+    parser.add_argument("--out-md")
+    parser.add_argument("--format", choices=["json", "md"], default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_signal_trends(
+            _read_json(args.proof_checklist_json) or {},
+            history_records=_read_jsonl(args.history_jsonl),
+            safe_fix_rollup=_read_json(args.safe_fix_rollup_json),
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    md_text = render_markdown(payload)
+
+    if args.out_json:
+        Path(args.out_json).write_text(json_text, encoding="utf-8")
+    if args.out_md:
+        Path(args.out_md).write_text(md_text, encoding="utf-8")
+
+    print(json_text if args.format == "json" else md_text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_maintenance_on_demand_signal_trends_workflow.py
+++ b/tests/test_maintenance_on_demand_signal_trends_workflow.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/maintenance-on-demand.yml")
+
+
+def test_maintenance_on_demand_builds_signal_trends_after_proof_checklist():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Build maintenance signal trends" in text
+    assert "python -m sdetkit.maintenance_signal_trends" in text
+    assert "if [ -f artifacts/maintenance-proof-checklist.json ]; then" in text
+    assert "--proof-checklist-json artifacts/maintenance-proof-checklist.json" in text
+    assert "--history-jsonl artifacts/maintenance-policy-decisions-history.jsonl" in text
+    assert "--out-json artifacts/maintenance-signal-trends.json" in text
+    assert "--out-md artifacts/maintenance-signal-trends.md" in text
+    assert text.index("Build maintenance proof checklist") < text.index(
+        "Build maintenance signal trends"
+    )
+    assert text.index("Build maintenance signal trends") < text.index(
+        "Record maintenance policy decision history"
+    )
+
+
+def test_maintenance_on_demand_uploads_signal_trend_artifacts():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "artifacts/maintenance-signal-trends.json" in text
+    assert "artifacts/maintenance-signal-trends.md" in text
+    assert "if-no-files-found: ignore" in text
+
+
+def test_maintenance_issue_comment_includes_signal_trends_when_present():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "const signalTrendsMd = fs.existsSync('artifacts/maintenance-signal-trends.md')" in text
+    assert "### Maintenance signal trends" in text
+    assert "signalTrendsMd.length > 3000" in text
+
+
+def test_signal_trends_appear_before_proof_checklist_in_issue_comment():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.index("### Maintenance signal trends") < text.index(
+        "### Maintenance proof checklist"
+    )

--- a/tests/test_maintenance_signal_trends.py
+++ b/tests/test_maintenance_signal_trends.py
@@ -1,0 +1,196 @@
+import json
+
+from sdetkit import maintenance_signal_trends as trends
+
+
+def _proof_payload():
+    return {
+        "schema_version": "sdetkit.maintenance.proof_checklist.v1",
+        "ok": True,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "items": [
+            {
+                "rank": 1,
+                "signal": "Run ruff check",
+                "memory_lookup_key": "diagnosis:RUFF_FIXABLE_LINT:lint",
+                "diagnosis_class": "RUFF_FIXABLE_LINT",
+                "category": "lint",
+                "risk_level": "low",
+                "safe_fix_route": "candidate_later",
+                "proof_status": "missing",
+            },
+            {
+                "rank": 2,
+                "signal": "Run pytest -q",
+                "memory_lookup_key": "diagnosis:PRODUCT_LOGIC_FAILURE:tests",
+                "diagnosis_class": "PRODUCT_LOGIC_FAILURE",
+                "category": "product_logic",
+                "risk_level": "high",
+                "safe_fix_route": "review_first",
+                "proof_status": "missing",
+            },
+            {
+                "rank": 3,
+                "signal": "Unknown maintenance signal",
+                "memory_lookup_key": "diagnosis:UNKNOWN_REVIEW_REQUIRED:unknown",
+                "diagnosis_class": "UNKNOWN_REVIEW_REQUIRED",
+                "category": "unknown",
+                "risk_level": "medium",
+                "safe_fix_route": "review_first",
+                "proof_status": "missing",
+            },
+        ],
+    }
+
+
+def _history_records():
+    return [
+        {
+            "run_id": "1",
+            "decisions": [
+                {
+                    "memory_lookup_key": "diagnosis:PRODUCT_LOGIC_FAILURE:tests",
+                    "decision": "REVIEW_REQUIRED",
+                    "title": "Run pytest -q",
+                }
+            ],
+        },
+        {
+            "run_id": "2",
+            "decisions": [
+                {
+                    "memory_lookup_key": "diagnosis:PRODUCT_LOGIC_FAILURE:tests",
+                    "decision": "REVIEW_REQUIRED",
+                    "title": "Run pytest -q",
+                }
+            ],
+        },
+        {
+            "run_id": "3",
+            "decisions": [
+                {
+                    "memory_lookup_key": "diagnosis:PRODUCT_LOGIC_FAILURE:tests",
+                    "decision": "REVIEW_REQUIRED",
+                    "title": "Run pytest -q",
+                },
+                {
+                    "memory_lookup_key": "diagnosis:UNKNOWN_REVIEW_REQUIRED:unknown",
+                    "decision": "REVIEW_REQUIRED",
+                    "title": "Unknown maintenance signal",
+                },
+            ],
+        },
+    ]
+
+
+def _safe_fix_rollup():
+    return {
+        "schema_version": "sdetkit.adaptive.safe_fix_memory_rollup.v1",
+        "groups": [
+            {
+                "fix_type": "ruff_fixable_lint",
+                "code": "RUFF_FIXABLE_LINT",
+                "remediation_attempts": 2,
+                "remediation_successes": 2,
+                "commit_pushes": 1,
+                "latest_remediation_status": "success",
+            }
+        ],
+    }
+
+
+def test_build_signal_trends_uses_history_and_safe_fix_rollup():
+    payload = trends.build_signal_trends(
+        _proof_payload(),
+        history_records=_history_records(),
+        safe_fix_rollup=_safe_fix_rollup(),
+    )
+
+    assert payload["schema_version"] == "sdetkit.maintenance.signal_trends.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["signal_count"] == 3
+    assert payload["repeated_signal_count"] == 1
+    assert payload["prior_safe_fix_success_count"] == 1
+
+    by_key = {item["memory_lookup_key"]: item for item in payload["signals"]}
+
+    ruff = by_key["diagnosis:RUFF_FIXABLE_LINT:lint"]
+    assert ruff["trend"] == "previously_fixed"
+    assert ruff["safe_fix_attempts"] == 2
+    assert ruff["safe_fix_successes"] == 2
+    assert ruff["recommendation_impact"] == "candidate_later"
+
+    product = by_key["diagnosis:PRODUCT_LOGIC_FAILURE:tests"]
+    assert product["seen_count"] == 3
+    assert product["recent_count"] == 1
+    assert product["trend"] == "recurring"
+    assert product["recommendation_impact"] == "prioritize_review"
+
+    unknown = by_key["diagnosis:UNKNOWN_REVIEW_REQUIRED:unknown"]
+    assert unknown["seen_count"] == 1
+    assert unknown["trend"] == "new"
+    assert unknown["recommendation_impact"] == "observe"
+
+
+def test_empty_history_keeps_signals_new_and_diagnostic_only():
+    payload = trends.build_signal_trends(_proof_payload())
+
+    assert payload["automation_allowed"] is False
+    assert payload["counts_by_trend"] == {"new": 3}
+    assert all(item["trend"] == "new" for item in payload["signals"])
+
+
+def test_render_markdown_is_comment_ready():
+    payload = trends.build_signal_trends(
+        _proof_payload(),
+        history_records=_history_records(),
+        safe_fix_rollup=_safe_fix_rollup(),
+    )
+    rendered = trends.render_markdown(payload)
+
+    assert "# Maintenance signal trends" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "prior safe-fix successes: **1**" in rendered
+    assert "Signal trends" in rendered
+    assert "RUFF_FIXABLE_LINT" in rendered
+    assert "previously_fixed" in rendered
+
+
+def test_cli_writes_json_and_markdown(tmp_path):
+    proof = tmp_path / "proof.json"
+    history = tmp_path / "history.jsonl"
+    rollup = tmp_path / "safe-fix-rollup.json"
+    out_json = tmp_path / "trends.json"
+    out_md = tmp_path / "trends.md"
+
+    proof.write_text(json.dumps(_proof_payload()), encoding="utf-8")
+    history.write_text(
+        "\n".join(json.dumps(row) for row in _history_records()) + "\n",
+        encoding="utf-8",
+    )
+    rollup.write_text(json.dumps(_safe_fix_rollup()), encoding="utf-8")
+
+    rc = trends.main(
+        [
+            "--proof-checklist-json",
+            str(proof),
+            "--history-jsonl",
+            str(history),
+            "--safe-fix-rollup-json",
+            str(rollup),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--format",
+            "md",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.maintenance.signal_trends.v1"
+    assert payload["prior_safe_fix_success_count"] == 1
+    assert "Maintenance signal trends" in out_md.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #1160

## Summary

- Add diagnostic-only maintenance signal trend artifacts.
- Use proof checklist items, policy decision history, and safe-fix learning rollups to classify signals as new, repeated, recurring, worsening, or previously fixed.
- Publish maintenance-signal-trends JSON/Markdown artifacts in maintenance-on-demand.
- Add signal trends to maintenance issue comments before the proof checklist.

## Safety

- Diagnostic-only.
- automation_allowed remains false.
- Trends inform recommendation context only.
- No auto-fix behavior added.

## Verification

- PYTHONPATH=src .venv311/bin/python -m pytest -q tests/test_maintenance_signal_trends.py tests/test_maintenance_on_demand_signal_trends_workflow.py tests/test_maintenance_proof_checklist.py tests/test_maintenance_on_demand_proof_checklist_workflow.py tests/test_maintenance_action_categories.py tests/test_maintenance_on_demand_action_categories_workflow.py
- .venv311/bin/python -m pre_commit clean
- ./scripts/pr_preflight.sh
- ./scripts/pr_preflight.sh