### PR TITLE
Add failure investigation command

### DIFF
--- a/src/sdetkit/__main__.py
+++ b/src/sdetkit/__main__.py
@@ -23,6 +23,12 @@ def _cassette_get(argv: list[str]) -> int:
     return int(cassette_get(argv))
 
 
+def _investigate(argv: list[str]) -> int:
+    from .investigate import main as investigate_main
+
+    return int(investigate_main(argv))
+
+
 def _run_cli_main() -> int | None:
     from sdetkit.cli import main as cli_main
 
@@ -39,6 +45,12 @@ def main() -> int:
     if len(argv) > 1 and argv[1] == "cassette-get":
         try:
             return _cassette_get(argv[2:])
+        except Exception as exc:  # pragma: no cover - defensive entrypoint handling
+            sys.stderr.write(f"{exc}\n")
+            return 2
+    if len(argv) > 1 and argv[1] == "investigate":
+        try:
+            return _investigate(argv[2:])
         except Exception as exc:  # pragma: no cover - defensive entrypoint handling
             sys.stderr.write(f"{exc}\n")
             return 2

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -157,6 +157,11 @@ Then use stability-aware command discovery:
     )
     _add_passthrough_subcommand(
         sub,
+        "investigate",
+        help_text="[Advanced but supported] Human-friendly adaptive investigation front door",
+    )
+    _add_passthrough_subcommand(
+        sub,
         "integration",
         help_text="[Advanced but supported] Integration Assurance Kit (primary surface)",
     )

--- a/src/sdetkit/investigate.py
+++ b/src/sdetkit/investigate.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from sdetkit import adaptive_diagnosis
+
+SCHEMA_VERSION = "sdetkit.investigate.failure.v1"
+
+
+def _read_log(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _payload_for_failure(log_text: str) -> dict[str, Any]:
+    diagnosis_payload = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    diagnoses = diagnosis_payload.get("diagnoses", [])
+    first = diagnoses[0] if diagnoses and isinstance(diagnoses[0], dict) else {}
+
+    fix_plan = diagnosis_payload.get("fix_plan", [])
+    first_plan = fix_plan[0] if fix_plan and isinstance(fix_plan[0], dict) else {}
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": True,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "command": "investigate failure",
+        "classification": str(first.get("code", "UNKNOWN_REVIEW_REQUIRED")),
+        "confidence": str(first.get("confidence", "medium")),
+        "safe_to_auto_fix": bool(first_plan.get("safe_to_auto_fix", False)),
+        "requires_human_review": bool(first_plan.get("requires_human_review", True)),
+        "summary": str(first.get("summary", "")),
+        "why_it_matters": str(first.get("why_it_matters", "")),
+        "next_actions": list(first.get("next_actions", []))
+        if isinstance(first.get("next_actions"), list)
+        else [],
+        "proof_commands": list(first.get("proof_commands", []))
+        if isinstance(first.get("proof_commands"), list)
+        else [],
+        "memory_lookup_key": str(first.get("memory_lookup_key", "")),
+        "diagnosis": diagnosis_payload,
+    }
+
+
+def render_failure_markdown(payload: dict[str, Any]) -> str:
+    proof = payload.get("proof_commands", [])
+    actions = payload.get("next_actions", [])
+    lines = [
+        "# Failure investigation",
+        "",
+        f"- classification: **{payload.get('classification', 'UNKNOWN_REVIEW_REQUIRED')}**",
+        f"- confidence: **{payload.get('confidence', 'medium')}**",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- safe to auto-fix: **{payload.get('safe_to_auto_fix', False)}**",
+        f"- requires human review: **{payload.get('requires_human_review', True)}**",
+        "",
+        "## Summary",
+        "",
+        str(payload.get("summary", "") or "No summary was available."),
+        "",
+        "## Why it matters",
+        "",
+        str(payload.get("why_it_matters", "") or "No additional context was available."),
+    ]
+
+    if actions:
+        lines.extend(["", "## Next actions", ""])
+        for action in actions:
+            lines.append(f"- {action}")
+
+    if proof:
+        lines.extend(["", "## Proof commands", ""])
+        lines.append("```bash")
+        for command in proof:
+            lines.append(str(command))
+        lines.append("```")
+
+    key = str(payload.get("memory_lookup_key", "")).strip()
+    if key:
+        lines.extend(["", "## Memory lookup key", "", f"`{key}`"])
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit investigate")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    failure = sub.add_parser("failure", help="Classify a failure log with adaptive diagnosis")
+    failure.add_argument("--log", required=True, help="Path to a text log to investigate")
+    failure.add_argument("--format", choices=["json", "markdown"], default="json")
+    failure.add_argument("--out", default="", help="Optional output file")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.cmd != "failure":
+        return 2
+
+    try:
+        payload = _payload_for_failure(_read_log(args.log))
+    except OSError as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+
+    rendered = (
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        if args.format == "json"
+        else render_failure_markdown(payload)
+    )
+
+    if args.out:
+        Path(args.out).write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_investigate_failure.py
+++ b/tests/test_investigate_failure.py
@@ -1,0 +1,126 @@
+import json
+from pathlib import Path
+
+from sdetkit import investigate
+
+
+def test_failure_investigation_wraps_adaptive_diagnosis_without_autofix(tmp_path):
+    log = tmp_path / "failure.log"
+    log.write_text(
+        "AttributeError: SdetAsyncHttpClient object has no attribute "
+        "get_json_list_paginated_envelope async parity",
+        encoding="utf-8",
+    )
+
+    payload = investigate._payload_for_failure(log.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == "sdetkit.investigate.failure.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["classification"] == "MISSING_PUBLIC_API_PARITY"
+    assert payload["safe_to_auto_fix"] is False
+    assert payload["requires_human_review"] is True
+    assert payload["diagnosis"]["diagnoses"][0]["code"] == "MISSING_PUBLIC_API_PARITY"
+
+
+def test_failure_investigation_json_cli_writes_output(tmp_path, capsys):
+    log = tmp_path / "failure.log"
+    out = tmp_path / "investigation.json"
+    log.write_text("Exit: Missing test dependencies: hypothesis, yaml.", encoding="utf-8")
+
+    rc = investigate.main(["failure", "--log", str(log), "--format", "json", "--out", str(out)])
+
+    assert rc == 0
+    written = json.loads(out.read_text(encoding="utf-8"))
+    printed = json.loads(capsys.readouterr().out)
+    assert written["classification"] == "MISSING_TEST_DEPENDENCY"
+    assert printed["classification"] == "MISSING_TEST_DEPENDENCY"
+    assert written["automation_allowed"] is False
+
+
+def test_failure_investigation_markdown_cli(tmp_path, capsys):
+    log = tmp_path / "failure.log"
+    log.write_text(
+        "TypeError: Resp() takes no arguments because test double defines init_ instead of __init__",
+        encoding="utf-8",
+    )
+
+    rc = investigate.main(["failure", "--log", str(log), "--format", "markdown"])
+
+    assert rc == 0
+    rendered = capsys.readouterr().out
+    assert "# Failure investigation" in rendered
+    assert "BROKEN_TEST_DOUBLE" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "requires human review: **True**" in rendered
+
+
+def test_failure_investigation_missing_log_returns_2(tmp_path, capsys):
+    missing = tmp_path / "missing.log"
+
+    rc = investigate.main(["failure", "--log", str(missing), "--format", "json"])
+
+    assert rc == 2
+    assert "error=" in capsys.readouterr().err
+
+
+def test_failure_markdown_includes_proof_commands():
+    payload = {
+        "classification": "MISSING_PUBLIC_API_PARITY",
+        "confidence": "high",
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "safe_to_auto_fix": False,
+        "requires_human_review": True,
+        "summary": "Missing public API parity detected.",
+        "why_it_matters": "Users can hit runtime AttributeError.",
+        "next_actions": ["Add parity coverage."],
+        "proof_commands": ["python -m pytest -q tests/test_netclient_envelope_parity.py"],
+        "memory_lookup_key": "diagnosis:MISSING_PUBLIC_API_PARITY:netclient",
+    }
+
+    rendered = investigate.render_failure_markdown(payload)
+
+    assert "## Proof commands" in rendered
+    assert "python -m pytest -q tests/test_netclient_envelope_parity.py" in rendered
+    assert "diagnosis:MISSING_PUBLIC_API_PARITY:netclient" in rendered
+
+
+def test_python_m_sdetkit_investigate_failure_outputs_json(tmp_path):
+    import os
+    import subprocess
+    import sys
+
+    log = tmp_path / "failure.log"
+    log.write_text(
+        "AttributeError: SdetAsyncHttpClient object has no attribute "
+        "get_json_list_paginated_envelope async parity",
+        encoding="utf-8",
+    )
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "src"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "investigate",
+            "failure",
+            "--log",
+            str(log),
+            "--format",
+            "json",
+        ],
+        cwd=Path.cwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["classification"] == "MISSING_PUBLIC_API_PARITY"
+    assert payload["automation_allowed"] is False


### PR DESCRIPTION
Closes #1161

## Summary

- Add a human-friendly investigate failure command.
- Route `python -m sdetkit investigate failure` to adaptive diagnosis.
- Support JSON and Markdown output.
- Keep the command diagnostic-only and automation-disabled.
- Add subprocess coverage for the real `python -m sdetkit` path.

## Safety

- No duplicate investigation brain.
- Reuses adaptive_diagnosis for classification.
- automation_allowed remains false.
- No auto-fix behavior added.

## Verification

- PYTHONPATH=src .venv311/bin/python -m pytest -q tests/test_investigate_failure.py tests/test_adaptive_diagnosis.py
- PYTHONPATH=src .venv311/bin/python -m sdetkit investigate failure --log <tmp-log> --format json
- PYTHONPATH=src .venv311/bin/python -m sdetkit investigate failure --log <tmp-log> --format markdown
- .venv311/bin/python -m pre_commit clean
- ./scripts/pr_preflight.sh
- ./scripts/pr_preflight.sh