### PR TITLE
Write investigation candidate evidence

### DIFF
--- a/src/sdetkit/investigate.py
+++ b/src/sdetkit/investigate.py
@@ -11,6 +11,7 @@ from typing import Any
 from sdetkit import adaptive_diagnosis
 from sdetkit.boost import build_scan
 from sdetkit.index import IGNORED_DIRS
+from sdetkit.investigation_evidence import build_investigation_evidence
 
 FAILURE_SCHEMA_VERSION = "sdetkit.investigate.failure.v1"
 REPO_SCHEMA_VERSION = "sdetkit.investigate.repo.v1"
@@ -433,6 +434,30 @@ def render_surface_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def render_evidence_markdown(payload: dict[str, Any]) -> str:
+    files = payload.get("files", {}) if isinstance(payload.get("files"), dict) else {}
+    lines = [
+        "# Investigation evidence",
+        "",
+        f"- classification: **{payload.get('classification', '')}**",
+        f"- surface: **{payload.get('surface', '')}**",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- proof status: **{payload.get('proof_status', '')}**",
+        "",
+        "## Generated files",
+        "",
+    ]
+    for key in sorted(files):
+        lines.append(f"- {key}: `{files[key]}`")
+    proof = payload.get("proof_commands", [])
+    if proof:
+        lines.extend(["", "## Proof commands", "", "```bash"])
+        lines.extend(str(command) for command in proof)
+        lines.append("```")
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit investigate")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -452,6 +477,14 @@ def build_parser() -> argparse.ArgumentParser:
     surface.add_argument("--surface", required=True, help="Surface name to investigate")
     surface.add_argument("--format", choices=["json", "markdown"], default="json")
     surface.add_argument("--out", default="", help="Optional output file")
+
+    evidence = sub.add_parser("evidence", help="Write investigation candidate evidence artifacts")
+    evidence.add_argument("--classification", required=True, help="Diagnosis classification")
+    evidence.add_argument("--surface", required=True, help="Surface name for the evidence bundle")
+    evidence.add_argument("--out-dir", required=True, help="Directory for generated evidence")
+    evidence.add_argument("--root", default=".", help="Repository root for context")
+    evidence.add_argument("--format", choices=["json", "markdown"], default="json")
+    evidence.add_argument("--out", default="", help="Optional output file")
 
     return parser
 
@@ -479,6 +512,18 @@ def main(argv: list[str] | None = None) -> int:
                 json.dumps(payload, indent=2, sort_keys=True) + "\n"
                 if args.format == "json"
                 else render_surface_markdown(payload)
+            )
+        elif args.cmd == "evidence":
+            payload = build_investigation_evidence(
+                args.classification,
+                args.surface,
+                args.out_dir,
+                root=args.root,
+            )
+            rendered = (
+                json.dumps(payload, indent=2, sort_keys=True) + "\n"
+                if args.format == "json"
+                else render_evidence_markdown(payload)
             )
         else:
             return 2

--- a/src/sdetkit/investigation_evidence.py
+++ b/src/sdetkit/investigation_evidence.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.investigation.evidence.v1"
+DEFAULT_PROOF_COMMANDS = {
+    "MISSING_PUBLIC_API_PARITY": [
+        "python -m sdetkit investigate surface --root . --surface {surface} --format json",
+        "python -m pytest -q tests/test_{surface}.py",
+    ],
+    "PRODUCT_LOGIC_FAILURE": [
+        "python -m sdetkit investigate surface --root . --surface {surface} --format json",
+        "python -m pytest -q",
+    ],
+    "PRE_COMMIT_FORMAT_DRIFT": [
+        "python -m pre_commit run -a",
+        "./scripts/pr_preflight.sh",
+    ],
+    "RUFF_FIXABLE_LINT": [
+        "python -m ruff check .",
+        "python -m pre_commit run -a",
+    ],
+}
+
+
+def _clean_token(value: str, name: str) -> str:
+    clean = value.strip()
+    if not clean:
+        raise OSError(f"{name} is required")
+    return clean
+
+
+def _proof_commands(classification: str, surface: str) -> list[str]:
+    template = DEFAULT_PROOF_COMMANDS.get(
+        classification,
+        [
+            "python -m sdetkit investigate failure --log <log> --format markdown",
+            "./scripts/pr_preflight.sh",
+        ],
+    )
+    return [command.format(surface=surface) for command in template]
+
+
+def _candidate_freeze_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Investigation candidate freeze",
+        "",
+        f"- classification: **{payload['classification']}**",
+        f"- surface: **{payload['surface']}**",
+        f"- diagnostic only: **{payload['diagnostic_only']}**",
+        f"- automation allowed: **{payload['automation_allowed']}**",
+        f"- safe to auto-fix: **{payload['safe_to_auto_fix']}**",
+        f"- requires human review: **{payload['requires_human_review']}**",
+        "",
+        "## Freeze decision",
+        "",
+        "Review and prove this candidate before changing product behavior.",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _audit_result_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Investigation audit result",
+        "",
+        f"- classification: **{payload['classification']}**",
+        f"- surface: **{payload['surface']}**",
+        f"- proof status: **{payload['proof_status']}**",
+        f"- candidate status: **{payload['candidate_status']}**",
+        "",
+        "## Audit summary",
+        "",
+        payload["summary"],
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _proof_commands_markdown(payload: dict[str, Any]) -> str:
+    lines = ["# Investigation proof commands", "", "```bash"]
+    lines.extend(str(command) for command in payload["proof_commands"])
+    lines.extend(["```", ""])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_investigation_evidence(
+    classification: str,
+    surface: str,
+    out_dir: str | Path,
+    root: str | Path = ".",
+) -> dict[str, Any]:
+    clean_classification = _clean_token(classification, "classification")
+    clean_surface = _clean_token(surface, "surface")
+    output_dir = Path(out_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    commands = _proof_commands(clean_classification, clean_surface)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "safe_to_auto_fix": False,
+        "requires_human_review": True,
+        "command": "investigate evidence",
+        "classification": clean_classification,
+        "surface": clean_surface,
+        "root": Path(root).as_posix(),
+        "out_dir": output_dir.as_posix(),
+        "proof_status": "missing",
+        "candidate_status": "review_required",
+        "summary": "Investigation evidence bundle created for human review.",
+        "proof_commands": commands,
+        "files": {
+            "candidate_freeze": (output_dir / "CANDIDATE_FREEZE.md").as_posix(),
+            "audit_result": (output_dir / "AUDIT_RESULT.md").as_posix(),
+            "proof_commands": (output_dir / "proof-commands.md").as_posix(),
+            "investigation_json": (output_dir / "investigation.json").as_posix(),
+        },
+    }
+    (output_dir / "CANDIDATE_FREEZE.md").write_text(
+        _candidate_freeze_markdown(payload), encoding="utf-8"
+    )
+    (output_dir / "AUDIT_RESULT.md").write_text(_audit_result_markdown(payload), encoding="utf-8")
+    (output_dir / "proof-commands.md").write_text(
+        _proof_commands_markdown(payload), encoding="utf-8"
+    )
+    (output_dir / "investigation.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return payload

--- a/tests/test_investigation_evidence.py
+++ b/tests/test_investigation_evidence.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sdetkit import investigate
+from sdetkit.investigation_evidence import build_investigation_evidence
+
+
+def _env() -> dict[str, str]:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "src"
+    return env
+
+
+def test_build_investigation_evidence_writes_expected_files(tmp_path):
+    out_dir = tmp_path / "build" / "investigate" / "netclient"
+
+    payload = build_investigation_evidence(
+        "MISSING_PUBLIC_API_PARITY",
+        "netclient",
+        out_dir,
+        root=tmp_path,
+    )
+
+    assert payload["schema_version"] == "sdetkit.investigation.evidence.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["safe_to_auto_fix"] is False
+    assert payload["requires_human_review"] is True
+    assert payload["classification"] == "MISSING_PUBLIC_API_PARITY"
+    assert payload["surface"] == "netclient"
+    assert payload["proof_status"] == "missing"
+    assert payload["candidate_status"] == "review_required"
+    assert payload["proof_commands"] == [
+        "python -m sdetkit investigate surface --root . --surface netclient --format json",
+        "python -m pytest -q tests/test_netclient.py",
+    ]
+
+    expected_files = {
+        "CANDIDATE_FREEZE.md",
+        "AUDIT_RESULT.md",
+        "proof-commands.md",
+        "investigation.json",
+    }
+    assert {path.name for path in out_dir.iterdir()} == expected_files
+    written = json.loads((out_dir / "investigation.json").read_text(encoding="utf-8"))
+    assert written == payload
+    assert "# Investigation candidate freeze" in (out_dir / "CANDIDATE_FREEZE.md").read_text(
+        encoding="utf-8"
+    )
+    assert "# Investigation audit result" in (out_dir / "AUDIT_RESULT.md").read_text(
+        encoding="utf-8"
+    )
+    assert "python -m pytest -q tests/test_netclient.py" in (
+        out_dir / "proof-commands.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_evidence_writer_uses_default_review_commands_for_unknown_class(tmp_path):
+    payload = build_investigation_evidence(
+        "UNKNOWN_REVIEW_REQUIRED",
+        "mystery",
+        tmp_path / "evidence",
+    )
+
+    assert payload["proof_commands"] == [
+        "python -m sdetkit investigate failure --log <log> --format markdown",
+        "./scripts/pr_preflight.sh",
+    ]
+
+
+def test_investigate_evidence_json_cli_writes_output(tmp_path, capsys):
+    out_dir = tmp_path / "bundle"
+    out = tmp_path / "evidence.json"
+
+    rc = investigate.main(
+        [
+            "evidence",
+            "--classification",
+            "MISSING_PUBLIC_API_PARITY",
+            "--surface",
+            "netclient",
+            "--out-dir",
+            str(out_dir),
+            "--root",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    written = json.loads(out.read_text(encoding="utf-8"))
+    printed = json.loads(capsys.readouterr().out)
+    assert written["schema_version"] == "sdetkit.investigation.evidence.v1"
+    assert printed["command"] == "investigate evidence"
+    assert written["files"]["investigation_json"].endswith("investigation.json")
+    assert (out_dir / "CANDIDATE_FREEZE.md").exists()
+    assert (out_dir / "AUDIT_RESULT.md").exists()
+    assert (out_dir / "proof-commands.md").exists()
+    assert (out_dir / "investigation.json").exists()
+
+
+def test_investigate_evidence_markdown_cli(tmp_path, capsys):
+    rc = investigate.main(
+        [
+            "evidence",
+            "--classification",
+            "PRODUCT_LOGIC_FAILURE",
+            "--surface",
+            "release_room",
+            "--out-dir",
+            str(tmp_path / "evidence"),
+            "--format",
+            "markdown",
+        ]
+    )
+
+    assert rc == 0
+    rendered = capsys.readouterr().out
+    assert "# Investigation evidence" in rendered
+    assert "classification: **PRODUCT_LOGIC_FAILURE**" in rendered
+    assert "surface: **release_room**" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "python -m pytest -q" in rendered
+
+
+def test_investigate_evidence_blank_classification_returns_2(tmp_path, capsys):
+    rc = investigate.main(
+        [
+            "evidence",
+            "--classification",
+            " ",
+            "--surface",
+            "netclient",
+            "--out-dir",
+            str(tmp_path / "evidence"),
+        ]
+    )
+
+    assert rc == 2
+    assert "classification is required" in capsys.readouterr().err
+
+
+def test_investigate_evidence_blank_surface_returns_2(tmp_path, capsys):
+    rc = investigate.main(
+        [
+            "evidence",
+            "--classification",
+            "MISSING_PUBLIC_API_PARITY",
+            "--surface",
+            " ",
+            "--out-dir",
+            str(tmp_path / "evidence"),
+        ]
+    )
+
+    assert rc == 2
+    assert "surface is required" in capsys.readouterr().err
+
+
+def test_python_m_sdetkit_investigate_evidence_outputs_json(tmp_path):
+    out_dir = tmp_path / "bundle"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "investigate",
+            "evidence",
+            "--classification",
+            "MISSING_PUBLIC_API_PARITY",
+            "--surface",
+            "netclient",
+            "--out-dir",
+            str(out_dir),
+            "--format",
+            "json",
+        ],
+        cwd=Path.cwd(),
+        env=_env(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "sdetkit.investigation.evidence.v1"
+    assert payload["classification"] == "MISSING_PUBLIC_API_PARITY"
+    assert payload["automation_allowed"] is False
+    assert (out_dir / "investigation.json").exists()


### PR DESCRIPTION
## Summary

- Add `sdetkit.investigation_evidence.build_investigation_evidence`.
- Add `python -m sdetkit investigate evidence` for diagnostic evidence bundles.
- Generate `CANDIDATE_FREEZE.md`, `AUDIT_RESULT.md`, `proof-commands.md`, and `investigation.json` under the requested output directory.
- Include classification/surface metadata, review-first candidate status, and proof commands.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Adaptive M2 — Investigation Front Door
- Implements Phase 9: Write investigation candidate evidence

## Safety

- Diagnostic-only.
- No auto-fix behavior enabled.
- Does not create a second investigator brain.
- Writes only the requested evidence artifacts under `--out-dir`.
- Keeps candidates review-required with missing proof by default.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the evidence writer module, `investigate evidence` command, and tests.