### PR TITLE
Route investigation through safe-fix policy

### DIFF
--- a/src/sdetkit/investigation_evidence.py
+++ b/src/sdetkit/investigation_evidence.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from sdetkit.investigation_safe_fix_policy import route_investigation_safe_fix_policy
+
 SCHEMA_VERSION = "sdetkit.investigation.evidence.v1"
 DEFAULT_PROOF_COMMANDS = {
     "MISSING_PUBLIC_API_PARITY": [
@@ -43,7 +45,14 @@ def _proof_commands(classification: str, surface: str) -> list[str]:
     return [command.format(surface=surface) for command in template]
 
 
+def _candidate_status(policy: dict[str, Any]) -> str:
+    if bool(policy.get("candidate_later")):
+        return "candidate_later_after_policy"
+    return "review_required"
+
+
 def _candidate_freeze_markdown(payload: dict[str, Any]) -> str:
+    policy = payload["safe_fix_policy"]
     lines = [
         "# Investigation candidate freeze",
         "",
@@ -53,15 +62,17 @@ def _candidate_freeze_markdown(payload: dict[str, Any]) -> str:
         f"- automation allowed: **{payload['automation_allowed']}**",
         f"- safe to auto-fix: **{payload['safe_to_auto_fix']}**",
         f"- requires human review: **{payload['requires_human_review']}**",
+        f"- policy route: **{policy['route']}**",
         "",
         "## Freeze decision",
         "",
-        "Review and prove this candidate before changing product behavior.",
+        policy["blocking_reason"],
     ]
     return "\n".join(lines).rstrip() + "\n"
 
 
 def _audit_result_markdown(payload: dict[str, Any]) -> str:
+    policy = payload["safe_fix_policy"]
     lines = [
         "# Investigation audit result",
         "",
@@ -69,10 +80,15 @@ def _audit_result_markdown(payload: dict[str, Any]) -> str:
         f"- surface: **{payload['surface']}**",
         f"- proof status: **{payload['proof_status']}**",
         f"- candidate status: **{payload['candidate_status']}**",
+        f"- policy route: **{policy['route']}**",
         "",
         "## Audit summary",
         "",
         payload["summary"],
+        "",
+        "## Safe-fix policy",
+        "",
+        policy["reason"],
     ]
     return "\n".join(lines).rstrip() + "\n"
 
@@ -95,6 +111,7 @@ def build_investigation_evidence(
     output_dir = Path(out_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     commands = _proof_commands(clean_classification, clean_surface)
+    policy = route_investigation_safe_fix_policy(clean_classification)
     payload = {
         "schema_version": SCHEMA_VERSION,
         "diagnostic_only": True,
@@ -107,8 +124,9 @@ def build_investigation_evidence(
         "root": Path(root).as_posix(),
         "out_dir": output_dir.as_posix(),
         "proof_status": "missing",
-        "candidate_status": "review_required",
+        "candidate_status": _candidate_status(policy),
         "summary": "Investigation evidence bundle created for human review.",
+        "safe_fix_policy": policy,
         "proof_commands": commands,
         "files": {
             "candidate_freeze": (output_dir / "CANDIDATE_FREEZE.md").as_posix(),

--- a/src/sdetkit/investigation_safe_fix_policy.py
+++ b/src/sdetkit/investigation_safe_fix_policy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.investigation.safe_fix_policy.v1"
+MECHANICAL_CANDIDATE_CLASSES = {
+    "PRE_COMMIT_FORMAT_DRIFT": {
+        "route": "safe_mechanical_candidate_later",
+        "risk_level": "low",
+        "reason": "Formatting drift can become a narrow mechanical candidate after repeated proof.",
+    },
+    "RUFF_FIXABLE_LINT": {
+        "route": "safe_mechanical_candidate_later",
+        "risk_level": "low",
+        "reason": "Ruff fixable lint can become a narrow mechanical candidate after proof and policy.",
+    },
+}
+REVIEW_FIRST_CLASSES = {
+    "GIT_BRANCH_DIVERGED": ("command_guidance", "Git workflow drift needs explicit user sync."),
+    "REMOTE_BRANCH_DRIFT": ("sync_guidance", "Remote branch drift needs explicit user sync."),
+    "MISSING_TEST_DEPENDENCY": ("environment_guidance", "Dependency issues are environment guidance, not code mutation."),
+    "PYTHON_RUNTIME_COMPATIBILITY": ("compatibility_pr", "Runtime compatibility changes need review."),
+    "LOCAL_ENVIRONMENT_FRICTION": ("environment_guidance", "Local environment friction is guidance-only."),
+    "BROKEN_TEST_DOUBLE": ("review_first_test_fix", "Broken test doubles need review before changing tests."),
+    "MISSING_PUBLIC_API_PARITY": ("review_first_product_fix", "Public API gaps are product changes."),
+    "PRODUCT_LOGIC_FAILURE": ("review_first_product_fix", "Product logic failures need human review."),
+    "UNKNOWN_REVIEW_REQUIRED": ("review_first_unknown", "Unknown classifications remain review-required."),
+}
+
+
+def route_investigation_safe_fix_policy(classification: str) -> dict[str, Any]:
+    clean = classification.strip()
+    if not clean:
+        raise OSError("classification is required")
+    if clean in MECHANICAL_CANDIDATE_CLASSES:
+        meta = MECHANICAL_CANDIDATE_CLASSES[clean]
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "diagnostic_only": True,
+            "automation_allowed": False,
+            "classification": clean,
+            "auto_fix_allowed_now": False,
+            "safe_to_auto_fix": False,
+            "candidate_later": True,
+            "requires_human_review": True,
+            "risk_level": meta["risk_level"],
+            "route": meta["route"],
+            "blocking_reason": "Policy, proof history, dry run, and PR-only guardrails are still required.",
+            "reason": meta["reason"],
+        }
+    route, reason = REVIEW_FIRST_CLASSES.get(
+        clean,
+        ("review_first_unknown", "Unrecognized classification remains review-required."),
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "classification": clean,
+        "auto_fix_allowed_now": False,
+        "safe_to_auto_fix": False,
+        "candidate_later": False,
+        "requires_human_review": True,
+        "risk_level": "review_required",
+        "route": route,
+        "blocking_reason": "This classification is not eligible for automatic changes at this stage.",
+        "reason": reason,
+    }

--- a/src/sdetkit/investigation_safe_fix_policy.py
+++ b/src/sdetkit/investigation_safe_fix_policy.py
@@ -18,13 +18,34 @@ MECHANICAL_CANDIDATE_CLASSES = {
 REVIEW_FIRST_CLASSES = {
     "GIT_BRANCH_DIVERGED": ("command_guidance", "Git workflow drift needs explicit user sync."),
     "REMOTE_BRANCH_DRIFT": ("sync_guidance", "Remote branch drift needs explicit user sync."),
-    "MISSING_TEST_DEPENDENCY": ("environment_guidance", "Dependency issues are environment guidance, not code mutation."),
-    "PYTHON_RUNTIME_COMPATIBILITY": ("compatibility_pr", "Runtime compatibility changes need review."),
-    "LOCAL_ENVIRONMENT_FRICTION": ("environment_guidance", "Local environment friction is guidance-only."),
-    "BROKEN_TEST_DOUBLE": ("review_first_test_fix", "Broken test doubles need review before changing tests."),
-    "MISSING_PUBLIC_API_PARITY": ("review_first_product_fix", "Public API gaps are product changes."),
-    "PRODUCT_LOGIC_FAILURE": ("review_first_product_fix", "Product logic failures need human review."),
-    "UNKNOWN_REVIEW_REQUIRED": ("review_first_unknown", "Unknown classifications remain review-required."),
+    "MISSING_TEST_DEPENDENCY": (
+        "environment_guidance",
+        "Dependency issues are environment guidance, not code mutation.",
+    ),
+    "PYTHON_RUNTIME_COMPATIBILITY": (
+        "compatibility_pr",
+        "Runtime compatibility changes need review.",
+    ),
+    "LOCAL_ENVIRONMENT_FRICTION": (
+        "environment_guidance",
+        "Local environment friction is guidance-only.",
+    ),
+    "BROKEN_TEST_DOUBLE": (
+        "review_first_test_fix",
+        "Broken test doubles need review before changing tests.",
+    ),
+    "MISSING_PUBLIC_API_PARITY": (
+        "review_first_product_fix",
+        "Public API gaps are product changes.",
+    ),
+    "PRODUCT_LOGIC_FAILURE": (
+        "review_first_product_fix",
+        "Product logic failures need human review.",
+    ),
+    "UNKNOWN_REVIEW_REQUIRED": (
+        "review_first_unknown",
+        "Unknown classifications remain review-required.",
+    ),
 }
 
 

--- a/tests/test_investigation_safe_fix_policy.py
+++ b/tests/test_investigation_safe_fix_policy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_investigation_safe_fix_policy.py
+++ b/tests/test_investigation_safe_fix_policy.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit.investigation_evidence import build_investigation_evidence
+from sdetkit.investigation_safe_fix_policy import route_investigation_safe_fix_policy
+
+
+@pytest.mark.parametrize(
+    ("classification", "route"),
+    [
+        ("PRE_COMMIT_FORMAT_DRIFT", "safe_mechanical_candidate_later"),
+        ("RUFF_FIXABLE_LINT", "safe_mechanical_candidate_later"),
+    ],
+)
+def test_mechanical_classes_are_candidates_later_but_not_auto_fix_now(classification, route):
+    payload = route_investigation_safe_fix_policy(classification)
+
+    assert payload["schema_version"] == "sdetkit.investigation.safe_fix_policy.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["classification"] == classification
+    assert payload["route"] == route
+    assert payload["risk_level"] == "low"
+    assert payload["candidate_later"] is True
+    assert payload["auto_fix_allowed_now"] is False
+    assert payload["safe_to_auto_fix"] is False
+    assert payload["requires_human_review"] is True
+    assert "Policy" in payload["blocking_reason"]
+
+
+@pytest.mark.parametrize(
+    ("classification", "route"),
+    [
+        ("GIT_BRANCH_DIVERGED", "command_guidance"),
+        ("REMOTE_BRANCH_DRIFT", "sync_guidance"),
+        ("MISSING_TEST_DEPENDENCY", "environment_guidance"),
+        ("PYTHON_RUNTIME_COMPATIBILITY", "compatibility_pr"),
+        ("LOCAL_ENVIRONMENT_FRICTION", "environment_guidance"),
+        ("BROKEN_TEST_DOUBLE", "review_first_test_fix"),
+        ("MISSING_PUBLIC_API_PARITY", "review_first_product_fix"),
+        ("PRODUCT_LOGIC_FAILURE", "review_first_product_fix"),
+        ("UNKNOWN_REVIEW_REQUIRED", "review_first_unknown"),
+    ],
+)
+def test_review_first_classes_are_not_candidates(classification, route):
+    payload = route_investigation_safe_fix_policy(classification)
+
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["classification"] == classification
+    assert payload["route"] == route
+    assert payload["risk_level"] == "review_required"
+    assert payload["candidate_later"] is False
+    assert payload["auto_fix_allowed_now"] is False
+    assert payload["safe_to_auto_fix"] is False
+    assert payload["requires_human_review"] is True
+
+
+def test_unknown_classification_falls_back_to_review_required():
+    payload = route_investigation_safe_fix_policy("NEW_FAILURE_CLASS")
+
+    assert payload["classification"] == "NEW_FAILURE_CLASS"
+    assert payload["route"] == "review_first_unknown"
+    assert payload["candidate_later"] is False
+    assert payload["requires_human_review"] is True
+    assert "Unrecognized" in payload["reason"]
+
+
+def test_blank_classification_is_rejected():
+    with pytest.raises(OSError, match="classification is required"):
+        route_investigation_safe_fix_policy(" ")
+
+
+def test_evidence_bundle_includes_mechanical_policy_route(tmp_path):
+    out_dir = tmp_path / "evidence"
+
+    payload = build_investigation_evidence(
+        "PRE_COMMIT_FORMAT_DRIFT",
+        "formatting",
+        out_dir,
+        root=tmp_path,
+    )
+
+    assert payload["automation_allowed"] is False
+    assert payload["safe_to_auto_fix"] is False
+    assert payload["candidate_status"] == "candidate_later_after_policy"
+    assert payload["safe_fix_policy"]["route"] == "safe_mechanical_candidate_later"
+    assert payload["safe_fix_policy"]["candidate_later"] is True
+    assert payload["safe_fix_policy"]["auto_fix_allowed_now"] is False
+    written = json.loads((out_dir / "investigation.json").read_text(encoding="utf-8"))
+    assert written["safe_fix_policy"] == payload["safe_fix_policy"]
+    freeze = (out_dir / "CANDIDATE_FREEZE.md").read_text(encoding="utf-8")
+    assert "policy route: **safe_mechanical_candidate_later**" in freeze
+    assert "Policy, proof history" in freeze
+
+
+def test_evidence_bundle_includes_review_first_policy_route(tmp_path):
+    out_dir = tmp_path / "evidence"
+
+    payload = build_investigation_evidence(
+        "MISSING_PUBLIC_API_PARITY",
+        "netclient",
+        out_dir,
+        root=tmp_path,
+    )
+
+    assert payload["candidate_status"] == "review_required"
+    assert payload["safe_fix_policy"]["route"] == "review_first_product_fix"
+    assert payload["safe_fix_policy"]["candidate_later"] is False
+    assert payload["safe_fix_policy"]["auto_fix_allowed_now"] is False
+    audit = (out_dir / "AUDIT_RESULT.md").read_text(encoding="utf-8")
+    assert "policy route: **review_first_product_fix**" in audit
+    assert "Public API gaps are product changes." in audit


### PR DESCRIPTION
## Summary

- Add `sdetkit.investigation_safe_fix_policy.route_investigation_safe_fix_policy`.
- Route investigation classifications into diagnostic safe-fix policy outcomes.
- Mark narrow mechanical classes as candidate-later only, never auto-fix now.
- Keep product/API, runtime, dependency, git, test-double, and unknown classes review-first.
- Include safe-fix policy routing in investigation evidence bundles.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Adaptive M2 — Investigation Front Door
- Implements Phase 10: Route investigation diagnoses through safe-fix policy

## Safety

- Diagnostic-only.
- No auto-fix behavior enabled.
- `automation_allowed` remains false.
- `auto_fix_allowed_now` remains false for every classification.
- Mechanical classes still require proof history, policy, dry-run, and PR-only guardrails before any future automation.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_investigation_safe_fix_policy.py tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the investigation safe-fix policy router and evidence-bundle policy fields.