### PR TITLE
Add PR investigation summary

### DIFF
--- a/src/sdetkit/pr_investigation_summary.py
+++ b/src/sdetkit/pr_investigation_summary.py
@@ -8,6 +8,11 @@ from sdetkit import adaptive_diagnosis
 from sdetkit.investigation_safe_fix_policy import route_investigation_safe_fix_policy
 
 SCHEMA_VERSION = "sdetkit.pr_investigation_summary.v1"
+UNKNOWN_REVIEW_DIAGNOSIS = {
+    "code": "UNKNOWN_REVIEW_REQUIRED",
+    "confidence": "medium",
+    "proof_commands": [],
+}
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -18,6 +23,23 @@ def _first_diagnosis(payload: dict[str, Any]) -> dict[str, Any]:
     diagnoses = _as_list(payload.get("diagnoses"))
     first = diagnoses[0] if diagnoses and isinstance(diagnoses[0], dict) else {}
     return first
+
+
+def _diagnosis_for_log(log_text: str) -> dict[str, Any]:
+    if not log_text.strip():
+        return {
+            "schema_version": adaptive_diagnosis.SCHEMA_VERSION,
+            "ok": False,
+            "status": "needs_attention",
+            "risk_score": 0,
+            "confidence": "medium",
+            "summary": "No failure log was provided for PR investigation.",
+            "diagnosis_count": 1,
+            "diagnoses": [UNKNOWN_REVIEW_DIAGNOSIS],
+            "fix_plan": [],
+            "learning_updates": [],
+        }
+    return adaptive_diagnosis.analyze_evidence(log_text=log_text)
 
 
 def _first_proof_commands(first: dict[str, Any]) -> list[str]:
@@ -44,7 +66,7 @@ def build_pr_investigation_summary(
     memory_seen_count: int = 0,
     memory_fixed_count: int = 0,
 ) -> dict[str, Any]:
-    diagnosis = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    diagnosis = _diagnosis_for_log(log_text)
     first = _first_diagnosis(diagnosis)
     classification = str(first.get("code", "UNKNOWN_REVIEW_REQUIRED"))
     policy = route_investigation_safe_fix_policy(classification)

--- a/src/sdetkit/pr_investigation_summary.py
+++ b/src/sdetkit/pr_investigation_summary.py
@@ -48,7 +48,11 @@ def _first_proof_commands(first: dict[str, Any]) -> list[str]:
 
 
 def _next_command(proof_commands: list[str]) -> str:
-    return proof_commands[0] if proof_commands else "python -m sdetkit investigate failure --log <log> --format markdown"
+    return (
+        proof_commands[0]
+        if proof_commands
+        else "python -m sdetkit investigate failure --log <log> --format markdown"
+    )
 
 
 def _safe_fix_status(policy: dict[str, Any]) -> str:

--- a/src/sdetkit/pr_investigation_summary.py
+++ b/src/sdetkit/pr_investigation_summary.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from sdetkit import adaptive_diagnosis
+from sdetkit.investigation_safe_fix_policy import route_investigation_safe_fix_policy
+
+SCHEMA_VERSION = "sdetkit.pr_investigation_summary.v1"
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _first_diagnosis(payload: dict[str, Any]) -> dict[str, Any]:
+    diagnoses = _as_list(payload.get("diagnoses"))
+    first = diagnoses[0] if diagnoses and isinstance(diagnoses[0], dict) else {}
+    return first
+
+
+def _first_proof_commands(first: dict[str, Any]) -> list[str]:
+    commands = _as_list(first.get("proof_commands"))
+    return [str(command) for command in commands[:4]]
+
+
+def _next_command(proof_commands: list[str]) -> str:
+    return proof_commands[0] if proof_commands else "python -m sdetkit investigate failure --log <log> --format markdown"
+
+
+def _safe_fix_status(policy: dict[str, Any]) -> str:
+    if bool(policy.get("auto_fix_allowed_now")):
+        return "allowed_now"
+    if bool(policy.get("candidate_later")):
+        return "candidate later"
+    return "review required"
+
+
+def build_pr_investigation_summary(
+    *,
+    log_text: str,
+    surface: str = "",
+    memory_seen_count: int = 0,
+    memory_fixed_count: int = 0,
+) -> dict[str, Any]:
+    diagnosis = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    first = _first_diagnosis(diagnosis)
+    classification = str(first.get("code", "UNKNOWN_REVIEW_REQUIRED"))
+    policy = route_investigation_safe_fix_policy(classification)
+    proof_commands = _first_proof_commands(first)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "command": "pr investigation summary",
+        "classification": classification,
+        "confidence": str(first.get("confidence", diagnosis.get("confidence", "medium"))),
+        "surface": surface.strip(),
+        "safe_fix_status": _safe_fix_status(policy),
+        "auto_fix_allowed_now": False,
+        "requires_human_review": True,
+        "next_command": _next_command(proof_commands),
+        "proof_commands": proof_commands,
+        "memory": {
+            "seen_count": max(0, int(memory_seen_count)),
+            "manual_fix_count": max(0, int(memory_fixed_count)),
+        },
+        "safe_fix_policy": policy,
+        "diagnosis": diagnosis,
+    }
+    payload["markdown"] = render_pr_investigation_summary_markdown(payload)
+    return payload
+
+
+def render_pr_investigation_summary_markdown(payload: dict[str, Any]) -> str:
+    memory = payload.get("memory", {}) if isinstance(payload.get("memory"), dict) else {}
+    lines = [
+        "### Failure investigation",
+        "",
+        f"- classification: **{payload.get('classification', 'UNKNOWN_REVIEW_REQUIRED')}**",
+        f"- confidence: **{payload.get('confidence', 'medium')}**",
+        f"- safe-fix status: **{payload.get('safe_fix_status', 'review required')}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- next command: `{payload.get('next_command', '')}`",
+        "- memory: seen {seen} time(s), fixed manually {fixed} time(s)".format(
+            seen=memory.get("seen_count", 0), fixed=memory.get("manual_fix_count", 0)
+        ),
+    ]
+    surface = str(payload.get("surface", "")).strip()
+    if surface:
+        lines.append(f"- surface: **{surface}**")
+    proof = _as_list(payload.get("proof_commands"))
+    if proof:
+        lines.extend(["", "#### Proof commands", "", "```bash"])
+        lines.extend(str(command) for command in proof[:4])
+        lines.append("```")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_pr_investigation_summary(payload: dict[str, Any], out: str | Path) -> Path:
+    path = Path(out)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix.lower() == ".json":
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    else:
+        path.write_text(render_pr_investigation_summary_markdown(payload), encoding="utf-8")
+    return path

--- a/tests/test_pr_investigation_summary.py
+++ b/tests/test_pr_investigation_summary.py
@@ -68,13 +68,18 @@ def test_pr_investigation_summary_markdown_is_comment_ready():
 
 
 def test_pr_investigation_summary_blank_log_falls_back_to_review_required():
-    payload = build_pr_investigation_summary(log_text="", memory_seen_count=-3, memory_fixed_count=-1)
+    payload = build_pr_investigation_summary(
+        log_text="", memory_seen_count=-3, memory_fixed_count=-1
+    )
 
     assert payload["classification"] == "UNKNOWN_REVIEW_REQUIRED"
     assert payload["confidence"] == "medium"
     assert payload["safe_fix_status"] == "review required"
     assert payload["memory"] == {"seen_count": 0, "manual_fix_count": 0}
-    assert payload["next_command"] == "python -m sdetkit investigate failure --log <log> --format markdown"
+    assert (
+        payload["next_command"]
+        == "python -m sdetkit investigate failure --log <log> --format markdown"
+    )
 
 
 def test_write_pr_investigation_summary_json_and_markdown(tmp_path):

--- a/tests/test_pr_investigation_summary.py
+++ b/tests/test_pr_investigation_summary.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+
+from sdetkit.pr_investigation_summary import (
+    build_pr_investigation_summary,
+    render_pr_investigation_summary_markdown,
+    write_pr_investigation_summary,
+)
+
+
+def test_pr_investigation_summary_uses_adaptive_diagnosis_and_policy():
+    payload = build_pr_investigation_summary(
+        log_text=(
+            "AttributeError: SdetAsyncHttpClient object has no attribute "
+            "get_json_list_paginated_envelope async parity"
+        ),
+        surface="netclient",
+        memory_seen_count=3,
+        memory_fixed_count=2,
+    )
+
+    assert payload["schema_version"] == "sdetkit.pr_investigation_summary.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["classification"] == "MISSING_PUBLIC_API_PARITY"
+    assert payload["confidence"] == "high"
+    assert payload["safe_fix_status"] == "review required"
+    assert payload["auto_fix_allowed_now"] is False
+    assert payload["requires_human_review"] is True
+    assert payload["surface"] == "netclient"
+    assert payload["memory"] == {"seen_count": 3, "manual_fix_count": 2}
+    assert payload["safe_fix_policy"]["route"] == "review_first_product_fix"
+    assert payload["diagnosis"]["diagnoses"][0]["code"] == "MISSING_PUBLIC_API_PARITY"
+    assert "pytest" in payload["next_command"]
+
+
+def test_pr_investigation_summary_marks_mechanical_class_candidate_later():
+    payload = build_pr_investigation_summary(
+        log_text="ruff format failed: 2 files reformatted and files were modified by this hook",
+        surface="tests",
+    )
+
+    assert payload["classification"] == "PRE_COMMIT_FORMAT_DRIFT"
+    assert payload["safe_fix_status"] == "candidate later"
+    assert payload["safe_fix_policy"]["route"] == "safe_mechanical_candidate_later"
+    assert payload["safe_fix_policy"]["auto_fix_allowed_now"] is False
+    assert payload["automation_allowed"] is False
+
+
+def test_pr_investigation_summary_markdown_is_comment_ready():
+    payload = build_pr_investigation_summary(
+        log_text="Exit: Missing test dependencies: hypothesis, yaml.",
+        surface="dependencies",
+        memory_seen_count=1,
+        memory_fixed_count=0,
+    )
+
+    rendered = render_pr_investigation_summary_markdown(payload)
+
+    assert rendered.startswith("### Failure investigation")
+    assert "classification: **MISSING_TEST_DEPENDENCY**" in rendered
+    assert "safe-fix status: **review required**" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "memory: seen 1 time(s), fixed manually 0 time(s)" in rendered
+    assert "surface: **dependencies**" in rendered
+    assert "#### Proof commands" in rendered
+
+
+def test_pr_investigation_summary_blank_log_falls_back_to_review_required():
+    payload = build_pr_investigation_summary(log_text="", memory_seen_count=-3, memory_fixed_count=-1)
+
+    assert payload["classification"] == "UNKNOWN_REVIEW_REQUIRED"
+    assert payload["confidence"] == "medium"
+    assert payload["safe_fix_status"] == "review required"
+    assert payload["memory"] == {"seen_count": 0, "manual_fix_count": 0}
+    assert payload["next_command"] == "python -m sdetkit investigate failure --log <log> --format markdown"
+
+
+def test_write_pr_investigation_summary_json_and_markdown(tmp_path):
+    payload = build_pr_investigation_summary(
+        log_text="TypeError: Resp() takes no arguments because test double defines init_ instead of __init__",
+        surface="netclient",
+    )
+    json_out = tmp_path / "summary.json"
+    markdown_out = tmp_path / "summary.md"
+
+    assert write_pr_investigation_summary(payload, json_out) == json_out
+    assert write_pr_investigation_summary(payload, markdown_out) == markdown_out
+
+    written_json = json.loads(json_out.read_text(encoding="utf-8"))
+    written_markdown = markdown_out.read_text(encoding="utf-8")
+    assert written_json["classification"] == "BROKEN_TEST_DOUBLE"
+    assert written_json["safe_fix_policy"]["route"] == "review_first_test_fix"
+    assert "classification: **BROKEN_TEST_DOUBLE**" in written_markdown
+    assert "surface: **netclient**" in written_markdown


### PR DESCRIPTION
## Summary

- Add `sdetkit.pr_investigation_summary.build_pr_investigation_summary`.
- Render truncation-safe Markdown for PR failure comments.
- Include classification, confidence, safe-fix status, next command, memory counts, optional surface, and proof commands.
- Route classifications through the investigation safe-fix policy.
- Handle blank logs as `UNKNOWN_REVIEW_REQUIRED` instead of guessing another diagnosis.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Adaptive M2 — Investigation Front Door
- Implements Phase 11: Publish investigation summaries for PR failures

## Safety

- Diagnostic-only.
- No auto-fix behavior enabled.
- `automation_allowed` remains false.
- PR summary is a renderer over shared adaptive diagnosis and safe-fix policy routing, not a second investigator brain.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_pr_investigation_summary.py tests/test_investigation_safe_fix_policy.py tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the PR investigation summary renderer and tests.