### PR TITLE
Add investigation outcome memory

### DIFF
--- a/src/sdetkit/investigation_outcome_memory.py
+++ b/src/sdetkit/investigation_outcome_memory.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.investigation.outcome_memory.v1"
+
+
+def _clean_required(value: str, name: str) -> str:
+    clean = value.strip()
+    if not clean:
+        raise OSError(f"{name} is required")
+    return clean
+
+
+def _clean_optional(value: str) -> str:
+    return value.strip()
+
+
+def _as_nonnegative_int(value: int | str) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _as_list(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    if not values:
+        return []
+    return [str(value).strip() for value in values if str(value).strip()]
+
+
+def build_investigation_outcome_record(
+    *,
+    classification: str,
+    surface: str,
+    proof_command: str,
+    safe_fix_outcome: str = "not_attempted",
+    manual_fix_outcome: str = "unknown",
+    pr_number: int | str = 0,
+    merged: bool = False,
+    time_to_green_seconds: int | str = 0,
+    affected_files: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    return {
+        "classification": _clean_required(classification, "classification"),
+        "surface": _clean_required(surface, "surface"),
+        "affected_files": sorted(set(_as_list(affected_files))),
+        "proof_command": _clean_required(proof_command, "proof_command"),
+        "safe_fix_outcome": _clean_optional(safe_fix_outcome) or "not_attempted",
+        "manual_fix_outcome": _clean_optional(manual_fix_outcome) or "unknown",
+        "pr_number": _as_nonnegative_int(pr_number),
+        "merged": bool(merged),
+        "time_to_green_seconds": _as_nonnegative_int(time_to_green_seconds),
+    }
+
+
+def load_investigation_outcome_memory(path: str | Path) -> dict[str, Any]:
+    memory_path = Path(path)
+    if not memory_path.exists():
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "diagnostic_only": True,
+            "automation_allowed": False,
+            "records": [],
+        }
+    data = json.loads(memory_path.read_text(encoding="utf-8"))
+    records = data.get("records", []) if isinstance(data, dict) else []
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "records": records if isinstance(records, list) else [],
+    }
+
+
+def append_investigation_outcome_memory(path: str | Path, record: dict[str, Any]) -> dict[str, Any]:
+    memory = load_investigation_outcome_memory(path)
+    memory["records"].append(record)
+    memory["records"] = sorted(
+        memory["records"],
+        key=lambda item: (
+            str(item.get("classification", "")),
+            str(item.get("surface", "")),
+            int(item.get("pr_number", 0) or 0),
+            str(item.get("proof_command", "")),
+        ),
+    )
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(memory, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return memory
+
+
+def summarize_investigation_outcome_memory(memory: dict[str, Any]) -> dict[str, Any]:
+    records = memory.get("records", []) if isinstance(memory.get("records"), list) else []
+    merged_count = sum(1 for record in records if bool(record.get("merged")))
+    manual_success_count = sum(
+        1 for record in records if str(record.get("manual_fix_outcome", "")) == "merged"
+    )
+    safe_success_count = sum(
+        1 for record in records if str(record.get("safe_fix_outcome", "")) == "manual_success"
+    )
+    classifications = sorted({str(record.get("classification", "")) for record in records})
+    return {
+        "schema_version": "sdetkit.investigation.outcome_memory.summary.v1",
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "record_count": len(records),
+        "merged_count": merged_count,
+        "manual_success_count": manual_success_count,
+        "safe_fix_success_count": safe_success_count,
+        "classifications": [value for value in classifications if value],
+    }

--- a/tests/test_investigation_outcome_memory.py
+++ b/tests/test_investigation_outcome_memory.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sdetkit.investigation_outcome_memory import (
+    append_investigation_outcome_memory,
+    build_investigation_outcome_record,
+    load_investigation_outcome_memory,
+    summarize_investigation_outcome_memory,
+)
+
+
+def test_build_investigation_outcome_record_normalizes_fields():
+    record = build_investigation_outcome_record(
+        classification=" PRE_COMMIT_FORMAT_DRIFT ",
+        surface=" tests ",
+        affected_files=["tests/test_b.py", "tests/test_a.py", "tests/test_a.py", ""],
+        proof_command=" python -m pre_commit run -a ",
+        safe_fix_outcome=" manual_success ",
+        manual_fix_outcome=" merged ",
+        pr_number="1175",
+        merged=True,
+        time_to_green_seconds="42",
+    )
+
+    assert record == {
+        "classification": "PRE_COMMIT_FORMAT_DRIFT",
+        "surface": "tests",
+        "affected_files": ["tests/test_a.py", "tests/test_b.py"],
+        "proof_command": "python -m pre_commit run -a",
+        "safe_fix_outcome": "manual_success",
+        "manual_fix_outcome": "merged",
+        "pr_number": 1175,
+        "merged": True,
+        "time_to_green_seconds": 42,
+    }
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"classification": " "}, "classification is required"),
+        ({"surface": " "}, "surface is required"),
+        ({"proof_command": " "}, "proof_command is required"),
+    ],
+)
+def test_build_investigation_outcome_record_rejects_required_blank_fields(kwargs, message):
+    values = {
+        "classification": "MISSING_PUBLIC_API_PARITY",
+        "surface": "netclient",
+        "proof_command": "python -m pytest -q tests/test_netclient.py",
+    }
+    values.update(kwargs)
+
+    with pytest.raises(OSError, match=message):
+        build_investigation_outcome_record(**values)
+
+
+def test_load_missing_memory_returns_empty_diagnostic_payload(tmp_path):
+    payload = load_investigation_outcome_memory(tmp_path / "missing.json")
+
+    assert payload == {
+        "schema_version": "sdetkit.investigation.outcome_memory.v1",
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "records": [],
+    }
+
+
+def test_append_investigation_outcome_memory_writes_and_sorts_records(tmp_path):
+    path = tmp_path / "memory" / "investigation-outcomes.json"
+    later = build_investigation_outcome_record(
+        classification="PRODUCT_LOGIC_FAILURE",
+        surface="release_room",
+        proof_command="python -m pytest -q tests/test_release_room.py",
+        pr_number=1200,
+    )
+    earlier = build_investigation_outcome_record(
+        classification="MISSING_PUBLIC_API_PARITY",
+        surface="netclient",
+        proof_command="python -m pytest -q tests/test_netclient.py",
+        pr_number=1175,
+        merged=True,
+        manual_fix_outcome="merged",
+    )
+
+    append_investigation_outcome_memory(path, later)
+    payload = append_investigation_outcome_memory(path, earlier)
+
+    assert path.exists()
+    assert [record["classification"] for record in payload["records"]] == [
+        "MISSING_PUBLIC_API_PARITY",
+        "PRODUCT_LOGIC_FAILURE",
+    ]
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert written == payload
+    assert written["diagnostic_only"] is True
+    assert written["automation_allowed"] is False
+
+
+def test_load_populated_memory_preserves_records(tmp_path):
+    path = tmp_path / "memory.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "old",
+                "diagnostic_only": False,
+                "automation_allowed": True,
+                "records": [
+                    {
+                        "classification": "BROKEN_TEST_DOUBLE",
+                        "surface": "tests",
+                        "proof_command": "python -m pytest -q tests/test_example.py",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = load_investigation_outcome_memory(path)
+
+    assert payload["schema_version"] == "sdetkit.investigation.outcome_memory.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["records"][0]["classification"] == "BROKEN_TEST_DOUBLE"
+
+
+def test_summarize_investigation_outcome_memory_counts_records():
+    memory = {
+        "records": [
+            {
+                "classification": "PRE_COMMIT_FORMAT_DRIFT",
+                "merged": True,
+                "manual_fix_outcome": "merged",
+                "safe_fix_outcome": "manual_success",
+            },
+            {
+                "classification": "MISSING_PUBLIC_API_PARITY",
+                "merged": True,
+                "manual_fix_outcome": "merged",
+                "safe_fix_outcome": "not_attempted",
+            },
+            {
+                "classification": "PRODUCT_LOGIC_FAILURE",
+                "merged": False,
+                "manual_fix_outcome": "unknown",
+                "safe_fix_outcome": "not_attempted",
+            },
+        ]
+    }
+
+    summary = summarize_investigation_outcome_memory(memory)
+
+    assert summary == {
+        "schema_version": "sdetkit.investigation.outcome_memory.summary.v1",
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "record_count": 3,
+        "merged_count": 2,
+        "manual_success_count": 2,
+        "safe_fix_success_count": 1,
+        "classifications": [
+            "MISSING_PUBLIC_API_PARITY",
+            "PRE_COMMIT_FORMAT_DRIFT",
+            "PRODUCT_LOGIC_FAILURE",
+        ],
+    }


### PR DESCRIPTION
## Summary

- Add `sdetkit.investigation_outcome_memory`.
- Build normalized investigation outcome records for classification, surface, proof command, PR number, merge state, affected files, and time-to-green.
- Load and append diagnostic outcome-memory JSON records with deterministic sorting.
- Summarize merged/manual/safe-fix counts and classifications.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Adaptive M2 — Investigation Front Door
- Implements Phase 12: Record investigation outcome memory

## Safety

- Diagnostic-only.
- No auto-fix behavior enabled.
- `automation_allowed` remains false.
- Records outcomes and summaries only; does not execute remediation or modify product behavior.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_investigation_outcome_memory.py tests/test_pr_investigation_summary.py tests/test_investigation_safe_fix_policy.py tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the investigation outcome memory module and tests.