### PR TITLE
Publish safe-fix candidate registry

### DIFF
--- a/src/sdetkit/safe_fix_candidate_registry.py
+++ b/src/sdetkit/safe_fix_candidate_registry.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from sdetkit.investigation_safe_fix_policy import route_investigation_safe_fix_policy
+
+SCHEMA_VERSION = "sdetkit.safe_fix.candidates.v1"
+DEFAULT_CANDIDATE_CLASSES = ("PRE_COMMIT_FORMAT_DRIFT", "RUFF_FIXABLE_LINT")
+DEFAULT_ALLOWED_COMMANDS = {
+    "PRE_COMMIT_FORMAT_DRIFT": ["python -m pre_commit run -a", "./scripts/pr_preflight.sh"],
+    "RUFF_FIXABLE_LINT": ["python -m ruff check .", "python -m pre_commit run -a"],
+}
+DEFAULT_FORBIDDEN_PATHS = [".github/workflows", "pyproject.toml", "src/sdetkit/security"]
+REQUIRED_HISTORY_COUNT = 3
+REQUIRED_SUCCESS_COUNT = 3
+
+
+def _candidate_key(classification: str) -> str:
+    return f"diagnosis:{classification}"
+
+
+def _status_for(history_count: int, success_count: int) -> str:
+    if history_count < REQUIRED_HISTORY_COUNT:
+        return "OBSERVE_MORE"
+    if success_count < REQUIRED_SUCCESS_COUNT:
+        return "NOT_READY"
+    return "READY_FOR_POLICY_PR"
+
+
+def _counts_by_class(records: list[dict[str, Any]]) -> tuple[Counter[str], Counter[str]]:
+    seen: Counter[str] = Counter()
+    successes: Counter[str] = Counter()
+    for record in records:
+        classification = str(record.get("classification", "")).strip()
+        if not classification:
+            continue
+        seen[classification] += 1
+        if bool(record.get("merged")) and str(record.get("manual_fix_outcome", "")) == "merged":
+            successes[classification] += 1
+        elif str(record.get("safe_fix_outcome", "")) == "manual_success":
+            successes[classification] += 1
+    return seen, successes
+
+
+def _candidate_for_class(
+    classification: str,
+    history_count: int,
+    success_count: int,
+) -> dict[str, Any]:
+    policy = route_investigation_safe_fix_policy(classification)
+    return {
+        "candidate_key": _candidate_key(classification),
+        "classification": classification,
+        "category": "formatting" if classification == "PRE_COMMIT_FORMAT_DRIFT" else "lint",
+        "risk_level": policy["risk_level"],
+        "required_history_count": REQUIRED_HISTORY_COUNT,
+        "required_success_count": REQUIRED_SUCCESS_COUNT,
+        "observed_history_count": history_count,
+        "observed_success_count": success_count,
+        "allowed_commands": DEFAULT_ALLOWED_COMMANDS[classification],
+        "forbidden_paths": DEFAULT_FORBIDDEN_PATHS,
+        "rollback_required": True,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "current_status": _status_for(history_count, success_count),
+        "blocking_reason": policy["blocking_reason"],
+    }
+
+
+def build_safe_fix_candidate_registry(
+    outcome_memory: dict[str, Any] | None = None,
+    candidate_classes: tuple[str, ...] = DEFAULT_CANDIDATE_CLASSES,
+) -> dict[str, Any]:
+    records = outcome_memory.get("records", []) if isinstance(outcome_memory, dict) else []
+    records = records if isinstance(records, list) else []
+    seen, successes = _counts_by_class(records)
+    candidates = [
+        _candidate_for_class(
+            classification,
+            seen.get(classification, 0),
+            successes.get(classification, 0),
+        )
+        for classification in sorted(candidate_classes)
+    ]
+    counts = Counter(str(candidate["current_status"]) for candidate in candidates)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "candidate_count": len(candidates),
+        "counts_by_status": dict(sorted(counts.items())),
+        "candidates": candidates,
+    }
+
+
+def render_safe_fix_candidate_registry_markdown(payload: dict[str, Any]) -> str:
+    candidates = payload.get("candidates", []) if isinstance(payload.get("candidates"), list) else []
+    lines = [
+        "# Safe-fix candidate registry",
+        "",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- candidates: **{payload.get('candidate_count', 0)}**",
+        "",
+        "## Candidates",
+        "",
+        "| Candidate | Status | History | Successes | Allowed now |",
+        "|---|---|---:|---:|---|",
+    ]
+    for candidate in candidates:
+        lines.append(
+            "| `{key}` | {status} | {history} | {successes} | {allowed} |".format(
+                key=candidate.get("candidate_key", ""),
+                status=candidate.get("current_status", ""),
+                history=candidate.get("observed_history_count", 0),
+                successes=candidate.get("observed_success_count", 0),
+                allowed=candidate.get("auto_fix_allowed_now", False),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "",
+            "This registry is diagnostic-only. Candidates still require policy, proof, dry-run, rollback, and PR-only guardrails before any future automation.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/sdetkit/safe_fix_candidate_registry.py
+++ b/src/sdetkit/safe_fix_candidate_registry.py
@@ -95,7 +95,9 @@ def build_safe_fix_candidate_registry(
 
 
 def render_safe_fix_candidate_registry_markdown(payload: dict[str, Any]) -> str:
-    candidates = payload.get("candidates", []) if isinstance(payload.get("candidates"), list) else []
+    candidates = (
+        payload.get("candidates", []) if isinstance(payload.get("candidates"), list) else []
+    )
     lines = [
         "# Safe-fix candidate registry",
         "",

--- a/tests/test_safe_fix_candidate_registry.py
+++ b/tests/test_safe_fix_candidate_registry.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from sdetkit.safe_fix_candidate_registry import (
+    build_safe_fix_candidate_registry,
+    render_safe_fix_candidate_registry_markdown,
+)
+
+
+def _record(
+    classification: str,
+    *,
+    merged: bool = True,
+    manual_fix_outcome: str = "merged",
+    safe_fix_outcome: str = "not_attempted",
+) -> dict[str, object]:
+    return {
+        "classification": classification,
+        "surface": "tests",
+        "proof_command": "python -m pre_commit run -a",
+        "merged": merged,
+        "manual_fix_outcome": manual_fix_outcome,
+        "safe_fix_outcome": safe_fix_outcome,
+    }
+
+
+def test_candidate_registry_empty_memory_observes_more():
+    payload = build_safe_fix_candidate_registry()
+
+    assert payload["schema_version"] == "sdetkit.safe_fix.candidates.v1"
+    assert payload["diagnostic_only"] is True
+    assert payload["automation_allowed"] is False
+    assert payload["candidate_count"] == 2
+    assert payload["counts_by_status"] == {"OBSERVE_MORE": 2}
+    assert [candidate["candidate_key"] for candidate in payload["candidates"]] == [
+        "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+        "diagnosis:RUFF_FIXABLE_LINT",
+    ]
+    for candidate in payload["candidates"]:
+        assert candidate["automation_allowed"] is False
+        assert candidate["auto_fix_allowed_now"] is False
+        assert candidate["rollback_required"] is True
+        assert candidate["required_history_count"] == 3
+        assert candidate["required_success_count"] == 3
+
+
+def test_candidate_registry_counts_history_and_successes():
+    memory = {
+        "records": [
+            _record("PRE_COMMIT_FORMAT_DRIFT"),
+            _record("PRE_COMMIT_FORMAT_DRIFT"),
+            _record("PRE_COMMIT_FORMAT_DRIFT", merged=False, manual_fix_outcome="unknown"),
+            _record("RUFF_FIXABLE_LINT"),
+            _record("PRODUCT_LOGIC_FAILURE"),
+        ]
+    }
+
+    payload = build_safe_fix_candidate_registry(memory)
+    by_class = {candidate["classification"]: candidate for candidate in payload["candidates"]}
+
+    assert by_class["PRE_COMMIT_FORMAT_DRIFT"]["observed_history_count"] == 3
+    assert by_class["PRE_COMMIT_FORMAT_DRIFT"]["observed_success_count"] == 2
+    assert by_class["PRE_COMMIT_FORMAT_DRIFT"]["current_status"] == "NOT_READY"
+    assert by_class["RUFF_FIXABLE_LINT"]["observed_history_count"] == 1
+    assert by_class["RUFF_FIXABLE_LINT"]["observed_success_count"] == 1
+    assert by_class["RUFF_FIXABLE_LINT"]["current_status"] == "OBSERVE_MORE"
+    assert payload["counts_by_status"] == {"NOT_READY": 1, "OBSERVE_MORE": 1}
+
+
+def test_candidate_registry_ready_for_policy_when_thresholds_are_met():
+    memory = {
+        "records": [
+            _record("PRE_COMMIT_FORMAT_DRIFT"),
+            _record("PRE_COMMIT_FORMAT_DRIFT"),
+            _record("PRE_COMMIT_FORMAT_DRIFT"),
+            _record("RUFF_FIXABLE_LINT", safe_fix_outcome="manual_success"),
+            _record("RUFF_FIXABLE_LINT", safe_fix_outcome="manual_success"),
+            _record("RUFF_FIXABLE_LINT", safe_fix_outcome="manual_success"),
+        ]
+    }
+
+    payload = build_safe_fix_candidate_registry(memory)
+    by_class = {candidate["classification"]: candidate for candidate in payload["candidates"]}
+
+    assert by_class["PRE_COMMIT_FORMAT_DRIFT"]["current_status"] == "READY_FOR_POLICY_PR"
+    assert by_class["RUFF_FIXABLE_LINT"]["current_status"] == "READY_FOR_POLICY_PR"
+    assert payload["counts_by_status"] == {"READY_FOR_POLICY_PR": 2}
+    for candidate in payload["candidates"]:
+        assert candidate["auto_fix_allowed_now"] is False
+        assert "Policy" in candidate["blocking_reason"]
+
+
+def test_candidate_registry_markdown_is_operator_readable():
+    payload = build_safe_fix_candidate_registry(
+        {"records": [_record("PRE_COMMIT_FORMAT_DRIFT"), _record("PRE_COMMIT_FORMAT_DRIFT")]}
+    )
+
+    rendered = render_safe_fix_candidate_registry_markdown(payload)
+
+    assert rendered.startswith("# Safe-fix candidate registry")
+    assert "diagnostic only: **True**" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "`diagnosis:PRE_COMMIT_FORMAT_DRIFT`" in rendered
+    assert "`diagnosis:RUFF_FIXABLE_LINT`" in rendered
+    assert "OBSERVE_MORE" in rendered
+    assert "This registry is diagnostic-only" in rendered
+
+
+def test_candidate_registry_can_be_limited_to_one_class():
+    payload = build_safe_fix_candidate_registry(candidate_classes=("PRE_COMMIT_FORMAT_DRIFT",))
+
+    assert payload["candidate_count"] == 1
+    assert payload["candidates"][0]["classification"] == "PRE_COMMIT_FORMAT_DRIFT"
+    assert payload["candidates"][0]["category"] == "formatting"


### PR DESCRIPTION
## Summary

- Add `sdetkit.safe_fix_candidate_registry`.
- Publish diagnostic-only safe-fix candidate registry data for narrow mechanical classes.
- Track observed history counts and success counts from investigation outcome memory.
- Compute candidate status as `OBSERVE_MORE`, `NOT_READY`, or `READY_FOR_POLICY_PR`.
- Add Markdown rendering for operator-facing registry summaries.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Implements Phase 13: Publish safe-fix candidate registry

## Safety

- Diagnostic-only.
- No auto-fix behavior enabled.
- `automation_allowed` remains false.
- `auto_fix_allowed_now` remains false for every candidate.
- Candidates still require policy, proof, dry-run, rollback, and PR-only guardrails before any future automation.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_safe_fix_candidate_registry.py tests/test_investigation_outcome_memory.py tests/test_pr_investigation_summary.py tests/test_investigation_safe_fix_policy.py tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the safe-fix candidate registry module and tests.