### PR TITLE
Publish auto-fix probation report

### DIFF
--- a/src/sdetkit/auto_fix_probation_report.py
+++ b/src/sdetkit/auto_fix_probation_report.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.auto_fix.probation_report.v1"
+
+
+def _as_candidates(registry: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates = registry.get("candidates", []) if isinstance(registry, dict) else []
+    return candidates if isinstance(candidates, list) else []
+
+
+def _probation_status(candidate: dict[str, Any]) -> str:
+    if bool(candidate.get("auto_fix_allowed_now")):
+        return "POLICY_VIOLATION"
+    status = str(candidate.get("current_status", "OBSERVE_MORE"))
+    if status == "READY_FOR_POLICY_PR":
+        return "READY_FOR_PROBATION_REVIEW"
+    if status == "NOT_READY":
+        return "NEEDS_MORE_SUCCESSFUL_PROOF"
+    return "NEEDS_MORE_OBSERVATION"
+
+
+def _blocking_reasons(candidate: dict[str, Any], probation_status: str) -> list[str]:
+    reasons = [str(candidate.get("blocking_reason", "")).strip()]
+    if probation_status == "NEEDS_MORE_OBSERVATION":
+        reasons.append("Candidate has not met the required observation count.")
+    elif probation_status == "NEEDS_MORE_SUCCESSFUL_PROOF":
+        reasons.append("Candidate has enough observations but not enough successful manual outcomes.")
+    elif probation_status == "READY_FOR_PROBATION_REVIEW":
+        reasons.append("Candidate can be reviewed for a future policy PR, not executed now.")
+    elif probation_status == "POLICY_VIOLATION":
+        reasons.append("Candidate unexpectedly allows auto-fix now and must be blocked.")
+    return [reason for reason in reasons if reason]
+
+
+def _row(candidate: dict[str, Any]) -> dict[str, Any]:
+    status = _probation_status(candidate)
+    return {
+        "candidate_key": str(candidate.get("candidate_key", "")),
+        "classification": str(candidate.get("classification", "")),
+        "current_status": str(candidate.get("current_status", "")),
+        "probation_status": status,
+        "observed_history_count": int(candidate.get("observed_history_count", 0) or 0),
+        "observed_success_count": int(candidate.get("observed_success_count", 0) or 0),
+        "required_history_count": int(candidate.get("required_history_count", 0) or 0),
+        "required_success_count": int(candidate.get("required_success_count", 0) or 0),
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "blocking_reasons": _blocking_reasons(candidate, status),
+    }
+
+
+def build_auto_fix_probation_report(registry: dict[str, Any]) -> dict[str, Any]:
+    rows = [_row(candidate) for candidate in _as_candidates(registry)]
+    counts = Counter(row["probation_status"] for row in rows)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "candidate_count": len(rows),
+        "counts_by_probation_status": dict(sorted(counts.items())),
+        "probation_rows": sorted(rows, key=lambda row: row["candidate_key"]),
+    }
+
+
+def render_auto_fix_probation_report_markdown(payload: dict[str, Any]) -> str:
+    rows = (
+        payload.get("probation_rows", [])
+        if isinstance(payload.get("probation_rows"), list)
+        else []
+    )
+    lines = [
+        "# Auto-fix probation report",
+        "",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- auto-fix allowed now: **{payload.get('auto_fix_allowed_now', False)}**",
+        f"- candidates: **{payload.get('candidate_count', 0)}**",
+        "",
+        "## Candidate probation status",
+        "",
+        "| Candidate | Probation status | History | Successes | Allowed now |",
+        "|---|---|---:|---:|---|",
+    ]
+    for row in rows:
+        lines.append(
+            "| `{key}` | {status} | {history}/{required_history} | {successes}/{required_success} | {allowed} |".format(
+                key=row.get("candidate_key", ""),
+                status=row.get("probation_status", ""),
+                history=row.get("observed_history_count", 0),
+                required_history=row.get("required_history_count", 0),
+                successes=row.get("observed_success_count", 0),
+                required_success=row.get("required_success_count", 0),
+                allowed=row.get("auto_fix_allowed_now", False),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "",
+            "This report does not enable auto-fix. READY candidates still require a separate policy PR, dry-run plan, rollback plan, and PR-only guardrails.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/sdetkit/auto_fix_probation_report.py
+++ b/src/sdetkit/auto_fix_probation_report.py
@@ -27,7 +27,9 @@ def _blocking_reasons(candidate: dict[str, Any], probation_status: str) -> list[
     if probation_status == "NEEDS_MORE_OBSERVATION":
         reasons.append("Candidate has not met the required observation count.")
     elif probation_status == "NEEDS_MORE_SUCCESSFUL_PROOF":
-        reasons.append("Candidate has enough observations but not enough successful manual outcomes.")
+        reasons.append(
+            "Candidate has enough observations but not enough successful manual outcomes."
+        )
     elif probation_status == "READY_FOR_PROBATION_REVIEW":
         reasons.append("Candidate can be reviewed for a future policy PR, not executed now.")
     elif probation_status == "POLICY_VIOLATION":
@@ -68,9 +70,7 @@ def build_auto_fix_probation_report(registry: dict[str, Any]) -> dict[str, Any]:
 
 def render_auto_fix_probation_report_markdown(payload: dict[str, Any]) -> str:
     rows = (
-        payload.get("probation_rows", [])
-        if isinstance(payload.get("probation_rows"), list)
-        else []
+        payload.get("probation_rows", []) if isinstance(payload.get("probation_rows"), list) else []
     )
     lines = [
         "# Auto-fix probation report",

--- a/tests/test_auto_fix_probation_report.py
+++ b/tests/test_auto_fix_probation_report.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from sdetkit.auto_fix_probation_report import (
+    build_auto_fix_probation_report,
+    render_auto_fix_probation_report_markdown,
+)
+from sdetkit.safe_fix_candidate_registry import build_safe_fix_candidate_registry
+
+
+def _record(
+    classification: str,
+    *,
+    merged: bool = True,
+    manual_fix_outcome: str = "merged",
+    safe_fix_outcome: str = "not_attempted",
+) -> dict[str, object]:
+    return {
+        "classification": classification,
+        "surface": "tests",
+        "proof_command": "python -m pre_commit run -a",
+        "merged": merged,
+        "manual_fix_outcome": manual_fix_outcome,
+        "safe_fix_outcome": safe_fix_outcome,
+    }
+
+
+def test_probation_report_empty_registry_has_no_candidates():
+    payload = build_auto_fix_probation_report({})
+
+    assert payload == {
+        "schema_version": "sdetkit.auto_fix.probation_report.v1",
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "candidate_count": 0,
+        "counts_by_probation_status": {},
+        "probation_rows": [],
+    }
+
+
+def test_probation_report_marks_observe_more_candidates():
+    registry = build_safe_fix_candidate_registry()
+
+    payload = build_auto_fix_probation_report(registry)
+
+    assert payload["candidate_count"] == 2
+    assert payload["counts_by_probation_status"] == {"NEEDS_MORE_OBSERVATION": 2}
+    for row in payload["probation_rows"]:
+        assert row["probation_status"] == "NEEDS_MORE_OBSERVATION"
+        assert row["automation_allowed"] is False
+        assert row["auto_fix_allowed_now"] is False
+        assert "required observation count" in " ".join(row["blocking_reasons"])
+
+
+def test_probation_report_marks_not_ready_when_successes_are_short():
+    registry = build_safe_fix_candidate_registry(
+        {
+            "records": [
+                _record("PRE_COMMIT_FORMAT_DRIFT"),
+                _record("PRE_COMMIT_FORMAT_DRIFT"),
+                _record("PRE_COMMIT_FORMAT_DRIFT", merged=False, manual_fix_outcome="unknown"),
+            ]
+        },
+        candidate_classes=("PRE_COMMIT_FORMAT_DRIFT",),
+    )
+
+    payload = build_auto_fix_probation_report(registry)
+    row = payload["probation_rows"][0]
+
+    assert payload["counts_by_probation_status"] == {"NEEDS_MORE_SUCCESSFUL_PROOF": 1}
+    assert row["probation_status"] == "NEEDS_MORE_SUCCESSFUL_PROOF"
+    assert row["observed_history_count"] == 3
+    assert row["observed_success_count"] == 2
+    assert "not enough successful manual outcomes" in " ".join(row["blocking_reasons"])
+
+
+def test_probation_report_marks_ready_for_review_when_registry_thresholds_are_met():
+    registry = build_safe_fix_candidate_registry(
+        {
+            "records": [
+                _record("RUFF_FIXABLE_LINT", safe_fix_outcome="manual_success"),
+                _record("RUFF_FIXABLE_LINT", safe_fix_outcome="manual_success"),
+                _record("RUFF_FIXABLE_LINT", safe_fix_outcome="manual_success"),
+            ]
+        },
+        candidate_classes=("RUFF_FIXABLE_LINT",),
+    )
+
+    payload = build_auto_fix_probation_report(registry)
+    row = payload["probation_rows"][0]
+
+    assert payload["counts_by_probation_status"] == {"READY_FOR_PROBATION_REVIEW": 1}
+    assert row["probation_status"] == "READY_FOR_PROBATION_REVIEW"
+    assert row["observed_history_count"] == 3
+    assert row["observed_success_count"] == 3
+    assert row["auto_fix_allowed_now"] is False
+    assert "future policy PR" in " ".join(row["blocking_reasons"])
+
+
+def test_probation_report_blocks_policy_violation_if_candidate_allows_auto_fix_now():
+    registry = {
+        "candidates": [
+            {
+                "candidate_key": "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+                "classification": "PRE_COMMIT_FORMAT_DRIFT",
+                "current_status": "READY_FOR_POLICY_PR",
+                "observed_history_count": 3,
+                "observed_success_count": 3,
+                "required_history_count": 3,
+                "required_success_count": 3,
+                "auto_fix_allowed_now": True,
+                "blocking_reason": "unsafe test fixture",
+            }
+        ]
+    }
+
+    payload = build_auto_fix_probation_report(registry)
+    row = payload["probation_rows"][0]
+
+    assert payload["counts_by_probation_status"] == {"POLICY_VIOLATION": 1}
+    assert row["probation_status"] == "POLICY_VIOLATION"
+    assert row["auto_fix_allowed_now"] is False
+    assert "must be blocked" in " ".join(row["blocking_reasons"])
+
+
+def test_probation_report_markdown_is_operator_readable():
+    registry = build_safe_fix_candidate_registry(
+        {
+            "records": [
+                _record("PRE_COMMIT_FORMAT_DRIFT"),
+                _record("PRE_COMMIT_FORMAT_DRIFT"),
+                _record("PRE_COMMIT_FORMAT_DRIFT"),
+            ]
+        },
+        candidate_classes=("PRE_COMMIT_FORMAT_DRIFT",),
+    )
+    payload = build_auto_fix_probation_report(registry)
+
+    rendered = render_auto_fix_probation_report_markdown(payload)
+
+    assert rendered.startswith("# Auto-fix probation report")
+    assert "diagnostic only: **True**" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "auto-fix allowed now: **False**" in rendered
+    assert "`diagnosis:PRE_COMMIT_FORMAT_DRIFT`" in rendered
+    assert "READY_FOR_PROBATION_REVIEW" in rendered
+    assert "This report does not enable auto-fix" in rendered


### PR DESCRIPTION
## Summary

- Add `sdetkit.auto_fix_probation_report`.
- Build diagnostic-only probation reports from the safe-fix candidate registry.
- Classify candidate state as `NEEDS_MORE_OBSERVATION`, `NEEDS_MORE_SUCCESSFUL_PROOF`, `READY_FOR_PROBATION_REVIEW`, or `POLICY_VIOLATION`.
- Add Markdown rendering for operator-facing probation reports.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Implements Phase 14: Publish auto-fix probation report

## Safety

- Diagnostic-only.
- No auto-fix behavior enabled.
- `automation_allowed` remains false.
- `auto_fix_allowed_now` remains false for every candidate.
- READY candidates still require a separate policy PR, dry-run plan, rollback plan, and PR-only guardrails.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_auto_fix_probation_report.py tests/test_safe_fix_candidate_registry.py tests/test_investigation_outcome_memory.py tests/test_pr_investigation_summary.py tests/test_investigation_safe_fix_policy.py tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the auto-fix probation report module and tests.