### PR TITLE
Publish maintenance policy proposals

### DIFF
--- a/src/sdetkit/maintenance_policy_proposals.py
+++ b/src/sdetkit/maintenance_policy_proposals.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.maintenance.policy_proposals.v1"
+
+
+def _as_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = report.get("probation_rows", []) if isinstance(report, dict) else []
+    return rows if isinstance(rows, list) else []
+
+
+def _proposal_status(row: dict[str, Any]) -> str:
+    if bool(row.get("auto_fix_allowed_now")):
+        return "BLOCK_POLICY_VIOLATION"
+    status = str(row.get("probation_status", ""))
+    if status == "READY_FOR_PROBATION_REVIEW":
+        return "PROPOSE_POLICY_REVIEW"
+    if status == "NEEDS_MORE_SUCCESSFUL_PROOF":
+        return "WAIT_FOR_MORE_SUCCESSFUL_PROOF"
+    return "WAIT_FOR_MORE_OBSERVATION"
+
+
+def _recommended_next_step(status: str) -> str:
+    if status == "PROPOSE_POLICY_REVIEW":
+        return "Open a human-reviewed policy proposal PR before any dry-run or automation work."
+    if status == "WAIT_FOR_MORE_SUCCESSFUL_PROOF":
+        return "Collect additional successful manual outcomes before proposing policy."
+    if status == "BLOCK_POLICY_VIOLATION":
+        return "Block this candidate and investigate why auto-fix appears enabled too early."
+    return "Collect more observation history before proposing policy."
+
+
+def _proposal_for_row(row: dict[str, Any]) -> dict[str, Any]:
+    status = _proposal_status(row)
+    return {
+        "candidate_key": str(row.get("candidate_key", "")),
+        "classification": str(row.get("classification", "")),
+        "proposal_status": status,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "requires_human_review": True,
+        "recommended_next_step": _recommended_next_step(status),
+        "observed_history_count": int(row.get("observed_history_count", 0) or 0),
+        "observed_success_count": int(row.get("observed_success_count", 0) or 0),
+        "blocking_reasons": row.get("blocking_reasons", [])
+        if isinstance(row.get("blocking_reasons"), list)
+        else [],
+        "policy_requirements": [
+            "human_reviewed_policy_pr",
+            "dry_run_plan",
+            "rollback_plan",
+            "pr_only_guardrails",
+            "post_merge_outcome_memory",
+        ],
+    }
+
+
+def build_maintenance_policy_proposals(probation_report: dict[str, Any]) -> dict[str, Any]:
+    proposals = [_proposal_for_row(row) for row in _as_rows(probation_report)]
+    counts = Counter(proposal["proposal_status"] for proposal in proposals)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "proposal_count": len(proposals),
+        "counts_by_proposal_status": dict(sorted(counts.items())),
+        "proposals": sorted(proposals, key=lambda item: item["candidate_key"]),
+    }
+
+
+def render_maintenance_policy_proposals_markdown(payload: dict[str, Any]) -> str:
+    proposals = payload.get("proposals", []) if isinstance(payload.get("proposals"), list) else []
+    lines = [
+        "# Maintenance policy proposals",
+        "",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- auto-fix allowed now: **{payload.get('auto_fix_allowed_now', False)}**",
+        f"- proposals: **{payload.get('proposal_count', 0)}**",
+        "",
+        "## Proposal status",
+        "",
+        "| Candidate | Proposal status | History | Successes | Next step |",
+        "|---|---|---:|---:|---|",
+    ]
+    for proposal in proposals:
+        lines.append(
+            "| `{key}` | {status} | {history} | {successes} | {next_step} |".format(
+                key=proposal.get("candidate_key", ""),
+                status=proposal.get("proposal_status", ""),
+                history=proposal.get("observed_history_count", 0),
+                successes=proposal.get("observed_success_count", 0),
+                next_step=proposal.get("recommended_next_step", ""),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "",
+            "These are policy proposals only. They do not enable dry-runs, create fix branches, or execute auto-fix behavior.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_maintenance_policy_proposals.py
+++ b/tests/test_maintenance_policy_proposals.py
@@ -75,7 +75,9 @@ def test_policy_proposals_map_probation_statuses():
     assert by_key["diagnosis:PRE_COMMIT_FORMAT_DRIFT"]["proposal_status"] == "PROPOSE_POLICY_REVIEW"
     assert by_key["diagnosis:PRE_COMMIT_FORMAT_DRIFT"]["requires_human_review"] is True
     assert by_key["diagnosis:PRE_COMMIT_FORMAT_DRIFT"]["auto_fix_allowed_now"] is False
-    assert by_key["diagnosis:RUFF_FIXABLE_LINT"]["proposal_status"] == "WAIT_FOR_MORE_SUCCESSFUL_PROOF"
+    assert (
+        by_key["diagnosis:RUFF_FIXABLE_LINT"]["proposal_status"] == "WAIT_FOR_MORE_SUCCESSFUL_PROOF"
+    )
     assert by_key["diagnosis:UNKNOWN"]["proposal_status"] == "WAIT_FOR_MORE_OBSERVATION"
 
 

--- a/tests/test_maintenance_policy_proposals.py
+++ b/tests/test_maintenance_policy_proposals.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from sdetkit.maintenance_policy_proposals import (
+    build_maintenance_policy_proposals,
+    render_maintenance_policy_proposals_markdown,
+)
+
+
+def _row(
+    candidate_key: str,
+    probation_status: str,
+    *,
+    auto_fix_allowed_now: bool = False,
+    history: int = 0,
+    successes: int = 0,
+) -> dict[str, object]:
+    return {
+        "candidate_key": candidate_key,
+        "classification": candidate_key.removeprefix("diagnosis:"),
+        "probation_status": probation_status,
+        "observed_history_count": history,
+        "observed_success_count": successes,
+        "auto_fix_allowed_now": auto_fix_allowed_now,
+        "blocking_reasons": ["policy gate not complete"],
+    }
+
+
+def test_policy_proposals_empty_report_has_no_proposals():
+    payload = build_maintenance_policy_proposals({})
+
+    assert payload == {
+        "schema_version": "sdetkit.maintenance.policy_proposals.v1",
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "proposal_count": 0,
+        "counts_by_proposal_status": {},
+        "proposals": [],
+    }
+
+
+def test_policy_proposals_map_probation_statuses():
+    report = {
+        "probation_rows": [
+            _row(
+                "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+                "READY_FOR_PROBATION_REVIEW",
+                history=3,
+                successes=3,
+            ),
+            _row(
+                "diagnosis:RUFF_FIXABLE_LINT",
+                "NEEDS_MORE_SUCCESSFUL_PROOF",
+                history=3,
+                successes=2,
+            ),
+            _row(
+                "diagnosis:UNKNOWN",
+                "NEEDS_MORE_OBSERVATION",
+                history=1,
+                successes=1,
+            ),
+        ]
+    }
+
+    payload = build_maintenance_policy_proposals(report)
+    by_key = {proposal["candidate_key"]: proposal for proposal in payload["proposals"]}
+
+    assert payload["proposal_count"] == 3
+    assert payload["counts_by_proposal_status"] == {
+        "PROPOSE_POLICY_REVIEW": 1,
+        "WAIT_FOR_MORE_OBSERVATION": 1,
+        "WAIT_FOR_MORE_SUCCESSFUL_PROOF": 1,
+    }
+    assert by_key["diagnosis:PRE_COMMIT_FORMAT_DRIFT"]["proposal_status"] == "PROPOSE_POLICY_REVIEW"
+    assert by_key["diagnosis:PRE_COMMIT_FORMAT_DRIFT"]["requires_human_review"] is True
+    assert by_key["diagnosis:PRE_COMMIT_FORMAT_DRIFT"]["auto_fix_allowed_now"] is False
+    assert by_key["diagnosis:RUFF_FIXABLE_LINT"]["proposal_status"] == "WAIT_FOR_MORE_SUCCESSFUL_PROOF"
+    assert by_key["diagnosis:UNKNOWN"]["proposal_status"] == "WAIT_FOR_MORE_OBSERVATION"
+
+
+def test_policy_proposals_block_policy_violation():
+    payload = build_maintenance_policy_proposals(
+        {
+            "probation_rows": [
+                _row(
+                    "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+                    "READY_FOR_PROBATION_REVIEW",
+                    auto_fix_allowed_now=True,
+                    history=3,
+                    successes=3,
+                )
+            ]
+        }
+    )
+    proposal = payload["proposals"][0]
+
+    assert payload["counts_by_proposal_status"] == {"BLOCK_POLICY_VIOLATION": 1}
+    assert proposal["proposal_status"] == "BLOCK_POLICY_VIOLATION"
+    assert proposal["automation_allowed"] is False
+    assert proposal["auto_fix_allowed_now"] is False
+    assert "Block this candidate" in proposal["recommended_next_step"]
+
+
+def test_policy_proposals_include_required_future_gates():
+    payload = build_maintenance_policy_proposals(
+        {
+            "probation_rows": [
+                _row(
+                    "diagnosis:RUFF_FIXABLE_LINT",
+                    "READY_FOR_PROBATION_REVIEW",
+                    history=3,
+                    successes=3,
+                )
+            ]
+        }
+    )
+    proposal = payload["proposals"][0]
+
+    assert proposal["policy_requirements"] == [
+        "human_reviewed_policy_pr",
+        "dry_run_plan",
+        "rollback_plan",
+        "pr_only_guardrails",
+        "post_merge_outcome_memory",
+    ]
+    assert "policy proposal PR" in proposal["recommended_next_step"]
+
+
+def test_policy_proposals_markdown_is_operator_readable():
+    payload = build_maintenance_policy_proposals(
+        {
+            "probation_rows": [
+                _row(
+                    "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+                    "READY_FOR_PROBATION_REVIEW",
+                    history=3,
+                    successes=3,
+                )
+            ]
+        }
+    )
+
+    rendered = render_maintenance_policy_proposals_markdown(payload)
+
+    assert rendered.startswith("# Maintenance policy proposals")
+    assert "diagnostic only: **True**" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "auto-fix allowed now: **False**" in rendered
+    assert "`diagnosis:PRE_COMMIT_FORMAT_DRIFT`" in rendered
+    assert "PROPOSE_POLICY_REVIEW" in rendered
+    assert "These are policy proposals only" in rendered


### PR DESCRIPTION
## Summary

- Add `sdetkit.maintenance_policy_proposals`.
- Build diagnostic-only policy proposals from auto-fix probation rows.
- Map probation states to proposal statuses: `PROPOSE_POLICY_REVIEW`, `WAIT_FOR_MORE_OBSERVATION`, `WAIT_FOR_MORE_SUCCESSFUL_PROOF`, and `BLOCK_POLICY_VIOLATION`.
- Include required future gates for policy review, dry-run planning, rollback planning, PR-only guardrails, and outcome memory.
- Add Markdown rendering for operator-facing policy proposal summaries.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Implements Phase 15: Publish maintenance policy proposals

## Safety

- Diagnostic-only.
- No auto-fix behavior enabled.
- `automation_allowed` remains false.
- `auto_fix_allowed_now` remains false for every proposal.
- These proposals do not enable dry-runs, create fix branches, or execute auto-fix behavior.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_maintenance_policy_proposals.py tests/test_auto_fix_probation_report.py tests/test_safe_fix_candidate_registry.py tests/test_investigation_outcome_memory.py tests/test_pr_investigation_summary.py tests/test_investigation_safe_fix_policy.py tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the maintenance policy proposal module and tests.