### PR TITLE
Publish auto-fix dry-run plan

### DIFF
--- a/src/sdetkit/auto_fix_dry_run_plan.py
+++ b/src/sdetkit/auto_fix_dry_run_plan.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.auto_fix.dry_run_plan.v1"
+DRY_RUN_REQUIREMENTS = [
+    "human_reviewed_policy_pr",
+    "clean_worktree_required",
+    "branch_only_changes",
+    "no_direct_main_push",
+    "rollback_plan_required",
+    "post_run_evidence_required",
+]
+DEFAULT_COMMANDS = {
+    "PRE_COMMIT_FORMAT_DRIFT": [
+        "python -m pre_commit run -a",
+        "git diff --check",
+        "./scripts/pr_preflight.sh",
+    ],
+    "RUFF_FIXABLE_LINT": [
+        "python -m ruff check . --fix --diff",
+        "python -m ruff format --check .",
+        "python -m pre_commit run -a",
+    ],
+}
+
+
+def _as_proposals(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    proposals = payload.get("proposals", []) if isinstance(payload, dict) else []
+    return proposals if isinstance(proposals, list) else []
+
+
+def _plan_status(proposal: dict[str, Any]) -> str:
+    if bool(proposal.get("auto_fix_allowed_now")):
+        return "BLOCK_POLICY_VIOLATION"
+    if str(proposal.get("proposal_status", "")) == "PROPOSE_POLICY_REVIEW":
+        return "READY_FOR_DRY_RUN_PLAN_REVIEW"
+    return "NOT_READY_FOR_DRY_RUN"
+
+
+def _commands_for(classification: str) -> list[str]:
+    return DEFAULT_COMMANDS.get(
+        classification,
+        ["python -m sdetkit investigate failure --log <log> --format markdown"],
+    )
+
+
+def _blockers_for(status: str, proposal: dict[str, Any]) -> list[str]:
+    if status == "READY_FOR_DRY_RUN_PLAN_REVIEW":
+        return ["Dry-run plan still requires human approval before execution."]
+    if status == "BLOCK_POLICY_VIOLATION":
+        return ["Auto-fix appears enabled before dry-run policy approval."]
+    reasons = proposal.get("blocking_reasons", []) if isinstance(proposal.get("blocking_reasons"), list) else []
+    return [str(reason) for reason in reasons] or ["Policy proposal is not ready for dry-run planning."]
+
+
+def _plan_for_proposal(proposal: dict[str, Any]) -> dict[str, Any]:
+    classification = str(proposal.get("classification", ""))
+    status = _plan_status(proposal)
+    return {
+        "candidate_key": str(proposal.get("candidate_key", "")),
+        "classification": classification,
+        "dry_run_status": status,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "requires_human_review": True,
+        "dry_run_commands": _commands_for(classification),
+        "required_guardrails": DRY_RUN_REQUIREMENTS,
+        "expected_artifacts": [
+            "dry-run-command-log.txt",
+            "dry-run-diff.patch",
+            "dry-run-preflight-summary.md",
+            "dry-run-outcome.json",
+        ],
+        "rollback_plan": "Discard the dry-run branch or revert the dry-run diff before any PR is opened.",
+        "blockers": _blockers_for(status, proposal),
+    }
+
+
+def build_auto_fix_dry_run_plan(policy_proposals: dict[str, Any]) -> dict[str, Any]:
+    plans = [_plan_for_proposal(proposal) for proposal in _as_proposals(policy_proposals)]
+    counts = Counter(plan["dry_run_status"] for plan in plans)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "plan_count": len(plans),
+        "counts_by_dry_run_status": dict(sorted(counts.items())),
+        "plans": sorted(plans, key=lambda item: item["candidate_key"]),
+    }
+
+
+def render_auto_fix_dry_run_plan_markdown(payload: dict[str, Any]) -> str:
+    plans = payload.get("plans", []) if isinstance(payload.get("plans"), list) else []
+    lines = [
+        "# Auto-fix dry-run plan",
+        "",
+        f"- diagnostic only: **{payload.get('diagnostic_only', True)}**",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- auto-fix allowed now: **{payload.get('auto_fix_allowed_now', False)}**",
+        f"- plans: **{payload.get('plan_count', 0)}**",
+        "",
+        "## Plans",
+        "",
+        "| Candidate | Dry-run status | Commands | Artifacts |",
+        "|---|---|---:|---:|",
+    ]
+    for plan in plans:
+        commands = plan.get("dry_run_commands", []) if isinstance(plan.get("dry_run_commands"), list) else []
+        artifacts = plan.get("expected_artifacts", []) if isinstance(plan.get("expected_artifacts"), list) else []
+        lines.append(
+            "| `{key}` | {status} | {commands} | {artifacts} |".format(
+                key=plan.get("candidate_key", ""),
+                status=plan.get("dry_run_status", ""),
+                commands=len(commands),
+                artifacts=len(artifacts),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "",
+            "This is a plan only. It does not run commands, modify files, create branches, or open PRs.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/sdetkit/auto_fix_dry_run_plan.py
+++ b/src/sdetkit/auto_fix_dry_run_plan.py
@@ -9,6 +9,7 @@ DRY_RUN_REQUIREMENTS = [
     "clean_worktree_required",
     "branch_only_changes",
     "no_direct_main_push",
+    "pr_only_guardrails",
     "rollback_plan_required",
     "post_run_evidence_required",
 ]

--- a/src/sdetkit/auto_fix_dry_run_plan.py
+++ b/src/sdetkit/auto_fix_dry_run_plan.py
@@ -52,8 +52,14 @@ def _blockers_for(status: str, proposal: dict[str, Any]) -> list[str]:
         return ["Dry-run plan still requires human approval before execution."]
     if status == "BLOCK_POLICY_VIOLATION":
         return ["Auto-fix appears enabled before dry-run policy approval."]
-    reasons = proposal.get("blocking_reasons", []) if isinstance(proposal.get("blocking_reasons"), list) else []
-    return [str(reason) for reason in reasons] or ["Policy proposal is not ready for dry-run planning."]
+    reasons = (
+        proposal.get("blocking_reasons", [])
+        if isinstance(proposal.get("blocking_reasons"), list)
+        else []
+    )
+    return [str(reason) for reason in reasons] or [
+        "Policy proposal is not ready for dry-run planning."
+    ]
 
 
 def _plan_for_proposal(proposal: dict[str, Any]) -> dict[str, Any]:
@@ -109,8 +115,16 @@ def render_auto_fix_dry_run_plan_markdown(payload: dict[str, Any]) -> str:
         "|---|---|---:|---:|",
     ]
     for plan in plans:
-        commands = plan.get("dry_run_commands", []) if isinstance(plan.get("dry_run_commands"), list) else []
-        artifacts = plan.get("expected_artifacts", []) if isinstance(plan.get("expected_artifacts"), list) else []
+        commands = (
+            plan.get("dry_run_commands", [])
+            if isinstance(plan.get("dry_run_commands"), list)
+            else []
+        )
+        artifacts = (
+            plan.get("expected_artifacts", [])
+            if isinstance(plan.get("expected_artifacts"), list)
+            else []
+        )
         lines.append(
             "| `{key}` | {status} | {commands} | {artifacts} |".format(
                 key=plan.get("candidate_key", ""),

--- a/tests/test_auto_fix_dry_run_plan.py
+++ b/tests/test_auto_fix_dry_run_plan.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from sdetkit.auto_fix_dry_run_plan import (
+    build_auto_fix_dry_run_plan,
+    render_auto_fix_dry_run_plan_markdown,
+)
+
+
+def _proposal(
+    candidate_key: str,
+    proposal_status: str,
+    *,
+    auto_fix_allowed_now: bool = False,
+) -> dict[str, object]:
+    return {
+        "candidate_key": candidate_key,
+        "classification": candidate_key.removeprefix("diagnosis:"),
+        "proposal_status": proposal_status,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": auto_fix_allowed_now,
+        "requires_human_review": True,
+        "blocking_reasons": ["policy proposal not approved"],
+    }
+
+
+def test_dry_run_plan_empty_proposals_has_no_plans():
+    payload = build_auto_fix_dry_run_plan({})
+
+    assert payload == {
+        "schema_version": "sdetkit.auto_fix.dry_run_plan.v1",
+        "diagnostic_only": True,
+        "automation_allowed": False,
+        "auto_fix_allowed_now": False,
+        "plan_count": 0,
+        "counts_by_dry_run_status": {},
+        "plans": [],
+    }
+
+
+def test_dry_run_plan_maps_ready_policy_proposal_to_review_plan():
+    payload = build_auto_fix_dry_run_plan(
+        {
+            "proposals": [
+                _proposal("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "PROPOSE_POLICY_REVIEW")
+            ]
+        }
+    )
+    plan = payload["plans"][0]
+
+    assert payload["counts_by_dry_run_status"] == {"READY_FOR_DRY_RUN_PLAN_REVIEW": 1}
+    assert plan["dry_run_status"] == "READY_FOR_DRY_RUN_PLAN_REVIEW"
+    assert plan["automation_allowed"] is False
+    assert plan["auto_fix_allowed_now"] is False
+    assert plan["requires_human_review"] is True
+    assert plan["dry_run_commands"] == [
+        "python -m pre_commit run -a",
+        "git diff --check",
+        "./scripts/pr_preflight.sh",
+    ]
+    assert "dry-run-command-log.txt" in plan["expected_artifacts"]
+    assert "dry-run-diff.patch" in plan["expected_artifacts"]
+    assert "human_reviewed_policy_pr" in plan["required_guardrails"]
+    assert "pr_only_guardrails" in plan["required_guardrails"]
+    assert "human approval" in " ".join(plan["blockers"])
+
+
+def test_dry_run_plan_maps_waiting_policy_proposal_to_not_ready():
+    payload = build_auto_fix_dry_run_plan(
+        {
+            "proposals": [
+                _proposal("diagnosis:RUFF_FIXABLE_LINT", "WAIT_FOR_MORE_SUCCESSFUL_PROOF")
+            ]
+        }
+    )
+    plan = payload["plans"][0]
+
+    assert payload["counts_by_dry_run_status"] == {"NOT_READY_FOR_DRY_RUN": 1}
+    assert plan["dry_run_status"] == "NOT_READY_FOR_DRY_RUN"
+    assert plan["dry_run_commands"] == [
+        "python -m ruff check . --fix --diff",
+        "python -m ruff format --check .",
+        "python -m pre_commit run -a",
+    ]
+    assert plan["blockers"] == ["policy proposal not approved"]
+    assert plan["auto_fix_allowed_now"] is False
+
+
+def test_dry_run_plan_blocks_policy_violation():
+    payload = build_auto_fix_dry_run_plan(
+        {
+            "proposals": [
+                _proposal(
+                    "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+                    "PROPOSE_POLICY_REVIEW",
+                    auto_fix_allowed_now=True,
+                )
+            ]
+        }
+    )
+    plan = payload["plans"][0]
+
+    assert payload["counts_by_dry_run_status"] == {"BLOCK_POLICY_VIOLATION": 1}
+    assert plan["dry_run_status"] == "BLOCK_POLICY_VIOLATION"
+    assert plan["auto_fix_allowed_now"] is False
+    assert "enabled before dry-run policy approval" in " ".join(plan["blockers"])
+
+
+def test_dry_run_plan_uses_safe_fallback_command_for_unknown_classification():
+    payload = build_auto_fix_dry_run_plan(
+        {"proposals": [_proposal("diagnosis:UNKNOWN_REVIEW_REQUIRED", "PROPOSE_POLICY_REVIEW")]}
+    )
+    plan = payload["plans"][0]
+
+    assert plan["dry_run_commands"] == [
+        "python -m sdetkit investigate failure --log <log> --format markdown"
+    ]
+    assert plan["dry_run_status"] == "READY_FOR_DRY_RUN_PLAN_REVIEW"
+
+
+def test_dry_run_plan_sorts_plans_by_candidate_key():
+    payload = build_auto_fix_dry_run_plan(
+        {
+            "proposals": [
+                _proposal("diagnosis:RUFF_FIXABLE_LINT", "PROPOSE_POLICY_REVIEW"),
+                _proposal("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "PROPOSE_POLICY_REVIEW"),
+            ]
+        }
+    )
+
+    assert [plan["candidate_key"] for plan in payload["plans"]] == [
+        "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+        "diagnosis:RUFF_FIXABLE_LINT",
+    ]
+
+
+def test_dry_run_plan_markdown_is_operator_readable():
+    payload = build_auto_fix_dry_run_plan(
+        {
+            "proposals": [
+                _proposal("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "PROPOSE_POLICY_REVIEW")
+            ]
+        }
+    )
+
+    rendered = render_auto_fix_dry_run_plan_markdown(payload)
+
+    assert rendered.startswith("# Auto-fix dry-run plan")
+    assert "diagnostic only: **True**" in rendered
+    assert "automation allowed: **False**" in rendered
+    assert "auto-fix allowed now: **False**" in rendered
+    assert "`diagnosis:PRE_COMMIT_FORMAT_DRIFT`" in rendered
+    assert "READY_FOR_DRY_RUN_PLAN_REVIEW" in rendered
+    assert "This is a plan only" in rendered

--- a/tests/test_auto_fix_dry_run_plan.py
+++ b/tests/test_auto_fix_dry_run_plan.py
@@ -39,11 +39,7 @@ def test_dry_run_plan_empty_proposals_has_no_plans():
 
 def test_dry_run_plan_maps_ready_policy_proposal_to_review_plan():
     payload = build_auto_fix_dry_run_plan(
-        {
-            "proposals": [
-                _proposal("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "PROPOSE_POLICY_REVIEW")
-            ]
-        }
+        {"proposals": [_proposal("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "PROPOSE_POLICY_REVIEW")]}
     )
     plan = payload["plans"][0]
 
@@ -66,11 +62,7 @@ def test_dry_run_plan_maps_ready_policy_proposal_to_review_plan():
 
 def test_dry_run_plan_maps_waiting_policy_proposal_to_not_ready():
     payload = build_auto_fix_dry_run_plan(
-        {
-            "proposals": [
-                _proposal("diagnosis:RUFF_FIXABLE_LINT", "WAIT_FOR_MORE_SUCCESSFUL_PROOF")
-            ]
-        }
+        {"proposals": [_proposal("diagnosis:RUFF_FIXABLE_LINT", "WAIT_FOR_MORE_SUCCESSFUL_PROOF")]}
     )
     plan = payload["plans"][0]
 
@@ -135,11 +127,7 @@ def test_dry_run_plan_sorts_plans_by_candidate_key():
 
 def test_dry_run_plan_markdown_is_operator_readable():
     payload = build_auto_fix_dry_run_plan(
-        {
-            "proposals": [
-                _proposal("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "PROPOSE_POLICY_REVIEW")
-            ]
-        }
+        {"proposals": [_proposal("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "PROPOSE_POLICY_REVIEW")]}
     )
 
     rendered = render_auto_fix_dry_run_plan_markdown(payload)


### PR DESCRIPTION
## Summary

- Add `sdetkit.auto_fix_dry_run_plan`.
- Build diagnostic-only dry-run plans from maintenance policy proposals.
- Map proposal states to dry-run statuses: `READY_FOR_DRY_RUN_PLAN_REVIEW`, `NOT_READY_FOR_DRY_RUN`, and `BLOCK_POLICY_VIOLATION`.
- Include dry-run commands, required guardrails, expected artifacts, rollback plan, and blockers.
- Add Markdown rendering for operator-facing dry-run plan summaries.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Implements Phase 16: Publish auto-fix dry-run plan

## Safety

- Diagnostic-only.
- No auto-fix behavior enabled.
- `automation_allowed` remains false.
- `auto_fix_allowed_now` remains false for every plan.
- This is a plan only; it does not run commands, modify files, create branches, or open PRs.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_auto_fix_dry_run_plan.py tests/test_maintenance_policy_proposals.py tests/test_auto_fix_probation_report.py tests/test_safe_fix_candidate_registry.py tests/test_investigation_outcome_memory.py tests/test_pr_investigation_summary.py tests/test_investigation_safe_fix_policy.py tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the auto-fix dry-run plan module and tests.