### PR TITLE
Enable guarded PR-only auto-fix

### DIFF
--- a/src/sdetkit/pr_guardrail_decisions.py
+++ b/src/sdetkit/pr_guardrail_decisions.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.pr_guardrail_decisions.v1"
+REQUIRED_APPROVALS = [
+    "human_reviewed_policy_pr",
+    "dry_run_plan_approved",
+    "rollback_plan_approved",
+    "pr_only_guardrails",
+    "clean_worktree_confirmed",
+]
+READY_STATUSES = {"READY_FOR_DRY_RUN_PLAN_REVIEW"}
+
+
+def _as_plans(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    plans = payload.get("plans", []) if isinstance(payload, dict) else []
+    return plans if isinstance(plans, list) else []
+
+
+def _approved_set(approvals: list[str] | tuple[str, ...] | None) -> set[str]:
+    if not approvals:
+        return set()
+    return {str(value).strip() for value in approvals if str(value).strip()}
+
+
+def _missing_approvals(approved: set[str]) -> list[str]:
+    return [item for item in REQUIRED_APPROVALS if item not in approved]
+
+
+def _decision_status(plan: dict[str, Any], approved: set[str]) -> str:
+    if bool(plan.get("direct_to_main_allowed")):
+        return "BLOCK_DIRECT_TO_MAIN"
+    if str(plan.get("dry_run_status", "")) not in READY_STATUSES:
+        return "BLOCK_NOT_READY"
+    if _missing_approvals(approved):
+        return "BLOCK_MISSING_APPROVALS"
+    return "READY_FOR_PR_BRANCH_REVIEW"
+
+
+def _branch_name(candidate_key: str) -> str:
+    clean = candidate_key.replace("diagnosis:", "").lower().replace("_", "-")
+    return f"maintenance/{clean or 'candidate'}"
+
+
+def _decision_for_plan(plan: dict[str, Any], approved: set[str]) -> dict[str, Any]:
+    status = _decision_status(plan, approved)
+    candidate_key = str(plan.get("candidate_key", ""))
+    blockers = []
+    if status == "BLOCK_DIRECT_TO_MAIN":
+        blockers.append("Direct-to-main changes are blocked by policy.")
+    elif status == "BLOCK_NOT_READY":
+        blockers.append("Plan is not ready for a guarded PR branch.")
+    elif status == "BLOCK_MISSING_APPROVALS":
+        blockers.append("Required approvals are missing before a PR branch can be prepared.")
+    return {
+        "candidate_key": candidate_key,
+        "classification": str(plan.get("classification", "")),
+        "decision_status": status,
+        "change_allowed_now": False,
+        "direct_to_main_allowed": False,
+        "pr_only": True,
+        "requires_human_review": True,
+        "target_branch": _branch_name(candidate_key),
+        "required_approvals": REQUIRED_APPROVALS,
+        "missing_approvals": _missing_approvals(approved),
+        "review_commands": plan.get("dry_run_commands", [])
+        if isinstance(plan.get("dry_run_commands"), list)
+        else [],
+        "expected_artifacts": plan.get("expected_artifacts", [])
+        if isinstance(plan.get("expected_artifacts"), list)
+        else [],
+        "blockers": blockers,
+    }
+
+
+def build_pr_guardrail_decisions(
+    dry_run_plan: dict[str, Any],
+    approvals: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    approved = _approved_set(approvals)
+    decisions = [_decision_for_plan(plan, approved) for plan in _as_plans(dry_run_plan)]
+    counts = Counter(decision["decision_status"] for decision in decisions)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "automation_allowed": False,
+        "change_allowed_now": False,
+        "direct_to_main_allowed": False,
+        "decision_count": len(decisions),
+        "counts_by_decision_status": dict(sorted(counts.items())),
+        "decisions": sorted(decisions, key=lambda item: item["candidate_key"]),
+    }
+
+
+def render_pr_guardrail_decisions_markdown(payload: dict[str, Any]) -> str:
+    decisions = payload.get("decisions", []) if isinstance(payload.get("decisions"), list) else []
+    lines = [
+        "# PR guardrail decisions",
+        "",
+        f"- automation allowed: **{payload.get('automation_allowed', False)}**",
+        f"- change allowed now: **{payload.get('change_allowed_now', False)}**",
+        f"- direct-to-main allowed: **{payload.get('direct_to_main_allowed', False)}**",
+        f"- decisions: **{payload.get('decision_count', 0)}**",
+        "",
+        "## Decisions",
+        "",
+        "| Candidate | Decision | Target branch | Missing approvals |",
+        "|---|---|---|---:|",
+    ]
+    for decision in decisions:
+        missing = decision.get("missing_approvals", [])
+        missing_count = len(missing) if isinstance(missing, list) else 0
+        lines.append(
+            "| `{key}` | {status} | `{branch}` | {missing} |".format(
+                key=decision.get("candidate_key", ""),
+                status=decision.get("decision_status", ""),
+                branch=decision.get("target_branch", ""),
+                missing=missing_count,
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "",
+            "This layer only decides whether a candidate may proceed toward a PR branch for human review.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_pr_guardrail_decisions.py
+++ b/tests/test_pr_guardrail_decisions.py
@@ -5,7 +5,6 @@ from sdetkit.pr_guardrail_decisions import (
     render_pr_guardrail_decisions_markdown,
 )
 
-
 ALL_APPROVALS = [
     "human_reviewed_policy_pr",
     "dry_run_plan_approved",
@@ -47,11 +46,7 @@ def test_pr_guardrail_decisions_empty_plan_has_no_decisions():
 
 def test_pr_guardrail_decisions_ready_when_all_approvals_present():
     payload = build_pr_guardrail_decisions(
-        {
-            "plans": [
-                _plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW")
-            ]
-        },
+        {"plans": [_plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW")]},
         approvals=ALL_APPROVALS,
     )
     decision = payload["decisions"][0]
@@ -64,18 +59,17 @@ def test_pr_guardrail_decisions_ready_when_all_approvals_present():
     assert decision["requires_human_review"] is True
     assert decision["target_branch"] == "maintenance/pre-commit-format-drift"
     assert decision["missing_approvals"] == []
-    assert decision["review_commands"] == ["python -m pre_commit run -a", "./scripts/pr_preflight.sh"]
+    assert decision["review_commands"] == [
+        "python -m pre_commit run -a",
+        "./scripts/pr_preflight.sh",
+    ]
     assert decision["expected_artifacts"] == ["dry-run-command-log.txt", "dry-run-outcome.json"]
     assert decision["blockers"] == []
 
 
 def test_pr_guardrail_decisions_block_missing_approvals():
     payload = build_pr_guardrail_decisions(
-        {
-            "plans": [
-                _plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW")
-            ]
-        },
+        {"plans": [_plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW")]},
         approvals=["human_reviewed_policy_pr", "dry_run_plan_approved"],
     )
     decision = payload["decisions"][0]
@@ -145,11 +139,7 @@ def test_pr_guardrail_decisions_sort_by_candidate_key():
 
 def test_pr_guardrail_decisions_markdown_is_operator_readable():
     payload = build_pr_guardrail_decisions(
-        {
-            "plans": [
-                _plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW")
-            ]
-        },
+        {"plans": [_plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW")]},
         approvals=ALL_APPROVALS,
     )
 

--- a/tests/test_pr_guardrail_decisions.py
+++ b/tests/test_pr_guardrail_decisions.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from sdetkit.pr_guardrail_decisions import (
+    build_pr_guardrail_decisions,
+    render_pr_guardrail_decisions_markdown,
+)
+
+
+ALL_APPROVALS = [
+    "human_reviewed_policy_pr",
+    "dry_run_plan_approved",
+    "rollback_plan_approved",
+    "pr_only_guardrails",
+    "clean_worktree_confirmed",
+]
+
+
+def _plan(
+    candidate_key: str,
+    dry_run_status: str,
+    *,
+    direct_to_main_allowed: bool = False,
+) -> dict[str, object]:
+    return {
+        "candidate_key": candidate_key,
+        "classification": candidate_key.removeprefix("diagnosis:"),
+        "dry_run_status": dry_run_status,
+        "direct_to_main_allowed": direct_to_main_allowed,
+        "dry_run_commands": ["python -m pre_commit run -a", "./scripts/pr_preflight.sh"],
+        "expected_artifacts": ["dry-run-command-log.txt", "dry-run-outcome.json"],
+    }
+
+
+def test_pr_guardrail_decisions_empty_plan_has_no_decisions():
+    payload = build_pr_guardrail_decisions({})
+
+    assert payload == {
+        "schema_version": "sdetkit.pr_guardrail_decisions.v1",
+        "automation_allowed": False,
+        "change_allowed_now": False,
+        "direct_to_main_allowed": False,
+        "decision_count": 0,
+        "counts_by_decision_status": {},
+        "decisions": [],
+    }
+
+
+def test_pr_guardrail_decisions_ready_when_all_approvals_present():
+    payload = build_pr_guardrail_decisions(
+        {
+            "plans": [
+                _plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW")
+            ]
+        },
+        approvals=ALL_APPROVALS,
+    )
+    decision = payload["decisions"][0]
+
+    assert payload["counts_by_decision_status"] == {"READY_FOR_PR_BRANCH_REVIEW": 1}
+    assert decision["decision_status"] == "READY_FOR_PR_BRANCH_REVIEW"
+    assert decision["change_allowed_now"] is False
+    assert decision["direct_to_main_allowed"] is False
+    assert decision["pr_only"] is True
+    assert decision["requires_human_review"] is True
+    assert decision["target_branch"] == "maintenance/pre-commit-format-drift"
+    assert decision["missing_approvals"] == []
+    assert decision["review_commands"] == ["python -m pre_commit run -a", "./scripts/pr_preflight.sh"]
+    assert decision["expected_artifacts"] == ["dry-run-command-log.txt", "dry-run-outcome.json"]
+    assert decision["blockers"] == []
+
+
+def test_pr_guardrail_decisions_block_missing_approvals():
+    payload = build_pr_guardrail_decisions(
+        {
+            "plans": [
+                _plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW")
+            ]
+        },
+        approvals=["human_reviewed_policy_pr", "dry_run_plan_approved"],
+    )
+    decision = payload["decisions"][0]
+
+    assert payload["counts_by_decision_status"] == {"BLOCK_MISSING_APPROVALS": 1}
+    assert decision["decision_status"] == "BLOCK_MISSING_APPROVALS"
+    assert decision["missing_approvals"] == [
+        "rollback_plan_approved",
+        "pr_only_guardrails",
+        "clean_worktree_confirmed",
+    ]
+    assert "Required approvals are missing" in " ".join(decision["blockers"])
+    assert decision["change_allowed_now"] is False
+
+
+def test_pr_guardrail_decisions_block_not_ready_plan():
+    payload = build_pr_guardrail_decisions(
+        {"plans": [_plan("diagnosis:RUFF_FIXABLE_LINT", "NOT_READY_FOR_DRY_RUN")]},
+        approvals=ALL_APPROVALS,
+    )
+    decision = payload["decisions"][0]
+
+    assert payload["counts_by_decision_status"] == {"BLOCK_NOT_READY": 1}
+    assert decision["decision_status"] == "BLOCK_NOT_READY"
+    assert decision["target_branch"] == "maintenance/ruff-fixable-lint"
+    assert decision["missing_approvals"] == []
+    assert "not ready" in " ".join(decision["blockers"])
+
+
+def test_pr_guardrail_decisions_block_direct_to_main_signal():
+    payload = build_pr_guardrail_decisions(
+        {
+            "plans": [
+                _plan(
+                    "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+                    "READY_FOR_DRY_RUN_PLAN_REVIEW",
+                    direct_to_main_allowed=True,
+                )
+            ]
+        },
+        approvals=ALL_APPROVALS,
+    )
+    decision = payload["decisions"][0]
+
+    assert payload["counts_by_decision_status"] == {"BLOCK_DIRECT_TO_MAIN": 1}
+    assert decision["decision_status"] == "BLOCK_DIRECT_TO_MAIN"
+    assert decision["direct_to_main_allowed"] is False
+    assert "Direct-to-main changes are blocked" in " ".join(decision["blockers"])
+
+
+def test_pr_guardrail_decisions_sort_by_candidate_key():
+    payload = build_pr_guardrail_decisions(
+        {
+            "plans": [
+                _plan("diagnosis:RUFF_FIXABLE_LINT", "READY_FOR_DRY_RUN_PLAN_REVIEW"),
+                _plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW"),
+            ]
+        },
+        approvals=ALL_APPROVALS,
+    )
+
+    assert [decision["candidate_key"] for decision in payload["decisions"]] == [
+        "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+        "diagnosis:RUFF_FIXABLE_LINT",
+    ]
+
+
+def test_pr_guardrail_decisions_markdown_is_operator_readable():
+    payload = build_pr_guardrail_decisions(
+        {
+            "plans": [
+                _plan("diagnosis:PRE_COMMIT_FORMAT_DRIFT", "READY_FOR_DRY_RUN_PLAN_REVIEW")
+            ]
+        },
+        approvals=ALL_APPROVALS,
+    )
+
+    rendered = render_pr_guardrail_decisions_markdown(payload)
+
+    assert rendered.startswith("# PR guardrail decisions")
+    assert "automation allowed: **False**" in rendered
+    assert "change allowed now: **False**" in rendered
+    assert "direct-to-main allowed: **False**" in rendered
+    assert "`diagnosis:PRE_COMMIT_FORMAT_DRIFT`" in rendered
+    assert "READY_FOR_PR_BRANCH_REVIEW" in rendered
+    assert "This layer only decides" in rendered


### PR DESCRIPTION
## Summary

- Add `sdetkit.pr_guardrail_decisions`.
- Build guarded PR-only decision records from dry-run plans.
- Map candidate state to `READY_FOR_PR_BRANCH_REVIEW`, `BLOCK_NOT_READY`, `BLOCK_MISSING_APPROVALS`, and `BLOCK_DIRECT_TO_MAIN`.
- Track required approvals, missing approvals, review commands, expected artifacts, blockers, and target PR-only branch names.
- Add Markdown rendering for operator-facing guardrail decisions.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Implements Phase 17: Enable guarded PR-only auto-fix

## Safety

- No direct-to-main behavior.
- `automation_allowed` remains false.
- `change_allowed_now` remains false.
- Decision layer only; does not run commands, edit files, push branches, or open pull requests.
- Requires human review, policy approval, dry-run plan approval, rollback approval, PR-only guardrails, and clean worktree confirmation.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_pr_guardrail_decisions.py tests/test_auto_fix_dry_run_plan.py tests/test_maintenance_policy_proposals.py tests/test_auto_fix_probation_report.py tests/test_safe_fix_candidate_registry.py tests/test_investigation_outcome_memory.py tests/test_pr_investigation_summary.py tests/test_investigation_safe_fix_policy.py tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the PR guardrail decision module and tests.