### PR TITLE
Record auto-fix outcome memory

### DIFF
--- a/src/sdetkit/pr_guardrail_outcome_memory.py
+++ b/src/sdetkit/pr_guardrail_outcome_memory.py
@@ -100,7 +100,9 @@ def summarize_pr_guardrail_outcome_memory(memory: dict[str, Any]) -> dict[str, A
     statuses = Counter(str(record.get("outcome_status", "")) for record in records)
     decisions = Counter(str(record.get("decision_status", "")) for record in records)
     merged_count = sum(1 for record in records if bool(record.get("merged")))
-    blocked_count = sum(1 for record in records if str(record.get("outcome_status", "")).startswith("blocked"))
+    blocked_count = sum(
+        1 for record in records if str(record.get("outcome_status", "")).startswith("blocked")
+    )
     return {
         "schema_version": SUMMARY_SCHEMA_VERSION,
         "automation_allowed": False,

--- a/src/sdetkit/pr_guardrail_outcome_memory.py
+++ b/src/sdetkit/pr_guardrail_outcome_memory.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.pr_guardrail_outcome_memory.v1"
+SUMMARY_SCHEMA_VERSION = "sdetkit.pr_guardrail_outcome_memory.summary.v1"
+
+
+def _clean_required(value: str, name: str) -> str:
+    clean = value.strip()
+    if not clean:
+        raise OSError(f"{name} is required")
+    return clean
+
+
+def _as_nonnegative_int(value: int | str) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _as_list(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    if not values:
+        return []
+    return sorted({str(value).strip() for value in values if str(value).strip()})
+
+
+def build_pr_guardrail_outcome_record(
+    *,
+    candidate_key: str,
+    decision_status: str,
+    target_branch: str,
+    outcome_status: str,
+    pr_number: int | str = 0,
+    merged: bool = False,
+    approvals: list[str] | tuple[str, ...] | None = None,
+    artifacts: list[str] | tuple[str, ...] | None = None,
+    blockers: list[str] | tuple[str, ...] | None = None,
+    elapsed_seconds: int | str = 0,
+) -> dict[str, Any]:
+    return {
+        "candidate_key": _clean_required(candidate_key, "candidate_key"),
+        "decision_status": _clean_required(decision_status, "decision_status"),
+        "target_branch": _clean_required(target_branch, "target_branch"),
+        "outcome_status": _clean_required(outcome_status, "outcome_status"),
+        "pr_number": _as_nonnegative_int(pr_number),
+        "merged": bool(merged),
+        "approvals": _as_list(approvals),
+        "artifacts": _as_list(artifacts),
+        "blockers": _as_list(blockers),
+        "elapsed_seconds": _as_nonnegative_int(elapsed_seconds),
+    }
+
+
+def load_pr_guardrail_outcome_memory(path: str | Path) -> dict[str, Any]:
+    memory_path = Path(path)
+    if not memory_path.exists():
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "automation_allowed": False,
+            "change_allowed_now": False,
+            "direct_to_main_allowed": False,
+            "records": [],
+        }
+    data = json.loads(memory_path.read_text(encoding="utf-8"))
+    records = data.get("records", []) if isinstance(data, dict) else []
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "automation_allowed": False,
+        "change_allowed_now": False,
+        "direct_to_main_allowed": False,
+        "records": records if isinstance(records, list) else [],
+    }
+
+
+def append_pr_guardrail_outcome_memory(path: str | Path, record: dict[str, Any]) -> dict[str, Any]:
+    memory = load_pr_guardrail_outcome_memory(path)
+    memory["records"].append(record)
+    memory["records"] = sorted(
+        memory["records"],
+        key=lambda item: (
+            str(item.get("candidate_key", "")),
+            int(item.get("pr_number", 0) or 0),
+            str(item.get("target_branch", "")),
+            str(item.get("outcome_status", "")),
+        ),
+    )
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(memory, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return memory
+
+
+def summarize_pr_guardrail_outcome_memory(memory: dict[str, Any]) -> dict[str, Any]:
+    records = memory.get("records", []) if isinstance(memory.get("records"), list) else []
+    statuses = Counter(str(record.get("outcome_status", "")) for record in records)
+    decisions = Counter(str(record.get("decision_status", "")) for record in records)
+    merged_count = sum(1 for record in records if bool(record.get("merged")))
+    blocked_count = sum(1 for record in records if str(record.get("outcome_status", "")).startswith("blocked"))
+    return {
+        "schema_version": SUMMARY_SCHEMA_VERSION,
+        "automation_allowed": False,
+        "change_allowed_now": False,
+        "direct_to_main_allowed": False,
+        "record_count": len(records),
+        "merged_count": merged_count,
+        "blocked_count": blocked_count,
+        "counts_by_outcome_status": dict(sorted(statuses.items())),
+        "counts_by_decision_status": dict(sorted(decisions.items())),
+    }
+
+
+def render_pr_guardrail_outcome_summary_markdown(summary: dict[str, Any]) -> str:
+    outcome_counts = summary.get("counts_by_outcome_status", {})
+    decision_counts = summary.get("counts_by_decision_status", {})
+    lines = [
+        "# PR guardrail outcome memory",
+        "",
+        f"- automation allowed: **{summary.get('automation_allowed', False)}**",
+        f"- change allowed now: **{summary.get('change_allowed_now', False)}**",
+        f"- direct-to-main allowed: **{summary.get('direct_to_main_allowed', False)}**",
+        f"- records: **{summary.get('record_count', 0)}**",
+        f"- merged: **{summary.get('merged_count', 0)}**",
+        f"- blocked: **{summary.get('blocked_count', 0)}**",
+        "",
+        "## Outcomes",
+        "",
+    ]
+    if isinstance(outcome_counts, dict) and outcome_counts:
+        for status, count in sorted(outcome_counts.items()):
+            lines.append(f"- `{status}`: {count}")
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Decisions", ""])
+    if isinstance(decision_counts, dict) and decision_counts:
+        for status, count in sorted(decision_counts.items()):
+            lines.append(f"- `{status}`: {count}")
+    else:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "",
+            "This memory records reviewed PR-guardrail outcomes only. It does not make repository changes.",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_pr_guardrail_outcome_memory.py
+++ b/tests/test_pr_guardrail_outcome_memory.py
@@ -21,7 +21,12 @@ def test_build_pr_guardrail_outcome_record_normalizes_fields():
         outcome_status=" merged ",
         pr_number="1181",
         merged=True,
-        approvals=["dry_run_plan_approved", "human_reviewed_policy_pr", "human_reviewed_policy_pr", ""],
+        approvals=[
+            "dry_run_plan_approved",
+            "human_reviewed_policy_pr",
+            "human_reviewed_policy_pr",
+            "",
+        ],
         artifacts=["dry-run-outcome.json", "dry-run-command-log.txt", "dry-run-outcome.json"],
         blockers=[" ", "review completed"],
         elapsed_seconds="42",

--- a/tests/test_pr_guardrail_outcome_memory.py
+++ b/tests/test_pr_guardrail_outcome_memory.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sdetkit.pr_guardrail_outcome_memory import (
+    append_pr_guardrail_outcome_memory,
+    build_pr_guardrail_outcome_record,
+    load_pr_guardrail_outcome_memory,
+    render_pr_guardrail_outcome_summary_markdown,
+    summarize_pr_guardrail_outcome_memory,
+)
+
+
+def test_build_pr_guardrail_outcome_record_normalizes_fields():
+    record = build_pr_guardrail_outcome_record(
+        candidate_key=" diagnosis:PRE_COMMIT_FORMAT_DRIFT ",
+        decision_status=" READY_FOR_PR_BRANCH_REVIEW ",
+        target_branch=" maintenance/pre-commit-format-drift ",
+        outcome_status=" merged ",
+        pr_number="1181",
+        merged=True,
+        approvals=["dry_run_plan_approved", "human_reviewed_policy_pr", "human_reviewed_policy_pr", ""],
+        artifacts=["dry-run-outcome.json", "dry-run-command-log.txt", "dry-run-outcome.json"],
+        blockers=[" ", "review completed"],
+        elapsed_seconds="42",
+    )
+
+    assert record == {
+        "candidate_key": "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+        "decision_status": "READY_FOR_PR_BRANCH_REVIEW",
+        "target_branch": "maintenance/pre-commit-format-drift",
+        "outcome_status": "merged",
+        "pr_number": 1181,
+        "merged": True,
+        "approvals": ["dry_run_plan_approved", "human_reviewed_policy_pr"],
+        "artifacts": ["dry-run-command-log.txt", "dry-run-outcome.json"],
+        "blockers": ["review completed"],
+        "elapsed_seconds": 42,
+    }
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"candidate_key": " "}, "candidate_key is required"),
+        ({"decision_status": " "}, "decision_status is required"),
+        ({"target_branch": " "}, "target_branch is required"),
+        ({"outcome_status": " "}, "outcome_status is required"),
+    ],
+)
+def test_build_pr_guardrail_outcome_record_rejects_blank_required_fields(kwargs, message):
+    values = {
+        "candidate_key": "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+        "decision_status": "READY_FOR_PR_BRANCH_REVIEW",
+        "target_branch": "maintenance/pre-commit-format-drift",
+        "outcome_status": "merged",
+    }
+    values.update(kwargs)
+
+    with pytest.raises(OSError, match=message):
+        build_pr_guardrail_outcome_record(**values)
+
+
+def test_load_missing_outcome_memory_returns_empty_safe_payload(tmp_path):
+    payload = load_pr_guardrail_outcome_memory(tmp_path / "missing.json")
+
+    assert payload == {
+        "schema_version": "sdetkit.pr_guardrail_outcome_memory.v1",
+        "automation_allowed": False,
+        "change_allowed_now": False,
+        "direct_to_main_allowed": False,
+        "records": [],
+    }
+
+
+def test_append_pr_guardrail_outcome_memory_writes_and_sorts_records(tmp_path):
+    path = tmp_path / "memory" / "pr-guardrail-outcomes.json"
+    later = build_pr_guardrail_outcome_record(
+        candidate_key="diagnosis:RUFF_FIXABLE_LINT",
+        decision_status="BLOCK_MISSING_APPROVALS",
+        target_branch="maintenance/ruff-fixable-lint",
+        outcome_status="blocked_missing_approvals",
+        pr_number=1200,
+        blockers=["required approvals missing"],
+    )
+    earlier = build_pr_guardrail_outcome_record(
+        candidate_key="diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+        decision_status="READY_FOR_PR_BRANCH_REVIEW",
+        target_branch="maintenance/pre-commit-format-drift",
+        outcome_status="merged",
+        pr_number=1181,
+        merged=True,
+    )
+
+    append_pr_guardrail_outcome_memory(path, later)
+    payload = append_pr_guardrail_outcome_memory(path, earlier)
+
+    assert path.exists()
+    assert [record["candidate_key"] for record in payload["records"]] == [
+        "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+        "diagnosis:RUFF_FIXABLE_LINT",
+    ]
+    written = json.loads(path.read_text(encoding="utf-8"))
+    assert written == payload
+    assert written["automation_allowed"] is False
+    assert written["change_allowed_now"] is False
+    assert written["direct_to_main_allowed"] is False
+
+
+def test_load_populated_outcome_memory_preserves_records_but_resets_safety_flags(tmp_path):
+    path = tmp_path / "memory.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "old",
+                "automation_allowed": True,
+                "change_allowed_now": True,
+                "direct_to_main_allowed": True,
+                "records": [
+                    {
+                        "candidate_key": "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+                        "decision_status": "READY_FOR_PR_BRANCH_REVIEW",
+                        "target_branch": "maintenance/pre-commit-format-drift",
+                        "outcome_status": "merged",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = load_pr_guardrail_outcome_memory(path)
+
+    assert payload["schema_version"] == "sdetkit.pr_guardrail_outcome_memory.v1"
+    assert payload["automation_allowed"] is False
+    assert payload["change_allowed_now"] is False
+    assert payload["direct_to_main_allowed"] is False
+    assert payload["records"][0]["candidate_key"] == "diagnosis:PRE_COMMIT_FORMAT_DRIFT"
+
+
+def test_summarize_pr_guardrail_outcome_memory_counts_records():
+    memory = {
+        "records": [
+            {
+                "candidate_key": "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+                "decision_status": "READY_FOR_PR_BRANCH_REVIEW",
+                "outcome_status": "merged",
+                "merged": True,
+            },
+            {
+                "candidate_key": "diagnosis:RUFF_FIXABLE_LINT",
+                "decision_status": "BLOCK_MISSING_APPROVALS",
+                "outcome_status": "blocked_missing_approvals",
+                "merged": False,
+            },
+            {
+                "candidate_key": "diagnosis:RUFF_FIXABLE_LINT",
+                "decision_status": "BLOCK_NOT_READY",
+                "outcome_status": "blocked_not_ready",
+                "merged": False,
+            },
+        ]
+    }
+
+    summary = summarize_pr_guardrail_outcome_memory(memory)
+
+    assert summary == {
+        "schema_version": "sdetkit.pr_guardrail_outcome_memory.summary.v1",
+        "automation_allowed": False,
+        "change_allowed_now": False,
+        "direct_to_main_allowed": False,
+        "record_count": 3,
+        "merged_count": 1,
+        "blocked_count": 2,
+        "counts_by_outcome_status": {
+            "blocked_missing_approvals": 1,
+            "blocked_not_ready": 1,
+            "merged": 1,
+        },
+        "counts_by_decision_status": {
+            "BLOCK_MISSING_APPROVALS": 1,
+            "BLOCK_NOT_READY": 1,
+            "READY_FOR_PR_BRANCH_REVIEW": 1,
+        },
+    }
+
+
+def test_pr_guardrail_outcome_summary_markdown_is_operator_readable():
+    summary = summarize_pr_guardrail_outcome_memory(
+        {
+            "records": [
+                {
+                    "candidate_key": "diagnosis:PRE_COMMIT_FORMAT_DRIFT",
+                    "decision_status": "READY_FOR_PR_BRANCH_REVIEW",
+                    "outcome_status": "merged",
+                    "merged": True,
+                }
+            ]
+        }
+    )
+
+    rendered = render_pr_guardrail_outcome_summary_markdown(summary)
+
+    assert rendered.startswith("# PR guardrail outcome memory")
+    assert "automation allowed: **False**" in rendered
+    assert "change allowed now: **False**" in rendered
+    assert "direct-to-main allowed: **False**" in rendered
+    assert "records: **1**" in rendered
+    assert "merged: **1**" in rendered
+    assert "`merged`: 1" in rendered
+    assert "`READY_FOR_PR_BRANCH_REVIEW`: 1" in rendered
+    assert "does not make repository changes" in rendered


### PR DESCRIPTION
## Summary

- Add `sdetkit.pr_guardrail_outcome_memory`.
- Build normalized outcome records for PR guardrail decisions.
- Load and append outcome-memory JSON with deterministic sorting.
- Summarize merged, blocked, outcome-status, and decision-status counts.
- Add Markdown rendering for operator-facing outcome summaries.

## Roadmap

- Master Phase 3 — Quality intelligence and adaptive investigation
- Implements Phase 18: Record auto-fix outcome memory

## Safety

- Does not make repository changes.
- Does not run commands.
- Does not push branches or open pull requests.
- `automation_allowed`, `change_allowed_now`, and `direct_to_main_allowed` remain false.
- Records reviewed PR-guardrail outcomes only.

## Verification

- `pre-commit run --all-files`
- `python3 -m pytest tests/test_pr_guardrail_outcome_memory.py tests/test_pr_guardrail_decisions.py tests/test_auto_fix_dry_run_plan.py tests/test_maintenance_policy_proposals.py tests/test_auto_fix_probation_report.py tests/test_safe_fix_candidate_registry.py tests/test_investigation_outcome_memory.py tests/test_pr_investigation_summary.py tests/test_investigation_safe_fix_policy.py tests/test_investigation_evidence.py tests/test_public_api_parity.py tests/test_investigate_surface.py tests/test_investigate_repo.py tests/test_investigate_failure.py`
- `./scripts/pr_preflight.sh`

## Rollback

- Revert this PR to remove the PR guardrail outcome memory module and tests.