### PR TITLE
Expand CI preflight investigation guardrail slice

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -101,6 +101,15 @@ run_flagship_contracts() {
   python3 -m sdetkit forensics compare --from examples/kits/forensics/run-a.json --to examples/kits/forensics/run-b.json >/dev/null
 }
 
+run_investigation_guardrail_slice() {
+  PYTHONPATH=src python3 -m pytest -q \
+    tests/test_investigate_cli.py \
+    tests/test_investigate_failure.py \
+    tests/test_investigation_chain_no_mutation.py \
+    tests/test_pr_guardrail_decisions.py \
+    tests/test_maintenance_autopilot_safe_commit.py
+}
+
 run_docs() {
   if [[ "$skip_docs" -eq 1 ]]; then
     return 0
@@ -138,12 +147,14 @@ case "$mode" in
   quick)
     run_test_bootstrap_preflight
     run_gate_fast
+    run_investigation_guardrail_slice
     run_flagship_contracts
     run_operational_maturity_v2
     ;;
   all)
     run_test_bootstrap_preflight
     run_gate_fast
+    run_investigation_guardrail_slice
     run_flagship_contracts
     run_operational_maturity_v2
     run_docs

--- a/tests/test_ci_preflight_investigation_guardrail_slice.py
+++ b/tests/test_ci_preflight_investigation_guardrail_slice.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_ci_preflight_runs_investigation_and_guardrail_slice() -> None:
+    text = Path("scripts/ci.sh").read_text(encoding="utf-8")
+
+    assert "run_investigation_guardrail_slice()" in text
+    assert "tests/test_investigate_cli.py" in text
+    assert "tests/test_investigate_failure.py" in text
+    assert "tests/test_investigation_chain_no_mutation.py" in text
+    assert "tests/test_pr_guardrail_decisions.py" in text
+    assert "tests/test_maintenance_autopilot_safe_commit.py" in text
+
+
+def test_ci_quick_and_all_modes_include_investigation_guardrail_slice() -> None:
+    text = Path("scripts/ci.sh").read_text(encoding="utf-8")
+    quick_case = text.split("quick)", 1)[1].split(";;", 1)[0]
+    all_case = text.split("all)", 1)[1].split(";;", 1)[0]
+
+    assert "run_gate_fast" in quick_case
+    assert "run_investigation_guardrail_slice" in quick_case
+    assert "run_flagship_contracts" in quick_case
+
+    assert "run_gate_fast" in all_case
+    assert "run_investigation_guardrail_slice" in all_case
+    assert "run_flagship_contracts" in all_case


### PR DESCRIPTION
Adds the investigation and guardrail regression slice to scripts/ci.sh quick/all preflight paths. Includes a focused contract test for the CI helper. Focused local slice passed: 24 tests.