### PR TITLE
Add production workflow naming aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -686,3 +686,41 @@ powerfuel-contract: powerfuel-consolidation-score powerfuel-weekly-report powerf
 powerfuel-merge-ready: powerfuel-contract
 	@bash -lc ' . .venv/bin/activate && python scripts/render_powerfuel_merge_ready.py --date-tag $(POWERFUEL_DATE_TAG) --out docs/artifacts/powerfuel-merge-ready-$(POWERFUEL_DATE_TAG).md'
 	@bash -lc 'echo "Powerfuel merge-ready summary: docs/artifacts/powerfuel-merge-ready-$(POWERFUEL_DATE_TAG).md"'
+
+# Production workflow aliases. Keep legacy targets available for compatibility.
+.PHONY: quality-contract-check quality-contract-report quality-contract-run
+.PHONY: operations-baseline operations-status operations-next-action operations-snapshot operations-dashboard operations-weekly-pack operations-control-loop operations-run-all operations-artifact-set operations-telemetry operations-readiness-signal operations-remediation-plan operations-blocker-register operations-run operations-core-run operations-workflow operations-flow-contract operations-quality-gate operations-executive-report operations-cleanup-plan operations-complete operations-finalize operations-current operations-current-json
+.PHONY: governance-contract-check ecosystem-contract-check metrics-contract-check
+
+quality-contract-check: phase3-quality-contract
+quality-contract-report: phase3-quality-report
+quality-contract-run: phase3-do-it
+
+operations-baseline: phase1-baseline
+operations-status: phase1-status
+operations-next-action: phase1-next
+operations-snapshot: phase1-ops-snapshot
+operations-dashboard: phase1-dashboard
+operations-weekly-pack: phase1-weekly-pack
+operations-control-loop: phase1-control-loop
+operations-run-all: phase1-run-all
+operations-artifact-set: phase1-artifact-set
+operations-telemetry: phase1-telemetry
+operations-readiness-signal: phase1-finish-signal
+operations-remediation-plan: phase1-next-pass
+operations-blocker-register: phase1-blocker-register
+operations-run: phase1-do-it
+operations-core-run: phase1-execution-core
+operations-workflow: phase1-workflow
+operations-flow-contract: phase1-flow-contract
+operations-quality-gate: phase1-gate-phase2
+operations-executive-report: phase1-executive-report
+operations-cleanup-plan: phase1-retire-plan
+operations-complete: phase1-complete
+operations-finalize: phase1-closeout
+operations-current: phase-current
+operations-current-json: phase-current-json
+
+governance-contract-check: phase4-governance-contract
+ecosystem-contract-check: phase5-ecosystem-contract
+metrics-contract-check: phase6-metrics-contract

--- a/docs/production-workflow-naming-audit.md
+++ b/docs/production-workflow-naming-audit.md
@@ -1,0 +1,66 @@
+# Production workflow naming audit
+
+This repo still carries some internal phase-style workflow names. Those names remain available for compatibility, but new commands, docs, PR titles, branches, and tests should use production workflow language.
+
+## Naming direction
+
+Prefer production workflow names:
+
+- quality contract
+- operations status
+- operations readiness
+- operations completion
+- cleanup plan
+- remediation plan
+- governance contract
+- ecosystem contract
+- metrics contract
+
+Avoid adding new workflow names that read like internal sequencing or education labels:
+
+- phase1, phase2, phase3
+- do-it
+- closeout
+- finish-signal
+- retire-plan
+- next-pass
+- gate-phase2
+
+## Compatibility approach
+
+Do not break existing automation by removing old Make targets. Add production-name aliases first, then migrate workflows and docs gradually.
+
+## Initial alias map
+
+| Production alias | Compatibility target |
+|---|---|
+| `quality-contract-check` | `phase3-quality-contract` |
+| `quality-contract-report` | `phase3-quality-report` |
+| `quality-contract-run` | `phase3-do-it` |
+| `operations-baseline` | `phase1-baseline` |
+| `operations-status` | `phase1-status` |
+| `operations-next-action` | `phase1-next` |
+| `operations-snapshot` | `phase1-ops-snapshot` |
+| `operations-dashboard` | `phase1-dashboard` |
+| `operations-weekly-pack` | `phase1-weekly-pack` |
+| `operations-control-loop` | `phase1-control-loop` |
+| `operations-run-all` | `phase1-run-all` |
+| `operations-artifact-set` | `phase1-artifact-set` |
+| `operations-telemetry` | `phase1-telemetry` |
+| `operations-readiness-signal` | `phase1-finish-signal` |
+| `operations-remediation-plan` | `phase1-next-pass` |
+| `operations-blocker-register` | `phase1-blocker-register` |
+| `operations-run` | `phase1-do-it` |
+| `operations-core-run` | `phase1-execution-core` |
+| `operations-workflow` | `phase1-workflow` |
+| `operations-flow-contract` | `phase1-flow-contract` |
+| `operations-quality-gate` | `phase1-gate-phase2` |
+| `operations-executive-report` | `phase1-executive-report` |
+| `operations-cleanup-plan` | `phase1-retire-plan` |
+| `operations-complete` | `phase1-complete` |
+| `operations-finalize` | `phase1-closeout` |
+| `operations-current` | `phase-current` |
+| `operations-current-json` | `phase-current-json` |
+| `governance-contract-check` | `phase4-governance-contract` |
+| `ecosystem-contract-check` | `phase5-ecosystem-contract` |
+| `metrics-contract-check` | `phase6-metrics-contract` |

--- a/tests/test_production_workflow_naming_aliases.py
+++ b/tests/test_production_workflow_naming_aliases.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAKEFILE = ROOT / "Makefile"
+
+ALIASES = {
+    "quality-contract-check": "phase3-quality-contract",
+    "quality-contract-report": "phase3-quality-report",
+    "quality-contract-run": "phase3-do-it",
+    "operations-baseline": "phase1-baseline",
+    "operations-status": "phase1-status",
+    "operations-next-action": "phase1-next",
+    "operations-snapshot": "phase1-ops-snapshot",
+    "operations-dashboard": "phase1-dashboard",
+    "operations-weekly-pack": "phase1-weekly-pack",
+    "operations-control-loop": "phase1-control-loop",
+    "operations-run-all": "phase1-run-all",
+    "operations-artifact-set": "phase1-artifact-set",
+    "operations-telemetry": "phase1-telemetry",
+    "operations-readiness-signal": "phase1-finish-signal",
+    "operations-remediation-plan": "phase1-next-pass",
+    "operations-blocker-register": "phase1-blocker-register",
+    "operations-run": "phase1-do-it",
+    "operations-core-run": "phase1-execution-core",
+    "operations-workflow": "phase1-workflow",
+    "operations-flow-contract": "phase1-flow-contract",
+    "operations-quality-gate": "phase1-gate-phase2",
+    "operations-executive-report": "phase1-executive-report",
+    "operations-cleanup-plan": "phase1-retire-plan",
+    "operations-complete": "phase1-complete",
+    "operations-finalize": "phase1-closeout",
+    "operations-current": "phase-current",
+    "operations-current-json": "phase-current-json",
+    "governance-contract-check": "phase4-governance-contract",
+    "ecosystem-contract-check": "phase5-ecosystem-contract",
+    "metrics-contract-check": "phase6-metrics-contract",
+}
+
+
+def test_production_workflow_aliases_point_to_legacy_targets() -> None:
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+
+    for alias, target in ALIASES.items():
+        assert f"{alias}: {target}" in makefile
+
+
+def test_new_alias_names_avoid_internal_sequence_language() -> None:
+    banned_fragments = (
+        "phase",
+        "do-it",
+        "closeout",
+        "finish-signal",
+        "retire-plan",
+        "next-pass",
+        "gate-phase",
+    )
+
+    for alias in ALIASES:
+        for fragment in banned_fragments:
+            assert fragment not in alias


### PR DESCRIPTION
## Summary

Add non-breaking production workflow aliases for legacy internal phase-style Make targets.

The repo still has compatibility targets with names like `phase1-*`, `phase3-*`, `do-it`, `closeout`, `finish-signal`, and `retire-plan`. This PR does not remove those existing targets. It adds production-style aliases and documents the naming direction so future branches, tests, PR titles, and user-facing docs use real workflow language.

## What changed

- Added production workflow Make aliases such as:
  - `quality-contract-check`
  - `quality-contract-report`
  - `quality-contract-run`
  - `operations-status`
  - `operations-finalize`
  - `operations-cleanup-plan`
  - `governance-contract-check`
  - `ecosystem-contract-check`
  - `metrics-contract-check`
- Added `docs/production-workflow-naming-audit.md` with the compatibility-first naming policy.
- Added tests that verify aliases point to the legacy targets and that new alias names avoid internal sequencing language.

## Local proof

```text
python3 -m pytest -q tests/test_production_workflow_naming_aliases.py -o addopts=
# 2 passed in 0.19s
```

```text
make -n quality-contract-check
make -n quality-contract-run
make -n operations-finalize
make -n operations-cleanup-plan
make -n governance-contract-check
# all resolved without executing recipes
```

```text
python3 -m pre_commit run -a
# all hooks passed
```

## Risk

Low. This is alias-only and compatibility-first. Existing Make targets remain available; no current workflow or artifact path is removed or renamed.

## Follow-up

Future PRs can migrate docs and workflow references to the production aliases gradually, then deprecate legacy names only after usage is known to be safe.