### PR TITLE
Fix project docs navigation exclude scope

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,7 +221,7 @@ nav:
       - Archive overview: archive/index.md
       - Transition-era material map: archive/transition-era-material.md
 exclude_docs: |
-  README.md
+  /README.md
   artifacts/**
   roadmap/reports/**
   *-report.md

--- a/tests/test_mkdocs_exclude_docs_scope.py
+++ b/tests/test_mkdocs_exclude_docs_scope.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_mkdocs_excludes_only_top_level_docs_readme() -> None:
+    mkdocs = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+
+    assert "exclude_docs: |\n  /README.md\n" in mkdocs
+    assert "exclude_docs: |\n  README.md\n" not in mkdocs
+
+
+def test_project_docs_readme_stays_nav_visible() -> None:
+    mkdocs = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+
+    assert "project/README.md" in mkdocs

--- a/tests/test_mkdocs_strict_docs_map_links.py
+++ b/tests/test_mkdocs_strict_docs_map_links.py
@@ -9,7 +9,7 @@ def test_mkdocs_excludes_docs_readme_conflict() -> None:
     mkdocs = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
 
     assert "exclude_docs: |" in mkdocs
-    assert "  README.md" in mkdocs
+    assert "  /README.md" in mkdocs
 
 
 def test_docs_map_does_not_link_to_excluded_readme() -> None:


### PR DESCRIPTION
## Summary
- Scope `exclude_docs` to only the top-level docs README by using `/README.md`.
- Keep `docs/project/README.md` visible for the MkDocs navigation entry.
- Add a regression guard for the exclude pattern and update the existing strict-docs guardrail.

## Verification
- `python -m pytest -q tests/test_mkdocs_exclude_docs_scope.py -o addopts=`
- `python -m pytest -q tests/test_mkdocs_strict_docs_map_links.py tests/test_docs_qa.py::test_repository_front_doors_are_polished_and_consistent -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- confirmed the `project/README.md` nav-excluded warning is gone
- `python -m pre_commit run -a`