### PR TITLE
Adaptive: add scenario pack, learning loop, operator brief, and CLI integration

### DIFF
--- a/docs/adaptive-diagnosis.md
+++ b/docs/adaptive-diagnosis.md
@@ -171,3 +171,94 @@ This keeps the system explainable while moving toward the larger SDETKit loop wi
 ```text
 detect -> diagnose -> recommend -> plan -> prove -> classify -> trend -> candidate -> probation -> policy proposal -> dry run -> guarded PR auto-fix -> remember outcome
 ```
+
+## Scenario packs and layered intelligence
+
+The seeded adaptive scenario catalog is now a versioned data pack instead of an embedded Python-only table. The built-in pack lives at `src/sdetkit/data/adaptive_scenarios.json` and follows `schemas/adaptive-scenario-pack.schema.json`.
+
+Each scenario must declare stable review fields: `code`, `title`, `signals`, `keywords`, `checks`, `commands`, `risk_band`, and `prior_weight`. Optional `odds` and `tags` fields let teams add confidence hints and governance labels without changing the diagnosis output contract.
+
+Layering is deterministic:
+
+1. SDETKit loads the built-in pack first.
+2. A repository can add `.sdetkit/adaptive/scenarios.json` for repo-local scenarios.
+3. Operators can set `SDETKIT_ADAPTIVE_SCENARIO_PACKS` to one or more `os.pathsep`-separated pack paths for organization or private overlays.
+4. Later layers override earlier scenarios by `code`, and the final merged pack is sorted by code for stable output.
+
+This keeps the default product useful on first run while allowing real teams to extend the brain with reviewable, schema-validated scenario data.
+
+## Learning event loop
+
+After writing an adaptive diagnosis JSON artifact, record it into the diagnosis learning JSONL database:
+
+```bash
+python -m sdetkit adaptive learn record build/adaptive-diagnosis.json \
+  --db .sdetkit/adaptive-diagnosis-memory.jsonl \
+  --format json
+```
+
+Summarize recurring scenarios and weak lanes:
+
+```bash
+python -m sdetkit adaptive learn summarize \
+  --db .sdetkit/adaptive-diagnosis-memory.jsonl \
+  --format json
+```
+
+Each learning event stores matched failure signals, candidate scenarios, the selected primary diagnosis marker, recommended checks, proof commands, recurrence count, and review placeholders for `proof_passed`, `fix_accepted`, and `false_positive`. The summarize command rolls those JSONL events into `top_recurring_scenarios` and `weakest_lanes` so follow-up work can prioritize the lanes causing repeated release friction.
+
+### Outcome calibration
+
+When operators have proof feedback, attach it while recording the learning event:
+
+```bash
+python -m sdetkit adaptive learn record build/adaptive-diagnosis.json \
+  --db .sdetkit/adaptive-diagnosis-memory.jsonl \
+  --proof-passed \
+  --fix-accepted
+```
+
+Use `--proof-failed`, `--fix-rejected`, or `--false-positive` when the recommendation did not hold. The learning summary applies deterministic promotion/demotion rules: confirmed proof promotes confidence, false positives demote confidence, repeated recurrence increases risk, and thin evidence lowers confidence until better signals are available.
+
+### Calibration-aware candidate ranking
+
+Pass an adaptive learning summary back into diagnosis when you want local outcomes to influence candidate ordering:
+
+```bash
+PYTHONPATH=src python -m sdetkit.adaptive_diagnosis \
+  --log build/quality.log \
+  --adaptive-history build/adaptive-learning-summary.json \
+  --format json \
+  --out build/adaptive-diagnosis.json
+```
+
+When the summary contains `top_recurring_scenarios[].calibration`, promoted scenarios receive a ranking boost, false positives are demoted, recurrence can raise risk priority, and thin-evidence scenarios are kept lower until better signals exist. Unknown-review evidence includes a `candidate_calibration=` line whenever calibration affected a visible candidate.
+
+## Operator brief artifact
+
+Generate the trust-grade handoff brief after gate, diagnosis, and optional learning artifacts exist:
+
+```bash
+python -m sdetkit adaptive brief \
+  --gate build/gate-fast.json \
+  --diagnosis build/adaptive-diagnosis.json \
+  --learning-summary build/adaptive-learning-summary.json \
+  --out build/sdetkit/operator-brief.md
+```
+
+The brief combines the gate result, adaptive diagnosis, candidate scenarios, candidate calibration, first proof command, safe-fix decision, and next owner action into one Markdown file for PR or release handoff.
+
+
+### PR comment mode
+
+Use compact PR comment mode when a bot should post a short, review-safe summary instead of the full operator brief:
+
+```bash
+python -m sdetkit adaptive brief \
+  --gate build/gate-fast.json \
+  --diagnosis build/adaptive-diagnosis.json \
+  --format comment \
+  --out build/sdetkit/operator-comment.md
+```
+
+Comment mode is intentionally concise: green runs avoid fake adaptive blocks, safe mechanical issues show a scoped guardrail path, and unknown failures stay review-first with candidate scenarios and the first proof command.

--- a/docs/adaptive-memory.md
+++ b/docs/adaptive-memory.md
@@ -47,3 +47,38 @@ Schema version: `sdetkit.adaptive.memory.v1`.
 ## Git hygiene
 
 Adaptive DB files are generated local artifacts. Do not commit `.db` outputs or build evidence.
+
+## Adaptive diagnosis learning loop
+
+The local SQLite adaptive memory remains the repo-shape memory. Adaptive diagnosis outcomes use a JSONL learning loop so CI artifacts can be appended and reviewed without requiring database migrations.
+
+Record an adaptive diagnosis artifact:
+
+```bash
+python -m sdetkit adaptive learn record build/adaptive-diagnosis.json \
+  --db .sdetkit/adaptive-diagnosis-memory.jsonl
+```
+
+Summarize recurring diagnosis scenarios and weakest lanes:
+
+```bash
+python -m sdetkit adaptive learn summarize \
+  --db .sdetkit/adaptive-diagnosis-memory.jsonl \
+  --format json
+```
+
+Use the summary to pick the next follow-up: fix high-recurrence scenarios first, then add proof outcomes (`proof_passed`, `fix_accepted`, `false_positive`) as operators confirm or reject recommendations.
+
+
+### Capturing operator feedback
+
+The learning record command accepts outcome flags so confirmed or rejected recommendations affect the next summary:
+
+```bash
+python -m sdetkit adaptive learn record build/adaptive-diagnosis.json \
+  --db .sdetkit/adaptive-diagnosis-memory.jsonl \
+  --proof-passed \
+  --fix-accepted
+```
+
+Use `--false-positive` to demote a scenario when an operator confirms the diagnosis was wrong. The summarize command exposes calibration actions (`promote`, `demote`, `increase_risk`, `lower_confidence`) per scenario and as a `calibration_summary` rollup.

--- a/docs/artifact-reference.md
+++ b/docs/artifact-reference.md
@@ -20,6 +20,10 @@ A file that says a fix is possible is not approval to mutate the repository. Mut
 | Failure investigation | `build/investigation/failure.json` | `python -m sdetkit investigate failure --log build/quality.log --format json --out build/investigation/failure.json` | Diagnostic-only triage result. |
 | Repository investigation | `build/investigation/repo.json` | `python -m sdetkit investigate repo --root . --format json --out build/investigation/repo.json` | Diagnostic-only surface narrowing. |
 | Adaptive diagnosis | `build/adaptive-diagnosis.json` | `PYTHONPATH=src python -m sdetkit.adaptive_diagnosis --log build/quality.log --format json --out build/adaptive-diagnosis.json` | Evidence-fitted diagnosis and proof commands. |
+| Adaptive diagnosis learning | `.sdetkit/adaptive-diagnosis-memory.jsonl` | `python -m sdetkit adaptive learn record build/adaptive-diagnosis.json --db .sdetkit/adaptive-diagnosis-memory.jsonl` | JSONL learning events for matched signals, candidates, proof commands, recurrence, and operator outcome feedback. |
+| Adaptive learning summary | operator-chosen JSON/stdout | `python -m sdetkit adaptive learn summarize --db .sdetkit/adaptive-diagnosis-memory.jsonl --format json` | Rollup of top recurring scenarios, weakest lanes, and promotion/demotion calibration actions. |
+| Operator brief | `build/sdetkit/operator-brief.md` | `python -m sdetkit adaptive brief --gate build/gate-fast.json --diagnosis build/adaptive-diagnosis.json --out build/sdetkit/operator-brief.md` | One-page handoff with gate result, diagnosis, candidates, first proof command, safe-fix decision, and owner action. |
+| Operator PR comment | `build/sdetkit/operator-comment.md` | `python -m sdetkit adaptive brief --gate build/gate-fast.json --diagnosis build/adaptive-diagnosis.json --format comment --out build/sdetkit/operator-comment.md` | Compact PR-safe summary for green, safe mechanical, and review-first unknown flows. |
 
 For schema-oriented contracts, see [`artifact-contract-index.json`](artifact-contract-index.json). That JSON index is the machine-readable contract inventory; this page is the human map.
 

--- a/docs/roadmap/big-brain-toolkit-roadmap.md
+++ b/docs/roadmap/big-brain-toolkit-roadmap.md
@@ -62,25 +62,21 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
   - whether fix was accepted,
   - recurrence count,
   - false-positive marker.
-- Add promotion/demotion rules:
-  - promote scenario when proof passes after its recommendation,
-  - demote scenario when operator marks false positive,
-  - increase risk when recurrence grows,
-  - lower confidence when evidence is thin.
-- Add `sdetkit adaptive learn summarize` to show top recurring scenarios and weakest lanes.
+- Add promotion/demotion rules: **Done:** summaries now promote scenarios when proof/fix feedback succeeds, demote false positives, increase risk for recurring failures, and lower confidence for thin evidence.
+- Add `sdetkit adaptive learn summarize` to show top recurring scenarios and weakest lanes. **Done:** the CLI now rolls JSONL diagnosis events into `top_recurring_scenarios` and `weakest_lanes`.
 
 ### Phase 3 — Build the trust-grade operator experience
 
 **Outcome:** anyone trying the repo can see why SDETKit is valuable in one run.
 
-- Add a single generated `build/sdetkit/operator-brief.md` containing:
+- Add a single generated `build/sdetkit/operator-brief.md` containing: **Done via `sdetkit adaptive brief`.**
   - gate result,
   - adaptive diagnosis,
   - scenario candidates,
   - first proof command,
   - safe-fix decision,
   - next owner action.
-- Add a short PR comment mode:
+- Add a short PR comment mode: **Done via `sdetkit adaptive brief --format comment`.**
   - green run: no fake adaptive block,
   - known safe mechanical issue: scoped auto-fix path,
   - unknown failure: review-first candidate scenarios and checks.
@@ -130,11 +126,11 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
 
 | Priority | Work item | Acceptance check |
 | --- | --- | --- |
-| P0 | Extract scenario DB to a schema-validated pack | Unit tests load built-in pack and reject invalid packs. |
-| P0 | Add learning event records for adaptive diagnosis | A JSONL event includes signals, candidates, selected code, proof command, and outcome placeholder. |
-| P0 | Add operator brief artifact | `python -m sdetkit.adaptive_diagnosis` can produce a concise Markdown brief. |
+| P0 | Extract scenario DB to a schema-validated pack | Done: built-in scenarios now load from `src/sdetkit/data/adaptive_scenarios.json`, validate through loader rules, and are documented against `schemas/adaptive-scenario-pack.schema.json`. |
+| P0 | Add learning event records for adaptive diagnosis | Done: `sdetkit adaptive learn record` writes JSONL events with matched signals, candidates, selected primary diagnosis, checks, proof commands, recurrence count, and outcome placeholders. |
+| P0 | Add operator brief artifact | Done: `python -m sdetkit adaptive brief` generates `build/sdetkit/operator-brief.md` from gate, diagnosis, learning, and safe-fix artifacts. |
 | P1 | Add fixture corpus for top scenarios | Tests cover at least 20 realistic log fixtures. |
-| P1 | Add candidate confidence calibration | Candidate ranking includes confidence reason and historical boost/demotion. |
+| P1 | Add candidate confidence calibration | Done: adaptive diagnosis can consume learning-summary calibration to boost/demote candidate scenario ranking and emit `candidate_calibration` evidence. |
 | P1 | Add docs demo gallery | Docs show green, safe-fix, unknown-review, and recurring-failure examples. |
 | P2 | Add org-level pack overlay | Local and org packs merge deterministically with built-in scenarios. |
 | P2 | Add portfolio rollup | Multiple adaptive diagnosis outputs roll into a top-risk scenario report. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,4 +152,4 @@ whatsapp = "sdetkit.notify_plugins:whatsapp_adapter"
 
 [project.entry-points."sdetkit.ops_tasks"]
 [tool.setuptools.package-data]
-sdetkit = ["public_command_surface.json"]
+sdetkit = ["public_command_surface.json", "data/*.json"]

--- a/schemas/adaptive-scenario-pack.schema.json
+++ b/schemas/adaptive-scenario-pack.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sdetkit.dev/schemas/adaptive-scenario-pack.schema.json",
+  "title": "SDETKit adaptive scenario pack",
+  "description": "Versioned scenario pack used by adaptive diagnosis to rank failure families and recommend review-first proof commands.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "pack_id", "title", "scenarios"],
+  "properties": {
+    "schema_version": {
+      "const": "sdetkit.adaptive.scenario_pack.v1"
+    },
+    "pack_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_.-]*$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scenarios": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "code",
+          "title",
+          "signals",
+          "keywords",
+          "checks",
+          "commands",
+          "risk_band",
+          "prior_weight"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "pattern": "^[A-Z0-9_]+$"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "signals": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string", "minLength": 1},
+            "uniqueItems": true
+          },
+          "keywords": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string", "minLength": 1},
+            "uniqueItems": true
+          },
+          "checks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string", "minLength": 1},
+            "uniqueItems": true
+          },
+          "commands": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string", "minLength": 1},
+            "uniqueItems": true
+          },
+          "odds": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "uniqueItems": true,
+            "default": []
+          },
+          "tags": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "uniqueItems": true,
+            "default": []
+          },
+          "risk_band": {
+            "enum": ["low", "medium", "high"]
+          },
+          "prior_weight": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/sdetkit/adaptive_diagnosis.py
+++ b/src/sdetkit/adaptive_diagnosis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from collections import Counter
@@ -37,6 +38,7 @@ class SeededScenario:
     checks: tuple[str, ...]
     commands: tuple[str, ...]
     odds: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
     risk_band: str = "medium"
     prior_weight: int = 1
 
@@ -189,328 +191,136 @@ FAILURE_LIKE_SIGNAL_DB = (
 )
 
 
-SEEDED_SCENARIO_DB = (
-    SeededScenario(
-        "PYTEST_BEHAVIOR_REGRESSION",
-        "Pytest behavior regression",
-        ("pytest-node-failed", "pytest-failed-count", "assertion-error"),
-        ("assertionerror", "failed tests/", "== failures =="),
-        (
-            "Open the first failing pytest node and read the assertion delta before editing product code.",
-            "Check whether fixtures, clocks, network fakes, or snapshots changed the expected contract.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <first-failing-test> -vv",),
-    ),
-    SeededScenario(
-        "PYTEST_COLLECTION_IMPORT_FAILURE",
-        "Pytest collection/import failure",
-        ("python-exception", "pytest-error-count", "traceback"),
-        ("modulenotfounderror", "importerror while importing", "collected 0 items / 1 error"),
-        (
-            "Inspect the first import exception and confirm the missing package or public API is declared.",
-            "Check pyproject/requirements extras before changing runtime behavior.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <failing-test-file> --collect-only",),
-    ),
-    SeededScenario(
-        "RUFF_FORMAT_DRIFT",
-        "Ruff format drift",
-        ("ruff-format-failure",),
-        ("would reformat", "files were modified by this hook", "file reformatted"),
-        (
-            "Run Ruff format on only touched Python files and verify the diff is format-only.",
-            "Re-run Ruff format check after formatting.",
-        ),
-        ("PYTHONPATH=src python -m ruff format --check <touched-python-files>",),
-    ),
-    SeededScenario(
-        "RUFF_LINT_CONTRACT",
-        "Ruff lint contract failure",
-        ("ruff-check-failure",),
-        ("ruff check", "[*]", "fixable with the --fix option"),
-        (
-            "Read the first Ruff rule code and separate safe mechanical F401/I001 from logic-risk rules.",
-            "Only allow scoped auto-fix for the narrow safe allowlist.",
-        ),
-        ("PYTHONPATH=src python -m ruff check <touched-python-files>",),
-    ),
-    SeededScenario(
-        "MYPY_CONTRACT_DRIFT",
-        "Mypy type contract drift",
-        ("mypy-error",),
-        ("mypy", "error:", "Found "),
-        (
-            "Open the first mypy error and identify whether the public contract or test double type drifted.",
-            "Avoid blanket ignores until the narrow type boundary is understood.",
-        ),
-        ("PYTHONPATH=src python -m mypy src tests",),
-    ),
-    SeededScenario(
-        "COVERAGE_GATE_REGRESSION",
-        "Coverage threshold regression",
-        ("coverage-failure",),
-        ("fail under", "total coverage", "coverage"),
-        (
-            "Compare missing coverage lines to the PR diff and add focused tests for changed behavior.",
-            "Do not lower the threshold unless the release owner explicitly approves policy change.",
-        ),
-        ("bash quality.sh cov",),
-    ),
-    SeededScenario(
-        "CI_STEP_EXIT_NONZERO",
-        "CI step exited non-zero",
-        ("ci-exit-code", "command-failed"),
-        ("exit code", "command failed"),
-        (
-            "Scroll above the exit-code footer and identify the first actionable tool failure.",
-            "Classify the failure before considering automation.",
-        ),
-        ("python -m pre_commit run -a",),
-    ),
-    SeededScenario(
-        "QUALITY_GATE_POLICY_FAILURE",
-        "Quality gate policy failure",
-        ("gate-problems-found", "failed-steps"),
-        ("gate: problems found", "failed_steps", "no_ship"),
-        (
-            "Read the structured failed step list and map it to the first failing artifact.",
-            "Check whether the policy failure is release-blocking or evidence-thin.",
-        ),
-        ("PYTHONPATH=src python -m sdetkit mission-control --execute --doctor-cortex",),
-    ),
-    SeededScenario(
-        "PACKAGE_INSTALL_FAILURE",
-        "Package install or script failure",
-        ("package-manager-error",),
-        ("npm err!", "pnpm err!", "yarn", "pip install", "resolutionimpossible"),
-        (
-            "Inspect the package-manager error block before retrying; dependency resolution may be the root cause.",
-            "Check lockfiles and declared test requirements for drift.",
-        ),
-        ("python -m pip install -r requirements-test.txt -e .",),
-    ),
-    SeededScenario(
-        "PRE_COMMIT_HOOK_FAILURE",
-        "Pre-commit hook failure",
-        ("explicit-failed",),
-        ("pre-commit", "hook", "files were modified by this hook"),
-        (
-            "Identify the exact hook that failed and whether it changed files or reported a contract issue.",
-            "If files changed, review the diff before committing generated changes.",
-        ),
-        ("python -m pre_commit run -a",),
-    ),
-    SeededScenario(
-        "RUNTIME_EXCEPTION",
-        "Runtime exception or traceback",
-        ("traceback", "python-exception", "error-prefix"),
-        ("traceback", "exception:", "error:"),
-        (
-            "Start at the last frame in the first traceback and identify the smallest product or test boundary.",
-            "Check whether the exception happens during setup, import, or exercised behavior.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <focused-test> -vv",),
-    ),
-    SeededScenario(
-        "LOCAL_ENVIRONMENT_FRICTION",
-        "Local environment friction",
-        ("command-failed",),
-        ("/mnt/c/", "keyboardinterrupt", "venv", "site-packages"),
-        (
-            "Separate local filesystem/package friction from product failures before changing code.",
-            "Re-run from a native Linux filesystem or clean virtual environment if needed.",
-        ),
-        ("python -m venv .venv",),
-    ),
-    SeededScenario(
-        "GIT_REMOTE_DRIFT",
-        "Git branch or remote drift",
-        ("error-prefix", "command-failed"),
-        ("non-fast-forward", "fetch first", "remote contains work", "rebase"),
-        (
-            "Fetch and compare remote branch state before pushing or rewriting commits.",
-            "Re-run proof after rebase because previous proof may be stale.",
-        ),
-        ("git fetch --all --prune", "git status --short --branch"),
-    ),
-    SeededScenario(
-        "ASYNC_EVENT_LOOP_MISMATCH",
-        "Async event loop or fixture mismatch",
-        ("python-exception", "pytest-error-count"),
-        (
-            "event loop is closed",
-            "pytest-asyncio",
-            "anyio",
-            "asyncio.run",
-            "attached to a different loop",
-        ),
-        (
-            "Check the async test marker, fixture scope, and client lifecycle before changing production async code.",
-            "Reproduce one async test with verbose traceback and no parallelism.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <async-test> -vv",),
-    ),
-    SeededScenario(
-        "SNAPSHOT_GOLDEN_DRIFT",
-        "Snapshot or golden-file drift",
-        ("pytest-node-failed", "assertion-error"),
-        ("snapshot", "golden", "approval", "received", "expected"),
-        (
-            "Inspect the expected/received diff and confirm whether the contract intentionally changed.",
-            "Update golden files only after a focused behavior test proves the new output.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <snapshot-test> -vv",),
-    ),
-    SeededScenario(
-        "PROPERTY_FUZZ_COUNTEREXAMPLE",
-        "Property-test counterexample",
-        ("assertion-error", "pytest-node-failed"),
-        ("hypothesis", "falsifying example", "counterexample", "seed="),
-        (
-            "Copy the minimized counterexample into a focused regression test before broad refactors.",
-            "Check whether shrinking revealed an input contract gap or product bug.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <property-test> --hypothesis-show-statistics",),
-    ),
-    SeededScenario(
-        "FLAKY_ORDER_DEPENDENCE",
-        "Order-dependent or parallel test flake",
-        ("pytest-failed-count", "command-failed"),
-        ("xdist", "randomly", "rerun", "flaky", "order dependent"),
-        (
-            "Re-run the failing test alone and then with the previous neighbor to expose hidden shared state.",
-            "Check global caches, monkeypatch cleanup, time/freezer state, and temporary directories.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <failing-test> --count=3",),
-    ),
-    SeededScenario(
-        "NETWORK_SERVICE_FLAKE",
-        "Network/API service flake",
-        ("python-exception", "command-failed"),
-        ("timeout", "connectionerror", "429", "rate limit", "dns", "tls"),
-        (
-            "Separate product failures from remote-service instability using mocks or recorded fixtures.",
-            "Check retry/backoff behavior and whether the test is marked network opt-in.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <network-test> -vv",),
-    ),
-    SeededScenario(
-        "AUTH_SECRET_CONFIGURATION",
-        "Auth or secret configuration failure",
-        ("error-prefix", "python-exception"),
-        ("unauthorized", "forbidden", "401", "403", "missing secret", "token"),
-        (
-            "Confirm whether the workflow has the needed secret scope without printing secret values.",
-            "Check permission blocks and environment names before changing auth code.",
-        ),
-        ("git status --short",),
-    ),
-    SeededScenario(
-        "DOCKER_SERVICE_BOOT_FAILURE",
-        "Docker service boot failure",
-        ("command-failed", "ci-exit-code"),
-        ("docker", "compose", "container exited", "healthcheck", "port is already allocated"),
-        (
-            "Inspect service logs and health checks before retrying the full workflow.",
-            "Check port collisions, image pull failures, and startup readiness waits.",
-        ),
-        ("docker compose ps", "docker compose logs --tail=200"),
-    ),
-    SeededScenario(
-        "DATABASE_MIGRATION_DRIFT",
-        "Database migration or schema drift",
-        ("python-exception", "error-prefix"),
-        ("migration", "alembic", "schema", "relation does not exist", "duplicate column"),
-        (
-            "Compare migration head, generated schema, and test database setup before editing models.",
-            "Confirm whether the failure is stale fixtures or a real migration gap.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <db-test> -vv",),
-    ),
-    SeededScenario(
-        "TIMEZONE_CLOCK_DRIFT",
-        "Timezone or clock-dependent failure",
-        ("assertion-error", "pytest-node-failed"),
-        ("timezone", "utc", "dst", "freezegun", "datetime", "today"),
-        (
-            "Check timezone assumptions, frozen clocks, and date boundaries before changing expected output.",
-            "Reproduce with UTC and the failing local timezone if available.",
-        ),
-        ("TZ=UTC PYTHONPATH=src python -m pytest -q <time-test> -vv",),
-    ),
-    SeededScenario(
-        "PLATFORM_PATH_CASE_DRIFT",
-        "Platform path/case sensitivity drift",
-        ("python-exception", "assertion-error"),
-        ("filenotfounderror", "permission denied", "case-sensitive", "path", "windows"),
-        (
-            "Check path casing, separators, permissions, and temp-directory cleanup across platforms.",
-            "Avoid hard-coded absolute paths in tests and generated artifacts.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q <path-test> -vv",),
-    ),
-    SeededScenario(
-        "CACHE_ARTIFACT_POISONING",
-        "Cache or artifact poisoning",
-        ("command-failed", "error-prefix"),
-        ("cache", "artifact", "stale", "checksum", "hash mismatch"),
-        (
-            "Compare the failing run with a cache-cold run before changing product code.",
-            "Check cache keys include lockfiles, Python version, and relevant config files.",
-        ),
-        ("git diff -- pyproject.toml requirements-test.txt",),
-    ),
-    SeededScenario(
-        "DOCS_BUILD_CONTRACT",
-        "Docs build or link contract failure",
-        ("command-failed", "error-prefix"),
-        ("mkdocs", "sphinx", "markdown", "linkcheck", "broken link"),
-        (
-            "Open the first docs build error and check whether navigation, anchors, or generated files drifted.",
-            "Verify docs-only fixes do not mask product API drift.",
-        ),
-        ("PYTHONPATH=src python -m pytest -q tests/test_docs*.py",),
-    ),
-    SeededScenario(
-        "SECURITY_AUDIT_BLOCKER",
-        "Security audit blocker",
-        ("error-prefix", "gate-problems-found"),
-        ("vulnerability", "ghsa", "cve", "pip-audit", "bandit", "secret detected"),
-        (
-            "Treat security audit output as review-first; identify whether it is dependency, code, or secret exposure.",
-            "Check advisories and minimum patched versions before bumping packages.",
-        ),
-        ("python -m pip_audit",),
-    ),
-    SeededScenario(
-        "BUILD_BACKEND_FAILURE",
-        "Build backend or wheel failure",
-        ("package-manager-error", "python-exception"),
-        (
-            "building wheel",
-            "pyproject",
-            "setuptools",
-            "build backend",
-            "metadata-generation-failed",
-        ),
-        (
-            "Inspect build backend metadata errors and confirm declared build requirements.",
-            "Check whether a package only ships sdists for the active Python/platform.",
-        ),
-        ("python -m pip install -r requirements-test.txt -e .",),
-    ),
-    SeededScenario(
-        "RELEASE_VERSION_CONFLICT",
-        "Release/version metadata conflict",
-        ("error-prefix", "command-failed"),
-        ("version", "tag already exists", "duplicate release", "changelog", "twine"),
-        (
-            "Compare package version, git tags, changelog, and release artifact names.",
-            "Do not overwrite published artifacts; create a new version if release state escaped.",
-        ),
-        ("git tag --points-at HEAD", "python -m build --sdist --wheel"),
-    ),
-)
+BUILTIN_SCENARIO_PACK = "data/adaptive_scenarios.json"
+SCENARIO_PACK_SCHEMA_VERSION = "sdetkit.adaptive.scenario_pack.v1"
+VALID_RISK_BANDS = {"low", "medium", "high"}
+REQUIRED_SCENARIO_FIELDS = {
+    "code",
+    "title",
+    "signals",
+    "keywords",
+    "checks",
+    "commands",
+    "risk_band",
+    "prior_weight",
+}
+
+
+def _package_file(rel_path: str) -> Path:
+    return Path(__file__).resolve().parent / rel_path
+
+
+def _as_str_tuple(value: Any, field: str, code: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"scenario {code}: {field} must be a non-empty list")
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"scenario {code}: {field} must contain non-empty strings")
+        text = item.strip()
+        if text not in out:
+            out.append(text)
+    return tuple(out)
+
+
+def _as_optional_str_tuple(value: Any, field: str, code: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError(f"scenario {code}: {field} must be a list when provided")
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"scenario {code}: {field} must contain non-empty strings")
+        text = item.strip()
+        if text not in out:
+            out.append(text)
+    return tuple(out)
+
+
+def _scenario_from_row(row: Any, *, source: Path) -> SeededScenario:
+    if not isinstance(row, dict):
+        raise ValueError(f"scenario pack {source}: each scenario must be an object")
+    missing = sorted(REQUIRED_SCENARIO_FIELDS.difference(row))
+    raw_code = row.get("code", "UNKNOWN")
+    code = raw_code.strip() if isinstance(raw_code, str) else "UNKNOWN"
+    if missing:
+        raise ValueError(f"scenario {code}: missing required fields: {', '.join(missing)}")
+    if not code or not re.fullmatch(r"[A-Z0-9_]+", code):
+        raise ValueError(f"scenario {code}: code must be uppercase snake case")
+    title = row.get("title")
+    if not isinstance(title, str) or not title.strip():
+        raise ValueError(f"scenario {code}: title must be a non-empty string")
+    risk_band = row.get("risk_band")
+    if risk_band not in VALID_RISK_BANDS:
+        raise ValueError(f"scenario {code}: risk_band must be one of low, medium, high")
+    prior_weight = row.get("prior_weight")
+    if not isinstance(prior_weight, int) or isinstance(prior_weight, bool) or prior_weight < 1:
+        raise ValueError(f"scenario {code}: prior_weight must be a positive integer")
+    return SeededScenario(
+        code=code,
+        title=title.strip(),
+        signals=_as_str_tuple(row.get("signals"), "signals", code),
+        keywords=_as_str_tuple(row.get("keywords"), "keywords", code),
+        checks=_as_str_tuple(row.get("checks"), "checks", code),
+        commands=_as_str_tuple(row.get("commands"), "commands", code),
+        odds=_as_optional_str_tuple(row.get("odds"), "odds", code),
+        tags=_as_optional_str_tuple(row.get("tags"), "tags", code),
+        risk_band=str(risk_band),
+        prior_weight=prior_weight,
+    )
+
+
+def load_scenario_pack(path: Path) -> tuple[SeededScenario, ...]:
+    """Load and validate a versioned adaptive scenario pack."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"scenario pack {path}: root must be an object")
+    if payload.get("schema_version") != SCENARIO_PACK_SCHEMA_VERSION:
+        raise ValueError(
+            f"scenario pack {path}: schema_version must be {SCENARIO_PACK_SCHEMA_VERSION}"
+        )
+    rows = payload.get("scenarios")
+    if not isinstance(rows, list) or not rows:
+        raise ValueError(f"scenario pack {path}: scenarios must be a non-empty list")
+    scenarios = [_scenario_from_row(row, source=path) for row in rows]
+    codes = [scenario.code for scenario in scenarios]
+    duplicate_codes = sorted(code for code, count in Counter(codes).items() if count > 1)
+    if duplicate_codes:
+        raise ValueError(
+            f"scenario pack {path}: duplicate scenario codes: {', '.join(duplicate_codes)}"
+        )
+    return tuple(sorted(scenarios, key=lambda scenario: scenario.code))
+
+
+def merge_scenario_packs(*packs: Sequence[SeededScenario]) -> tuple[SeededScenario, ...]:
+    """Merge packs deterministically, allowing later packs to override by scenario code."""
+    merged: dict[str, SeededScenario] = {}
+    for pack in packs:
+        for scenario in pack:
+            merged[scenario.code] = scenario
+    return tuple(merged[code] for code in sorted(merged))
+
+
+def _default_layer_paths(root: Path | None = None) -> list[Path]:
+    base = root or Path.cwd()
+    env_paths = [
+        Path(item)
+        for item in os.environ.get("SDETKIT_ADAPTIVE_SCENARIO_PACKS", "").split(os.pathsep)
+        if item
+    ]
+    candidates = [base / ".sdetkit" / "adaptive" / "scenarios.json", *env_paths]
+    return [path for path in candidates if path.exists()]
+
+
+def load_layered_scenarios(root: Path | None = None) -> tuple[SeededScenario, ...]:
+    """Load built-in scenarios plus repo/org/private overlay packs in deterministic order."""
+    packs = [load_scenario_pack(_package_file(BUILTIN_SCENARIO_PACK))]
+    packs.extend(load_scenario_pack(path) for path in _default_layer_paths(root))
+    return merge_scenario_packs(*packs)
+
+
+SEEDED_SCENARIO_DB = load_scenario_pack(_package_file(BUILTIN_SCENARIO_PACK))
 
 
 def _as_int(value: Any) -> int:
@@ -600,6 +410,57 @@ def _failure_like_signals(text: str) -> list[FailureSignal]:
     return [signal for signal in FAILURE_LIKE_SIGNAL_DB if signal.pattern.search(text)]
 
 
+def _scenario_calibration_map(
+    adaptive_history: dict[str, Any] | None = None,
+) -> dict[str, dict[str, Any]]:
+    history = _as_dict(adaptive_history)
+    rows = _as_list(history.get("top_recurring_scenarios"))
+    out: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        item = _as_dict(row)
+        code = str(item.get("code", "")).strip()
+        if code:
+            out[code] = _as_dict(item.get("calibration"))
+    return out
+
+
+def _calibration_score(calibration: dict[str, Any]) -> int:
+    if not calibration:
+        return 0
+    actions = {str(value) for value in _as_list(calibration.get("actions"))}
+    score = _as_int(calibration.get("confidence_delta")) * 2
+    risk_delta = _as_int(calibration.get("risk_delta"))
+    if risk_delta > 0:
+        score += min(4, max(1, risk_delta // 8))
+    elif risk_delta < 0:
+        score -= min(4, max(1, abs(risk_delta) // 8))
+    if "promote" in actions:
+        score += 4
+    if "increase_risk" in actions:
+        score += 2
+    if "demote" in actions:
+        score -= 8
+    if "lower_confidence" in actions:
+        score -= 3
+    return score
+
+
+def _candidate_calibration_evidence(
+    candidates: Sequence[SeededScenario], calibration_by_code: dict[str, dict[str, Any]]
+) -> str:
+    parts: list[str] = []
+    for scenario in candidates[:4]:
+        calibration = calibration_by_code.get(scenario.code, {})
+        if not calibration:
+            continue
+        parts.append(
+            f"{scenario.code}:{calibration.get('primary_action', 'observe')}:"
+            f"confidence_delta={_as_int(calibration.get('confidence_delta'))}:"
+            f"risk_delta={_as_int(calibration.get('risk_delta'))}"
+        )
+    return "candidate_calibration=" + ";".join(parts) if parts else ""
+
+
 def _looks_failure_like(text: str) -> bool:
     return bool(_failure_like_signals(text))
 
@@ -608,21 +469,29 @@ def _has_failure_signal(text: str, name: str) -> bool:
     return any(signal.name == name for signal in _failure_like_signals(text))
 
 
-def _failure_like_evidence(text: str) -> list[str]:
+def _failure_like_evidence(text: str, adaptive_history: dict[str, Any] | None = None) -> list[str]:
     signals = _failure_like_signals(text)
+    calibration_by_code = _scenario_calibration_map(adaptive_history)
     evidence = ["matched_failure_signals=" + ",".join(signal.name for signal in signals[:6])]
     evidence.extend(signal.description for signal in signals[:3])
-    candidates = _candidate_scenarios(text, signals)
+    candidates = _candidate_scenarios(text, signals, calibration_by_code=calibration_by_code)
     if candidates:
         evidence.append(
             "candidate_scenarios=" + ",".join(scenario.code for scenario in candidates[:4])
         )
         evidence.append(_candidate_odds_evidence(candidates))
+        calibration_evidence = _candidate_calibration_evidence(candidates, calibration_by_code)
+        if calibration_evidence:
+            evidence.append(calibration_evidence)
     return evidence
 
 
 def _candidate_scenarios(
-    text: str, signals: Sequence[FailureSignal] | None = None, *, limit: int = 4
+    text: str,
+    signals: Sequence[FailureSignal] | None = None,
+    *,
+    limit: int = 4,
+    calibration_by_code: dict[str, dict[str, Any]] | None = None,
 ) -> list[SeededScenario]:
     lower = text.lower()
     signal_names = {signal.name for signal in (signals or _failure_like_signals(text))}
@@ -632,6 +501,7 @@ def _candidate_scenarios(
         keyword_hits = sum(1 for keyword in scenario.keywords if keyword.lower() in lower)
         odds_hits = sum(1 for odd in scenario.odds if odd.lower() in lower)
         score = signal_hits * 3 + keyword_hits + odds_hits + max(0, scenario.prior_weight - 1)
+        score += _calibration_score(_as_dict((calibration_by_code or {}).get(scenario.code)))
         if score:
             scored.append((-score, scenario.code, scenario))
     scored.sort()
@@ -653,9 +523,13 @@ def _candidate_odds_evidence(candidates: Sequence[SeededScenario]) -> str:
     return "candidate_odds=" + ";".join(parts)
 
 
-def _candidate_checks(text: str, limit: int = 5) -> list[str]:
+def _candidate_checks(
+    text: str, limit: int = 5, adaptive_history: dict[str, Any] | None = None
+) -> list[str]:
     checks: list[str] = []
-    for scenario in _candidate_scenarios(text):
+    for scenario in _candidate_scenarios(
+        text, calibration_by_code=_scenario_calibration_map(adaptive_history)
+    ):
         checks.append(f"Check candidate {scenario.code}: {scenario.checks[0]}")
         for check in scenario.checks[1:2]:
             checks.append(check)
@@ -667,9 +541,13 @@ def _candidate_checks(text: str, limit: int = 5) -> list[str]:
     return checks[:limit]
 
 
-def _candidate_commands(text: str, limit: int = 4) -> list[str]:
+def _candidate_commands(
+    text: str, limit: int = 4, adaptive_history: dict[str, Any] | None = None
+) -> list[str]:
     commands: list[str] = []
-    for scenario in _candidate_scenarios(text):
+    for scenario in _candidate_scenarios(
+        text, calibration_by_code=_scenario_calibration_map(adaptive_history)
+    ):
         for command in scenario.commands:
             if command not in commands:
                 commands.append(command)
@@ -916,7 +794,9 @@ def _append_local_investigation(
     return False
 
 
-def _append_log(text: str, diagnoses: list[dict[str, Any]]) -> None:
+def _append_log(
+    text: str, diagnoses: list[dict[str, Any]], adaptive_history: dict[str, Any] | None = None
+) -> None:
     lower = text.lower()
     files = _file_mentions(text)
     handled_local = _append_local_investigation(text, files, diagnoses)
@@ -973,9 +853,9 @@ def _append_log(text: str, diagnoses: list[dict[str, Any]]) -> None:
                 "Failure needs human review",
                 "The provided log contains failure-like text but did not match a known adaptive diagnosis family.",
                 "Unknown failures should not be guessed into a safe-fix route.",
-                _failure_like_evidence(text),
-                _candidate_checks(text),
-                _candidate_commands(text),
+                _failure_like_evidence(text, adaptive_history),
+                _candidate_checks(text, adaptive_history=adaptive_history),
+                _candidate_commands(text, adaptive_history=adaptive_history),
                 "Unclassified failures can be unsafe to automate.",
                 "unknown-review-required",
                 files=files,
@@ -1250,7 +1130,7 @@ def analyze_evidence(
 ) -> dict[str, Any]:
     diagnoses: list[dict[str, Any]] = []
     if log_text:
-        _append_log(log_text, diagnoses)
+        _append_log(log_text, diagnoses, _as_dict(adaptive_history))
     _append_mission(_as_dict(mission_control), diagnoses)
     _append_history(list(ledger_records or []), diagnoses)
     _append_adaptive(_as_dict(adaptive_history), diagnoses)

--- a/src/sdetkit/adaptive_diagnosis_memory.py
+++ b/src/sdetkit/adaptive_diagnosis_memory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -12,8 +13,11 @@ from sdetkit._datetime import UTC
 SCHEMA_VERSION = "sdetkit.adaptive_diagnosis.memory.v1"
 RECORD_SCHEMA_VERSION = "sdetkit.adaptive_diagnosis.learning_record.v1"
 SAFE_FIX_ROLLUP_SCHEMA_VERSION = "sdetkit.adaptive_safe_fix.rollup.v1"
+LEARN_SUMMARY_SCHEMA_VERSION = "sdetkit.adaptive.learn.summary.v1"
 SOURCE_SCHEMA_VERSION = "sdetkit.adaptive.diagnosis.v1"
 ACTIONABLE_STATUSES = {"needs_attention", "needs_fix"}
+CONFIDENCE_SCORE = {"low": 1, "medium": 2, "high": 3}
+SCORE_CONFIDENCE = {1: "low", 2: "medium", 3: "high"}
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -40,6 +44,50 @@ def _first(values: Any) -> str:
         if text:
             return text
     return ""
+
+
+def _prefixed_csv(values: Any, prefix: str) -> list[str]:
+    for value in _as_list(values):
+        text = str(value or "").strip()
+        if text.startswith(prefix):
+            return [item for item in text.removeprefix(prefix).split(",") if item]
+    return []
+
+
+def _lane_for_code(code: str, signal: str = "") -> str:
+    haystack = f"{code} {signal}".lower()
+    if any(token in haystack for token in ("ruff", "mypy", "format", "lint", "coverage")):
+        return "quality"
+    if any(token in haystack for token in ("pytest", "test", "fixture", "snapshot", "flake")):
+        return "test"
+    if any(token in haystack for token in ("package", "dependency", "install", "wheel", "build")):
+        return "dependency"
+    if any(token in haystack for token in ("security", "cve", "ghsa", "secret")):
+        return "security"
+    if any(token in haystack for token in ("release", "mission", "version", "tag")):
+        return "release"
+    if any(token in haystack for token in ("docs", "markdown", "mkdocs", "link")):
+        return "docs"
+    if any(token in haystack for token in ("git", "branch", "remote")):
+        return "source-control"
+    if any(token in haystack for token in ("network", "timeout", "api", "tls", "dns")):
+        return "environment"
+    return "unknown"
+
+
+def _bounded_confidence(base: str, delta: int) -> str:
+    score = CONFIDENCE_SCORE.get(str(base or "medium"), 2) + delta
+    return SCORE_CONFIDENCE[min(3, max(1, score))]
+
+
+def _optional_bool_from_flags(*, positive: bool = False, negative: bool = False) -> bool | None:
+    if positive and negative:
+        raise ValueError("outcome flags are mutually exclusive")
+    if positive:
+        return True
+    if negative:
+        return False
+    return None
 
 
 def _record_hash(parts: dict[str, Any]) -> str:
@@ -192,6 +240,9 @@ def build_learning_records(
     *,
     include_monitor: bool = False,
     learned_at_utc: str | None = None,
+    proof_passed: bool | None = None,
+    fix_accepted: bool | None = None,
+    false_positive: bool = False,
 ) -> list[dict[str, Any]]:
     status = str(payload.get("status", "unknown"))
     if status not in ACTIONABLE_STATUSES and not include_monitor:
@@ -210,6 +261,9 @@ def build_learning_records(
             "title": row.get("title", ""),
             "recommended_fix": _first(row.get("recommended_fix")),
             "proof_command": _first(row.get("proof_commands")),
+            "proof_passed": proof_passed,
+            "fix_accepted": fix_accepted,
+            "false_positive": false_positive,
         }
         records.append(
             {
@@ -230,10 +284,227 @@ def build_learning_records(
                 "proof_command": _first(row.get("proof_commands")),
                 "risk_if_ignored": str(row.get("risk_if_ignored", "")),
                 "repeat_count": _as_int(row.get("repeat_count")),
+                "recurrence_count": _as_int(row.get("repeat_count")),
                 "affected_files": [str(value) for value in _as_list(row.get("affected_files"))],
+                "matched_signals": _prefixed_csv(row.get("evidence"), "matched_failure_signals="),
+                "candidate_scenarios": _prefixed_csv(row.get("evidence"), "candidate_scenarios="),
+                "selected_primary_diagnosis": len(records) == 0,
+                "recommended_checks": [
+                    str(value) for value in _as_list(row.get("recommended_fix"))[:4]
+                ],
+                "proof_commands": [str(value) for value in _as_list(row.get("proof_commands"))[:4]],
+                "proof_passed": proof_passed,
+                "fix_accepted": fix_accepted,
+                "false_positive": false_positive,
+                "lane": _lane_for_code(code, signal),
             }
         )
     return records
+
+
+def _calibration_for_scenario(row: dict[str, Any]) -> dict[str, Any]:
+    records = _as_int(row.get("records"))
+    recurrence_count = _as_int(row.get("recurrence_count"))
+    false_positive_count = _as_int(row.get("false_positive_count"))
+    proof_passed_count = _as_int(row.get("proof_passed_count"))
+    fix_accepted_count = _as_int(row.get("fix_accepted_count"))
+    matched_signal_count = _as_int(row.get("matched_signal_count"))
+    candidate_scenario_count = _as_int(row.get("candidate_scenario_count"))
+
+    confidence_delta = 0
+    risk_delta = 0
+    actions: list[str] = []
+    reasons: list[str] = []
+
+    if false_positive_count:
+        confidence_delta -= 2
+        risk_delta -= min(20, false_positive_count * 8)
+        actions.append("demote")
+        reasons.append("operator marked false positive")
+    if proof_passed_count or fix_accepted_count:
+        confidence_delta += 1 + min(1, proof_passed_count + fix_accepted_count - 1)
+        actions.append("promote")
+        reasons.append("proof or accepted fix confirmed recommendation")
+    if recurrence_count >= 3:
+        risk_delta += min(30, recurrence_count * 3)
+        actions.append("increase_risk")
+        reasons.append("recurrence crossed promotion threshold")
+    if records and matched_signal_count == 0 and candidate_scenario_count == 0:
+        confidence_delta -= 1
+        actions.append("lower_confidence")
+        reasons.append("evidence is thin: no matched signals or candidate scenarios")
+
+    if not actions:
+        actions.append("observe")
+        reasons.append("not enough outcome evidence to promote or demote")
+
+    if "demote" in actions:
+        primary_action = "demote"
+    elif "promote" in actions and "increase_risk" in actions:
+        primary_action = "promote_and_increase_risk"
+    elif "promote" in actions:
+        primary_action = "promote"
+    elif "increase_risk" in actions:
+        primary_action = "increase_risk"
+    elif "lower_confidence" in actions:
+        primary_action = "lower_confidence"
+    else:
+        primary_action = "observe"
+
+    base_confidence = str(row.get("base_confidence", "medium"))
+    return {
+        "primary_action": primary_action,
+        "actions": actions,
+        "base_confidence": base_confidence,
+        "calibrated_confidence": _bounded_confidence(base_confidence, confidence_delta),
+        "confidence_delta": confidence_delta,
+        "risk_delta": risk_delta,
+        "reasons": reasons,
+    }
+
+
+def summarize_learning_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    scenario_groups: dict[str, dict[str, Any]] = {}
+    lane_groups: dict[str, dict[str, Any]] = {}
+    diagnosis_records = 0
+
+    for record in records:
+        row = _as_dict(record)
+        if row.get("source") != "adaptive_diagnosis":
+            continue
+        diagnosis_records += 1
+        code = str(row.get("code", "UNKNOWN"))
+        signal = str(row.get("signal", ""))
+        lane = str(row.get("lane") or _lane_for_code(code, signal))
+        repeat_count = _as_int(row.get("recurrence_count", row.get("repeat_count")))
+        false_positive = bool(row.get("false_positive", False))
+        proof_passed = row.get("proof_passed")
+        fix_accepted = row.get("fix_accepted")
+
+        scenario = scenario_groups.setdefault(
+            code,
+            {
+                "code": code,
+                "lane": lane,
+                "records": 0,
+                "recurrence_count": 0,
+                "false_positive_count": 0,
+                "proof_passed_count": 0,
+                "fix_accepted_count": 0,
+                "proof_failed_count": 0,
+                "fix_rejected_count": 0,
+                "matched_signal_count": 0,
+                "candidate_scenario_count": 0,
+                "base_confidence": str(row.get("confidence", "medium")),
+                "latest_record_id": "",
+                "latest_learned_at_utc": "",
+                "sample_signal": signal,
+                "sample_proof_command": str(row.get("proof_command", "")),
+            },
+        )
+        scenario["records"] += 1
+        scenario["recurrence_count"] += repeat_count
+        scenario["matched_signal_count"] += len(_as_list(row.get("matched_signals")))
+        scenario["candidate_scenario_count"] += len(_as_list(row.get("candidate_scenarios")))
+        if false_positive:
+            scenario["false_positive_count"] += 1
+        if proof_passed is True:
+            scenario["proof_passed_count"] += 1
+        elif proof_passed is False:
+            scenario["proof_failed_count"] += 1
+        if fix_accepted is True:
+            scenario["fix_accepted_count"] += 1
+        elif fix_accepted is False:
+            scenario["fix_rejected_count"] += 1
+        scenario["latest_record_id"] = str(row.get("record_id", ""))
+        scenario["latest_learned_at_utc"] = str(row.get("learned_at_utc", ""))
+
+        lane_group = lane_groups.setdefault(
+            lane,
+            {
+                "lane": lane,
+                "records": 0,
+                "recurrence_count": 0,
+                "false_positive_count": 0,
+                "proof_unknown_count": 0,
+                "scenario_codes": set(),
+            },
+        )
+        lane_group["records"] += 1
+        lane_group["recurrence_count"] += repeat_count
+        if false_positive:
+            lane_group["false_positive_count"] += 1
+        if proof_passed is None:
+            lane_group["proof_unknown_count"] += 1
+        lane_group["scenario_codes"].add(code)
+
+    for scenario in scenario_groups.values():
+        scenario["calibration"] = _calibration_for_scenario(scenario)
+
+    top_recurring = sorted(
+        scenario_groups.values(),
+        key=lambda item: (
+            -_as_int(item["recurrence_count"]),
+            -_as_int(item["records"]),
+            item["code"],
+        ),
+    )[:10]
+
+    weakest_lanes = []
+    for lane_group in lane_groups.values():
+        scenario_codes = sorted(lane_group.pop("scenario_codes"))
+        lane_group["scenario_count"] = len(scenario_codes)
+        lane_group["scenario_codes"] = scenario_codes[:8]
+        lane_group["weakness_score"] = (
+            _as_int(lane_group["records"])
+            + _as_int(lane_group["recurrence_count"])
+            + _as_int(lane_group["proof_unknown_count"])
+            + _as_int(lane_group["false_positive_count"]) * 2
+        )
+        weakest_lanes.append(lane_group)
+    weakest_lanes.sort(
+        key=lambda item: (-_as_int(item["weakness_score"]), -_as_int(item["records"]), item["lane"])
+    )
+
+    return {
+        "schema_version": LEARN_SUMMARY_SCHEMA_VERSION,
+        "ok": True,
+        "source": "adaptive_diagnosis_learning",
+        "input_records": len(records),
+        "diagnosis_records": diagnosis_records,
+        "scenario_count": len(scenario_groups),
+        "lane_count": len(weakest_lanes),
+        "top_recurring_scenarios": top_recurring,
+        "weakest_lanes": weakest_lanes[:10],
+        "calibration_summary": {
+            "promote": sum(
+                1
+                for item in scenario_groups.values()
+                if "promote" in _as_dict(item.get("calibration")).get("actions", [])
+            ),
+            "demote": sum(
+                1
+                for item in scenario_groups.values()
+                if "demote" in _as_dict(item.get("calibration")).get("actions", [])
+            ),
+            "increase_risk": sum(
+                1
+                for item in scenario_groups.values()
+                if "increase_risk" in _as_dict(item.get("calibration")).get("actions", [])
+            ),
+            "lower_confidence": sum(
+                1
+                for item in scenario_groups.values()
+                if "lower_confidence" in _as_dict(item.get("calibration")).get("actions", [])
+            ),
+        },
+    }
+
+
+def learning_summary_from_db(db_path: Path) -> dict[str, Any]:
+    summary = summarize_learning_records(_read_jsonl(db_path))
+    summary["db_path"] = db_path.as_posix()
+    return summary
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -280,10 +551,18 @@ def learn_from_diagnosis(
     *,
     include_monitor: bool = False,
     learned_at_utc: str | None = None,
+    proof_passed: bool | None = None,
+    fix_accepted: bool | None = None,
+    false_positive: bool = False,
 ) -> dict[str, Any]:
     payload = load_diagnosis(diagnosis_path)
     records = build_learning_records(
-        payload, include_monitor=include_monitor, learned_at_utc=learned_at_utc
+        payload,
+        include_monitor=include_monitor,
+        learned_at_utc=learned_at_utc,
+        proof_passed=proof_passed,
+        fix_accepted=fix_accepted,
+        false_positive=false_positive,
     )
     summary = append_learning_records(db_path, records)
     summary["source_path"] = diagnosis_path.as_posix()
@@ -296,17 +575,68 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("diagnosis_json")
     parser.add_argument("--db", default=".sdetkit/adaptive-diagnosis-memory.jsonl")
     parser.add_argument("--include-monitor", action="store_true")
+    parser.add_argument("--proof-passed", action="store_true")
+    parser.add_argument("--proof-failed", action="store_true")
+    parser.add_argument("--fix-accepted", action="store_true")
+    parser.add_argument("--fix-rejected", action="store_true")
+    parser.add_argument("--false-positive", action="store_true")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     return parser
 
 
+def build_summarize_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_diagnosis_memory summarize")
+    parser.add_argument("--db", default=".sdetkit/adaptive-diagnosis-memory.jsonl")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def _print_summary(summary: dict[str, Any], output_format: str) -> None:
+    if output_format == "json":
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return
+    print(f"adaptive learning db: {summary.get('db_path', '')}")
+    print(f"diagnosis records: {summary['diagnosis_records']}")
+    print(f"scenario count: {summary['scenario_count']}")
+    print(f"lane count: {summary['lane_count']}")
+    for lane in _as_list(summary.get("weakest_lanes"))[:5]:
+        row = _as_dict(lane)
+        print(
+            "weak lane: "
+            f"{row.get('lane')} records={row.get('records')} "
+            f"recurrence={row.get('recurrence_count')} score={row.get('weakness_score')}"
+        )
+
+
+def _main_summarize(argv: list[str]) -> int:
+    args = build_summarize_parser().parse_args(argv)
+    try:
+        summary = learning_summary_from_db(Path(args.db))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+    _print_summary(summary, str(args.format))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    arg_list = list(sys.argv[1:] if argv is None else argv)
+    if arg_list and arg_list[0] == "summarize":
+        return _main_summarize(arg_list[1:])
+
+    args = build_parser().parse_args(arg_list)
     try:
         summary = learn_from_diagnosis(
             Path(args.diagnosis_json),
             Path(args.db),
             include_monitor=bool(args.include_monitor),
+            proof_passed=_optional_bool_from_flags(
+                positive=bool(args.proof_passed), negative=bool(args.proof_failed)
+            ),
+            fix_accepted=_optional_bool_from_flags(
+                positive=bool(args.fix_accepted), negative=bool(args.fix_rejected)
+            ),
+            false_positive=bool(args.false_positive),
         )
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"error={exc}")

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -391,6 +391,37 @@ Then use stability-aware command discovery:
     adaptive_explain.add_argument("path")
     adaptive_explain.add_argument("--db", default=".sdetkit/adaptive.db")
     adaptive_explain.add_argument("--format", choices=["text", "operator-json"], default="text")
+    adaptive_learn = adaptive_sub.add_parser(
+        "learn", help="Record and summarize adaptive diagnosis learning events"
+    )
+    adaptive_learn_sub = adaptive_learn.add_subparsers(dest="adaptive_learn_cmd", required=True)
+    adaptive_learn_record = adaptive_learn_sub.add_parser(
+        "record", help="Record learning events from an adaptive diagnosis JSON artifact"
+    )
+    adaptive_learn_record.add_argument("diagnosis_json")
+    adaptive_learn_record.add_argument("--db", default=".sdetkit/adaptive-diagnosis-memory.jsonl")
+    adaptive_learn_record.add_argument("--include-monitor", action="store_true")
+    adaptive_learn_record.add_argument("--proof-passed", action="store_true")
+    adaptive_learn_record.add_argument("--proof-failed", action="store_true")
+    adaptive_learn_record.add_argument("--fix-accepted", action="store_true")
+    adaptive_learn_record.add_argument("--fix-rejected", action="store_true")
+    adaptive_learn_record.add_argument("--false-positive", action="store_true")
+    adaptive_learn_record.add_argument("--format", choices=["text", "json"], default="text")
+    adaptive_learn_summary = adaptive_learn_sub.add_parser(
+        "summarize", help="Summarize recurring scenarios and weakest adaptive lanes"
+    )
+    adaptive_learn_summary.add_argument("--db", default=".sdetkit/adaptive-diagnosis-memory.jsonl")
+    adaptive_learn_summary.add_argument("--format", choices=["text", "json"], default="text")
+    adaptive_brief = adaptive_sub.add_parser(
+        "brief",
+        help="Generate a concise operator brief from gate, diagnosis, and learning artifacts",
+    )
+    adaptive_brief.add_argument("--gate", default="")
+    adaptive_brief.add_argument("--diagnosis", default="")
+    adaptive_brief.add_argument("--learning-summary", default="")
+    adaptive_brief.add_argument("--safe-fix-plan", default="")
+    adaptive_brief.add_argument("--format", choices=["md", "json", "comment"], default="md")
+    adaptive_brief.add_argument("--out", default="build/sdetkit/operator-brief.md")
     index_sub = index.add_subparsers(dest="index_cmd", required=False)
     index_build = index_sub.add_parser(
         "build", help="Build deterministic local repo index evidence"
@@ -1023,6 +1054,43 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "sdetkit.adaptive",
                 ["explain", str(ns.path), "--db", str(ns.db), "--format", str(ns.format)],
             )
+        if getattr(ns, "adaptive_cmd", None) == "learn":
+            if getattr(ns, "adaptive_learn_cmd", None) == "record":
+                forwarded = [
+                    str(ns.diagnosis_json),
+                    "--db",
+                    str(ns.db),
+                    "--format",
+                    str(ns.format),
+                ]
+                if bool(ns.include_monitor):
+                    forwarded.append("--include-monitor")
+                for flag, enabled in (
+                    ("--proof-passed", bool(ns.proof_passed)),
+                    ("--proof-failed", bool(ns.proof_failed)),
+                    ("--fix-accepted", bool(ns.fix_accepted)),
+                    ("--fix-rejected", bool(ns.fix_rejected)),
+                    ("--false-positive", bool(ns.false_positive)),
+                ):
+                    if enabled:
+                        forwarded.append(flag)
+                return _run_module_main("sdetkit.adaptive_diagnosis_memory", forwarded)
+            if getattr(ns, "adaptive_learn_cmd", None) == "summarize":
+                return _run_module_main(
+                    "sdetkit.adaptive_diagnosis_memory",
+                    ["summarize", "--db", str(ns.db), "--format", str(ns.format)],
+                )
+        if getattr(ns, "adaptive_cmd", None) == "brief":
+            forwarded = ["--format", str(ns.format), "--out", str(ns.out)]
+            for flag, value in (
+                ("--gate", str(ns.gate)),
+                ("--diagnosis", str(ns.diagnosis)),
+                ("--learning-summary", str(ns.learning_summary)),
+                ("--safe-fix-plan", str(ns.safe_fix_plan)),
+            ):
+                if value:
+                    forwarded.extend([flag, value])
+            return _run_module_main("sdetkit.operator_brief", forwarded)
         return _run_module_main("sdetkit.adaptive", [])
 
     if ns.cmd == "index":

--- a/src/sdetkit/data/adaptive_scenarios.json
+++ b/src/sdetkit/data/adaptive_scenarios.json
@@ -1,0 +1,686 @@
+{
+  "pack_id": "sdetkit.built_in.adaptive_scenarios",
+  "scenarios": [
+    {
+      "checks": [
+        "Open the first failing pytest node and read the assertion delta before editing product code.",
+        "Check whether fixtures, clocks, network fakes, or snapshots changed the expected contract."
+      ],
+      "code": "PYTEST_BEHAVIOR_REGRESSION",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <first-failing-test> -vv"
+      ],
+      "keywords": [
+        "assertionerror",
+        "failed tests/",
+        "== failures =="
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "pytest-node-failed",
+        "pytest-failed-count",
+        "assertion-error"
+      ],
+      "title": "Pytest behavior regression"
+    },
+    {
+      "checks": [
+        "Inspect the first import exception and confirm the missing package or public API is declared.",
+        "Check pyproject/requirements extras before changing runtime behavior."
+      ],
+      "code": "PYTEST_COLLECTION_IMPORT_FAILURE",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <failing-test-file> --collect-only"
+      ],
+      "keywords": [
+        "modulenotfounderror",
+        "importerror while importing",
+        "collected 0 items / 1 error"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "python-exception",
+        "pytest-error-count",
+        "traceback"
+      ],
+      "title": "Pytest collection/import failure"
+    },
+    {
+      "checks": [
+        "Run Ruff format on only touched Python files and verify the diff is format-only.",
+        "Re-run Ruff format check after formatting."
+      ],
+      "code": "RUFF_FORMAT_DRIFT",
+      "commands": [
+        "PYTHONPATH=src python -m ruff format --check <touched-python-files>"
+      ],
+      "keywords": [
+        "would reformat",
+        "files were modified by this hook",
+        "file reformatted"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "ruff-format-failure"
+      ],
+      "title": "Ruff format drift"
+    },
+    {
+      "checks": [
+        "Read the first Ruff rule code and separate safe mechanical F401/I001 from logic-risk rules.",
+        "Only allow scoped auto-fix for the narrow safe allowlist."
+      ],
+      "code": "RUFF_LINT_CONTRACT",
+      "commands": [
+        "PYTHONPATH=src python -m ruff check <touched-python-files>"
+      ],
+      "keywords": [
+        "ruff check",
+        "[*]",
+        "fixable with the --fix option"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "ruff-check-failure"
+      ],
+      "title": "Ruff lint contract failure"
+    },
+    {
+      "checks": [
+        "Open the first mypy error and identify whether the public contract or test double type drifted.",
+        "Avoid blanket ignores until the narrow type boundary is understood."
+      ],
+      "code": "MYPY_CONTRACT_DRIFT",
+      "commands": [
+        "PYTHONPATH=src python -m mypy src tests"
+      ],
+      "keywords": [
+        "mypy",
+        "error:",
+        "Found "
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "mypy-error"
+      ],
+      "title": "Mypy type contract drift"
+    },
+    {
+      "checks": [
+        "Compare missing coverage lines to the PR diff and add focused tests for changed behavior.",
+        "Do not lower the threshold unless the release owner explicitly approves policy change."
+      ],
+      "code": "COVERAGE_GATE_REGRESSION",
+      "commands": [
+        "bash quality.sh cov"
+      ],
+      "keywords": [
+        "fail under",
+        "total coverage",
+        "coverage"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "coverage-failure"
+      ],
+      "title": "Coverage threshold regression"
+    },
+    {
+      "checks": [
+        "Scroll above the exit-code footer and identify the first actionable tool failure.",
+        "Classify the failure before considering automation."
+      ],
+      "code": "CI_STEP_EXIT_NONZERO",
+      "commands": [
+        "python -m pre_commit run -a"
+      ],
+      "keywords": [
+        "exit code",
+        "command failed"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "ci-exit-code",
+        "command-failed"
+      ],
+      "title": "CI step exited non-zero"
+    },
+    {
+      "checks": [
+        "Read the structured failed step list and map it to the first failing artifact.",
+        "Check whether the policy failure is release-blocking or evidence-thin."
+      ],
+      "code": "QUALITY_GATE_POLICY_FAILURE",
+      "commands": [
+        "PYTHONPATH=src python -m sdetkit mission-control --execute --doctor-cortex"
+      ],
+      "keywords": [
+        "gate: problems found",
+        "failed_steps",
+        "no_ship"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "gate-problems-found",
+        "failed-steps"
+      ],
+      "title": "Quality gate policy failure"
+    },
+    {
+      "checks": [
+        "Inspect the package-manager error block before retrying; dependency resolution may be the root cause.",
+        "Check lockfiles and declared test requirements for drift."
+      ],
+      "code": "PACKAGE_INSTALL_FAILURE",
+      "commands": [
+        "python -m pip install -r requirements-test.txt -e ."
+      ],
+      "keywords": [
+        "npm err!",
+        "pnpm err!",
+        "yarn",
+        "pip install",
+        "resolutionimpossible"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "package-manager-error"
+      ],
+      "title": "Package install or script failure"
+    },
+    {
+      "checks": [
+        "Identify the exact hook that failed and whether it changed files or reported a contract issue.",
+        "If files changed, review the diff before committing generated changes."
+      ],
+      "code": "PRE_COMMIT_HOOK_FAILURE",
+      "commands": [
+        "python -m pre_commit run -a"
+      ],
+      "keywords": [
+        "pre-commit",
+        "hook",
+        "files were modified by this hook"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "explicit-failed"
+      ],
+      "title": "Pre-commit hook failure"
+    },
+    {
+      "checks": [
+        "Start at the last frame in the first traceback and identify the smallest product or test boundary.",
+        "Check whether the exception happens during setup, import, or exercised behavior."
+      ],
+      "code": "RUNTIME_EXCEPTION",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <focused-test> -vv"
+      ],
+      "keywords": [
+        "traceback",
+        "exception:",
+        "error:"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "traceback",
+        "python-exception",
+        "error-prefix"
+      ],
+      "title": "Runtime exception or traceback"
+    },
+    {
+      "checks": [
+        "Separate local filesystem/package friction from product failures before changing code.",
+        "Re-run from a native Linux filesystem or clean virtual environment if needed."
+      ],
+      "code": "LOCAL_ENVIRONMENT_FRICTION",
+      "commands": [
+        "python -m venv .venv"
+      ],
+      "keywords": [
+        "/mnt/c/",
+        "keyboardinterrupt",
+        "venv",
+        "site-packages"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "command-failed"
+      ],
+      "title": "Local environment friction"
+    },
+    {
+      "checks": [
+        "Fetch and compare remote branch state before pushing or rewriting commits.",
+        "Re-run proof after rebase because previous proof may be stale."
+      ],
+      "code": "GIT_REMOTE_DRIFT",
+      "commands": [
+        "git fetch --all --prune",
+        "git status --short --branch"
+      ],
+      "keywords": [
+        "non-fast-forward",
+        "fetch first",
+        "remote contains work",
+        "rebase"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "error-prefix",
+        "command-failed"
+      ],
+      "title": "Git branch or remote drift"
+    },
+    {
+      "checks": [
+        "Check the async test marker, fixture scope, and client lifecycle before changing production async code.",
+        "Reproduce one async test with verbose traceback and no parallelism."
+      ],
+      "code": "ASYNC_EVENT_LOOP_MISMATCH",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <async-test> -vv"
+      ],
+      "keywords": [
+        "event loop is closed",
+        "pytest-asyncio",
+        "anyio",
+        "asyncio.run",
+        "attached to a different loop"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "python-exception",
+        "pytest-error-count"
+      ],
+      "title": "Async event loop or fixture mismatch"
+    },
+    {
+      "checks": [
+        "Inspect the expected/received diff and confirm whether the contract intentionally changed.",
+        "Update golden files only after a focused behavior test proves the new output."
+      ],
+      "code": "SNAPSHOT_GOLDEN_DRIFT",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <snapshot-test> -vv"
+      ],
+      "keywords": [
+        "snapshot",
+        "golden",
+        "approval",
+        "received",
+        "expected"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "pytest-node-failed",
+        "assertion-error"
+      ],
+      "title": "Snapshot or golden-file drift"
+    },
+    {
+      "checks": [
+        "Copy the minimized counterexample into a focused regression test before broad refactors.",
+        "Check whether shrinking revealed an input contract gap or product bug."
+      ],
+      "code": "PROPERTY_FUZZ_COUNTEREXAMPLE",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <property-test> --hypothesis-show-statistics"
+      ],
+      "keywords": [
+        "hypothesis",
+        "falsifying example",
+        "counterexample",
+        "seed="
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "assertion-error",
+        "pytest-node-failed"
+      ],
+      "title": "Property-test counterexample"
+    },
+    {
+      "checks": [
+        "Re-run the failing test alone and then with the previous neighbor to expose hidden shared state.",
+        "Check global caches, monkeypatch cleanup, time/freezer state, and temporary directories."
+      ],
+      "code": "FLAKY_ORDER_DEPENDENCE",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <failing-test> --count=3"
+      ],
+      "keywords": [
+        "xdist",
+        "randomly",
+        "rerun",
+        "flaky",
+        "order dependent"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "pytest-failed-count",
+        "command-failed"
+      ],
+      "title": "Order-dependent or parallel test flake"
+    },
+    {
+      "checks": [
+        "Separate product failures from remote-service instability using mocks or recorded fixtures.",
+        "Check retry/backoff behavior and whether the test is marked network opt-in."
+      ],
+      "code": "NETWORK_SERVICE_FLAKE",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <network-test> -vv"
+      ],
+      "keywords": [
+        "timeout",
+        "connectionerror",
+        "429",
+        "rate limit",
+        "dns",
+        "tls"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "python-exception",
+        "command-failed"
+      ],
+      "title": "Network/API service flake"
+    },
+    {
+      "checks": [
+        "Confirm whether the workflow has the needed secret scope without printing secret values.",
+        "Check permission blocks and environment names before changing auth code."
+      ],
+      "code": "AUTH_SECRET_CONFIGURATION",
+      "commands": [
+        "git status --short"
+      ],
+      "keywords": [
+        "unauthorized",
+        "forbidden",
+        "401",
+        "403",
+        "missing secret",
+        "token"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "error-prefix",
+        "python-exception"
+      ],
+      "title": "Auth or secret configuration failure"
+    },
+    {
+      "checks": [
+        "Inspect service logs and health checks before retrying the full workflow.",
+        "Check port collisions, image pull failures, and startup readiness waits."
+      ],
+      "code": "DOCKER_SERVICE_BOOT_FAILURE",
+      "commands": [
+        "docker compose ps",
+        "docker compose logs --tail=200"
+      ],
+      "keywords": [
+        "docker",
+        "compose",
+        "container exited",
+        "healthcheck",
+        "port is already allocated"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "command-failed",
+        "ci-exit-code"
+      ],
+      "title": "Docker service boot failure"
+    },
+    {
+      "checks": [
+        "Compare migration head, generated schema, and test database setup before editing models.",
+        "Confirm whether the failure is stale fixtures or a real migration gap."
+      ],
+      "code": "DATABASE_MIGRATION_DRIFT",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <db-test> -vv"
+      ],
+      "keywords": [
+        "migration",
+        "alembic",
+        "schema",
+        "relation does not exist",
+        "duplicate column"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "python-exception",
+        "error-prefix"
+      ],
+      "title": "Database migration or schema drift"
+    },
+    {
+      "checks": [
+        "Check timezone assumptions, frozen clocks, and date boundaries before changing expected output.",
+        "Reproduce with UTC and the failing local timezone if available."
+      ],
+      "code": "TIMEZONE_CLOCK_DRIFT",
+      "commands": [
+        "TZ=UTC PYTHONPATH=src python -m pytest -q <time-test> -vv"
+      ],
+      "keywords": [
+        "timezone",
+        "utc",
+        "dst",
+        "freezegun",
+        "datetime",
+        "today"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "assertion-error",
+        "pytest-node-failed"
+      ],
+      "title": "Timezone or clock-dependent failure"
+    },
+    {
+      "checks": [
+        "Check path casing, separators, permissions, and temp-directory cleanup across platforms.",
+        "Avoid hard-coded absolute paths in tests and generated artifacts."
+      ],
+      "code": "PLATFORM_PATH_CASE_DRIFT",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q <path-test> -vv"
+      ],
+      "keywords": [
+        "filenotfounderror",
+        "permission denied",
+        "case-sensitive",
+        "path",
+        "windows"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "python-exception",
+        "assertion-error"
+      ],
+      "title": "Platform path/case sensitivity drift"
+    },
+    {
+      "checks": [
+        "Compare the failing run with a cache-cold run before changing product code.",
+        "Check cache keys include lockfiles, Python version, and relevant config files."
+      ],
+      "code": "CACHE_ARTIFACT_POISONING",
+      "commands": [
+        "git diff -- pyproject.toml requirements-test.txt"
+      ],
+      "keywords": [
+        "cache",
+        "artifact",
+        "stale",
+        "checksum",
+        "hash mismatch"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "command-failed",
+        "error-prefix"
+      ],
+      "title": "Cache or artifact poisoning"
+    },
+    {
+      "checks": [
+        "Open the first docs build error and check whether navigation, anchors, or generated files drifted.",
+        "Verify docs-only fixes do not mask product API drift."
+      ],
+      "code": "DOCS_BUILD_CONTRACT",
+      "commands": [
+        "PYTHONPATH=src python -m pytest -q tests/test_docs*.py"
+      ],
+      "keywords": [
+        "mkdocs",
+        "sphinx",
+        "markdown",
+        "linkcheck",
+        "broken link"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "command-failed",
+        "error-prefix"
+      ],
+      "title": "Docs build or link contract failure"
+    },
+    {
+      "checks": [
+        "Treat security audit output as review-first; identify whether it is dependency, code, or secret exposure.",
+        "Check advisories and minimum patched versions before bumping packages."
+      ],
+      "code": "SECURITY_AUDIT_BLOCKER",
+      "commands": [
+        "python -m pip_audit"
+      ],
+      "keywords": [
+        "vulnerability",
+        "ghsa",
+        "cve",
+        "pip-audit",
+        "bandit",
+        "secret detected"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "error-prefix",
+        "gate-problems-found"
+      ],
+      "title": "Security audit blocker"
+    },
+    {
+      "checks": [
+        "Inspect build backend metadata errors and confirm declared build requirements.",
+        "Check whether a package only ships sdists for the active Python/platform."
+      ],
+      "code": "BUILD_BACKEND_FAILURE",
+      "commands": [
+        "python -m pip install -r requirements-test.txt -e ."
+      ],
+      "keywords": [
+        "building wheel",
+        "pyproject",
+        "setuptools",
+        "build backend",
+        "metadata-generation-failed"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "package-manager-error",
+        "python-exception"
+      ],
+      "title": "Build backend or wheel failure"
+    },
+    {
+      "checks": [
+        "Compare package version, git tags, changelog, and release artifact names.",
+        "Do not overwrite published artifacts; create a new version if release state escaped."
+      ],
+      "code": "RELEASE_VERSION_CONFLICT",
+      "commands": [
+        "git tag --points-at HEAD",
+        "python -m build --sdist --wheel"
+      ],
+      "keywords": [
+        "version",
+        "tag already exists",
+        "duplicate release",
+        "changelog",
+        "twine"
+      ],
+      "odds": [],
+      "prior_weight": 1,
+      "risk_band": "medium",
+      "signals": [
+        "error-prefix",
+        "command-failed"
+      ],
+      "title": "Release/version metadata conflict"
+    }
+  ],
+  "schema_version": "sdetkit.adaptive.scenario_pack.v1",
+  "title": "Built-in SDETKit adaptive scenario pack"
+}

--- a/src/sdetkit/operator_brief.py
+++ b/src/sdetkit/operator_brief.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.operator_brief.v1"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_text(value: Any, limit: int = 240) -> str:
+    text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _load_optional_json(path: str) -> dict[str, Any]:
+    if not path:
+        return {}
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _prefixed_value(values: Any, prefix: str) -> str:
+    for value in _as_list(values):
+        text = str(value or "")
+        if text.startswith(prefix):
+            return text.removeprefix(prefix)
+    return ""
+
+
+def _gate_result(gate: dict[str, Any]) -> dict[str, Any]:
+    if not gate:
+        return {
+            "status": "unknown",
+            "decision": "UNKNOWN",
+            "ok": None,
+            "summary": "No gate artifact supplied.",
+        }
+    ok = gate.get("ok")
+    decision = str(gate.get("decision") or gate.get("status") or "UNKNOWN").upper()
+    failed_steps = _as_list(gate.get("failed_steps")) or _as_list(gate.get("failures"))
+    if ok is True or decision in {"SHIP", "PASS", "PASSED", "OK"}:
+        status = "ship"
+    elif ok is False or failed_steps or decision in {"NO_SHIP", "FAIL", "FAILED"}:
+        status = "no_ship"
+    else:
+        status = "unknown"
+    summary = f"Gate status is {status}."
+    if failed_steps:
+        summary += f" Failed steps: {', '.join(_safe_text(step, 80) for step in failed_steps[:5])}."
+    return {"status": status, "decision": decision, "ok": ok, "summary": summary}
+
+
+def _primary_diagnosis(diagnosis: dict[str, Any]) -> dict[str, Any]:
+    diagnoses = [_as_dict(item) for item in _as_list(diagnosis.get("diagnoses"))]
+    primary = diagnoses[0] if diagnoses else {}
+    evidence = _as_list(primary.get("evidence"))
+    proof_commands = _as_list(primary.get("proof_commands"))
+    return {
+        "status": str(diagnosis.get("status", "unknown")),
+        "summary": _safe_text(diagnosis.get("summary") or "No adaptive diagnosis supplied.", 500),
+        "code": str(primary.get("code", "NONE")),
+        "title": _safe_text(primary.get("title") or "No diagnosis", 240),
+        "severity": str(primary.get("severity", "unknown")),
+        "confidence": str(primary.get("confidence", "unknown")),
+        "candidate_scenarios": _prefixed_value(evidence, "candidate_scenarios="),
+        "candidate_calibration": _prefixed_value(evidence, "candidate_calibration="),
+        "first_proof_command": _safe_text(proof_commands[0] if proof_commands else "", 300),
+        "recommended_fix": [
+            _safe_text(item, 260) for item in _as_list(primary.get("recommended_fix"))[:4]
+        ],
+    }
+
+
+def _safe_fix_decision(diagnosis: dict[str, Any], safe_fix_plan: dict[str, Any]) -> dict[str, Any]:
+    plan = _as_dict(safe_fix_plan)
+    if plan:
+        safe = bool(plan.get("safe_to_auto_fix", False))
+        requires_review = bool(plan.get("requires_human_review", not safe))
+        return {
+            "safe_to_auto_fix": safe,
+            "requires_human_review": requires_review,
+            "source": "safe_fix_plan",
+            "reason": _safe_text(
+                plan.get("reason") or plan.get("title") or "safe-fix plan supplied", 300
+            ),
+        }
+    fix_plan = [_as_dict(item) for item in _as_list(diagnosis.get("fix_plan"))]
+    if fix_plan:
+        first = fix_plan[0]
+        safe = bool(first.get("safe_to_auto_fix", False))
+        return {
+            "safe_to_auto_fix": safe,
+            "requires_human_review": not safe,
+            "source": "adaptive_diagnosis.fix_plan",
+            "reason": _safe_text(
+                first.get("title") or first.get("code") or "adaptive fix plan", 300
+            ),
+        }
+    return {
+        "safe_to_auto_fix": False,
+        "requires_human_review": True,
+        "source": "none",
+        "reason": "No safe-fix plan supplied; keep review-first posture.",
+    }
+
+
+def _next_owner_action(
+    gate: dict[str, Any], diagnosis: dict[str, Any], safe_fix: dict[str, Any]
+) -> str:
+    gate_status = str(gate.get("status", "unknown"))
+    diagnosis_status = str(diagnosis.get("status", "unknown"))
+    if gate_status == "ship" and diagnosis_status in {"clear", "monitor", "unknown"}:
+        return "Owner action: proceed with normal release review; no adaptive remediation block is present."
+    if bool(safe_fix.get("safe_to_auto_fix")):
+        return "Owner action: review the scoped safe-fix plan, run the first proof command, and only then use guarded remediation."
+    first_proof = diagnosis.get("first_proof_command")
+    if first_proof:
+        return f"Owner action: run `{first_proof}` and review the candidate scenario before changing code."
+    return "Owner action: collect a focused failing log or gate artifact before remediation."
+
+
+def build_operator_brief(
+    *,
+    gate: dict[str, Any] | None = None,
+    diagnosis: dict[str, Any] | None = None,
+    learning_summary: dict[str, Any] | None = None,
+    safe_fix_plan: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    gate_result = _gate_result(_as_dict(gate))
+    primary = _primary_diagnosis(_as_dict(diagnosis))
+    learning = _as_dict(learning_summary)
+    calibration_summary = _as_dict(learning.get("calibration_summary"))
+    safe_fix = _safe_fix_decision(_as_dict(diagnosis), _as_dict(safe_fix_plan))
+    next_action = _next_owner_action(gate_result, primary, safe_fix)
+    ok = gate_result["status"] == "ship" and primary["status"] in {"clear", "monitor", "unknown"}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": ok,
+        "gate_result": gate_result,
+        "adaptive_diagnosis": primary,
+        "learning_calibration": {
+            "schema_version": str(learning.get("schema_version", "")),
+            "calibration_summary": calibration_summary,
+            "top_recurring_count": len(_as_list(learning.get("top_recurring_scenarios"))),
+            "weakest_lane_count": len(_as_list(learning.get("weakest_lanes"))),
+        },
+        "safe_fix_decision": safe_fix,
+        "next_owner_action": next_action,
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    gate = _as_dict(payload.get("gate_result"))
+    diagnosis = _as_dict(payload.get("adaptive_diagnosis"))
+    learning = _as_dict(payload.get("learning_calibration"))
+    safe_fix = _as_dict(payload.get("safe_fix_decision"))
+    lines = [
+        "# SDETKit Operator Brief",
+        "",
+        f"- Schema: `{payload.get('schema_version')}`",
+        f"- Overall OK: `{str(payload.get('ok')).lower()}`",
+        "",
+        "## Gate result",
+        "",
+        f"- Status: `{gate.get('status')}`",
+        f"- Decision: `{gate.get('decision')}`",
+        f"- Summary: {gate.get('summary')}",
+        "",
+        "## Adaptive diagnosis",
+        "",
+        f"- Status: `{diagnosis.get('status')}`",
+        f"- Primary: `{diagnosis.get('code')}` — {diagnosis.get('title')}",
+        f"- Severity / confidence: `{diagnosis.get('severity')}` / `{diagnosis.get('confidence')}`",
+        f"- Summary: {diagnosis.get('summary')}",
+    ]
+    if diagnosis.get("candidate_scenarios"):
+        lines.append(f"- Candidate scenarios: `{diagnosis.get('candidate_scenarios')}`")
+    if diagnosis.get("candidate_calibration"):
+        lines.append(f"- Candidate calibration: `{diagnosis.get('candidate_calibration')}`")
+    if diagnosis.get("first_proof_command"):
+        lines.append(f"- First proof command: `{diagnosis.get('first_proof_command')}`")
+    fixes = _as_list(diagnosis.get("recommended_fix"))
+    if fixes:
+        lines += ["", "Recommended checks:"] + [f"- {fix}" for fix in fixes]
+    lines += [
+        "",
+        "## Safe-fix decision",
+        "",
+        f"- Safe to auto-fix: `{str(safe_fix.get('safe_to_auto_fix')).lower()}`",
+        f"- Requires human review: `{str(safe_fix.get('requires_human_review')).lower()}`",
+        f"- Source: `{safe_fix.get('source')}`",
+        f"- Reason: {safe_fix.get('reason')}",
+        "",
+        "## Learning calibration",
+        "",
+        f"- Summary schema: `{learning.get('schema_version')}`",
+        f"- Calibration summary: `{json.dumps(_as_dict(learning.get('calibration_summary')), sort_keys=True)}`",
+        f"- Top recurring scenarios: `{learning.get('top_recurring_count')}`",
+        f"- Weakest lanes: `{learning.get('weakest_lane_count')}`",
+        "",
+        "## Next owner action",
+        "",
+        str(payload.get("next_owner_action", "")),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def render_pr_comment(payload: dict[str, Any]) -> str:
+    gate = _as_dict(payload.get("gate_result"))
+    diagnosis = _as_dict(payload.get("adaptive_diagnosis"))
+    safe_fix = _as_dict(payload.get("safe_fix_decision"))
+    gate_status = str(gate.get("status", "unknown"))
+    diagnosis_status = str(diagnosis.get("status", "unknown"))
+
+    if gate_status == "ship" and diagnosis_status in {"clear", "monitor", "unknown"}:
+        return "### SDETKit release signal\n\n✅ Gate is ship-ready; no adaptive remediation block is present.\n"
+
+    lines = [
+        "### SDETKit adaptive handoff",
+        "",
+        f"- Gate: `{gate_status}`",
+        f"- Adaptive status: `{diagnosis_status}`",
+        f"- Primary: `{diagnosis.get('code')}` — {diagnosis.get('title')}",
+    ]
+    if diagnosis.get("candidate_scenarios"):
+        lines.append(f"- Candidate scenarios: `{diagnosis.get('candidate_scenarios')}`")
+    if diagnosis.get("candidate_calibration"):
+        lines.append(f"- Calibration: `{diagnosis.get('candidate_calibration')}`")
+    if diagnosis.get("first_proof_command"):
+        lines.append(f"- First proof: `{diagnosis.get('first_proof_command')}`")
+
+    lines += ["", "**Safe-fix status**"]
+    if bool(safe_fix.get("safe_to_auto_fix")):
+        lines.append(
+            "- Scoped safe-fix path is available, but only after guardrails and proof artifacts pass."
+        )
+    else:
+        lines.append("- Review-first: this evidence is not approved for automatic remediation.")
+
+    lines += ["", "**Next owner action**", f"- {payload.get('next_owner_action', '')}"]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.operator_brief")
+    parser.add_argument("--gate", default="")
+    parser.add_argument("--diagnosis", default="")
+    parser.add_argument("--learning-summary", default="")
+    parser.add_argument("--safe-fix-plan", default="")
+    parser.add_argument("--format", choices=["md", "json", "comment"], default="md")
+    parser.add_argument("--out", default="build/sdetkit/operator-brief.md")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        payload = build_operator_brief(
+            gate=_load_optional_json(str(args.gate)),
+            diagnosis=_load_optional_json(str(args.diagnosis)),
+            learning_summary=_load_optional_json(str(args.learning_summary)),
+            safe_fix_plan=_load_optional_json(str(args.safe_fix_plan)),
+        )
+        if args.format == "json":
+            rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        elif args.format == "comment":
+            rendered = render_pr_comment(payload)
+        else:
+            rendered = render_markdown(payload) + "\n"
+        if args.out:
+            out_path = Path(args.out)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_adaptive_diagnosis.py
+++ b/tests/test_adaptive_diagnosis.py
@@ -416,3 +416,111 @@ def test_safe_auto_fix_codes_remain_narrow_for_local_investigation_classes():
     )
     assert safe_payload["diagnoses"][0]["code"] == "PRE_COMMIT_FORMAT_DRIFT"
     assert safe_payload["fix_plan"][0]["safe_to_auto_fix"] is True
+
+
+def _scenario_pack_payload(**overrides):
+    payload = {
+        "schema_version": "sdetkit.adaptive.scenario_pack.v1",
+        "pack_id": "test.pack",
+        "title": "Test pack",
+        "scenarios": [
+            {
+                "code": "TEST_SIGNAL",
+                "title": "Test signal",
+                "signals": ["error-prefix"],
+                "keywords": ["test signal"],
+                "checks": ["Check the test signal."],
+                "commands": ["python -m pytest -q tests/test_signal.py"],
+                "risk_band": "medium",
+                "prior_weight": 2,
+                "tags": ["test"],
+            }
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_builtin_scenario_pack_is_schema_validated_data_product():
+    scenarios = adaptive_diagnosis.SEEDED_SCENARIO_DB
+    codes = [scenario.code for scenario in scenarios]
+
+    assert len(scenarios) >= 25
+    assert codes == sorted(codes)
+    assert "PACKAGE_INSTALL_FAILURE" in codes
+    assert all(scenario.checks and scenario.commands for scenario in scenarios)
+
+
+def test_scenario_pack_loader_rejects_malformed_pack(tmp_path):
+    pack_path = tmp_path / "bad-scenarios.json"
+    payload = _scenario_pack_payload()
+    del payload["scenarios"][0]["commands"]
+    pack_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        adaptive_diagnosis.load_scenario_pack(pack_path)
+    except ValueError as exc:
+        assert "missing required fields: commands" in str(exc)
+    else:
+        raise AssertionError("expected malformed scenario pack to be rejected")
+
+
+def test_layered_scenario_packs_merge_deterministically(tmp_path):
+    local_dir = tmp_path / ".sdetkit" / "adaptive"
+    local_dir.mkdir(parents=True)
+    local_pack = local_dir / "scenarios.json"
+    local_pack.write_text(json.dumps(_scenario_pack_payload()), encoding="utf-8")
+
+    scenarios = adaptive_diagnosis.load_layered_scenarios(tmp_path)
+    codes = [scenario.code for scenario in scenarios]
+
+    assert codes == sorted(codes)
+    assert "TEST_SIGNAL" in codes
+    assert len(codes) == len(set(codes))
+
+
+def test_learning_calibration_reranks_unknown_candidate_scenarios():
+    adaptive_history = {
+        "schema_version": "sdetkit.adaptive.learn.summary.v1",
+        "top_recurring_scenarios": [
+            {
+                "code": "RELEASE_VERSION_CONFLICT",
+                "calibration": {
+                    "primary_action": "promote_and_increase_risk",
+                    "actions": ["promote", "increase_risk"],
+                    "confidence_delta": 2,
+                    "risk_delta": 12,
+                },
+            },
+            {
+                "code": "CACHE_ARTIFACT_POISONING",
+                "calibration": {
+                    "primary_action": "demote",
+                    "actions": ["demote"],
+                    "confidence_delta": -2,
+                    "risk_delta": -8,
+                },
+            },
+        ],
+    }
+
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="Error: command failed",
+        adaptive_history=adaptive_history,
+    )
+    diagnosis = payload["diagnoses"][0]
+
+    assert diagnosis["code"] == "UNKNOWN_REVIEW_REQUIRED"
+    assert any(
+        item.startswith("candidate_scenarios=RELEASE_VERSION_CONFLICT")
+        for item in diagnosis["evidence"]
+    )
+    assert any(
+        item.startswith("candidate_calibration=RELEASE_VERSION_CONFLICT:promote_and_increase_risk")
+        for item in diagnosis["evidence"]
+    )
+    assert diagnosis["recommended_fix"][0].startswith("Check candidate RELEASE_VERSION_CONFLICT")
+    assert diagnosis["proof_commands"][:2] == [
+        "git tag --points-at HEAD",
+        "python -m build --sdist --wheel",
+    ]

--- a/tests/test_adaptive_diagnosis_memory.py
+++ b/tests/test_adaptive_diagnosis_memory.py
@@ -20,7 +20,11 @@ def _diagnosis_payload(status="needs_fix"):
                 "title": "Formatter drift blocked pre-commit",
                 "diagnosis": "ruff-format changed files after tests passed.",
                 "why_developers_miss_it": "Developers often see green tests first.",
-                "evidence": ["ruff-format modified files"],
+                "evidence": [
+                    "matched_failure_signals=ruff-format-failure,explicit-failed",
+                    "candidate_scenarios=RUFF_FORMAT_DRIFT,PRE_COMMIT_HOOK_FAILURE",
+                    "ruff-format modified files",
+                ],
                 "recommended_fix": ["Run ruff format on touched files."],
                 "proof_commands": [
                     "PYTHONPATH=src python -m ruff format --check <touched-python-files>"
@@ -178,6 +182,17 @@ def test_build_learning_records_from_actionable_diagnosis():
     assert record["proof_command"].startswith("PYTHONPATH=src python -m ruff")
     assert record["repeat_count"] == 2
     assert record["affected_files"] == ["tests/test_case.py"]
+    assert record["matched_signals"] == ["ruff-format-failure", "explicit-failed"]
+    assert record["candidate_scenarios"] == ["RUFF_FORMAT_DRIFT", "PRE_COMMIT_HOOK_FAILURE"]
+    assert record["selected_primary_diagnosis"] is True
+    assert record["recommended_checks"] == ["Run ruff format on touched files."]
+    assert record["proof_commands"] == [
+        "PYTHONPATH=src python -m ruff format --check <touched-python-files>"
+    ]
+    assert record["proof_passed"] is None
+    assert record["fix_accepted"] is None
+    assert record["false_positive"] is False
+    assert record["lane"] == "quality"
     assert record["learned_at_utc"] == "2026-05-05T00:00:00Z"
     assert len(record["record_id"]) == 16
 
@@ -247,3 +262,129 @@ def test_cli_writes_summary_and_rejects_bad_schema(tmp_path, capsys):
 
     assert rc == 2
     assert "unsupported adaptive diagnosis schema" in capsys.readouterr().out
+
+
+def test_learning_summary_shows_recurring_scenarios_and_weakest_lanes(tmp_path):
+    db_path = tmp_path / "memory.jsonl"
+    records = adaptive_diagnosis_memory.build_learning_records(
+        _diagnosis_payload(), learned_at_utc="2026-05-05T00:00:00Z"
+    )
+    adaptive_diagnosis_memory.append_learning_records(db_path, records)
+
+    summary = adaptive_diagnosis_memory.learning_summary_from_db(db_path)
+
+    assert summary["schema_version"] == "sdetkit.adaptive.learn.summary.v1"
+    assert summary["diagnosis_records"] == 1
+    assert summary["top_recurring_scenarios"][0]["code"] == "PRE_COMMIT_FORMAT_DRIFT"
+    assert summary["top_recurring_scenarios"][0]["recurrence_count"] == 2
+    assert summary["weakest_lanes"][0]["lane"] == "quality"
+    assert summary["weakest_lanes"][0]["scenario_codes"] == ["PRE_COMMIT_FORMAT_DRIFT"]
+
+
+def test_summarize_cli_outputs_learning_summary(tmp_path, capsys):
+    diagnosis_path = tmp_path / "adaptive-diagnosis.json"
+    db_path = tmp_path / "memory.jsonl"
+    diagnosis_path.write_text(json.dumps(_diagnosis_payload()), encoding="utf-8")
+    assert adaptive_diagnosis_memory.main([str(diagnosis_path), "--db", str(db_path)]) == 0
+    capsys.readouterr()
+
+    rc = adaptive_diagnosis_memory.main(["summarize", "--db", str(db_path), "--format", "json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "sdetkit.adaptive.learn.summary.v1"
+    assert payload["weakest_lanes"][0]["lane"] == "quality"
+
+
+def test_learning_summary_calibrates_promotion_and_risk_from_outcomes():
+    payload = _diagnosis_payload()
+    payload["diagnoses"][0]["repeat_count"] = 3
+    records = adaptive_diagnosis_memory.build_learning_records(
+        payload,
+        learned_at_utc="2026-05-05T00:00:00Z",
+        proof_passed=True,
+        fix_accepted=True,
+    )
+
+    summary = adaptive_diagnosis_memory.summarize_learning_records(records)
+    scenario = summary["top_recurring_scenarios"][0]
+
+    assert scenario["proof_passed_count"] == 1
+    assert scenario["fix_accepted_count"] == 1
+    assert scenario["calibration"]["primary_action"] == "promote_and_increase_risk"
+    assert scenario["calibration"]["calibrated_confidence"] == "high"
+    assert scenario["calibration"]["risk_delta"] > 0
+    assert "promote" in scenario["calibration"]["actions"]
+    assert summary["calibration_summary"] == {
+        "promote": 1,
+        "demote": 0,
+        "increase_risk": 1,
+        "lower_confidence": 0,
+    }
+
+
+def test_learning_summary_demotes_false_positive_and_lowers_thin_evidence():
+    payload = _diagnosis_payload()
+    payload["diagnoses"][0]["evidence"] = ["custom tool failed without classifier context"]
+    records = adaptive_diagnosis_memory.build_learning_records(
+        payload,
+        learned_at_utc="2026-05-05T00:00:00Z",
+        proof_passed=False,
+        fix_accepted=False,
+        false_positive=True,
+    )
+
+    summary = adaptive_diagnosis_memory.summarize_learning_records(records)
+    scenario = summary["top_recurring_scenarios"][0]
+
+    assert scenario["false_positive_count"] == 1
+    assert scenario["proof_failed_count"] == 1
+    assert scenario["fix_rejected_count"] == 1
+    assert scenario["calibration"]["primary_action"] == "demote"
+    assert scenario["calibration"]["calibrated_confidence"] == "low"
+    assert "lower_confidence" in scenario["calibration"]["actions"]
+    assert summary["calibration_summary"]["demote"] == 1
+    assert summary["calibration_summary"]["lower_confidence"] == 1
+
+
+def test_cli_record_accepts_operator_outcome_flags(tmp_path, capsys):
+    diagnosis_path = tmp_path / "adaptive-diagnosis.json"
+    db_path = tmp_path / "memory.jsonl"
+    diagnosis_path.write_text(json.dumps(_diagnosis_payload()), encoding="utf-8")
+
+    rc = adaptive_diagnosis_memory.main(
+        [
+            str(diagnosis_path),
+            "--db",
+            str(db_path),
+            "--proof-passed",
+            "--fix-accepted",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["appended_records"] == 1
+    row = json.loads(db_path.read_text(encoding="utf-8").strip())
+    assert row["proof_passed"] is True
+    assert row["fix_accepted"] is True
+
+
+def test_cli_rejects_conflicting_outcome_flags(tmp_path, capsys):
+    diagnosis_path = tmp_path / "adaptive-diagnosis.json"
+    db_path = tmp_path / "memory.jsonl"
+    diagnosis_path.write_text(json.dumps(_diagnosis_payload()), encoding="utf-8")
+
+    rc = adaptive_diagnosis_memory.main(
+        [
+            str(diagnosis_path),
+            "--db",
+            str(db_path),
+            "--proof-passed",
+            "--proof-failed",
+        ]
+    )
+
+    assert rc == 2
+    assert "outcome flags are mutually exclusive" in capsys.readouterr().out

--- a/tests/test_adaptive_memory.py
+++ b/tests/test_adaptive_memory.py
@@ -83,8 +83,72 @@ def test_adaptive_cli_help_discoverability() -> None:
     assert "ingest" in proc.stdout
     assert "history" in proc.stdout
     assert "explain" in proc.stdout
+    assert "learn" in proc.stdout
+    assert "brief" in proc.stdout
 
     assert _run("adaptive", "init", "--help").returncode == 0
     assert _run("adaptive", "ingest", "--help").returncode == 0
     assert _run("adaptive", "history", "--help").returncode == 0
     assert _run("adaptive", "explain", "--help").returncode == 0
+    assert _run("adaptive", "learn", "--help").returncode == 0
+    assert _run("adaptive", "learn", "record", "--help").returncode == 0
+    assert _run("adaptive", "learn", "summarize", "--help").returncode == 0
+    assert _run("adaptive", "brief", "--help").returncode == 0
+
+
+def test_adaptive_learn_record_and_summarize_cli(tmp_path: Path) -> None:
+    diagnosis = {
+        "schema_version": "sdetkit.adaptive.diagnosis.v1",
+        "status": "needs_fix",
+        "confidence": "high",
+        "risk_score": 40,
+        "diagnoses": [
+            {
+                "code": "PRE_COMMIT_FORMAT_DRIFT",
+                "severity": "medium",
+                "confidence": "high",
+                "title": "Formatter drift blocked pre-commit",
+                "evidence": [
+                    "matched_failure_signals=ruff-format-failure",
+                    "candidate_scenarios=RUFF_FORMAT_DRIFT",
+                ],
+                "recommended_fix": ["Run ruff format on touched files."],
+                "proof_commands": [
+                    "PYTHONPATH=src python -m ruff format --check tests/test_case.py"
+                ],
+                "risk_if_ignored": "CI stays red.",
+                "learning_signal": "formatting-drift-after-green-tests",
+                "repeat_count": 3,
+                "affected_files": ["tests/test_case.py"],
+            }
+        ],
+    }
+    diagnosis_path = tmp_path / "adaptive-diagnosis.json"
+    db_path = tmp_path / "adaptive-learning.jsonl"
+    diagnosis_path.write_text(json.dumps(diagnosis), encoding="utf-8")
+
+    record = _run(
+        "adaptive",
+        "learn",
+        "record",
+        str(diagnosis_path),
+        "--db",
+        str(db_path),
+        "--format",
+        "json",
+        "--proof-passed",
+        "--fix-accepted",
+    )
+    assert record.returncode == 0, record.stderr + record.stdout
+    assert json.loads(record.stdout)["appended_records"] == 1
+
+    summary = _run("adaptive", "learn", "summarize", "--db", str(db_path), "--format", "json")
+    assert summary.returncode == 0, summary.stderr + summary.stdout
+    payload = json.loads(summary.stdout)
+    assert payload["schema_version"] == "sdetkit.adaptive.learn.summary.v1"
+    assert payload["top_recurring_scenarios"][0]["code"] == "PRE_COMMIT_FORMAT_DRIFT"
+    assert payload["top_recurring_scenarios"][0]["calibration"]["primary_action"] == (
+        "promote_and_increase_risk"
+    )
+    assert payload["calibration_summary"]["promote"] == 1
+    assert payload["weakest_lanes"][0]["lane"] == "quality"

--- a/tests/test_operator_brief.py
+++ b/tests/test_operator_brief.py
@@ -1,0 +1,222 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from sdetkit import operator_brief
+
+
+def _diagnosis_payload():
+    return {
+        "schema_version": "sdetkit.adaptive.diagnosis.v1",
+        "status": "needs_fix",
+        "summary": "Primary issue: Failure needs human review.",
+        "diagnoses": [
+            {
+                "code": "UNKNOWN_REVIEW_REQUIRED",
+                "severity": "high",
+                "confidence": "medium",
+                "title": "Failure needs human review",
+                "evidence": [
+                    "candidate_scenarios=RELEASE_VERSION_CONFLICT,DOCS_BUILD_CONTRACT",
+                    "candidate_calibration=RELEASE_VERSION_CONFLICT:promote_and_increase_risk:confidence_delta=2:risk_delta=12",
+                ],
+                "recommended_fix": [
+                    "Check candidate RELEASE_VERSION_CONFLICT: Compare package version."
+                ],
+                "proof_commands": ["git tag --points-at HEAD"],
+            }
+        ],
+        "fix_plan": [
+            {
+                "code": "UNKNOWN_REVIEW_REQUIRED",
+                "title": "Failure needs human review",
+                "safe_to_auto_fix": False,
+            }
+        ],
+    }
+
+
+def _learning_summary():
+    return {
+        "schema_version": "sdetkit.adaptive.learn.summary.v1",
+        "calibration_summary": {
+            "promote": 1,
+            "demote": 0,
+            "increase_risk": 1,
+            "lower_confidence": 0,
+        },
+        "top_recurring_scenarios": [{"code": "RELEASE_VERSION_CONFLICT"}],
+        "weakest_lanes": [{"lane": "release"}],
+    }
+
+
+def test_build_operator_brief_collects_decision_surfaces():
+    payload = operator_brief.build_operator_brief(
+        gate={"ok": False, "failed_steps": ["release-preflight"]},
+        diagnosis=_diagnosis_payload(),
+        learning_summary=_learning_summary(),
+    )
+
+    assert payload["schema_version"] == "sdetkit.operator_brief.v1"
+    assert payload["ok"] is False
+    assert payload["gate_result"]["status"] == "no_ship"
+    assert payload["adaptive_diagnosis"]["candidate_scenarios"].startswith(
+        "RELEASE_VERSION_CONFLICT"
+    )
+    assert payload["adaptive_diagnosis"]["first_proof_command"] == "git tag --points-at HEAD"
+    assert payload["safe_fix_decision"]["safe_to_auto_fix"] is False
+    assert "git tag --points-at HEAD" in payload["next_owner_action"]
+
+
+def test_render_markdown_includes_operator_handoff_sections():
+    payload = operator_brief.build_operator_brief(
+        gate={"ok": True, "decision": "SHIP"},
+        diagnosis=_diagnosis_payload(),
+        learning_summary=_learning_summary(),
+    )
+    rendered = operator_brief.render_markdown(payload)
+
+    assert "# SDETKit Operator Brief" in rendered
+    assert "## Gate result" in rendered
+    assert "## Adaptive diagnosis" in rendered
+    assert "Candidate calibration" in rendered
+    assert "## Safe-fix decision" in rendered
+    assert "## Next owner action" in rendered
+
+
+def test_render_pr_comment_green_run_has_no_fake_adaptive_block():
+    payload = operator_brief.build_operator_brief(
+        gate={"ok": True, "decision": "SHIP"},
+        diagnosis={"status": "clear", "diagnoses": [], "fix_plan": []},
+    )
+
+    rendered = operator_brief.render_pr_comment(payload)
+
+    assert "SDETKit release signal" in rendered
+    assert "adaptive handoff" not in rendered
+    assert "no adaptive remediation block" in rendered
+
+
+def test_render_pr_comment_safe_mechanical_path_is_scoped():
+    diagnosis = _diagnosis_payload()
+    diagnosis["diagnoses"][0]["code"] = "PRE_COMMIT_FORMAT_DRIFT"
+    diagnosis["diagnoses"][0]["title"] = "Formatter drift blocked pre-commit"
+    diagnosis["fix_plan"][0] = {
+        "code": "PRE_COMMIT_FORMAT_DRIFT",
+        "title": "Formatter drift blocked pre-commit",
+        "safe_to_auto_fix": True,
+    }
+    payload = operator_brief.build_operator_brief(
+        gate={"ok": False, "failed_steps": ["format"]}, diagnosis=diagnosis
+    )
+
+    rendered = operator_brief.render_pr_comment(payload)
+
+    assert "SDETKit adaptive handoff" in rendered
+    assert "Scoped safe-fix path is available" in rendered
+    assert "guardrails and proof artifacts" in rendered
+
+
+def test_render_pr_comment_unknown_failure_is_review_first():
+    payload = operator_brief.build_operator_brief(
+        gate={"ok": False, "failed_steps": ["gate-fast"]},
+        diagnosis=_diagnosis_payload(),
+        learning_summary=_learning_summary(),
+    )
+
+    rendered = operator_brief.render_pr_comment(payload)
+
+    assert "Review-first" in rendered
+    assert "Candidate scenarios" in rendered
+    assert "First proof" in rendered
+    assert "git tag --points-at HEAD" in rendered
+
+
+def test_operator_brief_cli_writes_markdown_and_json(tmp_path, capsys):
+    gate_path = tmp_path / "gate.json"
+    diagnosis_path = tmp_path / "diagnosis.json"
+    learning_path = tmp_path / "learning.json"
+    md_out = tmp_path / "operator-brief.md"
+    json_out = tmp_path / "operator-brief.json"
+    gate_path.write_text(json.dumps({"ok": False, "failed_steps": ["gate-fast"]}), encoding="utf-8")
+    diagnosis_path.write_text(json.dumps(_diagnosis_payload()), encoding="utf-8")
+    learning_path.write_text(json.dumps(_learning_summary()), encoding="utf-8")
+
+    rc = operator_brief.main(
+        [
+            "--gate",
+            str(gate_path),
+            "--diagnosis",
+            str(diagnosis_path),
+            "--learning-summary",
+            str(learning_path),
+            "--out",
+            str(md_out),
+        ]
+    )
+    assert rc == 0
+    assert "SDETKit Operator Brief" in md_out.read_text(encoding="utf-8")
+    assert capsys.readouterr().out == ""
+
+    rc = operator_brief.main(
+        [
+            "--gate",
+            str(gate_path),
+            "--diagnosis",
+            str(diagnosis_path),
+            "--format",
+            "json",
+            "--out",
+            str(json_out),
+        ]
+    )
+    assert rc == 0
+    assert json.loads(json_out.read_text(encoding="utf-8"))["schema_version"] == (
+        "sdetkit.operator_brief.v1"
+    )
+
+    comment_out = tmp_path / "operator-comment.md"
+    rc = operator_brief.main(
+        [
+            "--gate",
+            str(gate_path),
+            "--diagnosis",
+            str(diagnosis_path),
+            "--format",
+            "comment",
+            "--out",
+            str(comment_out),
+        ]
+    )
+    assert rc == 0
+    assert "SDETKit adaptive handoff" in comment_out.read_text(encoding="utf-8")
+
+
+def test_sdetkit_adaptive_brief_subprocess(tmp_path: Path):
+    gate_path = tmp_path / "gate.json"
+    diagnosis_path = tmp_path / "diagnosis.json"
+    out = tmp_path / "brief.md"
+    gate_path.write_text(json.dumps({"ok": False, "failed_steps": ["gate-fast"]}), encoding="utf-8")
+    diagnosis_path.write_text(json.dumps(_diagnosis_payload()), encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "adaptive",
+            "brief",
+            "--gate",
+            str(gate_path),
+            "--diagnosis",
+            str(diagnosis_path),
+            "--out",
+            str(out),
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "SDETKit Operator Brief" in out.read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation

- Convert the seeded adaptive scenario catalog to a versioned, schema-validated data pack so scenarios are reviewable, overlayable, and deterministic.
- Close the adaptive diagnosis learning loop so CI artifacts can be recorded as JSONL learning events and used to calibrate candidate ranking over time.
- Provide a concise operator handoff artifact (Markdown/PR comment/JSON) to make gate→diagnosis→learning→safe-fix decisions consumable by humans and bots.

### Description

- Add a JSON Schema `schemas/adaptive-scenario-pack.schema.json` and a built-in scenario pack at `src/sdetkit/data/adaptive_scenarios.json`, and update `pyproject.toml` package-data to include `data/*.json`.
- Replace the embedded Python scenario table with pack loading and deterministic layered merging in `src/sdetkit/adaptive_diagnosis.py`, add pack validation, overlay support via `SDETKIT_ADAPTIVE_SCENARIO_PACKS`, and calibration hooks so learning summaries can influence candidate ranking and evidence.
- Implement a learning loop in `src/sdetkit/adaptive_diagnosis_memory.py` that builds JSONL learning records from diagnosis artifacts, accepts operator outcome flags (`--proof-passed`, `--proof-failed`, `--fix-accepted`, `--fix-rejected`, `--false-positive`), summarizes records into `top_recurring_scenarios`/`weakest_lanes`, and exposes a `summarize` subcommand.
- Add `src/sdetkit/operator_brief.py` to produce an operator brief (Markdown/JSON/PR comment) from gate, diagnosis, learning summary, and safe-fix plan artifacts, and wire new `adaptive learn` and `adaptive brief` CLI entries in `src/sdetkit/cli.py`.
- Update docs (`docs/*`) to describe scenario packs, the learning loop, operator brief, and PR comment mode.
- Add and extend unit tests covering pack loading, layered overlays, calibration/reranking, learning record building/appending/summarization, CLI discoverability and subcommands, and operator brief rendering (`tests/test_adaptive_diagnosis.py`, `tests/test_adaptive_diagnosis_memory.py`, `tests/test_adaptive_memory.py`, `tests/test_operator_brief.py`).

### Testing

- Ran the full unit test suite with `pytest -q`; the added and updated tests exercised scenario pack validation, layered loading, learning record creation, summarize output, CLI subcommands (`adaptive learn record`, `adaptive learn summarize`, `adaptive brief`), and operator brief rendering, and all tests passed.
- Exercised the learning CLI and summarize path via the test harness which calls the module entrypoints (e.g. `sdetkit.adaptive_diagnosis_memory`), confirming JSONL append/deduplication and summary rollup behavior.
- Exercised the operator brief generation and PR comment rendering via unit tests that call `sdetkit.operator_brief` and the `sdetkit` CLI entrypoint, confirming Markdown/JSON/comment outputs and file writes succeeded.
- Verified deterministic ordering and duplicate-code detection in scenario packs via unit tests that create temporary pack overlays and assert merged output stability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb293be1c8332be8cde2d8ac975a3)