### PR TITLE
Guard docs map against excluded README links

### DIFF
--- a/docs/docs-map.md
+++ b/docs/docs-map.md
@@ -24,7 +24,7 @@ Use this map when the `docs/` tree feels large. It separates the primary operato
 | Quality gates | [Premium quality gate](premium-quality-gate.md), [Security gate](security-gate.md), [Determinism checklist](determinism-checklist.md), [Determinism contract](determinism-contract.md) | Gate docs explain proof and policy, not broad default auto-fix. |
 | Artifact reference | [Artifact reference](artifact-reference.md), [CI artifact walkthrough](ci-artifact-walkthrough.md), [Evidence showcase](evidence-showcase.md) | Runtime artifacts live under `build/` and `.sdetkit/`; committed examples live under `docs/artifacts/`. |
 | Contributor / developer docs | [Repo tour](repo-tour.md), [Contributing](contributing.md), [Release process](project/release-process.md), [Test bootstrap](test-bootstrap.md), [Project structure](project-structure.md) | Keep implementation and contribution material secondary to the operator path. |
-| Generated/sample artifacts | [docs/artifacts/README.md](artifacts/README.md), [Live-adoption product proof](live-adoption-product-proof.md) | Historical packs are preserved for traceability and are not the current runbook. |
+| Generated/sample artifacts | [Artifact reference](artifact-reference.md), [Live-adoption product proof](live-adoption-product-proof.md) | Historical packs are preserved for traceability and are not the current runbook. |
 | Historical archive | [Archive overview](archive/index.md), [Transition-era material map](archive/transition-era-material.md) | Non-primary; use only after the canonical path is working. |
 
 ## Directory guide

--- a/tests/test_docs_qa.py
+++ b/tests/test_docs_qa.py
@@ -458,7 +458,11 @@ def test_docs_map_declares_tidy_information_architecture() -> None:
     ):
         assert area in docs_map
 
-    assert "[docs/artifacts/README.md](artifacts/README.md)" in docs_map
+    assert "[docs/artifacts/README.md](artifacts/README.md)" not in docs_map
+    assert (
+        "| Generated/sample artifacts | [Artifact reference](artifact-reference.md), "
+        "[Live-adoption product proof](live-adoption-product-proof.md) |"
+    ) in docs_map
     assert "Do not move historical/generated artifact packs" in docs_map
     assert "diagnostic/report-only by default" in docs_map
     assert "Docs map and organization" in docs_home

--- a/tests/test_mkdocs_strict_docs_map_links.py
+++ b/tests/test_mkdocs_strict_docs_map_links.py
@@ -15,5 +15,5 @@ def test_mkdocs_excludes_docs_readme_conflict() -> None:
 def test_docs_map_does_not_link_to_excluded_readme() -> None:
     docs_map = (ROOT / "docs" / "docs-map.md").read_text(encoding="utf-8")
 
-    assert "(README.md)" not in docs_map
+    assert "README.md)" not in docs_map
     assert "(index.md)" in docs_map


### PR DESCRIPTION
## Summary
- Replace the docs-map link to the excluded `docs/artifacts/README.md` target with the built-site Artifact reference page.
- Tighten the docs-map guardrail so future README links are rejected, including nested README targets.

## Why
- MkDocs strict was green, but it reported an excluded-link quality signal from `docs/docs-map.md`.
- This keeps the docs map aligned with built-site navigation without broad docs cleanup.

## Verification
- `python -m pytest -q tests/test_mkdocs_strict_docs_map_links.py tests/test_mkdocs_exclude_docs_scope.py -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`

## Risk
- Low
- Rollback: easy

## Notes
- Remaining MkDocs INFO lines are pre-existing docs quality opportunities and are intentionally out of scope.
