### PR TITLE
Align production readiness docs links

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ Track release-level updates, notable features, and operational changes in the pr
 - Repository changelog: [CHANGELOG.md](https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/CHANGELOG.md)
 - Release guide: [Releasing](releasing.md)
 - Public release install verification records: [Release verification](release-verification.md)
-- Quality and release controls: [Production readiness](production-readiness.md)
+- Quality and release controls: [Release readiness](release-readiness.md)
 
 !!! tip "Recommended release flow"
     Review `CHANGELOG.md` before each release cut, then execute the release gate documented in the release and production-readiness guides.

--- a/docs/global-production-transformation-playbook.md
+++ b/docs/global-production-transformation-playbook.md
@@ -2,5 +2,5 @@
 
 This page is the global index for production transformation workflows.
 
-- Readiness: [Production readiness](production-readiness.md)
+- Readiness: [Release readiness](release-readiness.md)
 - Program framing: [World class quality program](world-class-quality-program.md)


### PR DESCRIPTION
## Summary
- Replace two built-site links to the excluded `production-readiness.md` page with `release-readiness.md`.

## Why
- MkDocs strict was green, but it reported excluded-link quality signals from built docs.
- This keeps release/readiness docs links aligned with the built site while preserving historical artifact references.

## Verification
- `python -m pytest -q tests/test_docs_qa.py::test_docs_map_declares_tidy_information_architecture tests/test_mkdocs_strict_docs_map_links.py tests/test_mkdocs_exclude_docs_scope.py -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`

## Risk
- Low
- Rollback: easy

## Notes
- Remaining MkDocs INFO lines are pre-existing docs quality opportunities and are intentionally out of scope.
