### PR TITLE
Clean up excluded-link docs references

### DIFF
--- a/docs/cto-execution-workflow.md
+++ b/docs/cto-execution-workflow.md
@@ -21,7 +21,7 @@ Lock the active scope and evidence sources before making additional delivery cha
 
 ### Inputs to lock
 
-- blueprint: [`docs/cto-full-package-review.md`](cto-full-package-review.md)
+- blueprint: `docs/cto-full-package-review.md`.
 - control plane: [`docs/top-tier-program-dashboard.md`](top-tier-program-dashboard.md)
 - execution JSON: [`plans/top-tier-repo-execution-plan-2026-q2.json`](https://github.com/sherif69-sa/DevS69-sdetkit/blob/main/plans/top-tier-repo-execution-plan-2026-q2.json)
 
@@ -74,8 +74,8 @@ Lock the active scope and evidence sources before making additional delivery cha
 - Evidence:
   - [Pilot to rollout guide](pilot-to-rollout-guide.md)
   - [Role-based quickstarts](role-based-quickstarts.md)
-  - [Executive weekly template](executive-weekly-template.md)
-  - [Executive monthly template](executive-monthly-template.md)
+  - `docs/executive-weekly-template.md` — Executive weekly template
+  - `docs/executive-monthly-template.md` — Executive monthly template
 
 ---
 
@@ -83,4 +83,4 @@ Lock the active scope and evidence sources before making additional delivery cha
 
 After all six points are complete, continue with:
 
-- [CTO Phase 2 launch plan](cto-phase2-launch-plan.md)
+- `docs/cto-phase2-launch-plan.md`.

--- a/docs/kpi-schema.md
+++ b/docs/kpi-schema.md
@@ -5,9 +5,9 @@ This page defines the weekly KPI contract for CTO/dashboard reporting and links 
 ## Contract artifacts
 
 - JSON schema: [`docs/kpi-schema.v1.json`](kpi-schema.v1.json)
-- First seed baseline instance: [`docs/kpi-baseline-week-2026-04-17.md`](kpi-baseline-week-2026-04-17.md)
-- Generated KPI sample: [`docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json`](artifacts/kpi-weekly-from-portfolio-2026-04-17.json)
-- KPI contract check report: [`docs/artifacts/kpi-weekly-contract-check-2026-04-17.json`](artifacts/kpi-weekly-contract-check-2026-04-17.json)
+- First seed baseline instance: `docs/kpi-baseline-week-2026-04-17.md`.
+- Generated KPI sample: `docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json`.
+- KPI contract check report: `docs/artifacts/kpi-weekly-contract-check-2026-04-17.json`.
 
 ## KPI keys (required)
 

--- a/docs/platform-problem-authoring.md
+++ b/docs/platform-problem-authoring.md
@@ -2,5 +2,5 @@
 
 This page has moved into the platform problem template and automation docs.
 
-- Start here: [Automation templates engine](automation-templates-engine.md)
+- Start here: [Automation bots and maintenance control loop](automation-bots.md)
 - Related: [Policy and baselines](policy-and-baselines.md)

--- a/docs/portfolio-reporting-recipe.md
+++ b/docs/portfolio-reporting-recipe.md
@@ -105,8 +105,8 @@ Risk tier thresholds:
 
 ## Worked sample artifacts
 
-- Input sample: [`docs/artifacts/portfolio-input-sample-2026-04-17.jsonl`](artifacts/portfolio-input-sample-2026-04-17.jsonl)
-- Output sample: [`docs/artifacts/portfolio-scorecard-sample-2026-04-17.json`](artifacts/portfolio-scorecard-sample-2026-04-17.json)
+- Input sample: `docs/artifacts/portfolio-input-sample-2026-04-17.jsonl`.
+- Output sample: `docs/artifacts/portfolio-scorecard-sample-2026-04-17.json`.
 
 Use these files as a template for weekly portfolio board generation and review.
 
@@ -134,9 +134,9 @@ python scripts/build_top_tier_reporting_bundle.py \
 
 CI automation option: `.github/workflows/top-tier-reporting-sample.yml`.
 
-Bundle manifest example: [`docs/artifacts/top-tier-bundle-manifest-2026-04-17.json`](artifacts/top-tier-bundle-manifest-2026-04-17.json).
+Bundle manifest example: `docs/artifacts/top-tier-bundle-manifest-2026-04-17.json`.
 
-Bundle manifest check example: [`docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json`](artifacts/top-tier-bundle-manifest-check-2026-04-17.json).
+Bundle manifest check example: `docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json`.
 
 
 ## Cross-artifact consistency check

--- a/docs/top-tier-program-dashboard.md
+++ b/docs/top-tier-program-dashboard.md
@@ -3,9 +3,9 @@
 This dashboard is the weekly control plane for the **DevS69 SDETKit top-tier full-package transformation**.
 
 - Program plan source: `plans/top-tier-repo-execution-plan-2026-q2.json`
-- Leadership blueprint: [CTO full-package review](cto-full-package-review.md)
-- Execution workflow: [CTO execution workflow (6-point)](cto-execution-workflow.md)
-- Post-completion plan: [CTO Phase 2 launch plan](cto-phase2-launch-plan.md)
+- Leadership blueprint: `docs/cto-full-package-review.md`.
+- Execution workflow: `docs/cto-execution-workflow.md`.
+- Post-completion plan: `docs/cto-phase2-launch-plan.md`.
 - Reporting cadence: Monday planning, Wednesday risk review, Friday closeout
 
 ## Weekly status snapshot
@@ -60,17 +60,17 @@ Track weekly:
 
 ### Completed
 - [Portfolio aggregation schema](portfolio-aggregation-schema.md)
-- [Portfolio scorecard sample (2026-04-17)](artifacts/portfolio-scorecard-sample-2026-04-17.json)
+- `docs/artifacts/portfolio-scorecard-sample-2026-04-17.json` — portfolio scorecard sample.
 - [Role-based quickstarts](role-based-quickstarts.md)
 - [KPI schema (v1)](kpi-schema.md)
-- [KPI baseline snapshot (2026-04-17)](kpi-baseline-week-2026-04-17.md)
-- [Generated KPI weekly sample (from portfolio)](artifacts/kpi-weekly-from-portfolio-2026-04-17.json)
-- [KPI weekly contract check (2026-04-17)](artifacts/kpi-weekly-contract-check-2026-04-17.json)
-- [Top-tier reporting contract check (2026-04-17)](artifacts/top-tier-contract-check-2026-04-17.json)
-- [Top-tier bundle manifest (2026-04-17)](artifacts/top-tier-bundle-manifest-2026-04-17.json)
-- [Top-tier bundle manifest check (2026-04-17)](artifacts/top-tier-bundle-manifest-check-2026-04-17.json)
-- [Executive weekly report (2026-04-17)](executive-weekly-2026-04-17.md)
-- [Executive monthly report (2026-04)](executive-monthly-2026-04.md)
+- `docs/kpi-baseline-week-2026-04-17.md` — KPI baseline snapshot.
+- `docs/artifacts/kpi-weekly-from-portfolio-2026-04-17.json` — generated KPI weekly sample.
+- `docs/artifacts/kpi-weekly-contract-check-2026-04-17.json` — KPI weekly contract check.
+- `docs/artifacts/top-tier-contract-check-2026-04-17.json` — top-tier contract check.
+- `docs/artifacts/top-tier-bundle-manifest-2026-04-17.json` — top-tier bundle manifest.
+- `docs/artifacts/top-tier-bundle-manifest-check-2026-04-17.json` — top-tier bundle manifest check.
+- `docs/executive-weekly-2026-04-17.md` — executive weekly report.
+- `docs/executive-monthly-2026-04.md` — executive monthly report.
 - [Full release package checklist](full-release-package-checklist.md)
 
 ### KPI movement

--- a/tests/test_mkdocs_strict_docs_map_links.py
+++ b/tests/test_mkdocs_strict_docs_map_links.py
@@ -17,3 +17,29 @@ def test_docs_map_does_not_link_to_excluded_readme() -> None:
 
     assert "README.md)" not in docs_map
     assert "(index.md)" in docs_map
+
+
+def test_built_docs_do_not_link_to_intentionally_excluded_targets() -> None:
+    warning_prone_docs = [
+        ROOT / "docs" / "platform-problem-authoring.md",
+        ROOT / "docs" / "kpi-schema.md",
+        ROOT / "docs" / "portfolio-reporting-recipe.md",
+        ROOT / "docs" / "top-tier-program-dashboard.md",
+        ROOT / "docs" / "cto-execution-workflow.md",
+    ]
+    excluded_link_fragments = [
+        "](artifacts/",
+        "](automation-templates-engine.md)",
+        "](kpi-baseline-week-",
+        "](cto-",
+        "](executive-",
+    ]
+
+    offenders: list[str] = []
+    for doc_path in warning_prone_docs:
+        doc_text = doc_path.read_text(encoding="utf-8")
+        for fragment in excluded_link_fragments:
+            if fragment in doc_text:
+                offenders.append(f"{doc_path.relative_to(ROOT)} contains {fragment}")
+
+    assert offenders == []


### PR DESCRIPTION
## Summary
- Convert built-doc links to intentionally excluded artifact/report/template targets into plain repository-path references.
- Update the platform authoring page to link to a built-site automation page.
- Add a regression guardrail for warning-prone built docs so they do not reintroduce excluded-target Markdown links.

## Why
- MkDocs strict was green, but excluded-link INFO messages made docs quality noisier.
- The excluded files are historical reports, generated artifacts, or intentionally non-primary pages, so built docs should reference them as repository paths instead of site links.

## Verification
- `python -m pytest -q tests/test_mkdocs_strict_docs_map_links.py tests/test_mkdocs_exclude_docs_scope.py tests/test_docs_qa.py::test_docs_map_declares_tidy_information_architecture -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`

## Risk
- Low
- Rollback: easy

## Notes
- This intentionally leaves the broad “pages exist but are not in nav” inventory out of scope.
