### PR TITLE
Add adaptive next-wave: dashboard, analytics, governance, remediation policy, patch/repair lanes, adapters, learning import, portfolio rollup, and repo adoption scan

### DIFF
--- a/config/adaptive_remediation_policy.default.json
+++ b/config/adaptive_remediation_policy.default.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "sdetkit.adaptive.remediation_policy.v1",
+  "name": "default-adaptive-remediation-policy",
+  "allowed_safe_fix_types": ["format_only", "ruff_fixable_lint"],
+  "max_changed_files": 8,
+  "required_proof_outcomes": ["proof_passed"],
+  "allow_review_required_auto_fix": false,
+  "blocked_auto_source_codes": ["UNKNOWN", "UNKNOWN_REVIEW_REQUIRED"]
+}

--- a/docs/adaptive-dashboard.md
+++ b/docs/adaptive-dashboard.md
@@ -1,0 +1,50 @@
+# Adaptive next-wave dashboard
+
+The adaptive next-wave dashboard is a deterministic, local-only HTML artifact that links the adaptive evidence set for release-room review. It does not host data, phone home, or execute remediation; it only summarizes and links artifacts already produced by other adaptive commands.
+
+## Command
+
+```bash
+python -m sdetkit adaptive dashboard \
+  --diagnosis build/sdetkit/adaptive-diagnosis.json \
+  --brief build/sdetkit/operator-brief.md \
+  --portfolio build/sdetkit/adaptive-portfolio.json \
+  --fix-audit build/sdetkit/fix-audit-summary.json \
+  --governance build/sdetkit/enterprise-governance.json \
+  --adapter build/sdetkit/integration-adapter.json \
+  --analytics build/sdetkit/adaptive-enterprise-analytics.json \
+  --remediation-policy build/sdetkit/remediation-policy-result.json \
+  --out build/sdetkit/adaptive-dashboard.html
+```
+
+Use JSON output for automation checks:
+
+```bash
+python -m sdetkit adaptive dashboard \
+  --analytics build/sdetkit/adaptive-enterprise-analytics.json \
+  --format json \
+  --out build/sdetkit/adaptive-dashboard.json
+```
+
+## Linked artifact cards
+
+| Card | Typical source |
+| --- | --- |
+| Adaptive diagnosis | `sdetkit adaptive diagnosis` output or saved diagnosis JSON |
+| Operator brief | `sdetkit adaptive brief` Markdown/JSON/comment output |
+| Portfolio rollup | `sdetkit adaptive portfolio-rollup --format json` |
+| Fix audit | `sdetkit adaptive fix-audit summarize --format json` or JSONL audit records |
+| Enterprise governance | `sdetkit adaptive enterprise-governance report --format json` |
+| Integration adapter | `sdetkit adaptive integration-adapter validate --format json` |
+| Enterprise analytics | `sdetkit adaptive enterprise-analytics --format json` |
+| Remediation policy | `sdetkit adaptive remediation-policy validate --format json` |
+
+Missing optional artifacts are rendered as warning cards so the dashboard remains usable during partial rollout.
+
+## Guardrails
+
+- Local-only static HTML output.
+- Deterministic card ordering.
+- No external assets, scripts, tracking, or hosted dependencies.
+- Links point to local artifacts supplied on the command line.
+- Unknown or review-required diagnoses remain governed by the remediation policy and patch-plan lanes; the dashboard only displays their evidence.

--- a/docs/adaptive-demo-gallery.md
+++ b/docs/adaptive-demo-gallery.md
@@ -1,0 +1,146 @@
+# Adaptive demo gallery
+
+Use this gallery when you want a quick, reviewer-friendly picture of what the Big-Brain adaptive lane should show in pull requests and release reviews.
+
+The examples are intentionally compact. They demonstrate the expected operator behavior for the top scenario families: stay quiet on green evidence, give precise proof commands for known failures, and keep unknown or risky failures review-first.
+
+## How to generate matching artifacts
+
+```bash
+python -m sdetkit.adaptive_diagnosis --log build/ci.log --format json --out build/sdetkit/adaptive-diagnosis.json
+python -m sdetkit adaptive learn record build/sdetkit/adaptive-diagnosis.json --proof-passed --fix-accepted --format json
+python -m sdetkit adaptive learn summarize --format json > build/sdetkit/adaptive-learning-summary.json
+python -m sdetkit adaptive brief \
+  --diagnosis build/sdetkit/adaptive-diagnosis.json \
+  --learning-summary build/sdetkit/adaptive-learning-summary.json \
+  --format comment \
+  --out build/sdetkit/adaptive-pr-comment.md
+python -m sdetkit adaptive portfolio-rollup build/*/adaptive-diagnosis.json --format md --out build/sdetkit/adaptive-portfolio-rollup.md
+```
+
+## PR comment patterns
+
+### 1. Green run — no fake intelligence
+
+```md
+### SDETKit release signal
+
+✅ Gate is ship-ready; no adaptive remediation block is present.
+```
+
+Use this when the gate is ship-ready and adaptive diagnosis is `clear` or only low-risk `monitor`. The comment should not invent a remediation section when there is no failure signal.
+
+### 2. Safe mechanical issue — scoped safe-fix path
+
+```md
+### SDETKit adaptive handoff
+
+- Gate: `needs_fix`
+- Adaptive status: `needs_fix`
+- Primary: `PRE_COMMIT_FORMAT_DRIFT` — Pre-commit formatting drift detected
+- First proof: `PYTHONPATH=src python -m ruff format --check tests/test_widget.py`
+
+**Safe-fix status**
+- Scoped safe-fix path is available, but only after guardrails and proof artifacts pass.
+
+**Next owner action**
+- Run the scoped format fix, re-run the proof command, and attach the updated diagnosis artifact.
+```
+
+Use this for narrow mechanical fixes only, such as format drift or safe Ruff import cleanup. Unknown failures must never be routed here.
+
+### 3. Unknown failure — review-first candidates
+
+```md
+### SDETKit adaptive handoff
+
+- Gate: `needs_fix`
+- Adaptive status: `needs_fix`
+- Primary: `UNKNOWN_REVIEW_REQUIRED` — Failure-like evidence needs human review
+- Candidate scenarios: `PACKAGE_INSTALL_FAILURE,RUNTIME_EXCEPTION,CACHE_ARTIFACT_POISONING`
+- First proof: `python -m pip install -r requirements-test.txt -e .`
+
+**Safe-fix status**
+- Review-first: this evidence is not approved for automatic remediation.
+
+**Next owner action**
+- Start with the first proof command, confirm the matching scenario, then record whether the proof passed or failed.
+```
+
+Use this when logs contain failure-like signals but no known safe remediation path.
+
+### 4. Recurring scenario — learning calibration visible
+
+```md
+### SDETKit adaptive handoff
+
+- Gate: `needs_attention`
+- Adaptive status: `needs_attention`
+- Primary: `KNOWN_ADAPTIVE_PATTERN_AVAILABLE` — Adaptive memory has reusable context
+- Candidate scenarios: `RELEASE_VERSION_CONFLICT,CACHE_ARTIFACT_POISONING`
+- Calibration: `RELEASE_VERSION_CONFLICT:promote_and_increase_risk:confidence_delta=2:risk_delta=12`
+- First proof: `git tag --points-at HEAD`
+
+**Safe-fix status**
+- Review-first: this evidence is not approved for automatic remediation.
+
+**Next owner action**
+- Compare the current release artifact with prior accepted diagnosis events before changing release metadata.
+```
+
+Use this when learning summary data has promoted or demoted candidates based on prior proof/fix outcomes.
+
+## Top scenario review checklist
+
+| Scenario family | What reviewers should see first | Proof command pattern | Automation posture |
+| --- | --- | --- | --- |
+| `PYTEST_BEHAVIOR_REGRESSION` | First failing test node and assertion summary. | `PYTHONPATH=src python -m pytest -q tests/path.py::test_name` | Human review; code behavior changed. |
+| `PYTEST_COLLECTION_IMPORT_FAILURE` | Import traceback and missing module or symbol. | `PYTHONPATH=src python -m pytest -q tests/path.py` | Human review unless environment-only dependency is proven. |
+| `RUFF_FORMAT_DRIFT` | File list from format check. | `PYTHONPATH=src python -m ruff format --check <files>` | Safe only for scoped formatting. |
+| `RUFF_LINT_CONTRACT` | Ruff rule codes and affected files. | `PYTHONPATH=src python -m ruff check <files>` | Safe only for allowlisted mechanical rules. |
+| `MYPY_CONTRACT_DRIFT` | First typed API mismatch and owning module. | `PYTHONPATH=src python -m mypy <module-or-package>` | Human review; type contract may reveal design drift. |
+| `COVERAGE_GATE_REGRESSION` | Threshold delta and missed file/package. | `PYTHONPATH=src python -m pytest --cov` | Human review; decide test or threshold response. |
+| `PACKAGE_INSTALL_FAILURE` | Resolver/build error, missing extra, or script failure. | `python -m pip install -r requirements-test.txt -e .` | Review-first; environment and dependency state matter. |
+| `CACHE_ARTIFACT_POISONING` | Cache key, stale artifact hint, or mismatch after restore. | `python -m pytest -q --cache-clear` | Review-first; clear/rebuild before code changes. |
+| `DOCS_BUILD_CONTRACT` | Broken link, strict MkDocs warning, or missing page. | `NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q` | Human review unless link target is obvious and local. |
+| `RELEASE_VERSION_CONFLICT` | Tag/version mismatch or duplicate artifact version. | `git tag --points-at HEAD` and `python -m build --sdist --wheel` | Review-first; release metadata changes are high impact. |
+
+## Portfolio rollup interpretation
+
+A portfolio rollup should answer three leadership questions:
+
+1. **Which scenario family is hurting the most repos?** Check `top_risk_scenarios[].repo_count`.
+2. **Which repo blocks release signoff?** Check `needs_fix_repos` and `recurrence_by_repo[].max_status`.
+3. **What should the owner do next?** Use `next_owner_action` as the release-room handoff sentence.
+
+Example compact output:
+
+```text
+schema_version=sdetkit.adaptive.portfolio_rollup.v1
+ok=false
+recommendation=NO_SHIP
+repo_count=3
+artifact_count=3
+portfolio_risk_score=100
+scenario=PYTEST_BEHAVIOR_REGRESSION|risk=82|repos=2
+next_owner_action=Block release signoff for api; start with top scenario PYTEST_BEHAVIOR_REGRESSION.
+```
+
+## Real-world operator guidance contract
+
+Adaptive diagnosis output is intended to explain a real observed failure, not emit random fixed advice. Each diagnosis now includes `operator_guidance` with:
+
+- `what_is_going_on` — the interpreted failure contract;
+- `what_to_fix_first` and `how_to_fix` — the first concrete repair lane;
+- `how_to_verify` — proof commands to rerun;
+- `automation_boundary` — whether the lane is safe mechanical automation or review-first no-mutation;
+- `observed_failure_lines` — sanitized lines from the current log that triggered the diagnosis;
+- `why_this_is_not_random` — the traceability statement tying guidance to current evidence.
+
+Unknown, product-risk, or non-mechanical failures stay review-first. Only narrow mechanical lanes such as formatter drift and safe Ruff F401/I001 fixes may be marked safe after proof.
+
+## Real-world scenario database scale
+
+The adaptive database is no longer a tiny fixed set of examples. It combines a curated scenario pack with a deterministic generated failure matrix covering pytest, collection/import failures, Ruff, format drift, mypy, coverage, package managers, docs, Git, CI, network, runtime, cache, release, security, and artifact/dashboard families across operating systems, runners, architectures, network modes, and symptoms. The runtime payload reports `scenario_database.curated_scenario_count`, `generated_matrix_scenario_count`, `total_scenario_count`, and `odds_space_size` so operators can see the actual search space used for candidate matching.
+
+This does not mean the tool auto-fixes everything. The larger database improves matching and guidance; automation remains limited to proven narrow mechanical fixes.

--- a/docs/adaptive-enterprise-analytics.md
+++ b/docs/adaptive-enterprise-analytics.md
@@ -1,0 +1,43 @@
+# Adaptive enterprise analytics
+
+Adaptive enterprise analytics turns local adaptive portfolio and fix-audit artifacts into a leadership-ready release signal. It stays evidence-first: every metric is derived from a portfolio rollup JSON file and a fix-audit JSONL file produced by the existing adaptive commands.
+
+## Command
+
+```bash
+python -m sdetkit adaptive enterprise-analytics \
+  --portfolio build/sdetkit/adaptive-portfolio.json \
+  --fix-audit .sdetkit/adaptive-fix-audit.jsonl \
+  --format json \
+  --out build/sdetkit/adaptive-enterprise-analytics.json
+```
+
+The module can also be run directly:
+
+```bash
+python -m sdetkit.adaptive_enterprise_analytics \
+  --portfolio build/sdetkit/adaptive-portfolio.json \
+  --fix-audit .sdetkit/adaptive-fix-audit.jsonl \
+  --format text
+```
+
+## Metrics emitted
+
+| Metric | Meaning |
+| --- | --- |
+| `remediation_success_rate` | Share of planned/applied remediation decisions that reached a matching `proof_passed` record. |
+| `missing_proof_rate` | Share of planned/applied remediation decisions that do not yet have proof, revert, or rejection closure. |
+| `failed_proof_rate` | Share of proof outcomes that are `proof_failed`. |
+| `mean_time_to_proof_seconds` | Average elapsed time from planned/applied remediation to the earliest matching proof outcome when timestamps are available. |
+| `top_recurring_source_codes` | Combined recurring source codes from portfolio scenarios and fix-audit records. |
+| `top_risky_repos` | Portfolio repositories ordered by risk score when recurrence-by-repo evidence is present. |
+
+## Release-room recommendation
+
+The analytics recommendation is intentionally conservative:
+
+- `NO_SHIP` when failed proof exists or the portfolio recommendation is `NO_SHIP`.
+- `SHIP_WITH_CONTROLS` when proof is missing or the portfolio requires controls.
+- `SHIP` only when portfolio and proof evidence are complete.
+
+Unknown or review-required diagnoses remain review-first; this lane reports risk and proof completeness but does not enable automatic remediation.

--- a/docs/adaptive-hosted-readiness-boundary.md
+++ b/docs/adaptive-hosted-readiness-boundary.md
@@ -1,0 +1,35 @@
+# Adaptive hosted/managed readiness boundary
+
+The adaptive next wave remains local-first. This boundary defines what can safely become a managed or hosted input later and what must stay local-only until stronger privacy, tenancy, and data-retention controls exist.
+
+## Local-only evidence
+
+These artifacts should stay on the operator workstation or CI artifact store by default:
+
+- raw adaptive diagnosis logs and stack traces;
+- operator briefs that include repository context;
+- fix-audit JSONL with notes, source paths, changed files, and proof commands;
+- assisted patch plans and safe-fix plans before redaction;
+- dashboard HTML that links local artifact paths.
+
+## Optional managed inputs later
+
+The following can be considered for managed workflows only after explicit opt-in and redaction validation:
+
+- anonymized learning exports with `<redacted>` private fields;
+- aggregate enterprise analytics metrics without raw paths;
+- portfolio counts and source-code recurrence without repository identifiers;
+- adapter contract status with artifact names normalized.
+
+## Unsupported data classes
+
+Do not send these to any hosted service from this toolkit lane:
+
+- secrets, tokens, credentials, or environment dumps;
+- raw source files or patches;
+- customer data, production payloads, or screenshots containing private data;
+- unredacted repository names, usernames, hostnames, absolute paths, or private issue links.
+
+## Readiness rule
+
+Hosted behavior remains unsupported until documentation, retention controls, tenant isolation, deletion workflow, and redaction enforcement are implemented and tested. Until then, deterministic static artifacts and anonymized imports are the supported boundary.

--- a/docs/adaptive-integration-adapters.md
+++ b/docs/adaptive-integration-adapters.md
@@ -1,0 +1,57 @@
+# Adaptive integration adapters
+
+Adaptive integration adapters define the minimum artifact contract for publishing adaptive evidence from CI providers.
+
+Supported providers:
+
+- `github-actions`
+- `gitlab`
+- `jenkins`
+- `local`
+
+## Required artifacts
+
+| Artifact key | Purpose |
+| --- | --- |
+| `adaptive_diagnosis_json` | Machine-readable adaptive diagnosis output. |
+| `operator_brief_md` | Human-readable release/operator handoff. |
+
+Optional artifacts include `fix_audit_jsonl`, `portfolio_rollup_json`, and `enterprise_governance_json`.
+
+## Validate an adapter payload
+
+Create an artifact map:
+
+```json
+{
+  "artifacts": {
+    "adaptive_diagnosis_json": "build/sdetkit/adaptive-diagnosis.json",
+    "operator_brief_md": "build/sdetkit/operator-brief.md",
+    "fix_audit_jsonl": ".sdetkit/adaptive-fix-audit.jsonl"
+  }
+}
+```
+
+Then validate it for the target provider:
+
+```bash
+python -m sdetkit adaptive integration-adapter validate \
+  --provider github-actions \
+  --artifacts build/sdetkit/adaptive-artifacts.json \
+  --root . \
+  --format json \
+  --out build/sdetkit/adaptive-adapter-contract.json
+```
+
+The contract returns `READY` only when required artifacts exist. Otherwise it returns `BLOCKED` with the missing input keys so the CI job can fail before publishing incomplete evidence.
+
+## Provider behavior
+
+| Provider | Upload target |
+| --- | --- |
+| `github-actions` | `actions-artifact` |
+| `gitlab` | `job-artifacts` |
+| `jenkins` | `archiveArtifacts` |
+| `local` | `filesystem` |
+
+The adapter contract is intentionally provider-light: it normalizes required artifact paths and target names, while each CI template remains responsible for native upload syntax.

--- a/docs/adaptive-learning-import.md
+++ b/docs/adaptive-learning-import.md
@@ -1,0 +1,32 @@
+# Adaptive anonymized learning import
+
+Adaptive learning import consumes anonymized organization learning exports without accepting repo-private identifiers. It validates redaction first, then emits local calibration hints that can inform operator review without exposing repository names, paths, notes, or files.
+
+## Command
+
+```bash
+python -m sdetkit adaptive learning-import build/sdetkit/anonymized-learning-export.json \
+  --format json \
+  --out build/sdetkit/adaptive-learning-import.json
+```
+
+JSONL records are also accepted when each line is already anonymized.
+
+## Privacy validation
+
+The importer rejects records when:
+
+- private fields such as `repo`, `repository`, `source_path`, `note`, `changed_file_scope`, `affected_files`, or `files` are not `<redacted>`;
+- strings look like raw filesystem paths, private file identifiers, URLs, hostnames, or email addresses;
+- the input is malformed JSON/JSONL.
+
+## Calibration hints
+
+Accepted imports are grouped by scenario code and produce hints such as:
+
+- `promote` when proof passed or a fix was accepted;
+- `review_guardrail` when imported proof failed;
+- `demote` when records are marked false-positive;
+- `observe` when evidence is not strong enough to move confidence.
+
+Hints are local-only; they do not mutate built-in scenario packs or enable automatic remediation. Operator feedback hardening now rejects private URLs, hostnames, and email addresses as well as raw paths/files.

--- a/docs/adaptive-remediation-policy.md
+++ b/docs/adaptive-remediation-policy.md
@@ -1,0 +1,56 @@
+# Adaptive remediation policy
+
+Adaptive remediation policy packs make the safe-remediation lane configurable without weakening the review-first safety model. A policy can narrow allowed safe-fix types, require proof outcomes, and cap changed-file scope, but it cannot turn unknown or review-required diagnoses into automatic fixes.
+
+## Default policy
+
+The default policy lives at `config/adaptive_remediation_policy.default.json` and is described by `schemas/adaptive-remediation-policy.schema.json`.
+
+```json
+{
+  "schema_version": "sdetkit.adaptive.remediation_policy.v1",
+  "allowed_safe_fix_types": ["format_only", "ruff_fixable_lint"],
+  "max_changed_files": 8,
+  "required_proof_outcomes": ["proof_passed"],
+  "allow_review_required_auto_fix": false,
+  "blocked_auto_source_codes": ["UNKNOWN", "UNKNOWN_REVIEW_REQUIRED"]
+}
+```
+
+## Commands
+
+Print a policy template:
+
+```bash
+python -m sdetkit adaptive remediation-policy template --format json \
+  --out config/adaptive_remediation_policy.default.json
+```
+
+Validate a safe-fix or assisted patch-plan artifact:
+
+```bash
+python -m sdetkit adaptive remediation-policy validate build/sdetkit/safe-fix.json \
+  --policy config/adaptive_remediation_policy.default.json \
+  --format json \
+  --out build/sdetkit/remediation-policy-result.json
+```
+
+## Guardrails enforced
+
+| Guardrail | Why it matters |
+| --- | --- |
+| Allowed safe-fix types | Keeps auto-fix behavior limited to known mechanical lanes such as formatting and narrow Ruff fixes. |
+| Required proof outcomes | Requires `proof_passed` as the signoff target before remediation can be considered complete. |
+| Changed-file scope | Prevents broad automatic edits by rejecting plans above `max_changed_files`. |
+| Blocked source codes | Keeps `UNKNOWN` and `UNKNOWN_REVIEW_REQUIRED` diagnoses out of automatic remediation even if a custom policy tries to allow them. |
+| Review-first patch plans | Assisted patch plans must remain dry-run-only and human-owned. |
+
+## Recommendations
+
+The validator emits one of three recommendations:
+
+- `APPROVE` when the policy and plan satisfy all guardrails.
+- `REJECT_POLICY` when the policy itself attempts unsafe expansion.
+- `REJECT_PLAN` when the plan violates policy limits.
+
+This lane does not execute fixes. It only evaluates whether a remediation plan is allowed to proceed to its existing proof and audit workflow.

--- a/docs/governance-and-org-packs.md
+++ b/docs/governance-and-org-packs.md
@@ -4,3 +4,81 @@ Governance packs bundle policy, ownership, and operating rhythm artifacts.
 
 - Governance baseline: [Policy and baselines](policy-and-baselines.md)
 - Enterprise framing: [Enterprise productization blueprint](enterprise-productization-blueprint.md)
+
+## Adaptive scenario pack overlay governance
+
+SDETKit loads adaptive scenario intelligence in deterministic layers:
+
+1. built-in SDETKit scenario pack,
+2. repo-local `.sdetkit/adaptive/scenarios.json`,
+3. additional organization or private packs listed in `SDETKIT_ADAPTIVE_SCENARIO_PACKS`.
+
+Use this governance policy when an organization pack changes diagnosis behavior across multiple repositories.
+
+### Approval rules
+
+- New scenario codes are allowed when the pack validates against `schemas/adaptive-scenario-pack.schema.json`.
+- Overriding an existing scenario code requires the replacing scenario to include the explicit `override-approved` tag.
+- Approved overrides should include owner review notes in the PR description and a proof command that shows the new scenario ranking or proof path.
+- Security-sensitive scenarios should live in private packs and avoid embedding secret values, customer identifiers, or unredacted internal hostnames.
+
+### Validation commands
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from sdetkit import adaptive_diagnosis
+
+report = adaptive_diagnosis.validate_layered_scenario_packs(Path('.'))
+print(report['schema_version'])
+print(report['layer_count'])
+print(report['overrides'])
+PY
+```
+
+For inspection without enforcing override approval, use:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from sdetkit import adaptive_diagnosis
+
+report = adaptive_diagnosis.layered_scenario_pack_report(Path('.'))
+print(report['layers'])
+print(report['merged_codes'][:10])
+PY
+```
+
+### Review checklist
+
+- [ ] Pack schema validates and loads deterministically.
+- [ ] Pack source appears in the layer metadata as `repo-local` or `overlay-N`.
+- [ ] Any duplicate scenario code is intentional and tagged with `override-approved`.
+- [ ] Override PR includes before/after diagnosis evidence.
+- [ ] Proof commands do not require secrets or write access.
+- [ ] Rollback is simple: remove the overlay pack or revert the scenario row.
+
+## Enterprise adaptive governance report
+
+Use the enterprise governance report when scenario packs or learning exports cross repo boundaries.
+
+```bash
+python -m sdetkit adaptive enterprise-governance report --root . --format json --out build/adaptive-enterprise-governance.json
+```
+
+The report enforces these controls:
+
+- duplicate scenario-code overrides must be explicitly approved by the layered pack policy,
+- scenarios tagged `security-sensitive`, `secret-sensitive`, or `private-sensitive` must also carry `security-isolated`,
+- governance output includes an `APPROVED` or `BLOCKED` recommendation and the next owner action.
+
+For cross-repo learning exports, anonymize local identifiers before sharing outside the source repo:
+
+```bash
+python -m sdetkit adaptive enterprise-governance anonymize-learning \
+  .sdetkit/adaptive-fix-audit.jsonl \
+  --format json \
+  --out build/adaptive-learning-export.anonymized.json
+```
+
+The anonymized export redacts repo identifiers, source paths, changed-file scope, affected files, and free-form notes while preserving scenario codes, outcomes, and aggregate learning signals.

--- a/docs/repo-adoption-scan.md
+++ b/docs/repo-adoption-scan.md
@@ -1,0 +1,22 @@
+# Repo adoption scan
+
+`adopt-scan` is the repo-level entrypoint for adopting SDETKit in a real company repository. It inventories the repo, detects likely stacks and CI/docs/test contracts, reports adoption gaps, and gives the exact commands to establish release-confidence evidence.
+
+## Command
+
+```bash
+python -m sdetkit adopt-scan . --format json --out build/sdetkit-adopt-scan.json
+```
+
+## What it detects
+
+- Python, JavaScript/TypeScript, docs, Docker, GitHub Actions, GitLab CI, tests, README, and license surfaces.
+- Missing CI contract, missing tests, missing Python project metadata, missing test dependency contract, missing docs build contract, missing README, and missing license/compliance policy.
+- Recommended first commands for `gate fast`, `gate release`, `doctor`, `review`, pytest, Ruff, MkDocs, and the adaptive dashboard when gaps exist.
+
+## How teams use it
+
+1. Run `adopt-scan` on every repo before rollout.
+2. Fix high-severity adoption gaps first, especially missing tests and missing CI.
+3. Publish the recommended JSON artifacts in CI.
+4. Use the adaptive dashboard and diagnosis output for evidence-based remediation rather than random fixes.

--- a/docs/roadmap/adaptive-next-wave-roadmap.md
+++ b/docs/roadmap/adaptive-next-wave-roadmap.md
@@ -1,0 +1,62 @@
+# Adaptive next-wave roadmap
+
+The Big-Brain execution plan is complete. This next wave turns the completed adaptive foundation into deeper enterprise analytics, stronger remediation governance, and optional operator-facing product surfaces without weakening the review-first safety model.
+
+## Completion baseline carried forward
+
+| Completed Big-Brain lane | Proof surface to protect |
+| --- | --- |
+| Scenario packs and layered governance | `adaptive_diagnosis.load_layered_scenarios()`, `layered_scenario_pack_report()`, `validate_layered_scenario_packs()` |
+| Learning loop and calibration | `sdetkit adaptive learn record`, `sdetkit adaptive learn summarize`, `candidate_calibration=...` evidence |
+| Operator experience | `sdetkit adaptive brief`, PR comment output, demo gallery, fixture corpus |
+| Safe remediation expansion | safe-fix plans, assisted patch plans, fix-audit records, post-fix proof enforcement |
+| Enterprise scale | portfolio rollup, enterprise governance report, anonymized export, integration-adapter contract validation |
+
+## Next-wave priorities
+
+| Priority | Work item | Outcome | Acceptance check |
+| --- | --- | --- | --- |
+| NW-P0 | Enterprise analytics rollup metrics | Convert portfolio and fix-audit evidence into leadership metrics. | **Done:** `sdetkit adaptive enterprise-analytics` reports remediation success rate, missing-proof rate, failed-proof rate, top recurring source codes, top risky repos, and mean time to proof when timestamps are available. |
+| NW-P0 | Remediation governance policy pack | Make remediation guardrails configurable without allowing unknown auto-fix. | **Done:** `sdetkit adaptive remediation-policy` validates policy files, safe-fix plans, assisted patch plans, proof requirements, changed-file scope, and unsafe expansion attempts. |
+| NW-P1 | Next-wave dashboard artifact | Produce a static local dashboard from adaptive artifacts. | **Done:** `sdetkit adaptive dashboard` emits `build/sdetkit/adaptive-dashboard.html` with local links for diagnosis, brief, portfolio, fix-audit, governance, adapter, analytics, and remediation-policy artifacts. |
+| NW-P1 | Cross-repo anonymized learning import | Let teams consume anonymized organization learning without exposing repo details. | **Done:** `sdetkit adaptive learning-import` validates redaction policy, rejects raw paths/private identifiers, and emits local calibration hints. |
+| NW-P2 | Hosted/managed readiness boundary | Define what can be hosted later and what stays local-only. | **Done:** hosted readiness boundary docs separate local-only evidence, optional managed inputs, privacy controls, and unsupported data classes. |
+
+## Current next-wave progress
+
+| Completed next-wave items | Total tracked items | Progress | Latest completed item |
+| ---: | ---: | ---: | --- |
+| 5 | 5 | 100% | Cross-repo anonymized learning import and hosted readiness boundary. |
+
+## Latest completed next-wave PR
+
+**PR:** `Finalize adaptive next-wave learning import and readiness boundary`
+
+**Delivered:**
+
+1. Added `sdetkit adaptive learning-import` for anonymized cross-repo learning validation and calibration hints.
+2. Rejects unredacted private fields, raw paths, and private file identifiers before import.
+3. Added hosted/managed readiness boundary docs for local-only evidence, optional managed inputs, privacy controls, and unsupported data classes.
+4. Completed the adaptive next-wave roadmap at 5 / 5 items.
+
+## Next-wave completion status
+
+The adaptive next wave is complete. Future PRs should focus on hardening, operator feedback, and bug fixes rather than expanding hosted behavior before the readiness boundary controls are implemented.
+
+## Guardrails for the next wave
+
+1. Do not turn unknown review-required diagnoses into automatic fixes.
+2. Keep every analytics output traceable to local JSON/JSONL evidence.
+3. Redact repo-private identifiers before any cross-repo learning export or import.
+4. Prefer deterministic static artifacts over hosted behavior until privacy boundaries are documented.
+5. Keep every new lane represented in CLI help and docs navigation.
+
+## Progress tracking rule
+
+Every next-wave PR should update this page with:
+
+- completed next-wave item count,
+- exact progress percentage,
+- latest completed item,
+- next recommended PR,
+- validation commands.

--- a/docs/roadmap/big-brain-progress-tracker.md
+++ b/docs/roadmap/big-brain-progress-tracker.md
@@ -1,0 +1,80 @@
+# Big-Brain Toolkit progress tracker
+
+This tracker keeps the Big-Brain Toolkit roadmap measurable after every follow-up PR. It is the quick answer for: **how much did we achieve, what changed in the latest pass, what should the next PR do, and what follow-ups must stay on track?**
+
+## Current progress snapshot
+
+| Scope | Completed | Total | Progress | Status |
+| --- | ---: | ---: | ---: | --- |
+| Immediate backlog | 8 | 8 | 100% | Immediate backlog complete; continue into Phase 4/5 follow-ups. |
+| Phase 1 — Externalize the big-brain database | 4 | 4 | 100% | Built-in scenarios are data-backed and schema validated. |
+| Phase 2 — Close the learning loop | 3 | 3 | 100% | Learning records, summaries, promotion/demotion, and calibration are active. |
+| Phase 3 — Trust-grade operator experience | 3 | 3 | 100% | Operator brief, PR comment mode, and demo gallery are complete. |
+| Phase 4 — Safe remediation expansion | 4 | 4 | 100% | Safe-fix, assisted patch-plan, fix-audit records, and proof enforcement are in place. |
+| Phase 5 — Enterprise scale | 3 | 3 | 100% | Portfolio rollup, enterprise governance controls, and adapter hardening are complete. |
+
+## Completed immediate-backlog items
+
+| Priority | Completed item | Proof surface |
+| --- | --- | --- |
+| P0 | Extract scenario DB to a schema-validated pack. | `src/sdetkit/data/adaptive_scenarios.json`, `schemas/adaptive-scenario-pack.schema.json`, loader validation tests. |
+| P0 | Add learning event records for adaptive diagnosis. | `sdetkit adaptive learn record` JSONL events. |
+| P0 | Add operator brief artifact. | `sdetkit adaptive brief` with Markdown, JSON, and PR comment outputs. |
+| P1 | Add candidate confidence calibration. | `candidate_calibration=...` evidence in adaptive diagnosis output. |
+| P1 | Add docs demo gallery. | `docs/adaptive-demo-gallery.md` with green, safe-fix, unknown-review, recurring-learning, and portfolio examples. |
+| P1 | Add fixture corpus for top scenarios. | `tests/fixtures/adaptive_logs/` plus parametrized coverage for 20 realistic adaptive failure logs. |
+| P2 | Add portfolio rollup. | `sdetkit adaptive portfolio-rollup` with top-risk scenarios, recurrence by repo, and next owner action. |
+| P2 | Harden org-level pack overlay. | Layer metadata, override approval validation, and governance docs for org/private scenario packs. |
+
+## Remaining immediate-backlog items
+
+All immediate backlog items are complete. Continue with the Phase 4/5 follow-up queue below.
+
+## Latest progress made
+
+The latest pass finalized the adaptive next wave by adding anonymized learning import validation and the hosted/managed readiness boundary. Operators can now reject unredacted cross-repo learning inputs, emit local calibration hints, and rely on documented local-only versus optional-managed data boundaries.
+
+## Next-wave progress snapshot
+
+| Scope | Completed | Total | Progress | Status |
+| --- | ---: | ---: | ---: | --- |
+| Adaptive next wave | 5 | 5 | 100% | Next-wave analytics, remediation policy, dashboard, anonymized import, and hosted readiness boundary are complete. |
+
+## Latest next-wave completion
+
+**Completed PR:** `Finalize adaptive next-wave learning import and readiness boundary`
+
+**Delivered:** cross-repo anonymized learning import validation, privacy-safe calibration hints, and hosted/managed readiness boundary docs. The adaptive next wave is now complete at 5 / 5 items.
+
+**Validation commands:**
+
+1. `PYTHONPATH=src python -m pytest tests/test_adaptive_learning_import.py`
+2. `PYTHONPATH=src python -m pytest tests/test_docs_navigation.py tests/test_adaptive_learning_import.py tests/test_adaptive_dashboard.py tests/test_adaptive_enterprise_governance.py`
+
+## Latest stabilization pass
+
+**Completed PR:** `Harden adaptive learning import privacy checks`
+
+**Goal:** keep the completed next-wave feature set stable through targeted redaction hardening rather than new hosted behavior.
+
+**Delivered:**
+
+1. Learning import now rejects private URLs, hostnames, and email addresses in addition to raw paths/files.
+2. Regression tests cover the new operator feedback privacy examples.
+3. Hosted behavior remains out of scope until readiness controls are implemented and tested.
+
+## Follow-up PR queue
+
+| Order | Suggested PR | Target progress impact | Notes |
+| ---: | --- | --- | --- |
+| 1 | Continue adaptive next-wave operator feedback hardening. | Maintains 100% completion. | Bug fixes, redaction examples, and docs polish for completed local-only adaptive lanes. |
+
+## Operating rule for future updates
+
+Every Big-Brain follow-up PR should update this file with:
+
+1. progress percentage after the PR,
+2. what was completed in that pass,
+3. the recommended next PR,
+4. remaining follow-ups and risk notes,
+5. the exact commands used to validate the update.

--- a/docs/roadmap/big-brain-toolkit-roadmap.md
+++ b/docs/roadmap/big-brain-toolkit-roadmap.md
@@ -80,20 +80,20 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
   - green run: no fake adaptive block,
   - known safe mechanical issue: scoped auto-fix path,
   - unknown failure: review-first candidate scenarios and checks.
-- Add screenshots or sample PR comments in docs for the top 10 scenarios.
+- Add screenshots or sample PR comments in docs for the top 10 scenarios. **Done:** `docs/adaptive-demo-gallery.md` now shows green, safe-fix, unknown-review, recurring-learning, top-scenario, and portfolio rollup examples.
 
 ### Phase 4 — Expand safe remediation without weakening safety
 
 **Outcome:** more fixes are assisted, but unknown failures remain human-reviewed.
 
 - Keep current safe auto-fix route narrow.
-- Add a second lane: **assisted patch plan** for non-mechanical cases.
+- Add a second lane: **assisted patch plan** for non-mechanical cases. **Done:** `sdetkit adaptive patch-plan` emits review-only patch steps, guardrails, proof commands, and rollback notes without allowing mutation.
 - Require four gates before any non-format PR automation:
   - deterministic reproduction,
   - scenario confidence threshold,
   - changed-file scope limit,
-  - post-fix proof command.
-- Add fix-audit records for every automated change.
+  - post-fix proof command. **Done:** fix-audit summaries now flag missing proof, block failed proof, and emit release recommendations.
+- Add fix-audit records for every automated change. **Done:** `sdetkit adaptive fix-audit record` stores safe-fix and assisted patch-plan decisions with guardrails, proof commands, changed-file scope, rollback notes, and outcomes.
 
 ### Phase 5 — Make it enterprise-scale
 
@@ -106,12 +106,16 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
   - dependency drift hotspots,
   - remediation success rate,
   - mean time to first actionable proof.
-- Add governance controls:
+- Add governance controls: **Done:** `sdetkit adaptive enterprise-governance report` and `anonymize-learning` cover pack approvals, policy override boundaries, security-sensitive scenario isolation, and anonymized learning export.
   - pack approval workflow,
   - policy overrides,
   - security-sensitive scenario isolation,
   - anonymized learning export.
-- Add adapters for GitHub Actions, GitLab, Jenkins, and local-only operation.
+- Add adapters for GitHub Actions, GitLab, Jenkins, and local-only operation. **Done:** `sdetkit adaptive integration-adapter validate` checks required adaptive artifact inputs and provider upload targets.
+
+## Completion checkpoint
+
+The Big-Brain execution plan is now complete across the immediate backlog, Phase 4 safe-remediation expansion, and Phase 5 enterprise-scale lanes. CLI discoverability for every adaptive lane is covered by regression tests so the next work can move into a fresh roadmap wave without losing these command surfaces. The next wave is tracked in [`adaptive-next-wave-roadmap.md`](adaptive-next-wave-roadmap.md).
 
 ## Big-win differentiators to protect
 
@@ -129,11 +133,15 @@ The goal is not to hard-code millions of brittle rules. The goal is to combine a
 | P0 | Extract scenario DB to a schema-validated pack | Done: built-in scenarios now load from `src/sdetkit/data/adaptive_scenarios.json`, validate through loader rules, and are documented against `schemas/adaptive-scenario-pack.schema.json`. |
 | P0 | Add learning event records for adaptive diagnosis | Done: `sdetkit adaptive learn record` writes JSONL events with matched signals, candidates, selected primary diagnosis, checks, proof commands, recurrence count, and outcome placeholders. |
 | P0 | Add operator brief artifact | Done: `python -m sdetkit adaptive brief` generates `build/sdetkit/operator-brief.md` from gate, diagnosis, learning, and safe-fix artifacts. |
-| P1 | Add fixture corpus for top scenarios | Tests cover at least 20 realistic log fixtures. |
+| P1 | Add fixture corpus for top scenarios | Done: `tests/fixtures/adaptive_logs/` covers 20 realistic log fixtures with expected primary diagnosis, first proof command, candidate scenario, and safe-fix posture assertions. |
 | P1 | Add candidate confidence calibration | Done: adaptive diagnosis can consume learning-summary calibration to boost/demote candidate scenario ranking and emit `candidate_calibration` evidence. |
-| P1 | Add docs demo gallery | Docs show green, safe-fix, unknown-review, and recurring-failure examples. |
-| P2 | Add org-level pack overlay | Local and org packs merge deterministically with built-in scenarios. |
-| P2 | Add portfolio rollup | Multiple adaptive diagnosis outputs roll into a top-risk scenario report. |
+| P1 | Add docs demo gallery | Done: `docs/adaptive-demo-gallery.md` shows green, safe-fix, unknown-review, recurring-learning, top-10 scenario, and portfolio rollup examples. |
+| P2 | Add org-level pack overlay | Done: layered packs emit source metadata, governance validation rejects unapproved duplicate-code overrides, and `docs/governance-and-org-packs.md` documents approval expectations. |
+| P2 | Add portfolio rollup | Done: `sdetkit adaptive portfolio-rollup` rolls multiple adaptive diagnosis outputs into a top-risk scenario report with recurrence by repo, candidate mentions, release recommendation, and next owner action. |
+
+## Progress tracking
+
+Current measurable progress, latest movement, next-PR recommendation, and follow-up queue are tracked in [`big-brain-progress-tracker.md`](big-brain-progress-tracker.md).
 
 ## Definition of “real big win”
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,14 @@ nav:
       - Operator essentials: operator-essentials.md
       - Investigation operator guide: investigation-operator-guide.md
       - Adaptive Diagnosis Intelligence: adaptive-diagnosis.md
+      - Adaptive demo gallery: adaptive-demo-gallery.md
+      - Adaptive integration adapters: adaptive-integration-adapters.md
+      - Adaptive enterprise analytics: adaptive-enterprise-analytics.md
+      - Adaptive remediation policy: adaptive-remediation-policy.md
+      - Adaptive next-wave dashboard: adaptive-dashboard.md
+      - Adaptive anonymized learning import: adaptive-learning-import.md
+      - Adaptive hosted readiness boundary: adaptive-hosted-readiness-boundary.md
+      - Repo adoption scan: repo-adoption-scan.md
       - Artifact reference and generated sample map: artifact-reference.md
       - CI artifact walkthrough: ci-artifact-walkthrough.md
       - Remediation cookbook: remediation-cookbook.md
@@ -202,6 +210,8 @@ nav:
           - Enterprise offerings: project/enterprise-offerings.md
           - Adaptive investigation roadmap: roadmap/adaptive-investigation-roadmap.md
           - Big-brain toolkit roadmap: roadmap/big-brain-toolkit-roadmap.md
+          - Big-brain progress tracker: roadmap/big-brain-progress-tracker.md
+          - Adaptive next-wave roadmap: roadmap/adaptive-next-wave-roadmap.md
           - Product roadmap: roadmap/product-roadmap.md
           - Why not just separate tools?: why-not-just-tools.md
           - Product strategy: product-strategy.md

--- a/schemas/adaptive-remediation-policy.schema.json
+++ b/schemas/adaptive-remediation-policy.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://devs69.github.io/sdetkit/schemas/adaptive-remediation-policy.schema.json",
+  "title": "SDETKit adaptive remediation policy",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "allowed_safe_fix_types",
+    "max_changed_files",
+    "required_proof_outcomes",
+    "allow_review_required_auto_fix"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "sdetkit.adaptive.remediation_policy.v1"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "allowed_safe_fix_types": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "max_changed_files": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "required_proof_outcomes": {
+      "type": "array",
+      "items": {
+        "enum": ["proof_passed", "proof_failed", "reverted", "rejected"]
+      },
+      "uniqueItems": true,
+      "minItems": 1
+    },
+    "allow_review_required_auto_fix": {
+      "type": "boolean"
+    },
+    "blocked_auto_source_codes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/sdetkit/adaptive_dashboard.py
+++ b/src/sdetkit/adaptive_dashboard.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive.dashboard.v1"
+ARTIFACT_SPECS = [
+    ("diagnosis", "Adaptive diagnosis"),
+    ("brief", "Operator brief"),
+    ("portfolio", "Portfolio rollup"),
+    ("fix_audit", "Fix audit"),
+    ("governance", "Enterprise governance"),
+    ("adapter", "Integration adapter"),
+    ("analytics", "Enterprise analytics"),
+    ("remediation_policy", "Remediation policy"),
+]
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_text(value: Any, limit: int = 180) -> str:
+    text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _load_artifact(path: Path) -> tuple[dict[str, Any] | None, str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"read_error={exc}"
+    if not text.strip():
+        return None, "empty_artifact"
+    if path.suffix.lower() in {".json", ".jsonl"}:
+        if path.suffix.lower() == ".jsonl":
+            rows = []
+            for line in text.splitlines():
+                if line.strip():
+                    rows.append(json.loads(line))
+            return {"schema_version": "jsonl", "record_count": len(rows), "records": rows[-5:]}, "jsonl"
+        payload = json.loads(text)
+        if isinstance(payload, dict):
+            return payload, "json"
+        return {"schema_version": "json", "value": payload}, "json"
+    return {"schema_version": "text", "preview": _safe_text(text, 600)}, "text"
+
+
+def _relative_link(path: Path, out_path: Path) -> str:
+    try:
+        return path.resolve().relative_to(out_path.resolve().parent).as_posix()
+    except ValueError:
+        try:
+            return path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+        except ValueError:
+            return path.as_posix()
+
+
+def _summary_fields(kind: str, payload: dict[str, Any]) -> dict[str, Any]:
+    fields: dict[str, Any] = {
+        "schema_version": payload.get("schema_version", "unknown"),
+    }
+    for key in (
+        "status",
+        "recommendation",
+        "ok",
+        "risk_score",
+        "portfolio_risk_score",
+        "repo_count",
+        "artifact_count",
+        "record_count",
+        "finding_count",
+        "critical_finding_count",
+        "provider",
+    ):
+        if key in payload:
+            fields[key] = payload[key]
+    if kind == "diagnosis":
+        fields["diagnosis_count"] = payload.get("diagnosis_count", len(_as_list(payload.get("diagnoses"))))
+        first = _as_dict((_as_list(payload.get("diagnoses")) or [{}])[0])
+        if first:
+            fields["top_code"] = first.get("code", "UNKNOWN")
+    if kind == "analytics":
+        metrics = _as_dict(payload.get("metrics"))
+        for key in ("remediation_success_rate", "missing_proof_rate", "failed_proof_rate"):
+            if key in metrics:
+                fields[key] = metrics[key]
+    if kind == "portfolio" and _as_list(payload.get("top_risk_scenarios")):
+        fields["top_scenario"] = _as_dict(payload["top_risk_scenarios"][0]).get("code")
+    if kind == "adapter" and _as_list(payload.get("missing_artifacts")):
+        fields["missing_artifacts"] = len(_as_list(payload.get("missing_artifacts")))
+    return fields
+
+
+def build_dashboard(artifact_paths: dict[str, str], *, out_path: Path) -> dict[str, Any]:
+    artifacts: list[dict[str, Any]] = []
+    missing: list[dict[str, str]] = []
+    for kind, label in ARTIFACT_SPECS:
+        raw_path = artifact_paths.get(kind, "")
+        if not raw_path:
+            missing.append({"kind": kind, "label": label, "reason": "not_configured"})
+            artifacts.append(
+                {
+                    "kind": kind,
+                    "label": label,
+                    "present": False,
+                    "reason": "not_configured",
+                }
+            )
+            continue
+        path = Path(raw_path)
+        if not path.exists():
+            missing.append({"kind": kind, "label": label, "path": raw_path, "reason": "missing"})
+            artifacts.append(
+                {
+                    "kind": kind,
+                    "label": label,
+                    "path": raw_path,
+                    "present": False,
+                    "reason": "missing",
+                }
+            )
+            continue
+        payload, artifact_format = _load_artifact(path)
+        if payload is None:
+            missing.append({"kind": kind, "label": label, "path": raw_path, "reason": artifact_format})
+            artifacts.append(
+                {
+                    "kind": kind,
+                    "label": label,
+                    "path": raw_path,
+                    "present": False,
+                    "reason": artifact_format,
+                }
+            )
+            continue
+        artifacts.append(
+            {
+                "kind": kind,
+                "label": label,
+                "path": raw_path,
+                "link": _relative_link(path, out_path),
+                "present": True,
+                "format": artifact_format,
+                "summary": _summary_fields(kind, payload),
+            }
+        )
+    present_count = sum(1 for item in artifacts if item.get("present"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": present_count > 0,
+        "artifact_count": len(artifacts),
+        "present_artifact_count": present_count,
+        "missing_artifact_count": len(missing),
+        "local_only": True,
+        "artifacts": artifacts,
+        "missing_artifacts": missing,
+        "next_owner_action": _next_owner_action(present_count, missing),
+    }
+
+
+def _next_owner_action(present_count: int, missing: list[dict[str, str]]) -> str:
+    if present_count == 0:
+        return "Generate adaptive artifacts before using the dashboard for release-room review."
+    if missing:
+        kinds = ", ".join(row["kind"] for row in missing[:4])
+        return f"Dashboard is usable with warnings; add missing artifacts next: {kinds}."
+    return "Dashboard has all adaptive next-wave artifacts linked for local release-room review."
+
+
+def render_html(payload: dict[str, Any]) -> str:
+    cards: list[str] = []
+    for item in _as_list(payload.get("artifacts")):
+        row = _as_dict(item)
+        label = html.escape(str(row.get("label", row.get("kind", "artifact"))))
+        kind = html.escape(str(row.get("kind", "artifact")))
+        if not row.get("present"):
+            reason = html.escape(str(row.get("reason", "missing")))
+            cards.append(
+                f'<article class="card missing"><h2>{label}</h2><p class="meta">{kind}</p>'
+                f'<p class="status">Missing: {reason}</p></article>'
+            )
+            continue
+        link = html.escape(str(row.get("link", "#")), quote=True)
+        summary_items = []
+        for key, value in sorted(_as_dict(row.get("summary")).items()):
+            summary_items.append(
+                f"<li><strong>{html.escape(str(key))}</strong>: {html.escape(_safe_text(value))}</li>"
+            )
+        cards.append(
+            f'<article class="card present"><h2>{label}</h2><p class="meta">{kind}</p>'
+            f'<p><a href="{link}">Open local artifact</a></p><ul>{"".join(summary_items)}</ul></article>'
+        )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive next-wave dashboard</title>
+  <style>
+    body {{ font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; color: #172033; background: #f7f8fb; }}
+    header {{ margin-bottom: 1.5rem; }}
+    .summary {{ display: flex; gap: 1rem; flex-wrap: wrap; }}
+    .pill {{ background: white; border: 1px solid #d7dce8; border-radius: 999px; padding: .5rem .9rem; }}
+    .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }}
+    .card {{ background: white; border: 1px solid #d7dce8; border-radius: 14px; padding: 1rem; box-shadow: 0 1px 2px rgb(20 30 50 / 8%); }}
+    .present {{ border-top: 5px solid #247a3f; }}
+    .missing {{ border-top: 5px solid #b25c00; }}
+    .meta {{ color: #667085; font-size: .9rem; }}
+    .status {{ font-weight: 650; }}
+    a {{ color: #175cd3; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Adaptive next-wave dashboard</h1>
+    <p>Deterministic local-only dashboard for adaptive diagnosis, remediation, governance, and analytics artifacts.</p>
+    <div class="summary">
+      <span class="pill">schema: {html.escape(str(payload.get('schema_version')))}</span>
+      <span class="pill">present: {payload.get('present_artifact_count')} / {payload.get('artifact_count')}</span>
+      <span class="pill">missing: {payload.get('missing_artifact_count')}</span>
+      <span class="pill">local only: {str(payload.get('local_only')).lower()}</span>
+    </div>
+    <p><strong>Next owner action:</strong> {html.escape(str(payload.get('next_owner_action', '')))}</p>
+  </header>
+  <main class="grid">
+    {''.join(cards)}
+  </main>
+</body>
+</html>
+"""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_dashboard")
+    for kind, label in ARTIFACT_SPECS:
+        parser.add_argument(f"--{kind.replace('_', '-')}", default="", help=f"Path to {label} artifact")
+    parser.add_argument("--format", choices=["html", "json"], default="html")
+    parser.add_argument("--out", default="build/sdetkit/adaptive-dashboard.html")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    out_path = Path(str(args.out))
+    artifact_paths = {kind: str(getattr(args, kind)) for kind, _label in ARTIFACT_SPECS}
+    try:
+        payload = build_dashboard(artifact_paths, out_path=out_path)
+        rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n" if args.format == "json" else render_html(payload)
+        if args.out:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_dashboard.py
+++ b/src/sdetkit/adaptive_dashboard.py
@@ -46,7 +46,11 @@ def _load_artifact(path: Path) -> tuple[dict[str, Any] | None, str]:
             for line in text.splitlines():
                 if line.strip():
                     rows.append(json.loads(line))
-            return {"schema_version": "jsonl", "record_count": len(rows), "records": rows[-5:]}, "jsonl"
+            return {
+                "schema_version": "jsonl",
+                "record_count": len(rows),
+                "records": rows[-5:],
+            }, "jsonl"
         payload = json.loads(text)
         if isinstance(payload, dict):
             return payload, "json"
@@ -84,7 +88,9 @@ def _summary_fields(kind: str, payload: dict[str, Any]) -> dict[str, Any]:
         if key in payload:
             fields[key] = payload[key]
     if kind == "diagnosis":
-        fields["diagnosis_count"] = payload.get("diagnosis_count", len(_as_list(payload.get("diagnoses"))))
+        fields["diagnosis_count"] = payload.get(
+            "diagnosis_count", len(_as_list(payload.get("diagnoses")))
+        )
         first = _as_dict((_as_list(payload.get("diagnoses")) or [{}])[0])
         if first:
             fields["top_code"] = first.get("code", "UNKNOWN")
@@ -131,7 +137,9 @@ def build_dashboard(artifact_paths: dict[str, str], *, out_path: Path) -> dict[s
             continue
         payload, artifact_format = _load_artifact(path)
         if payload is None:
-            missing.append({"kind": kind, "label": label, "path": raw_path, "reason": artifact_format})
+            missing.append(
+                {"kind": kind, "label": label, "path": raw_path, "reason": artifact_format}
+            )
             artifacts.append(
                 {
                     "kind": kind,
@@ -223,15 +231,15 @@ def render_html(payload: dict[str, Any]) -> str:
     <h1>Adaptive next-wave dashboard</h1>
     <p>Deterministic local-only dashboard for adaptive diagnosis, remediation, governance, and analytics artifacts.</p>
     <div class="summary">
-      <span class="pill">schema: {html.escape(str(payload.get('schema_version')))}</span>
-      <span class="pill">present: {payload.get('present_artifact_count')} / {payload.get('artifact_count')}</span>
-      <span class="pill">missing: {payload.get('missing_artifact_count')}</span>
-      <span class="pill">local only: {str(payload.get('local_only')).lower()}</span>
+      <span class="pill">schema: {html.escape(str(payload.get("schema_version")))}</span>
+      <span class="pill">present: {payload.get("present_artifact_count")} / {payload.get("artifact_count")}</span>
+      <span class="pill">missing: {payload.get("missing_artifact_count")}</span>
+      <span class="pill">local only: {str(payload.get("local_only")).lower()}</span>
     </div>
-    <p><strong>Next owner action:</strong> {html.escape(str(payload.get('next_owner_action', '')))}</p>
+    <p><strong>Next owner action:</strong> {html.escape(str(payload.get("next_owner_action", "")))}</p>
   </header>
   <main class="grid">
-    {''.join(cards)}
+    {"".join(cards)}
   </main>
 </body>
 </html>
@@ -241,7 +249,9 @@ def render_html(payload: dict[str, Any]) -> str:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_dashboard")
     for kind, label in ARTIFACT_SPECS:
-        parser.add_argument(f"--{kind.replace('_', '-')}", default="", help=f"Path to {label} artifact")
+        parser.add_argument(
+            f"--{kind.replace('_', '-')}", default="", help=f"Path to {label} artifact"
+        )
     parser.add_argument("--format", choices=["html", "json"], default="html")
     parser.add_argument("--out", default="build/sdetkit/adaptive-dashboard.html")
     return parser
@@ -253,7 +263,11 @@ def main(argv: list[str] | None = None) -> int:
     artifact_paths = {kind: str(getattr(args, kind)) for kind, _label in ARTIFACT_SPECS}
     try:
         payload = build_dashboard(artifact_paths, out_path=out_path)
-        rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n" if args.format == "json" else render_html(payload)
+        rendered = (
+            json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            if args.format == "json"
+            else render_html(payload)
+        )
         if args.out:
             out_path.parent.mkdir(parents=True, exist_ok=True)
             out_path.write_text(rendered, encoding="utf-8")

--- a/src/sdetkit/adaptive_diagnosis.py
+++ b/src/sdetkit/adaptive_diagnosis.py
@@ -49,6 +49,217 @@ class OddsAxis:
     values: tuple[str, ...]
 
 
+
+
+@dataclass(frozen=True)
+class FailureMatrixFamily:
+    name: str
+    signals: tuple[str, ...]
+    keywords: tuple[str, ...]
+    check: str
+    command: str
+    risk_band: str = "medium"
+
+
+MATRIX_ENVIRONMENTS = (
+    "linux",
+    "macos",
+    "windows",
+    "container",
+    "github_actions",
+    "gitlab_ci",
+    "jenkins",
+    "self_hosted",
+    "arm64",
+    "x86_64",
+    "wsl",
+    "docker_compose",
+    "kubernetes",
+    "air_gapped",
+    "proxy_network",
+    "readonly_workspace",
+)
+
+MATRIX_SYMPTOMS = (
+    "assertion_delta",
+    "fixture_missing",
+    "import_missing",
+    "timeout",
+    "flaky_rerun",
+    "permission_denied",
+    "cache_stale",
+    "lockfile_drift",
+    "version_conflict",
+    "schema_mismatch",
+    "api_parity",
+    "type_mismatch",
+    "format_drift",
+    "lint_unsafe",
+    "coverage_drop",
+    "docs_link",
+    "network_timeout",
+    "tls_proxy",
+    "rate_limit",
+    "disk_full",
+    "timezone",
+    "parallel_order",
+    "artifact_missing",
+    "release_duplicate",
+)
+
+MATRIX_FAMILIES = (
+    FailureMatrixFamily(
+        "pytest",
+        ("pytest-node-failed", "pytest-failed-count", "assertion-error"),
+        ("pytest", "failed", "assertionerror"),
+        "Reproduce the first failing pytest node and inspect the assertion delta.",
+        "PYTHONPATH=src python -m pytest -q <first-failing-test> -vv",
+        "high",
+    ),
+    FailureMatrixFamily(
+        "pytest_collection",
+        ("pytest-error-count", "python-exception"),
+        ("modulenotfounderror", "importerror while importing", "fixture"),
+        "Run collection-only on the failing test file and repair imports/fixtures first.",
+        "PYTHONPATH=src python -m pytest -q <failing-test-file> --collect-only",
+        "high",
+    ),
+    FailureMatrixFamily(
+        "ruff",
+        ("ruff-check-failure",),
+        ("ruff", "found", "fixable"),
+        "Identify whether the Ruff rule is safe mechanical or requires review.",
+        "PYTHONPATH=src python -m ruff check <touched-python-files>",
+    ),
+    FailureMatrixFamily(
+        "format",
+        ("ruff-format-failure",),
+        ("ruff format", "would reformat", "files were modified"),
+        "Run formatter locally and verify no product files changed unexpectedly.",
+        "PYTHONPATH=src python -m ruff format --check <touched-python-files>",
+    ),
+    FailureMatrixFamily(
+        "mypy",
+        ("mypy-error",),
+        ("mypy", "error:", "attr-defined", "arg-type", "union-attr"),
+        "Open the first mypy error and fix the declared type/API contract.",
+        "PYTHONPATH=src python -m mypy <module-or-package>",
+    ),
+    FailureMatrixFamily(
+        "coverage",
+        ("coverage-failure",),
+        ("coverage", "fail under", "threshold"),
+        "Find the missed file or branch that moved coverage below policy.",
+        "PYTHONPATH=src python -m pytest --cov",
+    ),
+    FailureMatrixFamily(
+        "package",
+        ("package-manager-error", "python-exception"),
+        ("pip", "npm err", "resolver", "wheel", "lockfile"),
+        "Recreate dependency resolution from a clean environment before editing product code.",
+        "python -m pip install -r requirements-test.txt -e .",
+        "high",
+    ),
+    FailureMatrixFamily(
+        "docs",
+        ("error-prefix", "command-failed"),
+        ("mkdocs", "docs", "link", "markdown"),
+        "Build docs in strict mode and fix the first broken page/link.",
+        "NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q",
+    ),
+    FailureMatrixFamily(
+        "git",
+        ("command-failed",),
+        ("git", "non-fast-forward", "rejected", "fetch first"),
+        "Fetch/rebase before retrying push and rerun proof after rebase.",
+        "git fetch origin <branch>",
+    ),
+    FailureMatrixFamily(
+        "ci",
+        ("ci-exit-code", "failed-steps"),
+        ("exit code", "failed_steps", "workflow"),
+        "Open the first failed CI step and map it back to the local proof command.",
+        "python -m sdetkit adaptive dashboard --format json",
+        "high",
+    ),
+    FailureMatrixFamily(
+        "network",
+        ("error-prefix", "command-failed"),
+        ("timeout", "dns", "tls", "rate limit", "connection"),
+        "Separate transient service/network failure from deterministic product failure.",
+        "python -m pytest -q <network-marked-tests> -vv",
+    ),
+    FailureMatrixFamily(
+        "runtime",
+        ("python-exception",),
+        ("python", "datetime.utc", "syntaxerror", "runtime"),
+        "Verify the failing interpreter and supported Python compatibility lane.",
+        "python --version",
+        "high",
+    ),
+    FailureMatrixFamily(
+        "cache",
+        ("error-prefix", "command-failed"),
+        ("cache", "artifact", "restore", "stale"),
+        "Clear or rebuild cache before changing product code.",
+        "PYTHONPATH=src python -m pytest -q --cache-clear",
+    ),
+    FailureMatrixFamily(
+        "release",
+        ("error-prefix", "command-failed"),
+        ("release", "tag", "version", "twine", "duplicate"),
+        "Compare version metadata, tags, and built artifacts before publishing.",
+        "git tag --points-at HEAD",
+        "high",
+    ),
+    FailureMatrixFamily(
+        "security",
+        ("gate-problems-found", "error-prefix"),
+        ("secret", "token", "bandit", "policy"),
+        "Treat security-policy failures as review-first and verify redaction before sharing logs.",
+        "python -m sdetkit security --help",
+        "high",
+    ),
+    FailureMatrixFamily(
+        "dashboard",
+        ("failed-steps", "error-prefix"),
+        ("artifact", "dashboard", "json", "contract"),
+        "Check local artifact contracts and regenerate deterministic dashboard evidence.",
+        "python -m sdetkit adaptive dashboard --format json",
+    ),
+)
+
+
+def _generated_scenario_matrix() -> tuple[SeededScenario, ...]:
+    scenarios: list[SeededScenario] = []
+    for family in MATRIX_FAMILIES:
+        for environment in MATRIX_ENVIRONMENTS:
+            for symptom in MATRIX_SYMPTOMS:
+                code = f"MATRIX_{family.name}_{environment}_{symptom}".upper()
+                title = (
+                    f"{family.name.replace('_', ' ').title()} failure on "
+                    f"{environment.replace('_', ' ')} with {symptom.replace('_', ' ')}"
+                )
+                scenarios.append(
+                    SeededScenario(
+                        code=code,
+                        title=title,
+                        signals=family.signals,
+                        keywords=tuple(dict.fromkeys((*family.keywords, environment, symptom))),
+                        checks=(
+                            family.check,
+                            f"Confirm whether environment={environment} changes reproduction.",
+                            f"Use symptom={symptom} to choose the narrowest proof command.",
+                        ),
+                        commands=(family.command,),
+                        odds=(environment, symptom, family.name),
+                        tags=("generated-matrix", "real-world-scale"),
+                        risk_band=family.risk_band,
+                        prior_weight=1,
+                    )
+                )
+    return tuple(sorted(scenarios, key=lambda scenario: scenario.code))
+
 ODDS_EXPANSION_AXES = (
     OddsAxis(
         "runner", ("github-hosted", "self-hosted", "container", "local-wsl", "macos", "windows")
@@ -193,6 +404,8 @@ FAILURE_LIKE_SIGNAL_DB = (
 
 BUILTIN_SCENARIO_PACK = "data/adaptive_scenarios.json"
 SCENARIO_PACK_SCHEMA_VERSION = "sdetkit.adaptive.scenario_pack.v1"
+SCENARIO_PACK_REPORT_SCHEMA_VERSION = "sdetkit.adaptive.scenario_pack_report.v1"
+APPROVED_OVERRIDE_TAG = "override-approved"
 VALID_RISK_BANDS = {"low", "medium", "high"}
 REQUIRED_SCENARIO_FIELDS = {
     "code",
@@ -302,6 +515,89 @@ def merge_scenario_packs(*packs: Sequence[SeededScenario]) -> tuple[SeededScenar
     return tuple(merged[code] for code in sorted(merged))
 
 
+def _scenario_layer_name(path: Path, index: int) -> str:
+    if index == 0:
+        return "builtin"
+    normalized = path.as_posix()
+    if normalized.endswith(".sdetkit/adaptive/scenarios.json"):
+        return "repo-local"
+    return f"overlay-{index}"
+
+
+def _scenario_layer_paths(root: Path | None = None) -> list[Path]:
+    return [_package_file(BUILTIN_SCENARIO_PACK), *_default_layer_paths(root)]
+
+
+def _scenario_layer_metadata(
+    *, path: Path, index: int, scenarios: Sequence[SeededScenario]
+) -> dict[str, Any]:
+    codes = [scenario.code for scenario in scenarios]
+    return {
+        "index": index,
+        "source": _scenario_layer_name(path, index),
+        "path": str(path),
+        "scenario_count": len(scenarios),
+        "codes": codes,
+    }
+
+
+def layered_scenario_pack_report(
+    root: Path | None = None, *, require_override_approval: bool = False
+) -> dict[str, Any]:
+    """Return deterministic scenario pack layer metadata and merged scenario codes.
+
+    Overrides are allowed for normal loading so existing local packs remain compatible.
+    Governance checks can set ``require_override_approval`` to reject overrides unless the
+    replacing scenario carries the explicit ``override-approved`` tag.
+    """
+    merged: dict[str, SeededScenario] = {}
+    seen_sources: dict[str, str] = {}
+    layers: list[dict[str, Any]] = []
+    overrides: list[dict[str, Any]] = []
+    for index, path in enumerate(_scenario_layer_paths(root)):
+        scenarios = load_scenario_pack(path)
+        source = _scenario_layer_name(path, index)
+        layers.append(_scenario_layer_metadata(path=path, index=index, scenarios=scenarios))
+        for scenario in scenarios:
+            previous_source = seen_sources.get(scenario.code)
+            if previous_source is not None:
+                approved = APPROVED_OVERRIDE_TAG in scenario.tags
+                override = {
+                    "code": scenario.code,
+                    "previous_source": previous_source,
+                    "source": source,
+                    "approved": approved,
+                    "approval_tag": APPROVED_OVERRIDE_TAG if approved else "",
+                }
+                overrides.append(override)
+                if require_override_approval and not approved:
+                    raise ValueError(
+                        f"scenario {scenario.code}: override from {source} requires "
+                        f"{APPROVED_OVERRIDE_TAG} tag"
+                    )
+            merged[scenario.code] = scenario
+            seen_sources[scenario.code] = source
+    merged_codes = sorted(merged)
+    return {
+        "schema_version": SCENARIO_PACK_REPORT_SCHEMA_VERSION,
+        "ok": True,
+        "layer_count": len(layers),
+        "scenario_count": len(merged_codes),
+        "layers": layers,
+        "overrides": sorted(overrides, key=lambda row: (row["code"], row["source"])),
+        "merged_codes": merged_codes,
+        "override_policy": {
+            "require_override_approval": require_override_approval,
+            "approval_tag": APPROVED_OVERRIDE_TAG,
+        },
+    }
+
+
+def validate_layered_scenario_packs(root: Path | None = None) -> dict[str, Any]:
+    """Validate layered packs using governance override policy."""
+    return layered_scenario_pack_report(root, require_override_approval=True)
+
+
 def _default_layer_paths(root: Path | None = None) -> list[Path]:
     base = root or Path.cwd()
     env_paths = [
@@ -315,12 +611,13 @@ def _default_layer_paths(root: Path | None = None) -> list[Path]:
 
 def load_layered_scenarios(root: Path | None = None) -> tuple[SeededScenario, ...]:
     """Load built-in scenarios plus repo/org/private overlay packs in deterministic order."""
-    packs = [load_scenario_pack(_package_file(BUILTIN_SCENARIO_PACK))]
-    packs.extend(load_scenario_pack(path) for path in _default_layer_paths(root))
+    packs = [SEEDED_SCENARIO_DB, *[load_scenario_pack(path) for path in _default_layer_paths(root)]]
     return merge_scenario_packs(*packs)
 
 
-SEEDED_SCENARIO_DB = load_scenario_pack(_package_file(BUILTIN_SCENARIO_PACK))
+CURATED_SCENARIO_DB = load_scenario_pack(_package_file(BUILTIN_SCENARIO_PACK))
+GENERATED_SCENARIO_DB = _generated_scenario_matrix()
+SEEDED_SCENARIO_DB = merge_scenario_packs(CURATED_SCENARIO_DB, GENERATED_SCENARIO_DB)
 
 
 def _as_int(value: Any) -> int:
@@ -360,6 +657,33 @@ def _safe_list(values: Sequence[Any], limit: int = 6) -> list[str]:
     return out
 
 
+def _operator_guidance(
+    *, code: str, diagnosis: str, fixes: Sequence[str], commands: Sequence[str], files: Sequence[str]
+) -> dict[str, Any]:
+    safe_to_auto_fix = code in SAFE_AUTO_FIX_CODES
+    safe_fixes = _safe_list(fixes, 5)
+    safe_commands = _safe_list(commands, 5)
+    safe_files = _safe_list(files, 8)
+    return {
+        "what_is_going_on": _safe(diagnosis, 700),
+        "what_to_fix_first": safe_fixes[0]
+        if safe_fixes
+        else "Start with the first concrete failing line in the captured evidence.",
+        "how_to_fix": safe_fixes,
+        "how_to_verify": safe_commands,
+        "affected_files": safe_files,
+        "automation_boundary": (
+            "safe_mechanical_fix_allowed_after_proof"
+            if safe_to_auto_fix
+            else "review_first_no_auto_mutation"
+        ),
+        "why_this_is_not_random": (
+            "Not random: generated from matched failure signals, affected files, and proof commands "
+            "in the current evidence; unknown or unsafe failures stay review-first."
+        ),
+    }
+
+
 def _diag(
     code: str,
     severity: str,
@@ -376,6 +700,9 @@ def _diag(
     repeat_count: int = 0,
     files: Sequence[str] = (),
 ) -> dict[str, Any]:
+    safe_fixes = _safe_list(fixes, 8)
+    safe_commands = _safe_list(commands, 8)
+    safe_files = _safe_list(files, 8)
     return {
         "code": code,
         "severity": severity,
@@ -384,12 +711,15 @@ def _diag(
         "diagnosis": _safe(diagnosis, 900),
         "why_developers_miss_it": _safe(why, 900),
         "evidence": _safe_list(evidence, 8),
-        "recommended_fix": _safe_list(fixes, 8),
-        "proof_commands": _safe_list(commands, 8),
+        "recommended_fix": safe_fixes,
+        "proof_commands": safe_commands,
         "risk_if_ignored": _safe(risk, 500),
         "learning_signal": _safe(signal, 160),
         "repeat_count": max(0, repeat_count),
-        "affected_files": _safe_list(files, 8),
+        "affected_files": safe_files,
+        "operator_guidance": _operator_guidance(
+            code=code, diagnosis=diagnosis, fixes=safe_fixes, commands=safe_commands, files=safe_files
+        ),
     }
 
 
@@ -501,6 +831,10 @@ def _candidate_scenarios(
         keyword_hits = sum(1 for keyword in scenario.keywords if keyword.lower() in lower)
         odds_hits = sum(1 for odd in scenario.odds if odd.lower() in lower)
         score = signal_hits * 3 + keyword_hits + odds_hits + max(0, scenario.prior_weight - 1)
+        if score and "generated-matrix" in scenario.tags:
+            score = max(1, score - 2)
+        elif score:
+            score += 20
         score += _calibration_score(_as_dict((calibration_by_code or {}).get(scenario.code)))
         if score:
             scored.append((-score, scenario.code, scenario))
@@ -559,6 +893,8 @@ def _candidate_commands(
 def _seeded_scenario_evidence() -> list[str]:
     return [
         f"seeded_scenario_count={len(SEEDED_SCENARIO_DB)}",
+        f"curated_scenario_count={len(CURATED_SCENARIO_DB)}",
+        f"generated_matrix_scenario_count={len(GENERATED_SCENARIO_DB)}",
         f"seeded_odds_space_size={_odds_space_size()}",
         "seeded_scenario_examples="
         + ",".join(scenario.code for scenario in SEEDED_SCENARIO_DB[:5]),
@@ -794,9 +1130,45 @@ def _append_local_investigation(
     return False
 
 
+
+
+def _failure_snippets(text: str, *, limit: int = 5) -> list[str]:
+    snippets: list[str] = []
+    marker = re.compile(
+        r"(FAILED|FAILURES|AssertionError|Traceback|Error:|error:|ruff|mypy|ModuleNotFoundError|ImportError|Process completed with exit code|Found [1-9])",
+        re.IGNORECASE,
+    )
+    for line in text.splitlines():
+        cleaned = _safe(line, 260)
+        if not cleaned or not marker.search(cleaned):
+            continue
+        if cleaned not in snippets:
+            snippets.append(cleaned)
+        if len(snippets) >= limit:
+            break
+    return snippets
+
+
+def _attach_log_context(diagnoses: list[dict[str, Any]], start_index: int, text: str) -> None:
+    snippets = _failure_snippets(text)
+    if not snippets:
+        return
+    for diagnosis in diagnoses[start_index:]:
+        guidance = _as_dict(diagnosis.get("operator_guidance"))
+        guidance["observed_failure_lines"] = snippets
+        guidance["matched_from_current_log"] = True
+        diagnosis["operator_guidance"] = guidance
+        evidence = _as_list(diagnosis.get("evidence"))
+        for index, snippet in enumerate(snippets[:3], start=1):
+            item = f"observed_failure_line_{index}={snippet}"
+            if item not in evidence:
+                evidence.append(item)
+        diagnosis["evidence"] = _safe_list(evidence, 8)
+
 def _append_log(
     text: str, diagnoses: list[dict[str, Any]], adaptive_history: dict[str, Any] | None = None
 ) -> None:
+    start_index = len(diagnoses)
     lower = text.lower()
     files = _file_mentions(text)
     handled_local = _append_local_investigation(text, files, diagnoses)
@@ -861,6 +1233,7 @@ def _append_log(
                 files=files,
             )
         )
+    _attach_log_context(diagnoses, start_index, text)
 
 
 def _format_count(text: str) -> int:
@@ -1181,6 +1554,14 @@ def _payload(diagnoses: list[dict[str, Any]], status: str) -> dict[str, Any]:
             }
             for item in diagnoses[:5]
         ],
+        "scenario_database": {
+            "curated_scenario_count": len(CURATED_SCENARIO_DB),
+            "generated_matrix_scenario_count": len(GENERATED_SCENARIO_DB),
+            "total_scenario_count": len(SEEDED_SCENARIO_DB),
+            "failure_signal_count": len(FAILURE_LIKE_SIGNAL_DB),
+            "odds_space_size": _odds_space_size(),
+            "generation_strategy": "curated_pack_plus_deterministic_real_world_failure_matrix",
+        },
         "learning_updates": [
             {
                 "signal": item["learning_signal"],
@@ -1227,6 +1608,19 @@ def _diagnosis_markdown(row: dict[str, Any]) -> list[str]:
         "Evidence:",
     ]
     lines += [f"- {value}" for value in _as_list(row.get("evidence"))]
+    guidance = _as_dict(row.get("operator_guidance"))
+    if guidance:
+        lines += ["", "Operator guidance:"]
+        lines += [
+            f"- What is going on: {guidance.get('what_is_going_on', '')}",
+            f"- Fix first: {guidance.get('what_to_fix_first', '')}",
+            f"- Automation boundary: {guidance.get('automation_boundary', '')}",
+            f"- Why this is not random: {guidance.get('why_this_is_not_random', '')}",
+        ]
+        observed = _as_list(guidance.get("observed_failure_lines"))
+        if observed:
+            lines += ["- Observed failure lines:"]
+            lines += [f"  - `{value}`" for value in observed[:5]]
     lines += ["", "Recommended fix:"]
     lines += [f"- {value}" for value in _as_list(row.get("recommended_fix"))]
     lines += ["", "Proof commands:"]

--- a/src/sdetkit/adaptive_diagnosis.py
+++ b/src/sdetkit/adaptive_diagnosis.py
@@ -49,8 +49,6 @@ class OddsAxis:
     values: tuple[str, ...]
 
 
-
-
 @dataclass(frozen=True)
 class FailureMatrixFamily:
     name: str
@@ -259,6 +257,7 @@ def _generated_scenario_matrix() -> tuple[SeededScenario, ...]:
                     )
                 )
     return tuple(sorted(scenarios, key=lambda scenario: scenario.code))
+
 
 ODDS_EXPANSION_AXES = (
     OddsAxis(
@@ -658,7 +657,12 @@ def _safe_list(values: Sequence[Any], limit: int = 6) -> list[str]:
 
 
 def _operator_guidance(
-    *, code: str, diagnosis: str, fixes: Sequence[str], commands: Sequence[str], files: Sequence[str]
+    *,
+    code: str,
+    diagnosis: str,
+    fixes: Sequence[str],
+    commands: Sequence[str],
+    files: Sequence[str],
 ) -> dict[str, Any]:
     safe_to_auto_fix = code in SAFE_AUTO_FIX_CODES
     safe_fixes = _safe_list(fixes, 5)
@@ -718,7 +722,11 @@ def _diag(
         "repeat_count": max(0, repeat_count),
         "affected_files": safe_files,
         "operator_guidance": _operator_guidance(
-            code=code, diagnosis=diagnosis, fixes=safe_fixes, commands=safe_commands, files=safe_files
+            code=code,
+            diagnosis=diagnosis,
+            fixes=safe_fixes,
+            commands=safe_commands,
+            files=safe_files,
         ),
     }
 
@@ -1130,8 +1138,6 @@ def _append_local_investigation(
     return False
 
 
-
-
 def _failure_snippets(text: str, *, limit: int = 5) -> list[str]:
     snippets: list[str] = []
     marker = re.compile(
@@ -1164,6 +1170,7 @@ def _attach_log_context(diagnoses: list[dict[str, Any]], start_index: int, text:
             if item not in evidence:
                 evidence.append(item)
         diagnosis["evidence"] = _safe_list(evidence, 8)
+
 
 def _append_log(
     text: str, diagnoses: list[dict[str, Any]], adaptive_history: dict[str, Any] | None = None

--- a/src/sdetkit/adaptive_enterprise_analytics.py
+++ b/src/sdetkit/adaptive_enterprise_analytics.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive.enterprise_analytics.v1"
+TERMINAL_PROOF_OUTCOMES = {"proof_passed", "proof_failed"}
+CLOSED_OUTCOMES = TERMINAL_PROOF_OUTCOMES | {"reverted", "rejected"}
+PENDING_OUTCOMES = {"planned", "applied"}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value.strip())
+    return 0
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 4)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSONL at line {line_number}: {exc}") from exc
+        if isinstance(payload, dict):
+            records.append(payload)
+    return records
+
+
+def _record_key(row: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(row.get("source_path", "")),
+        str(row.get("plan_kind", "unknown")),
+        str(row.get("source_code", "UNKNOWN")),
+        str(row.get("action_type", "unknown")),
+    )
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _seconds_between(start: datetime, end: datetime) -> float | None:
+    if start.tzinfo is None and end.tzinfo is not None:
+        end = end.replace(tzinfo=None)
+    elif start.tzinfo is not None and end.tzinfo is None:
+        start = start.replace(tzinfo=None)
+    delta = (end - start).total_seconds()
+    if delta < 0:
+        return None
+    return delta
+
+
+def _portfolio_source_codes(portfolio: dict[str, Any]) -> Counter[str]:
+    counter: Counter[str] = Counter()
+    for row in _as_list(portfolio.get("top_risk_scenarios")):
+        item = _as_dict(row)
+        code = str(item.get("code", "UNKNOWN") or "UNKNOWN")
+        counter[code] += max(1, _as_int(item.get("occurrences")))
+    return counter
+
+
+def _top_risky_repos(portfolio: dict[str, Any]) -> list[dict[str, Any]]:
+    repos: list[dict[str, Any]] = []
+    for row in _as_list(portfolio.get("recurrence_by_repo")):
+        item = _as_dict(row)
+        repo = str(item.get("repo", "unknown") or "unknown")
+        repos.append(
+            {
+                "repo": repo,
+                "risk_score": _as_int(item.get("risk_score")),
+                "max_status": str(item.get("max_status", "unknown")),
+                "diagnosis_count": _as_int(item.get("diagnosis_count")),
+                "artifact_count": _as_int(item.get("artifact_count")),
+            }
+        )
+    return sorted(repos, key=lambda row: (-_as_int(row.get("risk_score")), str(row.get("repo"))))[:10]
+
+
+def _proof_metrics(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    outcomes = Counter(str(row.get("outcome", "unknown")) for row in records)
+    source_codes = Counter(str(row.get("source_code", "UNKNOWN") or "UNKNOWN") for row in records)
+    terminal_by_key: dict[tuple[str, str, str, str], list[dict[str, Any]]] = {}
+    pending_records: list[dict[str, Any]] = []
+    proof_durations: list[float] = []
+
+    for row in records:
+        outcome = str(row.get("outcome", "unknown"))
+        key = _record_key(row)
+        if outcome in CLOSED_OUTCOMES:
+            terminal_by_key.setdefault(key, []).append(row)
+        if outcome in PENDING_OUTCOMES:
+            pending_records.append(row)
+
+    for row in pending_records:
+        key = _record_key(row)
+        start = _parse_datetime(row.get("recorded_at"))
+        terminals = terminal_by_key.get(key, [])
+        if start is not None:
+            candidate_seconds = []
+            for terminal in terminals:
+                if str(terminal.get("outcome")) not in TERMINAL_PROOF_OUTCOMES:
+                    continue
+                end = _parse_datetime(terminal.get("recorded_at"))
+                if end is None:
+                    continue
+                seconds = _seconds_between(start, end)
+                if seconds is not None:
+                    candidate_seconds.append(seconds)
+            if candidate_seconds:
+                proof_durations.append(min(candidate_seconds))
+
+    missing_proof = [
+        row
+        for row in pending_records
+        if not any(str(item.get("outcome")) in CLOSED_OUTCOMES for item in terminal_by_key.get(_record_key(row), []))
+    ]
+    remediation_decision_count = len(pending_records)
+    proof_passed_count = outcomes.get("proof_passed", 0)
+    proof_failed_count = outcomes.get("proof_failed", 0)
+    successful_closed_count = sum(
+        1
+        for key, terminals in terminal_by_key.items()
+        if any(str(row.get("outcome")) == "proof_passed" for row in terminals)
+        and any(_record_key(pending) == key for pending in pending_records)
+    )
+    return {
+        "record_count": len(records),
+        "outcomes": dict(sorted(outcomes.items())),
+        "remediation_decision_count": remediation_decision_count,
+        "proof_passed_count": proof_passed_count,
+        "proof_failed_count": proof_failed_count,
+        "missing_proof_count": len(missing_proof),
+        "remediation_success_rate": _rate(successful_closed_count, remediation_decision_count),
+        "missing_proof_rate": _rate(len(missing_proof), remediation_decision_count),
+        "failed_proof_rate": _rate(proof_failed_count, max(1, proof_passed_count + proof_failed_count)),
+        "mean_time_to_proof_seconds": round(sum(proof_durations) / len(proof_durations), 2)
+        if proof_durations
+        else None,
+        "proof_duration_sample_count": len(proof_durations),
+        "source_codes": source_codes,
+    }
+
+
+def build_enterprise_analytics(
+    portfolio: dict[str, Any], fix_audit_records: Sequence[dict[str, Any]]
+) -> dict[str, Any]:
+    proof = _proof_metrics(fix_audit_records)
+    portfolio_counter = _portfolio_source_codes(portfolio)
+    source_codes = Counter(proof.pop("source_codes"))
+    source_codes.update(portfolio_counter)
+    top_recurring_source_codes = [
+        {"code": code, "count": count} for code, count in source_codes.most_common(10)
+    ]
+    top_risky_repos = _top_risky_repos(portfolio)
+    portfolio_recommendation = str(portfolio.get("recommendation", "UNKNOWN"))
+    if proof["proof_failed_count"] > 0 or portfolio_recommendation == "NO_SHIP":
+        recommendation = "NO_SHIP"
+        next_owner_action = "Block release signoff; resolve failed proof or top portfolio risk first."
+    elif proof["missing_proof_count"] > 0 or portfolio_recommendation == "SHIP_WITH_CONTROLS":
+        recommendation = "SHIP_WITH_CONTROLS"
+        next_owner_action = "Ship only with explicit controls; collect missing proof and review top recurring sources."
+    else:
+        recommendation = "SHIP"
+        next_owner_action = "Proof and portfolio signals are complete; continue collecting analytics evidence."
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": recommendation != "NO_SHIP",
+        "recommendation": recommendation,
+        "next_owner_action": next_owner_action,
+        "portfolio": {
+            "schema_version": str(portfolio.get("schema_version", "unknown")),
+            "recommendation": portfolio_recommendation,
+            "repo_count": _as_int(portfolio.get("repo_count")),
+            "artifact_count": _as_int(portfolio.get("artifact_count")),
+            "portfolio_risk_score": _as_int(portfolio.get("portfolio_risk_score")),
+        },
+        "metrics": proof,
+        "top_recurring_source_codes": top_recurring_source_codes,
+        "top_risky_repos": top_risky_repos,
+    }
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    metrics = _as_dict(payload.get("metrics"))
+    portfolio = _as_dict(payload.get("portfolio"))
+    lines = [
+        f"schema_version={payload['schema_version']}",
+        f"ok={str(payload['ok']).lower()}",
+        f"recommendation={payload['recommendation']}",
+        f"repo_count={portfolio.get('repo_count', 0)}",
+        f"portfolio_risk_score={portfolio.get('portfolio_risk_score', 0)}",
+        f"remediation_success_rate={metrics.get('remediation_success_rate', 0.0)}",
+        f"missing_proof_rate={metrics.get('missing_proof_rate', 0.0)}",
+        f"failed_proof_rate={metrics.get('failed_proof_rate', 0.0)}",
+        f"mean_time_to_proof_seconds={metrics.get('mean_time_to_proof_seconds')}",
+    ]
+    for row in _as_list(payload.get("top_recurring_source_codes"))[:5]:
+        item = _as_dict(row)
+        lines.append(f"source_code={item.get('code')}|count={item.get('count')}")
+    for row in _as_list(payload.get("top_risky_repos"))[:5]:
+        item = _as_dict(row)
+        lines.append(f"repo={item.get('repo')}|risk={item.get('risk_score')}|status={item.get('max_status')}")
+    lines.append(f"next_owner_action={payload['next_owner_action']}")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_enterprise_analytics")
+    parser.add_argument("--portfolio", required=True, help="Adaptive portfolio rollup JSON artifact")
+    parser.add_argument("--fix-audit", required=True, help="Adaptive fix-audit JSONL records")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--out", default="")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(list(argv if argv is not None else sys.argv[1:]))
+    try:
+        payload = build_enterprise_analytics(
+            _load_json(Path(args.portfolio)), read_jsonl(Path(args.fix_audit))
+        )
+        rendered = (
+            json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            if args.format == "json"
+            else render_text(payload)
+        )
+        if args.out:
+            out_path = Path(args.out)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_enterprise_analytics.py
+++ b/src/sdetkit/adaptive_enterprise_analytics.py
@@ -117,7 +117,9 @@ def _top_risky_repos(portfolio: dict[str, Any]) -> list[dict[str, Any]]:
                 "artifact_count": _as_int(item.get("artifact_count")),
             }
         )
-    return sorted(repos, key=lambda row: (-_as_int(row.get("risk_score")), str(row.get("repo"))))[:10]
+    return sorted(repos, key=lambda row: (-_as_int(row.get("risk_score")), str(row.get("repo"))))[
+        :10
+    ]
 
 
 def _proof_metrics(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
@@ -156,7 +158,10 @@ def _proof_metrics(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
     missing_proof = [
         row
         for row in pending_records
-        if not any(str(item.get("outcome")) in CLOSED_OUTCOMES for item in terminal_by_key.get(_record_key(row), []))
+        if not any(
+            str(item.get("outcome")) in CLOSED_OUTCOMES
+            for item in terminal_by_key.get(_record_key(row), [])
+        )
     ]
     remediation_decision_count = len(pending_records)
     proof_passed_count = outcomes.get("proof_passed", 0)
@@ -176,7 +181,9 @@ def _proof_metrics(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
         "missing_proof_count": len(missing_proof),
         "remediation_success_rate": _rate(successful_closed_count, remediation_decision_count),
         "missing_proof_rate": _rate(len(missing_proof), remediation_decision_count),
-        "failed_proof_rate": _rate(proof_failed_count, max(1, proof_passed_count + proof_failed_count)),
+        "failed_proof_rate": _rate(
+            proof_failed_count, max(1, proof_passed_count + proof_failed_count)
+        ),
         "mean_time_to_proof_seconds": round(sum(proof_durations) / len(proof_durations), 2)
         if proof_durations
         else None,
@@ -199,13 +206,17 @@ def build_enterprise_analytics(
     portfolio_recommendation = str(portfolio.get("recommendation", "UNKNOWN"))
     if proof["proof_failed_count"] > 0 or portfolio_recommendation == "NO_SHIP":
         recommendation = "NO_SHIP"
-        next_owner_action = "Block release signoff; resolve failed proof or top portfolio risk first."
+        next_owner_action = (
+            "Block release signoff; resolve failed proof or top portfolio risk first."
+        )
     elif proof["missing_proof_count"] > 0 or portfolio_recommendation == "SHIP_WITH_CONTROLS":
         recommendation = "SHIP_WITH_CONTROLS"
         next_owner_action = "Ship only with explicit controls; collect missing proof and review top recurring sources."
     else:
         recommendation = "SHIP"
-        next_owner_action = "Proof and portfolio signals are complete; continue collecting analytics evidence."
+        next_owner_action = (
+            "Proof and portfolio signals are complete; continue collecting analytics evidence."
+        )
     return {
         "schema_version": SCHEMA_VERSION,
         "ok": recommendation != "NO_SHIP",
@@ -243,14 +254,18 @@ def render_text(payload: dict[str, Any]) -> str:
         lines.append(f"source_code={item.get('code')}|count={item.get('count')}")
     for row in _as_list(payload.get("top_risky_repos"))[:5]:
         item = _as_dict(row)
-        lines.append(f"repo={item.get('repo')}|risk={item.get('risk_score')}|status={item.get('max_status')}")
+        lines.append(
+            f"repo={item.get('repo')}|risk={item.get('risk_score')}|status={item.get('max_status')}"
+        )
     lines.append(f"next_owner_action={payload['next_owner_action']}")
     return "\n".join(lines) + "\n"
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_enterprise_analytics")
-    parser.add_argument("--portfolio", required=True, help="Adaptive portfolio rollup JSON artifact")
+    parser.add_argument(
+        "--portfolio", required=True, help="Adaptive portfolio rollup JSON artifact"
+    )
     parser.add_argument("--fix-audit", required=True, help="Adaptive fix-audit JSONL records")
     parser.add_argument("--format", choices=["text", "json"], default="text")
     parser.add_argument("--out", default="")

--- a/src/sdetkit/adaptive_enterprise_governance.py
+++ b/src/sdetkit/adaptive_enterprise_governance.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from sdetkit import adaptive_diagnosis
+
+SCHEMA_VERSION = "sdetkit.adaptive.enterprise_governance.v1"
+EXPORT_SCHEMA_VERSION = "sdetkit.adaptive.enterprise_learning_export.v1"
+SENSITIVE_TAGS = {"security-sensitive", "secret-sensitive", "private-sensitive"}
+ISOLATION_TAG = "security-isolated"
+APPROVAL_TAG = adaptive_diagnosis.APPROVED_OVERRIDE_TAG
+REDACTED = "<redacted>"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSONL at line {line_number}: {exc}") from exc
+        if isinstance(payload, dict):
+            records.append(payload)
+    return records
+
+
+def _scenario_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for layer in _as_list(report.get("layers")):
+        item = _as_dict(layer)
+        source = str(item.get("source", "unknown"))
+        path = Path(str(item.get("path", "")))
+        if not path.exists():
+            continue
+        for scenario in adaptive_diagnosis.load_scenario_pack(path):
+            rows.append(
+                {
+                    "code": scenario.code,
+                    "source": source,
+                    "tags": list(scenario.tags),
+                    "risk_band": scenario.risk_band,
+                }
+            )
+    return rows
+
+
+def _violation(kind: str, message: str, **extra: Any) -> dict[str, Any]:
+    return {"kind": kind, "message": message, **extra}
+
+
+def build_governance_report(root: Path | None = None) -> dict[str, Any]:
+    pack_report = adaptive_diagnosis.layered_scenario_pack_report(root)
+    scenario_rows = _scenario_rows(pack_report)
+    violations: list[dict[str, Any]] = []
+    for override in _as_list(pack_report.get("overrides")):
+        item = _as_dict(override)
+        if not bool(item.get("approved")):
+            violations.append(
+                _violation(
+                    "unapproved_override",
+                    f"Scenario {item.get('code')} override requires {APPROVAL_TAG}.",
+                    code=item.get("code"),
+                    source=item.get("source"),
+                )
+            )
+    sensitive_rows: list[dict[str, Any]] = []
+    for row in scenario_rows:
+        tags = {str(tag) for tag in _as_list(row.get("tags"))}
+        if not tags.intersection(SENSITIVE_TAGS):
+            continue
+        sensitive_rows.append(row)
+        if ISOLATION_TAG not in tags:
+            violations.append(
+                _violation(
+                    "sensitive_scenario_not_isolated",
+                    f"Scenario {row.get('code')} is sensitive but missing {ISOLATION_TAG}.",
+                    code=row.get("code"),
+                    source=row.get("source"),
+                )
+            )
+    recommendation = "APPROVED" if not violations else "BLOCKED"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": not violations,
+        "recommendation": recommendation,
+        "next_owner_action": "Governance controls passed; pack overlays may be used."
+        if not violations
+        else "Resolve pack approval or sensitive-scenario isolation violations before rollout.",
+        "pack_report_schema_version": pack_report.get("schema_version"),
+        "layer_count": pack_report.get("layer_count", 0),
+        "scenario_count": pack_report.get("scenario_count", 0),
+        "override_count": len(_as_list(pack_report.get("overrides"))),
+        "sensitive_scenario_count": len(sensitive_rows),
+        "violations": violations,
+        "controls": {
+            "override_approval_tag": APPROVAL_TAG,
+            "sensitive_tags": sorted(SENSITIVE_TAGS),
+            "isolation_tag": ISOLATION_TAG,
+            "anonymized_learning_export": True,
+        },
+    }
+
+
+def anonymize_record(record: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in record.items():
+        if key in {"repo", "repository", "source_path", "note", "changed_file_scope"}:
+            out[key] = REDACTED if not isinstance(value, list) else [REDACTED for _ in value]
+        elif key in {"affected_files", "files"}:
+            out[key] = [REDACTED for _ in _as_list(value)]
+        elif isinstance(value, dict):
+            out[key] = anonymize_record(value)
+        elif isinstance(value, list):
+            out[key] = [
+                anonymize_record(item) if isinstance(item, dict) else item for item in value
+            ]
+        else:
+            out[key] = value
+    return out
+
+
+def build_anonymized_learning_export(records: list[dict[str, Any]]) -> dict[str, Any]:
+    anonymized = [anonymize_record(record) for record in records]
+    return {
+        "schema_version": EXPORT_SCHEMA_VERSION,
+        "ok": True,
+        "record_count": len(anonymized),
+        "redaction_policy": {
+            "redacted_fields": [
+                "repo",
+                "repository",
+                "source_path",
+                "note",
+                "changed_file_scope",
+                "affected_files",
+                "files",
+            ],
+            "placeholder": REDACTED,
+        },
+        "records": anonymized,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_enterprise_governance")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    report = sub.add_parser("report", help="Build adaptive enterprise governance report")
+    report.add_argument("--root", default=".")
+    report.add_argument("--format", choices=["text", "json"], default="text")
+    report.add_argument("--out", default="")
+    export = sub.add_parser(
+        "anonymize-learning", help="Anonymize adaptive JSONL records for export"
+    )
+    export.add_argument("jsonl_path")
+    export.add_argument("--format", choices=["text", "json"], default="json")
+    export.add_argument("--out", default="")
+    return parser
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    if payload.get("schema_version") == EXPORT_SCHEMA_VERSION:
+        return (
+            f"schema_version={payload['schema_version']}\n"
+            f"ok={str(payload['ok']).lower()}\n"
+            f"record_count={payload['record_count']}\n"
+        )
+    return (
+        f"schema_version={payload['schema_version']}\n"
+        f"ok={str(payload['ok']).lower()}\n"
+        f"recommendation={payload['recommendation']}\n"
+        f"violation_count={len(_as_list(payload.get('violations')))}\n"
+        f"next_owner_action={payload['next_owner_action']}\n"
+    )
+
+
+def _write_or_print(rendered: str, out: str) -> None:
+    if out:
+        out_path = Path(out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.cmd == "report":
+            payload = build_governance_report(Path(args.root))
+        else:
+            payload = build_anonymized_learning_export(_load_jsonl(Path(args.jsonl_path)))
+        rendered = (
+            json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            if args.format == "json"
+            else _render_text(payload)
+        )
+        _write_or_print(rendered, str(args.out))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_fix_audit.py
+++ b/src/sdetkit/adaptive_fix_audit.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive.fix_audit.v1"
+SUMMARY_SCHEMA_VERSION = "sdetkit.adaptive.fix_audit.summary.v1"
+SUPPORTED_PLAN_SCHEMAS = {
+    "sdetkit.adaptive_safe_fix.v1": "safe_fix",
+    "sdetkit.adaptive.patch_plan.v1": "assisted_patch_plan",
+}
+VALID_OUTCOMES = {"planned", "applied", "proof_passed", "proof_failed", "reverted", "rejected"}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_text(value: Any, limit: int = 300) -> str:
+    text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _plan_kind(payload: dict[str, Any]) -> str:
+    schema = str(payload.get("schema_version", ""))
+    if schema not in SUPPORTED_PLAN_SCHEMAS:
+        raise ValueError(f"unsupported remediation plan schema: {schema}")
+    return SUPPORTED_PLAN_SCHEMAS[schema]
+
+
+def _proof_commands(payload: dict[str, Any]) -> list[str]:
+    return [_safe_text(value, 240) for value in _as_list(payload.get("proof_commands"))][:6]
+
+
+def _rollback_notes(payload: dict[str, Any]) -> list[str]:
+    notes = [_safe_text(value, 240) for value in _as_list(payload.get("rollback_notes"))]
+    if notes:
+        return notes[:6]
+    if bool(payload.get("safe_to_auto_fix")):
+        return ["Revert the safe-fix commit if proof fails."]
+    return ["Keep patch review scoped; revert human changes if focused proof fails."]
+
+
+def _guardrails(payload: dict[str, Any]) -> dict[str, Any]:
+    guardrails = _as_dict(payload.get("guardrails"))
+    if guardrails:
+        return guardrails
+    return {
+        "deterministic_reproduction_required": True,
+        "post_fix_proof_required": True,
+        "automation_mutation_allowed": bool(payload.get("safe_to_auto_fix")),
+    }
+
+
+def build_audit_record(
+    plan: dict[str, Any], *, source_path: str = "", outcome: str = "planned", note: str = ""
+) -> dict[str, Any]:
+    if outcome not in VALID_OUTCOMES:
+        raise ValueError(f"outcome must be one of {', '.join(sorted(VALID_OUTCOMES))}")
+    kind = _plan_kind(plan)
+    source_code = str(plan.get("source_code", "UNKNOWN") or "UNKNOWN")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "recorded_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "outcome": outcome,
+        "plan_kind": kind,
+        "plan_schema_version": str(plan.get("schema_version", "")),
+        "source_path": source_path,
+        "source_code": source_code,
+        "source_status": str(plan.get("source_status", "unknown")),
+        "action_type": str(plan.get("fix_type", plan.get("status", kind))),
+        "safe_to_auto_fix": bool(plan.get("safe_to_auto_fix")),
+        "requires_human_review": bool(plan.get("requires_human_review", True)),
+        "dry_run_only": bool(plan.get("dry_run_only", not bool(plan.get("safe_to_auto_fix")))),
+        "changed_file_scope": _as_list(plan.get("affected_files"))[:8],
+        "guardrails": _guardrails(plan),
+        "proof_commands": _proof_commands(plan),
+        "rollback_notes": _rollback_notes(plan),
+        "reason": _safe_text(plan.get("reason"), 600),
+        "note": _safe_text(note, 500),
+    }
+
+
+def append_record(db_path: Path, record: dict[str, Any]) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with db_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def read_records(db_path: Path) -> list[dict[str, Any]]:
+    if not db_path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(db_path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSONL at line {line_number}: {exc}") from exc
+        if isinstance(payload, dict):
+            records.append(payload)
+    return records
+
+
+def _record_key(row: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(row.get("source_path", "")),
+        str(row.get("plan_kind", "unknown")),
+        str(row.get("source_code", "UNKNOWN")),
+        str(row.get("action_type", "unknown")),
+    )
+
+
+def _proof_enforcement(records: list[dict[str, Any]]) -> dict[str, Any]:
+    terminal_by_key: dict[tuple[str, str, str, str], set[str]] = {}
+    pending_records: list[dict[str, Any]] = []
+    failed_records: list[dict[str, Any]] = []
+    for row in records:
+        outcome = str(row.get("outcome", "unknown"))
+        key = _record_key(row)
+        if outcome in {"proof_passed", "proof_failed", "reverted", "rejected"}:
+            terminal_by_key.setdefault(key, set()).add(outcome)
+        if outcome in {"planned", "applied"}:
+            pending_records.append(row)
+        if outcome == "proof_failed":
+            failed_records.append(row)
+    missing_proof = [
+        row
+        for row in pending_records
+        if not terminal_by_key.get(_record_key(row), set()).intersection(
+            {"proof_passed", "proof_failed", "reverted", "rejected"}
+        )
+    ]
+    if failed_records:
+        recommendation = "NO_SHIP"
+        next_owner_action = (
+            "Block release signoff until failed remediation proof is fixed or reverted."
+        )
+    elif missing_proof:
+        recommendation = "SHIP_WITH_CONTROLS"
+        next_owner_action = (
+            "Collect post-fix proof or rejection/revert records before final release signoff."
+        )
+    else:
+        recommendation = "SHIP"
+        next_owner_action = "Proof outcomes are complete for recorded remediation decisions."
+    return {
+        "recommendation": recommendation,
+        "next_owner_action": next_owner_action,
+        "missing_proof_count": len(missing_proof),
+        "proof_failed_count": len(failed_records),
+        "missing_proof_records": missing_proof[:10],
+        "proof_failed_records": failed_records[:10],
+    }
+
+
+def summarize_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    outcomes = Counter(str(row.get("outcome", "unknown")) for row in records)
+    plan_kinds = Counter(str(row.get("plan_kind", "unknown")) for row in records)
+    source_codes = Counter(str(row.get("source_code", "UNKNOWN")) for row in records)
+    unsafe_mutation_attempts = [
+        row
+        for row in records
+        if bool(_as_dict(row.get("guardrails")).get("automation_mutation_allowed"))
+        and bool(row.get("requires_human_review"))
+    ]
+    proof = _proof_enforcement(records)
+    return {
+        "schema_version": SUMMARY_SCHEMA_VERSION,
+        "ok": not unsafe_mutation_attempts and proof["recommendation"] != "NO_SHIP",
+        "recommendation": proof["recommendation"],
+        "next_owner_action": proof["next_owner_action"],
+        "record_count": len(records),
+        "outcomes": dict(sorted(outcomes.items())),
+        "plan_kinds": dict(sorted(plan_kinds.items())),
+        "top_source_codes": [
+            {"code": code, "count": count} for code, count in source_codes.most_common(10)
+        ],
+        "unsafe_mutation_attempt_count": len(unsafe_mutation_attempts),
+        "missing_proof_count": proof["missing_proof_count"],
+        "proof_failed_count": proof["proof_failed_count"],
+        "missing_proof_records": proof["missing_proof_records"],
+        "proof_failed_records": proof["proof_failed_records"],
+        "latest_records": records[-5:],
+    }
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    if payload.get("schema_version") == SUMMARY_SCHEMA_VERSION:
+        lines = [
+            f"schema_version={payload['schema_version']}",
+            f"ok={str(payload['ok']).lower()}",
+            f"recommendation={payload['recommendation']}",
+            f"record_count={payload['record_count']}",
+            f"unsafe_mutation_attempt_count={payload['unsafe_mutation_attempt_count']}",
+            f"missing_proof_count={payload['missing_proof_count']}",
+            f"proof_failed_count={payload['proof_failed_count']}",
+        ]
+        for row in _as_list(payload.get("top_source_codes"))[:5]:
+            item = _as_dict(row)
+            lines.append(f"source_code={item.get('code')}|count={item.get('count')}")
+        return "\n".join(lines) + "\n"
+    return (
+        f"schema_version={payload['schema_version']}\n"
+        f"outcome={payload['outcome']}\n"
+        f"plan_kind={payload['plan_kind']}\n"
+        f"source_code={payload['source_code']}\n"
+        f"safe_to_auto_fix={str(payload['safe_to_auto_fix']).lower()}\n"
+        f"requires_human_review={str(payload['requires_human_review']).lower()}\n"
+    )
+
+
+def record_from_file(
+    plan_path: Path, db_path: Path, *, outcome: str = "planned", note: str = ""
+) -> dict[str, Any]:
+    plan = _load_json(plan_path)
+    record = build_audit_record(plan, source_path=plan_path.as_posix(), outcome=outcome, note=note)
+    append_record(db_path, record)
+    return record
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_fix_audit")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    record = sub.add_parser("record", help="Append a remediation plan audit record")
+    record.add_argument("plan_json")
+    record.add_argument("--db", default=".sdetkit/adaptive-fix-audit.jsonl")
+    record.add_argument("--outcome", choices=sorted(VALID_OUTCOMES), default="planned")
+    record.add_argument("--note", default="")
+    record.add_argument("--format", choices=["text", "json"], default="text")
+    summarize = sub.add_parser("summarize", help="Summarize adaptive fix-audit records")
+    summarize.add_argument("--db", default=".sdetkit/adaptive-fix-audit.jsonl")
+    summarize.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.cmd == "record":
+            payload = record_from_file(
+                Path(args.plan_json), Path(args.db), outcome=str(args.outcome), note=str(args.note)
+            )
+        else:
+            payload = summarize_records(read_records(Path(args.db)))
+        if args.format == "json":
+            sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        else:
+            sys.stdout.write(render_text(payload))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_fix_audit.py
+++ b/src/sdetkit/adaptive_fix_audit.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import sys
 from collections import Counter
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -77,7 +77,7 @@ def build_audit_record(
     source_code = str(plan.get("source_code", "UNKNOWN") or "UNKNOWN")
     return {
         "schema_version": SCHEMA_VERSION,
-        "recorded_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "recorded_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "outcome": outcome,
         "plan_kind": kind,
         "plan_schema_version": str(plan.get("schema_version", "")),

--- a/src/sdetkit/adaptive_integration_adapters.py
+++ b/src/sdetkit/adaptive_integration_adapters.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive.integration_adapter_contract.v1"
+PROVIDERS = {"github-actions", "gitlab", "jenkins", "local"}
+REQUIRED_INPUTS = ("adaptive_diagnosis_json", "operator_brief_md")
+OPTIONAL_INPUTS = ("fix_audit_jsonl", "portfolio_rollup_json", "enterprise_governance_json")
+UPLOAD_TARGETS = {
+    "github-actions": "actions-artifact",
+    "gitlab": "job-artifacts",
+    "jenkins": "archiveArtifacts",
+    "local": "filesystem",
+}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _artifact_map(payload: dict[str, Any]) -> dict[str, str]:
+    raw = _as_dict(payload.get("artifacts", payload))
+    return {str(key): str(value) for key, value in raw.items() if str(value).strip()}
+
+
+def _resolve(root: Path, value: str) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else root / path
+
+
+def validate_adapter_contract(
+    *, provider: str, artifacts: dict[str, str], root: Path | None = None
+) -> dict[str, Any]:
+    if provider not in PROVIDERS:
+        raise ValueError(f"provider must be one of {', '.join(sorted(PROVIDERS))}")
+    base = root or Path.cwd()
+    normalized: dict[str, str] = {}
+    missing: list[str] = []
+    present: list[str] = []
+    for name in (*REQUIRED_INPUTS, *OPTIONAL_INPUTS):
+        value = artifacts.get(name, "")
+        if not value:
+            if name in REQUIRED_INPUTS:
+                missing.append(name)
+            continue
+        path = _resolve(base, value)
+        normalized[name] = path.as_posix()
+        if path.exists():
+            present.append(name)
+        elif name in REQUIRED_INPUTS:
+            missing.append(name)
+    outputs = {
+        "upload_target": UPLOAD_TARGETS[provider],
+        "artifact_names": [
+            name for name in (*REQUIRED_INPUTS, *OPTIONAL_INPUTS) if name in normalized
+        ],
+        "local_retention_dir": (base / "build" / "sdetkit").as_posix(),
+    }
+    ok = not missing
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": ok,
+        "provider": provider,
+        "required_inputs": list(REQUIRED_INPUTS),
+        "optional_inputs": list(OPTIONAL_INPUTS),
+        "present_inputs": present,
+        "missing_inputs": missing,
+        "normalized_artifacts": normalized,
+        "outputs": outputs,
+        "recommendation": "READY" if ok else "BLOCKED",
+        "next_owner_action": "Adapter contract is ready for CI artifact upload."
+        if ok
+        else "Generate the missing adaptive artifacts before running this adapter.",
+    }
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"schema_version={payload['schema_version']}",
+        f"ok={str(payload['ok']).lower()}",
+        f"provider={payload['provider']}",
+        f"recommendation={payload['recommendation']}",
+        f"missing_inputs={','.join(payload.get('missing_inputs', []))}",
+        f"upload_target={_as_dict(payload.get('outputs')).get('upload_target')}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_integration_adapters")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    validate = sub.add_parser("validate", help="Validate adaptive integration adapter artifacts")
+    validate.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    validate.add_argument(
+        "--artifacts", required=True, help="JSON file containing artifact path map"
+    )
+    validate.add_argument("--root", default=".")
+    validate.add_argument("--format", choices=["text", "json"], default="text")
+    validate.add_argument("--out", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        artifact_map = _artifact_map(_load_json(Path(args.artifacts)))
+        payload = validate_adapter_contract(
+            provider=str(args.provider), artifacts=artifact_map, root=Path(args.root)
+        )
+        rendered = (
+            json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            if args.format == "json"
+            else render_text(payload)
+        )
+        if args.out:
+            out_path = Path(args.out)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0 if payload.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_learning_import.py
+++ b/src/sdetkit/adaptive_learning_import.py
@@ -264,7 +264,11 @@ def main(argv: list[str] | None = None) -> int:
         else:
             payload = _load_json(path)
         result = build_learning_import(payload)
-        rendered = json.dumps(result, indent=2, sort_keys=True) + "\n" if args.format == "json" else render_text(result)
+        rendered = (
+            json.dumps(result, indent=2, sort_keys=True) + "\n"
+            if args.format == "json"
+            else render_text(result)
+        )
         if args.out:
             out_path = Path(args.out)
             out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/sdetkit/adaptive_learning_import.py
+++ b/src/sdetkit/adaptive_learning_import.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive.learning_import.v1"
+SUPPORTED_EXPORT_SCHEMA = "sdetkit.adaptive.enterprise_learning_export.v1"
+REDACTED = "<redacted>"
+PRIVATE_KEYS = {
+    "repo",
+    "repository",
+    "source_path",
+    "note",
+    "changed_file_scope",
+    "affected_files",
+    "files",
+    "url",
+    "issue_url",
+    "hostname",
+    "host",
+    "user",
+    "username",
+}
+PATH_PATTERN = re.compile(r"(^|[\s=:/\\])([A-Za-z]:)?([./~]?[^\s|,;:]+[\\/][^\s|,;:]+)")
+FILE_PATTERN = re.compile(r"\b[\w.-]+\.(py|toml|yaml|yml|json|md|txt|log|ini|cfg)\b")
+URL_PATTERN = re.compile(r"https?://[^\s]+")
+HOSTNAME_PATTERN = re.compile(
+    r"\b(?!(?:sdetkit|adaptive|enterprise|learning|export|schema|version)\b)"
+    r"[a-zA-Z0-9][a-zA-Z0-9-]*(?:\.[a-zA-Z0-9][a-zA-Z0-9-]*)+\b"
+)
+EMAIL_PATTERN = re.compile(r"\b[^\s@]+@[^\s@]+\.[^\s@]+\b")
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_text(value: Any, limit: int = 240) -> str:
+    text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object at line {line_number}")
+        records.append(payload)
+    return records
+
+
+def _records_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    if payload.get("schema_version") == SUPPORTED_EXPORT_SCHEMA:
+        return [_as_dict(row) for row in _as_list(payload.get("records")) if isinstance(row, dict)]
+    if "records" in payload:
+        return [_as_dict(row) for row in _as_list(payload.get("records")) if isinstance(row, dict)]
+    return [payload]
+
+
+def _is_redacted_value(value: Any) -> bool:
+    if value == REDACTED:
+        return True
+    if isinstance(value, list):
+        return all(item == REDACTED for item in value)
+    return False
+
+
+def _private_identifier_code(value: str) -> str | None:
+    if URL_PATTERN.search(value):
+        return "PRIVATE_URL_PATTERN"
+    if EMAIL_PATTERN.search(value):
+        return "PRIVATE_EMAIL_PATTERN"
+    if PATH_PATTERN.search(value) or FILE_PATTERN.search(value):
+        return "PRIVATE_IDENTIFIER_PATTERN"
+    if HOSTNAME_PATTERN.search(value):
+        return "PRIVATE_HOSTNAME_PATTERN"
+    return None
+
+
+def _redaction_findings(value: Any, path: str = "$") -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            child_path = f"{path}.{key}"
+            if key in PRIVATE_KEYS and not _is_redacted_value(item):
+                findings.append(
+                    {
+                        "code": "PRIVATE_FIELD_NOT_REDACTED",
+                        "severity": "critical",
+                        "path": child_path,
+                        "message": f"Private field {key} must be {REDACTED} before import.",
+                    }
+                )
+            findings.extend(_redaction_findings(item, child_path))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            findings.extend(_redaction_findings(item, f"{path}[{index}]"))
+    elif isinstance(value, str) and value != REDACTED:
+        code = _private_identifier_code(value)
+        if code is not None:
+            findings.append(
+                {
+                    "code": code,
+                    "severity": "critical",
+                    "path": path,
+                    "message": (
+                        "String looks like a private path, URL, hostname, email, or file "
+                        "identifier and cannot be imported."
+                    ),
+                    "evidence": _safe_text(value, 120),
+                }
+            )
+    return findings
+
+
+def _scenario_code(row: dict[str, Any]) -> str:
+    for key in ("source_code", "code", "scenario_code"):
+        value = row.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "UNKNOWN"
+
+
+def _calibration_hints(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "records": 0,
+            "proof_passed_count": 0,
+            "proof_failed_count": 0,
+            "false_positive_count": 0,
+            "fix_accepted_count": 0,
+            "outcomes": Counter(),
+        }
+    )
+    for row in records:
+        code = _scenario_code(row)
+        group = groups[code]
+        group["records"] += 1
+        outcome = str(row.get("outcome", "unknown"))
+        group["outcomes"][outcome] += 1
+        if outcome == "proof_passed" or bool(row.get("proof_passed")):
+            group["proof_passed_count"] += 1
+        if outcome == "proof_failed" or bool(row.get("proof_failed")):
+            group["proof_failed_count"] += 1
+        if bool(row.get("false_positive")):
+            group["false_positive_count"] += 1
+        if bool(row.get("fix_accepted")):
+            group["fix_accepted_count"] += 1
+    hints: list[dict[str, Any]] = []
+    for code, group in sorted(groups.items()):
+        action = "observe"
+        confidence_delta = 0
+        risk_delta = 0
+        if group["false_positive_count"]:
+            action = "demote"
+            confidence_delta = -2
+            risk_delta = -10
+        elif group["proof_failed_count"]:
+            action = "review_guardrail"
+            confidence_delta = -1
+            risk_delta = 8
+        elif group["proof_passed_count"] or group["fix_accepted_count"]:
+            action = "promote"
+            confidence_delta = 1
+            risk_delta = 4
+        hints.append(
+            {
+                "scenario_code": code,
+                "records": group["records"],
+                "action": action,
+                "confidence_delta": confidence_delta,
+                "risk_delta": risk_delta,
+                "proof_passed_count": group["proof_passed_count"],
+                "proof_failed_count": group["proof_failed_count"],
+                "false_positive_count": group["false_positive_count"],
+                "fix_accepted_count": group["fix_accepted_count"],
+                "outcomes": dict(sorted(group["outcomes"].items())),
+            }
+        )
+    return hints
+
+
+def build_learning_import(payload: dict[str, Any]) -> dict[str, Any]:
+    records = _records_from_payload(payload)
+    findings: list[dict[str, Any]] = []
+    for index, record in enumerate(records):
+        findings.extend(_redaction_findings(record, f"$.records[{index}]"))
+    hints = [] if findings else _calibration_hints(records)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": not findings,
+        "recommendation": "IMPORT" if not findings else "REJECT_IMPORT",
+        "record_count": len(records),
+        "finding_count": len(findings),
+        "findings": findings[:20],
+        "calibration_hints": hints,
+        "calibration_hint_count": len(hints),
+        "privacy_controls": {
+            "required_placeholder": REDACTED,
+            "private_keys": sorted(PRIVATE_KEYS),
+            "raw_path_detection": True,
+            "url_hostname_email_detection": True,
+        },
+        "next_owner_action": "Import calibration hints into local adaptive review only."
+        if not findings
+        else "Reject import and re-run anonymized export/redaction before sharing learning.",
+    }
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"schema_version={payload['schema_version']}",
+        f"ok={str(payload['ok']).lower()}",
+        f"recommendation={payload['recommendation']}",
+        f"record_count={payload['record_count']}",
+        f"finding_count={payload['finding_count']}",
+        f"calibration_hint_count={payload['calibration_hint_count']}",
+    ]
+    for row in _as_list(payload.get("calibration_hints"))[:8]:
+        item = _as_dict(row)
+        lines.append(
+            f"hint={item.get('scenario_code')}|action={item.get('action')}|records={item.get('records')}"
+        )
+    for row in _as_list(payload.get("findings"))[:8]:
+        item = _as_dict(row)
+        lines.append(f"finding={item.get('code')}|{item.get('path')}|{item.get('message')}")
+    lines.append(f"next_owner_action={payload['next_owner_action']}")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_learning_import")
+    parser.add_argument("learning_export", help="Anonymized learning JSON export or JSONL records")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--out", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        path = Path(args.learning_export)
+        if path.suffix.lower() == ".jsonl":
+            payload = {"records": _load_jsonl(path)}
+        else:
+            payload = _load_json(path)
+        result = build_learning_import(payload)
+        rendered = json.dumps(result, indent=2, sort_keys=True) + "\n" if args.format == "json" else render_text(result)
+        if args.out:
+            out_path = Path(args.out)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_patch_plan.py
+++ b/src/sdetkit/adaptive_patch_plan.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive.patch_plan.v1"
+SOURCE_SCHEMA_VERSION = "sdetkit.adaptive.diagnosis.v1"
+SAFE_MECHANICAL_CODES = {"PRE_COMMIT_FORMAT_DRIFT", "RUFF_FIXABLE_LINT"}
+ACTIONABLE_STATUSES = {"needs_fix", "needs_attention"}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_text(value: Any, limit: int = 300) -> str:
+    text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _load_diagnosis(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    if payload.get("schema_version") != SOURCE_SCHEMA_VERSION:
+        raise ValueError(f"unsupported adaptive diagnosis schema in {path}")
+    return payload
+
+
+def _first_diagnosis(payload: dict[str, Any]) -> dict[str, Any]:
+    for item in _as_list(payload.get("diagnoses")):
+        row = _as_dict(item)
+        if row:
+            return row
+    return {}
+
+
+def _candidate_scenarios(diagnosis: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for item in _as_list(diagnosis.get("evidence")):
+        text = str(item)
+        if not text.startswith("candidate_scenarios="):
+            continue
+        for code in text.split("=", 1)[1].split(","):
+            code = code.strip()
+            if code and code not in out:
+                out.append(code)
+    return out
+
+
+def _target_files(diagnosis: dict[str, Any]) -> list[str]:
+    files = [_safe_text(value, 180) for value in _as_list(diagnosis.get("affected_files"))]
+    return [value for value in files if value and "<" not in value and ">" not in value]
+
+
+def _proof_commands(diagnosis: dict[str, Any]) -> list[str]:
+    commands = [_safe_text(value, 240) for value in _as_list(diagnosis.get("proof_commands"))]
+    return [command for command in commands if command][:4]
+
+
+def _confidence_meets_review_threshold(diagnosis: dict[str, Any]) -> bool:
+    return str(diagnosis.get("confidence", "low")) in {"medium", "high"}
+
+
+def _reproduction_available(diagnosis: dict[str, Any]) -> bool:
+    return bool(_proof_commands(diagnosis))
+
+
+def _patch_steps(diagnosis: dict[str, Any]) -> list[dict[str, Any]]:
+    code = _safe_text(diagnosis.get("code") or "UNKNOWN", 80)
+    files = _target_files(diagnosis) or ["<identify-from-first-proof>"]
+    candidates = _candidate_scenarios(diagnosis)
+    steps: list[dict[str, Any]] = [
+        {
+            "order": 1,
+            "action": "reproduce",
+            "target": _proof_commands(diagnosis)[:1] or ["<run-first-proof-command>"],
+            "rationale": "Confirm the failure deterministically before proposing code changes.",
+            "mutation_allowed": False,
+        },
+        {
+            "order": 2,
+            "action": "inspect_scope",
+            "target": files,
+            "rationale": "Limit review to the first failing file, traceback, or contract surface.",
+            "mutation_allowed": False,
+        },
+        {
+            "order": 3,
+            "action": "draft_patch_hypothesis",
+            "target": candidates[:3] or [code],
+            "rationale": "Write a human-reviewed patch hypothesis tied to scenario evidence, not a broad rewrite.",
+            "mutation_allowed": False,
+        },
+        {
+            "order": 4,
+            "action": "prove_after_patch",
+            "target": _proof_commands(diagnosis) or ["<rerun-focused-proof>"],
+            "rationale": "Any human-applied patch must be followed by the same focused proof commands.",
+            "mutation_allowed": False,
+        },
+    ]
+    return steps
+
+
+def build_patch_plan(payload: dict[str, Any]) -> dict[str, Any]:
+    diagnosis = _first_diagnosis(payload)
+    code = _safe_text(diagnosis.get("code") or "UNKNOWN", 80)
+    source_status = str(payload.get("status", "unknown"))
+    confidence = str(diagnosis.get("confidence", payload.get("confidence", "unknown")))
+    proof_commands = _proof_commands(diagnosis)
+    actionable = bool(diagnosis) and source_status in ACTIONABLE_STATUSES
+    mechanical = code in SAFE_MECHANICAL_CODES
+    confidence_ready = _confidence_meets_review_threshold(diagnosis)
+    reproduction_ready = _reproduction_available(diagnosis)
+    plan_status = "review_required" if actionable and not mechanical else "not_applicable"
+    if not diagnosis:
+        reason = "No diagnosis was available to build an assisted patch plan."
+    elif mechanical:
+        reason = f"{code} is a safe mechanical diagnosis; use adaptive safe-fix planning instead."
+    elif not actionable:
+        reason = (
+            f"source status {source_status} is not actionable enough for assisted patch planning."
+        )
+    else:
+        reason = (
+            f"{code} is not approved for automatic remediation; this is a review-only patch plan "
+            "that preserves human ownership and proof-first sequencing."
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_schema_version": str(payload.get("schema_version", "")),
+        "ok": True,
+        "status": plan_status,
+        "source_status": source_status,
+        "source_code": code,
+        "confidence": confidence,
+        "safe_to_auto_fix": False,
+        "dry_run_only": True,
+        "requires_human_review": True,
+        "reason": reason,
+        "guardrails": {
+            "deterministic_reproduction_required": True,
+            "deterministic_reproduction_available": reproduction_ready,
+            "scenario_confidence_threshold": "medium",
+            "scenario_confidence_threshold_met": confidence_ready,
+            "changed_file_scope_limit": "review identified files only",
+            "post_fix_proof_required": True,
+            "automation_mutation_allowed": False,
+        },
+        "candidate_scenarios": _candidate_scenarios(diagnosis),
+        "affected_files": _target_files(diagnosis),
+        "proof_commands": proof_commands,
+        "patch_steps": [] if plan_status == "not_applicable" else _patch_steps(diagnosis),
+        "rollback_notes": [
+            "Keep changes in a small reviewable commit.",
+            "If focused proof fails, revert the patch and record the diagnosis feedback event.",
+        ],
+    }
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"schema_version={payload['schema_version']}",
+        f"status={payload['status']}",
+        f"source_code={payload['source_code']}",
+        f"safe_to_auto_fix={str(payload['safe_to_auto_fix']).lower()}",
+        f"requires_human_review={str(payload['requires_human_review']).lower()}",
+        f"reason={payload['reason']}",
+    ]
+    for step in _as_list(payload.get("patch_steps")):
+        row = _as_dict(step)
+        lines.append(f"step={row.get('order')}|{row.get('action')}|mutation_allowed=false")
+    return "\n".join(lines) + "\n"
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Adaptive assisted patch plan",
+        "",
+        f"- Status: `{payload['status']}`",
+        f"- Source code: `{payload['source_code']}`",
+        f"- Safe to auto-fix: `{str(payload['safe_to_auto_fix']).lower()}`",
+        f"- Requires human review: `{str(payload['requires_human_review']).lower()}`",
+        f"- Reason: {payload['reason']}",
+        "",
+        "## Guardrails",
+        "",
+    ]
+    for key, value in _as_dict(payload.get("guardrails")).items():
+        lines.append(f"- `{key}`: `{str(value).lower() if isinstance(value, bool) else value}`")
+    lines += ["", "## Review-only steps", ""]
+    if not _as_list(payload.get("patch_steps")):
+        lines.append("- No assisted patch steps are applicable for this diagnosis.")
+    for step in _as_list(payload.get("patch_steps")):
+        row = _as_dict(step)
+        lines.append(
+            f"{row.get('order')}. **{row.get('action')}** — {row.get('rationale')} "
+            f"Mutation allowed: `{str(row.get('mutation_allowed')).lower()}`."
+        )
+    lines += ["", "## Proof commands", ""]
+    for command in _as_list(payload.get("proof_commands")):
+        lines.append(f"- `{command}`")
+    if not _as_list(payload.get("proof_commands")):
+        lines.append("- `<add-focused-proof-command>`")
+    return "\n".join(lines) + "\n"
+
+
+def patch_plan_from_file(diagnosis_path: Path, out_path: Path | None = None) -> dict[str, Any]:
+    plan = build_patch_plan(_load_diagnosis(diagnosis_path))
+    plan["source_path"] = diagnosis_path.as_posix()
+    if out_path is not None:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return plan
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_patch_plan")
+    parser.add_argument("diagnosis_json")
+    parser.add_argument("--format", choices=["text", "json", "md"], default="text")
+    parser.add_argument("--out", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        plan = patch_plan_from_file(Path(args.diagnosis_json))
+        if args.format == "json":
+            rendered = json.dumps(plan, indent=2, sort_keys=True) + "\n"
+        elif args.format == "md":
+            rendered = render_markdown(plan)
+        else:
+            rendered = render_text(plan)
+        if args.out:
+            out_path = Path(args.out)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_portfolio_rollup.py
+++ b/src/sdetkit/adaptive_portfolio_rollup.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive.portfolio_rollup.v1"
+SEVERITY_SCORE = {"high": 30, "medium": 18, "low": 8, "info": 3}
+STATUS_RANK = {"needs_fix": 4, "needs_attention": 3, "monitor": 2, "clear": 1}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value.strip())
+    return 0
+
+
+def _safe(value: Any, limit: int = 240) -> str:
+    text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _repo_name(payload: dict[str, Any], path: Path | None = None) -> str:
+    for key in ("repo", "repository", "repo_name"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    metadata = _as_dict(payload.get("metadata"))
+    for key in ("repo", "repository", "repo_name"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if path is not None:
+        return path.parent.name or path.stem
+    return "unknown"
+
+
+def _diagnosis_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = [_as_dict(item) for item in _as_list(payload.get("diagnoses"))]
+    return [row for row in rows if row]
+
+
+def _candidate_codes(row: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for item in _as_list(row.get("evidence")):
+        text = str(item)
+        if not text.startswith("candidate_scenarios="):
+            continue
+        for code in text.split("=", 1)[1].split(","):
+            code = code.strip()
+            if code and code not in out:
+                out.append(code)
+    return out
+
+
+def _append_scenario(
+    scenarios: dict[str, dict[str, Any]],
+    *,
+    code: str,
+    title: str,
+    repo: str,
+    severity: str,
+    confidence: str,
+    repeat_count: int,
+    risk_points: int,
+    source: str,
+) -> None:
+    row = scenarios.setdefault(
+        code,
+        {
+            "code": code,
+            "title": _safe(title, 160),
+            "repo_count": 0,
+            "repos": [],
+            "occurrences": 0,
+            "candidate_mentions": 0,
+            "severity_counts": {},
+            "confidence_counts": {},
+            "repeat_count": 0,
+            "risk_points": 0,
+            "source_counts": {},
+        },
+    )
+    if repo not in row["repos"]:
+        row["repos"].append(repo)
+        row["repo_count"] = len(row["repos"])
+    row["occurrences"] += 1
+    if source == "candidate":
+        row["candidate_mentions"] += 1
+    row["repeat_count"] += max(0, repeat_count)
+    row["risk_points"] += max(0, risk_points)
+    row["severity_counts"][severity] = _as_int(row["severity_counts"].get(severity)) + 1
+    row["confidence_counts"][confidence] = _as_int(row["confidence_counts"].get(confidence)) + 1
+    row["source_counts"][source] = _as_int(row["source_counts"].get(source)) + 1
+
+
+def _risk_points(payload: dict[str, Any], row: dict[str, Any]) -> int:
+    severity = str(row.get("severity", "info"))
+    repeat_count = _as_int(row.get("repeat_count"))
+    return (
+        SEVERITY_SCORE.get(severity, 3)
+        + min(repeat_count, 5) * 2
+        + min(
+            _as_int(payload.get("risk_score")),
+            100,
+        )
+        // 10
+    )
+
+
+def build_portfolio_rollup(
+    payloads: Sequence[dict[str, Any]], paths: Sequence[Path] | None = None
+) -> dict[str, Any]:
+    path_list = list(paths or [])
+    scenarios: dict[str, dict[str, Any]] = {}
+    repo_status: dict[str, dict[str, Any]] = {}
+    repo_risk: dict[str, int] = defaultdict(int)
+    status_counts: Counter[str] = Counter()
+    confidence_counts: Counter[str] = Counter()
+
+    for index, payload in enumerate(payloads):
+        path = path_list[index] if index < len(path_list) else None
+        repo = _repo_name(payload, path)
+        status = str(payload.get("status", "unknown"))
+        status_counts[status] += 1
+        confidence_counts[str(payload.get("confidence", "unknown"))] += 1
+        repo_risk[repo] += _as_int(payload.get("risk_score"))
+        repo_status.setdefault(
+            repo,
+            {
+                "repo": repo,
+                "artifact_count": 0,
+                "max_status": "clear",
+                "risk_score": 0,
+                "diagnosis_count": 0,
+            },
+        )
+        repo_status[repo]["artifact_count"] += 1
+        repo_status[repo]["risk_score"] += _as_int(payload.get("risk_score"))
+        repo_status[repo]["diagnosis_count"] += _as_int(payload.get("diagnosis_count"))
+        if STATUS_RANK.get(status, 0) > STATUS_RANK.get(str(repo_status[repo]["max_status"]), 0):
+            repo_status[repo]["max_status"] = status
+
+        for row in _diagnosis_rows(payload):
+            code = _safe(row.get("code") or "UNKNOWN", 80)
+            risk_points = _risk_points(payload, row)
+            _append_scenario(
+                scenarios,
+                code=code,
+                title=str(row.get("title") or code),
+                repo=repo,
+                severity=str(row.get("severity", "info")),
+                confidence=str(row.get("confidence", "unknown")),
+                repeat_count=_as_int(row.get("repeat_count")),
+                risk_points=risk_points,
+                source="primary" if code else "unknown",
+            )
+            for candidate in _candidate_codes(row):
+                _append_scenario(
+                    scenarios,
+                    code=candidate,
+                    title=f"Candidate scenario {candidate}",
+                    repo=repo,
+                    severity="info",
+                    confidence="candidate",
+                    repeat_count=0,
+                    risk_points=max(1, risk_points // 3),
+                    source="candidate",
+                )
+
+    top_risk = sorted(
+        scenarios.values(),
+        key=lambda row: (
+            -_as_int(row.get("risk_points")),
+            -_as_int(row.get("repo_count")),
+            str(row.get("code")),
+        ),
+    )
+    repo_rows = sorted(
+        repo_status.values(),
+        key=lambda row: (-_as_int(row.get("risk_score")), str(row.get("repo"))),
+    )
+    needs_fix_repos = [row["repo"] for row in repo_rows if row.get("max_status") == "needs_fix"]
+    portfolio_risk_score = min(100, sum(repo_risk.values()))
+    recommendation = "NO_SHIP" if needs_fix_repos else "SHIP_WITH_CONTROLS" if top_risk else "SHIP"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": not needs_fix_repos,
+        "recommendation": recommendation,
+        "artifact_count": len(payloads),
+        "repo_count": len(repo_rows),
+        "portfolio_risk_score": portfolio_risk_score,
+        "status_counts": dict(sorted(status_counts.items())),
+        "confidence_counts": dict(sorted(confidence_counts.items())),
+        "needs_fix_repos": needs_fix_repos,
+        "top_risk_scenarios": top_risk[:10],
+        "recurrence_by_repo": repo_rows,
+        "next_owner_action": _next_owner_action(recommendation, top_risk, needs_fix_repos),
+    }
+
+
+def _next_owner_action(
+    recommendation: str, top_risk: Sequence[dict[str, Any]], needs_fix_repos: Sequence[str]
+) -> str:
+    if recommendation == "SHIP":
+        return "No adaptive diagnosis risks were present; keep collecting portfolio evidence."
+    if needs_fix_repos:
+        repo_list = ", ".join(needs_fix_repos[:5])
+        scenario = top_risk[0].get("code") if top_risk else "UNKNOWN"
+        return f"Block release signoff for {repo_list}; start with top scenario {scenario}."
+    scenario = top_risk[0].get("code") if top_risk else "UNKNOWN"
+    return (
+        f"Ship only with controls and review recurring scenario {scenario} before the next batch."
+    )
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"schema_version={payload['schema_version']}",
+        f"ok={str(payload['ok']).lower()}",
+        f"recommendation={payload['recommendation']}",
+        f"repo_count={payload['repo_count']}",
+        f"artifact_count={payload['artifact_count']}",
+        f"portfolio_risk_score={payload['portfolio_risk_score']}",
+    ]
+    for row in _as_list(payload.get("top_risk_scenarios"))[:5]:
+        item = _as_dict(row)
+        lines.append(
+            "scenario="
+            f"{item.get('code')}|risk={item.get('risk_points')}|repos={item.get('repo_count')}"
+        )
+    lines.append(f"next_owner_action={payload['next_owner_action']}")
+    return "\n".join(lines) + "\n"
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Adaptive Portfolio Rollup",
+        "",
+        f"- Recommendation: `{payload['recommendation']}`",
+        f"- OK: `{str(payload['ok']).lower()}`",
+        f"- Portfolio risk score: `{payload['portfolio_risk_score']}`",
+        f"- Repositories: `{payload['repo_count']}`",
+        f"- Artifacts: `{payload['artifact_count']}`",
+        "",
+        "## Top-risk scenarios",
+        "",
+        "| Scenario | Risk points | Repos | Occurrences | Candidate mentions |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for row in _as_list(payload.get("top_risk_scenarios"))[:10]:
+        item = _as_dict(row)
+        lines.append(
+            f"| `{item.get('code')}` | {item.get('risk_points')} | {item.get('repo_count')} | "
+            f"{item.get('occurrences')} | {item.get('candidate_mentions')} |"
+        )
+    if not _as_list(payload.get("top_risk_scenarios")):
+        lines.append("| none | 0 | 0 | 0 | 0 |")
+    lines += [
+        "",
+        "## Recurrence by repo",
+        "",
+        "| Repo | Max status | Risk score | Diagnosis count | Artifacts |",
+        "| --- | --- | ---: | ---: | ---: |",
+    ]
+    for row in _as_list(payload.get("recurrence_by_repo")):
+        item = _as_dict(row)
+        lines.append(
+            f"| `{item.get('repo')}` | `{item.get('max_status')}` | {item.get('risk_score')} | "
+            f"{item.get('diagnosis_count')} | {item.get('artifact_count')} |"
+        )
+    lines += ["", "## Next owner action", "", str(payload.get("next_owner_action", "")), ""]
+    return "\n".join(lines)
+
+
+def _load_payload(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_portfolio_rollup")
+    parser.add_argument("diagnosis_json", nargs="+", help="Adaptive diagnosis JSON artifact(s)")
+    parser.add_argument("--format", choices=["text", "json", "md"], default="text")
+    parser.add_argument("--out", default="")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(list(argv if argv is not None else sys.argv[1:]))
+    paths = [Path(item) for item in args.diagnosis_json]
+    try:
+        payload = build_portfolio_rollup([_load_payload(path) for path in paths], paths)
+        if args.format == "json":
+            rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        elif args.format == "md":
+            rendered = render_markdown(payload) + "\n"
+        else:
+            rendered = render_text(payload)
+        if args.out:
+            out_path = Path(args.out)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/adaptive_remediation_policy.py
+++ b/src/sdetkit/adaptive_remediation_policy.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive.remediation_policy.v1"
+RESULT_SCHEMA_VERSION = "sdetkit.adaptive.remediation_policy.result.v1"
+SAFE_FIX_SCHEMA_VERSION = "sdetkit.adaptive_safe_fix.v1"
+PATCH_PLAN_SCHEMA_VERSION = "sdetkit.adaptive.patch_plan.v1"
+DEFAULT_POLICY_PATH = "config/adaptive_remediation_policy.default.json"
+SAFE_BUILT_IN_FIX_TYPES = {"format_only", "ruff_fixable_lint"}
+UNSAFE_AUTO_FIX_TYPES = {"review_required", "unknown", "assisted_patch_plan"}
+UNSAFE_AUTO_SOURCE_CODES = {"UNKNOWN", "UNKNOWN_REVIEW_REQUIRED"}
+VALID_PROOF_OUTCOMES = {"proof_passed", "proof_failed", "reverted", "rejected"}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_text(value: Any, limit: int = 240) -> str:
+    text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return payload
+
+
+def default_policy() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "name": "default-adaptive-remediation-policy",
+        "allowed_safe_fix_types": sorted(SAFE_BUILT_IN_FIX_TYPES),
+        "max_changed_files": 8,
+        "required_proof_outcomes": ["proof_passed"],
+        "allow_review_required_auto_fix": False,
+        "blocked_auto_source_codes": sorted(UNSAFE_AUTO_SOURCE_CODES),
+    }
+
+
+def _policy_findings(policy: dict[str, Any]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    if policy.get("schema_version") != SCHEMA_VERSION:
+        findings.append(
+            {
+                "code": "POLICY_SCHEMA_UNSUPPORTED",
+                "severity": "high",
+                "message": f"Policy schema must be {SCHEMA_VERSION}.",
+            }
+        )
+    allowed_types = {str(item) for item in _as_list(policy.get("allowed_safe_fix_types"))}
+    if not allowed_types:
+        findings.append(
+            {
+                "code": "POLICY_ALLOWED_FIX_TYPES_EMPTY",
+                "severity": "high",
+                "message": "Policy must list at least one allowed safe-fix type.",
+            }
+        )
+    unsafe_types = sorted(allowed_types.intersection(UNSAFE_AUTO_FIX_TYPES))
+    if unsafe_types:
+        findings.append(
+            {
+                "code": "POLICY_UNSAFE_FIX_TYPE_ALLOWED",
+                "severity": "critical",
+                "message": "Policy cannot allow review-required or unknown automatic fixes.",
+                "evidence": unsafe_types,
+            }
+        )
+    if bool(policy.get("allow_review_required_auto_fix")):
+        findings.append(
+            {
+                "code": "POLICY_REVIEW_REQUIRED_AUTO_FIX_ENABLED",
+                "severity": "critical",
+                "message": "Review-required diagnoses must remain human-owned.",
+            }
+        )
+    max_changed_files = policy.get("max_changed_files")
+    if not isinstance(max_changed_files, int) or isinstance(max_changed_files, bool):
+        findings.append(
+            {
+                "code": "POLICY_CHANGED_FILE_SCOPE_INVALID",
+                "severity": "high",
+                "message": "max_changed_files must be an integer.",
+            }
+        )
+    elif max_changed_files < 0:
+        findings.append(
+            {
+                "code": "POLICY_CHANGED_FILE_SCOPE_NEGATIVE",
+                "severity": "high",
+                "message": "max_changed_files cannot be negative.",
+            }
+        )
+    required_outcomes = {str(item) for item in _as_list(policy.get("required_proof_outcomes"))}
+    if "proof_passed" not in required_outcomes:
+        findings.append(
+            {
+                "code": "POLICY_PROOF_PASS_REQUIRED",
+                "severity": "critical",
+                "message": "Policy must require proof_passed before remediation signoff.",
+            }
+        )
+    invalid_outcomes = sorted(required_outcomes.difference(VALID_PROOF_OUTCOMES))
+    if invalid_outcomes:
+        findings.append(
+            {
+                "code": "POLICY_PROOF_OUTCOME_INVALID",
+                "severity": "high",
+                "message": "Policy lists unsupported proof outcomes.",
+                "evidence": invalid_outcomes,
+            }
+        )
+    return findings
+
+
+def _plan_kind(plan: dict[str, Any]) -> str:
+    schema = str(plan.get("schema_version", ""))
+    if schema == SAFE_FIX_SCHEMA_VERSION:
+        return "safe_fix"
+    if schema == PATCH_PLAN_SCHEMA_VERSION:
+        return "assisted_patch_plan"
+    return "unknown"
+
+
+def _plan_findings(policy: dict[str, Any], plan: dict[str, Any]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    plan_kind = _plan_kind(plan)
+    safe_to_auto_fix = bool(plan.get("safe_to_auto_fix"))
+    requires_human_review = bool(plan.get("requires_human_review", True))
+    source_code = str(plan.get("source_code", "UNKNOWN") or "UNKNOWN")
+    fix_type = str(plan.get("fix_type", plan.get("status", "unknown")) or "unknown")
+    affected_files = [_safe_text(item) for item in _as_list(plan.get("affected_files"))]
+    proof_commands = [_safe_text(item) for item in _as_list(plan.get("proof_commands"))]
+    max_changed_files = int(policy.get("max_changed_files", 0))
+    allowed_types = {str(item) for item in _as_list(policy.get("allowed_safe_fix_types"))}
+    blocked_codes = {str(item) for item in _as_list(policy.get("blocked_auto_source_codes"))}
+    blocked_codes.update(UNSAFE_AUTO_SOURCE_CODES)
+
+    if plan_kind == "unknown":
+        findings.append(
+            {
+                "code": "PLAN_SCHEMA_UNSUPPORTED",
+                "severity": "high",
+                "message": "Plan must be an adaptive safe-fix or assisted patch-plan artifact.",
+            }
+        )
+        return findings
+
+    if safe_to_auto_fix:
+        if requires_human_review:
+            findings.append(
+                {
+                    "code": "PLAN_AUTO_FIX_REQUIRES_REVIEW",
+                    "severity": "critical",
+                    "message": "Plans requiring human review cannot be automatic fixes.",
+                }
+            )
+        if fix_type not in allowed_types:
+            findings.append(
+                {
+                    "code": "PLAN_FIX_TYPE_NOT_ALLOWED",
+                    "severity": "high",
+                    "message": f"Fix type {fix_type} is not allowed by policy.",
+                }
+            )
+        if source_code in blocked_codes:
+            findings.append(
+                {
+                    "code": "PLAN_SOURCE_CODE_BLOCKED_FOR_AUTO_FIX",
+                    "severity": "critical",
+                    "message": f"Source code {source_code} cannot be auto-fixed.",
+                }
+            )
+        if len(affected_files) > max_changed_files:
+            findings.append(
+                {
+                    "code": "PLAN_CHANGED_FILE_SCOPE_EXCEEDED",
+                    "severity": "high",
+                    "message": "Plan changes more files than the policy permits.",
+                    "evidence": {
+                        "affected_file_count": len(affected_files),
+                        "max_changed_files": max_changed_files,
+                    },
+                }
+            )
+        if not proof_commands:
+            findings.append(
+                {
+                    "code": "PLAN_PROOF_COMMANDS_MISSING",
+                    "severity": "critical",
+                    "message": "Automatic fixes must include proof commands.",
+                }
+            )
+    else:
+        if plan_kind == "assisted_patch_plan" and not bool(plan.get("dry_run_only", False)):
+            findings.append(
+                {
+                    "code": "PATCH_PLAN_NOT_DRY_RUN_ONLY",
+                    "severity": "critical",
+                    "message": "Assisted patch plans must remain dry-run-only.",
+                }
+            )
+        if not requires_human_review:
+            findings.append(
+                {
+                    "code": "REVIEW_REQUIRED_PLAN_NOT_HUMAN_OWNED",
+                    "severity": "critical",
+                    "message": "Non-auto remediation plans must require human review.",
+                }
+            )
+    return findings
+
+
+def evaluate_policy(policy: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
+    policy_findings = _policy_findings(policy)
+    plan_findings = [] if policy_findings else _plan_findings(policy, plan)
+    findings = policy_findings + plan_findings
+    critical = [row for row in findings if row.get("severity") == "critical"]
+    recommendation = "APPROVE"
+    if policy_findings:
+        recommendation = "REJECT_POLICY"
+    elif plan_findings:
+        recommendation = "REJECT_PLAN"
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "ok": not findings,
+        "recommendation": recommendation,
+        "policy_name": str(policy.get("name", "unnamed")),
+        "plan_kind": _plan_kind(plan),
+        "source_code": str(plan.get("source_code", "UNKNOWN") or "UNKNOWN"),
+        "fix_type": str(plan.get("fix_type", plan.get("status", "unknown")) or "unknown"),
+        "safe_to_auto_fix": bool(plan.get("safe_to_auto_fix")),
+        "affected_file_count": len(_as_list(plan.get("affected_files"))),
+        "finding_count": len(findings),
+        "critical_finding_count": len(critical),
+        "findings": findings,
+        "next_owner_action": _next_owner_action(recommendation, findings),
+    }
+
+
+def _next_owner_action(recommendation: str, findings: list[dict[str, Any]]) -> str:
+    if recommendation == "APPROVE":
+        return "Policy allows this remediation plan; keep proof evidence before signoff."
+    first = findings[0].get("code", "UNKNOWN") if findings else "UNKNOWN"
+    if recommendation == "REJECT_POLICY":
+        return f"Fix remediation policy before evaluating plans; first failure is {first}."
+    return f"Keep remediation review-first; fix or narrow the plan before execution ({first})."
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"schema_version={payload['schema_version']}",
+        f"ok={str(payload['ok']).lower()}",
+        f"recommendation={payload['recommendation']}",
+        f"plan_kind={payload['plan_kind']}",
+        f"source_code={payload['source_code']}",
+        f"fix_type={payload['fix_type']}",
+        f"safe_to_auto_fix={str(payload['safe_to_auto_fix']).lower()}",
+        f"finding_count={payload['finding_count']}",
+        f"critical_finding_count={payload['critical_finding_count']}",
+    ]
+    for row in _as_list(payload.get("findings")):
+        item = row if isinstance(row, dict) else {}
+        lines.append(f"finding={item.get('severity')}|{item.get('code')}|{item.get('message')}")
+    lines.append(f"next_owner_action={payload['next_owner_action']}")
+    return "\n".join(lines) + "\n"
+
+
+def _write_or_print(rendered: str, out: str) -> None:
+    if out:
+        out_path = Path(out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.adaptive_remediation_policy")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    template = sub.add_parser("template", help="Print the default adaptive remediation policy")
+    template.add_argument("--format", choices=["text", "json"], default="json")
+    template.add_argument("--out", default="")
+    validate = sub.add_parser("validate", help="Validate a remediation plan against policy")
+    validate.add_argument("plan_json")
+    validate.add_argument("--policy", default=DEFAULT_POLICY_PATH)
+    validate.add_argument("--format", choices=["text", "json"], default="text")
+    validate.add_argument("--out", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.cmd == "template":
+            policy = default_policy()
+            rendered = (
+                json.dumps(policy, indent=2, sort_keys=True) + "\n"
+                if args.format == "json"
+                else render_text(evaluate_policy(policy, {}))
+            )
+            _write_or_print(rendered, str(args.out))
+            return 0
+        policy = _load_json(Path(args.policy))
+        plan = _load_json(Path(args.plan_json))
+        payload = evaluate_policy(policy, plan)
+        rendered = (
+            json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            if args.format == "json"
+            else render_text(payload)
+        )
+        _write_or_print(rendered, str(args.out))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -422,6 +422,133 @@ Then use stability-aware command discovery:
     adaptive_brief.add_argument("--safe-fix-plan", default="")
     adaptive_brief.add_argument("--format", choices=["md", "json", "comment"], default="md")
     adaptive_brief.add_argument("--out", default="build/sdetkit/operator-brief.md")
+    adaptive_portfolio = adaptive_sub.add_parser(
+        "portfolio-rollup",
+        help="Roll multiple adaptive diagnosis outputs into a top-risk portfolio report",
+    )
+    adaptive_portfolio.add_argument("diagnosis_json", nargs="+")
+    adaptive_portfolio.add_argument("--format", choices=["text", "json", "md"], default="text")
+    adaptive_portfolio.add_argument("--out", default="")
+    adaptive_patch_plan = adaptive_sub.add_parser(
+        "patch-plan",
+        help="Build a review-only assisted patch plan from an adaptive diagnosis artifact",
+    )
+    adaptive_patch_plan.add_argument("diagnosis_json")
+    adaptive_patch_plan.add_argument("--format", choices=["text", "json", "md"], default="text")
+    adaptive_patch_plan.add_argument("--out", default="")
+    adaptive_fix_audit = adaptive_sub.add_parser(
+        "fix-audit", help="Record and summarize adaptive remediation audit events"
+    )
+    adaptive_fix_audit_sub = adaptive_fix_audit.add_subparsers(
+        dest="adaptive_fix_audit_cmd", required=True
+    )
+    adaptive_fix_audit_record = adaptive_fix_audit_sub.add_parser(
+        "record", help="Append a remediation plan audit record"
+    )
+    adaptive_fix_audit_record.add_argument("plan_json")
+    adaptive_fix_audit_record.add_argument("--db", default=".sdetkit/adaptive-fix-audit.jsonl")
+    adaptive_fix_audit_record.add_argument(
+        "--outcome",
+        choices=["planned", "applied", "proof_passed", "proof_failed", "reverted", "rejected"],
+        default="planned",
+    )
+    adaptive_fix_audit_record.add_argument("--note", default="")
+    adaptive_fix_audit_record.add_argument("--format", choices=["text", "json"], default="text")
+    adaptive_fix_audit_summary = adaptive_fix_audit_sub.add_parser(
+        "summarize", help="Summarize adaptive remediation audit records"
+    )
+    adaptive_fix_audit_summary.add_argument("--db", default=".sdetkit/adaptive-fix-audit.jsonl")
+    adaptive_fix_audit_summary.add_argument("--format", choices=["text", "json"], default="text")
+    adaptive_analytics = adaptive_sub.add_parser(
+        "enterprise-analytics",
+        help="Build leadership metrics from portfolio rollup and fix-audit evidence",
+    )
+    adaptive_analytics.add_argument("--portfolio", required=True)
+    adaptive_analytics.add_argument("--fix-audit", required=True)
+    adaptive_analytics.add_argument("--format", choices=["text", "json"], default="text")
+    adaptive_analytics.add_argument("--out", default="")
+    adaptive_remediation_policy = adaptive_sub.add_parser(
+        "remediation-policy",
+        help="Validate safe remediation plans against configurable guardrails",
+    )
+    adaptive_remediation_policy_sub = adaptive_remediation_policy.add_subparsers(
+        dest="adaptive_remediation_policy_cmd", required=True
+    )
+    adaptive_remediation_policy_template = adaptive_remediation_policy_sub.add_parser(
+        "template", help="Print the default adaptive remediation policy"
+    )
+    adaptive_remediation_policy_template.add_argument(
+        "--format", choices=["text", "json"], default="json"
+    )
+    adaptive_remediation_policy_template.add_argument("--out", default="")
+    adaptive_remediation_policy_validate = adaptive_remediation_policy_sub.add_parser(
+        "validate", help="Validate a remediation plan against policy"
+    )
+    adaptive_remediation_policy_validate.add_argument("plan_json")
+    adaptive_remediation_policy_validate.add_argument(
+        "--policy", default="config/adaptive_remediation_policy.default.json"
+    )
+    adaptive_remediation_policy_validate.add_argument(
+        "--format", choices=["text", "json"], default="text"
+    )
+    adaptive_remediation_policy_validate.add_argument("--out", default="")
+    adaptive_dashboard = adaptive_sub.add_parser(
+        "dashboard", help="Build a static local dashboard from adaptive artifacts"
+    )
+    for flag in (
+        "diagnosis",
+        "brief",
+        "portfolio",
+        "fix-audit",
+        "governance",
+        "adapter",
+        "analytics",
+        "remediation-policy",
+    ):
+        adaptive_dashboard.add_argument(f"--{flag}", default="")
+    adaptive_dashboard.add_argument("--format", choices=["html", "json"], default="html")
+    adaptive_dashboard.add_argument("--out", default="build/sdetkit/adaptive-dashboard.html")
+    adaptive_learning_import = adaptive_sub.add_parser(
+        "learning-import", help="Validate anonymized cross-repo learning and emit calibration hints"
+    )
+    adaptive_learning_import.add_argument("learning_export")
+    adaptive_learning_import.add_argument("--format", choices=["text", "json"], default="text")
+    adaptive_learning_import.add_argument("--out", default="")
+    adaptive_enterprise = adaptive_sub.add_parser(
+        "enterprise-governance",
+        help="Build enterprise adaptive governance reports and anonymized exports",
+    )
+    adaptive_enterprise_sub = adaptive_enterprise.add_subparsers(
+        dest="adaptive_enterprise_cmd", required=True
+    )
+    adaptive_enterprise_report = adaptive_enterprise_sub.add_parser(
+        "report", help="Build adaptive enterprise governance report"
+    )
+    adaptive_enterprise_report.add_argument("--root", default=".")
+    adaptive_enterprise_report.add_argument("--format", choices=["text", "json"], default="text")
+    adaptive_enterprise_report.add_argument("--out", default="")
+    adaptive_enterprise_export = adaptive_enterprise_sub.add_parser(
+        "anonymize-learning", help="Anonymize adaptive JSONL records for export"
+    )
+    adaptive_enterprise_export.add_argument("jsonl_path")
+    adaptive_enterprise_export.add_argument("--format", choices=["text", "json"], default="json")
+    adaptive_enterprise_export.add_argument("--out", default="")
+    adaptive_adapter = adaptive_sub.add_parser(
+        "integration-adapter", help="Validate adaptive CI integration adapter artifact contracts"
+    )
+    adaptive_adapter_sub = adaptive_adapter.add_subparsers(
+        dest="adaptive_adapter_cmd", required=True
+    )
+    adaptive_adapter_validate = adaptive_adapter_sub.add_parser(
+        "validate", help="Validate adaptive integration adapter artifacts"
+    )
+    adaptive_adapter_validate.add_argument(
+        "--provider", choices=["github-actions", "gitlab", "jenkins", "local"], required=True
+    )
+    adaptive_adapter_validate.add_argument("--artifacts", required=True)
+    adaptive_adapter_validate.add_argument("--root", default=".")
+    adaptive_adapter_validate.add_argument("--format", choices=["text", "json"], default="text")
+    adaptive_adapter_validate.add_argument("--out", default="")
     index_sub = index.add_subparsers(dest="index_cmd", required=False)
     index_build = index_sub.add_parser(
         "build", help="Build deterministic local repo index evidence"
@@ -485,6 +612,14 @@ Then use stability-aware command discovery:
     fit.add_argument("--compliance-pressure", choices=["low", "medium", "high"], default="low")
     fit.add_argument("--format", choices=["text", "json"], default="text")
     fit.add_argument("--out", default="")
+
+    adopt_scan = sub.add_parser(
+        "adopt-scan", help="Scan a repo and produce an SDETKit adoption plan"
+    )
+    adopt_scan.add_argument("path", nargs="?", default=".")
+    adopt_scan.add_argument("--max-files", type=int, default=4000)
+    adopt_scan.add_argument("--format", choices=["text", "json"], default="text")
+    adopt_scan.add_argument("--out", default="")
 
     sta = sub.add_parser(
         "start",
@@ -1091,6 +1226,113 @@ def main(argv: Sequence[str] | None = None) -> int:
                 if value:
                     forwarded.extend([flag, value])
             return _run_module_main("sdetkit.operator_brief", forwarded)
+        if getattr(ns, "adaptive_cmd", None) == "portfolio-rollup":
+            forwarded = [*map(str, ns.diagnosis_json), "--format", str(ns.format)]
+            if str(ns.out):
+                forwarded.extend(["--out", str(ns.out)])
+            return _run_module_main("sdetkit.adaptive_portfolio_rollup", forwarded)
+        if getattr(ns, "adaptive_cmd", None) == "patch-plan":
+            forwarded = [str(ns.diagnosis_json), "--format", str(ns.format)]
+            if str(ns.out):
+                forwarded.extend(["--out", str(ns.out)])
+            return _run_module_main("sdetkit.adaptive_patch_plan", forwarded)
+        if getattr(ns, "adaptive_cmd", None) == "fix-audit":
+            if getattr(ns, "adaptive_fix_audit_cmd", None) == "record":
+                forwarded = [
+                    "record",
+                    str(ns.plan_json),
+                    "--db",
+                    str(ns.db),
+                    "--outcome",
+                    str(ns.outcome),
+                    "--format",
+                    str(ns.format),
+                ]
+                if str(ns.note):
+                    forwarded.extend(["--note", str(ns.note)])
+                return _run_module_main("sdetkit.adaptive_fix_audit", forwarded)
+            if getattr(ns, "adaptive_fix_audit_cmd", None) == "summarize":
+                return _run_module_main(
+                    "sdetkit.adaptive_fix_audit",
+                    ["summarize", "--db", str(ns.db), "--format", str(ns.format)],
+                )
+        if getattr(ns, "adaptive_cmd", None) == "enterprise-analytics":
+            forwarded = [
+                "--portfolio",
+                str(ns.portfolio),
+                "--fix-audit",
+                str(ns.fix_audit),
+                "--format",
+                str(ns.format),
+            ]
+            if str(ns.out):
+                forwarded.extend(["--out", str(ns.out)])
+            return _run_module_main("sdetkit.adaptive_enterprise_analytics", forwarded)
+        if getattr(ns, "adaptive_cmd", None) == "remediation-policy":
+            if getattr(ns, "adaptive_remediation_policy_cmd", None) == "template":
+                forwarded = ["template", "--format", str(ns.format)]
+                if str(ns.out):
+                    forwarded.extend(["--out", str(ns.out)])
+                return _run_module_main("sdetkit.adaptive_remediation_policy", forwarded)
+            if getattr(ns, "adaptive_remediation_policy_cmd", None) == "validate":
+                forwarded = [
+                    "validate",
+                    str(ns.plan_json),
+                    "--policy",
+                    str(ns.policy),
+                    "--format",
+                    str(ns.format),
+                ]
+                if str(ns.out):
+                    forwarded.extend(["--out", str(ns.out)])
+                return _run_module_main("sdetkit.adaptive_remediation_policy", forwarded)
+        if getattr(ns, "adaptive_cmd", None) == "dashboard":
+            forwarded = ["--format", str(ns.format), "--out", str(ns.out)]
+            for flag, value in (
+                ("--diagnosis", str(ns.diagnosis)),
+                ("--brief", str(ns.brief)),
+                ("--portfolio", str(ns.portfolio)),
+                ("--fix-audit", str(ns.fix_audit)),
+                ("--governance", str(ns.governance)),
+                ("--adapter", str(ns.adapter)),
+                ("--analytics", str(ns.analytics)),
+                ("--remediation-policy", str(ns.remediation_policy)),
+            ):
+                if value:
+                    forwarded.extend([flag, value])
+            return _run_module_main("sdetkit.adaptive_dashboard", forwarded)
+        if getattr(ns, "adaptive_cmd", None) == "learning-import":
+            forwarded = [str(ns.learning_export), "--format", str(ns.format)]
+            if str(ns.out):
+                forwarded.extend(["--out", str(ns.out)])
+            return _run_module_main("sdetkit.adaptive_learning_import", forwarded)
+        if getattr(ns, "adaptive_cmd", None) == "enterprise-governance":
+            if getattr(ns, "adaptive_enterprise_cmd", None) == "report":
+                forwarded = ["report", "--root", str(ns.root), "--format", str(ns.format)]
+                if str(ns.out):
+                    forwarded.extend(["--out", str(ns.out)])
+                return _run_module_main("sdetkit.adaptive_enterprise_governance", forwarded)
+            if getattr(ns, "adaptive_enterprise_cmd", None) == "anonymize-learning":
+                forwarded = ["anonymize-learning", str(ns.jsonl_path), "--format", str(ns.format)]
+                if str(ns.out):
+                    forwarded.extend(["--out", str(ns.out)])
+                return _run_module_main("sdetkit.adaptive_enterprise_governance", forwarded)
+        if getattr(ns, "adaptive_cmd", None) == "integration-adapter":
+            if getattr(ns, "adaptive_adapter_cmd", None) == "validate":
+                forwarded = [
+                    "validate",
+                    "--provider",
+                    str(ns.provider),
+                    "--artifacts",
+                    str(ns.artifacts),
+                    "--root",
+                    str(ns.root),
+                    "--format",
+                    str(ns.format),
+                ]
+                if str(ns.out):
+                    forwarded.extend(["--out", str(ns.out)])
+                return _run_module_main("sdetkit.adaptive_integration_adapters", forwarded)
         return _run_module_main("sdetkit.adaptive", [])
 
     if ns.cmd == "index":
@@ -1102,6 +1344,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 ["inspect", str(ns.path), "--format", str(ns.format)],
             )
         return _run_module_main("sdetkit.index", [])
+
+    if ns.cmd == "adopt-scan":
+        forwarded = [str(ns.path), "--max-files", str(ns.max_files), "--format", str(ns.format)]
+        if str(ns.out):
+            forwarded.extend(["--out", str(ns.out)])
+        return _run_module_main("sdetkit.repo_adoption_scan", forwarded)
 
     if ns.cmd == "fit":
         forwarded = [

--- a/src/sdetkit/repo_adoption_scan.py
+++ b/src/sdetkit/repo_adoption_scan.py
@@ -7,7 +7,17 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "sdetkit.repo_adoption_scan.v1"
-SKIP_DIRS = {".git", ".venv", "venv", "node_modules", "dist", "build", ".mypy_cache", ".ruff_cache", "__pycache__"}
+SKIP_DIRS = {
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "dist",
+    "build",
+    ".mypy_cache",
+    ".ruff_cache",
+    "__pycache__",
+}
 
 
 def _rel(path: Path, root: Path) -> str:
@@ -37,13 +47,19 @@ def _detect_stack(root: Path, files: list[Path]) -> dict[str, Any]:
     suffixes = {path.suffix.lower() for path in files}
     names = {path.name for path in files}
     return {
-        "python": _exists(root, "pyproject.toml", "setup.py", "requirements.txt") or ".py" in suffixes,
-        "javascript": _exists(root, "package.json", "pnpm-lock.yaml", "yarn.lock") or ".js" in suffixes or ".ts" in suffixes,
-        "docs": _exists(root, "mkdocs.yml", "docs") or any(part == "docs" for path in files for part in path.parts),
+        "python": _exists(root, "pyproject.toml", "setup.py", "requirements.txt")
+        or ".py" in suffixes,
+        "javascript": _exists(root, "package.json", "pnpm-lock.yaml", "yarn.lock")
+        or ".js" in suffixes
+        or ".ts" in suffixes,
+        "docs": _exists(root, "mkdocs.yml", "docs")
+        or any(part == "docs" for path in files for part in path.parts),
         "docker": _exists(root, "Dockerfile", "docker-compose.yml", "compose.yaml"),
         "github_actions": (root / ".github" / "workflows").exists(),
         "gitlab_ci": (root / ".gitlab-ci.yml").exists(),
-        "has_tests": any(path.parts and ("test" in path.name.lower() or "tests" in path.parts) for path in files),
+        "has_tests": any(
+            path.parts and ("test" in path.name.lower() or "tests" in path.parts) for path in files
+        ),
         "has_readme": "README.md" in names or "README.rst" in names,
         "has_license": "LICENSE" in names or "LICENSE.md" in names,
     }
@@ -52,19 +68,63 @@ def _detect_stack(root: Path, files: list[Path]) -> dict[str, Any]:
 def _adoption_gaps(root: Path, stack: dict[str, Any]) -> list[dict[str, Any]]:
     gaps: list[dict[str, Any]] = []
     if stack["python"] and not (root / "pyproject.toml").exists():
-        gaps.append({"code": "PYTHON_PROJECT_METADATA_MISSING", "severity": "medium", "fix": "Add pyproject.toml or document the Python build/test contract."})
-    if stack["python"] and not _exists(root, "requirements-test.txt", "requirements-dev.txt", "pyproject.toml"):
-        gaps.append({"code": "TEST_DEPENDENCY_CONTRACT_MISSING", "severity": "medium", "fix": "Declare test dependencies so CI and local proof are reproducible."})
+        gaps.append(
+            {
+                "code": "PYTHON_PROJECT_METADATA_MISSING",
+                "severity": "medium",
+                "fix": "Add pyproject.toml or document the Python build/test contract.",
+            }
+        )
+    if stack["python"] and not _exists(
+        root, "requirements-test.txt", "requirements-dev.txt", "pyproject.toml"
+    ):
+        gaps.append(
+            {
+                "code": "TEST_DEPENDENCY_CONTRACT_MISSING",
+                "severity": "medium",
+                "fix": "Declare test dependencies so CI and local proof are reproducible.",
+            }
+        )
     if not stack["has_tests"]:
-        gaps.append({"code": "TEST_SURFACE_MISSING", "severity": "high", "fix": "Add a minimal smoke/regression test surface before release gating."})
+        gaps.append(
+            {
+                "code": "TEST_SURFACE_MISSING",
+                "severity": "high",
+                "fix": "Add a minimal smoke/regression test surface before release gating.",
+            }
+        )
     if not (stack["github_actions"] or stack["gitlab_ci"]):
-        gaps.append({"code": "CI_CONTRACT_MISSING", "severity": "high", "fix": "Add CI that runs the canonical SDETKit gate and adaptive evidence commands."})
+        gaps.append(
+            {
+                "code": "CI_CONTRACT_MISSING",
+                "severity": "high",
+                "fix": "Add CI that runs the canonical SDETKit gate and adaptive evidence commands.",
+            }
+        )
     if stack["docs"] and not (root / "mkdocs.yml").exists():
-        gaps.append({"code": "DOCS_BUILD_CONTRACT_MISSING", "severity": "low", "fix": "Add mkdocs.yml or document the docs build command."})
+        gaps.append(
+            {
+                "code": "DOCS_BUILD_CONTRACT_MISSING",
+                "severity": "low",
+                "fix": "Add mkdocs.yml or document the docs build command.",
+            }
+        )
     if not stack["has_readme"]:
-        gaps.append({"code": "README_MISSING", "severity": "medium", "fix": "Add README quickstart, test command, and release proof instructions."})
+        gaps.append(
+            {
+                "code": "README_MISSING",
+                "severity": "medium",
+                "fix": "Add README quickstart, test command, and release proof instructions.",
+            }
+        )
     if not stack["has_license"]:
-        gaps.append({"code": "LICENSE_MISSING", "severity": "low", "fix": "Add or document the license/compliance policy."})
+        gaps.append(
+            {
+                "code": "LICENSE_MISSING",
+                "severity": "low",
+                "fix": "Add or document the license/compliance policy.",
+            }
+        )
     return gaps
 
 
@@ -81,7 +141,9 @@ def _recommended_commands(stack: dict[str, Any], gaps: list[dict[str, Any]]) -> 
     if stack["docs"]:
         commands.append("NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q")
     if gaps:
-        commands.append("python -m sdetkit adaptive dashboard --format html --out build/sdetkit/adaptive-dashboard.html")
+        commands.append(
+            "python -m sdetkit adaptive dashboard --format html --out build/sdetkit/adaptive-dashboard.html"
+        )
     return commands
 
 
@@ -117,7 +179,9 @@ def build_repo_adoption_scan(root: Path, *, max_files: int = 4000) -> dict[str, 
             "Fix high-severity adoption gaps before requiring release-room signoff.",
             "Publish build/sdetkit-review and adaptive dashboard artifacts in CI.",
         ],
-        "next_owner_action": gaps[0]["fix"] if gaps else "Adopt the canonical gate/review path in CI now.",
+        "next_owner_action": gaps[0]["fix"]
+        if gaps
+        else "Adopt the canonical gate/review path in CI now.",
     }
 
 
@@ -152,7 +216,11 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         payload = build_repo_adoption_scan(Path(args.path), max_files=int(args.max_files))
-        rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n" if args.format == "json" else render_text(payload)
+        rendered = (
+            json.dumps(payload, indent=2, sort_keys=True) + "\n"
+            if args.format == "json"
+            else render_text(payload)
+        )
         if args.out:
             out = Path(args.out)
             out.parent.mkdir(parents=True, exist_ok=True)

--- a/src/sdetkit/repo_adoption_scan.py
+++ b/src/sdetkit/repo_adoption_scan.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.repo_adoption_scan.v1"
+SKIP_DIRS = {".git", ".venv", "venv", "node_modules", "dist", "build", ".mypy_cache", ".ruff_cache", "__pycache__"}
+
+
+def _rel(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _iter_files(root: Path, *, max_files: int) -> list[Path]:
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if len(files) >= max_files:
+            break
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if path.is_file():
+            files.append(path)
+    return sorted(files, key=lambda item: item.as_posix())
+
+
+def _exists(root: Path, *names: str) -> bool:
+    return any((root / name).exists() for name in names)
+
+
+def _detect_stack(root: Path, files: list[Path]) -> dict[str, Any]:
+    suffixes = {path.suffix.lower() for path in files}
+    names = {path.name for path in files}
+    return {
+        "python": _exists(root, "pyproject.toml", "setup.py", "requirements.txt") or ".py" in suffixes,
+        "javascript": _exists(root, "package.json", "pnpm-lock.yaml", "yarn.lock") or ".js" in suffixes or ".ts" in suffixes,
+        "docs": _exists(root, "mkdocs.yml", "docs") or any(part == "docs" for path in files for part in path.parts),
+        "docker": _exists(root, "Dockerfile", "docker-compose.yml", "compose.yaml"),
+        "github_actions": (root / ".github" / "workflows").exists(),
+        "gitlab_ci": (root / ".gitlab-ci.yml").exists(),
+        "has_tests": any(path.parts and ("test" in path.name.lower() or "tests" in path.parts) for path in files),
+        "has_readme": "README.md" in names or "README.rst" in names,
+        "has_license": "LICENSE" in names or "LICENSE.md" in names,
+    }
+
+
+def _adoption_gaps(root: Path, stack: dict[str, Any]) -> list[dict[str, Any]]:
+    gaps: list[dict[str, Any]] = []
+    if stack["python"] and not (root / "pyproject.toml").exists():
+        gaps.append({"code": "PYTHON_PROJECT_METADATA_MISSING", "severity": "medium", "fix": "Add pyproject.toml or document the Python build/test contract."})
+    if stack["python"] and not _exists(root, "requirements-test.txt", "requirements-dev.txt", "pyproject.toml"):
+        gaps.append({"code": "TEST_DEPENDENCY_CONTRACT_MISSING", "severity": "medium", "fix": "Declare test dependencies so CI and local proof are reproducible."})
+    if not stack["has_tests"]:
+        gaps.append({"code": "TEST_SURFACE_MISSING", "severity": "high", "fix": "Add a minimal smoke/regression test surface before release gating."})
+    if not (stack["github_actions"] or stack["gitlab_ci"]):
+        gaps.append({"code": "CI_CONTRACT_MISSING", "severity": "high", "fix": "Add CI that runs the canonical SDETKit gate and adaptive evidence commands."})
+    if stack["docs"] and not (root / "mkdocs.yml").exists():
+        gaps.append({"code": "DOCS_BUILD_CONTRACT_MISSING", "severity": "low", "fix": "Add mkdocs.yml or document the docs build command."})
+    if not stack["has_readme"]:
+        gaps.append({"code": "README_MISSING", "severity": "medium", "fix": "Add README quickstart, test command, and release proof instructions."})
+    if not stack["has_license"]:
+        gaps.append({"code": "LICENSE_MISSING", "severity": "low", "fix": "Add or document the license/compliance policy."})
+    return gaps
+
+
+def _recommended_commands(stack: dict[str, Any], gaps: list[dict[str, Any]]) -> list[str]:
+    commands = [
+        "python -m sdetkit gate fast --format json --stable-json --out build/gate-fast.json",
+        "python -m sdetkit gate release --format json --out build/release-preflight.json",
+        "python -m sdetkit doctor --format json --out build/doctor.json",
+        "python -m sdetkit review . --format operator-json --out-dir build/sdetkit-review",
+    ]
+    if stack["python"]:
+        commands.append("PYTHONPATH=src python -m pytest -q")
+        commands.append("PYTHONPATH=src python -m ruff check .")
+    if stack["docs"]:
+        commands.append("NO_MKDOCS_2_WARNING=1 python -m mkdocs build -q")
+    if gaps:
+        commands.append("python -m sdetkit adaptive dashboard --format html --out build/sdetkit/adaptive-dashboard.html")
+    return commands
+
+
+def _risk_score(gaps: list[dict[str, Any]]) -> int:
+    weights = {"high": 30, "medium": 15, "low": 5}
+    return min(100, sum(weights.get(str(gap.get("severity")), 5) for gap in gaps))
+
+
+def build_repo_adoption_scan(root: Path, *, max_files: int = 4000) -> dict[str, Any]:
+    root = root.resolve()
+    files = _iter_files(root, max_files=max_files)
+    stack = _detect_stack(root, files)
+    gaps = _adoption_gaps(root, stack)
+    risk_score = _risk_score(gaps)
+    if risk_score >= 60:
+        recommendation = "ADOPT_WITH_FOUNDATION_FIXES"
+    elif risk_score:
+        recommendation = "ADOPT_WITH_CONTROLS"
+    else:
+        recommendation = "READY_FOR_CANONICAL_ADOPTION"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": risk_score < 60,
+        "root": root.as_posix(),
+        "file_count_sampled": len(files),
+        "stack": stack,
+        "risk_score": risk_score,
+        "recommendation": recommendation,
+        "adoption_gaps": gaps,
+        "recommended_commands": _recommended_commands(stack, gaps),
+        "first_72h_plan": [
+            "Run gate fast/release and doctor to establish baseline evidence.",
+            "Fix high-severity adoption gaps before requiring release-room signoff.",
+            "Publish build/sdetkit-review and adaptive dashboard artifacts in CI.",
+        ],
+        "next_owner_action": gaps[0]["fix"] if gaps else "Adopt the canonical gate/review path in CI now.",
+    }
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"schema_version={payload['schema_version']}",
+        f"ok={str(payload['ok']).lower()}",
+        f"recommendation={payload['recommendation']}",
+        f"risk_score={payload['risk_score']}",
+        f"file_count_sampled={payload['file_count_sampled']}",
+    ]
+    for key, value in payload["stack"].items():
+        lines.append(f"stack_{key}={str(value).lower()}")
+    for gap in payload["adoption_gaps"]:
+        lines.append(f"gap={gap['severity']}|{gap['code']}|{gap['fix']}")
+    lines.append("recommended_commands:")
+    lines.extend(f"- {command}" for command in payload["recommended_commands"])
+    lines.append(f"next_owner_action={payload['next_owner_action']}")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.repo_adoption_scan")
+    parser.add_argument("path", nargs="?", default=".")
+    parser.add_argument("--max-files", type=int, default=4000)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--out", default="")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_repo_adoption_scan(Path(args.path), max_files=int(args.max_files))
+        rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n" if args.format == "json" else render_text(payload)
+        if args.out:
+            out = Path(args.out)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+    except (OSError, ValueError) as exc:
+        print(f"error={exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/adaptive_logs/broken_test_double.log
+++ b/tests/fixtures/adaptive_logs/broken_test_double.log
@@ -1,0 +1,2 @@
+FAILED tests/test_client.py::test_fake_response
+TypeError: Resp() takes no arguments because test double defines init_ instead of __init__

--- a/tests/fixtures/adaptive_logs/cache_artifact_unknown.log
+++ b/tests/fixtures/adaptive_logs/cache_artifact_unknown.log
@@ -1,0 +1,3 @@
+Error: command failed after restoring cache key py310-main
+stale artifact restored from cache caused checksum mismatch
+Process completed with exit code 1

--- a/tests/fixtures/adaptive_logs/coverage_gate_unknown.log
+++ b/tests/fixtures/adaptive_logs/coverage_gate_unknown.log
@@ -1,0 +1,3 @@
+coverage report failed
+Coverage failure: total 71 is under fail under 85
+Process completed with exit code 1

--- a/tests/fixtures/adaptive_logs/docs_build_unknown.log
+++ b/tests/fixtures/adaptive_logs/docs_build_unknown.log
@@ -1,0 +1,3 @@
+Error: mkdocs build failed
+WARNING - Documentation file 'missing.md' contains a link to 'gone.md' which is not found
+Process completed with exit code 1

--- a/tests/fixtures/adaptive_logs/format_drift.log
+++ b/tests/fixtures/adaptive_logs/format_drift.log
@@ -1,0 +1,4 @@
+ruff format failed
+1 file reformatted
+pytest passed rc=0
+tests/test_new_feature.py

--- a/tests/fixtures/adaptive_logs/git_branch_diverged.log
+++ b/tests/fixtures/adaptive_logs/git_branch_diverged.log
@@ -1,0 +1,3 @@
+! [rejected] feature -> feature (fetch first)
+error: failed to push some refs to 'origin'
+Updates were rejected because the remote contains work that you do not have locally.

--- a/tests/fixtures/adaptive_logs/local_environment_friction.log
+++ b/tests/fixtures/adaptive_logs/local_environment_friction.log
@@ -1,0 +1,2 @@
+Running pip install inside /mnt/c/work/repo/.venv/site-packages became slow and stuck
+KeyboardInterrupt while creating venv

--- a/tests/fixtures/adaptive_logs/metadata.json
+++ b/tests/fixtures/adaptive_logs/metadata.json
@@ -1,0 +1,128 @@
+[
+  {
+    "file": "pytest_assertion.log",
+    "primary": "PYTEST_ASSERTION_FAILURE",
+    "proof_contains": "pytest -q tests/test_checkout.py::test_total_contract",
+    "safe": false
+  },
+  {
+    "file": "pytest_import_failure.log",
+    "primary": "PYTEST_IMPORT_FAILURE",
+    "proof_contains": "pytest -q unknown test",
+    "safe": false
+  },
+  {
+    "file": "missing_test_dependency.log",
+    "primary": "MISSING_TEST_DEPENDENCY",
+    "proof_contains": "pip install -r requirements-test.txt",
+    "safe": false
+  },
+  {
+    "file": "python_runtime_compatibility.log",
+    "primary": "PYTHON_RUNTIME_COMPATIBILITY",
+    "proof_contains": "python --version",
+    "safe": false
+  },
+  {
+    "file": "local_environment_friction.log",
+    "primary": "LOCAL_ENVIRONMENT_FRICTION",
+    "proof_contains": "python -m venv .venv",
+    "safe": false
+  },
+  {
+    "file": "broken_test_double.log",
+    "primary": "BROKEN_TEST_DOUBLE",
+    "proof_contains": "pytest -q <focused-test>",
+    "safe": false
+  },
+  {
+    "file": "missing_public_api_parity.log",
+    "primary": "MISSING_PUBLIC_API_PARITY",
+    "proof_contains": "pytest -q <focused-parity-test>",
+    "safe": false
+  },
+  {
+    "file": "git_branch_diverged.log",
+    "primary": "GIT_BRANCH_DIVERGED",
+    "proof_contains": "git fetch origin <branch>",
+    "safe": false
+  },
+  {
+    "file": "remote_branch_drift.log",
+    "primary": "REMOTE_BRANCH_DRIFT",
+    "proof_contains": "pre_commit run -a",
+    "safe": false
+  },
+  {
+    "file": "product_logic_failure.log",
+    "primary": "PRODUCT_LOGIC_FAILURE",
+    "proof_contains": "pytest -q <focused-test>",
+    "safe": false
+  },
+  {
+    "file": "format_drift.log",
+    "primary": "PRE_COMMIT_FORMAT_DRIFT",
+    "proof_contains": "ruff format --check <touched-python-files>",
+    "safe": true
+  },
+  {
+    "file": "ruff_fixable_lint.log",
+    "primary": "RUFF_FIXABLE_LINT",
+    "proof_contains": "ruff check tests/test_imports.py",
+    "safe": true
+  },
+  {
+    "file": "ruff_unsafe_lint.log",
+    "primary": "RUFF_LINT_FAILURE",
+    "proof_contains": "ruff check <touched-python-files>",
+    "safe": false
+  },
+  {
+    "file": "mypy_type_contract.log",
+    "primary": "MYPY_TYPE_CONTRACT_DRIFT",
+    "proof_contains": "ruff check <touched-python-files>",
+    "safe": false
+  },
+  {
+    "file": "package_install_unknown.log",
+    "primary": "UNKNOWN_REVIEW_REQUIRED",
+    "proof_contains": "pip install -r requirements-test.txt -e .",
+    "safe": false,
+    "candidate": "PACKAGE_INSTALL_FAILURE"
+  },
+  {
+    "file": "cache_artifact_unknown.log",
+    "primary": "UNKNOWN_REVIEW_REQUIRED",
+    "proof_contains": "git diff -- pyproject.toml requirements-test.txt",
+    "safe": false,
+    "candidate": "CACHE_ARTIFACT_POISONING"
+  },
+  {
+    "file": "docs_build_unknown.log",
+    "primary": "UNKNOWN_REVIEW_REQUIRED",
+    "proof_contains": "tests/test_docs*.py",
+    "safe": false,
+    "candidate": "DOCS_BUILD_CONTRACT"
+  },
+  {
+    "file": "release_version_unknown.log",
+    "primary": "UNKNOWN_REVIEW_REQUIRED",
+    "proof_contains": "git tag --points-at HEAD",
+    "safe": false,
+    "candidate": "RELEASE_VERSION_CONFLICT"
+  },
+  {
+    "file": "network_service_unknown.log",
+    "primary": "UNKNOWN_REVIEW_REQUIRED",
+    "proof_contains": "<network-test>",
+    "safe": false,
+    "candidate": "NETWORK_SERVICE_FLAKE"
+  },
+  {
+    "file": "coverage_gate_unknown.log",
+    "primary": "UNKNOWN_REVIEW_REQUIRED",
+    "proof_contains": "bash quality.sh cov",
+    "safe": false,
+    "candidate": "COVERAGE_GATE_REGRESSION"
+  }
+]

--- a/tests/fixtures/adaptive_logs/missing_public_api_parity.log
+++ b/tests/fixtures/adaptive_logs/missing_public_api_parity.log
@@ -1,0 +1,2 @@
+FAILED tests/test_async_client.py::test_async_parity
+AttributeError: SdetAsyncHttpClient object has no attribute get_json_list_paginated_envelope async parity

--- a/tests/fixtures/adaptive_logs/missing_test_dependency.log
+++ b/tests/fixtures/adaptive_logs/missing_test_dependency.log
@@ -1,0 +1,2 @@
+Exit: Missing test dependencies: hypothesis and yaml.
+Run aborted before collection.

--- a/tests/fixtures/adaptive_logs/mypy_type_contract.log
+++ b/tests/fixtures/adaptive_logs/mypy_type_contract.log
@@ -1,0 +1,3 @@
+mypy failed
+src/app.py:12: error: Incompatible return value type (got "int", expected "str")
+Found 1 error in 1 file

--- a/tests/fixtures/adaptive_logs/network_service_unknown.log
+++ b/tests/fixtures/adaptive_logs/network_service_unknown.log
@@ -1,0 +1,3 @@
+Error: command failed while calling external API
+ConnectionError timeout dns rate limit from remote service
+Process completed with exit code 1

--- a/tests/fixtures/adaptive_logs/package_install_unknown.log
+++ b/tests/fixtures/adaptive_logs/package_install_unknown.log
@@ -1,0 +1,3 @@
+npm ERR! command failed during package install
+pip install resolutionimpossible for internal-widget==9.9.9
+Process completed with exit code 1

--- a/tests/fixtures/adaptive_logs/product_logic_failure.log
+++ b/tests/fixtures/adaptive_logs/product_logic_failure.log
@@ -1,0 +1,2 @@
+Product logic failure: deterministic product behavior failure in widget contract
+FAILED tests/test_widget.py::test_widget_contract

--- a/tests/fixtures/adaptive_logs/pytest_assertion.log
+++ b/tests/fixtures/adaptive_logs/pytest_assertion.log
@@ -1,0 +1,2 @@
+FAILED tests/test_checkout.py::test_total_contract - AssertionError
+E   AssertionError: expected 42

--- a/tests/fixtures/adaptive_logs/pytest_import_failure.log
+++ b/tests/fixtures/adaptive_logs/pytest_import_failure.log
@@ -1,0 +1,2 @@
+ImportError while importing test module tests/test_api.py
+ModuleNotFoundError: No module named 'project_api'

--- a/tests/fixtures/adaptive_logs/python_runtime_compatibility.log
+++ b/tests/fixtures/adaptive_logs/python_runtime_compatibility.log
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "src/example.py", line 1, in <module>
+ImportError: cannot import name 'UTC' from 'datetime'

--- a/tests/fixtures/adaptive_logs/release_version_unknown.log
+++ b/tests/fixtures/adaptive_logs/release_version_unknown.log
@@ -1,0 +1,3 @@
+Error: release version conflict
+Git tag v1.2.3 already exists and package version was already published
+Process completed with exit code 1

--- a/tests/fixtures/adaptive_logs/remote_branch_drift.log
+++ b/tests/fixtures/adaptive_logs/remote_branch_drift.log
@@ -1,0 +1,1 @@
+Successfully rebased and updated refs/heads/feature on origin/feature.

--- a/tests/fixtures/adaptive_logs/ruff_fixable_lint.log
+++ b/tests/fixtures/adaptive_logs/ruff_fixable_lint.log
@@ -1,0 +1,4 @@
+ruff check failed
+Found 1 error.
+tests/test_imports.py:1:1: F401 [*] `os` imported but unused
+[*] 1 fixable with the `--fix` option.

--- a/tests/fixtures/adaptive_logs/ruff_unsafe_lint.log
+++ b/tests/fixtures/adaptive_logs/ruff_unsafe_lint.log
@@ -1,0 +1,3 @@
+ruff check failed
+Found 1 error.
+src/app.py:10:5: B006 Do not use mutable data structures for argument defaults

--- a/tests/test_adaptive_dashboard.py
+++ b/tests/test_adaptive_dashboard.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_dashboard
+from sdetkit.cli import main as top_level_main
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_adaptive_dashboard_builds_summary_with_missing_warnings(tmp_path: Path) -> None:
+    diagnosis = _write_json(
+        tmp_path / "diagnosis.json",
+        {
+            "schema_version": "sdetkit.adaptive.diagnosis.v1",
+            "status": "needs_attention",
+            "risk_score": 42,
+            "diagnoses": [{"code": "RUFF_FIXABLE_LINT"}],
+        },
+    )
+    portfolio = _write_json(
+        tmp_path / "portfolio.json",
+        {
+            "schema_version": "sdetkit.adaptive.portfolio_rollup.v1",
+            "recommendation": "SHIP_WITH_CONTROLS",
+            "repo_count": 2,
+            "portfolio_risk_score": 64,
+            "top_risk_scenarios": [{"code": "RUFF_FIXABLE_LINT"}],
+        },
+    )
+    out = tmp_path / "build" / "adaptive-dashboard.html"
+
+    payload = adaptive_dashboard.build_dashboard(
+        {"diagnosis": str(diagnosis), "portfolio": str(portfolio)}, out_path=out
+    )
+
+    assert payload["schema_version"] == "sdetkit.adaptive.dashboard.v1"
+    assert payload["ok"] is True
+    assert payload["present_artifact_count"] == 2
+    assert payload["missing_artifact_count"] == 6
+    diagnosis_card = next(row for row in payload["artifacts"] if row["kind"] == "diagnosis")
+    assert diagnosis_card["summary"]["top_code"] == "RUFF_FIXABLE_LINT"
+    assert "brief" in payload["next_owner_action"]
+
+
+def test_adaptive_dashboard_renders_static_local_html(tmp_path: Path) -> None:
+    analytics = _write_json(
+        tmp_path / "analytics.json",
+        {
+            "schema_version": "sdetkit.adaptive.enterprise_analytics.v1",
+            "recommendation": "SHIP_WITH_CONTROLS",
+            "metrics": {
+                "remediation_success_rate": 0.75,
+                "missing_proof_rate": 0.25,
+                "failed_proof_rate": 0.0,
+            },
+        },
+    )
+    out = tmp_path / "dashboard.html"
+
+    rc = adaptive_dashboard.main(
+        ["--analytics", str(analytics), "--format", "html", "--out", str(out)]
+    )
+
+    assert rc == 0
+    text = out.read_text(encoding="utf-8")
+    assert "Adaptive next-wave dashboard" in text
+    assert "Enterprise analytics" in text
+    assert "remediation_success_rate" in text
+    assert "local only: true" in text
+
+
+def test_top_level_cli_adaptive_dashboard_passthrough(tmp_path: Path) -> None:
+    policy = _write_json(
+        tmp_path / "policy-result.json",
+        {
+            "schema_version": "sdetkit.adaptive.remediation_policy.result.v1",
+            "ok": True,
+            "recommendation": "APPROVE",
+            "finding_count": 0,
+        },
+    )
+    out = tmp_path / "dashboard.json"
+
+    rc = top_level_main(
+        [
+            "adaptive",
+            "dashboard",
+            "--remediation-policy",
+            str(policy),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["present_artifact_count"] == 1
+    policy_card = next(row for row in payload["artifacts"] if row["kind"] == "remediation_policy")
+    assert policy_card["summary"]["recommendation"] == "APPROVE"

--- a/tests/test_adaptive_diagnosis.py
+++ b/tests/test_adaptive_diagnosis.py
@@ -229,7 +229,7 @@ def test_pytest_assertion_failure_uses_first_test_as_fix_anchor():
     assert payload["status"] == "needs_fix"
     assert diagnosis["code"] == "PYTEST_ASSERTION_FAILURE"
     assert diagnosis["severity"] == "high"
-    assert diagnosis["evidence"] == [
+    assert diagnosis["evidence"][:2] == [
         "pytest failure",
         "first_failed_test=tests/test_widget.py::test_widget_contract",
     ]
@@ -445,7 +445,8 @@ def test_builtin_scenario_pack_is_schema_validated_data_product():
     scenarios = adaptive_diagnosis.SEEDED_SCENARIO_DB
     codes = [scenario.code for scenario in scenarios]
 
-    assert len(scenarios) >= 25
+    assert len(scenarios) >= 5000
+    assert len(adaptive_diagnosis.GENERATED_SCENARIO_DB) >= 5000
     assert codes == sorted(codes)
     assert "PACKAGE_INSTALL_FAILURE" in codes
     assert all(scenario.checks and scenario.commands for scenario in scenarios)
@@ -524,3 +525,135 @@ def test_learning_calibration_reranks_unknown_candidate_scenarios():
         "git tag --points-at HEAD",
         "python -m build --sdist --wheel",
     ]
+
+
+def test_layered_scenario_pack_report_emits_source_metadata(tmp_path):
+    local_dir = tmp_path / ".sdetkit" / "adaptive"
+    local_dir.mkdir(parents=True)
+    local_pack = local_dir / "scenarios.json"
+    local_pack.write_text(json.dumps(_scenario_pack_payload()), encoding="utf-8")
+
+    report = adaptive_diagnosis.layered_scenario_pack_report(tmp_path)
+
+    assert report["schema_version"] == "sdetkit.adaptive.scenario_pack_report.v1"
+    assert report["layer_count"] == 2
+    assert [layer["source"] for layer in report["layers"]] == ["builtin", "repo-local"]
+    assert "TEST_SIGNAL" in report["merged_codes"]
+    assert report["overrides"] == []
+
+
+def test_layered_scenario_pack_report_rejects_unapproved_overrides(tmp_path):
+    local_dir = tmp_path / ".sdetkit" / "adaptive"
+    local_dir.mkdir(parents=True)
+    local_pack = local_dir / "scenarios.json"
+    payload = _scenario_pack_payload()
+    payload["scenarios"][0]["code"] = "PACKAGE_INSTALL_FAILURE"
+    local_pack.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        adaptive_diagnosis.validate_layered_scenario_packs(tmp_path)
+    except ValueError as exc:
+        assert "PACKAGE_INSTALL_FAILURE" in str(exc)
+        assert "override-approved" in str(exc)
+    else:
+        raise AssertionError("expected unapproved scenario override to be rejected")
+
+
+def test_layered_scenario_pack_report_allows_approved_overrides(tmp_path):
+    local_dir = tmp_path / ".sdetkit" / "adaptive"
+    local_dir.mkdir(parents=True)
+    local_pack = local_dir / "scenarios.json"
+    payload = _scenario_pack_payload()
+    payload["scenarios"][0]["code"] = "PACKAGE_INSTALL_FAILURE"
+    payload["scenarios"][0]["title"] = "Approved package install override"
+    payload["scenarios"][0]["tags"] = ["test", "override-approved"]
+    local_pack.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = adaptive_diagnosis.validate_layered_scenario_packs(tmp_path)
+    scenarios = adaptive_diagnosis.load_layered_scenarios(tmp_path)
+    overridden = {scenario.code: scenario for scenario in scenarios}["PACKAGE_INSTALL_FAILURE"]
+
+    assert report["overrides"] == [
+        {
+            "code": "PACKAGE_INSTALL_FAILURE",
+            "previous_source": "builtin",
+            "source": "repo-local",
+            "approved": True,
+            "approval_tag": "override-approved",
+        }
+    ]
+    assert overridden.title == "Approved package install override"
+
+
+def test_adaptive_diagnosis_operator_guidance_uses_observed_failure_lines() -> None:
+    log_text = """
+    FAILED tests/test_real_checkout.py::test_checkout_total - AssertionError
+    E   AssertionError: expected 42 but got 41
+    Process completed with exit code 1
+    """
+
+    payload = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    diagnosis = payload["diagnoses"][0]
+    guidance = diagnosis["operator_guidance"]
+
+    assert diagnosis["code"] == "PYTEST_ASSERTION_FAILURE"
+    assert guidance["matched_from_current_log"] is True
+    assert guidance["automation_boundary"] == "review_first_no_auto_mutation"
+    assert guidance["what_to_fix_first"] == "Reproduce the first failing test only."
+    assert any("test_real_checkout.py::test_checkout_total" in line for line in guidance["observed_failure_lines"])
+    assert any(item.startswith("observed_failure_line_1=") for item in diagnosis["evidence"])
+    assert "random" in guidance["why_this_is_not_random"]
+
+
+def test_adaptive_diagnosis_safe_mechanical_guidance_boundary() -> None:
+    log_text = """
+    ruff check..............................................................Failed
+    tests/test_api.py:2:21: F401 [*] `pathlib.Path` imported but unused
+    Found 1 error.
+    [*] 1 fixable with the `--fix` option.
+    """
+
+    payload = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    guidance = payload["diagnoses"][0]["operator_guidance"]
+
+    assert payload["diagnoses"][0]["code"] == "RUFF_FIXABLE_LINT"
+    assert guidance["automation_boundary"] == "safe_mechanical_fix_allowed_after_proof"
+    assert guidance["affected_files"] == ["tests/test_api.py"]
+    assert "ruff check --fix" in " ".join(guidance["how_to_fix"])
+
+
+def test_adaptive_scenario_database_scales_to_real_world_matrix() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text=(
+            "FAILED tests/test_api.py::test_contract - AssertionError\n"
+            "mypy src/app.py:10: error: Argument 1 has incompatible type [arg-type]\n"
+            "ruff check Failed Found 1 error.\n"
+            "npm ERR! lifecycle script failed\n"
+            "coverage fail under configured threshold\n"
+            "Process completed with exit code 1"
+        )
+    )
+
+    db = payload["scenario_database"]
+    assert db["curated_scenario_count"] >= 25
+    assert db["generated_matrix_scenario_count"] >= 5000
+    assert db["total_scenario_count"] >= 5000
+    codes = {diagnosis["code"] for diagnosis in payload["diagnoses"]}
+    assert "PYTEST_ASSERTION_FAILURE" in codes
+    assert "MYPY_TYPE_CONTRACT_DRIFT" in codes
+    assert any(
+        "observed_failure_line_" in evidence
+        for diagnosis in payload["diagnoses"]
+        for evidence in diagnosis["evidence"]
+    )
+
+
+def test_generated_matrix_candidates_are_not_fixed_three_scenarios() -> None:
+    candidates = adaptive_diagnosis._candidate_scenarios(
+        "github actions pytest timeout flaky_rerun Process completed with exit code 1",
+        limit=80,
+    )
+
+    assert len(adaptive_diagnosis.SEEDED_SCENARIO_DB) >= 5000
+    assert any(candidate.code.startswith("MATRIX_") for candidate in candidates)
+    assert len({candidate.code for candidate in candidates}) > 3

--- a/tests/test_adaptive_diagnosis.py
+++ b/tests/test_adaptive_diagnosis.py
@@ -600,7 +600,10 @@ def test_adaptive_diagnosis_operator_guidance_uses_observed_failure_lines() -> N
     assert guidance["matched_from_current_log"] is True
     assert guidance["automation_boundary"] == "review_first_no_auto_mutation"
     assert guidance["what_to_fix_first"] == "Reproduce the first failing test only."
-    assert any("test_real_checkout.py::test_checkout_total" in line for line in guidance["observed_failure_lines"])
+    assert any(
+        "test_real_checkout.py::test_checkout_total" in line
+        for line in guidance["observed_failure_lines"]
+    )
     assert any(item.startswith("observed_failure_line_1=") for item in diagnosis["evidence"])
     assert "random" in guidance["why_this_is_not_random"]
 

--- a/tests/test_adaptive_enterprise_analytics.py
+++ b/tests/test_adaptive_enterprise_analytics.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_enterprise_analytics
+from sdetkit.cli import main as top_level_main
+
+
+def _portfolio() -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive.portfolio_rollup.v1",
+        "recommendation": "SHIP_WITH_CONTROLS",
+        "repo_count": 2,
+        "artifact_count": 2,
+        "portfolio_risk_score": 72,
+        "top_risk_scenarios": [
+            {"code": "PYTEST_ASSERTION_FAILURE", "occurrences": 3, "risk_points": 44},
+            {"code": "RUFF_LINT_FAILURE", "occurrences": 1, "risk_points": 18},
+        ],
+        "recurrence_by_repo": [
+            {
+                "repo": "api",
+                "max_status": "needs_attention",
+                "risk_score": 42,
+                "diagnosis_count": 2,
+                "artifact_count": 1,
+            },
+            {
+                "repo": "web",
+                "max_status": "monitor",
+                "risk_score": 30,
+                "diagnosis_count": 1,
+                "artifact_count": 1,
+            },
+        ],
+    }
+
+
+def _audit_records() -> list[dict[str, object]]:
+    base = {
+        "schema_version": "sdetkit.adaptive.fix_audit.v1",
+        "plan_kind": "safe_fix",
+        "source_path": "build/format-plan.json",
+        "source_code": "RUFF_LINT_FAILURE",
+        "action_type": "format_only",
+    }
+    unknown = {
+        "schema_version": "sdetkit.adaptive.fix_audit.v1",
+        "plan_kind": "assisted_patch_plan",
+        "source_path": "build/unknown-plan.json",
+        "source_code": "UNKNOWN_REVIEW_REQUIRED",
+        "action_type": "review_required",
+    }
+    return [
+        {**base, "outcome": "planned", "recorded_at": "2026-05-08T10:00:00+00:00"},
+        {**base, "outcome": "proof_passed", "recorded_at": "2026-05-08T10:10:00+00:00"},
+        {**unknown, "outcome": "planned", "recorded_at": "2026-05-08T11:00:00+00:00"},
+    ]
+
+
+def test_enterprise_analytics_combines_portfolio_and_fix_audit_metrics() -> None:
+    payload = adaptive_enterprise_analytics.build_enterprise_analytics(
+        _portfolio(), _audit_records()
+    )
+
+    assert payload["schema_version"] == "sdetkit.adaptive.enterprise_analytics.v1"
+    assert payload["recommendation"] == "SHIP_WITH_CONTROLS"
+    assert payload["metrics"]["record_count"] == 3
+    assert payload["metrics"]["remediation_decision_count"] == 2
+    assert payload["metrics"]["remediation_success_rate"] == 0.5
+    assert payload["metrics"]["missing_proof_rate"] == 0.5
+    assert payload["metrics"]["failed_proof_rate"] == 0.0
+    assert payload["metrics"]["mean_time_to_proof_seconds"] == 600.0
+    top_codes = {row["code"]: row["count"] for row in payload["top_recurring_source_codes"]}
+    assert top_codes["PYTEST_ASSERTION_FAILURE"] == 3
+    assert top_codes["RUFF_LINT_FAILURE"] == 3
+    assert payload["top_risky_repos"][0]["repo"] == "api"
+
+
+def test_enterprise_analytics_blocks_release_on_failed_proof() -> None:
+    records = [
+        *_audit_records(),
+        {
+            "schema_version": "sdetkit.adaptive.fix_audit.v1",
+            "plan_kind": "safe_fix",
+            "source_path": "build/import-plan.json",
+            "source_code": "PYTEST_IMPORT_FAILURE",
+            "action_type": "dependency_install",
+            "outcome": "proof_failed",
+            "recorded_at": "2026-05-08T12:00:00+00:00",
+        },
+    ]
+
+    payload = adaptive_enterprise_analytics.build_enterprise_analytics(_portfolio(), records)
+
+    assert payload["ok"] is False
+    assert payload["recommendation"] == "NO_SHIP"
+    assert payload["metrics"]["proof_failed_count"] == 1
+    assert payload["metrics"]["failed_proof_rate"] == 0.5
+
+
+def test_enterprise_analytics_cli_and_top_level_passthrough(tmp_path: Path) -> None:
+    portfolio = tmp_path / "portfolio.json"
+    audit = tmp_path / "audit.jsonl"
+    out = tmp_path / "analytics.json"
+    portfolio.write_text(json.dumps(_portfolio()), encoding="utf-8")
+    audit.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in _audit_records()) + "\n",
+        encoding="utf-8",
+    )
+
+    rc = top_level_main(
+        [
+            "adaptive",
+            "enterprise-analytics",
+            "--portfolio",
+            str(portfolio),
+            "--fix-audit",
+            str(audit),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["portfolio"]["portfolio_risk_score"] == 72
+    assert payload["metrics"]["missing_proof_count"] == 1

--- a/tests/test_adaptive_enterprise_governance.py
+++ b/tests/test_adaptive_enterprise_governance.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_enterprise_governance
+from sdetkit.cli import main as top_level_main
+
+
+def _pack(code: str, tags: list[str]) -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive.scenario_pack.v1",
+        "pack_id": "enterprise.test",
+        "title": "Enterprise test pack",
+        "scenarios": [
+            {
+                "code": code,
+                "title": "Enterprise scenario",
+                "signals": ["error-prefix"],
+                "keywords": ["enterprise"],
+                "checks": ["Check enterprise scenario."],
+                "commands": ["python -m pytest -q tests/test_enterprise.py"],
+                "risk_band": "high",
+                "prior_weight": 2,
+                "tags": tags,
+            }
+        ],
+    }
+
+
+def _write_local_pack(root: Path, payload: dict[str, object]) -> Path:
+    local_dir = root / ".sdetkit" / "adaptive"
+    local_dir.mkdir(parents=True)
+    path = local_dir / "scenarios.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_enterprise_governance_blocks_sensitive_pack_without_isolation(tmp_path: Path) -> None:
+    _write_local_pack(tmp_path, _pack("ENTERPRISE_SECRET_SIGNAL", ["security-sensitive"]))
+
+    report = adaptive_enterprise_governance.build_governance_report(tmp_path)
+
+    assert report["ok"] is False
+    assert report["recommendation"] == "BLOCKED"
+    assert report["sensitive_scenario_count"] == 1
+    assert report["violations"][0]["kind"] == "sensitive_scenario_not_isolated"
+
+
+def test_enterprise_governance_allows_isolated_sensitive_pack(tmp_path: Path) -> None:
+    _write_local_pack(
+        tmp_path,
+        _pack("ENTERPRISE_SECRET_SIGNAL", ["security-sensitive", "security-isolated"]),
+    )
+
+    report = adaptive_enterprise_governance.build_governance_report(tmp_path)
+
+    assert report["ok"] is True
+    assert report["recommendation"] == "APPROVED"
+    assert report["sensitive_scenario_count"] == 1
+    assert report["violations"] == []
+
+
+def test_enterprise_governance_anonymizes_learning_records() -> None:
+    payload = adaptive_enterprise_governance.build_anonymized_learning_export(
+        [
+            {
+                "repo": "private/repo",
+                "source_path": "build/private-plan.json",
+                "changed_file_scope": ["src/private.py"],
+                "affected_files": ["tests/private_test.py"],
+                "source_code": "UNKNOWN_REVIEW_REQUIRED",
+                "nested": {"note": "customer context"},
+            }
+        ]
+    )
+
+    record = payload["records"][0]
+    assert record["repo"] == "<redacted>"
+    assert record["source_path"] == "<redacted>"
+    assert record["changed_file_scope"] == ["<redacted>"]
+    assert record["affected_files"] == ["<redacted>"]
+    assert record["source_code"] == "UNKNOWN_REVIEW_REQUIRED"
+    assert record["nested"]["note"] == "<redacted>"
+
+
+def test_top_level_cli_enterprise_governance_passthrough(tmp_path: Path) -> None:
+    _write_local_pack(
+        tmp_path,
+        _pack("ENTERPRISE_SECRET_SIGNAL", ["security-sensitive", "security-isolated"]),
+    )
+    out = tmp_path / "governance.json"
+
+    rc = top_level_main(
+        [
+            "adaptive",
+            "enterprise-governance",
+            "report",
+            "--root",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["recommendation"] == "APPROVED"

--- a/tests/test_adaptive_fix_audit.py
+++ b/tests/test_adaptive_fix_audit.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_fix_audit
+from sdetkit.cli import main as top_level_main
+
+
+def _patch_plan() -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive.patch_plan.v1",
+        "status": "review_required",
+        "source_status": "needs_fix",
+        "source_code": "UNKNOWN_REVIEW_REQUIRED",
+        "safe_to_auto_fix": False,
+        "dry_run_only": True,
+        "requires_human_review": True,
+        "reason": "Review-only patch plan.",
+        "guardrails": {
+            "automation_mutation_allowed": False,
+            "post_fix_proof_required": True,
+        },
+        "affected_files": ["pyproject.toml"],
+        "proof_commands": ["python -m pip install -r requirements-test.txt -e ."],
+        "rollback_notes": ["Revert reviewed changes if proof fails."],
+    }
+
+
+def _safe_fix_plan() -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive_safe_fix.v1",
+        "source_status": "needs_fix",
+        "source_code": "PRE_COMMIT_FORMAT_DRIFT",
+        "safe_to_auto_fix": True,
+        "requires_human_review": False,
+        "fix_type": "format_only",
+        "reason": "Formatter drift is safe to plan.",
+        "affected_files": ["tests/test_widget.py"],
+        "proof_commands": ["PYTHONPATH=src python -m ruff format --check tests/test_widget.py"],
+    }
+
+
+def test_fix_audit_record_captures_patch_plan_guardrails() -> None:
+    record = adaptive_fix_audit.build_audit_record(
+        _patch_plan(), source_path="build/patch-plan.json", outcome="planned", note="triage"
+    )
+
+    assert record["schema_version"] == "sdetkit.adaptive.fix_audit.v1"
+    assert record["plan_kind"] == "assisted_patch_plan"
+    assert record["source_code"] == "UNKNOWN_REVIEW_REQUIRED"
+    assert record["safe_to_auto_fix"] is False
+    assert record["requires_human_review"] is True
+    assert record["dry_run_only"] is True
+    assert record["guardrails"]["automation_mutation_allowed"] is False
+    assert record["proof_commands"] == ["python -m pip install -r requirements-test.txt -e ."]
+    assert record["rollback_notes"] == ["Revert reviewed changes if proof fails."]
+
+
+def test_fix_audit_record_and_summary_round_trip(tmp_path: Path) -> None:
+    db = tmp_path / "audit.jsonl"
+    patch_path = tmp_path / "patch-plan.json"
+    safe_path = tmp_path / "safe-fix.json"
+    patch_path.write_text(json.dumps(_patch_plan()), encoding="utf-8")
+    safe_path.write_text(json.dumps(_safe_fix_plan()), encoding="utf-8")
+
+    patch_record = adaptive_fix_audit.record_from_file(patch_path, db, outcome="planned")
+    safe_record = adaptive_fix_audit.record_from_file(safe_path, db, outcome="proof_passed")
+    summary = adaptive_fix_audit.summarize_records(adaptive_fix_audit.read_records(db))
+
+    assert patch_record["plan_kind"] == "assisted_patch_plan"
+    assert safe_record["plan_kind"] == "safe_fix"
+    assert summary["record_count"] == 2
+    assert summary["outcomes"] == {"planned": 1, "proof_passed": 1}
+    assert summary["plan_kinds"] == {"assisted_patch_plan": 1, "safe_fix": 1}
+    assert summary["unsafe_mutation_attempt_count"] == 0
+    assert summary["ok"] is True
+
+
+def test_fix_audit_cli_and_top_level_passthrough(tmp_path: Path) -> None:
+    db = tmp_path / "audit.jsonl"
+    plan = tmp_path / "patch-plan.json"
+    plan.write_text(json.dumps(_patch_plan()), encoding="utf-8")
+
+    rc = top_level_main(
+        [
+            "adaptive",
+            "fix-audit",
+            "record",
+            str(plan),
+            "--db",
+            str(db),
+            "--outcome",
+            "planned",
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+
+    rc = top_level_main(["adaptive", "fix-audit", "summarize", "--db", str(db), "--format", "json"])
+    assert rc == 0
+    summary = adaptive_fix_audit.summarize_records(adaptive_fix_audit.read_records(db))
+    assert summary["record_count"] == 1
+    assert summary["top_source_codes"][0] == {"code": "UNKNOWN_REVIEW_REQUIRED", "count": 1}
+
+
+def test_fix_audit_summary_flags_missing_post_fix_proof(tmp_path: Path) -> None:
+    db = tmp_path / "audit.jsonl"
+    plan = tmp_path / "patch-plan.json"
+    plan.write_text(json.dumps(_patch_plan()), encoding="utf-8")
+    adaptive_fix_audit.record_from_file(plan, db, outcome="planned")
+
+    summary = adaptive_fix_audit.summarize_records(adaptive_fix_audit.read_records(db))
+
+    assert summary["recommendation"] == "SHIP_WITH_CONTROLS"
+    assert summary["missing_proof_count"] == 1
+    assert summary["proof_failed_count"] == 0
+    assert summary["next_owner_action"].startswith("Collect post-fix proof")
+
+
+def test_fix_audit_summary_clears_missing_proof_after_terminal_outcome(tmp_path: Path) -> None:
+    db = tmp_path / "audit.jsonl"
+    plan = tmp_path / "patch-plan.json"
+    plan.write_text(json.dumps(_patch_plan()), encoding="utf-8")
+    adaptive_fix_audit.record_from_file(plan, db, outcome="planned")
+    adaptive_fix_audit.record_from_file(plan, db, outcome="proof_passed")
+
+    summary = adaptive_fix_audit.summarize_records(adaptive_fix_audit.read_records(db))
+
+    assert summary["recommendation"] == "SHIP"
+    assert summary["missing_proof_count"] == 0
+    assert summary["proof_failed_count"] == 0
+    assert summary["ok"] is True
+
+
+def test_fix_audit_summary_blocks_release_on_failed_proof(tmp_path: Path) -> None:
+    db = tmp_path / "audit.jsonl"
+    plan = tmp_path / "patch-plan.json"
+    plan.write_text(json.dumps(_patch_plan()), encoding="utf-8")
+    adaptive_fix_audit.record_from_file(plan, db, outcome="planned")
+    adaptive_fix_audit.record_from_file(plan, db, outcome="proof_failed")
+
+    summary = adaptive_fix_audit.summarize_records(adaptive_fix_audit.read_records(db))
+
+    assert summary["recommendation"] == "NO_SHIP"
+    assert summary["missing_proof_count"] == 0
+    assert summary["proof_failed_count"] == 1
+    assert summary["ok"] is False
+    assert summary["next_owner_action"].startswith("Block release signoff")

--- a/tests/test_adaptive_fixture_corpus.py
+++ b/tests/test_adaptive_fixture_corpus.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sdetkit import adaptive_diagnosis
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "adaptive_logs"
+METADATA = json.loads((FIXTURE_DIR / "metadata.json").read_text(encoding="utf-8"))
+
+
+def _all_text(values: object) -> str:
+    return json.dumps(values, sort_keys=True)
+
+
+@pytest.mark.parametrize("case", METADATA, ids=[row["file"] for row in METADATA])
+def test_top_scenario_fixture_corpus_preserves_expected_diagnosis(case: dict[str, object]) -> None:
+    log_text = (FIXTURE_DIR / str(case["file"])).read_text(encoding="utf-8")
+
+    payload = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+
+    assert payload["diagnoses"], case["file"]
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis["code"] == case["primary"]
+    assert case["proof_contains"] in _all_text(diagnosis["proof_commands"])
+    assert payload["fix_plan"][0]["safe_to_auto_fix"] is case["safe"]
+    if candidate := case.get("candidate"):
+        assert candidate in _all_text(diagnosis["evidence"])
+
+
+def test_top_scenario_fixture_corpus_covers_at_least_twenty_realistic_logs() -> None:
+    assert len(METADATA) >= 20
+    assert {row["primary"] for row in METADATA} >= {
+        "PYTEST_ASSERTION_FAILURE",
+        "PYTEST_IMPORT_FAILURE",
+        "PRE_COMMIT_FORMAT_DRIFT",
+        "RUFF_FIXABLE_LINT",
+        "RUFF_LINT_FAILURE",
+        "MYPY_TYPE_CONTRACT_DRIFT",
+        "UNKNOWN_REVIEW_REQUIRED",
+    }

--- a/tests/test_adaptive_integration_adapters.py
+++ b/tests/test_adaptive_integration_adapters.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_integration_adapters
+from sdetkit.cli import main as top_level_main
+
+
+def _write_required(root: Path) -> dict[str, str]:
+    diagnosis = root / "adaptive-diagnosis.json"
+    brief = root / "operator-brief.md"
+    diagnosis.write_text('{"schema_version":"sdetkit.adaptive.diagnosis.v1"}\n', encoding="utf-8")
+    brief.write_text("# brief\n", encoding="utf-8")
+    return {
+        "adaptive_diagnosis_json": diagnosis.name,
+        "operator_brief_md": brief.name,
+    }
+
+
+def test_integration_adapter_contract_ready_for_supported_providers(tmp_path: Path) -> None:
+    artifacts = _write_required(tmp_path)
+
+    for provider in ["github-actions", "gitlab", "jenkins", "local"]:
+        payload = adaptive_integration_adapters.validate_adapter_contract(
+            provider=provider, artifacts=artifacts, root=tmp_path
+        )
+        assert payload["ok"] is True
+        assert payload["recommendation"] == "READY"
+        assert payload["missing_inputs"] == []
+        assert payload["outputs"]["upload_target"]
+
+
+def test_integration_adapter_contract_blocks_missing_required_artifact(tmp_path: Path) -> None:
+    artifacts = {"adaptive_diagnosis_json": "missing.json"}
+
+    payload = adaptive_integration_adapters.validate_adapter_contract(
+        provider="github-actions", artifacts=artifacts, root=tmp_path
+    )
+
+    assert payload["ok"] is False
+    assert payload["recommendation"] == "BLOCKED"
+    assert payload["missing_inputs"] == ["adaptive_diagnosis_json", "operator_brief_md"]
+
+
+def test_integration_adapter_cli_and_top_level_passthrough(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts.json"
+    out = tmp_path / "adapter.json"
+    artifacts.write_text(json.dumps({"artifacts": _write_required(tmp_path)}), encoding="utf-8")
+
+    rc = top_level_main(
+        [
+            "adaptive",
+            "integration-adapter",
+            "validate",
+            "--provider",
+            "gitlab",
+            "--artifacts",
+            str(artifacts),
+            "--root",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["provider"] == "gitlab"
+    assert payload["ok"] is True

--- a/tests/test_adaptive_learning_import.py
+++ b/tests/test_adaptive_learning_import.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_learning_import
+from sdetkit.cli import main as top_level_main
+
+
+def _export(records: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive.enterprise_learning_export.v1",
+        "ok": True,
+        "record_count": len(records),
+        "redaction_policy": {"placeholder": "<redacted>"},
+        "records": records,
+    }
+
+
+def test_learning_import_accepts_redacted_export_and_emits_calibration_hints() -> None:
+    payload = adaptive_learning_import.build_learning_import(
+        _export(
+            [
+                {
+                    "source_code": "RUFF_FIXABLE_LINT",
+                    "outcome": "proof_passed",
+                    "repo": "<redacted>",
+                    "affected_files": ["<redacted>"],
+                    "source_path": "<redacted>",
+                },
+                {
+                    "source_code": "PYTEST_ASSERTION_FAILURE",
+                    "outcome": "proof_failed",
+                    "repository": "<redacted>",
+                    "files": ["<redacted>"],
+                },
+            ]
+        )
+    )
+
+    assert payload["ok"] is True
+    assert payload["recommendation"] == "IMPORT"
+    hints = {row["scenario_code"]: row for row in payload["calibration_hints"]}
+    assert hints["RUFF_FIXABLE_LINT"]["action"] == "promote"
+    assert hints["PYTEST_ASSERTION_FAILURE"]["action"] == "review_guardrail"
+
+
+def test_learning_import_rejects_private_fields_and_raw_paths() -> None:
+    payload = adaptive_learning_import.build_learning_import(
+        _export(
+            [
+                {
+                    "source_code": "RUFF_FIXABLE_LINT",
+                    "repo": "private-repo",
+                    "affected_files": ["src/private_widget.py"],
+                    "evidence": "failure in /home/alice/work/private/tests/test_widget.py",
+                }
+            ]
+        )
+    )
+
+    assert payload["ok"] is False
+    assert payload["recommendation"] == "REJECT_IMPORT"
+    codes = {row["code"] for row in payload["findings"]}
+    assert "PRIVATE_FIELD_NOT_REDACTED" in codes
+    assert "PRIVATE_IDENTIFIER_PATTERN" in codes
+    assert payload["calibration_hint_count"] == 0
+
+
+
+
+def test_learning_import_rejects_private_urls_hosts_and_emails() -> None:
+    payload = adaptive_learning_import.build_learning_import(
+        _export(
+            [
+                {
+                    "source_code": "PYTEST_ASSERTION_FAILURE",
+                    "repo": "<redacted>",
+                    "affected_files": ["<redacted>"],
+                    "issue_url": "https://github.example.internal/acme/private-repo/issues/123",
+                    "hostname": "ci-runner-17.internal.example.com",
+                    "owner": "alice@example.internal",
+                }
+            ]
+        )
+    )
+
+    assert payload["ok"] is False
+    assert payload["recommendation"] == "REJECT_IMPORT"
+    codes = {row["code"] for row in payload["findings"]}
+    assert "PRIVATE_FIELD_NOT_REDACTED" in codes
+    assert "PRIVATE_URL_PATTERN" in codes
+    assert "PRIVATE_HOSTNAME_PATTERN" in codes
+    assert "PRIVATE_EMAIL_PATTERN" in codes
+
+def test_learning_import_cli_and_top_level_passthrough(tmp_path: Path) -> None:
+    export = tmp_path / "learning-export.json"
+    out = tmp_path / "import-result.json"
+    export.write_text(
+        json.dumps(
+            _export(
+                [
+                    {
+                        "source_code": "PRE_COMMIT_FORMAT_DRIFT",
+                        "outcome": "proof_passed",
+                        "repo": "<redacted>",
+                        "affected_files": ["<redacted>"],
+                    }
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    rc = top_level_main(
+        [
+            "adaptive",
+            "learning-import",
+            str(export),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+    assert payload["calibration_hints"][0]["scenario_code"] == "PRE_COMMIT_FORMAT_DRIFT"

--- a/tests/test_adaptive_learning_import.py
+++ b/tests/test_adaptive_learning_import.py
@@ -67,8 +67,6 @@ def test_learning_import_rejects_private_fields_and_raw_paths() -> None:
     assert payload["calibration_hint_count"] == 0
 
 
-
-
 def test_learning_import_rejects_private_urls_hosts_and_emails() -> None:
     payload = adaptive_learning_import.build_learning_import(
         _export(
@@ -92,6 +90,7 @@ def test_learning_import_rejects_private_urls_hosts_and_emails() -> None:
     assert "PRIVATE_URL_PATTERN" in codes
     assert "PRIVATE_HOSTNAME_PATTERN" in codes
     assert "PRIVATE_EMAIL_PATTERN" in codes
+
 
 def test_learning_import_cli_and_top_level_passthrough(tmp_path: Path) -> None:
     export = tmp_path / "learning-export.json"

--- a/tests/test_adaptive_memory.py
+++ b/tests/test_adaptive_memory.py
@@ -85,6 +85,11 @@ def test_adaptive_cli_help_discoverability() -> None:
     assert "explain" in proc.stdout
     assert "learn" in proc.stdout
     assert "brief" in proc.stdout
+    assert "portfolio-rollup" in proc.stdout
+    assert "patch-plan" in proc.stdout
+    assert "fix-audit" in proc.stdout
+    assert "enterprise-governance" in proc.stdout
+    assert "integration-adapter" in proc.stdout
 
     assert _run("adaptive", "init", "--help").returncode == 0
     assert _run("adaptive", "ingest", "--help").returncode == 0
@@ -94,6 +99,16 @@ def test_adaptive_cli_help_discoverability() -> None:
     assert _run("adaptive", "learn", "record", "--help").returncode == 0
     assert _run("adaptive", "learn", "summarize", "--help").returncode == 0
     assert _run("adaptive", "brief", "--help").returncode == 0
+    assert _run("adaptive", "portfolio-rollup", "--help").returncode == 0
+    assert _run("adaptive", "patch-plan", "--help").returncode == 0
+    assert _run("adaptive", "fix-audit", "--help").returncode == 0
+    assert _run("adaptive", "fix-audit", "record", "--help").returncode == 0
+    assert _run("adaptive", "fix-audit", "summarize", "--help").returncode == 0
+    assert _run("adaptive", "enterprise-governance", "--help").returncode == 0
+    assert _run("adaptive", "enterprise-governance", "report", "--help").returncode == 0
+    assert _run("adaptive", "enterprise-governance", "anonymize-learning", "--help").returncode == 0
+    assert _run("adaptive", "integration-adapter", "--help").returncode == 0
+    assert _run("adaptive", "integration-adapter", "validate", "--help").returncode == 0
 
 
 def test_adaptive_learn_record_and_summarize_cli(tmp_path: Path) -> None:

--- a/tests/test_adaptive_patch_plan.py
+++ b/tests/test_adaptive_patch_plan.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_patch_plan
+from sdetkit.cli import main as top_level_main
+
+
+def _diagnosis(
+    code: str = "UNKNOWN_REVIEW_REQUIRED", confidence: str = "medium"
+) -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive.diagnosis.v1",
+        "status": "needs_fix",
+        "confidence": confidence,
+        "diagnosis_count": 1,
+        "diagnoses": [
+            {
+                "code": code,
+                "title": "Failure needs human review",
+                "severity": "high",
+                "confidence": confidence,
+                "evidence": [
+                    "candidate_scenarios=PACKAGE_INSTALL_FAILURE,CACHE_ARTIFACT_POISONING"
+                ],
+                "proof_commands": ["python -m pip install -r requirements-test.txt -e ."],
+                "affected_files": ["pyproject.toml"],
+            }
+        ],
+    }
+
+
+def test_assisted_patch_plan_is_review_only_for_unknown_failures() -> None:
+    plan = adaptive_patch_plan.build_patch_plan(_diagnosis())
+
+    assert plan["schema_version"] == "sdetkit.adaptive.patch_plan.v1"
+    assert plan["status"] == "review_required"
+    assert plan["safe_to_auto_fix"] is False
+    assert plan["dry_run_only"] is True
+    assert plan["requires_human_review"] is True
+    assert plan["guardrails"]["automation_mutation_allowed"] is False
+    assert plan["guardrails"]["deterministic_reproduction_available"] is True
+    assert plan["guardrails"]["scenario_confidence_threshold_met"] is True
+    assert plan["candidate_scenarios"] == [
+        "PACKAGE_INSTALL_FAILURE",
+        "CACHE_ARTIFACT_POISONING",
+    ]
+    assert all(step["mutation_allowed"] is False for step in plan["patch_steps"])
+    assert plan["patch_steps"][0]["action"] == "reproduce"
+
+
+def test_assisted_patch_plan_defers_safe_mechanical_diagnoses() -> None:
+    plan = adaptive_patch_plan.build_patch_plan(_diagnosis("PRE_COMMIT_FORMAT_DRIFT", "high"))
+
+    assert plan["status"] == "not_applicable"
+    assert plan["safe_to_auto_fix"] is False
+    assert plan["patch_steps"] == []
+    assert "safe mechanical diagnosis" in plan["reason"]
+
+
+def test_patch_plan_cli_writes_markdown(tmp_path: Path) -> None:
+    diagnosis = tmp_path / "diagnosis.json"
+    out = tmp_path / "patch-plan.md"
+    diagnosis.write_text(json.dumps(_diagnosis()), encoding="utf-8")
+
+    rc = adaptive_patch_plan.main([str(diagnosis), "--format", "md", "--out", str(out)])
+
+    assert rc == 0
+    text = out.read_text(encoding="utf-8")
+    assert "# Adaptive assisted patch plan" in text
+    assert "Mutation allowed: `false`" in text
+    assert "python -m pip install" in text
+
+
+def test_top_level_cli_adaptive_patch_plan_passthrough(tmp_path: Path) -> None:
+    diagnosis = tmp_path / "diagnosis.json"
+    out = tmp_path / "patch-plan.json"
+    diagnosis.write_text(json.dumps(_diagnosis()), encoding="utf-8")
+
+    rc = top_level_main(
+        ["adaptive", "patch-plan", str(diagnosis), "--format", "json", "--out", str(out)]
+    )
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["status"] == "review_required"
+    assert payload["guardrails"]["post_fix_proof_required"] is True

--- a/tests/test_adaptive_portfolio_rollup.py
+++ b/tests/test_adaptive_portfolio_rollup.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_portfolio_rollup
+from sdetkit.cli import main as top_level_main
+
+
+def _diagnosis_payload(repo: str, status: str, code: str, risk_score: int) -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive.diagnosis.v1",
+        "repo": repo,
+        "status": status,
+        "risk_score": risk_score,
+        "confidence": "high",
+        "diagnosis_count": 1,
+        "diagnoses": [
+            {
+                "code": code,
+                "title": f"{code} title",
+                "severity": "high" if status == "needs_fix" else "medium",
+                "confidence": "high",
+                "repeat_count": 2 if status == "needs_fix" else 0,
+                "evidence": [
+                    "candidate_scenarios=PACKAGE_INSTALL_FAILURE,CACHE_ARTIFACT_POISONING"
+                ],
+            }
+        ],
+    }
+
+
+def test_adaptive_portfolio_rollup_prioritizes_cross_repo_risks() -> None:
+    payload = adaptive_portfolio_rollup.build_portfolio_rollup(
+        [
+            _diagnosis_payload("api", "needs_fix", "PYTEST_ASSERTION_FAILURE", 70),
+            _diagnosis_payload("web", "needs_attention", "PYTEST_ASSERTION_FAILURE", 35),
+            _diagnosis_payload("ops", "monitor", "KNOWN_ADAPTIVE_PATTERN_AVAILABLE", 8),
+        ]
+    )
+
+    assert payload["schema_version"] == "sdetkit.adaptive.portfolio_rollup.v1"
+    assert payload["ok"] is False
+    assert payload["recommendation"] == "NO_SHIP"
+    assert payload["repo_count"] == 3
+    assert payload["needs_fix_repos"] == ["api"]
+    assert payload["top_risk_scenarios"][0]["code"] == "PYTEST_ASSERTION_FAILURE"
+    assert payload["top_risk_scenarios"][0]["repo_count"] == 2
+    assert any(
+        row["code"] == "PACKAGE_INSTALL_FAILURE" and row["candidate_mentions"] == 3
+        for row in payload["top_risk_scenarios"]
+    )
+    assert payload["next_owner_action"].startswith("Block release signoff for api")
+
+
+def test_adaptive_portfolio_rollup_cli_writes_markdown(tmp_path: Path) -> None:
+    api = tmp_path / "api" / "diagnosis.json"
+    web = tmp_path / "web" / "diagnosis.json"
+    out = tmp_path / "rollup.md"
+    api.parent.mkdir()
+    web.parent.mkdir()
+    api.write_text(json.dumps(_diagnosis_payload("api", "needs_fix", "RUFF_LINT_FAILURE", 64)))
+    web.write_text(json.dumps(_diagnosis_payload("web", "monitor", "LEARNING_DB_EMPTY", 12)))
+
+    rc = adaptive_portfolio_rollup.main([str(api), str(web), "--format", "md", "--out", str(out)])
+
+    assert rc == 0
+    text = out.read_text(encoding="utf-8")
+    assert "# Adaptive Portfolio Rollup" in text
+    assert "`RUFF_LINT_FAILURE`" in text
+    assert "Block release signoff for api" in text
+
+
+def test_top_level_cli_adaptive_portfolio_rollup_passthrough(tmp_path: Path) -> None:
+    artifact = tmp_path / "diagnosis.json"
+    out = tmp_path / "rollup.json"
+    artifact.write_text(
+        json.dumps(_diagnosis_payload("api", "needs_attention", "MYPY_TYPE_FAILURE", 40)),
+        encoding="utf-8",
+    )
+
+    rc = top_level_main(
+        ["adaptive", "portfolio-rollup", str(artifact), "--format", "json", "--out", str(out)]
+    )
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["recommendation"] == "SHIP_WITH_CONTROLS"
+    assert payload["top_risk_scenarios"][0]["code"] == "MYPY_TYPE_FAILURE"

--- a/tests/test_adaptive_remediation_policy.py
+++ b/tests/test_adaptive_remediation_policy.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_remediation_policy
+from sdetkit.cli import main as top_level_main
+
+
+def _safe_plan(file_count: int = 2) -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive_safe_fix.v1",
+        "source_status": "needs_fix",
+        "source_code": "RUFF_FIXABLE_LINT",
+        "safe_to_auto_fix": True,
+        "fix_type": "ruff_fixable_lint",
+        "requires_human_review": False,
+        "affected_files": [f"tests/test_{index}.py" for index in range(file_count)],
+        "proof_commands": [
+            "PYTHONPATH=src python -m ruff check tests/test_0.py",
+            "PYTHONPATH=src python -m pytest -q <targeted-tests>",
+        ],
+    }
+
+
+def _patch_plan() -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.adaptive.patch_plan.v1",
+        "status": "review_required",
+        "source_status": "needs_fix",
+        "source_code": "UNKNOWN_REVIEW_REQUIRED",
+        "safe_to_auto_fix": False,
+        "dry_run_only": True,
+        "requires_human_review": True,
+        "affected_files": ["pyproject.toml"],
+        "proof_commands": ["python -m pip install -r requirements-test.txt -e ."],
+    }
+
+
+def test_remediation_policy_approves_narrow_safe_fix() -> None:
+    payload = adaptive_remediation_policy.evaluate_policy(
+        adaptive_remediation_policy.default_policy(), _safe_plan()
+    )
+
+    assert payload["schema_version"] == "sdetkit.adaptive.remediation_policy.result.v1"
+    assert payload["ok"] is True
+    assert payload["recommendation"] == "APPROVE"
+    assert payload["plan_kind"] == "safe_fix"
+    assert payload["finding_count"] == 0
+
+
+def test_remediation_policy_rejects_unsafe_policy_expansion() -> None:
+    policy = {
+        **adaptive_remediation_policy.default_policy(),
+        "allowed_safe_fix_types": ["format_only", "review_required"],
+        "allow_review_required_auto_fix": True,
+    }
+
+    payload = adaptive_remediation_policy.evaluate_policy(policy, _safe_plan())
+
+    assert payload["ok"] is False
+    assert payload["recommendation"] == "REJECT_POLICY"
+    assert {row["code"] for row in payload["findings"]} >= {
+        "POLICY_UNSAFE_FIX_TYPE_ALLOWED",
+        "POLICY_REVIEW_REQUIRED_AUTO_FIX_ENABLED",
+    }
+
+
+def test_remediation_policy_rejects_unknown_auto_fix_even_if_policy_tries_to_allow_it() -> None:
+    policy = adaptive_remediation_policy.default_policy()
+    plan = {
+        **_safe_plan(),
+        "source_code": "UNKNOWN_REVIEW_REQUIRED",
+        "fix_type": "format_only",
+    }
+
+    payload = adaptive_remediation_policy.evaluate_policy(policy, plan)
+
+    assert payload["ok"] is False
+    assert payload["recommendation"] == "REJECT_PLAN"
+    assert payload["findings"][0]["code"] == "PLAN_SOURCE_CODE_BLOCKED_FOR_AUTO_FIX"
+
+
+def test_remediation_policy_rejects_changed_file_scope_over_limit() -> None:
+    policy = {**adaptive_remediation_policy.default_policy(), "max_changed_files": 1}
+
+    payload = adaptive_remediation_policy.evaluate_policy(policy, _safe_plan(file_count=3))
+
+    assert payload["ok"] is False
+    assert payload["recommendation"] == "REJECT_PLAN"
+    assert payload["findings"][0]["code"] == "PLAN_CHANGED_FILE_SCOPE_EXCEEDED"
+
+
+def test_remediation_policy_accepts_review_only_patch_plan() -> None:
+    payload = adaptive_remediation_policy.evaluate_policy(
+        adaptive_remediation_policy.default_policy(), _patch_plan()
+    )
+
+    assert payload["ok"] is True
+    assert payload["recommendation"] == "APPROVE"
+    assert payload["plan_kind"] == "assisted_patch_plan"
+    assert payload["safe_to_auto_fix"] is False
+
+
+def test_remediation_policy_cli_and_top_level_passthrough(tmp_path: Path) -> None:
+    policy = tmp_path / "policy.json"
+    plan = tmp_path / "safe-plan.json"
+    out = tmp_path / "result.json"
+    policy.write_text(json.dumps(adaptive_remediation_policy.default_policy()), encoding="utf-8")
+    plan.write_text(json.dumps(_safe_plan()), encoding="utf-8")
+
+    rc = top_level_main(
+        [
+            "adaptive",
+            "remediation-policy",
+            "validate",
+            str(plan),
+            "--policy",
+            str(policy),
+            "--format",
+            "json",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["ok"] is True
+    assert payload["recommendation"] == "APPROVE"
+
+
+def test_remediation_policy_template_writes_default(tmp_path: Path) -> None:
+    out = tmp_path / "policy.json"
+
+    rc = adaptive_remediation_policy.main(["template", "--format", "json", "--out", str(out)])
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "sdetkit.adaptive.remediation_policy.v1"
+    assert payload["allow_review_required_auto_fix"] is False

--- a/tests/test_repo_adoption_scan.py
+++ b/tests/test_repo_adoption_scan.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import repo_adoption_scan
+from sdetkit.cli import main as top_level_main
+
+
+def test_repo_adoption_scan_detects_stack_and_gaps(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('hi')\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# demo\n", encoding="utf-8")
+
+    payload = repo_adoption_scan.build_repo_adoption_scan(tmp_path)
+
+    assert payload["schema_version"] == "sdetkit.repo_adoption_scan.v1"
+    assert payload["stack"]["python"] is True
+    assert payload["stack"]["has_tests"] is False
+    codes = {gap["code"] for gap in payload["adoption_gaps"]}
+    assert "TEST_SURFACE_MISSING" in codes
+    assert "CI_CONTRACT_MISSING" in codes
+    assert any("sdetkit review" in command for command in payload["recommended_commands"])
+
+
+def test_repo_adoption_scan_ready_repo_has_canonical_commands(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# demo\n", encoding="utf-8")
+    (tmp_path / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_smoke.py").write_text("def test_smoke(): assert True\n", encoding="utf-8")
+    workflow = tmp_path / ".github" / "workflows"
+    workflow.mkdir(parents=True)
+    (workflow / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+
+    payload = repo_adoption_scan.build_repo_adoption_scan(tmp_path)
+
+    assert payload["recommendation"] == "READY_FOR_CANONICAL_ADOPTION"
+    assert payload["ok"] is True
+    assert payload["risk_score"] == 0
+    assert payload["next_owner_action"] == "Adopt the canonical gate/review path in CI now."
+
+
+def test_top_level_cli_adopt_scan_passthrough(tmp_path: Path) -> None:
+    out = tmp_path / "adopt-scan.json"
+    (tmp_path / "package.json").write_text('{"scripts":{"test":"node test.js"}}\n', encoding="utf-8")
+
+    rc = top_level_main(["adopt-scan", str(tmp_path), "--format", "json", "--out", str(out)])
+
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["stack"]["javascript"] is True
+    assert payload["adoption_gaps"]

--- a/tests/test_repo_adoption_scan.py
+++ b/tests/test_repo_adoption_scan.py
@@ -29,7 +29,9 @@ def test_repo_adoption_scan_ready_repo_has_canonical_commands(tmp_path: Path) ->
     (tmp_path / "README.md").write_text("# demo\n", encoding="utf-8")
     (tmp_path / "LICENSE").write_text("MIT\n", encoding="utf-8")
     (tmp_path / "tests").mkdir()
-    (tmp_path / "tests" / "test_smoke.py").write_text("def test_smoke(): assert True\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_smoke.py").write_text(
+        "def test_smoke(): assert True\n", encoding="utf-8"
+    )
     workflow = tmp_path / ".github" / "workflows"
     workflow.mkdir(parents=True)
     (workflow / "ci.yml").write_text("name: ci\n", encoding="utf-8")
@@ -44,7 +46,9 @@ def test_repo_adoption_scan_ready_repo_has_canonical_commands(tmp_path: Path) ->
 
 def test_top_level_cli_adopt_scan_passthrough(tmp_path: Path) -> None:
     out = tmp_path / "adopt-scan.json"
-    (tmp_path / "package.json").write_text('{"scripts":{"test":"node test.js"}}\n', encoding="utf-8")
+    (tmp_path / "package.json").write_text(
+        '{"scripts":{"test":"node test.js"}}\n', encoding="utf-8"
+    )
 
     rc = top_level_main(["adopt-scan", str(tmp_path), "--format", "json", "--out", str(out)])
 


### PR DESCRIPTION
### Motivation

- Continue the adaptive "next-wave" by providing review-first operator surfaces, enterprise metrics, governance controls, and safe remediation guardrails without enabling hosted data leakage or unsafe auto-fixes.
- Make the adaptive scenario database scale to real-world diagnostic coverage and expose deterministic artifacts (dashboard, rollups, audits) for release-room review and automation observability.

### Description

- Added a static local Adaptive dashboard generator at `src/sdetkit/adaptive_dashboard.py` and docs `docs/adaptive-dashboard.md`, plus a default dashboard HTML/JSON CLI surface wired into `src/sdetkit/cli.py` and `mkdocs.yml`.
- Implemented enterprise analytics, governance, fix-audit, integration-adapter validation, learning-import, patch-plan (review-only assisted patch plans), portfolio rollup, remediation policy validation, and repo adoption scan as new CLI modules under `src/sdetkit/` with corresponding docs and schemas (e.g., `adaptive_enterprise_analytics.py`, `adaptive_enterprise_governance.py`, `adaptive_fix_audit.py`, `adaptive_integration_adapters.py`, `adaptive_learning_import.py`, `adaptive_patch_plan.py`, `adaptive_portfolio_rollup.py`, `adaptive_remediation_policy.py`, `repo_adoption_scan.py`).
- Hardened `adaptive_diagnosis` to include a generated failure-matrix (large deterministic scenario set), operator guidance blocks attached to diagnoses, observed-failure snippets, layered pack reporting and override governance, and merged seeded scenario DB (`SEEDED_SCENARIO_DB`) combining curated and generated scenarios.
- Added configuration schema and default policy at `schemas/adaptive-remediation-policy.schema.json` and `config/adaptive_remediation_policy.default.json` to control allowed safe-fix types, changed-file scope, required proof outcomes, and blocked source codes.
- Updated top-level CLI (`src/sdetkit/cli.py`) to expose new adaptive subcommands (`portfolio-rollup`, `patch-plan`, `fix-audit`, `enterprise-analytics`, `remediation-policy`, `dashboard`, `learning-import`, `enterprise-governance`, `integration-adapter`) and added `adopt-scan` entrypoint for repo adoption scans.
- Documentation: added demo gallery, analytics, integration-adapter, remediation policy, hosted-readiness boundary, learning-import, roadmap updates, governance pack guidance, and repo adoption scan docs; updated `mkdocs.yml` to include new pages.
- Tests and fixtures: added a comprehensive fixture corpus and many unit tests under `tests/` covering the new modules, scenario pack behavior, CLI passthroughs, and policy/analytics/audit flows.

### Testing

- Ran the unit test suite with `pytest tests/` covering new modules and fixtures; the new test files include `tests/test_adaptive_*.py`, `tests/test_adaptive_dashboard.py`, `tests/test_adaptive_enterprise_*.py`, `tests/test_adaptive_fix_audit.py`, `tests/test_adaptive_patch_plan.py`, `tests/test_adaptive_portfolio_rollup.py`, `tests/test_adaptive_remediation_policy.py`, and `tests/test_repo_adoption_scan.py`, and all tests passed.
- Exercised CLI entrypoints with the top-level dispatch via `python -m sdetkit.cli` for representative commands (dashboard, enterprise-analytics, enterprise-governance, fix-audit record/summarize, integration-adapter validate, learning-import, patch-plan, portfolio-rollup, remediation-policy template/validate) as covered by tests and integration unit tests, which returned expected exit codes (0) and produced valid JSON/HTML artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3bb19ed08332a8daa30380455a9c)