### PR TITLE
Expand current docs navigation governance

### DIFF
--- a/docs/docs-nav-cleanup-progress.md
+++ b/docs/docs-nav-cleanup-progress.md
@@ -86,3 +86,101 @@ Expected outcome:
 
 - fewer warning-only pages in `mkdocs build` output for operational docs,
 - faster navigation to execution-critical runbooks.
+
+
+## Current-docs navigation slice
+
+This cleanup pass promotes current operator-facing documentation into the MkDocs navigation without trying to absorb the full historical inventory in one change. The intent is to make active docs discoverable while leaving report archives, one-off plans, and timebound closeout material for later curation.
+
+### Scope policy
+
+The current slice is intentionally limited to documents that serve an active reader journey:
+
+- first-proof material that helps a new operator get from install to repeatable evidence
+- team adoption material that explains rollout, roles, onboarding, and common adoption paths
+- operator evidence material that explains diagnostic surfaces and proof artifacts
+- current reference material that defines supported contracts, compatibility, CI status, and integration packs
+
+The slice is not historical reports, dated investor/audit material, old upgrade closeouts, one-off execution plans, or broad archive cleanup. Those documents may still be useful, but they need a separate archive strategy rather than being mixed into the primary nav.
+
+### Added first-proof discoverability
+
+The first-proof path now exposes the docs that help a user move from a blank repo to a reliable first run:
+
+- Day 1 proof starter
+- First-failure triage
+- First-proof troubleshooting
+- First-proof learning database
+- First-proof benchmark narrative
+
+This keeps first-run guidance near the existing install, quickstart, guided run, adoption, container runtime, and CI flow pages.
+
+### Added team adoption discoverability
+
+The team adoption section now includes role and rollout docs that were previously built but not visible in navigation:
+
+- Role-based quickstarts
+- Platform engineer quickstart
+- QA governance quickstart
+- Release owner quickstart
+- Operator onboarding 7-day plan
+- Onboarding optimization
+- Adoption examples
+- Adoption scorecard
+- Adoption troubleshooting
+- Small-team adoption walkthrough
+- Enterprise platform-team adoption walkthrough
+- Example adoption flow
+- Pilot to rollout guide
+- Proof sprint checklist
+
+This keeps role-specific onboarding beside the team rollout, release-confidence, KPI, and adoption proof pages.
+
+### Added operator evidence discoverability
+
+The operator evidence section now includes current diagnostic and proof surfaces:
+
+- Adaptive review
+- Doctor Cortex CLI
+- Doctor diagnosis contract
+- Doctor prescriptions
+- Golden-path health signal
+- Proof log
+
+These docs explain how operators interpret diagnostics, prescriptions, adaptive review output, and proof records.
+
+### Added current reference discoverability
+
+The current reference section now includes active contract and integration docs:
+
+- Docs navigation cleanup progress
+- Environment compatibility matrix
+- Git workflow branch tracking health
+- Legacy required status bridge
+- Core command contract
+- CI cost telemetry contract
+- GitHub Actions reference pack
+- GitLab CI reference pack
+- Jenkins reference pack
+- Rollback and remediation examples
+
+These pages are treated as current reference material because they document supported environment assumptions, command contracts, CI expectations, and integration examples.
+
+### Guardrail
+
+The branch adds a regression test that loads `mkdocs.yml`, handles MkDocs Python YAML tags, calculates the built-doc inventory, and checks that the current-doc slice is explicit in `nav`. This prevents these docs from silently falling back into the broad “pages exist but are not included in nav” inventory.
+
+### Remaining inventory
+
+The remaining MkDocs inventory still includes many useful pages, but it is mixed across several categories:
+
+- historical reports
+- dated execution plans
+- portfolio and investor-readiness material
+- migration notes
+- support docs
+- productization notes
+- roadmap artifacts
+- archive-like generated closeout packs
+
+Those groups should be handled as separate PRs with their own navigation or archive policy. This pass deliberately avoids turning the whole inventory into primary navigation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,12 @@ nav:
       - Why SDETKit for teams: why-sdetkit-for-teams.md
       - Team use cases: use-cases.md
       - Start Here in 5 Minutes: start-here-5-minutes.md
+      - Role-based quickstarts: role-based-quickstarts.md
+      - "Quickstart: Platform engineer": quickstart-role-platform-engineer.md
+      - "Quickstart: QA governance": quickstart-role-qa-governance.md
+      - "Quickstart: Release owner": quickstart-role-release-owner.md
+      - Operator onboarding 7-day plan: operator-onboarding-7-day.md
+      - Onboarding optimization: onboarding-optimization.md
       - Release confidence model: release-confidence.md
       - Decision guide: decision-guide.md
       - Release confidence flow: release-confidence-flow.md
@@ -119,6 +125,7 @@ nav:
       - Operator essentials: operator-essentials.md
       - Investigation operator guide: investigation-operator-guide.md
       - Adaptive Diagnosis Intelligence: adaptive-diagnosis.md
+      - Adaptive review: adaptive-review.md
       - Adaptive demo gallery: adaptive-demo-gallery.md
       - Adaptive integration adapters: adaptive-integration-adapters.md
       - Adaptive enterprise analytics: adaptive-enterprise-analytics.md
@@ -147,6 +154,10 @@ nav:
       - Stability levels: stability-levels.md
       - Versioning and support posture: versioning-and-support.md
       - Integrations and extension boundary: integrations-and-extension-boundary.md
+      - GitHub Actions reference pack: integrations/github-actions-reference-pack.md
+      - GitLab CI reference pack: integrations/gitlab-reference-pack.md
+      - Jenkins reference pack: integrations/jenkins-reference-pack.md
+      - Rollback and remediation examples: integrations/rollback-remediation-examples.md
       - Release verification records: release-verification.md
       - Docs map: docs-map.md
       - Roadmap: roadmap.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,11 +88,24 @@ nav:
   - Canonical first-proof path (primary):
       - Install: install.md
       - Quickstart (copy-paste): quickstart-copy-paste.md
+      - Day 1 proof starter: day1-proof-starter.md
+      - First-failure triage: first-failure-triage.md
+      - First-proof troubleshooting: first-proof-troubleshooting.md
+      - First-proof learning database: first-proof-learning-db.md
+      - First-proof benchmark narrative: first-proof-benchmark-narrative.md
       - Blank repo to value in 60 seconds: blank-repo-to-value-60-seconds.md
       - Guided first run: ready-to-use.md
       - Team adoption checklist: team-adoption-checklist.md
       - Choose your path (30-second router): choose-your-path.md
       - Adopt in your repository: adoption.md
+      - Adoption examples: adoption-examples.md
+      - Adoption scorecard: adoption-scorecard.md
+      - Adoption troubleshooting: adoption-troubleshooting.md
+      - "Adoption walkthrough: small team": adoption-walkthrough-small-team.md
+      - "Adoption walkthrough: enterprise platform team": adoption-walkthrough-enterprise.md
+      - Example adoption flow: example-adoption-flow.md
+      - Pilot to rollout guide: pilot-to-rollout-guide.md
+      - Proof sprint checklist: proof-sprint-checklist.md
       - Team rollout playbook: team-rollout-playbook.md
       - Team rollout scenario: team-rollout-scenario.md
       - Container runtime: container-runtime.md
@@ -123,6 +136,11 @@ nav:
   - Operator and evidence (primary):
       - Docs map and organization: docs-map.md
       - Operator essentials: operator-essentials.md
+      - Doctor Cortex CLI: doctor-cortex.md
+      - Doctor diagnosis contract: doctor-diagnosis.md
+      - Doctor prescriptions: doctor-prescriptions.md
+      - Golden-path health signal: golden-path-health.md
+      - Proof log: proof-log.md
       - Investigation operator guide: investigation-operator-guide.md
       - Adaptive Diagnosis Intelligence: adaptive-diagnosis.md
       - Adaptive review: adaptive-review.md
@@ -160,6 +178,12 @@ nav:
       - Rollback and remediation examples: integrations/rollback-remediation-examples.md
       - Release verification records: release-verification.md
       - Docs map: docs-map.md
+      - Docs navigation cleanup progress: docs-nav-cleanup-progress.md
+      - Environment compatibility matrix: environment-compatibility.md
+      - Git workflow branch tracking health: git-workflow.md
+      - Legacy required status bridge: ci-legacy-status-bridge.md
+      - Core command contract: core-command-contract.md
+      - CI cost telemetry contract: ci-cost-telemetry-contract.md
       - Roadmap: roadmap.md
       - Changelog: changelog.md
       - License: license.md

--- a/tests/test_docs_nav_current_discoverability.py
+++ b/tests/test_docs_nav_current_discoverability.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+MKDOCS = ROOT / "mkdocs.yml"
+
+
+class MkDocsInspectionLoader(yaml.SafeLoader):
+    pass
+
+
+def _ignore_python_name(loader: yaml.Loader, suffix: str, node: yaml.Node) -> str:
+    return suffix
+
+
+MkDocsInspectionLoader.add_multi_constructor(
+    "tag:yaml.org,2002:python/name:",
+    _ignore_python_name,
+)
+
+
+CURRENT_NAV_GROUPS = {
+    "canonical_first_proof": (
+        "day1-proof-starter.md",
+        "first-failure-triage.md",
+        "first-proof-troubleshooting.md",
+        "first-proof-learning-db.md",
+        "first-proof-benchmark-narrative.md",
+    ),
+    "team_adoption": (
+        "role-based-quickstarts.md",
+        "quickstart-role-platform-engineer.md",
+        "quickstart-role-qa-governance.md",
+        "quickstart-role-release-owner.md",
+        "operator-onboarding-7-day.md",
+        "onboarding-optimization.md",
+        "adoption-examples.md",
+        "adoption-scorecard.md",
+        "adoption-troubleshooting.md",
+        "adoption-walkthrough-small-team.md",
+        "adoption-walkthrough-enterprise.md",
+        "example-adoption-flow.md",
+        "pilot-to-rollout-guide.md",
+        "proof-sprint-checklist.md",
+    ),
+    "operator_evidence": (
+        "adaptive-review.md",
+        "doctor-cortex.md",
+        "doctor-diagnosis.md",
+        "doctor-prescriptions.md",
+        "golden-path-health.md",
+        "proof-log.md",
+    ),
+    "current_reference": (
+        "docs-nav-cleanup-progress.md",
+        "environment-compatibility.md",
+        "git-workflow.md",
+        "ci-legacy-status-bridge.md",
+        "core-command-contract.md",
+        "ci-cost-telemetry-contract.md",
+        "integrations/github-actions-reference-pack.md",
+        "integrations/gitlab-reference-pack.md",
+        "integrations/jenkins-reference-pack.md",
+        "integrations/rollback-remediation-examples.md",
+    ),
+}
+
+
+def _load_mkdocs() -> dict:
+    return yaml.load(
+        MKDOCS.read_text(encoding="utf-8"),
+        Loader=MkDocsInspectionLoader,
+    )
+
+
+def _walk_nav(node: object) -> list[str]:
+    if isinstance(node, str):
+        return [node]
+    if isinstance(node, list):
+        paths: list[str] = []
+        for item in node:
+            paths.extend(_walk_nav(item))
+        return paths
+    if isinstance(node, dict):
+        paths = []
+        for value in node.values():
+            paths.extend(_walk_nav(value))
+        return paths
+    return []
+
+
+def _nav_paths() -> set[str]:
+    config = _load_mkdocs()
+    return {
+        item
+        for item in _walk_nav(config.get("nav", []))
+        if isinstance(item, str) and item.endswith(".md")
+    }
+
+
+def _exclude_patterns() -> list[str]:
+    config = _load_mkdocs()
+    exclude_raw = config.get("exclude_docs", "") or ""
+    return [
+        line.strip().lstrip("/")
+        for line in exclude_raw.splitlines()
+        if line.strip() and not line.strip().startswith("!")
+    ]
+
+
+def _is_excluded(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def _built_doc_paths() -> set[str]:
+    patterns = _exclude_patterns()
+    return {
+        str(path.relative_to(DOCS))
+        for path in DOCS.rglob("*.md")
+        if not _is_excluded(str(path.relative_to(DOCS)), patterns)
+    }
+
+
+def _required_current_docs() -> tuple[str, ...]:
+    docs: list[str] = []
+    for group in CURRENT_NAV_GROUPS.values():
+        docs.extend(group)
+    return tuple(docs)
+
+
+def test_current_docs_nav_groups_have_unique_paths() -> None:
+    docs = _required_current_docs()
+
+    assert len(docs) == len(set(docs))
+
+
+def test_current_docs_nav_groups_reference_existing_docs() -> None:
+    missing = [doc_path for doc_path in _required_current_docs() if not (DOCS / doc_path).is_file()]
+
+    assert missing == []
+
+
+def test_current_docs_nav_groups_are_not_excluded_from_mkdocs_build() -> None:
+    built_docs = _built_doc_paths()
+    excluded_required_docs = [
+        doc_path for doc_path in _required_current_docs() if doc_path not in built_docs
+    ]
+
+    assert excluded_required_docs == []
+
+
+def test_current_docs_nav_groups_are_in_mkdocs_nav() -> None:
+    nav_paths = _nav_paths()
+    missing_from_nav = [
+        doc_path for doc_path in _required_current_docs() if doc_path not in nav_paths
+    ]
+
+    assert missing_from_nav == []
+
+
+def test_current_docs_slice_no_longer_contributes_to_mkdocs_nav_inventory() -> None:
+    built_docs = _built_doc_paths()
+    nav_paths = _nav_paths()
+    not_in_nav = built_docs - nav_paths
+
+    current_docs_still_missing = [
+        doc_path for doc_path in _required_current_docs() if doc_path in not_in_nav
+    ]
+
+    assert current_docs_still_missing == []
+
+
+def test_docs_nav_cleanup_progress_records_current_slice_policy() -> None:
+    progress_doc = DOCS / "docs-nav-cleanup-progress.md"
+    text = progress_doc.read_text(encoding="utf-8")
+
+    required_markers = [
+        "Current-docs navigation slice",
+        "first-proof",
+        "team adoption",
+        "operator evidence",
+        "current reference",
+        "not historical reports",
+    ]
+    missing_markers = [marker for marker in required_markers if marker not in text]
+
+    assert missing_markers == []
+
+
+def test_nav_inventory_keeps_current_docs_explicit_not_implicit() -> None:
+    nav_paths = _nav_paths()
+
+    for group_name, group_docs in CURRENT_NAV_GROUPS.items():
+        missing = [doc_path for doc_path in group_docs if doc_path not in nav_paths]
+        assert missing == [], f"{group_name} missing nav docs: {missing}"

--- a/tests/test_docs_nav_current_discoverability.py
+++ b/tests/test_docs_nav_current_discoverability.py
@@ -10,20 +10,6 @@ DOCS = ROOT / "docs"
 MKDOCS = ROOT / "mkdocs.yml"
 
 
-class MkDocsInspectionLoader(yaml.SafeLoader):
-    pass
-
-
-def _ignore_python_name(loader: yaml.Loader, suffix: str, node: yaml.Node) -> str:
-    return suffix
-
-
-MkDocsInspectionLoader.add_multi_constructor(
-    "tag:yaml.org,2002:python/name:",
-    _ignore_python_name,
-)
-
-
 CURRENT_NAV_GROUPS = {
     "canonical_first_proof": (
         "day1-proof-starter.md",
@@ -72,10 +58,14 @@ CURRENT_NAV_GROUPS = {
 
 
 def _load_mkdocs() -> dict:
-    return yaml.load(
-        MKDOCS.read_text(encoding="utf-8"),
-        Loader=MkDocsInspectionLoader,
+    text = MKDOCS.read_text(encoding="utf-8")
+    text = text.replace(
+        "!!python/name:pymdownx.superfences.fence_code_format",
+        "pymdownx.superfences.fence_code_format",
     )
+    payload = yaml.safe_load(text)
+    assert isinstance(payload, dict)
+    return payload
 
 
 def _walk_nav(node: object) -> list[str]:


### PR DESCRIPTION
## Summary
- Add active first-proof, adoption, onboarding, operator-evidence, and integration reference docs to MkDocs nav
- Record the current-docs navigation cleanup policy
- Add a regression test that keeps the current-doc slice out of the broad not-in-nav inventory

## Verification
- python -m pytest -q tests/test_docs_nav_current_discoverability.py -o addopts=
- python -m pytest -q tests/test_mkdocs_strict_docs_map_links.py tests/test_docs_qa.py -o addopts=
- NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
- python -m pre_commit run -a
- bash ci.sh quick --skip-docs --artifact-dir build
- added_lines=322