### PR TITLE
Add docs archive navigation policy

### DIFF
--- a/docs/archive-navigation-policy.md
+++ b/docs/archive-navigation-policy.md
@@ -1,0 +1,237 @@
+# Archive navigation policy
+
+This policy explains how SDETKit handles documentation that is built by MkDocs but intentionally not promoted into the primary navigation.
+
+The goal is to keep the public documentation useful for active operators while still preserving older reports, closeout notes, implementation plans, and supporting material. A page being outside `nav` is not automatically a defect. It means the page needs one of three clear outcomes:
+
+1. promote it into primary navigation,
+2. group it under an archive or supporting-reference section,
+3. leave it outside navigation because it is generated, timebound, or transitional evidence.
+
+## Why this policy exists
+
+The documentation set contains both product documentation and operating history. Those are different reader experiences.
+
+Product documentation should help a user install, run, adopt, verify, integrate, and operate SDETKit. Those pages belong in the active navigation.
+
+Operating history captures the work that produced the toolkit. That includes upgrade reports, dated execution plans, closeout records, investor-readiness snapshots, roadmap artifacts, and one-off follow-up trackers. Those pages can remain valuable, but they should not crowd the active reader journey.
+
+The MkDocs inventory warning is therefore treated as a triage signal, not a blanket order to add every Markdown file to the nav.
+
+This policy is not historical reports promotion; it is archive triage for stable navigation.
+
+## Navigation tiers
+
+SDETKit uses four practical documentation tiers.
+
+### Tier 1: primary journey docs
+
+Primary journey docs belong in the main nav when they are current, maintained, and directly useful to a new or returning operator.
+
+Examples include:
+
+- install and quickstart pages
+- first-proof guidance
+- adoption and rollout guidance
+- release-confidence guidance
+- operator evidence guidance
+- active CLI, API, and command references
+- integration reference packs
+- compatibility and contract pages
+
+A Tier 1 page should answer an active user question without requiring historical context.
+
+### Tier 2: current supporting references
+
+Supporting references may belong in nav when they define current contracts, policies, compatibility rules, or operational expectations.
+
+Examples include:
+
+- command contracts
+- CI status bridge docs
+- environment compatibility docs
+- docs cleanup progress docs
+- integration examples
+- active policy records
+- current troubleshooting pages
+
+These pages may be secondary, but they still support an active operating decision.
+
+### Tier 3: archive candidates
+
+Archive candidates are valid docs that should usually not be mixed into the primary journey.
+
+Examples include:
+
+- dated upgrade reports
+- execution plans tied to a specific date
+- cycle closeout reports
+- investor-readiness snapshots
+- historical audit records
+- one-off follow-up trackers
+- generated roadmap artifact packs
+- old productization notes that are preserved for traceability
+
+Archive candidates need a separate archive strategy before nav promotion.
+
+### Tier 4: generated or intentionally excluded material
+
+Some docs are intentionally excluded from nav or excluded from the built site.
+
+Examples include:
+
+- generated sample outputs
+- raw artifact folders
+- automation template internals
+- generated weekly packs
+- machine-produced report fragments
+
+These should not be promoted into nav unless a human-facing index page is created.
+
+## Promotion rules
+
+A page may be promoted from the inventory into `nav` when all of these are true:
+
+- it serves an active user journey,
+- its title is stable enough to appear in public navigation,
+- it does not duplicate a better canonical page,
+- it is not merely a dated report or historical snapshot,
+- it has enough context to be useful when opened directly,
+- it belongs near an existing section without confusing the nav hierarchy.
+
+Promotion should be done in cohesive slices, not one-off additions.
+
+Good slices include:
+
+- first-proof and adoption docs,
+- operator evidence docs,
+- integration reference docs,
+- release room and readiness docs,
+- support and escalation docs,
+- archive index docs.
+
+Poor slices include:
+
+- one random report,
+- one generated artifact,
+- every remaining Markdown file,
+- a mix of unrelated old plans and current references,
+- dated closeout records added to the primary journey.
+
+## Archive rules
+
+A page should stay outside primary navigation when it is mostly historical or timebound.
+
+Common archive markers include:
+
+- a date in the file name or title,
+- a cycle number in the file name or title,
+- report or closeout language,
+- investor or audit snapshot language,
+- plan-execution follow-up language,
+- generated weekly-pack paths,
+- roadmap artifact paths.
+
+Archive pages can still be linked from an archive index, a roadmap index, or a cleanup progress page.
+
+The preferred pattern is to create a curated index before adding many archive pages to nav.
+
+## Current examples of archive candidates
+
+The following groups are examples of pages that should not be blindly promoted into primary navigation:
+
+### Continuous upgrade closeout reports
+
+Files like `continuous-upgrade-big-upgrade-report-1.md` through later cycle reports are historical closeout material. They may be useful for traceability, but they should live behind an archive or upgrade-history index.
+
+### Dated execution plans
+
+Files such as `powerfuel-execution-plan-2026-05-03.md` and `plan-execution-followup-2026-04-23.md` are dated operating records. They should not appear beside stable operator docs unless curated into a historical execution archive.
+
+### Investor and readiness snapshots
+
+Files like `investor-readiness-review-2026-04-18.md` and `enterprise-readiness-audit-2026-04.md` are timebound evidence snapshots. They are not primary docs for everyday users.
+
+### Roadmap artifact packs
+
+Files under `roadmap/artifacts/weekly-pack-*` are generated or package-like supporting artifacts. They should be linked from a roadmap archive or release pack index rather than added one by one.
+
+### Productization history
+
+Docs such as `enterprise-productization-blueprint.md`, `final-enterprise-reliability-plan.md`, and older program dashboards may still matter, but they need curation before primary nav placement.
+
+## Active-reference examples
+
+Some pages may look secondary but should be considered current-reference candidates.
+
+Examples include:
+
+- support and escalation guidance,
+- environment compatibility guidance,
+- release readiness guidance,
+- workflow consolidation maps,
+- security suite guidance,
+- policy and baseline guidance,
+- compatibility and deprecation policy.
+
+These should be promoted only in a coherent slice with tests.
+
+## Test expectations
+
+Navigation policy tests should avoid checking that every Markdown file is in nav.
+
+Instead, tests should check that:
+
+- active slices that were intentionally promoted stay in nav,
+- archive-policy docs are present and discoverable,
+- known archive examples remain classified as archive candidates,
+- generated or timebound material is not accidentally treated as primary navigation,
+- MkDocs config is parsed safely without unsafe YAML loading.
+
+The test contract should protect intent without freezing the entire inventory forever.
+
+## Pull request sizing
+
+Navigation cleanup PRs should be large enough to be worth review.
+
+For this repository, do not push tiny nav-only fixes. A navigation governance PR should generally include:
+
+- a coherent policy or cleanup slice,
+- a regression test,
+- proof that the slice stays out of the inventory warning,
+- at least 260 added lines unless the change is an urgent CI repair.
+
+This keeps documentation work reviewable and avoids noisy micro PRs.
+
+## Review checklist
+
+Before opening a docs navigation PR, verify:
+
+- `mkdocs.yml` is valid YAML,
+- page titles with colons are quoted,
+- new docs are ASCII-safe unless there is a deliberate exception,
+- tests avoid `yaml.load`,
+- MkDocs strict build passes,
+- pre-commit passes,
+- fast CI gate passes,
+- added-line count meets the branch size bar,
+- the PR body explains why the slice belongs together.
+
+## Merge guidance
+
+Merge navigation cleanup only when the hard gates are green.
+
+Bot comments from adaptive diagnosis may be advisory when lint, tests, coverage, and required checks are green. Unknown adaptive diagnoses should be reviewed, but they should not be treated as automatic blockers unless they point to a concrete failing gate.
+
+## Future cleanup lanes
+
+Recommended future lanes:
+
+1. release readiness and release room docs,
+2. support and escalation docs,
+3. security and policy docs,
+4. archive index for dated reports,
+5. roadmap archive index,
+6. generated artifact reference cleanup.
+
+Each lane should be its own PR with a clear title, proof commands, and a guardrail test when behavior can regress.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,6 +179,7 @@ nav:
       - Release verification records: release-verification.md
       - Docs map: docs-map.md
       - Docs navigation cleanup progress: docs-nav-cleanup-progress.md
+      - Archive navigation policy: archive-navigation-policy.md
       - Environment compatibility matrix: environment-compatibility.md
       - Git workflow branch tracking health: git-workflow.md
       - Legacy required status bridge: ci-legacy-status-bridge.md

--- a/tests/test_docs_archive_navigation_policy.py
+++ b/tests/test_docs_archive_navigation_policy.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+MKDOCS = ROOT / "mkdocs.yml"
+POLICY_DOC = DOCS / "archive-navigation-policy.md"
+
+
+ARCHIVE_EXAMPLES = (
+    "continuous-upgrade-big-upgrade-report-1.md",
+    "continuous-upgrade-big-upgrade-report-10.md",
+    "enterprise-readiness-audit-2026-04.md",
+    "investor-readiness-review-2026-04-18.md",
+    "plan-execution-followup-2026-04-23.md",
+    "powerfuel-execution-plan-2026-05-03.md",
+    "roadmap/artifacts/weekly-pack-21/closeout-checklist-21.md",
+    "roadmap/artifacts/weekly-pack-21/contributor-response-plan-21.md",
+    "roadmap/artifacts/weekly-pack-21/release-narrative-brief-21.md",
+)
+
+ACTIVE_REFERENCE_EXAMPLES = (
+    "archive-navigation-policy.md",
+    "docs-nav-cleanup-progress.md",
+    "environment-compatibility.md",
+    "git-workflow.md",
+    "ci-legacy-status-bridge.md",
+    "core-command-contract.md",
+    "ci-cost-telemetry-contract.md",
+)
+
+
+def _mkdocs_text_for_safe_load() -> str:
+    text = MKDOCS.read_text(encoding="utf-8")
+    return text.replace(
+        "!!python/name:pymdownx.superfences.fence_code_format",
+        "pymdownx.superfences.fence_code_format",
+    )
+
+
+def _load_mkdocs() -> dict:
+    payload = yaml.safe_load(_mkdocs_text_for_safe_load())
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _walk_nav(node: object) -> list[str]:
+    if isinstance(node, str):
+        return [node]
+    if isinstance(node, list):
+        paths: list[str] = []
+        for item in node:
+            paths.extend(_walk_nav(item))
+        return paths
+    if isinstance(node, dict):
+        paths = []
+        for value in node.values():
+            paths.extend(_walk_nav(value))
+        return paths
+    return []
+
+
+def _nav_paths() -> set[str]:
+    config = _load_mkdocs()
+    return {
+        item
+        for item in _walk_nav(config.get("nav", []))
+        if isinstance(item, str) and item.endswith(".md")
+    }
+
+
+def _exclude_patterns() -> list[str]:
+    config = _load_mkdocs()
+    exclude_raw = config.get("exclude_docs", "") or ""
+    return [
+        line.strip().lstrip("/")
+        for line in exclude_raw.splitlines()
+        if line.strip() and not line.strip().startswith("!")
+    ]
+
+
+def _is_excluded(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def _built_doc_paths() -> set[str]:
+    patterns = _exclude_patterns()
+    return {
+        str(path.relative_to(DOCS))
+        for path in DOCS.rglob("*.md")
+        if not _is_excluded(str(path.relative_to(DOCS)), patterns)
+    }
+
+
+def test_archive_navigation_policy_is_in_current_reference_nav() -> None:
+    nav_paths = _nav_paths()
+
+    assert "archive-navigation-policy.md" in nav_paths
+
+
+def test_archive_navigation_policy_doc_is_ascii_text() -> None:
+    raw = POLICY_DOC.read_bytes()
+
+    raw.decode("ascii")
+
+
+def test_archive_navigation_policy_names_required_tiers() -> None:
+    text = POLICY_DOC.read_text(encoding="utf-8")
+
+    required = [
+        "Tier 1: primary journey docs",
+        "Tier 2: current supporting references",
+        "Tier 3: archive candidates",
+        "Tier 4: generated or intentionally excluded material",
+    ]
+    missing = [marker for marker in required if marker not in text]
+
+    assert missing == []
+
+
+def test_archive_navigation_policy_records_promotion_and_archive_rules() -> None:
+    text = POLICY_DOC.read_text(encoding="utf-8")
+
+    required = [
+        "Promotion rules",
+        "Archive rules",
+        "Current examples of archive candidates",
+        "Active-reference examples",
+        "Test expectations",
+        "Pull request sizing",
+        "at least 260 added lines",
+    ]
+    missing = [marker for marker in required if marker not in text]
+
+    assert missing == []
+
+
+def test_archive_examples_exist_and_are_built_docs() -> None:
+    built_docs = _built_doc_paths()
+    missing = [path for path in ARCHIVE_EXAMPLES if path not in built_docs]
+
+    assert missing == []
+
+
+def test_archive_examples_are_not_primary_nav_promotions() -> None:
+    nav_paths = _nav_paths()
+    promoted_archive_examples = [path for path in ARCHIVE_EXAMPLES if path in nav_paths]
+
+    assert promoted_archive_examples == []
+
+
+def test_policy_doc_classifies_known_archive_examples() -> None:
+    text = POLICY_DOC.read_text(encoding="utf-8")
+
+    required_markers = [
+        "continuous-upgrade-big-upgrade-report-1.md",
+        "powerfuel-execution-plan-2026-05-03.md",
+        "investor-readiness-review-2026-04-18.md",
+        "enterprise-readiness-audit-2026-04.md",
+        "roadmap/artifacts/weekly-pack-*",
+    ]
+    missing = [marker for marker in required_markers if marker not in text]
+
+    assert missing == []
+
+
+def test_active_reference_examples_are_explicit_nav_paths() -> None:
+    nav_paths = _nav_paths()
+    missing = [path for path in ACTIVE_REFERENCE_EXAMPLES if path not in nav_paths]
+
+    assert missing == []
+
+
+def test_policy_uses_safe_yaml_parsing_contract_language() -> None:
+    test_source = Path(__file__).read_text(encoding="utf-8")
+    policy_text = POLICY_DOC.read_text(encoding="utf-8")
+
+    assert "yaml.safe_load" in test_source
+    forbidden_yaml_load_call = "yaml." + "load("
+    assert forbidden_yaml_load_call not in test_source
+    assert "tests avoid `yaml.load`" in policy_text
+
+
+def test_archive_policy_keeps_inventory_warning_as_triage_signal() -> None:
+    text = POLICY_DOC.read_text(encoding="utf-8")
+
+    required = [
+        "triage signal",
+        "not a blanket order",
+        "separate archive strategy",
+        "not historical reports",
+        "not accidentally treated as primary navigation",
+    ]
+    missing = [marker for marker in required if marker not in text]
+
+    assert missing == []


### PR DESCRIPTION
## Summary
- Add an archive navigation policy for built docs that should not enter primary nav
- Add the policy page to current reference navigation
- Add regression coverage for archive examples, active-reference examples, safe MkDocs YAML parsing, and the +260 PR sizing rule

## Verification
- python -m pytest -q tests/test_docs_archive_navigation_policy.py -o addopts=
- python -m pytest -q tests/test_docs_nav_current_discoverability.py -o addopts=
- NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
- python -m pre_commit run -a
- bash ci.sh quick --skip-docs --artifact-dir build
- sdetkit repo check . --profile enterprise --format json --out sdet_check.json --force
- added_lines=438