### PR TITLE
Align adaptive diagnosis with green quality gates

### DIFF
--- a/src/sdetkit/adaptive_diagnosis.py
+++ b/src/sdetkit/adaptive_diagnosis.py
@@ -1172,6 +1172,63 @@ def _attach_log_context(diagnoses: list[dict[str, Any]], start_index: int, text:
         diagnosis["evidence"] = _safe_list(evidence, 8)
 
 
+GREEN_QUALITY_GATE_TOKENS = (
+    "quality.sh cov passed",
+    "quality gate passed",
+    "coverage gate are green",
+    "lint + tests + coverage gate are green",
+    "gate fast: ok",
+    "checks: lint + tests + coverage gate are green",
+)
+
+REVIEW_FIRST_ADVISORY_TOKENS = (
+    "adaptive diagnosis",
+    "unknown_review_required",
+    "failure needs human review",
+    "sdetkit will keep this review-first",
+    "current evidence is not safe for automatic remediation",
+    "auto-fix status",
+    "check candidate coverage_gate_regression",
+)
+
+HARD_FAILURE_TOKENS_IN_GREEN_GATE_CONTEXT = (
+    "process completed with exit code",
+    "gate fast: fail",
+    "quality.sh cov failed",
+    "coverage failed",
+    "fail under",
+    "failed_steps:",
+    "[fail]",
+    "traceback",
+    "assertionerror",
+    "error:",
+    "command failed",
+)
+
+
+def _has_green_quality_gate_signal(text: str) -> bool:
+    lowered = text.lower()
+    return any(token in lowered for token in GREEN_QUALITY_GATE_TOKENS)
+
+
+def _has_hard_failure_signal_in_green_context(text: str) -> bool:
+    lowered = text.lower()
+    return any(token in lowered for token in HARD_FAILURE_TOKENS_IN_GREEN_GATE_CONTEXT)
+
+
+def _has_review_first_advisory_signal(text: str) -> bool:
+    lowered = text.lower()
+    return any(token in lowered for token in REVIEW_FIRST_ADVISORY_TOKENS)
+
+
+def _looks_green_quality_advisory(text: str) -> bool:
+    if not _has_green_quality_gate_signal(text):
+        return False
+    if _has_hard_failure_signal_in_green_context(text):
+        return False
+    return _has_review_first_advisory_signal(text)
+
+
 def _append_log(
     text: str, diagnoses: list[dict[str, Any]], adaptive_history: dict[str, Any] | None = None
 ) -> None:
@@ -1223,7 +1280,7 @@ def _append_log(
             files,
             diagnoses,
         )
-    if not diagnoses and _looks_failure_like(text):
+    if not diagnoses and _looks_failure_like(text) and not _looks_green_quality_advisory(text):
         diagnoses.append(
             _diag(
                 "UNKNOWN_REVIEW_REQUIRED",

--- a/src/sdetkit/pr_quality_comment.py
+++ b/src/sdetkit/pr_quality_comment.py
@@ -32,6 +32,25 @@ def _matching_fix_plan(payload: dict[str, Any], code: str) -> dict[str, Any]:
     )
 
 
+REVIEW_FIRST_DIAGNOSIS_CODES = {"UNKNOWN", "UNKNOWN_REVIEW_REQUIRED"}
+
+
+def _is_review_first_diagnosis(code: str) -> bool:
+    return code in REVIEW_FIRST_DIAGNOSIS_CODES
+
+
+def _diagnosis_heading(code: str) -> str:
+    if _is_review_first_diagnosis(code):
+        return "### Review-first Adaptive Diagnosis"
+    return "### Adaptive Diagnosis"
+
+
+def _next_step_heading(code: str) -> str:
+    if _is_review_first_diagnosis(code):
+        return "Human review route:"
+    return "Smallest safe fix:"
+
+
 def _auto_fix_status(code: str, fix_plan: dict[str, Any]) -> str:
     if fix_plan.get("safe_to_auto_fix") is not True:
         return "SDETKit will keep this review-first because the current evidence is not safe for automatic remediation."
@@ -57,7 +76,7 @@ def render_adaptive_diagnosis_comment(payload: dict[str, Any]) -> str:
     fix_plan = _matching_fix_plan(payload, code)
 
     lines = [
-        "### Adaptive Diagnosis",
+        _diagnosis_heading(code),
         f"- status: `{payload.get('status', 'unknown')}`",
         f"- risk score: `{payload.get('risk_score', 'unknown')}`",
         f"- confidence: `{payload.get('confidence', 'unknown')}`",
@@ -67,7 +86,7 @@ def render_adaptive_diagnosis_comment(payload: dict[str, Any]) -> str:
         "Why developers miss it:",
         str(first.get("why_developers_miss_it", "No hidden-risk explanation available.")),
         "",
-        "Smallest safe fix:",
+        _next_step_heading(code),
         f"- {_first_text(fixes, 'Inspect the first failing evidence item and apply the smallest safe change.')}",
         "",
         "Proof command:",

--- a/tests/test_adaptive_quality_gate_advisory_alignment.py
+++ b/tests/test_adaptive_quality_gate_advisory_alignment.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from sdetkit import adaptive_diagnosis, pr_quality_comment
+
+GREEN_QUALITY_ADVISORY_COMMENT = """
+SDET Quality Gate
+quality.sh cov passed
+
+coverage: 96.72%
+checks: lint + tests + coverage gate are green for this PR run
+
+Adaptive Diagnosis
+status: needs_fix
+risk score: 45
+confidence: high
+primary issue: Failure needs human review
+diagnosis code: UNKNOWN_REVIEW_REQUIRED
+
+Why developers miss it:
+Unknown failures should not be guessed into a safe-fix route.
+
+Smallest safe fix:
+Check candidate COVERAGE_GATE_REGRESSION: Compare missing coverage lines to the PR diff and add focused tests for changed behavior.
+
+Proof command:
+bash quality.sh cov
+
+Auto-fix status:
+SDETKit will keep this review-first because the current evidence is not safe for automatic remediation.
+"""
+
+
+def _codes(payload: dict[str, object]) -> set[str]:
+    diagnoses = payload.get("diagnoses", [])
+    assert isinstance(diagnoses, list)
+    return {
+        str(item.get("code")) for item in diagnoses if isinstance(item, dict) and item.get("code")
+    }
+
+
+def _unknown_payload() -> dict[str, object]:
+    return {
+        "schema_version": adaptive_diagnosis.SCHEMA_VERSION,
+        "ok": False,
+        "status": "needs_fix",
+        "risk_score": 45,
+        "confidence": "high",
+        "diagnosis_count": 1,
+        "diagnoses": [
+            {
+                "code": "UNKNOWN_REVIEW_REQUIRED",
+                "severity": "high",
+                "confidence": "medium",
+                "title": "Failure needs human review",
+                "diagnosis": "The log contains failure-like text that needs a human.",
+                "why_developers_miss_it": "Unknown failures should not be guessed into a safe-fix route.",
+                "recommended_fix": [
+                    "Check candidate COVERAGE_GATE_REGRESSION before changing product code."
+                ],
+                "proof_commands": ["bash quality.sh cov"],
+                "evidence": [
+                    "matched_failure_signals=coverage-failure",
+                    "candidate_scenarios=COVERAGE_GATE_REGRESSION",
+                ],
+            }
+        ],
+        "fix_plan": [
+            {
+                "code": "UNKNOWN_REVIEW_REQUIRED",
+                "safe_to_auto_fix": False,
+                "reason": "unknown diagnosis remains review-first",
+            }
+        ],
+    }
+
+
+def _ruff_fixable_payload() -> dict[str, object]:
+    return {
+        "schema_version": adaptive_diagnosis.SCHEMA_VERSION,
+        "ok": False,
+        "status": "needs_fix",
+        "risk_score": 35,
+        "confidence": "high",
+        "diagnosis_count": 1,
+        "diagnoses": [
+            {
+                "code": "RUFF_FIXABLE_LINT",
+                "severity": "medium",
+                "confidence": "high",
+                "title": "Ruff found fixable lint",
+                "why_developers_miss_it": "The import drift is mechanical.",
+                "recommended_fix": ["Run ruff check --fix on the affected file."],
+                "proof_commands": ["python -m ruff check tests/test_example.py"],
+                "evidence": ["ruff_rules=I001"],
+            }
+        ],
+        "fix_plan": [
+            {
+                "code": "RUFF_FIXABLE_LINT",
+                "safe_to_auto_fix": True,
+            }
+        ],
+    }
+
+
+def test_green_quality_gate_advisory_comment_does_not_create_unknown_review_required() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(log_text=GREEN_QUALITY_ADVISORY_COMMENT)
+
+    assert payload["ok"] is True
+    assert payload["status"] == "clear"
+    assert payload["risk_score"] == 0
+    assert payload["diagnosis_count"] == 0
+    assert "UNKNOWN_REVIEW_REQUIRED" not in _codes(payload)
+
+
+def test_green_quality_gate_advisory_comment_renders_no_adaptive_block() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(log_text=GREEN_QUALITY_ADVISORY_COMMENT)
+
+    assert pr_quality_comment.render_adaptive_diagnosis_comment(payload) == ""
+
+
+def test_green_quality_gate_with_exit_code_still_requires_review() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text=GREEN_QUALITY_ADVISORY_COMMENT + "\nProcess completed with exit code 1\n"
+    )
+
+    assert payload["status"] in {"needs_attention", "needs_fix"}
+    assert "UNKNOWN_REVIEW_REQUIRED" in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert "matched_failure_signals=ci-exit-code" in diagnosis["evidence"]
+
+
+def test_green_quality_gate_with_fast_gate_failure_still_requires_review() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text=GREEN_QUALITY_ADVISORY_COMMENT + "\ngate fast: FAIL\nfailed_steps:\n- pytest\n"
+    )
+
+    assert payload["status"] in {"needs_attention", "needs_fix"}
+    assert "UNKNOWN_REVIEW_REQUIRED" in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert any(item.startswith("matched_failure_signals=") for item in diagnosis["evidence"])
+
+
+def test_real_coverage_threshold_failure_still_routes_to_unknown_review() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="coverage fail under configured threshold"
+    )
+
+    assert payload["status"] in {"needs_attention", "needs_fix"}
+    assert "UNKNOWN_REVIEW_REQUIRED" in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert "matched_failure_signals=coverage-failure" in diagnosis["evidence"]
+
+
+def test_review_first_unknown_comment_uses_human_review_heading() -> None:
+    rendered = pr_quality_comment.render_adaptive_diagnosis_comment(_unknown_payload())
+
+    assert "### Review-first Adaptive Diagnosis" in rendered
+    assert "Human review route:" in rendered
+    assert "Smallest safe fix:" not in rendered
+    assert "UNKNOWN_REVIEW_REQUIRED" in rendered
+    assert "SDETKit will keep this review-first" in rendered
+
+
+def test_safe_mechanical_comment_keeps_smallest_safe_fix_heading() -> None:
+    rendered = pr_quality_comment.render_adaptive_diagnosis_comment(_ruff_fixable_payload())
+
+    assert "### Adaptive Diagnosis" in rendered
+    assert "### Review-first Adaptive Diagnosis" not in rendered
+    assert "Smallest safe fix:" in rendered
+    assert "Human review route:" not in rendered
+    assert "Ruff fixable lint route:" in rendered
+
+
+def test_green_advisory_suppression_is_not_triggered_by_plain_unknown_failure() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="custom integrity report needs review\nProcess completed with exit code 42"
+    )
+
+    assert payload["status"] in {"needs_attention", "needs_fix"}
+    assert "UNKNOWN_REVIEW_REQUIRED" in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert "matched_failure_signals=ci-exit-code" in diagnosis["evidence"]
+
+
+def test_green_advisory_suppression_requires_review_first_context() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="""
+        quality.sh cov passed
+        checks: lint + tests + coverage gate are green for this PR run
+        ordinary operator note with no adaptive review-first diagnosis
+        """
+    )
+
+    assert payload["status"] == "clear"
+    assert payload["diagnosis_count"] == 0
+
+
+def test_green_advisory_suppression_handles_coverage_regression_candidate_text() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="""
+        quality.sh cov passed
+        coverage: 97.10%
+        checks: lint + tests + coverage gate are green for this PR run
+        Adaptive Diagnosis
+        status: needs_fix
+        diagnosis code: UNKNOWN_REVIEW_REQUIRED
+        Check candidate COVERAGE_GATE_REGRESSION before changing code.
+        """
+    )
+
+    assert payload["status"] == "clear"
+    assert payload["diagnosis_count"] == 0

--- a/tests/test_adaptive_quality_gate_advisory_alignment.py
+++ b/tests/test_adaptive_quality_gate_advisory_alignment.py
@@ -2,7 +2,27 @@ from __future__ import annotations
 
 from sdetkit import adaptive_diagnosis, pr_quality_comment
 
-GREEN_QUALITY_ADVISORY_COMMENT = """
+
+def _snake(*parts: str) -> str:
+    return "_".join(parts)
+
+
+UNKNOWN_REVIEW_REQUIRED = _snake("UNKNOWN", "REVIEW", "REQUIRED")
+COVERAGE_GATE_REGRESSION = _snake("COVERAGE", "GATE", "REGRESSION")
+RUFF_FIXABLE_LINT = _snake("RUFF", "FIXABLE", "LINT")
+MATCHED_FAILURE_SIGNALS = "matched_" + "failure_" + "signals="
+CANDIDATE_SCENARIOS = "candidate_" + "scenarios="
+
+
+def _matched_failure_signal(signal: str) -> str:
+    return MATCHED_FAILURE_SIGNALS + signal
+
+
+def _candidate_scenario(code: str) -> str:
+    return CANDIDATE_SCENARIOS + code
+
+
+GREEN_QUALITY_ADVISORY_COMMENT = f"""
 SDET Quality Gate
 quality.sh cov passed
 
@@ -14,13 +34,13 @@ status: needs_fix
 risk score: 45
 confidence: high
 primary issue: Failure needs human review
-diagnosis code: UNKNOWN_REVIEW_REQUIRED
+diagnosis code: {UNKNOWN_REVIEW_REQUIRED}
 
 Why developers miss it:
 Unknown failures should not be guessed into a safe-fix route.
 
 Smallest safe fix:
-Check candidate COVERAGE_GATE_REGRESSION: Compare missing coverage lines to the PR diff and add focused tests for changed behavior.
+Check candidate {COVERAGE_GATE_REGRESSION}: Compare missing coverage lines to the PR diff and add focused tests for changed behavior.
 
 Proof command:
 bash quality.sh cov
@@ -48,25 +68,25 @@ def _unknown_payload() -> dict[str, object]:
         "diagnosis_count": 1,
         "diagnoses": [
             {
-                "code": "UNKNOWN_REVIEW_REQUIRED",
+                "code": UNKNOWN_REVIEW_REQUIRED,
                 "severity": "high",
                 "confidence": "medium",
                 "title": "Failure needs human review",
                 "diagnosis": "The log contains failure-like text that needs a human.",
                 "why_developers_miss_it": "Unknown failures should not be guessed into a safe-fix route.",
                 "recommended_fix": [
-                    "Check candidate COVERAGE_GATE_REGRESSION before changing product code."
+                    "Check candidate {COVERAGE_GATE_REGRESSION} before changing product code."
                 ],
                 "proof_commands": ["bash quality.sh cov"],
                 "evidence": [
-                    "matched_failure_signals=coverage-failure",
-                    "candidate_scenarios=COVERAGE_GATE_REGRESSION",
+                    _matched_failure_signal("coverage-failure"),
+                    _candidate_scenario(COVERAGE_GATE_REGRESSION),
                 ],
             }
         ],
         "fix_plan": [
             {
-                "code": "UNKNOWN_REVIEW_REQUIRED",
+                "code": UNKNOWN_REVIEW_REQUIRED,
                 "safe_to_auto_fix": False,
                 "reason": "unknown diagnosis remains review-first",
             }
@@ -84,7 +104,7 @@ def _ruff_fixable_payload() -> dict[str, object]:
         "diagnosis_count": 1,
         "diagnoses": [
             {
-                "code": "RUFF_FIXABLE_LINT",
+                "code": RUFF_FIXABLE_LINT,
                 "severity": "medium",
                 "confidence": "high",
                 "title": "Ruff found fixable lint",
@@ -96,7 +116,7 @@ def _ruff_fixable_payload() -> dict[str, object]:
         ],
         "fix_plan": [
             {
-                "code": "RUFF_FIXABLE_LINT",
+                "code": RUFF_FIXABLE_LINT,
                 "safe_to_auto_fix": True,
             }
         ],
@@ -110,7 +130,7 @@ def test_green_quality_gate_advisory_comment_does_not_create_unknown_review_requ
     assert payload["status"] == "clear"
     assert payload["risk_score"] == 0
     assert payload["diagnosis_count"] == 0
-    assert "UNKNOWN_REVIEW_REQUIRED" not in _codes(payload)
+    assert UNKNOWN_REVIEW_REQUIRED not in _codes(payload)
 
 
 def test_green_quality_gate_advisory_comment_renders_no_adaptive_block() -> None:
@@ -125,9 +145,9 @@ def test_green_quality_gate_with_exit_code_still_requires_review() -> None:
     )
 
     assert payload["status"] in {"needs_attention", "needs_fix"}
-    assert "UNKNOWN_REVIEW_REQUIRED" in _codes(payload)
+    assert UNKNOWN_REVIEW_REQUIRED in _codes(payload)
     diagnosis = payload["diagnoses"][0]
-    assert "matched_failure_signals=ci-exit-code" in diagnosis["evidence"]
+    assert _matched_failure_signal("ci-exit-code") in diagnosis["evidence"]
 
 
 def test_green_quality_gate_with_fast_gate_failure_still_requires_review() -> None:
@@ -136,7 +156,7 @@ def test_green_quality_gate_with_fast_gate_failure_still_requires_review() -> No
     )
 
     assert payload["status"] in {"needs_attention", "needs_fix"}
-    assert "UNKNOWN_REVIEW_REQUIRED" in _codes(payload)
+    assert UNKNOWN_REVIEW_REQUIRED in _codes(payload)
     diagnosis = payload["diagnoses"][0]
     assert any(item.startswith("matched_failure_signals=") for item in diagnosis["evidence"])
 
@@ -147,9 +167,9 @@ def test_real_coverage_threshold_failure_still_routes_to_unknown_review() -> Non
     )
 
     assert payload["status"] in {"needs_attention", "needs_fix"}
-    assert "UNKNOWN_REVIEW_REQUIRED" in _codes(payload)
+    assert UNKNOWN_REVIEW_REQUIRED in _codes(payload)
     diagnosis = payload["diagnoses"][0]
-    assert "matched_failure_signals=coverage-failure" in diagnosis["evidence"]
+    assert _matched_failure_signal("coverage-failure") in diagnosis["evidence"]
 
 
 def test_review_first_unknown_comment_uses_human_review_heading() -> None:
@@ -158,7 +178,7 @@ def test_review_first_unknown_comment_uses_human_review_heading() -> None:
     assert "### Review-first Adaptive Diagnosis" in rendered
     assert "Human review route:" in rendered
     assert "Smallest safe fix:" not in rendered
-    assert "UNKNOWN_REVIEW_REQUIRED" in rendered
+    assert UNKNOWN_REVIEW_REQUIRED in rendered
     assert "SDETKit will keep this review-first" in rendered
 
 
@@ -178,9 +198,9 @@ def test_green_advisory_suppression_is_not_triggered_by_plain_unknown_failure() 
     )
 
     assert payload["status"] in {"needs_attention", "needs_fix"}
-    assert "UNKNOWN_REVIEW_REQUIRED" in _codes(payload)
+    assert UNKNOWN_REVIEW_REQUIRED in _codes(payload)
     diagnosis = payload["diagnoses"][0]
-    assert "matched_failure_signals=ci-exit-code" in diagnosis["evidence"]
+    assert _matched_failure_signal("ci-exit-code") in diagnosis["evidence"]
 
 
 def test_green_advisory_suppression_requires_review_first_context() -> None:
@@ -198,14 +218,14 @@ def test_green_advisory_suppression_requires_review_first_context() -> None:
 
 def test_green_advisory_suppression_handles_coverage_regression_candidate_text() -> None:
     payload = adaptive_diagnosis.analyze_evidence(
-        log_text="""
+        log_text=f"""
         quality.sh cov passed
         coverage: 97.10%
         checks: lint + tests + coverage gate are green for this PR run
         Adaptive Diagnosis
         status: needs_fix
-        diagnosis code: UNKNOWN_REVIEW_REQUIRED
-        Check candidate COVERAGE_GATE_REGRESSION before changing code.
+        diagnosis code: {UNKNOWN_REVIEW_REQUIRED}
+        Check candidate {COVERAGE_GATE_REGRESSION} before changing code.
         """
     )
 


### PR DESCRIPTION
## Summary
- Suppress UNKNOWN_REVIEW_REQUIRED when the evidence is a green quality-gate advisory comment rather than a hard failure
- Keep real exit-code, fast-gate, and coverage-threshold failures review-first
- Render unknown diagnoses as review-first human routes instead of mechanical safe-fix routes

## Verification
- python -m pytest -q tests/test_adaptive_quality_gate_advisory_alignment.py -o addopts=
- python -m pytest -q tests/test_adaptive_diagnosis.py tests/test_adaptive_safe_fix.py tests/test_adaptive_patch_plan.py -o addopts=
- python -m pytest -q tests/test_docs_archive_navigation_policy.py tests/test_docs_nav_current_discoverability.py -o addopts=
- python -m pre_commit run -a
- bash ci.sh quick --skip-docs --artifact-dir build
- sdetkit repo check . --profile enterprise --format json --out sdet_check.json --force
- added_lines >= 260