### PR TITLE
Clean up agent approval prompting

### DIFF
--- a/src/sdetkit/agent/core.py
+++ b/src/sdetkit/agent/core.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 import sys
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -87,15 +88,36 @@ class RunRecord:
     cache: dict[str, Any]
 
 
+def _approval_relative_path(raw_path: str) -> str:
+    if raw_path.startswith(("\\\\", "//")):
+        return raw_path
+    rel = raw_path.replace("\\", "/")
+    while "//" in rel:
+        rel = rel.replace("//", "/")
+    return rel.lstrip("/")
+
+
+def _read_terminal_answer(prompt: str) -> str:
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    return sys.stdin.readline()
+
+
 class ApprovalGate:
-    def __init__(self, *, auto_approve: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        auto_approve: bool = False,
+        answer_reader: Callable[[str], str] | None = None,
+    ) -> None:
         self.auto_approve = auto_approve
+        self._answer_reader = answer_reader or _read_terminal_answer
 
     def requires_approval(self, action: str, params: dict[str, Any]) -> bool:
         if action == "shell.run":
             return True
         if action == "fs.write":
-            rel = str(params.get("path", "")).replace("\\", "/").lstrip("/")
+            rel = _approval_relative_path(str(params.get("path", "")))
             return not (
                 rel == ".sdetkit/agent/workdir" or rel.startswith(".sdetkit/agent/workdir/")
             )
@@ -109,7 +131,7 @@ class ApprovalGate:
         if not sys.stdin.isatty():
             return False, "approval required (non-interactive)"
         prompt = f"approve dangerous action '{action}' with params={json.dumps(params, sort_keys=True)}? [y/N]: "
-        answer = input(prompt).strip().lower()
+        answer = self._answer_reader(prompt).strip().lower()
         if answer in {"y", "yes"}:
             return True, "approved"
         return False, "denied"

--- a/tests/test_agent_approval_gate.py
+++ b/tests/test_agent_approval_gate.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import sys
+
+from sdetkit.agent.core import ApprovalGate
+
+
+def test_safe_action_does_not_prompt() -> None:
+    calls: list[str] = []
+    gate = ApprovalGate(answer_reader=lambda prompt: calls.append(prompt) or "yes\n")
+
+    approved, reason = gate.approve("repo.audit", {"profile": "default"})
+
+    assert approved is True
+    assert reason == "not-dangerous"
+    assert calls == []
+
+
+def test_auto_approve_bypasses_prompt_for_dangerous_action() -> None:
+    calls: list[str] = []
+    gate = ApprovalGate(
+        auto_approve=True,
+        answer_reader=lambda prompt: calls.append(prompt) or "no\n",
+    )
+
+    approved, reason = gate.approve("shell.run", {"cmd": "echo ok"})
+
+    assert approved is True
+    assert reason == "auto-approved"
+    assert calls == []
+
+
+def test_non_interactive_dangerous_action_is_denied(monkeypatch) -> None:
+    class NonInteractiveStdin:
+        def isatty(self) -> bool:
+            return False
+
+    monkeypatch.setattr(sys, "stdin", NonInteractiveStdin())
+
+    calls: list[str] = []
+    gate = ApprovalGate(answer_reader=lambda prompt: calls.append(prompt) or "yes\n")
+
+    approved, reason = gate.approve("shell.run", {"cmd": "echo ok"})
+
+    assert approved is False
+    assert reason == "approval required (non-interactive)"
+    assert calls == []
+
+
+def test_interactive_yes_approves_dangerous_action(monkeypatch) -> None:
+    class InteractiveStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(sys, "stdin", InteractiveStdin())
+
+    prompts: list[str] = []
+    gate = ApprovalGate(answer_reader=lambda prompt: prompts.append(prompt) or "yes\n")
+
+    approved, reason = gate.approve("shell.run", {"cmd": "echo ok"})
+
+    assert approved is True
+    assert reason == "approved"
+    assert len(prompts) == 1
+    assert "approve dangerous action" in prompts[0]
+
+
+def test_interactive_no_denies_dangerous_action(monkeypatch) -> None:
+    class InteractiveStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(sys, "stdin", InteractiveStdin())
+
+    gate = ApprovalGate(answer_reader=lambda prompt: "no\n")
+
+    approved, reason = gate.approve("shell.run", {"cmd": "echo ok"})
+
+    assert approved is False
+    assert reason == "denied"
+
+
+def test_fs_write_outside_workdir_requires_approval() -> None:
+    gate = ApprovalGate(auto_approve=True)
+
+    assert gate.requires_approval("fs.write", {"path": "README.md"}) is True
+
+
+def test_fs_write_inside_agent_workdir_does_not_require_approval() -> None:
+    gate = ApprovalGate()
+
+    assert (
+        gate.requires_approval(
+            "fs.write",
+            {"path": ".sdetkit/agent/workdir/report.json"},
+        )
+        is False
+    )
+
+
+def test_fs_write_normalizes_leading_slashes_and_backslashes() -> None:
+    gate = ApprovalGate()
+
+    assert (
+        gate.requires_approval(
+            "fs.write",
+            {"path": ".sdetkit\\\\agent\\\\workdir\\\\report.json"},
+        )
+        is False
+    )
+
+
+def test_unc_style_fs_write_path_still_requires_approval() -> None:
+    gate = ApprovalGate()
+
+    assert (
+        gate.requires_approval(
+            "fs.write",
+            {"path": "\\\\server\\share\\.sdetkit\\agent\\workdir\\report.json"},
+        )
+        is True
+    )


### PR DESCRIPTION
## Summary
- Make the agent approval gate easier to reason about in interactive and non-interactive runs
- Keep dangerous actions review-gated while avoiding direct terminal input calls in the approval path
- Add focused coverage for safe actions, denied non-interactive actions, explicit operator approval, and workdir path normalization

## Verification
- python -m pytest -q tests/test_agent_approval_gate.py -o addopts=
- python -m pre_commit run -a
- sdetkit repo check . --profile enterprise --format json --out sdet_check.json --force