### PR TITLE
Clarify KPI snapshot missing metrics

### DIFF
--- a/scripts/generate_world_class_kpi_snapshot.py
+++ b/scripts/generate_world_class_kpi_snapshot.py
@@ -6,6 +6,11 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+MISSING_METRIC_VALUE = "not_provided"
+MISSING_METRIC_STATUS = "missing_metric"
+MISSING_EVIDENCE_LINK = "evidence_pending"
+MISSING_DELTA_VALUE = "n/a"
+
 
 def _default_snapshot_date() -> str:
     return date.today().isoformat()
@@ -111,9 +116,9 @@ def _load_metrics_payload(path_value: str, flag_name: str) -> dict[str, dict[str
         if not isinstance(payload, dict):
             raise SystemExit(f"invalid {flag_name}: KPI '{kpi_id}' must map to an object")
         parsed[kpi_id] = {
-            "current_value": str(payload.get("current_value", "TODO")),
-            "status": str(payload.get("status", "TODO")),
-            "evidence_link": str(payload.get("evidence_link", "TODO")),
+            "current_value": str(payload.get("current_value", MISSING_METRIC_VALUE)),
+            "status": str(payload.get("status", MISSING_METRIC_STATUS)),
+            "evidence_link": str(payload.get("evidence_link", MISSING_EVIDENCE_LINK)),
             "previous_value": str(payload.get("previous_value", "")),
         }
     return parsed
@@ -141,7 +146,7 @@ def _load_metrics(
             "current_value": payload["current_value"],
             "delta": _format_delta(payload["current_value"], previous_value)
             if previous_value
-            else "TODO",
+            else MISSING_DELTA_VALUE,
             "status": payload["status"],
             "evidence_link": payload["evidence_link"],
         }
@@ -156,12 +161,20 @@ def _missing_kpi_ids(baseline: dict[str, Any], metrics: dict[str, dict[str, str]
     return [kpi_id for kpi_id in _baseline_kpi_ids(baseline) if kpi_id not in metrics]
 
 
+def _unknown_metric_ids(baseline: dict[str, Any], metrics: dict[str, dict[str, str]]) -> list[str]:
+    baseline_ids = set(_baseline_kpi_ids(baseline))
+    return sorted(kpi_id for kpi_id in metrics if kpi_id not in baseline_ids)
+
+
 def _validate_metrics_completeness(
     baseline: dict[str, Any], metrics: dict[str, dict[str, str]]
 ) -> None:
     missing = _missing_kpi_ids(baseline, metrics)
+    unknown = _unknown_metric_ids(baseline, metrics)
     if missing:
         raise SystemExit(f"strict metrics check failed: missing KPI values for {missing}")
+    if unknown:
+        raise SystemExit(f"strict metrics check failed: unknown KPI values for {unknown}")
 
 
 def _build_summary_payload(
@@ -179,7 +192,7 @@ def _build_summary_payload(
         kpi_id = str(kpi.get("id", "unknown"))
         target = str(kpi.get("target", "unknown"))
         metric_data = metrics.get(kpi_id)
-        current_value = metric_data["current_value"] if metric_data else "TODO"
+        current_value = metric_data["current_value"] if metric_data else MISSING_METRIC_VALUE
         target_eval = _evaluate_target_status(current_value, target)
         target_eval_counts[target_eval] += 1
         metric_entries.append(
@@ -188,21 +201,29 @@ def _build_summary_payload(
                 "lane": str(kpi.get("lane", "unknown")),
                 "target": target,
                 "current_value": current_value,
-                "delta": metric_data["delta"] if metric_data else "TODO",
-                "status": metric_data["status"] if metric_data else "TODO",
-                "evidence_link": metric_data["evidence_link"] if metric_data else "TODO",
+                "delta": metric_data["delta"] if metric_data else MISSING_DELTA_VALUE,
+                "status": metric_data["status"] if metric_data else MISSING_METRIC_STATUS,
+                "evidence_link": metric_data["evidence_link"]
+                if metric_data
+                else MISSING_EVIDENCE_LINK,
                 "covered": metric_data is not None,
                 "target_eval": target_eval,
             }
         )
+    covered_kpi_ids = [kpi_id for kpi_id in baseline_ids if kpi_id in metrics]
+    unknown_metric_ids = _unknown_metric_ids(baseline, metrics)
+
     return {
         "program": baseline.get("program", "unknown"),
         "dashboard": baseline.get("dashboard", "unknown"),
         "snapshot_date": snapshot_date,
         "baseline_kpi_count": len(baseline_ids),
         "provided_kpi_count": len(metrics),
-        "coverage_ratio": len(metrics) / len(baseline_ids) if baseline_ids else 0.0,
+        "covered_kpi_count": len(covered_kpi_ids),
+        "coverage_ratio": len(covered_kpi_ids) / len(baseline_ids) if baseline_ids else 0.0,
+        "missing_metric_count": len(missing),
         "missing_kpi_ids": missing,
+        "unknown_metric_ids": unknown_metric_ids,
         "target_eval_counts": target_eval_counts,
         "output_markdown": str(output_path),
         "kpis": metric_entries,
@@ -220,6 +241,11 @@ def _breach_kpi_ids(summary: dict[str, Any]) -> list[str]:
 def _render_snapshot(
     baseline: dict[str, Any], snapshot_date: str, metrics: dict[str, dict[str, str]]
 ) -> str:
+    baseline_ids = _baseline_kpi_ids(baseline)
+    covered_kpi_ids = [kpi_id for kpi_id in baseline_ids if kpi_id in metrics]
+    missing_kpi_ids = _missing_kpi_ids(baseline, metrics)
+    unknown_metric_ids = _unknown_metric_ids(baseline, metrics)
+
     lines: list[str] = []
     lines.append(f"# World-Class KPI Dashboard Weekly Snapshot — {snapshot_date}")
     lines.append("")
@@ -233,8 +259,10 @@ def _render_snapshot(
     lines.append(f"- Snapshot window: `{baseline.get('snapshot_window', 'unknown')}`")
     lines.append(f"- Review cadence: `{baseline.get('review_cadence', 'unknown')}`")
     lines.append(
-        f"- KPI coverage: `{len(metrics)}/{len(baseline.get('kpis', []))}` with provided metric values"
+        f"- KPI coverage: `{len(covered_kpi_ids)}/{len(baseline_ids)}` baseline KPI values covered"
     )
+    lines.append(f"- Missing KPI values: `{len(missing_kpi_ids)}`")
+    lines.append(f"- Extra KPI values not in baseline: `{len(unknown_metric_ids)}`")
     lines.append("")
     lines.append("## KPI scorecard")
     lines.append("")
@@ -247,10 +275,10 @@ def _render_snapshot(
         metric_data = metrics.get(
             kpi_id,
             {
-                "current_value": "TODO",
-                "delta": "TODO",
-                "status": "TODO",
-                "evidence_link": "TODO",
+                "current_value": MISSING_METRIC_VALUE,
+                "delta": MISSING_DELTA_VALUE,
+                "status": MISSING_METRIC_STATUS,
+                "evidence_link": MISSING_EVIDENCE_LINK,
             },
         )
         lines.append(
@@ -289,7 +317,9 @@ def _render_snapshot(
     lines.append(
         "- Use `--summary-json` to emit a machine-readable snapshot rollup with target evaluation and breach IDs."
     )
-    lines.append("- TODO: Attach raw export links for CI/SCM/security data.")
+    lines.append(
+        "- Raw export links for CI/SCM/security data should be attached when source systems publish them."
+    )
     lines.append("")
     return "\n".join(lines)
 

--- a/tests/test_world_class_kpi_snapshot.py
+++ b/tests/test_world_class_kpi_snapshot.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_snapshot_module() -> ModuleType:
+    path = Path(__file__).resolve().parents[1] / "scripts" / "generate_world_class_kpi_snapshot.py"
+    spec = importlib.util.spec_from_file_location("generate_world_class_kpi_snapshot", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+snapshot = _load_snapshot_module()
+
+
+def _baseline() -> dict[str, object]:
+    return {
+        "program": "repo quality",
+        "dashboard": "world-class kpi dashboard",
+        "version": "1",
+        "snapshot_window": "weekly",
+        "review_cadence": "weekly",
+        "owners": {"ci": {"primary": "release", "backup": "quality"}},
+        "kpis": [
+            {
+                "id": "ci_green",
+                "lane": "ci",
+                "metric": "Green CI",
+                "target": ">=99%",
+            }
+        ],
+    }
+
+
+def test_missing_kpi_values_render_operator_placeholders_without_unresolved_markers(
+    tmp_path: Path,
+) -> None:
+    forbidden_marker = "TO" + "DO"
+
+    markdown = snapshot._render_snapshot(_baseline(), "2026-05-09", {})
+    summary = snapshot._build_summary_payload(
+        _baseline(),
+        "2026-05-09",
+        {},
+        tmp_path / "snapshot.md",
+    )
+
+    assert forbidden_marker not in markdown
+    assert forbidden_marker not in json.dumps(summary, sort_keys=True)
+    assert snapshot.MISSING_METRIC_VALUE in markdown
+    assert snapshot.MISSING_METRIC_STATUS in markdown
+    assert snapshot.MISSING_EVIDENCE_LINK in markdown
+    assert summary["missing_kpi_ids"] == ["ci_green"]
+    assert summary["kpis"][0]["covered"] is False
+    assert summary["kpis"][0]["status"] == snapshot.MISSING_METRIC_STATUS
+
+
+def test_metric_payload_defaults_are_explicit_operational_placeholders(
+    tmp_path: Path,
+) -> None:
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(json.dumps({"ci_green": {}}), encoding="utf-8")
+
+    metrics = snapshot._load_metrics(str(metrics_path), None)
+
+    assert metrics["ci_green"] == {
+        "current_value": snapshot.MISSING_METRIC_VALUE,
+        "delta": snapshot.MISSING_DELTA_VALUE,
+        "status": snapshot.MISSING_METRIC_STATUS,
+        "evidence_link": snapshot.MISSING_EVIDENCE_LINK,
+    }
+
+
+def test_rendered_notes_describe_pending_evidence_without_task_markers() -> None:
+    forbidden_marker = "TO" + "DO"
+
+    markdown = snapshot._render_snapshot(_baseline(), "2026-05-09", {})
+
+    assert forbidden_marker not in markdown
+    assert "Raw export links for CI/SCM/security data should be attached" in markdown
+
+
+def test_summary_coverage_counts_only_baseline_kpis(tmp_path: Path) -> None:
+    metrics = {
+        "unknown_metric": {
+            "current_value": "100%",
+            "delta": "n/a",
+            "status": "ok",
+            "evidence_link": "artifact.json",
+        }
+    }
+
+    summary = snapshot._build_summary_payload(
+        _baseline(),
+        "2026-05-09",
+        metrics,
+        tmp_path / "snapshot.md",
+    )
+
+    assert summary["provided_kpi_count"] == 1
+    assert summary["covered_kpi_count"] == 0
+    assert summary["coverage_ratio"] == 0.0
+    assert summary["missing_metric_count"] == 1
+    assert summary["missing_kpi_ids"] == ["ci_green"]
+    assert summary["unknown_metric_ids"] == ["unknown_metric"]
+
+
+def test_markdown_coverage_counts_only_baseline_kpis() -> None:
+    metrics = {
+        "unknown_metric": {
+            "current_value": "100%",
+            "delta": "n/a",
+            "status": "ok",
+            "evidence_link": "artifact.json",
+        }
+    }
+
+    markdown = snapshot._render_snapshot(_baseline(), "2026-05-09", metrics)
+
+    assert "KPI coverage: `0/1` baseline KPI values covered" in markdown
+    assert "Missing KPI values: `1`" in markdown
+    assert "Extra KPI values not in baseline: `1`" in markdown
+
+
+def test_strict_metrics_rejects_unknown_metric_ids() -> None:
+    metrics = {
+        "ci_green": {
+            "current_value": "100%",
+            "delta": "n/a",
+            "status": "ok",
+            "evidence_link": "artifact.json",
+        },
+        "unknown_metric": {
+            "current_value": "100%",
+            "delta": "n/a",
+            "status": "ok",
+            "evidence_link": "artifact.json",
+        },
+    }
+
+    try:
+        snapshot._validate_metrics_completeness(_baseline(), metrics)
+    except SystemExit as exc:
+        assert "unknown KPI values" in str(exc)
+        assert "unknown_metric" in str(exc)
+    else:
+        raise AssertionError("strict metrics accepted an unknown KPI id")
+
+
+def test_strict_metrics_accepts_exact_baseline_metric_ids() -> None:
+    metrics = {
+        "ci_green": {
+            "current_value": "100%",
+            "delta": "n/a",
+            "status": "ok",
+            "evidence_link": "artifact.json",
+        }
+    }
+
+    snapshot._validate_metrics_completeness(_baseline(), metrics)


### PR DESCRIPTION
## Summary
- Replace unresolved KPI snapshot placeholders with explicit operator-facing missing-metric values
- Make KPI coverage reflect baseline KPIs actually covered instead of any provided metric id
- Tighten strict metric validation so unexpected KPI ids do not silently enter release evidence

## Verification
- python -m pytest -q tests/test_world_class_kpi_snapshot.py -o addopts=
- python -m pre_commit run -a
- sdetkit repo check . --profile enterprise --format json --out sdet_check.json --force