### PR TITLE
Clarify author novelty guidance

### DIFF
--- a/src/sdetkit/author_problem.py
+++ b/src/sdetkit/author_problem.py
@@ -25,6 +25,12 @@ _DEFAULT_WORKFLOW_PATH = Path(".sdetkit/workflows/platform_problem.yaml")
 _ALLOWED_TEST_METADATA_EDIT = "tests/conftest.py"
 _TOOLKIT_MOUNT = "/opt/sdetkit"
 _REPO_EXPORT_ROOT = Path("artifacts/platform_problem/latest")
+_NOVELTY_REVIEW_SOURCES = ("issues", "PRs", "releases", "docs", "discussions")
+_NOVELTY_REVIEW_GUIDANCE = (
+    "- Verify novelty against "
+    + ", ".join(_NOVELTY_REVIEW_SOURCES[:-1])
+    + f", and {_NOVELTY_REVIEW_SOURCES[-1]} before accepting a candidate."
+)
 _KNOWN_PYTEST_PACKAGES = (
     "pytest",
     "pytest-asyncio",
@@ -1423,7 +1429,7 @@ def _scaffold_novelty_gate(workdir: Path, inspection: RepoInspection, topic: str
         f"- candidate topic: {topic}",
         f"- metadata files: {', '.join(inspection.metadata_files) or 'none'}",
         f"- CI files: {', '.join(inspection.ci_files) or 'none'}",
-        "- TODO: compare against issues, PRs, releases, docs, and discussions before accepting a candidate.",
+        _NOVELTY_REVIEW_GUIDANCE,
     ]
     _append_note(workdir / "novelty_gate.txt", "## machine-notes", lines)
     _append_note(

--- a/tests/test_author_problem_guidance_contract.py
+++ b/tests/test_author_problem_guidance_contract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdetkit import author_problem
+
+
+def test_author_problem_guidance_uses_actionable_novelty_language() -> None:
+    assert author_problem._NOVELTY_REVIEW_SOURCES == (
+        "issues",
+        "PRs",
+        "releases",
+        "docs",
+        "discussions",
+    )
+    assert author_problem._NOVELTY_REVIEW_GUIDANCE == (
+        "- Verify novelty against issues, PRs, releases, docs, and discussions "
+        "before accepting a candidate."
+    )
+
+
+def test_author_problem_guidance_is_named_instead_of_inline_task_marker() -> None:
+    text = Path("src/sdetkit/author_problem.py").read_text(encoding="utf-8")
+
+    assert "_NOVELTY_REVIEW_GUIDANCE" in text
+    assert "TODO: compare against issues" not in text
+
+
+def test_author_problem_source_does_not_emit_unresolved_task_markers() -> None:
+    text = Path("src/sdetkit/author_problem.py").read_text(encoding="utf-8")
+
+    forbidden = "TO" + "DO"
+    assert forbidden not in text


### PR DESCRIPTION
## Summary
- Replace unresolved novelty-review wording with actionable authoring guidance
- Keep the novelty review sources in a named source contract
- Add focused coverage so generated authoring guidance does not regress to unfinished markers

## Verification
- python -m pytest -q tests/test_author_problem_guidance_contract.py -o addopts=
- python -m pre_commit run -a
- sdetkit repo check . --profile enterprise --format json --out sdet_check.json --force