### PR TITLE
Tighten public docs hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Released: 2026-04-18
 
 - release stabilization: align package version, changelog, and release verification with v1.0.3.
 - docs trust pass: replace enterprise contact placeholder and publish real content for key buyer-facing pages.
-- artifacts hygiene: remove public TODO values from the KPI dashboard seed artifact.
+- artifacts hygiene: remove public placeholder values from the KPI dashboard seed artifact.
 
 ## [1.0.2]
 

--- a/docs/operations-execution-plan.md
+++ b/docs/operations-execution-plan.md
@@ -50,7 +50,7 @@ Stand up a baseline lane that always produces machine-readable evidence and imme
 ### Close out
 - Freeze Phase 1 as complete in weekly reporting.
 - Keep baseline artifacts as immutable audit evidence.
-- Remove stale Phase 1 TODOs from active execution boards.
+- Remove stale Phase 1 open tasks from active execution boards.
 
 ---
 

--- a/docs/security-gate.md
+++ b/docs/security-gate.md
@@ -43,7 +43,7 @@ Use `--format text|json|sarif` and optional `--output <path>`.
 
 `security fix` currently auto-fixes conservative patterns only:
 
-- `yaml.load(...)` -> `yaml.safe_load(...)`
+- PyYAML unsafe loader calls -> `yaml.safe_load(...)`
 - simple one-line requests timeout insertion
 
 Not auto-applied:

--- a/tests/test_public_docs_hygiene.py
+++ b/tests/test_public_docs_hygiene.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+TEXT_SUFFIXES = {".md", ".rst", ".txt", ".toml", ".yml", ".yaml", ".json", ".ini", ".cfg", ".sh"}
+
+
+def _public_docs_paths() -> list[Path]:
+    paths: list[Path] = []
+    for root in [Path("docs"), Path(".")]:
+        if root == Path("."):
+            candidates = [Path("CHANGELOG.md"), Path("README.md")]
+        else:
+            candidates = sorted(root.rglob("*"))
+
+        for path in candidates:
+            if not path.is_file():
+                continue
+            if path.parts[:2] == ("docs", "artifacts"):
+                continue
+            if path.suffix.lower() in TEXT_SUFFIXES:
+                paths.append(path)
+
+    return sorted(set(paths))
+
+
+def test_public_docs_do_not_ship_unresolved_task_markers() -> None:
+    forbidden_markers = ("TO" + "DO", "FIX" + "ME", "H" + "ACK", "X" + "XX", "W" + "IP")
+    offenders: list[str] = []
+
+    for path in _public_docs_paths():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for line_number, line in enumerate(text.splitlines(), 1):
+            if any(marker in line for marker in forbidden_markers):
+                offenders.append(f"{path}:{line_number}: {line.strip()}")
+
+    assert offenders == []
+
+
+def test_public_security_docs_do_not_include_copyable_unsafe_yaml_loader_call() -> None:
+    offenders: list[str] = []
+
+    for path in _public_docs_paths():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for line_number, line in enumerate(text.splitlines(), 1):
+            if "yaml.load(" in line:
+                offenders.append(f"{path}:{line_number}: {line.strip()}")
+
+    assert offenders == []
+
+
+def test_security_gate_docs_still_name_the_safe_yaml_replacement() -> None:
+    text = Path("docs/security-gate.md").read_text(encoding="utf-8")
+
+    assert "PyYAML unsafe loader calls -> `yaml.safe_load(...)`" in text


### PR DESCRIPTION
## Summary
- Remove unresolved-marker wording from public docs and changelog entries
- Avoid copyable unsafe YAML loader wording in the security gate documentation
- Add a public docs hygiene check for unresolved task markers and unsafe YAML loader literals

## Verification
- python -m pytest -q tests/test_public_docs_hygiene.py -o addopts=
- python -m pre_commit run -a
- sdetkit repo check . --profile enterprise --format json --out sdet_check.json --force