### PR TITLE
Add CI failure triage advisor

### DIFF
--- a/src/sdetkit/ci_failure_triage.py
+++ b/src/sdetkit/ci_failure_triage.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.ci_failure_triage.v1"
+
+PYTEST_NODE_RE = re.compile(r"FAILED\s+([A-Za-z0-9_./:-]+::[^\s]+)(?:\s+-\s+(.+))?")
+MYPY_ERROR_RE = re.compile(r"^(.+?\.py):\d+:\s+error:\s+(.+)$", re.MULTILINE)
+PYTHON_EXCEPTION_RE = re.compile(r"\b([A-Z][A-Za-z]+Error|Exception):\s*(.+)")
+EXIT_CODE_RE = re.compile(r"Process completed with exit code (?!0\b)(\d+)")
+FILE_PATH_RE = re.compile(r"\b(?:src|tests)/[A-Za-z0-9_./-]+\.py\b")
+
+
+@dataclass(frozen=True)
+class CiFailureTriageReport:
+    schema_version: str
+    classification: str
+    blocker: bool
+    headline_failure: str
+    actual_failure: str
+    root_cause_candidates: tuple[str, ...]
+    likely_owner_files: tuple[str, ...]
+    contract_that_failed: str
+    noise_to_ignore: tuple[str, ...]
+    recommended_fix_shape: str
+    verification_commands: tuple[str, ...]
+    confidence: str
+    next_best_action: str
+
+
+def _clean(value: object, *, limit: int = 260) -> str:
+    text = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    text = re.sub(r"\s+", " ", text)
+    if len(text) > limit:
+        return text[: limit - 1].rstrip() + "…"
+    return text
+
+
+def _unique(values: Sequence[str], *, limit: int = 8) -> tuple[str, ...]:
+    out: list[str] = []
+    for value in values:
+        item = _clean(value)
+        if item and item not in out:
+            out.append(item)
+        if len(out) >= limit:
+            break
+    return tuple(out)
+
+
+def _coverage_lines(lines: Sequence[str]) -> tuple[str, ...]:
+    hits: list[str] = []
+    for line in lines:
+        lowered = line.lower()
+        if "coverage" in lowered and any(
+            token in lowered for token in ("fail", "under", "threshold", "required")
+        ):
+            hits.append(line)
+    return _unique(hits, limit=3)
+
+
+def _exit_lines(lines: Sequence[str]) -> tuple[str, ...]:
+    return _unique([line for line in lines if EXIT_CODE_RE.search(line)], limit=3)
+
+
+def _pytest_failure(text: str) -> tuple[str, str, str] | None:
+    match = PYTEST_NODE_RE.search(text)
+    if not match:
+        return None
+    node = _clean(match.group(1))
+    detail = _clean(match.group(2) or "pytest node failed")
+    owner = node.split("::", 1)[0]
+    return node, detail, owner
+
+
+def _mypy_failure(text: str) -> tuple[str, str] | None:
+    match = MYPY_ERROR_RE.search(text)
+    if not match:
+        return None
+    return _clean(match.group(1)), _clean(match.group(2))
+
+
+def _python_exception(text: str) -> str:
+    match = PYTHON_EXCEPTION_RE.search(text)
+    if not match:
+        return ""
+    return _clean(f"{match.group(1)}: {match.group(2)}")
+
+
+def _file_mentions(text: str) -> tuple[str, ...]:
+    return _unique(FILE_PATH_RE.findall(text), limit=8)
+
+
+def _as_payload(report: CiFailureTriageReport) -> dict[str, Any]:
+    return asdict(report)
+
+
+def build_triage_report(text: str) -> CiFailureTriageReport:
+    lines = text.splitlines()
+    coverage = _coverage_lines(lines)
+    exits = _exit_lines(lines)
+    pytest = _pytest_failure(text)
+    mypy = _mypy_failure(text)
+    exception = _python_exception(text)
+    owners = list(_file_mentions(text))
+
+    if pytest is not None:
+        node, detail, owner = pytest
+        if owner not in owners:
+            owners.insert(0, owner)
+        noise = []
+        if coverage:
+            noise.append("coverage wrapper reported after an earlier pytest failure")
+        if exits:
+            noise.append("nonzero process exit is a wrapper after the failing test")
+        return CiFailureTriageReport(
+            schema_version=SCHEMA_VERSION,
+            classification="test_failure",
+            blocker=True,
+            headline_failure=coverage[-1] if coverage else (exits[-1] if exits else node),
+            actual_failure=f"{node} - {detail}",
+            root_cause_candidates=(
+                "the first failing pytest assertion is the real blocker",
+                "later CI wrapper failures should not be patched first",
+            ),
+            likely_owner_files=_unique(owners),
+            contract_that_failed="pytest behavior contract",
+            noise_to_ignore=_unique(noise),
+            recommended_fix_shape=(
+                "Fix the failing pytest assertion or owner implementation before changing "
+                "coverage, workflow, or quality gates."
+            ),
+            verification_commands=(f"python -m pytest -q {node} -o addopts=",),
+            confidence="high",
+            next_best_action=f"open {owner} and reproduce {node}",
+        )
+
+    if mypy is not None:
+        owner, detail = mypy
+        if owner not in owners:
+            owners.insert(0, owner)
+        return CiFailureTriageReport(
+            schema_version=SCHEMA_VERSION,
+            classification="test_contract_failure",
+            blocker=True,
+            headline_failure=exits[-1] if exits else f"{owner}: {detail}",
+            actual_failure=f"{owner}: {detail}",
+            root_cause_candidates=("type/API contract mismatch",),
+            likely_owner_files=_unique(owners),
+            contract_that_failed="mypy type contract",
+            noise_to_ignore=_unique(["nonzero process exit is a wrapper"] if exits else []),
+            recommended_fix_shape="Fix the first type/API mismatch; do not broaden into style cleanup.",
+            verification_commands=("python -m mypy src",),
+            confidence="medium",
+            next_best_action=f"inspect the first mypy error in {owner}",
+        )
+
+    if coverage:
+        return CiFailureTriageReport(
+            schema_version=SCHEMA_VERSION,
+            classification="quality_wrapper",
+            blocker=True,
+            headline_failure=coverage[-1],
+            actual_failure=coverage[0],
+            root_cause_candidates=("coverage gate reported below-threshold evidence",),
+            likely_owner_files=_unique(owners),
+            contract_that_failed="coverage policy",
+            noise_to_ignore=_unique(["no earlier pytest node failure was found in the log"]),
+            recommended_fix_shape=(
+                "Inspect missed coverage or missing regression tests; do not lower the gate "
+                "unless policy intentionally changed."
+            ),
+            verification_commands=("python -m pytest --cov",),
+            confidence="medium",
+            next_best_action="rerun coverage locally and inspect the first missed owner file",
+        )
+
+    if exception:
+        return CiFailureTriageReport(
+            schema_version=SCHEMA_VERSION,
+            classification="product_bug",
+            blocker=True,
+            headline_failure=exits[-1] if exits else exception,
+            actual_failure=exception,
+            root_cause_candidates=("Python exception raised during CI command",),
+            likely_owner_files=_unique(owners),
+            contract_that_failed="runtime command contract",
+            noise_to_ignore=_unique(["nonzero process exit is a wrapper"] if exits else []),
+            recommended_fix_shape="Reproduce the command path and patch the smallest owner module.",
+            verification_commands=("python -m pytest -q <focused-test> -o addopts=",),
+            confidence="medium",
+            next_best_action="inspect the traceback owner file and add a focused regression test",
+        )
+
+    if exits:
+        return CiFailureTriageReport(
+            schema_version=SCHEMA_VERSION,
+            classification="ci_failure_real_flake",
+            blocker=True,
+            headline_failure=exits[-1],
+            actual_failure=exits[0],
+            root_cause_candidates=("nonzero CI exit found without a more specific parsed blocker",),
+            likely_owner_files=_unique(owners),
+            contract_that_failed="CI command contract",
+            noise_to_ignore=(),
+            recommended_fix_shape="Open the failed step log around the first nonzero command.",
+            verification_commands=("python -m pytest -q <focused-test> -o addopts=",),
+            confidence="low",
+            next_best_action="capture more log context around the first failed command",
+        )
+
+    return CiFailureTriageReport(
+        schema_version=SCHEMA_VERSION,
+        classification="unknown",
+        blocker=False,
+        headline_failure="none",
+        actual_failure="none",
+        root_cause_candidates=(),
+        likely_owner_files=_unique(owners),
+        contract_that_failed="none",
+        noise_to_ignore=(),
+        recommended_fix_shape="No actionable CI failure signature was found.",
+        verification_commands=(),
+        confidence="low",
+        next_best_action="provide a failed job log with the failing step output",
+    )
+
+
+def _render_text(report: CiFailureTriageReport) -> str:
+    payload = _as_payload(report)
+    lines: list[str] = []
+    for key, value in payload.items():
+        if isinstance(value, bool):
+            rendered = "yes" if value else "no"
+        elif isinstance(value, (list, tuple)):
+            rendered = ", ".join(str(item) for item in value) if value else "none"
+        else:
+            rendered = str(value)
+        lines.append(f"{key}={rendered}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_markdown(report: CiFailureTriageReport) -> str:
+    return (
+        "# CI failure triage\n\n"
+        f"- classification: `{report.classification}`\n"
+        f"- blocker: `{'yes' if report.blocker else 'no'}`\n"
+        f"- headline failure: {report.headline_failure}\n"
+        f"- actual failure: {report.actual_failure}\n"
+        f"- contract that failed: {report.contract_that_failed}\n"
+        f"- likely owner files: {', '.join(report.likely_owner_files) or 'none'}\n"
+        f"- noise to ignore: {', '.join(report.noise_to_ignore) or 'none'}\n"
+        f"- recommended fix shape: {report.recommended_fix_shape}\n"
+        f"- verification: {', '.join(report.verification_commands) or 'none'}\n"
+        f"- confidence: `{report.confidence}`\n"
+        f"- next best action: {report.next_best_action}\n"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sdetkit triage-ci",
+        description="Diagnose failed CI logs and recommend advisory-only verification.",
+    )
+    parser.add_argument("--log", required=True, help="Path to a saved failed CI job log.")
+    parser.add_argument(
+        "--format",
+        choices=["text", "json", "md", "markdown"],
+        default="text",
+        help="Output format.",
+    )
+    parser.add_argument("--output", default="", help="Optional file path to write the report.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    text = Path(args.log).read_text(encoding="utf-8", errors="replace")
+    report = build_triage_report(text)
+
+    if args.format == "json":
+        rendered = json.dumps(_as_payload(report), indent=2, sort_keys=True) + "\n"
+    elif args.format in {"md", "markdown"}:
+        rendered = _render_markdown(report)
+    else:
+        rendered = _render_text(report)
+
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(rendered, encoding="utf-8")
+
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -292,6 +292,12 @@ Then use stability-aware command discovery:
 
     _add_passthrough_subcommand(sub, "ci", help_text="CI template and pipeline validation")
 
+    _add_passthrough_subcommand(
+        sub,
+        "triage-ci",
+        help_text="[Advanced but supported] Diagnose failed CI logs without applying fixes",
+    )
+
     _add_passthrough_subcommand(sub, "patch", help_text="Apply controlled file/text patches")
 
     _add_passthrough_subcommand(
@@ -1012,6 +1018,10 @@ Then use stability-aware command discovery:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    argv_list = list(sys.argv[1:] if argv is None else argv)
+    if argv_list and argv_list[0] == "triage-ci":
+        return _run_module_main("sdetkit.ci_failure_triage", argv_list[1:])
+    argv = argv_list
     if argv is None:
         argv = sys.argv[1:]
 

--- a/src/sdetkit/parsed_shortcuts.py
+++ b/src/sdetkit/parsed_shortcuts.py
@@ -34,6 +34,7 @@ _PARSED_MODULE_SHORTCUTS: tuple[tuple[str, str], ...] = (
     ("first-contribution", "sdetkit.first_contribution"),
     ("contributor-funnel", "sdetkit.contributor_funnel"),
     ("evidence-assets", "sdetkit.proof"),
+    ("triage-ci", "sdetkit.ci_failure_triage"),
     ("triage-templates", "sdetkit.triage_templates"),
     ("docs-quality", "sdetkit.docs_qa"),
     ("weekly-review", "sdetkit.weekly_review"),

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import ci_failure_triage
+
+
+def test_pytest_failure_is_actual_blocker_before_coverage_wrapper() -> None:
+    log = """
+    ============================= FAILURES =============================
+    FAILED tests/test_maintenance_cli.py::test_deterministic_mode_is_byte_identical_across_runs - AssertionError: output drift
+    E   AssertionError: output drift
+    Required test coverage of 95% not reached. Total coverage: 94.7%
+    Process completed with exit code 1
+    """
+
+    report = ci_failure_triage.build_triage_report(log)
+
+    assert report.classification == "test_failure"
+    assert report.blocker is True
+    assert "coverage" in report.headline_failure.lower()
+    assert (
+        report.actual_failure
+        == "tests/test_maintenance_cli.py::test_deterministic_mode_is_byte_identical_across_runs - AssertionError: output drift"
+    )
+    assert report.likely_owner_files[0] == "tests/test_maintenance_cli.py"
+    assert "coverage wrapper" in report.noise_to_ignore[0]
+    assert report.verification_commands == (
+        "python -m pytest -q tests/test_maintenance_cli.py::test_deterministic_mode_is_byte_identical_across_runs -o addopts=",
+    )
+
+
+def test_coverage_only_failure_is_quality_wrapper() -> None:
+    report = ci_failure_triage.build_triage_report(
+        "Required test coverage of 95% not reached. Total coverage: 94.7%\n"
+    )
+
+    assert report.classification == "quality_wrapper"
+    assert report.blocker is True
+    assert report.actual_failure == report.headline_failure
+    assert report.contract_that_failed == "coverage policy"
+    assert report.verification_commands == ("python -m pytest --cov",)
+
+
+def test_mypy_error_reports_owner_file_and_type_contract() -> None:
+    report = ci_failure_triage.build_triage_report(
+        "src/sdetkit/example.py:12: error: Incompatible return value type\n"
+        "Process completed with exit code 1\n"
+    )
+
+    assert report.classification == "test_contract_failure"
+    assert report.likely_owner_files[0] == "src/sdetkit/example.py"
+    assert report.contract_that_failed == "mypy type contract"
+    assert report.noise_to_ignore == ("nonzero process exit is a wrapper",)
+
+
+def test_unknown_log_is_non_blocking() -> None:
+    report = ci_failure_triage.build_triage_report("371 passed in 1.23s\n")
+
+    assert report.classification == "unknown"
+    assert report.blocker is False
+    assert report.next_best_action == "provide a failed job log with the failing step output"
+
+
+def test_json_output_contains_advisory_contract(tmp_path: Path, capsys) -> None:
+    log = tmp_path / "ci.log"
+    log.write_text(
+        "FAILED tests/test_x.py::test_a - AssertionError: nope\n"
+        "Process completed with exit code 1\n",
+        encoding="utf-8",
+    )
+
+    rc = ci_failure_triage.main(["--log", str(log), "--format", "json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "sdetkit.ci_failure_triage.v1"
+    assert payload["classification"] == "test_failure"
+    assert payload["blocker"] is True
+    assert payload["verification_commands"] == [
+        "python -m pytest -q tests/test_x.py::test_a -o addopts="
+    ]
+
+
+def test_markdown_output_is_operator_readable(tmp_path: Path, capsys) -> None:
+    log = tmp_path / "ci.log"
+    log.write_text(
+        "FAILED tests/test_x.py::test_a - AssertionError: nope\n",
+        encoding="utf-8",
+    )
+
+    rc = ci_failure_triage.main(["--log", str(log), "--format", "md"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "# CI failure triage" in out
+    assert "classification: `test_failure`" in out
+    assert "tests/test_x.py::test_a" in out
+
+
+def test_root_cli_dispatches_triage_ci_arguments(tmp_path: Path, capsys) -> None:
+    from sdetkit import cli
+
+    log = tmp_path / "ci.log"
+    log.write_text(
+        "FAILED tests/test_x.py::test_a - AssertionError: nope\n"
+        "Process completed with exit code 1\n",
+        encoding="utf-8",
+    )
+
+    rc = cli.main(["triage-ci", "--log", str(log), "--format", "json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["classification"] == "test_failure"
+    assert payload["actual_failure"].startswith("tests/test_x.py::test_a")
+
+
+def test_root_help_keeps_patch_and_triage_ci_commands(capsys) -> None:
+    from sdetkit import cli
+
+    try:
+        cli.main(["--help"])
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    out = capsys.readouterr().out
+    assert "triage-ci" in out
+    assert "patch" in out


### PR DESCRIPTION
## Summary
- Add advisory-only CI failure triage for saved job logs.
- Classify pytest, mypy, coverage-wrapper, exception, and generic nonzero-exit signals.
- Expose `sdetkit triage-ci --log <path> --format text|json|md`.
- Preserve the existing `patch` CLI surface and add regression coverage for both commands.

## Why
- CI logs often show a loud wrapper failure after the real blocker.
- This gives maintainers a concise diagnosis with owner files, noise to ignore, and exact verification commands.

## Verification
- `python -m pytest -q tests/test_ci_failure_triage.py tests/test_workflow_alias_regression_guards.py -o addopts=`
- `python -m sdetkit triage-ci --log /tmp/sdetkit-ci-triage-sample.log --format json`
- `python -m sdetkit patch --help`
- `python -m pre_commit run -a`

## Risk
- Medium
- Rollback: easy, revert the new module, tests, and CLI shortcut wiring.

## Notes
- Advisory only. No auto-fix, mutation, commit, push, or merge behavior.