### PR TITLE
Refine CI triage advisor failure classifications

### DIFF
--- a/src/sdetkit/ci_failure_triage.py
+++ b/src/sdetkit/ci_failure_triage.py
@@ -14,7 +14,11 @@ PYTEST_NODE_RE = re.compile(r"FAILED\s+([A-Za-z0-9_./:-]+::[^\s]+)(?:\s+-\s+(.+)
 MYPY_ERROR_RE = re.compile(r"^(.+?\.py):\d+:\s+error:\s+(.+)$", re.MULTILINE)
 PYTHON_EXCEPTION_RE = re.compile(r"\b([A-Z][A-Za-z]+Error|Exception):\s*(.+)")
 EXIT_CODE_RE = re.compile(r"Process completed with exit code (?!0\b)(\d+)")
-FILE_PATH_RE = re.compile(r"\b(?:src|tests)/[A-Za-z0-9_./-]+\.py\b")
+FILE_PATH_RE = re.compile(r"\b(?:src|tests|docs)/[A-Za-z0-9_./-]+\.(?:py|md)\b")
+HOOK_FAILURE_RE = re.compile(r"^(.+?)\.+Failed$", re.MULTILINE)
+HOOK_ID_RE = re.compile(r"- hook id:\s*([A-Za-z0-9_.-]+)")
+MKDOCS_ERROR_RE = re.compile(r"ERROR\s+-\s+(.+)")
+PYTEST_COLLECTION_RE = re.compile(r"ERROR collecting ([^\s]+)")
 
 
 @dataclass(frozen=True)
@@ -96,6 +100,42 @@ def _file_mentions(text: str) -> tuple[str, ...]:
     return _unique(FILE_PATH_RE.findall(text), limit=8)
 
 
+def _hook_failure(text: str) -> tuple[str, str] | None:
+    hook_id = HOOK_ID_RE.search(text)
+    failed = HOOK_FAILURE_RE.search(text)
+    if hook_id:
+        return _clean(hook_id.group(1)), _clean(failed.group(1)) if failed else _clean(
+            hook_id.group(1)
+        )
+    if failed and "hook id:" in text.lower():
+        return _clean(failed.group(1)), _clean(failed.group(1))
+    if failed and "ruff format" in failed.group(1).lower():
+        return "ruff-format", _clean(failed.group(1))
+    return None
+
+
+def _mkdocs_failure(text: str) -> str:
+    lowered = text.lower()
+    if "mkdocs" not in lowered and "documentation file" not in lowered:
+        return ""
+    match = MKDOCS_ERROR_RE.search(text)
+    if match:
+        return _clean(match.group(1))
+    if "strict mode" in lowered:
+        return "MkDocs strict mode failed"
+    return ""
+
+
+def _pytest_collection_failure(text: str) -> tuple[str, str] | None:
+    match = PYTEST_COLLECTION_RE.search(text)
+    if not match:
+        return None
+    owner = _clean(match.group(1))
+    exception = _python_exception(text)
+    actual = exception or f"ERROR collecting {owner}"
+    return owner, actual
+
+
 def _as_payload(report: CiFailureTriageReport) -> dict[str, Any]:
     return asdict(report)
 
@@ -106,8 +146,88 @@ def build_triage_report(text: str) -> CiFailureTriageReport:
     exits = _exit_lines(lines)
     pytest = _pytest_failure(text)
     mypy = _mypy_failure(text)
+    hook = _hook_failure(text)
+    mkdocs = _mkdocs_failure(text)
+    collection = _pytest_collection_failure(text)
     exception = _python_exception(text)
     owners = list(_file_mentions(text))
+
+    if collection is not None:
+        owner, actual = collection
+        if owner not in owners:
+            owners.insert(0, owner)
+        return CiFailureTriageReport(
+            schema_version=SCHEMA_VERSION,
+            classification="pytest_collection_failure",
+            blocker=True,
+            headline_failure=exits[-1] if exits else f"ERROR collecting {owner}",
+            actual_failure=actual,
+            root_cause_candidates=(
+                "pytest could not import or collect the test module",
+                "fix import/module availability before debugging assertions",
+            ),
+            likely_owner_files=_unique(owners),
+            contract_that_failed="pytest collection/import contract",
+            noise_to_ignore=_unique(["nonzero process exit is a wrapper"] if exits else []),
+            recommended_fix_shape=(
+                "Fix the missing import, package exposure, or test module collection path; "
+                "do not change assertion behavior first."
+            ),
+            verification_commands=(f"python -m pytest -q {owner} --collect-only -o addopts=",),
+            confidence="high",
+            next_best_action=f"run collection-only for {owner} and inspect the first import error",
+        )
+
+    if hook is not None:
+        hook_id, hook_title = hook
+        is_ruff_format = hook_id == "ruff-format" or "ruff format" in hook_title.lower()
+        classification = "formatting_drift" if is_ruff_format else "pre_commit_hook_failure"
+        contract = "ruff formatting contract" if is_ruff_format else "pre-commit hook contract"
+        command = (
+            "python -m ruff format --check ."
+            if is_ruff_format
+            else f"python -m pre_commit run {hook_id} --all-files"
+        )
+        return CiFailureTriageReport(
+            schema_version=SCHEMA_VERSION,
+            classification=classification,
+            blocker=True,
+            headline_failure=hook_title,
+            actual_failure=f"{hook_id} modified files or reported failure",
+            root_cause_candidates=(
+                "a pre-commit hook changed the worktree",
+                "accept hook edits and rerun the same proof before committing",
+            ),
+            likely_owner_files=_unique(owners),
+            contract_that_failed=contract,
+            noise_to_ignore=_unique(["nonzero process exit is a wrapper"] if exits else []),
+            recommended_fix_shape=(
+                "Accept the hook-produced file changes, rerun focused tests, then rerun pre-commit."
+            ),
+            verification_commands=(command, "python -m pre_commit run -a"),
+            confidence="high",
+            next_best_action=f"rerun {hook_id} after accepting generated formatting changes",
+        )
+
+    if mkdocs:
+        return CiFailureTriageReport(
+            schema_version=SCHEMA_VERSION,
+            classification="docs_contract_gap",
+            blocker=True,
+            headline_failure=mkdocs,
+            actual_failure=mkdocs,
+            root_cause_candidates=(
+                "MkDocs strict mode found a documentation contract problem",
+                "fix the first missing page/link before changing unrelated docs",
+            ),
+            likely_owner_files=_unique(owners),
+            contract_that_failed="MkDocs strict documentation contract",
+            noise_to_ignore=_unique(["nonzero process exit is a wrapper"] if exits else []),
+            recommended_fix_shape="Repair the first strict docs error and rebuild the docs locally.",
+            verification_commands=("NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict",),
+            confidence="high",
+            next_best_action="open the referenced docs page or missing link target",
+        )
 
     if pytest is not None:
         node, detail, owner = pytest

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -139,12 +139,16 @@ def test_ruff_format_failure_is_actionable_quality_signal() -> None:
         "Process completed with exit code 1\n"
     )
 
-    assert report.classification in {"quality_wrapper", "ci_failure_real_flake"}
+    assert report.classification == "formatting_drift"
     assert report.blocker is True
-    assert (
-        "exit code" in report.headline_failure.lower() or "ruff" in report.headline_failure.lower()
+    assert report.actual_failure == "ruff-format modified files or reported failure"
+    assert report.contract_that_failed == "ruff formatting contract"
+    assert report.noise_to_ignore == ("nonzero process exit is a wrapper",)
+    assert report.verification_commands == (
+        "python -m ruff format --check .",
+        "python -m pre_commit run -a",
     )
-    assert report.confidence in {"low", "medium"}
+    assert report.confidence == "high"
 
 
 def test_pre_commit_hook_failure_keeps_hook_as_actual_failure() -> None:
@@ -156,11 +160,16 @@ def test_pre_commit_hook_failure_keeps_hook_as_actual_failure() -> None:
         "Process completed with exit code 1\n"
     )
 
-    assert report.classification in {"quality_wrapper", "ci_failure_real_flake"}
+    assert report.classification == "pre_commit_hook_failure"
     assert report.blocker is True
-    assert (
-        "end-of-file-fixer" in report.actual_failure or "exit code" in report.actual_failure.lower()
+    assert report.actual_failure == "end-of-file-fixer modified files or reported failure"
+    assert report.contract_that_failed == "pre-commit hook contract"
+    assert report.noise_to_ignore == ("nonzero process exit is a wrapper",)
+    assert report.verification_commands == (
+        "python -m pre_commit run end-of-file-fixer --all-files",
+        "python -m pre_commit run -a",
     )
+    assert report.confidence == "high"
 
 
 def test_mkdocs_strict_failure_points_to_docs_contract() -> None:
@@ -171,12 +180,17 @@ def test_mkdocs_strict_failure_points_to_docs_contract() -> None:
         "Process completed with exit code 1\n"
     )
 
+    assert report.classification == "docs_contract_gap"
     assert report.blocker is True
-    assert report.classification in {"product_bug", "ci_failure_real_flake"}
-    assert "docs" in " ".join(report.likely_owner_files).lower() or report.confidence in {
-        "low",
-        "medium",
-    }
+    assert report.actual_failure == (
+        "Documentation file 'docs/index.md' contains a link to 'missing.md' which is not found"
+    )
+    assert report.contract_that_failed == "MkDocs strict documentation contract"
+    assert report.noise_to_ignore == ("nonzero process exit is a wrapper",)
+    assert report.verification_commands == (
+        "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict",
+    )
+    assert report.confidence == "high"
 
 
 def test_import_error_collection_failure_points_to_pytest_collection() -> None:
@@ -187,7 +201,11 @@ def test_import_error_collection_failure_points_to_pytest_collection() -> None:
         "Process completed with exit code 2\n"
     )
 
-    assert report.classification == "product_bug"
+    assert report.classification == "pytest_collection_failure"
     assert report.blocker is True
     assert "ModuleNotFoundError" in report.actual_failure
-    assert report.contract_that_failed == "runtime command contract"
+    assert report.contract_that_failed == "pytest collection/import contract"
+    assert report.verification_commands == (
+        "python -m pytest -q tests/test_example.py --collect-only -o addopts=",
+    )
+    assert report.confidence == "high"


### PR DESCRIPTION
## Summary
- Refine CI failure triage classifications for common maintainer-facing failure families.
- Classify Ruff format failures as `formatting_drift`.
- Classify pre-commit hook failures as `pre_commit_hook_failure`.
- Classify MkDocs strict failures as `docs_contract_gap`.
- Classify pytest collection/import failures as `pytest_collection_failure`.

## Why
- The advisor should identify the real blocker instead of reporting generic wrapper failures.
- These refinements build directly on the fixture coverage added in the previous PR.

## Verification
- `python -m pytest -q tests/test_ci_failure_triage.py tests/test_workflow_alias_regression_guards.py -o addopts=`
- `python -m sdetkit triage-ci --help`
- `python -m sdetkit patch --help`
- `python -m pre_commit run -a`
- `git diff --check`

## Risk
- Medium
- Changes advisory classification output only.
- No auto-fix, mutation, commit, push, or merge behavior.
- Rollback: revert the classifier refinement commit.
