### PR TITLE
Improve CI triage report headlines

### DIFF
--- a/src/sdetkit/ci_failure_triage.py
+++ b/src/sdetkit/ci_failure_triage.py
@@ -160,7 +160,7 @@ def build_triage_report(text: str) -> CiFailureTriageReport:
             schema_version=SCHEMA_VERSION,
             classification="pytest_collection_failure",
             blocker=True,
-            headline_failure=exits[-1] if exits else f"ERROR collecting {owner}",
+            headline_failure=f"ERROR collecting {owner}",
             actual_failure=actual,
             root_cause_candidates=(
                 "pytest could not import or collect the test module",
@@ -268,7 +268,7 @@ def build_triage_report(text: str) -> CiFailureTriageReport:
             schema_version=SCHEMA_VERSION,
             classification="test_contract_failure",
             blocker=True,
-            headline_failure=exits[-1] if exits else f"{owner}: {detail}",
+            headline_failure=f"{owner}: {detail}",
             actual_failure=f"{owner}: {detail}",
             root_cause_candidates=("type/API contract mismatch",),
             likely_owner_files=_unique(owners),

--- a/src/sdetkit/ci_failure_triage.py
+++ b/src/sdetkit/ci_failure_triage.py
@@ -305,7 +305,7 @@ def build_triage_report(text: str) -> CiFailureTriageReport:
             schema_version=SCHEMA_VERSION,
             classification="product_bug",
             blocker=True,
-            headline_failure=exits[-1] if exits else exception,
+            headline_failure=exception,
             actual_failure=exception,
             root_cause_candidates=("Python exception raised during CI command",),
             likely_owner_files=_unique(owners),

--- a/src/sdetkit/ci_failure_triage.py
+++ b/src/sdetkit/ci_failure_triage.py
@@ -290,7 +290,12 @@ def build_triage_report(text: str) -> CiFailureTriageReport:
             root_cause_candidates=("coverage gate reported below-threshold evidence",),
             likely_owner_files=_unique(owners),
             contract_that_failed="coverage policy",
-            noise_to_ignore=_unique(["no earlier pytest node failure was found in the log"]),
+            noise_to_ignore=_unique(
+                [
+                    "no earlier pytest node failure was found in the log",
+                    *(["nonzero process exit is a wrapper"] if exits else []),
+                ]
+            ),
             recommended_fix_shape=(
                 "Inspect missed coverage or missing regression tests; do not lower the gate "
                 "unless policy intentionally changed."

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -164,6 +164,7 @@ def test_pre_commit_hook_failure_keeps_hook_as_actual_failure() -> None:
     assert report.classification == "pre_commit_hook_failure"
     assert report.blocker is True
     assert report.actual_failure == "end-of-file-fixer modified files or reported failure"
+    assert report.likely_owner_files == ("tests/test_ci_failure_triage.py",)
     assert report.contract_that_failed == "pre-commit hook contract"
     assert report.noise_to_ignore == ("nonzero process exit is a wrapper",)
     assert report.verification_commands == (

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -227,3 +227,24 @@ def test_runtime_exception_headline_prefers_exception_over_exit_wrapper() -> Non
     assert report.actual_failure == "ValueError: invalid config shape"
     assert report.likely_owner_files == ("src/sdetkit/example.py",)
     assert report.noise_to_ignore == ("nonzero process exit is a wrapper",)
+
+
+def test_coverage_only_failure_marks_exit_as_wrapper_noise() -> None:
+    report = ci_failure_triage.build_triage_report(
+        "Required test coverage of 95% not reached. Total coverage: 94.7%\n"
+        "Process completed with exit code 1\n"
+    )
+
+    assert report.classification == "quality_wrapper"
+    assert report.blocker is True
+    assert (
+        report.headline_failure
+        == "Required test coverage of 95% not reached. Total coverage: 94.7%"
+    )
+    assert (
+        report.actual_failure == "Required test coverage of 95% not reached. Total coverage: 94.7%"
+    )
+    assert report.noise_to_ignore == (
+        "no earlier pytest node failure was found in the log",
+        "nonzero process exit is a wrapper",
+    )

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -211,3 +211,19 @@ def test_import_error_collection_failure_points_to_pytest_collection() -> None:
         "python -m pytest -q tests/test_example.py --collect-only -o addopts=",
     )
     assert report.confidence == "high"
+
+
+def test_runtime_exception_headline_prefers_exception_over_exit_wrapper() -> None:
+    report = ci_failure_triage.build_triage_report(
+        "Traceback (most recent call last):\n"
+        '  File "src/sdetkit/example.py", line 12, in main\n'
+        "ValueError: invalid config shape\n"
+        "Process completed with exit code 1\n"
+    )
+
+    assert report.classification == "product_bug"
+    assert report.blocker is True
+    assert report.headline_failure == "ValueError: invalid config shape"
+    assert report.actual_failure == "ValueError: invalid config shape"
+    assert report.likely_owner_files == ("src/sdetkit/example.py",)
+    assert report.noise_to_ignore == ("nonzero process exit is a wrapper",)

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -52,6 +52,7 @@ def test_mypy_error_reports_owner_file_and_type_contract() -> None:
     assert report.classification == "test_contract_failure"
     assert report.likely_owner_files[0] == "src/sdetkit/example.py"
     assert report.contract_that_failed == "mypy type contract"
+    assert report.headline_failure == "src/sdetkit/example.py: Incompatible return value type"
     assert report.noise_to_ignore == ("nonzero process exit is a wrapper",)
 
 
@@ -203,6 +204,7 @@ def test_import_error_collection_failure_points_to_pytest_collection() -> None:
 
     assert report.classification == "pytest_collection_failure"
     assert report.blocker is True
+    assert report.headline_failure == "ERROR collecting tests/test_example.py"
     assert "ModuleNotFoundError" in report.actual_failure
     assert report.contract_that_failed == "pytest collection/import contract"
     assert report.verification_commands == (


### PR DESCRIPTION
## Summary
- Improve CI triage report quality for parsed blocker signals.
- Keep parsed mypy, pytest collection, and runtime exception failures as the report headline instead of generic process-exit wrappers.
- Clarify coverage-only wrapper noise when a nonzero process exit is present.
- Lock hook owner-file reporting for hook-modified files.

## Why
- Maintainers should see the actionable blocker first when the advisor already parsed it.
- Process-exit lines should remain supporting wrapper noise, not the primary failure when a better signal exists.
- Owner-file reporting should stay stable for hook-generated file edits.

## Verification
- `python -m pytest -q tests/test_ci_failure_triage.py tests/test_workflow_alias_regression_guards.py -o addopts=`
- `python -m sdetkit triage-ci --help`
- `python -m sdetkit patch --help`
- `python -m pre_commit run -a`
- `git diff --check`

## Risk
- Low to medium
- Advisory report wording and test coverage only.
- No CLI surface change.
- No auto-fix, mutation, commit, push, or merge behavior.
- Rollback: revert the stacked report-quality commits on this branch.