### PR TITLE
Improve CI triage output readability

### DIFF
--- a/src/sdetkit/ci_failure_triage.py
+++ b/src/sdetkit/ci_failure_triage.py
@@ -371,18 +371,25 @@ def _render_text(report: CiFailureTriageReport) -> str:
 
 
 def _render_markdown(report: CiFailureTriageReport) -> str:
+    owner_files = ", ".join(report.likely_owner_files) or "none"
+    noise = ", ".join(report.noise_to_ignore) or "none"
+    verification = ", ".join(report.verification_commands) or "none"
     return (
         "# CI failure triage\n\n"
+        "## Summary\n\n"
         f"- classification: `{report.classification}`\n"
         f"- blocker: `{'yes' if report.blocker else 'no'}`\n"
+        f"- confidence: `{report.confidence}`\n\n"
+        "## Failure\n\n"
         f"- headline failure: {report.headline_failure}\n"
         f"- actual failure: {report.actual_failure}\n"
-        f"- contract that failed: {report.contract_that_failed}\n"
-        f"- likely owner files: {', '.join(report.likely_owner_files) or 'none'}\n"
-        f"- noise to ignore: {', '.join(report.noise_to_ignore) or 'none'}\n"
+        f"- contract that failed: {report.contract_that_failed}\n\n"
+        "## Ownership and noise\n\n"
+        f"- likely owner files: {owner_files}\n"
+        f"- noise to ignore: {noise}\n\n"
+        "## Recommended action\n\n"
         f"- recommended fix shape: {report.recommended_fix_shape}\n"
-        f"- verification: {', '.join(report.verification_commands) or 'none'}\n"
-        f"- confidence: `{report.confidence}`\n"
+        f"- verification: {verification}\n"
         f"- next best action: {report.next_best_action}\n"
     )
 

--- a/src/sdetkit/ci_failure_triage.py
+++ b/src/sdetkit/ci_failure_triage.py
@@ -363,7 +363,7 @@ def _render_text(report: CiFailureTriageReport) -> str:
         if isinstance(value, bool):
             rendered = "yes" if value else "no"
         elif isinstance(value, (list, tuple)):
-            rendered = ", ".join(str(item) for item in value) if value else "none"
+            rendered = "; ".join(str(item) for item in value) if value else "none"
         else:
             rendered = str(value)
         lines.append(f"{key}={rendered}")

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -249,3 +249,23 @@ def test_coverage_only_failure_marks_exit_as_wrapper_noise() -> None:
         "no earlier pytest node failure was found in the log",
         "nonzero process exit is a wrapper",
     )
+
+
+def test_markdown_output_groups_operator_sections(tmp_path: Path, capsys) -> None:
+    log = tmp_path / "ci.log"
+    log.write_text(
+        "FAILED tests/test_x.py::test_a - AssertionError: nope\n"
+        "Process completed with exit code 1\n",
+        encoding="utf-8",
+    )
+
+    rc = ci_failure_triage.main(["--log", str(log), "--format", "md"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "## Summary" in out
+    assert "## Failure" in out
+    assert "## Ownership and noise" in out
+    assert "## Recommended action" in out
+    assert "classification: `test_failure`" in out
+    assert "verification: python -m pytest -q tests/test_x.py::test_a -o addopts=" in out

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -269,3 +269,23 @@ def test_markdown_output_groups_operator_sections(tmp_path: Path, capsys) -> Non
     assert "## Recommended action" in out
     assert "classification: `test_failure`" in out
     assert "verification: python -m pytest -q tests/test_x.py::test_a -o addopts=" in out
+
+
+def test_text_output_uses_semicolon_list_separator(tmp_path: Path, capsys) -> None:
+    log = tmp_path / "ci.log"
+    log.write_text(
+        "ruff format..............................................................Failed\n"
+        "- hook id: ruff-format\n"
+        "- files were modified by this hook\n"
+        "Process completed with exit code 1\n",
+        encoding="utf-8",
+    )
+
+    rc = ci_failure_triage.main(["--log", str(log), "--format", "text"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert (
+        "verification_commands=python -m ruff format --check .; python -m pre_commit run -a" in out
+    )
+    assert "noise_to_ignore=nonzero process exit is a wrapper" in out


### PR DESCRIPTION
## Summary
- Improve CI triage markdown output readability with grouped operator sections.
- Keep text output stable while making list fields easier to read with semicolon separators.
- Add tests for markdown section grouping and text list rendering.

## Why
- Maintainers should be able to scan `--format md` output quickly during CI triage.
- Text output should remain copy/paste friendly without ambiguous comma-separated command lists.
- This improves report presentation only; it does not expand classifier behavior.

## Verification
- `python -m pytest -q tests/test_ci_failure_triage.py tests/test_workflow_alias_regression_guards.py -o addopts=`
- `python -m sdetkit triage-ci --help`
- `python -m sdetkit patch --help`
- `python -m pre_commit run -a`
- `git diff --check`

## Risk
- Low
- Output formatting/readability only.
- JSON payload remains unchanged.
- No CLI surface change.
- No auto-fix, mutation, commit, push, or merge behavior.
- Rollback: revert the output-readability commits.
