### PR TITLE
Document CI triage saved-log workflow

### DIFF
--- a/docs/first-failure-triage.md
+++ b/docs/first-failure-triage.md
@@ -12,6 +12,20 @@ Goal: recover quickly, fix the right thing first, and avoid guessing.
 4. Run `gate release` after fast gate + security posture are stable.
 5. Use `doctor --release` when release prerequisites are unclear.
 
+## Saved CI log triage
+
+When a GitHub Actions job already failed, save the failed step log to a local file and ask the advisory triage command to summarize the real blocker:
+
+```bash
+python -m sdetkit triage-ci --log /tmp/failed-ci.log --format md
+```
+
+Use `--format json` when another tool needs the same report fields, or `--format text` for compact terminal output.
+
+The report is advisory only. It identifies the parsed blocker, likely owner files, wrapper noise to ignore, and verification commands. It does not edit files, lower gates, commit, push, or merge anything.
+
+Use it before patching when the loud final line is only a wrapper, such as a nonzero process exit after a pytest, mypy, MkDocs, coverage, or pre-commit failure.
+
 ## Fix-first matrix
 
 | What failed? | Check first | Fix before moving on | Run next |


### PR DESCRIPTION
## Summary
- Document the saved CI log workflow for `sdetkit triage-ci` in the first-failure triage guide.
- Show the markdown command path for a saved failed job log.
- Clarify that the triage report is advisory only and does not edit files, lower gates, commit, push, or merge.

## Why
- The CI triage advisor now has enough coverage and output quality to be operator-facing.
- Maintainers need a concise place to learn when to run it before patching noisy wrapper failures.

## Verification
- `python -m pytest -q tests/test_docs_nav_current_discoverability.py tests/test_mkdocs_strict_docs_map_links.py tests/test_docs_qa.py::test_repository_front_doors_are_polished_and_consistent -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`

## Risk
- Low
- Docs-only change.
- No CLI behavior change.
- Rollback: revert the docs update commit.