### PR TITLE
Note CI triage advisor in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- CI triage advisor: add `sdetkit triage-ci` for advisory saved-log diagnosis, with fixture coverage, clearer failure classifications, readable text/markdown output, and first-failure operator docs.
+
 ## [1.0.3]
 
 Released: 2026-04-18


### PR DESCRIPTION
## Summary
- Add an Unreleased changelog note for the completed CI triage advisor wave.
- Mention saved-log diagnosis, fixture coverage, clearer classifications, readable output, and operator docs.

## Why
- The feature is now operator-facing and documented.
- The root changelog should capture the completed CI triage capability before the next release cut.

## Verification
- `python -m pytest -q tests/test_docs_nav_current_discoverability.py tests/test_mkdocs_strict_docs_map_links.py tests/test_docs_qa.py::test_repository_front_doors_are_polished_and_consistent tests/test_ci_failure_triage.py -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`
- `git diff --check`

## Risk
- Low
- Changelog-only change.
- No runtime behavior change.
- Rollback: revert the changelog note.
