### PR TITLE
Surface CI triage in CLI discovery

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -87,7 +87,9 @@ These remain fully supported for existing automation and muscle memory:
 
 Available utility lanes include:
 
-- `kv`, `apiget`, `cassette-get`, `patch`, `maintenance`, `ops`, `notify`, `agent`
+`triage-ci` reads a saved failed CI job log and emits an advisory report in text, JSON, or Markdown. Use it before patching when the final process-exit line is only wrapper noise.
+
+- `triage-ci`, `kv`, `apiget`, `cassette-get`, `patch`, `maintenance`, `ops`, `notify`, `agent`
 
 ## Transition-era and legacy-oriented material
 

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -35,7 +35,7 @@ This table is sourced from `src/sdetkit/public_surface_contract.py`.
 
 - Advanced kits and discovery: `sdetkit kits list`, `sdetkit kits describe <kit>`, then `release`, `intelligence`, `integration`, `forensics`
 - Compatibility aliases: `gate`, `doctor`, `security`, `repo`, `evidence`, `report`, `policy`
-- Supporting utilities and automation: `kv`, `inspect`, `review`, `apiget`, `cassette-get`, `patch`, `maintenance`, `dev`, `ci`, `ops`, `notify`, `agent`, `feature-registry`
+- Supporting utilities and automation: `triage-ci`, `kv`, `inspect`, `review`, `apiget`, `cassette-get`, `patch`, `maintenance`, `dev`, `ci`, `ops`, `notify`, `agent`, `feature-registry`
 
 ## Transition-era and historical lanes
 

--- a/src/sdetkit/public_surface_contract.py
+++ b/src/sdetkit/public_surface_contract.py
@@ -54,6 +54,7 @@ PUBLIC_SURFACE_CONTRACT: tuple[CommandFamilyContract, ...] = (
             "dev",
             "maintenance",
             "ci",
+            "triage-ci",
             "kv",
             "inspect",
             "review",


### PR DESCRIPTION
## Summary
- Add `triage-ci` to CLI discovery docs and command-surface references.
- Include `triage-ci` in the supporting-utilities command-family contract.
- Briefly explain the saved-log advisory workflow from the CLI reference.

## Why
- The CI triage advisor is now implemented, tested, documented, and captured in the changelog.
- Operators should be able to discover it from the current CLI reference and command-family help surfaces.

## Verification
- `python -m pytest -q tests/test_docs_nav_current_discoverability.py tests/test_mkdocs_strict_docs_map_links.py tests/test_docs_qa.py::test_repository_front_doors_are_polished_and_consistent tests/test_workflow_alias_regression_guards.py -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`
- `git diff --check`

## Risk
- Low
- Discovery/docs contract only.
- No CLI behavior change.
- Rollback: revert the discovery docs/contract commit.
