### PR TITLE
Summarize new doctor snapshot evidence

### DIFF
--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -587,6 +587,59 @@ def _read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _evidence_identity(item: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(item.get("type", "")),
+        str(item.get("path", "")),
+        str(item.get("message", "")),
+    )
+
+
+def _new_snapshot_evidence(snapshot_text: str, current: dict[str, Any]) -> list[dict[str, str]]:
+    try:
+        previous = json.loads(snapshot_text)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(previous, dict):
+        return []
+
+    previous_checks = previous.get("checks")
+    current_checks = current.get("checks")
+    if not isinstance(previous_checks, dict) or not isinstance(current_checks, dict):
+        return []
+
+    new_items: list[dict[str, str]] = []
+    for check_id, check in sorted(current_checks.items()):
+        if not isinstance(check, dict):
+            continue
+        current_evidence = check.get("evidence", [])
+        if not isinstance(current_evidence, list):
+            continue
+
+        previous_check = previous_checks.get(check_id, {})
+        previous_evidence = (
+            previous_check.get("evidence", []) if isinstance(previous_check, dict) else []
+        )
+        previous_keys = {
+            _evidence_identity(item) for item in previous_evidence if isinstance(item, dict)
+        }
+
+        for item in current_evidence:
+            if not isinstance(item, dict):
+                continue
+            if _evidence_identity(item) in previous_keys:
+                continue
+
+            entry = {"check": str(check_id)}
+            for field in ("type", "path", "message"):
+                value = item.get(field)
+                if value is not None:
+                    entry[field] = str(value)
+            new_items.append(entry)
+
+    return new_items
+
+
 def _build_explain_payload(data: dict[str, Any]) -> dict[str, Any]:
     judgment = data.get("judgment", {}) if isinstance(data.get("judgment"), dict) else {}
     confidence_obj = judgment.get("confidence", {}) if isinstance(judgment, dict) else {}
@@ -3477,6 +3530,9 @@ def main(argv: list[str] | None = None) -> int:
 
         data["snapshot_diff_ok"] = diff_ok
         data["snapshot_diff_summary"] = diff_summary
+        new_evidence = _new_snapshot_evidence(snap_text, data) if snap_text else []
+        if new_evidence:
+            data["snapshot_new_evidence"] = new_evidence
 
         if getattr(ns, "diff", False) and not diff_ok:
             n = int(getattr(ns, "diff_context", 3) or 0)

--- a/tests/test_doctor_snapshot.py
+++ b/tests/test_doctor_snapshot.py
@@ -50,3 +50,55 @@ def test_doctor_diff_snapshot_fails_on_missing_file(tmp_path: Path, monkeypatch,
     data = json.loads(capsys.readouterr().out)
     assert rc == 2
     assert data["snapshot_diff_ok"] is False
+
+
+def test_doctor_diff_snapshot_reports_new_evidence_items(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "src" / "old_ascii.py").write_text('MESSAGE = "old debt …"\n', encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    snap = tmp_path / "snap.json"
+    rc1 = doctor.main(
+        [
+            "--only",
+            "ascii",
+            "--fail-on",
+            "high",
+            "--format",
+            "json",
+            "--snapshot",
+            str(snap),
+        ]
+    )
+    assert rc1 == 0
+    capsys.readouterr()
+
+    (tmp_path / "tools" / "new_ascii.py").write_text('MESSAGE = "new debt …"\n', encoding="utf-8")
+
+    rc2 = doctor.main(
+        [
+            "--only",
+            "ascii",
+            "--fail-on",
+            "high",
+            "--format",
+            "json",
+            "--diff-snapshot",
+            str(snap),
+        ]
+    )
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc2 == 2
+    assert data["snapshot_diff_ok"] is False
+    assert data["snapshot_new_evidence"] == [
+        {
+            "check": "ascii",
+            "message": "non-ASCII bytes detected",
+            "path": "tools/new_ascii.py",
+            "type": "non_ascii",
+        }
+    ]


### PR DESCRIPTION
## Summary
- Add `snapshot_new_evidence` to doctor snapshot diff output.
- Report newly introduced evidence items as structured JSON with check, type, path, and message.
- Add regression coverage for newly introduced ASCII evidence.

## Why
- `doctor baseline check --diff` already detects snapshot drift, but the actionable new evidence can be buried inside a large raw diff.
- This makes current-change debt easier to identify without hiding the full `snapshot_diff`.

## Verification
- `python -m pytest -q tests/test_doctor_snapshot.py tests/test_doctor_baseline.py tests/test_doctor_ascii.py tests/test_gate_fast.py -o addopts=`
- `python -m pre_commit run -a`
- Real probe confirmed `snapshot_new_evidence` reports `tools/_doctor_ascii_probe_tmp.py`.

## Risk
- Low
- Additive JSON field only when new evidence exists.
- Existing `snapshot_diff_ok`, `snapshot_diff_summary`, and optional `snapshot_diff` behavior remain intact.
- Rollback: revert the commit.
