### PR TITLE
Fix Python 3.10 version alignment test import

### DIFF
--- a/tests/test_version_alignment_docs.py
+++ b/tests/test_version_alignment_docs.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 compatibility
+    import tomli as tomllib
 
 
 def test_releasing_doc_and_hero_badge_match_pyproject_version() -> None:


### PR DESCRIPTION
## Summary
- Add a Python 3.10-compatible `tomli` fallback for `tests/test_version_alignment_docs.py`.
- Keep Python 3.11+ using stdlib `tomllib`.
- Restore full-suite collection under the repo's declared Python 3.10 support.

## Why
- The project supports Python 3.10.
- `tomllib` is only available in Python 3.11+.
- The repo already depends on `tomli` for Python versions below 3.11.

## Verification
- `python -m pytest -q tests/test_version_alignment_docs.py -o addopts=`
- `python -m pytest -q -o addopts=`
- `python -m pre_commit run -a`
- `git diff --check`

## Risk
- Low
- Test-only compatibility import.
- No runtime package behavior change.
- Rollback: revert the import fallback.
