### PR TITLE
Harden release workflow guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,4 +293,4 @@ jobs:
         run: bash quality.sh cov
 
       - name: Docs build
-        run: NO_MKDOCS_2_WARNING=1 python -m mkdocs build
+        run: NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict

--- a/.github/workflows/first-proof-artifact-publish.yml
+++ b/.github/workflows/first-proof-artifact-publish.yml
@@ -11,6 +11,9 @@ on:
       - "pyproject.toml"
       - "requirements*.txt"
 
+permissions:
+  contents: read
+
 jobs:
   publish-first-proof-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/impact-release-control.yml
+++ b/.github/workflows/impact-release-control.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   impact-release-control:
     runs-on: ubuntu-latest
@@ -18,9 +21,8 @@ jobs:
 
       - name: Install package + test deps
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-          python -m pip install -r requirements-test.txt
+          python -m pip install -c constraints-ci.txt -e .
+          python -m pip install -c constraints-ci.txt -r requirements-test.txt
 
 
       - name: Validate impact policy

--- a/.github/workflows/phase4-governance-contract.yml
+++ b/.github/workflows/phase4-governance-contract.yml
@@ -17,6 +17,9 @@ on:
       - 'docs/**'
       - 'Makefile'
       - '.github/workflows/phase4-governance-contract.yml'
+permissions:
+  contents: read
+
 jobs:
   phase4-governance:
     runs-on: ubuntu-latest
@@ -29,7 +32,7 @@ jobs:
         run: |
           python -m venv .venv
           . .venv/bin/activate
-          pip install -e .
+          python -m pip install -c constraints-ci.txt -e .
       - name: Run phase4 contract
         run: |
           . .venv/bin/activate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           COV_FAIL_UNDER: "95"
         run: |
           set -euo pipefail
-          python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .[packaging]
+          python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .[packaging]
           bash quality.sh cov
 
       - name: Build dist

--- a/tests/test_workflow_release_guardrails.py
+++ b/tests/test_workflow_release_guardrails.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _workflow(name: str) -> str:
+    return (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+
+
+def test_release_workflow_installs_release_dependencies_with_constraints() -> None:
+    text = _workflow("release.yml")
+
+    assert (
+        "python -m pip install -c constraints-ci.txt -r requirements-test.txt "
+        "-r requirements-docs.txt -e .[packaging]"
+    ) in text
+    assert (
+        "python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .[packaging]"
+    ) not in text
+
+
+def test_impact_release_control_uses_least_privilege_permissions_and_constraints() -> None:
+    text = _workflow("impact-release-control.yml")
+
+    assert "\npermissions:\n  contents: read\n" in text
+    assert "python -m pip install -c constraints-ci.txt -e ." in text
+    assert "python -m pip install -c constraints-ci.txt -r requirements-test.txt" in text
+    assert "python -m pip install --upgrade pip" not in text
+
+
+def test_artifact_publish_and_governance_workflows_declare_permissions() -> None:
+    for workflow_name in [
+        "first-proof-artifact-publish.yml",
+        "phase4-governance-contract.yml",
+    ]:
+        text = _workflow(workflow_name)
+        assert "\npermissions:\n  contents: read\n" in text
+
+
+def test_phase4_governance_contract_install_uses_constraints() -> None:
+    text = _workflow("phase4-governance-contract.yml")
+
+    assert "python -m pip install -c constraints-ci.txt -e ." in text
+    assert "pip install -e ." not in text
+
+
+def test_full_ci_docs_build_is_strict() -> None:
+    text = _workflow("ci.yml")
+
+    assert "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict" in text
+    assert "NO_MKDOCS_2_WARNING=1 python -m mkdocs build\n" not in text


### PR DESCRIPTION
## Summary
- constrain release workflow dependency installation with constraints-ci.txt
- add least-privilege permissions to release-adjacent workflows
- make the full CI docs build strict
- add workflow guardrail tests for release dependency constraints, workflow permissions, and strict docs build

## Why it matters
This hardens release and release-adjacent CI lanes against dependency drift and implicit workflow permissions while preserving existing public behavior.

## Proof
- python -m ruff check tests/test_workflow_release_guardrails.py
- python -m ruff format --check tests/test_workflow_release_guardrails.py
- python -m build
- python -m twine check dist/*
- python -m check_wheel_contents --ignore W009 dist/*.whl
- python -m pip install --force-reinstall dist/*.whl
- sdetkit --help
- python -m pytest -q
- python -m pre_commit run -a
- targeted final guard: 11 passed

Full local suite result: 3166 passed, 1 skipped, 3 deselected.

## Rollback
Revert c37e203b. No public CLI/API behavior changed.
