### PR TITLE
Refresh roadmap manifest after workflow guardrail update

### DIFF
--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 80
+        "tests_referencing_module": 81
       },
       {
         "contract_script_paths": [


### PR DESCRIPTION
## Summary
- refresh docs/roadmap/manifest.json using the repo-owned roadmap manifest generator

## Why it matters
PR #1233 added a workflow guardrail test, which changed the generated roadmap manifest's test-reference count. The manifest freshness test now fails on main until the tracked generated artifact is refreshed.

## Proof
- python -m pytest -q tests/test_roadmap_manifest_tooling.py tests/test_roadmap_manifest_edges_wave12.py -o addopts=
- python -m pytest -q tests/test_workflow_release_guardrails.py tests/test_workflow_contract.py tests/test_legacy_required_status_bridge_workflow.py tests/test_production_workflow_docs_references.py tests/test_workflow_alias_regression_guards.py -o addopts=
- python -m pre_commit run -a
- NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict

## Rollback
Revert 33e92246.
