### PR TITLE
Improve GitHub Actions annotation action-ref parsing

### DIFF
--- a/src/sdetkit/github_actions_annotation_hygiene.py
+++ b/src/sdetkit/github_actions_annotation_hygiene.py
@@ -8,7 +8,9 @@ from typing import Any
 
 SCHEMA_VERSION = "sdetkit.github_actions.annotation_hygiene.v1"
 
-_NODE20_ACTION_RE = re.compile(r"(?P<action>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[A-Za-z0-9_.:/-]+)")
+_NODE20_ACTION_RE = re.compile(
+    r"(?P<action>[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+@[A-Za-z0-9_.:/-]+)"
+)
 _JOB_RE = re.compile(r"^(?P<job>[A-Za-z0-9_. -]+)$")
 
 

--- a/src/sdetkit/github_actions_annotation_hygiene.py
+++ b/src/sdetkit/github_actions_annotation_hygiene.py
@@ -33,7 +33,9 @@ def _nearest_job(lines: list[str], index: int) -> str:
 
 def _extract_action(line: str) -> str:
     match = _NODE20_ACTION_RE.search(line)
-    return match.group("action") if match else ""
+    if not match:
+        return ""
+    return match.group("action").rstrip(".,;:)")
 
 
 def analyze_annotations(text: str) -> dict[str, Any]:

--- a/tests/test_github_actions_annotation_hygiene.py
+++ b/tests/test_github_actions_annotation_hygiene.py
@@ -64,3 +64,20 @@ def test_cli_returns_zero_when_no_warnings(tmp_path, capsys):
 
     assert rc == 0
     assert "No GitHub Actions annotation hygiene findings" in capsys.readouterr().out
+
+
+def test_action_extraction_trims_sentence_punctuation() -> None:
+    payload = hygiene.analyze_annotations(
+        "release\n"
+        "Node.js 20 actions are deprecated. The following actions are running on "
+        "Node.js 20 and may not work as expected: "
+        "actions/component-detection-dependency-submission-action@374343effede691df3a5ffaf36b4e7acab919590.\n"
+    )
+
+    finding = next(
+        item for item in payload["findings"] if item["id"] == "github_actions_node20_deprecation"
+    )
+    assert (
+        finding["action"]
+        == "actions/component-detection-dependency-submission-action@374343effede691df3a5ffaf36b4e7acab919590"
+    )

--- a/tests/test_github_actions_annotation_hygiene.py
+++ b/tests/test_github_actions_annotation_hygiene.py
@@ -81,3 +81,20 @@ def test_action_extraction_trims_sentence_punctuation() -> None:
         finding["action"]
         == "actions/component-detection-dependency-submission-action@374343effede691df3a5ffaf36b4e7acab919590"
     )
+
+
+def test_action_extraction_preserves_nested_action_path() -> None:
+    payload = hygiene.analyze_annotations(
+        "release\n"
+        "Node.js 20 actions are deprecated. The following actions are running on "
+        "Node.js 20 and may not work as expected: "
+        "github/codeql-action/upload-sarif@374343effede691df3a5ffaf36b4e7acab919590.\n"
+    )
+
+    finding = next(
+        item for item in payload["findings"] if item["id"] == "github_actions_node20_deprecation"
+    )
+    assert (
+        finding["action"]
+        == "github/codeql-action/upload-sarif@374343effede691df3a5ffaf36b4e7acab919590"
+    )


### PR DESCRIPTION
## Summary
- normalize GitHub Actions annotation action refs by trimming trailing sentence punctuation
- preserve nested action paths such as github/codeql-action/upload-sarif@...
- add regression coverage for both annotation parser precision cases

## Why it matters
The annotation hygiene report is used for CI/release diagnostics. Incorrect action refs make follow-up harder by pointing maintainers at malformed or incomplete action identifiers.

## Proof
- python -m pytest -q tests/test_github_actions_annotation_hygiene.py tests/test_github_actions_annotation_hygiene_report.py tests/test_github_actions_annotation_hygiene_check.py -o addopts=
- python -m pytest -q tests/test_github_setup_python_pinning.py tests/test_branch_protection_workflow_alignment.py tests/test_ci_workflow_premerge_gate.py tests/test_github_actions_annotation_hygiene.py tests/test_github_actions_annotation_hygiene_check.py tests/test_github_actions_annotation_hygiene_report.py tests/test_repo_security_suite.py tests/test_security_baseline_stability.py tests/test_release_preflight.py tests/test_release_readiness.py tests/test_doctor_release_meta.py -o addopts=
- python -m mypy src
- python -m pre_commit run -a
- python -m pytest -q tests/test_generated_artifacts_freshness.py tests/test_roadmap_manifest_tooling.py tests/test_roadmap_manifest_edges_wave12.py -o addopts=
- NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict
- python -m build
- python -m twine check dist/*
- python -m check_wheel_contents --ignore W009 dist/*.whl
- smoke-installed built wheel and ran sdetkit --help

## Rollback
Revert the two commits on this branch. No public CLI command contract changed.
