### PR TITLE
Align workflow dependency installs with constraints

### DIFF
--- a/.github/workflows/adoption-real-repo-canonical.yml
+++ b/.github/workflows/adoption-real-repo-canonical.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install sdetkit from this repo
-        run: python -m pip install -e .
+        run: python -m pip install -c constraints-ci.txt -e .
 
       - name: Verify canonical goldens are fresh
         run: python scripts/regenerate_real_repo_adoption_goldens.py --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install project
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
+          python -m pip install -c constraints-ci.txt -e .
 
       - name: Run repo audit
         run: sdetkit repo check --format json --out report.json --force
@@ -166,7 +166,7 @@ jobs:
       - name: Install project
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
+          python -m pip install -c constraints-ci.txt -e .
 
       - name: Run deterministic demo
         run: |

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Audit dependencies (blocking, baseline aware)
         run: |
-          python -m pip install -e .
+          python -m pip install -c constraints-ci.txt -e .
           pip-audit --format json -o pip-audit-report.json -r requirements-test.txt -r requirements-docs.txt --ignore-vuln CVE-2026-4539
           python .github/scripts/check_pip_audit_baseline.py
 

--- a/.github/workflows/dependency-radar-bot.yml
+++ b/.github/workflows/dependency-radar-bot.yml
@@ -26,7 +26,7 @@ jobs:
             requirements-docs.txt
 
       - name: Install repo
-        run: python -m pip install -e .
+        run: python -m pip install -c constraints-ci.txt -e .
 
       - name: Generate dependency radar artifacts
         run: |

--- a/.github/workflows/enterprise-gate.yml
+++ b/.github/workflows/enterprise-gate.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install package
         run: |
           python -m pip install -U pip
-          python -m pip install -e .
+          python -m pip install -c constraints-ci.txt -e .
 
       - name: Doctor
         run: |

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install -r requirements-test.txt -r requirements-docs.txt
-          python -m pip install -e .
+          python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt
+          python -m pip install -c constraints-ci.txt -e .
           python -m pip install mutmut
 
       - name: Run mutation tests

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install docs dependencies
         run: |
-          python -m pip install -r requirements-docs.txt -e .
+          python -m pip install -c constraints-ci.txt -r requirements-docs.txt -e .
 
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
         with:

--- a/.github/workflows/pr-helper-bot.yml
+++ b/.github/workflows/pr-helper-bot.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Install
         if: steps.pr.outputs.cmd != '/hint'
         run: |
-          python -m pip install -r requirements-test.txt -r requirements-docs.txt
-          python -m pip install -e .
-          python -m pip install pre-commit==4.3.0
+          python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt
+          python -m pip install -c constraints-ci.txt -e .
+          python -m pip install -c constraints-ci.txt pre-commit
 
       - name: Run doctor
         if: steps.pr.outputs.cmd == '/doctor'
@@ -116,7 +116,7 @@ jobs:
                 body += '\nCould not read quality.log.\n';
               }
               body += `\nCoverage (last reported): ${coverage}\n`;
-              body += '- Suggested local fix: `python -m pip install -r requirements-test.txt -e . && bash quality.sh cov`\n';
+              body += '- Suggested local fix: `python -m pip install -c constraints-ci.txt -r requirements-test.txt -e . && bash quality.sh cov`\n';
             }
 
             if (cmd === '/hint') {

--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .
+          python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .
 
       - name: Run quality gate
         id: quality
@@ -69,7 +69,7 @@ jobs:
             {
               echo '❌ quality.sh cov failed (see workflow logs for details)'
               echo "- coverage (last reported): ${coverage_pct}%"
-              echo '- suggested fix: run `python -m pip install -r requirements-test.txt -e . && bash quality.sh cov` locally'
+              echo '- suggested fix: run `python -m pip install -c constraints-ci.txt -r requirements-test.txt -e . && bash quality.sh cov` locally'
               if [ -s build/pr-quality/adaptive-diagnosis-comment.md ]; then
                 echo ''
                 cat build/pr-quality/adaptive-diagnosis-comment.md

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install pre-commit
         run: |
-          python -m pip install pre-commit==4.3.0
+          python -m pip install -c constraints-ci.txt pre-commit
 
       - name: Update hooks
         run: pre-commit autoupdate

--- a/.github/workflows/premium-gate.yml
+++ b/.github/workflows/premium-gate.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e '.[dev,test,docs]'
+          python -m pip install -c constraints-ci.txt -e '.[dev,test,docs]'
       - name: Run premium gate
         run: bash premium-gate.sh
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install project dependencies + CycloneDX
         run: |
-          python -m pip install -r requirements-test.txt -r requirements-docs.txt -e .
+          python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .
           python -m pip install cyclonedx-bom==4.1.0
 
       - name: Generate SBOM

--- a/tests/test_workflow_dependency_install_contract.py
+++ b/tests/test_workflow_dependency_install_contract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOW_DIR = Path(".github/workflows")
+
+# These installs are intentionally outside the repo dependency resolver contract.
+_ALLOWED_UNCONSTRAINED_PATTERNS = (
+    "python -m pip install --upgrade pip",
+    "python -m pip install -U pip",
+    'python -m pip install "$WHEEL_PATH"',
+    "python -m pip install --force-reinstall dist/*.whl",
+    "python -m pip install pip-audit==",
+    "python -m pip install cyclonedx-bom==",
+    "python -m pip install mutmut",
+)
+
+# Reference/example workflows demonstrate third-party project behavior rather than
+# this repository's active dependency contract.
+_ALLOWED_WORKFLOW_PATH_PARTS = ("advanced-github-actions-reference",)
+
+
+def _is_allowed_unconstrained_install(path: Path, line: str) -> bool:
+    if any(part in path.name for part in _ALLOWED_WORKFLOW_PATH_PARTS):
+        return True
+    return any(pattern in line for pattern in _ALLOWED_UNCONSTRAINED_PATTERNS)
+
+
+def test_active_workflow_repo_dependency_installs_use_constraints() -> None:
+    offenders: list[str] = []
+
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
+        text = path.read_text(encoding="utf-8")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            stripped = line.strip()
+            if "pip install" not in stripped:
+                continue
+            if "constraints-ci.txt" in stripped:
+                continue
+            if _is_allowed_unconstrained_install(path, stripped):
+                continue
+            installs_repo_dependencies = any(
+                marker in stripped
+                for marker in (
+                    "-e .",
+                    "-e .[",
+                    "-e '.[",
+                    "-r requirements-test.txt",
+                    "-r requirements-docs.txt",
+                    "pre-commit==",
+                )
+            )
+            if installs_repo_dependencies:
+                offenders.append(f"{path}:{line_no}: {stripped}")
+
+    assert not offenders, (
+        "Active GitHub workflows must install repo-managed dependencies through "
+        "constraints-ci.txt so CI, bot, docs, and local dependency behavior stay "
+        "aligned. Offending install lines:\n" + "\n".join(offenders)
+    )
+
+
+def test_workflows_do_not_hard_code_repo_managed_precommit_versions() -> None:
+    offenders: list[str] = []
+
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
+        text = path.read_text(encoding="utf-8")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            if re.search(r"pre-commit==\d", line):
+                offenders.append(f"{path}:{line_no}: {line.strip()}")
+
+    assert not offenders, (
+        "GitHub workflows must not hard-code repo-managed pre-commit versions. "
+        "Install pre-commit through constraints-ci.txt so workflow tooling stays "
+        "aligned with pyproject.toml, requirements.txt, and constraints-ci.txt:\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Summary
- Align active GitHub workflow repo dependency installs with `constraints-ci.txt`.
- Replace hard-coded workflow `pre-commit==4.3.0` installs with constrained installs.
- Add a workflow dependency guardrail preventing future unconstrained repo-managed installs.

## Why
- Workflow dependency installs should follow the same dependency truth surfaces as local and CI proof.
- This prevents bot, docs, SBOM, dependency audit, and quality workflows from drifting from `pyproject.toml`, requirements files, and `constraints-ci.txt`.

## Verification
- `python -m pytest -q tests/test_workflow_dependency_install_contract.py -o addopts=`
- `python -m pytest -q tests/test_workflow_release_guardrails.py tests/test_workflow_alias_regression_guards.py tests/test_production_workflow_docs_references.py tests/test_github_setup_python_pinning.py -o addopts=`
- `python -m pip install -c constraints-ci.txt -e '.[dev,test]'`
- `python -m pip install -c constraints-ci.txt -e '.[dev,packaging]'`
- `python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `python -m pytest -q -o addopts=`

## Risk
- Low to medium.
- Rollback: easy; revert workflow install-line changes and the guardrail test.

## Notes
- External tool pins such as `pip-audit`, `cyclonedx-bom`, and `mutmut` were intentionally left unchanged for a separate dependency-policy review.