### PR TITLE
Align SBOM workflow tool pin with requirements

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install project dependencies + CycloneDX
         run: |
           python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .
-          python -m pip install cyclonedx-bom==4.1.0
+          python -m pip install cyclonedx-bom==7.3.0
 
       - name: Generate SBOM
         run: |

--- a/tests/test_workflow_external_tool_pin_contract.py
+++ b/tests/test_workflow_external_tool_pin_contract.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(".")
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+
+PINNED_TOOLS = {
+    "pip-audit": {
+        "requirement_files": [ROOT / "requirements.txt"],
+        "workflow_files": [WORKFLOW_DIR / "dependency-audit.yml"],
+    },
+    "cyclonedx-bom": {
+        "requirement_files": [ROOT / "requirements.txt"],
+        "workflow_files": [WORKFLOW_DIR / "sbom.yml"],
+    },
+}
+
+
+def _requirement_pin(tool: str, files: list[Path]) -> str:
+    pattern = re.compile(rf"^{re.escape(tool)}==([^\s#]+)")
+    matches: list[str] = []
+
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            match = pattern.match(line.strip())
+            if match:
+                matches.append(match.group(1))
+
+    assert matches, f"No requirement pin found for {tool}"
+    assert len(set(matches)) == 1, f"Conflicting requirement pins for {tool}: {matches}"
+    return matches[0]
+
+
+def _workflow_pins(tool: str, files: list[Path]) -> list[str]:
+    pattern = re.compile(rf"{re.escape(tool)}==([^\s\"'`]+)")
+    pins: list[str] = []
+
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            match = pattern.search(line)
+            if match:
+                pins.append(match.group(1))
+
+    return pins
+
+
+def test_external_tool_workflow_pins_match_requirement_truth() -> None:
+    offenders: list[str] = []
+
+    for tool, config in PINNED_TOOLS.items():
+        expected = _requirement_pin(tool, config["requirement_files"])
+        actual_pins = _workflow_pins(tool, config["workflow_files"])
+        for actual in actual_pins:
+            if actual != expected:
+                offenders.append(f"{tool}: workflow={actual} requirements={expected}")
+
+    assert not offenders, (
+        "Workflow external tool pins must match the repo requirement truth "
+        "when the tool is already pinned in requirements files:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Summary
- Align the SBOM workflow `cyclonedx-bom` install with the repo requirement pin.
- Add a guardrail that checks workflow external tool pins against requirement truth for tools already pinned in repo dependency files.

## Why
- `requirements.txt` pinned `cyclonedx-bom==7.3.0`, while `.github/workflows/sbom.yml` installed `cyclonedx-bom==4.1.0`.
- Keeping workflow tool pins aligned prevents supply-chain evidence generation from drifting from repo dependency truth.

## Verification
- `python -m pytest -q tests/test_workflow_external_tool_pin_contract.py -o addopts=`
- `python -m pytest -q tests/test_workflow_dependency_install_contract.py tests/test_workflow_release_guardrails.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low.
- Rollback: easy; revert the workflow line and guardrail test.

## Notes
- `pip-audit` was already aligned at `2.10.0`.
- `mutmut` is already repo-managed through requirements and the mutation workflow install path.
