### PR TITLE
Remove redundant mutation workflow install

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -43,7 +43,6 @@ jobs:
         run: |
           python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt
           python -m pip install -c constraints-ci.txt -e .
-          python -m pip install mutmut
 
       - name: Run mutation tests
         env:

--- a/tests/test_mutation_workflow_dependency_contract.py
+++ b/tests/test_mutation_workflow_dependency_contract.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+MUTATION_WORKFLOW = Path(".github/workflows/mutation-tests.yml")
+REQUIREMENTS_TEST = Path("requirements-test.txt")
+
+
+def test_mutation_workflow_uses_requirements_test_for_mutmut() -> None:
+    workflow = MUTATION_WORKFLOW.read_text(encoding="utf-8")
+    requirements = REQUIREMENTS_TEST.read_text(encoding="utf-8")
+
+    assert "mutmut==3.5.0" in requirements
+    assert "python -m pip install -c constraints-ci.txt -r requirements-test.txt" in workflow
+    assert "python -m pip install mutmut" not in workflow


### PR DESCRIPTION
## Summary
- Remove the redundant unconstrained `python -m pip install mutmut` line from the mutation workflow.
- Add a guardrail proving the mutation workflow uses `requirements-test.txt` for the repo-managed `mutmut` install.

## Why
- `requirements-test.txt` already pins `mutmut==3.5.0`.
- `.github/workflows/mutation-tests.yml` already installs `requirements-test.txt` through `constraints-ci.txt`.
- The extra unconstrained install could drift from the repo’s declared test dependency truth.

## Verification
- `python -m pytest -q tests/test_mutation_workflow_dependency_contract.py -o addopts=`
- `python -m pytest -q tests/test_workflow_dependency_install_contract.py tests/test_workflow_external_tool_pin_contract.py -o addopts=`
- `python -m ruff check tests/test_mutation_workflow_dependency_contract.py`
- `python -m ruff format --check tests/test_mutation_workflow_dependency_contract.py`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low.
- Rollback: easy; restore the single workflow install line and remove the guardrail test.
