### PR TITLE
Clean real-repo adoption test workspace artifacts

### DIFF
--- a/tests/test_real_repo_adoption_contracts.py
+++ b/tests/test_real_repo_adoption_contracts.py
@@ -2,15 +2,27 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_ROOT = REPO_ROOT / "examples" / "adoption" / "real-repo"
+
+
+@pytest.fixture(autouse=True)
+def _clean_real_repo_sdetkit_workspace() -> Iterator[None]:
+    shutil.rmtree(FIXTURE_ROOT / ".sdetkit", ignore_errors=True)
+    yield
+    shutil.rmtree(FIXTURE_ROOT / ".sdetkit", ignore_errors=True)
+
+
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from real_repo_adoption_projection import (  # noqa: E402


### PR DESCRIPTION
## Summary
- Add cleanup around real-repo adoption contract tests.
- Prevent `tests/test_real_repo_adoption_contracts.py` from leaving `.sdetkit` workspace artifacts under `examples/adoption/real-repo/`.

## Why
- The docs/contracts scan found `examples/adoption/real-repo/.sdetkit/` appearing after `tests/test_real_repo_adoption_contracts.py`.
- The generated freshness script and regen helper tests did not reproduce the leak.
- The docs missing-link scan was classified as scan noise because MkDocs strict and active docs contract tests passed; the reported links were quoted snippets inside a historical proof artifact.

## Verification
- `python -m pytest -q tests/test_real_repo_adoption_contracts.py -o addopts=`
- `test ! -e examples/adoption/real-repo/.sdetkit`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pytest -q tests/test_mkdocs_strict_docs_map_links.py tests/test_docs_qa.py tests/test_docs_navigation.py tests/test_docs_nav_current_discoverability.py tests/test_docs_archive_navigation_policy.py tests/test_production_workflow_docs_references.py tests/test_real_repo_adoption_regen_helper.py tests/test_generated_artifacts_freshness.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low.
- Test-only cleanup; no public behavior change.
- Rollback: remove the cleanup fixture.
