### PR TITLE
Fix cached provider test fixture initialization

### DIFF
--- a/tests/test_agent_foundation.py
+++ b/tests/test_agent_foundation.py
@@ -16,7 +16,7 @@ from sdetkit.agent.providers import CachedProvider
 
 
 class CountingProvider:
-    def init_(self) -> None:
+    def __init__(self) -> None:
         self.calls = 0
 
     def complete(self, *, role: str, task: str, context: dict[str, object]) -> str:


### PR DESCRIPTION
## Summary
- Fixed the cached provider test fixture constructor typo so `CountingProvider.calls` initializes correctly.

## Why
- The release/package audit test set exposed a narrow test fixture bug: `init_` was not Python’s `__init__`, so `calls` was never initialized.

## Verification
- `python -m pytest -q tests/test_agent_foundation.py::test_cached_provider_hits_after_first_call tests/test_agent_foundation.py::test_cached_provider_miss_when_disabled -o addopts=` → 2 passed
- `python -m pytest -q tests/test_agent_foundation.py -o addopts=` → 17 passed
- `python -m pytest -q "${package_tests[@]}" -o addopts=` → 1894 passed
- `python -m pre_commit run -a` → passed

## Risk
- Low
- Rollback: revert commit `3c618b36`
