### PR TITLE
Fix constructor typos in test doubles

### DIFF
--- a/tests/test_agent_providers_extra.py
+++ b/tests/test_agent_providers_extra.py
@@ -9,7 +9,7 @@ from sdetkit.agent.providers import CachedProvider, FakeProvider, LocalHTTPProvi
 
 
 class _HTTPResponse:
-    def init_(self, payload: str) -> None:
+    def __init__(self, payload: str) -> None:
         self._payload = payload
 
     def __enter__(self):

--- a/tests/test_cli_smoke_coverage.py
+++ b/tests/test_cli_smoke_coverage.py
@@ -68,16 +68,16 @@ def _mock_httpx(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
     transport = httpx.MockTransport(handler)
 
     class PatchedClient(httpx.Client):
-        def init_(self, *args: Any, **kwargs: Any) -> None:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
             kwargs.setdefault("transport", transport)
             kwargs.setdefault("base_url", "https://example.invalid")
-            super().init_(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
     class PatchedAsyncClient(httpx.AsyncClient):
-        def init_(self, *args: Any, **kwargs: Any) -> None:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
             kwargs.setdefault("transport", transport)
             kwargs.setdefault("base_url", "https://example.invalid")
-            super().init_(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
     monkeypatch.setattr(httpx, "Client", PatchedClient)
     monkeypatch.setattr(httpx, "AsyncClient", PatchedAsyncClient)

--- a/tests/test_maintenance_cli.py
+++ b/tests/test_maintenance_cli.py
@@ -576,7 +576,7 @@ def test_security_check_uses_new_findings_when_baseline_exists(tmp_path: Path, m
 
 def test_security_check_requires_repeated_failure(tmp_path: Path, monkeypatch) -> None:
     class Result:
-        def init_(self, returncode: int, stdout: str) -> None:
+        def __init__(self, returncode: int, stdout: str) -> None:
             self.returncode = returncode
             self.stdout = stdout
             self.stderr = ""
@@ -608,7 +608,7 @@ def test_security_check_requires_repeated_failure(tmp_path: Path, monkeypatch) -
 
 def test_security_check_fix_mode_applies_fix_before_follow_up(tmp_path: Path, monkeypatch) -> None:
     class Result:
-        def init_(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
             self.returncode = returncode
             self.stdout = stdout
             self.stderr = stderr
@@ -706,7 +706,7 @@ def test_security_check_repeated_fingerprint_fails(tmp_path: Path, monkeypatch) 
 
 def test_security_check_autofix_runs_when_env_enabled(tmp_path: Path, monkeypatch) -> None:
     class Result:
-        def init_(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
             self.returncode = returncode
             self.stdout = stdout
             self.stderr = stderr


### PR DESCRIPTION
## Summary
- Fixed repeated `init_` constructor typos in test doubles that were masking real test behavior.
- Covered maintenance security-check result doubles, local HTTP provider response doubles, and patched HTTPX smoke-test clients.

## Why
- The repo-wide bug-hunting baseline exposed real `TypeError` / `AttributeError` failures from typoed constructors.
- The fix preserves test intent and does not change production behavior.

## Verification
- `python -m pytest -q tests/test_maintenance_cli.py::test_security_check_requires_repeated_failure tests/test_maintenance_cli.py::test_security_check_fix_mode_applies_fix_before_follow_up tests/test_maintenance_cli.py::test_security_check_autofix_runs_when_env_enabled -o addopts=` → 3 passed
- `python -m pytest -q tests/test_agent_providers_extra.py tests/test_cli_smoke_coverage.py -o addopts=` → 9 passed
- constructor candidate suite → 148 passed
- focused baseline after fixes → passed
- `python -m mypy src` → passed
- `python -m pre_commit run -a` → passed
- `python -m pytest -q -o addopts=` → 3175 passed, 1 skipped

## Risk
- Low
- Rollback: revert commit `cc0ca1fc`
