### PR TITLE
Tighten workflow permission guardrails

### DIFF
--- a/.github/workflows/adaptive-ops-weekly.yml
+++ b/.github/workflows/adaptive-ops-weekly.yml
@@ -10,6 +10,9 @@ on:
         required: false
         default: "balanced"
 
+permissions:
+  contents: read
+
 jobs:
   adaptive-ops:
     runs-on: ubuntu-latest

--- a/.github/workflows/phase3-quality-contract.yml
+++ b/.github/workflows/phase3-quality-contract.yml
@@ -11,6 +11,9 @@ on:
       - 'scripts/phase3_quality_engine.py'
       - 'tests/test_phase3_*.py'
 
+permissions:
+  contents: read
+
 jobs:
   phase3-contract:
     runs-on: ubuntu-latest

--- a/tests/test_workflow_release_guardrails.py
+++ b/tests/test_workflow_release_guardrails.py
@@ -49,3 +49,33 @@ def test_full_ci_docs_build_is_strict() -> None:
 
     assert "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict" in text
     assert "NO_MKDOCS_2_WARNING=1 python -m mkdocs build\n" not in text
+
+
+def test_active_workflows_declare_top_level_or_job_level_permissions() -> None:
+    workflow_dir = ROOT / ".github" / "workflows"
+    offenders = []
+
+    for workflow_path in sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml")):
+        text = workflow_path.read_text(encoding="utf-8")
+        has_top_level_permissions = any(
+            line.startswith("permissions:") for line in text.splitlines()
+        )
+        has_job_level_permissions = any(
+            line.startswith("    permissions:") for line in text.splitlines()
+        )
+        if not has_top_level_permissions and not has_job_level_permissions:
+            offenders.append(workflow_path.name)
+
+    assert not offenders, (
+        "Active workflows must declare explicit top-level or job-level permissions "
+        "so GitHub token scope is intentional:\n" + "\n".join(offenders)
+    )
+
+
+def test_adaptive_and_quality_contract_workflows_use_read_only_permissions() -> None:
+    for workflow_name in [
+        "adaptive-ops-weekly.yml",
+        "phase3-quality-contract.yml",
+    ]:
+        text = _workflow(workflow_name)
+        assert "\npermissions:\n  contents: read\n\njobs:\n" in text


### PR DESCRIPTION
## Summary
- Add explicit `contents: read` permissions to two read-only workflow lanes.
- Extend workflow release guardrails so every active workflow must declare top-level or job-level permissions.
- Preserve job-level permissions for workflows that intentionally need scoped write access.

## Why
- GitHub token scope should be intentional across all active workflows.
- The previous guardrail covered only selected workflows, allowing read-only lanes to rely on default permissions.

## Verification
- `python -m pytest -q tests/test_workflow_release_guardrails.py -o addopts=`
- `python -m pytest -q tests/test_workflow_alias_regression_guards.py tests/test_workflow_template_hygiene.py tests/test_repo_security_suite.py -o addopts=`
- `python -m pytest -q tests/test_workflow_release_guardrails.py tests/test_workflow_dependency_install_contract.py tests/test_workflow_external_tool_pin_contract.py tests/test_repo_security_suite.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low/Medium.
- Workflow behavior should be preserved; token permissions are narrowed to explicit read-only scope for two workflows.
- Rollback: easy, revert one commit.

## Notes
- This PR intentionally avoids unrelated workflow churn or broad cleanup.