### PR TITLE
Require constrained installs before workflow repo commands

### DIFF
--- a/.github/workflows/adaptive-ops-weekly.yml
+++ b/.github/workflows/adaptive-ops-weekly.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install repo
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install -c constraints-ci.txt -e .[dev,test,docs]
+
       - name: Build adaptive ops bundle
         shell: bash
         run: |

--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install repo
+        run: python -m pip install -c constraints-ci.txt -e .
+
       - name: Enforce branch protection
         env:
           BRANCH_PROTECTION_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}

--- a/.github/workflows/maintenance-issue-command-center.yml
+++ b/.github/workflows/maintenance-issue-command-center.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install repo
+        run: python -m pip install -c constraints-ci.txt -e .
+
       - name: Build doctor + adaptive reviewer snapshots
         run: |
           mkdir -p build/maintenance

--- a/tests/test_workflow_dependency_install_contract.py
+++ b/tests/test_workflow_dependency_install_contract.py
@@ -76,3 +76,54 @@ def test_workflows_do_not_hard_code_repo_managed_precommit_versions() -> None:
         "aligned with pyproject.toml, requirements.txt, and constraints-ci.txt:\n"
         + "\n".join(offenders)
     )
+
+
+def test_active_workflows_that_run_repo_code_install_repo_dependencies() -> None:
+    reference_workflow_name_parts = ("advanced-github-actions-reference",)
+    repo_code_markers = (
+        "python -m sdetkit",
+        "PYTHONPATH=src python -m sdetkit",
+        "python scripts/",
+        "python tools/",
+        "bash quality.sh",
+        "bash premium-gate.sh",
+        "bash scripts/",
+        "make ",
+        "sdetkit ",
+    )
+    constrained_install_markers = (
+        "pip install -c constraints-ci.txt -e .",
+        "pip install -c constraints-ci.txt -e .[",
+        "pip install -c constraints-ci.txt -e '.[",
+        "pip install -c constraints-ci.txt -r requirements",
+        "pip install -c constraints-ci.txt pre-commit",
+    )
+    stdlib_only_markers = (
+        "Path('pyproject.toml')",
+        'Path("pyproject.toml")',
+        "grep -Eq",
+        "version=$(python - <<'PY'",
+    )
+    offenders: list[str] = []
+
+    for workflow_path in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
+        if any(part in workflow_path.name for part in reference_workflow_name_parts):
+            continue
+
+        text = workflow_path.read_text(encoding="utf-8")
+        if "setup-python" not in text:
+            continue
+        if any(marker in text for marker in stdlib_only_markers):
+            continue
+        if not any(marker in text for marker in repo_code_markers):
+            continue
+        if any(marker in text for marker in constrained_install_markers):
+            continue
+
+        offenders.append(str(workflow_path))
+
+    assert not offenders, (
+        "Active workflows that run repo-owned Python, shell, Make, or CLI commands "
+        "after setup-python must install repo dependencies through constraints-ci.txt:\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Summary
- Add constrained repo installs before workflows execute repo-owned commands.
- Create a `.venv` install path for `adaptive-ops-weekly`, matching its Make target runtime contract.
- Add a workflow dependency guardrail for active workflows that run repo code after `setup-python`.

## Why
- Active workflows that execute repo-owned Python, shell, Make, or CLI commands should install dependencies through `constraints-ci.txt`.
- The previous guardrail caught unconstrained `pip install` lines, but not workflows that skipped repo dependency installation entirely.

## Verification
- `python -m pytest -q tests/test_workflow_dependency_install_contract.py -o addopts=`
- `python -m pytest -q tests/test_workflow_release_guardrails.py tests/test_workflow_alias_regression_guards.py tests/test_repo_security_suite.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low/Medium.
- Workflow behavior should be preserved, with dependency installation made explicit and constrained.
- Rollback: easy, revert one commit.

## Notes
- `advanced-github-actions-reference-64.yml` remains intentionally exempt as a reference workflow.
- `premium-gate.yml` was not changed because it already installs through `constraints-ci.txt`.