### PR TITLE
Tighten professional naming guardrail precision

### DIFF
--- a/tests/fixtures/professional_naming_legacy_surfaces.txt
+++ b/tests/fixtures/professional_naming_legacy_surfaces.txt
@@ -69,4 +69,3 @@ docs/integrations-stabilization-closeout.md :: path :: closeout :: docs/integrat
 docs/integrations-trust-assets-refresh-closeout.md :: path :: closeout :: docs/integrations-trust-assets-refresh-closeout.md
 docs/integrations-trust-faq-expansion-closeout.md :: path :: closeout :: docs/integrations-trust-faq-expansion-closeout.md
 docs/integrations-weekly-review-closeout.md :: path :: closeout :: docs/integrations-weekly-review-closeout.md
-mkdocs.yml :: mkdocs-nav-label :: demo :: - Adaptive product proof gallery: adaptive-demo-gallery.md

--- a/tests/test_owned_surface_hygiene_contract.py
+++ b/tests/test_owned_surface_hygiene_contract.py
@@ -216,7 +216,8 @@ def _professional_naming_debt_surfaces() -> set[str]:
                 for line in text.splitlines():
                     stripped = line.strip()
                     if stripped.startswith("- ") and ":" in stripped:
-                        surfaces.append(("mkdocs-nav-label", stripped))
+                        label = stripped[2:].split(":", 1)[0].strip()
+                        surfaces.append(("mkdocs-nav-label", label))
 
             if rel.startswith(".github/workflows/"):
                 for line in text.splitlines():


### PR DESCRIPTION
## Summary
- Tighten the professional naming guardrail so MkDocs nav checks scan the visible label text only.
- Regenerate the naming allowlist after removing the false-positive nav-label debt.

## Why
- The visible MkDocs label had already been professionalized.
- The guardrail was still treating the linked filename as part of the human nav label, creating a noisy naming-debt signal.

## Verification
- `python -m pytest -q tests/test_owned_surface_hygiene_contract.py -o addopts=`
- `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
- `python -m pre_commit run -a`

## Risk
- Low.
- Test/fixture-only precision fix.
- No docs filenames, workflow names, CLI commands, Make targets, or generated artifacts changed.