### PR TITLE
Suppress adaptive diagnosis on green quality verdict

### DIFF
--- a/src/sdetkit/adaptive_diagnosis.py
+++ b/src/sdetkit/adaptive_diagnosis.py
@@ -1558,6 +1558,49 @@ def _rank(item: dict[str, Any]) -> tuple[int, int, int, str]:
     )
 
 
+def _quality_final_verdict_is_green(log_text: str) -> bool:
+    """Return true when a quality.sh log contains an explicit final green verdict."""
+
+    normalized = log_text.lower()
+    has_green_final_verdict = (
+        "[quality] final verdict contract:" in normalized
+        and "[quality] blocking failures: none" in normalized
+        and "[quality] merge/release recommendation: ready-for-merge-review" in normalized
+    )
+    has_explicit_failure_signal = any(
+        marker in normalized
+        for marker in (
+            "[quality] blocking failures:",
+            "traceback",
+            " failed",
+            " error",
+            "no such file",
+            "coverage failure",
+            "quality.sh cov failed",
+        )
+        if marker != "[quality] blocking failures:"
+        or "[quality] blocking failures: none" not in normalized
+    )
+    return has_green_final_verdict and not has_explicit_failure_signal
+
+
+def _green_quality_final_verdict_payload() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "clear",
+        "risk_score": 0,
+        "confidence": "high",
+        "primary_issue": "No blocking quality failures detected",
+        "diagnosis_count": 0,
+        "diagnoses": [],
+        "evidence": {
+            "quality_final_verdict": "green",
+            "blocking_failures": "none",
+            "merge_recommendation": "ready-for-merge-review",
+        },
+    }
+
+
 def analyze_evidence(
     *,
     log_text: str = "",
@@ -1565,6 +1608,9 @@ def analyze_evidence(
     ledger_records: Sequence[dict[str, Any]] | None = None,
     adaptive_history: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    if log_text and _quality_final_verdict_is_green(log_text):
+        return _green_quality_final_verdict_payload()
+
     diagnoses: list[dict[str, Any]] = []
     if log_text:
         _append_log(log_text, diagnoses, _as_dict(adaptive_history))

--- a/tests/test_adaptive_quality_gate_advisory_alignment.py
+++ b/tests/test_adaptive_quality_gate_advisory_alignment.py
@@ -231,3 +231,33 @@ def test_green_advisory_suppression_handles_coverage_regression_candidate_text()
 
     assert payload["status"] == "clear"
     assert payload["diagnosis_count"] == 0
+
+
+REAL_GREEN_QUALITY_FINAL_VERDICT_LOG = """
+[quality] running coverage :: Coverage lane
+[bootstrap-contract] ok: True
+[bootstrap] python: 3.10.12 (required: 3.10+)
+[quality] coverage config: scope=core mode=standard fail-under=85 (COV_MODE=standard default)
+Required test coverage of 85% reached. Total coverage: 96.69%
+================ 3177 passed, 3 deselected in 287.49s (0:04:47) ================
+[quality] final verdict contract: sdetkit.final-verdict.v2
+[quality] profile used: standard
+[quality] checks run: 1
+[quality] checks skipped: 1
+[quality] blocking failures: none
+[quality] advisory findings:
+- coverage mode focuses on coverage gate
+[quality] confidence level: medium (standard validation)
+[quality] merge/release recommendation: ready-for-merge-review
+[quality] verdict json: .sdetkit/out/quality-verdict.json
+[quality] summary md: .sdetkit/out/quality-summary.md
+"""
+
+
+def test_green_quality_final_verdict_log_does_not_create_unknown_review_required() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(log_text=REAL_GREEN_QUALITY_FINAL_VERDICT_LOG)
+
+    assert payload["status"] == "clear"
+    assert payload["diagnosis_count"] == 0
+    assert UNKNOWN_REVIEW_REQUIRED not in _codes(payload)
+    assert pr_quality_comment.render_adaptive_diagnosis_comment(payload) == ""


### PR DESCRIPTION
## Summary

Fixes the PR quality comment path where a real green `quality.sh cov` log still triggered `UNKNOWN_REVIEW_REQUIRED`.

The analyzer already suppressed the older pasted advisory shape (`quality.sh cov passed`), but it did not recognize the actual `quality.sh` final verdict markers:

- `[quality] blocking failures: none`
- `[quality] merge/release recommendation: ready-for-merge-review`

This PR treats that final green quality verdict as clear evidence and prevents rendering Review-first Adaptive Diagnosis for a passing quality gate.

## Classification

- Diagnostic comment bug
- PR quality gate/adaptive diagnosis contract mismatch

## Verification

- Added regression for real green `quality.sh` final-verdict log.
- Focused adaptive / PR comment proof: `54 passed`
- `python -m mypy src`: passed
- `python -m pre_commit run -a`: passed
- `bash quality.sh cov`: passed
- Full quality lane: `3177 passed, 1 skipped, 3 deselected`
- Coverage: `96.69%`

## Risk

Low. This does not remove adaptive diagnosis. It only suppresses the review-first diagnosis block when the log has an explicit final green quality verdict with no blocking failures and a ready-for-merge recommendation. Failing or ambiguous logs still go through the normal diagnosis path.
