### PR TITLE
Classify coverage gate regressions explicitly

### DIFF
--- a/src/sdetkit/adaptive_diagnosis.py
+++ b/src/sdetkit/adaptive_diagnosis.py
@@ -1229,12 +1229,73 @@ def _looks_green_quality_advisory(text: str) -> bool:
     return _has_review_first_advisory_signal(text)
 
 
+def _is_coverage_gate_regression(text: str) -> bool:
+    normalized = text.lower()
+    return "coverage" in normalized and (
+        "coverage gate failed" in normalized
+        or "coverage fail under" in normalized
+        or "fail under configured threshold" in normalized
+        or ("required test coverage" in normalized and "not reached" in normalized)
+    )
+
+
+def _append_coverage_gate_regression(
+    text: str,
+    files: Sequence[str],
+    diagnoses: list[dict[str, Any]],
+    adaptive_history: dict[str, Any] | None = None,
+) -> None:
+    evidence = _failure_like_evidence(text, adaptive_history)
+
+    coverage_match = re.search(
+        r"total coverage:\s*([0-9]+(?:\.[0-9]+)?)%",
+        text,
+        re.IGNORECASE,
+    )
+    if coverage_match:
+        evidence.append(f"total_coverage={coverage_match.group(1)}%")
+
+    threshold_match = re.search(
+        r"required test coverage of\s*([0-9]+(?:\.[0-9]+)?)%",
+        text,
+        re.IGNORECASE,
+    )
+    if threshold_match:
+        evidence.append(f"required_coverage={threshold_match.group(1)}%")
+
+    diagnoses.append(
+        _diag(
+            "COVERAGE_GATE_REGRESSION",
+            "high",
+            "high",
+            "Coverage gate regression",
+            "Coverage dropped below the configured fail-under threshold.",
+            (
+                "Coverage failures often show up as a generic quality failure, "
+                "but the fix needs to compare missing coverage lines to the PR diff."
+            ),
+            evidence,
+            [
+                "Compare missing coverage lines to the PR diff.",
+                "Add focused tests for changed behavior instead of lowering the coverage threshold.",
+                "Rerun the coverage gate locally after the targeted tests are added.",
+            ],
+            ["bash quality.sh cov"],
+            "A real coverage regression can merge untested behavior if treated as a generic CI failure.",
+            "coverage-gate-regression",
+            files=files,
+        )
+    )
+
+
 def _append_log(
     text: str, diagnoses: list[dict[str, Any]], adaptive_history: dict[str, Any] | None = None
 ) -> None:
     start_index = len(diagnoses)
     lower = text.lower()
     files = _file_mentions(text)
+    if _is_coverage_gate_regression(text):
+        _append_coverage_gate_regression(text, files, diagnoses, adaptive_history)
     handled_local = _append_local_investigation(text, files, diagnoses)
     formatted = _format_count(text)
     if formatted:

--- a/src/sdetkit/pr_quality_comment.py
+++ b/src/sdetkit/pr_quality_comment.py
@@ -53,7 +53,9 @@ def _next_step_heading(code: str) -> str:
 
 def _auto_fix_status(code: str, fix_plan: dict[str, Any]) -> str:
     if fix_plan.get("safe_to_auto_fix") is not True:
-        return "SDETKit will keep this review-first because the current evidence is not safe for automatic remediation."
+        if _is_review_first_diagnosis(code):
+            return "SDETKit will keep this review-first because the current evidence is not safe for automatic remediation."
+        return "SDETKit will keep this as a human-reviewed adaptive diagnosis because the current evidence is not safe for automatic remediation."
     if code == "RUFF_FIXABLE_LINT":
         return "SDETKit can auto-fix this only when the safe plan, affected-file scope, remediation proof, and same-repo branch guards all pass."
     if code == "PRE_COMMIT_FORMAT_DRIFT":

--- a/tests/test_adaptive_diagnosis.py
+++ b/tests/test_adaptive_diagnosis.py
@@ -104,7 +104,6 @@ def test_failure_signal_database_covers_unclassified_failure_families():
         "error-prefix": "build tool Error: unexpected integrity result",
         "gate-problems-found": "quality gate: problems found in custom policy",
         "failed-steps": "summary failed_steps=custom_policy",
-        "coverage-failure": "coverage fail under configured threshold",
         "package-manager-error": "npm ERR! lifecycle script failed",
     }
 
@@ -114,6 +113,17 @@ def test_failure_signal_database_covers_unclassified_failure_families():
         assert payload["diagnoses"][0]["code"] == "UNKNOWN_REVIEW_REQUIRED"
         assert f"matched_failure_signals={expected_signal}" in payload["diagnoses"][0]["evidence"]
         assert payload["fix_plan"][0]["safe_to_auto_fix"] is False
+
+
+def test_coverage_failure_signal_routes_to_specific_coverage_gate_regression():
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="coverage fail under configured threshold"
+    )
+
+    codes = {diagnosis["code"] for diagnosis in payload["diagnoses"]}
+    assert "COVERAGE_GATE_REGRESSION" in codes
+    assert "UNKNOWN_REVIEW_REQUIRED" not in codes
+    assert "matched_failure_signals=coverage-failure" in payload["diagnoses"][0]["evidence"][0]
 
 
 def test_seeded_scenario_database_recommends_package_install_checks():

--- a/tests/test_adaptive_quality_gate_advisory_alignment.py
+++ b/tests/test_adaptive_quality_gate_advisory_alignment.py
@@ -161,15 +161,25 @@ def test_green_quality_gate_with_fast_gate_failure_still_requires_review() -> No
     assert any(item.startswith("matched_failure_signals=") for item in diagnosis["evidence"])
 
 
-def test_real_coverage_threshold_failure_still_routes_to_unknown_review() -> None:
+def test_real_coverage_threshold_failure_routes_to_coverage_gate_regression() -> None:
     payload = adaptive_diagnosis.analyze_evidence(
-        log_text="coverage fail under configured threshold"
+        log_text=(
+            "[quality] coverage config: scope=core mode=standard fail-under=85\n"
+            "Required test coverage of 85% not reached. Total coverage: 81.42%\n"
+            "[quality] blocking failures: coverage gate failed\n"
+        )
     )
-
-    assert payload["status"] in {"needs_attention", "needs_fix"}
-    assert UNKNOWN_REVIEW_REQUIRED in _codes(payload)
     diagnosis = payload["diagnoses"][0]
+
+    assert payload["status"] == "needs_fix"
+    assert "COVERAGE_GATE_REGRESSION" in _codes(payload)
+    assert UNKNOWN_REVIEW_REQUIRED not in _codes(payload)
+    assert diagnosis["code"] == "COVERAGE_GATE_REGRESSION"
+    assert diagnosis["title"] == "Coverage gate regression"
     assert _matched_failure_signal("coverage-failure") in diagnosis["evidence"]
+    assert "required_coverage=85%" in diagnosis["evidence"]
+    assert "total_coverage=81.42%" in diagnosis["evidence"]
+    assert "bash quality.sh cov" in diagnosis["proof_commands"]
 
 
 def test_review_first_unknown_comment_uses_human_review_heading() -> None:
@@ -261,3 +271,43 @@ def test_green_quality_final_verdict_log_does_not_create_unknown_review_required
     assert payload["diagnosis_count"] == 0
     assert UNKNOWN_REVIEW_REQUIRED not in _codes(payload)
     assert pr_quality_comment.render_adaptive_diagnosis_comment(payload) == ""
+
+
+def test_coverage_gate_regression_comment_is_specific_not_review_first() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text=(
+            "[quality] coverage config: scope=core mode=standard fail-under=85\n"
+            "Required test coverage of 85% not reached. Total coverage: 81.42%\n"
+            "[quality] blocking failures: coverage gate failed\n"
+        )
+    )
+
+    rendered = pr_quality_comment.render_adaptive_diagnosis_comment(payload)
+
+    assert "COVERAGE_GATE_REGRESSION" in rendered
+    assert "### Adaptive Diagnosis" in rendered
+    assert "### Review-first Adaptive Diagnosis" not in rendered
+    assert "keep this review-first" not in rendered
+    assert "human-reviewed adaptive diagnosis" in rendered
+
+
+def test_coverage_gate_regression_composes_with_other_failure_signals() -> None:
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text=(
+            "FAILED tests/test_api.py::test_contract - AssertionError\n"
+            "mypy src/app.py:10: error: Argument 1 has incompatible type [arg-type]\n"
+            "ruff check Failed Found 1 error.\n"
+            "[quality] coverage config: scope=core mode=standard fail-under=85\n"
+            "Required test coverage of 85% not reached. Total coverage: 81.42%\n"
+            "[quality] blocking failures: coverage gate failed\n"
+            "Process completed with exit code 1\n"
+        )
+    )
+
+    codes = {diagnosis["code"] for diagnosis in payload["diagnoses"]}
+
+    assert "COVERAGE_GATE_REGRESSION" in codes
+    assert "PYTEST_ASSERTION_FAILURE" in codes
+    assert "MYPY_TYPE_CONTRACT_DRIFT" in codes
+    assert "UNKNOWN_REVIEW_REQUIRED" not in codes
+    assert payload["scenario_database"]["total_scenario_count"] >= 5000

--- a/tests/test_pr_quality_comment.py
+++ b/tests/test_pr_quality_comment.py
@@ -44,13 +44,16 @@ def test_render_ruff_fixable_lint_comment_explains_auto_fix_route():
     assert "Logic-risk Ruff findings remain review-first." in rendered
 
 
-def test_render_review_first_comment_when_fix_plan_is_not_safe():
+def test_render_human_review_comment_for_specific_non_auto_fix_diagnosis():
     rendered = pr_quality_comment.render_adaptive_diagnosis_comment(
         _payload(code="PYTEST_ASSERTION_FAILURE", safe_to_auto_fix=False)
     )
 
+    assert "### Adaptive Diagnosis" in rendered
+    assert "### Review-first Adaptive Diagnosis" not in rendered
     assert "diagnosis code: `PYTEST_ASSERTION_FAILURE`" in rendered
-    assert "review-first" in rendered
+    assert "human-reviewed adaptive diagnosis" in rendered
+    assert "keep this review-first" not in rendered
     assert "Ruff fixable lint route:" not in rendered
 
 


### PR DESCRIPTION
## Summary

This PR makes adaptive diagnosis classify coverage gate failures as a specific known failure family instead of falling back to `UNKNOWN_REVIEW_REQUIRED`.

Coverage regressions now produce `COVERAGE_GATE_REGRESSION` with:

- coverage threshold evidence
- total coverage evidence
- targeted remediation guidance
- `bash quality.sh cov` proof command
- specific Adaptive Diagnosis PR-comment wording
- adaptive learning DB recordability

## Classification

- Diagnostic intelligence improvement
- Adaptive diagnosis / PR comment alignment
- Coverage gate failure classification

## Behavior change

Before:

- coverage gate failure → `UNKNOWN_REVIEW_REQUIRED`
- PR comment rendered as Review-first Adaptive Diagnosis
- adaptive learning could only record a generic unknown failure

After:

- coverage gate failure → `COVERAGE_GATE_REGRESSION`
- PR comment renders as specific Adaptive Diagnosis
- non-auto-fixable known diagnoses use human-reviewed adaptive wording
- unknown failures remain review-first
- coverage diagnosis composes with pytest/mypy signals
- adaptive learn record/summarize pipeline accepts the diagnosis artifact

## Verification

- Targeted coverage diagnosis proof: passed
- PR comment wording contracts: passed
- Focused adaptive engine proof: `78 passed`
- Adaptive DB pipeline smoke:
  - diagnosis JSON generated
  - PR comment rendered
  - learning record written
  - learning summary produced
- `python -m pre_commit run -a`: passed
- `bash quality.sh cov`: passed
- Full quality lane: `3180 passed, 1 skipped, 3 deselected`
- Coverage: `96.69%`

## Risk

Low-to-medium. This changes classification specificity only. It does not lower coverage, change `quality.sh`, auto-fix coverage failures, or remove review-first handling for truly unknown failures.
