### PR TITLE
Add adaptive failure intelligence bundle

### DIFF
--- a/docs/adaptive-diagnosis.md
+++ b/docs/adaptive-diagnosis.md
@@ -234,6 +234,33 @@ PYTHONPATH=src python -m sdetkit.adaptive_diagnosis \
 
 When the summary contains `top_recurring_scenarios[].calibration`, promoted scenarios receive a ranking boost, false positives are demoted, recurrence can raise risk priority, and thin-evidence scenarios are kept lower until better signals exist. Unknown-review evidence includes a `candidate_calibration=` line whenever calibration affected a visible candidate.
 
+## Unified failure intelligence bundle
+
+Use the failure bundle when a CI log needs one operator handoff artifact instead of several manually stitched commands:
+
+```bash
+python -m sdetkit adaptive failure-bundle \
+  --log build/quality.log \
+  --out-dir build/sdetkit/failure-intelligence \
+  --proof-failed \
+  --format text
+```
+
+The bundle writes:
+
+- `failure-intelligence-bundle.json`
+- `adaptive-diagnosis.json`
+- `adaptive-diagnosis-comment.md`
+- `adaptive-diagnosis-memory.jsonl`
+- `adaptive-learning-summary.json`
+- `adaptive-safe-fix-plan.json`
+- `adaptive-patch-plan.json`
+- `operator-brief.json`
+- `operator-brief.md`
+- `artifact-manifest.json`
+
+This command is still diagnostic and handoff-oriented. It does not apply fixes, create branches, push commits, or approve remediation. Known failure families become specific adaptive diagnoses; unknown failures remain review-first; green logs do not create fake adaptive blocks.
+
 ## Operator brief artifact
 
 Generate the trust-grade handoff brief after gate, diagnosis, and optional learning artifacts exist:

--- a/docs/operator-essentials.md
+++ b/docs/operator-essentials.md
@@ -40,6 +40,12 @@ When a log, check, or gate fails, collect evidence without mutating the reposito
 python -m sdetkit review . --no-workspace --format operator-json
 python -m sdetkit investigate failure --log build/quality.log --format markdown
 python -m sdetkit investigate failure --log build/quality.log --format json --out build/investigation/failure.json
+
+# One-shot handoff bundle when the operator needs diagnosis, comment, learning, safe-fix boundary, and brief artifacts together.
+python -m sdetkit adaptive failure-bundle \
+  --log build/quality.log \
+  --out-dir build/sdetkit/failure-intelligence \
+  --proof-failed
 ```
 
 Read these fields first in investigation output:

--- a/src/sdetkit/adaptive_failure_bundle.py
+++ b/src/sdetkit/adaptive_failure_bundle.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from . import (
+    adaptive_diagnosis,
+    adaptive_diagnosis_memory,
+    adaptive_patch_plan,
+    adaptive_safe_fix,
+    operator_brief,
+    pr_quality_comment,
+)
+
+SCHEMA_VERSION = "sdetkit.adaptive.failure_bundle.v1"
+MANIFEST_SCHEMA_VERSION = "sdetkit.adaptive.failure_bundle.manifest.v1"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _primary_diagnosis(diagnosis: dict[str, Any]) -> dict[str, Any]:
+    diagnoses = [_as_dict(item) for item in _as_list(diagnosis.get("diagnoses"))]
+    return diagnoses[0] if diagnoses else {}
+
+
+def _learning_summary(db_path: Path) -> dict[str, Any]:
+    if db_path.exists():
+        return adaptive_diagnosis_memory.learning_summary_from_db(db_path)
+    return adaptive_diagnosis_memory.summarize_learning_records([])
+
+
+def _outcome_flags(
+    *,
+    proof_passed: bool,
+    proof_failed: bool,
+    fix_accepted: bool,
+    fix_rejected: bool,
+) -> tuple[bool | None, bool | None]:
+    if proof_passed and proof_failed:
+        raise ValueError("--proof-passed and --proof-failed are mutually exclusive")
+    if fix_accepted and fix_rejected:
+        raise ValueError("--fix-accepted and --fix-rejected are mutually exclusive")
+    proof_result = True if proof_passed else False if proof_failed else None
+    fix_result = True if fix_accepted else False if fix_rejected else None
+    return proof_result, fix_result
+
+
+def build_failure_bundle(
+    *,
+    log_path: Path,
+    out_dir: Path,
+    memory_db: Path | None = None,
+    bundle_out: Path | None = None,
+    proof_passed: bool = False,
+    proof_failed: bool = False,
+    fix_accepted: bool = False,
+    fix_rejected: bool = False,
+    false_positive: bool = False,
+) -> dict[str, Any]:
+    log_text = log_path.read_text(encoding="utf-8", errors="replace")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    diagnosis = adaptive_diagnosis.analyze_evidence(log_text=log_text)
+    primary = _primary_diagnosis(diagnosis)
+    primary_code = str(primary.get("code", "") or "")
+    review_first = primary_code in {"UNKNOWN", "UNKNOWN_REVIEW_REQUIRED"}
+
+    diagnosis_path = out_dir / "adaptive-diagnosis.json"
+    _write_json(diagnosis_path, diagnosis)
+
+    comment_text = pr_quality_comment.render_adaptive_diagnosis_comment(diagnosis)
+    comment_path = out_dir / "adaptive-diagnosis-comment.md"
+    _write_text(comment_path, comment_text)
+
+    db_path = memory_db or (out_dir / "adaptive-diagnosis-memory.jsonl")
+    proof_result, fix_result = _outcome_flags(
+        proof_passed=proof_passed,
+        proof_failed=proof_failed,
+        fix_accepted=fix_accepted,
+        fix_rejected=fix_rejected,
+    )
+    records = adaptive_diagnosis_memory.build_learning_records(
+        diagnosis,
+        proof_passed=proof_result,
+        fix_accepted=fix_result,
+        false_positive=false_positive,
+    )
+    learning_record_summary: dict[str, Any] = {
+        "db_path": db_path.as_posix(),
+        "record_count": 0,
+    }
+    if records:
+        learning_record_summary = adaptive_diagnosis_memory.append_learning_records(
+            db_path, records
+        )
+
+    learning_summary = _learning_summary(db_path)
+    learning_summary_path = out_dir / "adaptive-learning-summary.json"
+    _write_json(learning_summary_path, learning_summary)
+
+    safe_fix_path = out_dir / "adaptive-safe-fix-plan.json"
+    safe_fix_plan = adaptive_safe_fix.plan_from_file(diagnosis_path, safe_fix_path)
+
+    patch_plan_path = out_dir / "adaptive-patch-plan.json"
+    patch_plan = adaptive_patch_plan.patch_plan_from_file(diagnosis_path, patch_plan_path)
+
+    gate_ok = str(diagnosis.get("status", "")) in {"clear", "monitor"}
+    gate = {
+        "ok": gate_ok,
+        "failed_steps": [] if gate_ok else [primary_code or "adaptive_diagnosis"],
+    }
+    brief_payload = operator_brief.build_operator_brief(
+        gate=gate,
+        diagnosis=diagnosis,
+        learning_summary=learning_summary,
+        safe_fix_plan=safe_fix_plan,
+    )
+    brief_json_path = out_dir / "operator-brief.json"
+    brief_md_path = out_dir / "operator-brief.md"
+    _write_json(brief_json_path, brief_payload)
+    _write_text(brief_md_path, operator_brief.render_markdown(brief_payload))
+
+    artifacts = {
+        "diagnosis_json": diagnosis_path.as_posix(),
+        "pr_comment_markdown": comment_path.as_posix(),
+        "learning_db": db_path.as_posix(),
+        "learning_summary_json": learning_summary_path.as_posix(),
+        "safe_fix_plan_json": safe_fix_path.as_posix(),
+        "patch_plan_json": patch_plan_path.as_posix(),
+        "operator_brief_json": brief_json_path.as_posix(),
+        "operator_brief_markdown": brief_md_path.as_posix(),
+    }
+
+    manifest = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "artifacts": artifacts,
+        "source_log": log_path.as_posix(),
+        "primary_diagnosis_code": primary_code,
+        "review_first": review_first,
+        "safe_to_auto_fix": bool(safe_fix_plan.get("safe_to_auto_fix", False)),
+    }
+    manifest_path = out_dir / "artifact-manifest.json"
+    _write_json(manifest_path, manifest)
+    artifacts["artifact_manifest_json"] = manifest_path.as_posix()
+
+    bundle = {
+        "schema_version": SCHEMA_VERSION,
+        "source_log": log_path.as_posix(),
+        "status": str(diagnosis.get("status", "unknown")),
+        "primary_diagnosis_code": primary_code,
+        "diagnosis_count": int(diagnosis.get("diagnosis_count", 0) or 0),
+        "review_first": review_first,
+        "safe_to_auto_fix": bool(safe_fix_plan.get("safe_to_auto_fix", False)),
+        "artifacts": artifacts,
+        "diagnosis": diagnosis,
+        "learning_record_summary": learning_record_summary,
+        "learning_summary": learning_summary,
+        "safe_fix_plan": safe_fix_plan,
+        "patch_plan": patch_plan,
+        "operator_brief": brief_payload,
+    }
+
+    final_bundle_path = bundle_out or (out_dir / "failure-intelligence-bundle.json")
+    _write_json(final_bundle_path, bundle)
+    bundle["bundle_path"] = final_bundle_path.as_posix()
+    _write_json(final_bundle_path, bundle)
+    return bundle
+
+
+def render_text(bundle: dict[str, Any]) -> str:
+    artifacts = _as_dict(bundle.get("artifacts"))
+    lines = [
+        f"schema_version={bundle.get('schema_version')}",
+        f"status={bundle.get('status')}",
+        f"primary_diagnosis_code={bundle.get('primary_diagnosis_code')}",
+        f"diagnosis_count={bundle.get('diagnosis_count')}",
+        f"review_first={str(bundle.get('review_first')).lower()}",
+        f"safe_to_auto_fix={str(bundle.get('safe_to_auto_fix')).lower()}",
+        f"bundle_path={bundle.get('bundle_path', '')}",
+    ]
+    for key in sorted(artifacts):
+        lines.append(f"artifact.{key}={artifacts[key]}")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.adaptive_failure_bundle",
+        description="Build a unified adaptive failure intelligence bundle from a log.",
+    )
+    parser.add_argument("--log", required=True, help="Failed CI or quality log to diagnose")
+    parser.add_argument("--out-dir", default="build/sdetkit/failure-intelligence")
+    parser.add_argument("--out", default="")
+    parser.add_argument("--memory-db", default="")
+    parser.add_argument("--proof-passed", action="store_true")
+    parser.add_argument("--proof-failed", action="store_true")
+    parser.add_argument("--fix-accepted", action="store_true")
+    parser.add_argument("--fix-rejected", action="store_true")
+    parser.add_argument("--false-positive", action="store_true")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        bundle = build_failure_bundle(
+            log_path=Path(args.log),
+            out_dir=Path(args.out_dir),
+            memory_db=Path(args.memory_db) if args.memory_db else None,
+            bundle_out=Path(args.out) if args.out else None,
+            proof_passed=bool(args.proof_passed),
+            proof_failed=bool(args.proof_failed),
+            fix_accepted=bool(args.fix_accepted),
+            fix_rejected=bool(args.fix_rejected),
+            false_positive=bool(args.false_positive),
+        )
+    except Exception as exc:
+        sys.stderr.write(f"adaptive failure-bundle: error: {exc}\n")
+        return 2
+
+    if args.format == "json":
+        sys.stdout.write(json.dumps(bundle, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_text(bundle))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -428,6 +428,20 @@ Then use stability-aware command discovery:
     adaptive_brief.add_argument("--safe-fix-plan", default="")
     adaptive_brief.add_argument("--format", choices=["md", "json", "comment"], default="md")
     adaptive_brief.add_argument("--out", default="build/sdetkit/operator-brief.md")
+    adaptive_failure_bundle = adaptive_sub.add_parser(
+        "failure-bundle",
+        help="Build a unified failure intelligence bundle from a failed log",
+    )
+    adaptive_failure_bundle.add_argument("--log", required=True)
+    adaptive_failure_bundle.add_argument("--out-dir", default="build/sdetkit/failure-intelligence")
+    adaptive_failure_bundle.add_argument("--out", default="")
+    adaptive_failure_bundle.add_argument("--memory-db", default="")
+    adaptive_failure_bundle.add_argument("--proof-passed", action="store_true")
+    adaptive_failure_bundle.add_argument("--proof-failed", action="store_true")
+    adaptive_failure_bundle.add_argument("--fix-accepted", action="store_true")
+    adaptive_failure_bundle.add_argument("--fix-rejected", action="store_true")
+    adaptive_failure_bundle.add_argument("--false-positive", action="store_true")
+    adaptive_failure_bundle.add_argument("--format", choices=["text", "json"], default="text")
     adaptive_portfolio = adaptive_sub.add_parser(
         "portfolio-rollup",
         help="Roll multiple adaptive diagnosis outputs into a top-risk portfolio report",
@@ -1225,6 +1239,29 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "sdetkit.adaptive_diagnosis_memory",
                     ["summarize", "--db", str(ns.db), "--format", str(ns.format)],
                 )
+        if getattr(ns, "adaptive_cmd", None) == "failure-bundle":
+            forwarded = [
+                "--log",
+                str(ns.log),
+                "--out-dir",
+                str(ns.out_dir),
+                "--format",
+                str(ns.format),
+            ]
+            if str(ns.out):
+                forwarded.extend(["--out", str(ns.out)])
+            if str(ns.memory_db):
+                forwarded.extend(["--memory-db", str(ns.memory_db)])
+            for attr, flag in [
+                ("proof_passed", "--proof-passed"),
+                ("proof_failed", "--proof-failed"),
+                ("fix_accepted", "--fix-accepted"),
+                ("fix_rejected", "--fix-rejected"),
+                ("false_positive", "--false-positive"),
+            ]:
+                if bool(getattr(ns, attr, False)):
+                    forwarded.append(flag)
+            return _run_module_main("sdetkit.adaptive_failure_bundle", forwarded)
         if getattr(ns, "adaptive_cmd", None) == "brief":
             forwarded = ["--format", str(ns.format), "--out", str(ns.out)]
             for flag, value in (

--- a/tests/test_adaptive_failure_bundle.py
+++ b/tests/test_adaptive_failure_bundle.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from sdetkit import adaptive_failure_bundle
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_failure_bundle_builds_full_operator_handoff_for_known_red(tmp_path: Path) -> None:
+    log = _write(
+        tmp_path / "coverage.log",
+        "\n".join(
+            [
+                "[quality] running coverage :: Coverage lane",
+                "[quality] coverage config: scope=core mode=standard fail-under=85",
+                "Required test coverage of 85% not reached. Total coverage: 81.42%",
+                "[quality] blocking failures: coverage gate failed",
+                "[quality] merge/release recommendation: needs-fix",
+            ]
+        ),
+    )
+
+    bundle = adaptive_failure_bundle.build_failure_bundle(
+        log_path=log,
+        out_dir=tmp_path / "bundle",
+        proof_failed=True,
+    )
+
+    assert bundle["schema_version"] == "sdetkit.adaptive.failure_bundle.v1"
+    assert bundle["status"] == "needs_fix"
+    assert bundle["primary_diagnosis_code"] == "COVERAGE_GATE_REGRESSION"
+    assert bundle["review_first"] is False
+    assert bundle["safe_to_auto_fix"] is False
+
+    artifacts = bundle["artifacts"]
+    for key in [
+        "diagnosis_json",
+        "pr_comment_markdown",
+        "learning_db",
+        "learning_summary_json",
+        "safe_fix_plan_json",
+        "patch_plan_json",
+        "operator_brief_markdown",
+        "artifact_manifest_json",
+    ]:
+        assert Path(artifacts[key]).exists(), key
+
+    comment = Path(artifacts["pr_comment_markdown"]).read_text(encoding="utf-8")
+    assert "### Adaptive Diagnosis" in comment
+    assert "### Review-first Adaptive Diagnosis" not in comment
+
+    learning = json.loads(Path(artifacts["learning_summary_json"]).read_text(encoding="utf-8"))
+    assert learning["ok"] is True
+    assert learning["diagnosis_records"] >= 1
+
+
+def test_failure_bundle_keeps_unknown_failures_review_first(tmp_path: Path) -> None:
+    log = _write(
+        tmp_path / "unknown.log",
+        "\n".join(
+            [
+                "Traceback (most recent call last):",
+                '  File "scripts/custom_policy.py", line 10, in <module>',
+                '    raise RuntimeError("unexpected integrity result")',
+                "RuntimeError: unexpected integrity result",
+            ]
+        ),
+    )
+
+    bundle = adaptive_failure_bundle.build_failure_bundle(
+        log_path=log,
+        out_dir=tmp_path / "bundle",
+        proof_failed=True,
+    )
+
+    assert bundle["status"] == "needs_fix"
+    assert bundle["primary_diagnosis_code"] == "UNKNOWN_REVIEW_REQUIRED"
+    assert bundle["review_first"] is True
+    assert bundle["safe_to_auto_fix"] is False
+
+    comment = Path(bundle["artifacts"]["pr_comment_markdown"]).read_text(encoding="utf-8")
+    assert "### Review-first Adaptive Diagnosis" in comment
+    assert "current evidence is not safe for automatic remediation" in comment
+
+    safe_fix = json.loads(
+        Path(bundle["artifacts"]["safe_fix_plan_json"]).read_text(encoding="utf-8")
+    )
+    assert safe_fix["safe_to_auto_fix"] is False
+    assert safe_fix["fix_type"] == "review_required"
+
+
+def test_failure_bundle_green_log_stays_quiet(tmp_path: Path) -> None:
+    log = _write(
+        tmp_path / "green.log",
+        "\n".join(
+            [
+                "[quality] running coverage :: Coverage lane",
+                "quality.sh cov passed",
+                "✅ quality.sh cov passed",
+            ]
+        ),
+    )
+
+    bundle = adaptive_failure_bundle.build_failure_bundle(
+        log_path=log,
+        out_dir=tmp_path / "bundle",
+    )
+
+    assert bundle["status"] == "clear"
+    assert bundle["diagnosis_count"] == 0
+    assert bundle["primary_diagnosis_code"] == ""
+    assert bundle["review_first"] is False
+    assert bundle["safe_to_auto_fix"] is False
+
+    comment = Path(bundle["artifacts"]["pr_comment_markdown"]).read_text(encoding="utf-8")
+    assert "Adaptive Diagnosis" not in comment
+    assert "Review-first Adaptive Diagnosis" not in comment
+
+
+def test_sdetkit_adaptive_failure_bundle_subprocess(tmp_path: Path) -> None:
+    log = _write(
+        tmp_path / "pytest.log",
+        "\n".join(
+            [
+                "FAILED tests/test_widget.py::test_widget_contract - AssertionError: expected stable evidence",
+                "=========================== short test summary info ===========================",
+                "FAILED tests/test_widget.py::test_widget_contract",
+            ]
+        ),
+    )
+    out_dir = tmp_path / "bundle"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sdetkit",
+            "adaptive",
+            "failure-bundle",
+            "--log",
+            str(log),
+            "--out-dir",
+            str(out_dir),
+            "--proof-failed",
+            "--format",
+            "json",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "sdetkit.adaptive.failure_bundle.v1"
+    assert payload["primary_diagnosis_code"] == "PYTEST_ASSERTION_FAILURE"
+    assert Path(payload["bundle_path"]).exists()
+    assert Path(payload["artifacts"]["operator_brief_markdown"]).exists()


### PR DESCRIPTION
## Summary
- Add `sdetkit adaptive failure-bundle` to build a unified failure-intelligence handoff from one failed log.
- Bundle adaptive diagnosis, PR comment markdown, learning DB/summary, safe-fix boundary, assisted patch plan, operator brief, and artifact manifest.
- Keep unknown failures review-first and green logs quiet.

## Why
The adaptive diagnosis pieces already worked individually, but operators had to manually stitch diagnosis, comment, learning, safe-fix posture, patch-plan, and operator brief artifacts. This PR creates one product-grade diagnostic handoff surface without expanding automatic remediation.

## Verification
- `python -m pytest -q tests/test_adaptive_failure_bundle.py tests/test_pr_quality_comment.py tests/test_operator_brief.py tests/test_adaptive_patch_plan.py tests/test_adaptive_safe_fix.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `bash quality.sh cov`

## Proof result
- Focused tests: 30 passed
- Mypy: passed
- Pre-commit: passed
- Coverage gate: passed
- Full quality run: 3184 passed, 1 skipped, 3 deselected
- Coverage: 96.69%
- Merge/release recommendation: ready-for-merge-review

## Risk
Medium-low.
- Additive command under the advanced adaptive surface.
- No public command removed.
- No auto-fix expansion.
- Unknown failures remain review-first.
- Green logs do not create fake adaptive blocks.

## Rollback
Remove:
- `src/sdetkit/adaptive_failure_bundle.py`
- `tests/test_adaptive_failure_bundle.py`
- the `failure-bundle` CLI route in `src/sdetkit/cli.py`
- the docs references in `docs/adaptive-diagnosis.md` and `docs/operator-essentials.md`