### PR TITLE
Adopt adaptive failure bundle in PR quality workflow

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -35,18 +35,17 @@ jobs:
         run: |
           bash quality.sh cov 2>&1 | tee quality.log
 
-      - name: Build adaptive diagnosis
+      - name: Build adaptive failure intelligence bundle
         if: always()
-        continue-on-error: true
         run: |
-          mkdir -p build/pr-quality
-          PYTHONPATH=src python -m sdetkit.adaptive_diagnosis \
-            --log quality.log \
-            --format json \
-            --out build/pr-quality/adaptive-diagnosis.json
-          PYTHONPATH=src python -m sdetkit.pr_quality_comment \
-            build/pr-quality/adaptive-diagnosis.json \
-            > build/pr-quality/adaptive-diagnosis-comment.md
+          mkdir -p build/pr-quality/failure-intelligence
+          if [ -f quality.log ]; then
+            PYTHONPATH=src python -m sdetkit adaptive failure-bundle \
+              --log quality.log \
+              --out-dir build/pr-quality/failure-intelligence \
+              --proof-failed \
+              --format text
+          fi
 
       - name: Build PR comment body
         run: |
@@ -60,9 +59,9 @@ jobs:
               echo '✅ quality.sh cov passed'
               echo "- coverage: ${coverage_pct}%"
               echo '- checks: lint + tests + coverage gate are green for this PR run'
-              if [ -s build/pr-quality/adaptive-diagnosis-comment.md ]; then
+              if [ -s build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md ]; then
                 echo ''
-                cat build/pr-quality/adaptive-diagnosis-comment.md
+                cat build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md
               fi
             } > build/pr-quality/pr-comment-body.md
           else
@@ -70,12 +69,20 @@ jobs:
               echo '❌ quality.sh cov failed (see workflow logs for details)'
               echo "- coverage (last reported): ${coverage_pct}%"
               echo '- suggested fix: run `python -m pip install -c constraints-ci.txt -r requirements-test.txt -e . && bash quality.sh cov` locally'
-              if [ -s build/pr-quality/adaptive-diagnosis-comment.md ]; then
+              if [ -s build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md ]; then
                 echo ''
-                cat build/pr-quality/adaptive-diagnosis-comment.md
+                cat build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md
               fi
             } > build/pr-quality/pr-comment-body.md
           fi
+
+      - name: Upload failure intelligence bundle
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: pr-quality-failure-intelligence
+          path: build/pr-quality/failure-intelligence/
+          if-no-files-found: ignore
 
       - name: Comment on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0

--- a/tests/test_pr_quality_failure_bundle_workflow.py
+++ b/tests/test_pr_quality_failure_bundle_workflow.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/pr-quality-comment.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_pr_quality_workflow_uses_failure_bundle_handoff() -> None:
+    text = _workflow_text()
+
+    assert "Build adaptive failure intelligence bundle" in text
+    assert "python -m sdetkit adaptive failure-bundle" in text
+    assert "--log quality.log" in text
+    assert "--out-dir build/pr-quality/failure-intelligence" in text
+    assert "--proof-failed" in text
+
+    assert "python -m sdetkit.adaptive_diagnosis" not in text
+    assert "python -m sdetkit.pr_quality_comment" not in text
+
+
+def test_pr_quality_workflow_comments_from_bundle_comment_artifact() -> None:
+    text = _workflow_text()
+
+    assert "build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md" in text
+    assert "build/pr-quality/adaptive-diagnosis-comment.md" not in text
+
+
+def test_pr_quality_workflow_uploads_failure_intelligence_bundle() -> None:
+    text = _workflow_text()
+
+    assert "Upload failure intelligence bundle" in text
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in text
+    assert "name: pr-quality-failure-intelligence" in text
+    assert "path: build/pr-quality/failure-intelligence/" in text
+    assert "if-no-files-found: ignore" in text


### PR DESCRIPTION
## Summary
- Replace manual PR quality adaptive diagnosis stitching with `sdetkit adaptive failure-bundle`.
- Comment from the bundle-generated adaptive diagnosis comment artifact.
- Upload the full failure-intelligence bundle as a PR workflow artifact.
- Add workflow contract coverage for the new handoff path.

## Why
The adaptive failure bundle is now the product-grade diagnostic handoff surface. This PR wires it into the real PR quality lane so failed quality runs produce one coherent evidence bundle instead of scattered artifacts.

## Verification
- `python -m pytest -q tests/test_pr_quality_failure_bundle_workflow.py tests/test_adaptive_failure_bundle.py tests/test_pr_quality_comment.py tests/test_operator_brief.py tests/test_workflow_external_tool_pin_contract.py tests/test_workflow_template_hygiene.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `bash quality.sh cov`

## Proof result
- Full quality run: 3187 passed, 1 skipped, 3 deselected
- Coverage: 96.69%
- Blocking failures: none
- Merge/release recommendation: ready-for-merge-review

## Risk
Low-medium.
- Workflow-only integration plus a contract test.
- No auto-fix behavior added.
- Unknown failures remain review-first through the bundle.
- Green runs remain quiet unless quality fails.

## Rollback
Revert this PR to restore direct `adaptive_diagnosis` + `pr_quality_comment` workflow stitching.