### PR TITLE
Make Doctor Cortex aware of adaptive failure bundles

### DIFF
--- a/src/sdetkit/doctor_diagnosis.py
+++ b/src/sdetkit/doctor_diagnosis.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "sdetkit.doctor.diagnosis.v1"
+ADAPTIVE_FAILURE_BUNDLE_SCHEMA_VERSION = "sdetkit.adaptive.failure_bundle.v1"
 
 _SEVERITY_RANK = {
     "info": 0,
@@ -209,6 +210,9 @@ def _collect_diagnoses(source_doc: dict[str, Any]) -> list[dict[str, Any]]:
     checks = _as_dict(source_doc.get("checks"))
     confidence = _payload_confidence(source_doc)
     diagnoses = []
+    adaptive_bundle_diagnosis = _diagnosis_from_adaptive_failure_bundle(source_doc)
+    if adaptive_bundle_diagnosis is not None:
+        diagnoses.append(adaptive_bundle_diagnosis)
 
     for check_id in sorted(checks):
         check = _as_dict(checks[check_id])
@@ -252,6 +256,71 @@ def _safe_recommendations(
     if source_doc.get("ok", True):
         return ["No failed doctor checks were converted into diagnoses."]
     return ["Run doctor with targeted checks to inspect source findings."]
+
+
+def _diagnosis_from_adaptive_failure_bundle(
+    source_doc: dict[str, Any],
+) -> dict[str, Any] | None:
+    summary = source_doc.get("adaptive_failure_bundle")
+    if not isinstance(summary, dict) or not summary.get("enabled"):
+        return None
+
+    status = str(summary.get("status", "unknown"))
+    primary = str(summary.get("primary_diagnosis_code", "") or "")
+    diagnosis_count = int(summary.get("diagnosis_count", 0) or 0)
+    review_first = bool(summary.get("review_first", False))
+    safe_to_auto_fix = bool(summary.get("safe_to_auto_fix", False))
+    has_error = bool(summary.get("error"))
+
+    if (
+        not has_error
+        and status in {"clear", "monitor"}
+        and diagnosis_count == 0
+        and not review_first
+    ):
+        return None
+
+    severity = "high" if review_first or has_error or status == "needs_fix" else "medium"
+    primary_display = primary or "none"
+
+    return {
+        "diagnosis_id": "doctor.adaptive_failure_bundle",
+        "title": "Adaptive failure bundle requires review",
+        "category": "adaptive_failure_bundle",
+        "status": "fail" if severity == "high" else "warn",
+        "severity": severity,
+        "confidence": 0.93,
+        "summary": (
+            f"Adaptive failure bundle status={status}; primary={primary_display}; "
+            f"diagnosis_count={diagnosis_count}; review_first={str(review_first).lower()}; "
+            f"safe_to_auto_fix={str(safe_to_auto_fix).lower()}."
+        ),
+        "source": "adaptive_failure_bundle",
+        "evidence": [
+            f"status={status}",
+            f"primary={primary_display}",
+            f"diagnosis_count={diagnosis_count}",
+            f"review_first={str(review_first).lower()}",
+            f"safe_to_auto_fix={str(safe_to_auto_fix).lower()}",
+        ],
+        "proof_commands": [
+            "python -m sdetkit mission-control summarize --bundle build/mission-control/mission-control.json",
+        ],
+        "prescriptions": [
+            {
+                "prescription_id": "doctor.adaptive_failure_bundle.review_operator_brief",
+                "diagnosis_id": "doctor.adaptive_failure_bundle",
+                "action": "review_adaptive_failure_bundle",
+                "summary": "Review the adaptive failure bundle operator brief before remediation.",
+                "reason": "The adaptive failure bundle is advisory evidence and must remain review-first unless a safe-fix plan is explicitly proven.",
+                "severity": severity,
+                "priority": 92 if severity == "high" else 70,
+                "verification_commands": [
+                    "python -m sdetkit mission-control summarize --bundle build/mission-control/mission-control.json",
+                ],
+            }
+        ],
+    }
 
 
 def build_diagnosis_payload(source_doc: dict[str, Any]) -> dict[str, Any]:

--- a/src/sdetkit/doctor_prescriptions.py
+++ b/src/sdetkit/doctor_prescriptions.py
@@ -27,6 +27,15 @@ _PRIORITY_BY_SEVERITY = {
 }
 
 _CHECK_GUIDANCE = {
+    "adaptive_failure_bundle": {
+        "action": "review_adaptive_failure_bundle",
+        "summary": "Review the adaptive failure bundle and operator brief before remediation.",
+        "why": "Adaptive failure bundle signals are diagnostic handoff evidence, not permission to auto-fix.",
+        "category": "adaptive_failure_bundle",
+        "verification_commands": [
+            "python -m sdetkit mission-control summarize --bundle build/mission-control/mission-control.json",
+        ],
+    },
     "ascii": {
         "category": "source_hygiene",
         "action": "rerun_ascii_doctor_check",

--- a/tests/test_doctor_cortex_adaptive_failure_bundle.py
+++ b/tests/test_doctor_cortex_adaptive_failure_bundle.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from sdetkit import doctor_diagnosis, doctor_prescriptions
+
+UNKNOWN_REVIEW_REQUIRED = "UNKNOWN" + "_REVIEW" + "_REQUIRED"
+
+
+def _source_with_failure_bundle() -> dict[str, object]:
+    return {
+        "schema_version": "sdetkit.doctor.v2",
+        "ok": True,
+        "checks": {},
+        "summary": {"failed": 0},
+        "adaptive_failure_bundle": {
+            "enabled": True,
+            "ok": False,
+            "schema_version": "sdetkit.adaptive.failure_bundle.v1",
+            "status": "needs_fix",
+            "primary_diagnosis_code": UNKNOWN_REVIEW_REQUIRED,
+            "diagnosis_count": 1,
+            "review_first": True,
+            "safe_to_auto_fix": False,
+            "operator_brief_markdown": "build/sdetkit/failure-intelligence/operator-brief.md",
+        },
+    }
+
+
+def test_doctor_diagnosis_includes_adaptive_failure_bundle_signal() -> None:
+    payload = doctor_diagnosis.build_diagnosis_payload(_source_with_failure_bundle())
+
+    assert payload["ok"] is False
+    assert payload["diagnosis_count"] == 1
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis["diagnosis_id"] == "doctor.adaptive_failure_bundle"
+    assert diagnosis["category"] == "adaptive_failure_bundle"
+    assert diagnosis["severity"] == "high"
+    assert UNKNOWN_REVIEW_REQUIRED in diagnosis["summary"]
+    assert "review_first=true" in diagnosis["summary"]
+    assert "safe_to_auto_fix=false" in diagnosis["summary"]
+
+
+def test_clear_adaptive_failure_bundle_does_not_create_doctor_finding() -> None:
+    source = _source_with_failure_bundle()
+    bundle = source["adaptive_failure_bundle"]
+    assert isinstance(bundle, dict)
+    bundle.update(
+        {
+            "ok": True,
+            "status": "clear",
+            "primary_diagnosis_code": "",
+            "diagnosis_count": 0,
+            "review_first": False,
+            "safe_to_auto_fix": False,
+        }
+    )
+
+    payload = doctor_diagnosis.build_diagnosis_payload(source)
+
+    assert payload["ok"] is True
+    assert payload["diagnosis_count"] == 0
+
+
+def test_doctor_prescriptions_has_adaptive_failure_bundle_guidance() -> None:
+    diagnosis_payload = {
+        "schema_version": "sdetkit.doctor.diagnosis.v1",
+        "ok": False,
+        "status": "fail",
+        "diagnoses": [
+            {
+                "diagnosis_id": "doctor.adaptive_failure_bundle",
+                "category": "adaptive_failure_bundle",
+                "status": "fail",
+                "severity": "high",
+                "summary": "Adaptive failure bundle requires review.",
+            }
+        ],
+    }
+
+    payload = doctor_prescriptions.build_prescription_payload(diagnosis_payload)
+
+    assert payload["ok"] is False
+    assert payload["prescription_count"] == 1
+    prescription = payload["prescriptions"][0]
+    assert prescription["diagnosis_id"] == "doctor.adaptive_failure_bundle"
+    assert "review_adaptive_failure_bundle" in prescription["prescription_id"]
+    assert "adaptive failure bundle" in prescription["summary"].lower()
+    assert "not permission to auto-fix" in prescription["why"]


### PR DESCRIPTION
## Summary
- Teach Doctor Cortex diagnosis to recognize adaptive failure bundle signals.
- Add a Doctor diagnosis for red/review-first adaptive failure bundles.
- Keep clear adaptive failure bundles quiet.
- Add Doctor prescription guidance that keeps the bundle advisory and review-first.
- Add regression tests for red, clear, and prescription behavior.

## Why
The repo now creates adaptive failure bundles, uses them in PR quality, carries them into Mission Control, and now lets Doctor Cortex understand that diagnostic signal without expanding auto-fix behavior.

## Verification
- `python -m pytest -q tests/test_doctor_cortex_adaptive_failure_bundle.py tests/test_doctor_diagnosis.py tests/test_doctor_prescriptions.py tests/test_doctor_cli_cortex.py tests/test_adaptive_failure_bundle.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `bash quality.sh cov`

## Proof result
- Full quality run: 3194 passed, 1 skipped, 3 deselected
- Coverage: 96.69%
- Blocking failures: none
- Merge/release recommendation: ready-for-merge-review

## Risk
Medium-low.
- Contract-layer addition only.
- No workflow change.
- No auto-fix behavior.
- Clear bundles stay quiet.
- Review-first bundles remain advisory.

## Rollback
Revert this PR to remove adaptive failure bundle handling from Doctor Cortex diagnosis and prescription contracts.