### PR TITLE
Add Doctor CLI failure-bundle input

### DIFF
--- a/src/sdetkit/doctor.py
+++ b/src/sdetkit/doctor.py
@@ -46,6 +46,7 @@ EXIT_FAILED = 2
 EVIDENCE_SCHEMA_VERSION = "sdetkit.doctor.evidence.v2"
 EVIDENCE_MANIFEST_SCHEMA_VERSION = "sdetkit.doctor.evidence.manifest.v1"
 NEXT_PASS_SCHEMA_VERSION = "sdetkit.doctor.next_pass.v1"
+ADAPTIVE_FAILURE_BUNDLE_SCHEMA_VERSION = "sdetkit.adaptive.failure_bundle.v1"
 EVIDENCE_PROFILES = ("ci", "release", "full")
 EVIDENCE_INCLUDES = ("failed", "actionable", "all")
 ENTERPRISE_RERUN_FAILED_COMMAND = "python -m sdetkit doctor --enterprise-rerun-failed --json"
@@ -2263,6 +2264,56 @@ def _evaluate_gate(checks: dict[str, dict[str, Any]], threshold: str) -> tuple[b
     return (not failed), failed
 
 
+def _load_adaptive_failure_bundle_signal(path: Path) -> dict[str, Any]:
+    resolved = path.resolve()
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {
+            "enabled": True,
+            "ok": False,
+            "path": resolved.as_posix(),
+            "error": f"failed to read adaptive failure bundle: {exc}",
+        }
+
+    if not isinstance(payload, dict):
+        return {
+            "enabled": True,
+            "ok": False,
+            "path": resolved.as_posix(),
+            "error": "adaptive failure bundle payload is not a JSON object",
+        }
+
+    schema_version = str(payload.get("schema_version", ""))
+    if schema_version != ADAPTIVE_FAILURE_BUNDLE_SCHEMA_VERSION:
+        return {
+            "enabled": True,
+            "ok": False,
+            "path": resolved.as_posix(),
+            "schema_version": schema_version,
+            "error": "unsupported adaptive failure bundle schema",
+        }
+
+    artifacts = payload.get("artifacts", {})
+    artifacts_map = artifacts if isinstance(artifacts, dict) else {}
+    status = str(payload.get("status", "unknown"))
+    review_first = bool(payload.get("review_first", False))
+    diagnosis_count = int(payload.get("diagnosis_count", 0) or 0)
+
+    return {
+        "enabled": True,
+        "ok": status in {"clear", "monitor"} and diagnosis_count == 0 and not review_first,
+        "path": resolved.as_posix(),
+        "schema_version": schema_version,
+        "status": status,
+        "primary_diagnosis_code": str(payload.get("primary_diagnosis_code", "") or ""),
+        "diagnosis_count": diagnosis_count,
+        "review_first": review_first,
+        "safe_to_auto_fix": bool(payload.get("safe_to_auto_fix", False)),
+        "operator_brief_markdown": str(artifacts_map.get("operator_brief_markdown", "")),
+    }
+
+
 def _split_cortex_args(argv: list[str]) -> tuple[bool, bool, str, str | None, list[str]]:
     diagnose = False
     prescribe = False
@@ -2293,6 +2344,16 @@ def _split_cortex_args(argv: list[str]) -> tuple[bool, bool, str, str | None, li
             continue
         if token.startswith("--format="):
             output_format = token.split("=", 1)[1]
+            index += 1
+            continue
+        if token == "--failure-bundle":
+            inner.append(token)
+            index += 1
+            inner.append(argv[index])
+            index += 1
+            continue
+        if token.startswith("--failure-bundle="):
+            inner.append(token)
             index += 1
             continue
         if token == "--out":
@@ -2344,6 +2405,20 @@ def _doctor_cortex_main(argv: list[str]) -> int | None:
         return rc if rc else 2
 
     from . import doctor_diagnosis
+
+    failure_bundle_path = ""
+    for index, token in enumerate(argv):
+        if token == "--failure-bundle" and index + 1 < len(argv):
+            failure_bundle_path = argv[index + 1]
+            break
+        if token.startswith("--failure-bundle="):
+            failure_bundle_path = token.split("=", 1)[1]
+            break
+
+    if failure_bundle_path and isinstance(doctor_payload, dict):
+        doctor_payload["adaptive_failure_bundle"] = _load_adaptive_failure_bundle_signal(
+            Path(failure_bundle_path)
+        )
 
     diagnosis_contract = doctor_diagnosis.build_diagnosis_payload(doctor_payload)
     target_path = Path(out_path) if out_path else None
@@ -2705,6 +2780,11 @@ def main(argv: list[str] | None = None) -> int:
         "--prescribe",
         action="store_true",
         help="emit the public Doctor prescription contract instead of the standard doctor report",
+    )
+    parser.add_argument(
+        "--failure-bundle",
+        default="",
+        help="Attach an adaptive failure intelligence bundle to Doctor Cortex diagnosis.",
     )
 
     ns = parser.parse_args(list(argv) if argv is not None else None)
@@ -3358,6 +3438,11 @@ def main(argv: list[str] | None = None) -> int:
         alternate_commands = [
             str(command).strip() for command in alternate_commands if str(command).strip()
         ]
+        if str(getattr(ns, "failure_bundle", "")):
+            data["adaptive_failure_bundle"] = _load_adaptive_failure_bundle_signal(
+                Path(str(ns.failure_bundle))
+            )
+
         if ns.diagnose or ns.prescribe:
             output_format = "json" if (ns.format == "json" or ns.json) else "text"
             out_path = Path(ns.out) if ns.out else None

--- a/tests/test_doctor_cli_failure_bundle_input.py
+++ b/tests/test_doctor_cli_failure_bundle_input.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import doctor
+
+UNKNOWN_REVIEW_REQUIRED = "UNKNOWN" + "_REVIEW" + "_REQUIRED"
+
+
+def _write_failure_bundle(path: Path, *, clear: bool = False) -> Path:
+    operator_brief = path.parent / "operator-brief.md"
+    operator_brief.write_text("# operator brief\n", encoding="utf-8")
+    payload = {
+        "schema_version": "sdetkit.adaptive.failure_bundle.v1",
+        "status": "clear" if clear else "needs_fix",
+        "primary_diagnosis_code": "" if clear else UNKNOWN_REVIEW_REQUIRED,
+        "diagnosis_count": 0 if clear else 1,
+        "review_first": False if clear else True,
+        "safe_to_auto_fix": False,
+        "artifacts": {"operator_brief_markdown": operator_brief.as_posix()},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_doctor_diagnose_cli_accepts_failure_bundle(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    bundle = _write_failure_bundle(tmp_path / "failure-intelligence-bundle.json")
+    out_path = tmp_path / "doctor-diagnosis.json"
+
+    rc = doctor.main(
+        [
+            "--diagnose",
+            "--failure-bundle",
+            str(bundle),
+            "--format",
+            "json",
+            "--out",
+            str(out_path),
+            "--no-workspace",
+        ]
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    ids = {item["diagnosis_id"] for item in payload["diagnoses"]}
+    assert "doctor.adaptive_failure_bundle" in ids
+
+
+def test_doctor_diagnose_cli_clear_failure_bundle_stays_quiet(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    bundle = _write_failure_bundle(tmp_path / "failure-intelligence-bundle.json", clear=True)
+    out_path = tmp_path / "doctor-diagnosis.json"
+
+    rc = doctor.main(
+        [
+            "--diagnose",
+            f"--failure-bundle={bundle}",
+            "--format",
+            "json",
+            "--out",
+            str(out_path),
+            "--no-workspace",
+        ]
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    ids = {item["diagnosis_id"] for item in payload["diagnoses"]}
+    assert "doctor.adaptive_failure_bundle" not in ids
+
+
+def test_doctor_prescribe_cli_accepts_failure_bundle(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    bundle = _write_failure_bundle(tmp_path / "failure-intelligence-bundle.json")
+    out_path = tmp_path / "doctor-prescriptions.json"
+
+    rc = doctor.main(
+        [
+            "--prescribe",
+            "--failure-bundle",
+            str(bundle),
+            "--format",
+            "json",
+            "--out",
+            str(out_path),
+            "--no-workspace",
+        ]
+    )
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["prescription_count"] >= 1


### PR DESCRIPTION
## Summary
- Add `doctor --failure-bundle <path>`.
- Support direct `doctor --diagnose --failure-bundle ...`.
- Support direct `doctor --prescribe --failure-bundle ...`.
- Keep clear bundles quiet.
- Add CLI regression tests for red bundle, clear bundle, and prescribe path.

## Why
Doctor Cortex already understands adaptive failure bundle signals at the contract layer. This PR exposes the operator-facing CLI path so users can attach a bundle directly to Doctor diagnosis/prescription commands.

## Verification
- `python -m pytest -q tests/test_doctor_cli_failure_bundle_input.py tests/test_doctor_cli_cortex.py tests/test_doctor_cortex_adaptive_failure_bundle.py tests/test_doctor_diagnosis.py tests/test_doctor_prescriptions.py tests/test_adaptive_failure_bundle.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `bash quality.sh cov`

## Proof result
- Full quality run: 3197 passed, 1 skipped, 3 deselected
- Coverage: 96.69%
- Blocking failures: none
- Merge/release recommendation: ready-for-merge-review

## Risk
Medium-low.
- CLI input is additive.
- No workflow change.
- No auto-fix behavior.
- Clear bundles stay quiet.
- Review-first bundles remain advisory.

## Rollback
Revert this PR to remove `doctor --failure-bundle` and its CLI tests.****