### PR TITLE
Make investigate failure emit adaptive failure bundles

### DIFF
--- a/src/sdetkit/investigate.py
+++ b/src/sdetkit/investigate.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
-from sdetkit import adaptive_diagnosis
+from sdetkit import adaptive_diagnosis, adaptive_failure_bundle
 from sdetkit.boost import build_scan
 from sdetkit.index import IGNORED_DIRS
 from sdetkit.investigation_evidence import build_investigation_evidence
@@ -335,6 +335,45 @@ def _payload_for_surface(root: str, surface: str) -> dict[str, Any]:
     }
 
 
+def _failure_bundle_handoff(bundle: dict[str, Any]) -> dict[str, Any]:
+    artifacts = bundle.get("artifacts", {})
+    artifacts_map = artifacts if isinstance(artifacts, dict) else {}
+    return {
+        "schema_version": str(bundle.get("schema_version", "")),
+        "bundle_path": str(bundle.get("bundle_path", "")),
+        "status": str(bundle.get("status", "unknown")),
+        "primary_diagnosis_code": str(bundle.get("primary_diagnosis_code", "") or ""),
+        "diagnosis_count": int(bundle.get("diagnosis_count", 0) or 0),
+        "review_first": bool(bundle.get("review_first", False)),
+        "safe_to_auto_fix": bool(bundle.get("safe_to_auto_fix", False)),
+        "artifacts": artifacts_map,
+    }
+
+
+def _attach_failure_bundle_handoff(
+    payload: dict[str, Any],
+    *,
+    log_path: str | Path,
+    out_dir: str | Path | None,
+) -> dict[str, Any]:
+    if not out_dir:
+        return payload
+
+    diagnosis = payload.get("diagnosis", {})
+    diagnosis_count = 0
+    if isinstance(diagnosis, dict):
+        diagnosis_count = int(diagnosis.get("diagnosis_count", 0) or 0)
+
+    bundle = adaptive_failure_bundle.build_failure_bundle(
+        log_path=Path(log_path),
+        out_dir=Path(out_dir),
+        proof_failed=bool(diagnosis_count),
+    )
+    updated = dict(payload)
+    updated["failure_bundle"] = _failure_bundle_handoff(bundle)
+    return updated
+
+
 def render_failure_markdown(payload: dict[str, Any]) -> str:
     proof = payload.get("proof_commands", [])
     actions = payload.get("next_actions", [])
@@ -372,6 +411,24 @@ def render_failure_markdown(payload: dict[str, Any]) -> str:
     key = str(payload.get("memory_lookup_key", "")).strip()
     if key:
         lines.extend(["", "## Memory lookup key", "", f"`{key}`"])
+
+    bundle = payload.get("failure_bundle")
+    if isinstance(bundle, dict):
+        lines.extend(
+            [
+                "",
+                "## Failure intelligence bundle",
+                f"- bundle path: `{bundle.get('bundle_path', '')}`",
+                f"- status: **{bundle.get('status', 'unknown')}**",
+                f"- primary diagnosis: **{bundle.get('primary_diagnosis_code', '') or 'none'}**",
+                f"- diagnosis count: **{bundle.get('diagnosis_count', 0)}**",
+                f"- review first: **{bundle.get('review_first', False)}**",
+                f"- safe to auto-fix: **{bundle.get('safe_to_auto_fix', False)}**",
+            ]
+        )
+        artifacts = bundle.get("artifacts", {})
+        if isinstance(artifacts, dict) and artifacts.get("operator_brief_markdown"):
+            lines.append(f"- operator brief: `{artifacts['operator_brief_markdown']}`")
 
     return "\n".join(lines).rstrip() + "\n"
 
@@ -494,6 +551,11 @@ def build_parser() -> argparse.ArgumentParser:
     failure.add_argument("--log", required=True, help="Path to a text log to investigate")
     failure.add_argument("--format", choices=["json", "markdown"], default="json")
     failure.add_argument("--out", default="", help="Optional output file")
+    failure.add_argument(
+        "--failure-bundle-out-dir",
+        default="",
+        help="Optional directory for a full adaptive failure intelligence bundle.",
+    )
 
     repo = sub.add_parser("repo", help="Summarize repository investigation surfaces")
     repo.add_argument("--root", default=".", help="Repository root to investigate")
@@ -521,7 +583,12 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         if args.cmd == "failure":
-            payload = _payload_for_failure(_read_log(args.log))
+            log_text = _read_log(args.log)
+            payload = _attach_failure_bundle_handoff(
+                _payload_for_failure(log_text),
+                log_path=args.log,
+                out_dir=args.failure_bundle_out_dir or None,
+            )
             rendered = (
                 json.dumps(payload, indent=2, sort_keys=True) + "\n"
                 if args.format == "json"

--- a/tests/test_investigate_failure.py
+++ b/tests/test_investigate_failure.py
@@ -134,3 +134,109 @@ def test_python_m_sdetkit_investigate_failure_outputs_json(tmp_path):
     payload = json.loads(result.stdout)
     assert payload["classification"] == "MISSING_PUBLIC_API_PARITY"
     assert payload["automation_allowed"] is False
+
+
+def test_failure_investigation_can_emit_failure_bundle(tmp_path, capsys):
+    log = tmp_path / "failure.log"
+    out = tmp_path / "investigation.json"
+    bundle_dir = tmp_path / "failure-intelligence"
+    log.write_text(
+        "\n".join(
+            [
+                "Traceback (most recent call last):",
+                '  File "scripts/custom_policy.py", line 10, in <module>',
+                '    raise RuntimeError("unexpected integrity result")',
+                "RuntimeError: unexpected integrity result",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    rc = investigate.main(
+        [
+            "failure",
+            "--log",
+            str(log),
+            "--format",
+            "json",
+            "--failure-bundle-out-dir",
+            str(bundle_dir),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert printed["failure_bundle"] == written["failure_bundle"]
+    bundle = written["failure_bundle"]
+    assert bundle["schema_version"] == "sdetkit.adaptive.failure_bundle.v1"
+    assert bundle["primary_diagnosis_code"] == "UNKNOWN_REVIEW_REQUIRED"
+    assert bundle["review_first"] is True
+    assert bundle["safe_to_auto_fix"] is False
+    assert Path(bundle["bundle_path"]).exists()
+    assert Path(bundle["artifacts"]["operator_brief_markdown"]).exists()
+
+
+def test_failure_investigation_bundle_markdown_handoff(tmp_path, capsys):
+    log = tmp_path / "failure.log"
+    bundle_dir = tmp_path / "failure-intelligence"
+    log.write_text(
+        "FAILED tests/test_widget.py::test_contract - AssertionError: expected stable evidence",
+        encoding="utf-8",
+    )
+
+    rc = investigate.main(
+        [
+            "failure",
+            "--log",
+            str(log),
+            "--format",
+            "markdown",
+            "--failure-bundle-out-dir",
+            str(bundle_dir),
+        ]
+    )
+
+    assert rc == 0
+    rendered = capsys.readouterr().out
+    assert "## Failure intelligence bundle" in rendered
+    assert "PYTEST_ASSERTION_FAILURE" in rendered
+    assert "operator-brief.md" in rendered
+
+
+def test_failure_investigation_green_bundle_stays_clear(tmp_path, capsys):
+    log = tmp_path / "green.log"
+    bundle_dir = tmp_path / "failure-intelligence"
+    log.write_text(
+        "\n".join(
+            [
+                "[quality] running coverage :: Coverage lane",
+                "quality.sh cov passed",
+                "[quality] blocking failures: none",
+                "[quality] merge/release recommendation: ready-for-merge-review",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    rc = investigate.main(
+        [
+            "failure",
+            "--log",
+            str(log),
+            "--format",
+            "json",
+            "--failure-bundle-out-dir",
+            str(bundle_dir),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    bundle = payload["failure_bundle"]
+    assert bundle["status"] == "clear"
+    assert bundle["diagnosis_count"] == 0
+    assert bundle["primary_diagnosis_code"] == ""
+    assert bundle["review_first"] is False


### PR DESCRIPTION
## Summary
- Add `investigate failure --failure-bundle-out-dir <dir>`.
- Generate a full adaptive failure intelligence bundle from the same failure log.
- Include failure bundle summary and artifact paths in investigation JSON.
- Add a concise failure intelligence bundle section to investigation markdown.
- Add regression tests for review-first unknown failures, markdown handoff, and green/clear bundle behavior.

## Why
`investigate failure` is the operator front door. The adaptive failure bundle chain already exists across PR quality, Mission Control, and Doctor Cortex; this PR lets the investigation command emit the same handoff bundle directly so operators do not need to stitch multiple commands together.

## Verification
- `python -m pytest -q tests/test_investigate_failure.py tests/test_investigate_cli.py tests/test_investigation_evidence.py tests/test_investigation_safe_fix_policy.py tests/test_adaptive_failure_bundle.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `bash quality.sh cov`

## Proof result
- Full quality run: 3200 passed, 1 skipped, 3 deselected
- Coverage: 96.69%
- Blocking failures: none
- Merge/release recommendation: ready-for-merge-review

## Risk
Medium-low.
- Additive CLI option only.
- Investigation remains diagnostic/read-only.
- No auto-fix behavior.
- No workflow change.
- Green logs stay clear.
- Unknown failures remain review-first.

## Rollback
Revert this PR to remove `--failure-bundle-out-dir` and the investigation bundle handoff tests.