### PR TITLE
Add adaptive sentinel control loop

### DIFF
--- a/src/sdetkit/adaptive_sentinel.py
+++ b/src/sdetkit/adaptive_sentinel.py
@@ -106,8 +106,7 @@ def _git_status(root: Path) -> dict[str, Any]:
         proc = subprocess.run(
             ["git", "-C", str(root), "status", "--porcelain"],
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             check=False,
             timeout=10,
         )

--- a/src/sdetkit/adaptive_sentinel.py
+++ b/src/sdetkit/adaptive_sentinel.py
@@ -1,0 +1,596 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.adaptive.sentinel.v1"
+EVENT_SCHEMA_VERSION = "sdetkit.adaptive.sentinel.event.v1"
+
+STATE_RANK = {
+    "healthy": 0,
+    "watch": 1,
+    "warning": 2,
+    "critical": 3,
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _as_dict(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: object) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any] | None, str]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, "missing"
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"unreadable: {exc}"
+    if not isinstance(payload, dict):
+        return None, "not_json_object"
+    return payload, ""
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _max_state(*states: str) -> str:
+    current = "healthy"
+    for state in states:
+        if STATE_RANK.get(state, 0) > STATE_RANK.get(current, 0):
+            current = state
+    return current
+
+
+def _artifact_candidates(root: Path) -> dict[str, list[Path]]:
+    return {
+        "adaptive_failure_bundle": [
+            root / "build/sdetkit/failure-intelligence/failure-intelligence-bundle.json",
+            root / "build/pr-quality/failure-intelligence/failure-intelligence-bundle.json",
+        ],
+        "investigation_failure": [
+            root / "build/investigation/failure.json",
+        ],
+        "doctor_diagnosis": [
+            root / "build/doctor-diagnosis.json",
+            root / "build/mission-control/doctor-cortex-diagnosis.json",
+        ],
+        "doctor_prescriptions": [
+            root / "build/doctor-prescriptions.json",
+            root / "build/mission-control/doctor-cortex-prescriptions.json",
+        ],
+        "mission_control": [
+            root / "build/mission-control/mission-control.json",
+        ],
+        "quality_verdict": [
+            root / ".sdetkit/out/quality-verdict.json",
+        ],
+    }
+
+
+def _first_existing(paths: list[Path]) -> Path | None:
+    for path in paths:
+        if path.exists():
+            return path
+    return None
+
+
+def _git_status(root: Path) -> dict[str, Any]:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "status", "--porcelain"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "available": False,
+            "dirty": False,
+            "error": str(exc),
+            "changed_paths": [],
+        }
+
+    if proc.returncode != 0:
+        return {
+            "available": False,
+            "dirty": False,
+            "error": proc.stderr.strip()[:300],
+            "changed_paths": [],
+        }
+
+    changed = [line[3:] for line in proc.stdout.splitlines() if len(line) >= 4]
+    return {
+        "available": True,
+        "dirty": bool(changed),
+        "changed_paths": changed[:50],
+    }
+
+
+def _finding(
+    *,
+    source: str,
+    state: str,
+    title: str,
+    summary: str,
+    evidence: list[str] | None = None,
+    commands: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "source": source,
+        "state": state,
+        "title": title,
+        "summary": summary,
+        "evidence": evidence or [],
+        "recommended_commands": commands or [],
+    }
+
+
+def _source_record(name: str, path: Path | None, present: bool, error: str = "") -> dict[str, Any]:
+    return {
+        "name": name,
+        "present": present,
+        "path": path.as_posix() if path else "",
+        "error": error,
+    }
+
+
+def _inspect_failure_bundle(path: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    status = str(payload.get("status", "unknown"))
+    primary = str(payload.get("primary_diagnosis_code", "") or "")
+    diagnosis_count = int(payload.get("diagnosis_count", 0) or 0)
+    review_first = bool(payload.get("review_first", False))
+    safe_to_auto_fix = bool(payload.get("safe_to_auto_fix", False))
+
+    if status in {"clear", "monitor"} and diagnosis_count == 0 and not review_first:
+        state = "healthy" if status == "clear" else "watch"
+        summary = "Adaptive failure bundle is clear."
+    elif review_first or primary in {"UNKNOWN", "UNKNOWN_REVIEW_REQUIRED"}:
+        state = "critical"
+        summary = "Adaptive failure bundle is review-first and must not be automated."
+    elif status == "needs_fix":
+        state = "warning"
+        summary = "Adaptive failure bundle identified a fixable failure path."
+    else:
+        state = "watch"
+        summary = "Adaptive failure bundle should be monitored."
+
+    commands = [
+        f"python -m sdetkit doctor --diagnose --failure-bundle {path.as_posix()} --format json",
+        "python -m sdetkit mission-control summarize --bundle build/mission-control/mission-control.json",
+    ]
+    if not safe_to_auto_fix:
+        commands.insert(
+            0,
+            "python -m sdetkit investigate failure --log build/quality.log "
+            "--failure-bundle-out-dir build/sdetkit/failure-intelligence --format markdown",
+        )
+
+    return _finding(
+        source="adaptive_failure_bundle",
+        state=state,
+        title="Adaptive failure bundle signal",
+        summary=summary,
+        evidence=[
+            f"status={status}",
+            f"primary={primary or 'none'}",
+            f"diagnosis_count={diagnosis_count}",
+            f"review_first={str(review_first).lower()}",
+            f"safe_to_auto_fix={str(safe_to_auto_fix).lower()}",
+        ],
+        commands=commands,
+    )
+
+
+def _inspect_investigation(path: Path, payload: dict[str, Any]) -> dict[str, Any] | None:
+    classification = str(payload.get("classification", "") or "")
+    if not classification:
+        return None
+
+    requires_review = bool(payload.get("requires_human_review", True))
+    state = "critical" if classification == "UNKNOWN_REVIEW_REQUIRED" else "warning"
+    if not requires_review:
+        state = "watch"
+
+    return _finding(
+        source="investigation_failure",
+        state=state,
+        title="Investigation failure signal",
+        summary=str(payload.get("summary", "Investigation artifact requires review.")),
+        evidence=[
+            f"classification={classification}",
+            f"requires_human_review={str(requires_review).lower()}",
+            f"safe_to_auto_fix={str(payload.get('safe_to_auto_fix', False)).lower()}",
+        ],
+        commands=_as_list(payload.get("proof_commands"))[:3]
+        or ["python -m sdetkit investigate failure --log build/quality.log --format markdown"],
+    )
+
+
+def _inspect_doctor(
+    path: Path,
+    payload: dict[str, Any],
+    *,
+    prescriptions: bool = False,
+) -> dict[str, Any] | None:
+    count_key = "prescription_count" if prescriptions else "diagnosis_count"
+    count = int(payload.get(count_key, 0) or 0)
+    if count <= 0 and bool(payload.get("ok", True)):
+        return None
+
+    noun = "prescription" if prescriptions else "diagnosis"
+    return _finding(
+        source=f"doctor_{noun}",
+        state="warning" if count > 0 else "watch",
+        title=f"Doctor Cortex {noun} signal",
+        summary=f"Doctor Cortex reported {count} {noun} item(s).",
+        evidence=[f"{count_key}={count}", f"path={path.as_posix()}"],
+        commands=[
+            "python -m sdetkit doctor --diagnose --format json",
+            "python -m sdetkit doctor --prescribe --format json",
+        ],
+    )
+
+
+def _inspect_mission_control(path: Path, payload: dict[str, Any]) -> dict[str, Any] | None:
+    decision = str(payload.get("decision", "") or "")
+    failed_step_count = int(payload.get("failed_step_count", 0) or 0)
+    findings = _as_list(payload.get("findings"))
+    if (
+        decision not in {"NO_SHIP", "SHIP_WITH_FINDINGS"}
+        and failed_step_count == 0
+        and not findings
+    ):
+        return None
+
+    state = "critical" if decision == "NO_SHIP" or failed_step_count > 0 else "warning"
+    return _finding(
+        source="mission_control",
+        state=state,
+        title="Mission Control release signal",
+        summary=f"Mission Control decision is {decision or 'unknown'} with {failed_step_count} failed step(s).",
+        evidence=[
+            f"decision={decision or 'unknown'}",
+            f"failed_step_count={failed_step_count}",
+            f"finding_count={len(findings)}",
+        ],
+        commands=[
+            f"python -m sdetkit mission-control summarize --bundle {path.as_posix()}",
+            "python -m sdetkit mission-control report --bundle build/mission-control/mission-control.json",
+        ],
+    )
+
+
+def _inspect_quality_verdict(path: Path, payload: dict[str, Any]) -> dict[str, Any] | None:
+    blocking = str(payload.get("blocking_failures", "") or "")
+    recommendation = str(
+        payload.get("merge_release_recommendation", "") or payload.get("recommendation", "") or ""
+    )
+    if blocking in {"", "none"} and recommendation in {"", "ready-for-merge-review"}:
+        return None
+
+    return _finding(
+        source="quality_verdict",
+        state="critical" if blocking and blocking != "none" else "warning",
+        title="Quality verdict signal",
+        summary="Quality verdict is not clean.",
+        evidence=[
+            f"blocking_failures={blocking or 'unknown'}",
+            f"recommendation={recommendation or 'unknown'}",
+            f"path={path.as_posix()}",
+        ],
+        commands=[
+            "bash quality.sh cov",
+            "python -m sdetkit investigate failure --log build/quality.log --format markdown",
+        ],
+    )
+
+
+def _inspect_sources(root: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    sources: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+
+    for name, candidates in _artifact_candidates(root).items():
+        path = _first_existing(candidates)
+        if path is None:
+            sources.append(_source_record(name, None, False))
+            continue
+
+        payload, error = _read_json(path)
+        sources.append(_source_record(name, path, payload is not None, error))
+        if payload is None:
+            findings.append(
+                _finding(
+                    source=name,
+                    state="warning",
+                    title="Unreadable sentinel source",
+                    summary=f"Sentinel found {name} but could not read it.",
+                    evidence=[f"path={path.as_posix()}", f"error={error}"],
+                    commands=["Inspect or regenerate the artifact before trusting it."],
+                )
+            )
+            continue
+
+        finding: dict[str, Any] | None = None
+        if name == "adaptive_failure_bundle":
+            finding = _inspect_failure_bundle(path, payload)
+        elif name == "investigation_failure":
+            finding = _inspect_investigation(path, payload)
+        elif name == "doctor_diagnosis":
+            finding = _inspect_doctor(path, payload)
+        elif name == "doctor_prescriptions":
+            finding = _inspect_doctor(path, payload, prescriptions=True)
+        elif name == "mission_control":
+            finding = _inspect_mission_control(path, payload)
+        elif name == "quality_verdict":
+            finding = _inspect_quality_verdict(path, payload)
+
+        if finding is not None:
+            findings.append(finding)
+
+    return sources, findings
+
+
+def _rank_recommendations(findings: list[dict[str, Any]]) -> list[str]:
+    commands: list[str] = []
+    for finding in sorted(
+        findings,
+        key=lambda item: STATE_RANK.get(str(item.get("state", "healthy")), 0),
+        reverse=True,
+    ):
+        for command in _as_list(finding.get("recommended_commands")):
+            if isinstance(command, str) and command and command not in commands:
+                commands.append(command)
+            if len(commands) >= 8:
+                return commands
+    return commands
+
+
+def build_sentinel_scan(
+    *,
+    root: str | Path = ".",
+    out_dir: str | Path = "build/sdetkit/sentinel",
+    event_log: str | Path | None = None,
+    write: bool = True,
+) -> dict[str, Any]:
+    root_path = Path(root).resolve()
+    out_path = Path(out_dir)
+    if not out_path.is_absolute():
+        out_path = root_path / out_path
+
+    sources, findings = _inspect_sources(root_path)
+
+    git_status = _git_status(root_path)
+    if git_status.get("dirty"):
+        findings.append(
+            _finding(
+                source="git",
+                state="watch",
+                title="Working tree has local changes",
+                summary="Sentinel detected uncommitted work; keep proof tied to the current diff.",
+                evidence=[f"changed_paths={len(_as_list(git_status.get('changed_paths')))}"],
+                commands=["git status -sb", "git diff --stat"],
+            )
+        )
+
+    state = _max_state(*(str(item.get("state", "healthy")) for item in findings))
+    if not findings:
+        findings = [
+            _finding(
+                source="sentinel",
+                state="healthy",
+                title="No active sentinel findings",
+                summary="No known failure artifacts or degraded repo state were detected.",
+                evidence=["no_active_artifact_findings=true"],
+                commands=[
+                    "bash quality.sh cov",
+                    "python -m sdetkit mission-control run --doctor-cortex",
+                ],
+            )
+        ]
+
+    recommendations = _rank_recommendations(findings)
+    event_path = (
+        Path(event_log)
+        if event_log is not None
+        else root_path / ".sdetkit/adaptive-sentinel/events.jsonl"
+    )
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at_utc": _utc_now(),
+        "root": root_path.as_posix(),
+        "state": state,
+        "ok": state in {"healthy", "watch"},
+        "finding_count": len([item for item in findings if item.get("source") != "sentinel"]),
+        "source_count": len(sources),
+        "sources": sources,
+        "git": git_status,
+        "findings": findings,
+        "recommendations": recommendations,
+        "artifacts": {
+            "json": (out_path / "sentinel.json").as_posix(),
+            "markdown": (out_path / "sentinel.md").as_posix(),
+            "events_jsonl": event_path.as_posix(),
+        },
+        "automation_allowed_now": False,
+        "automation_reason": "Adaptive sentinel is read-only: it watches, classifies, recommends, and records evidence.",
+    }
+
+    if write:
+        _write_json(out_path / "sentinel.json", payload)
+        _write_text(out_path / "sentinel.md", render_markdown(payload))
+        if not event_path.is_absolute():
+            event_path = root_path / event_path
+        _append_jsonl(
+            event_path,
+            {
+                "schema_version": EVENT_SCHEMA_VERSION,
+                "created_at_utc": payload["created_at_utc"],
+                "state": payload["state"],
+                "ok": payload["ok"],
+                "finding_count": payload["finding_count"],
+                "recommendations": payload["recommendations"][:3],
+                "sentinel_json": payload["artifacts"]["json"],
+            },
+        )
+
+    return payload
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"schema_version={payload['schema_version']}",
+        f"state={payload['state']}",
+        f"ok={str(payload['ok']).lower()}",
+        f"finding_count={payload['finding_count']}",
+    ]
+    for command in _as_list(payload.get("recommendations"))[:5]:
+        lines.append(f"recommendation={command}")
+    return "\n".join(lines) + "\n"
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Adaptive Sentinel",
+        "",
+        f"- State: **{payload.get('state', 'unknown')}**",
+        f"- OK: **{payload.get('ok', False)}**",
+        f"- Findings: **{payload.get('finding_count', 0)}**",
+        f"- Automation allowed now: **{payload.get('automation_allowed_now', False)}**",
+        "",
+        "## Findings",
+    ]
+    for finding in _as_list(payload.get("findings")):
+        item = _as_dict(finding)
+        lines.extend(
+            [
+                "",
+                f"### {item.get('title', 'Sentinel finding')}",
+                f"- source: `{item.get('source', 'unknown')}`",
+                f"- state: **{item.get('state', 'unknown')}**",
+                f"- summary: {item.get('summary', '')}",
+            ]
+        )
+        evidence = _as_list(item.get("evidence"))
+        if evidence:
+            lines.append("- evidence:")
+            for row in evidence[:6]:
+                lines.append(f"  - `{row}`")
+    lines.extend(["", "## Recommended next commands"])
+    for command in _as_list(payload.get("recommendations")):
+        lines.append(f"- `{command}`")
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            str(payload.get("automation_reason", "")),
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _render(payload: dict[str, Any], output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if output_format == "md":
+        return render_markdown(payload)
+    return render_text(payload)
+
+
+def _scan(args: argparse.Namespace) -> int:
+    payload = build_sentinel_scan(
+        root=args.root,
+        out_dir=args.out_dir,
+        event_log=args.event_log or None,
+        write=not bool(args.no_write),
+    )
+    sys.stdout.write(_render(payload, str(args.format)))
+    return 0 if bool(payload.get("ok", False)) or bool(args.no_fail) else 1
+
+
+def _watch(args: argparse.Namespace) -> int:
+    iterations = max(1, int(args.iterations))
+    last: dict[str, Any] = {}
+    for index in range(iterations):
+        last = build_sentinel_scan(
+            root=args.root,
+            out_dir=args.out_dir,
+            event_log=args.event_log or None,
+            write=not bool(args.no_write),
+        )
+        if index < iterations - 1:
+            time.sleep(max(0.0, float(args.interval_seconds)))
+    sys.stdout.write(_render(last, str(args.format)))
+    return 0 if bool(last.get("ok", False)) or bool(args.no_fail) else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.adaptive_sentinel",
+        description="Read-only adaptive sentinel scan/watch loop for repo health signals.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    scan = sub.add_parser("scan", help="Run one adaptive sentinel scan")
+    scan.add_argument("--root", default=".")
+    scan.add_argument("--out-dir", default="build/sdetkit/sentinel")
+    scan.add_argument("--event-log", default="")
+    scan.add_argument("--format", choices=["text", "json", "md"], default="text")
+    scan.add_argument("--no-write", action="store_true")
+    scan.add_argument("--no-fail", action="store_true")
+    scan.set_defaults(func=_scan)
+
+    watch = sub.add_parser("watch", help="Run repeated adaptive sentinel scans")
+    watch.add_argument("--root", default=".")
+    watch.add_argument("--out-dir", default="build/sdetkit/sentinel")
+    watch.add_argument("--event-log", default="")
+    watch.add_argument("--interval-seconds", type=float, default=5.0)
+    watch.add_argument("--iterations", type=int, default=3)
+    watch.add_argument("--format", choices=["text", "json", "md"], default="text")
+    watch.add_argument("--no-write", action="store_true")
+    watch.add_argument("--no-fail", action="store_true")
+    watch.set_defaults(func=_watch)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        sys.stderr.write(f"adaptive sentinel: error: {exc}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -442,6 +442,33 @@ Then use stability-aware command discovery:
     adaptive_failure_bundle.add_argument("--fix-rejected", action="store_true")
     adaptive_failure_bundle.add_argument("--false-positive", action="store_true")
     adaptive_failure_bundle.add_argument("--format", choices=["text", "json"], default="text")
+    adaptive_sentinel = adaptive_sub.add_parser(
+        "sentinel",
+        help="Run read-only adaptive sentinel scan/watch control loops",
+    )
+    adaptive_sentinel_sub = adaptive_sentinel.add_subparsers(
+        dest="adaptive_sentinel_cmd", required=True
+    )
+    adaptive_sentinel_scan = adaptive_sentinel_sub.add_parser(
+        "scan", help="Run one adaptive sentinel scan"
+    )
+    adaptive_sentinel_scan.add_argument("--root", default=".")
+    adaptive_sentinel_scan.add_argument("--out-dir", default="build/sdetkit/sentinel")
+    adaptive_sentinel_scan.add_argument("--event-log", default="")
+    adaptive_sentinel_scan.add_argument("--format", choices=["text", "json", "md"], default="text")
+    adaptive_sentinel_scan.add_argument("--no-write", action="store_true")
+    adaptive_sentinel_scan.add_argument("--no-fail", action="store_true")
+    adaptive_sentinel_watch = adaptive_sentinel_sub.add_parser(
+        "watch", help="Run repeated adaptive sentinel scans"
+    )
+    adaptive_sentinel_watch.add_argument("--root", default=".")
+    adaptive_sentinel_watch.add_argument("--out-dir", default="build/sdetkit/sentinel")
+    adaptive_sentinel_watch.add_argument("--event-log", default="")
+    adaptive_sentinel_watch.add_argument("--interval-seconds", type=float, default=5.0)
+    adaptive_sentinel_watch.add_argument("--iterations", type=int, default=3)
+    adaptive_sentinel_watch.add_argument("--format", choices=["text", "json", "md"], default="text")
+    adaptive_sentinel_watch.add_argument("--no-write", action="store_true")
+    adaptive_sentinel_watch.add_argument("--no-fail", action="store_true")
     adaptive_portfolio = adaptive_sub.add_parser(
         "portfolio-rollup",
         help="Roll multiple adaptive diagnosis outputs into a top-risk portfolio report",
@@ -1239,6 +1266,32 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "sdetkit.adaptive_diagnosis_memory",
                     ["summarize", "--db", str(ns.db), "--format", str(ns.format)],
                 )
+        if getattr(ns, "adaptive_cmd", None) == "sentinel":
+            forwarded = [
+                str(ns.adaptive_sentinel_cmd),
+                "--root",
+                str(ns.root),
+                "--out-dir",
+                str(ns.out_dir),
+                "--format",
+                str(ns.format),
+            ]
+            if str(ns.event_log):
+                forwarded.extend(["--event-log", str(ns.event_log)])
+            if getattr(ns, "adaptive_sentinel_cmd", None) == "watch":
+                forwarded.extend(
+                    [
+                        "--interval-seconds",
+                        str(ns.interval_seconds),
+                        "--iterations",
+                        str(ns.iterations),
+                    ]
+                )
+            if bool(getattr(ns, "no_write", False)):
+                forwarded.append("--no-write")
+            if bool(getattr(ns, "no_fail", False)):
+                forwarded.append("--no-fail")
+            return _run_module_main("sdetkit.adaptive_sentinel", forwarded)
         if getattr(ns, "adaptive_cmd", None) == "failure-bundle":
             forwarded = [
                 "--log",

--- a/tests/test_adaptive_sentinel.py
+++ b/tests/test_adaptive_sentinel.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_sentinel, cli
+
+UNKNOWN_REVIEW_REQUIRED = "UNKNOWN" + "_REVIEW" + "_REQUIRED"
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _failure_bundle(root: Path, *, clear: bool = False) -> Path:
+    return _write_json(
+        root / "build/sdetkit/failure-intelligence/failure-intelligence-bundle.json",
+        {
+            "schema_version": "sdetkit.adaptive.failure_bundle.v1",
+            "status": "clear" if clear else "needs_fix",
+            "primary_diagnosis_code": "" if clear else UNKNOWN_REVIEW_REQUIRED,
+            "diagnosis_count": 0 if clear else 1,
+            "review_first": False if clear else True,
+            "safe_to_auto_fix": False,
+            "artifacts": {
+                "operator_brief_markdown": (
+                    root / "build/sdetkit/failure-intelligence/operator-brief.md"
+                ).as_posix(),
+            },
+        },
+    )
+
+
+def test_sentinel_scan_flags_review_first_failure_bundle(tmp_path: Path) -> None:
+    _failure_bundle(tmp_path)
+
+    payload = adaptive_sentinel.build_sentinel_scan(root=tmp_path, write=True)
+
+    assert payload["schema_version"] == "sdetkit.adaptive.sentinel.v1"
+    assert payload["state"] == "critical"
+    assert payload["ok"] is False
+    assert payload["finding_count"] >= 1
+    finding = payload["findings"][0]
+    assert finding["source"] == "adaptive_failure_bundle"
+    assert "review-first" in finding["summary"]
+    joined = "\n".join(payload["recommendations"])
+    assert "investigate failure" in joined
+    assert "doctor --diagnose --failure-bundle" in joined
+    assert (tmp_path / "build/sdetkit/sentinel/sentinel.json").exists()
+    assert (tmp_path / "build/sdetkit/sentinel/sentinel.md").exists()
+    assert (tmp_path / ".sdetkit/adaptive-sentinel/events.jsonl").exists()
+
+
+def test_sentinel_scan_clear_bundle_is_healthy(tmp_path: Path) -> None:
+    _failure_bundle(tmp_path, clear=True)
+
+    payload = adaptive_sentinel.build_sentinel_scan(root=tmp_path, write=False)
+
+    assert payload["state"] == "healthy"
+    assert payload["ok"] is True
+    assert payload["findings"][0]["source"] == "adaptive_failure_bundle"
+    assert "status=clear" in payload["findings"][0]["evidence"]
+
+
+def test_sentinel_cli_route_and_help(tmp_path: Path, capsys) -> None:
+    _failure_bundle(tmp_path)
+
+    rc = cli.main(
+        [
+            "adaptive",
+            "sentinel",
+            "scan",
+            "--root",
+            str(tmp_path),
+            "--out-dir",
+            str(tmp_path / "sentinel"),
+            "--format",
+            "json",
+            "--no-fail",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["state"] == "critical"
+
+    try:
+        cli.main(["adaptive", "sentinel", "--help"])
+    except SystemExit as exc:
+        assert exc.code == 0
+    help_out = capsys.readouterr().out
+    assert "scan" in help_out
+    assert "watch" in help_out
+
+
+def test_sentinel_watch_writes_repeated_events(tmp_path: Path, capsys) -> None:
+    _failure_bundle(tmp_path)
+    event_log = tmp_path / "events.jsonl"
+
+    rc = adaptive_sentinel.main(
+        [
+            "watch",
+            "--root",
+            str(tmp_path),
+            "--out-dir",
+            str(tmp_path / "sentinel"),
+            "--event-log",
+            str(event_log),
+            "--interval-seconds",
+            "0",
+            "--iterations",
+            "2",
+            "--format",
+            "json",
+            "--no-fail",
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["state"] == "critical"
+    assert len(event_log.read_text(encoding="utf-8").splitlines()) == 2
+
+
+def test_sentinel_render_markdown_contains_boundary(tmp_path: Path) -> None:
+    _failure_bundle(tmp_path)
+    payload = adaptive_sentinel.build_sentinel_scan(root=tmp_path, write=False)
+
+    rendered = adaptive_sentinel.render_markdown(payload)
+
+    assert "# Adaptive Sentinel" in rendered
+    assert "Recommended next commands" in rendered
+    assert "read-only" in rendered


### PR DESCRIPTION
## Summary
- Add `sdetkit adaptive sentinel scan`.
- Add `sdetkit adaptive sentinel watch`.
- Read repo health signals from adaptive failure bundles, investigation artifacts, Doctor Cortex outputs, Mission Control, quality verdicts, and git status.
- Emit durable sentinel evidence:
  - `build/sdetkit/sentinel/sentinel.json`
  - `build/sdetkit/sentinel/sentinel.md`
  - `.sdetkit/adaptive-sentinel/events.jsonl`
- Classify repo state as `healthy`, `watch`, `warning`, or `critical`.
- Recommend exact next commands for investigation, Doctor Cortex, Mission Control, and quality proof.
- Keep the sentinel read-only: no branch creation, no commits, no auto-fix.

## Why
The adaptive diagnosis chain previously worked as a batch/operator-triggered flow. This PR adds the first always-scanning sentinel control loop so SDETKit can behave more like an antivirus-style repo health monitor: detect, classify, explain, recommend, and record evidence.

## Verification
- `python -m pytest -q tests/test_adaptive_sentinel.py tests/test_adaptive_failure_bundle.py tests/test_adaptive_diagnosis.py tests/test_doctor_cli_failure_bundle_input.py tests/test_investigate_failure.py tests/test_mission_control_adaptive_failure_bundle.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `bash quality.sh cov`

## Proof result
- Full quality run: 3205 passed, 1 skipped, 3 deselected
- Coverage: 96.69%
- Blocking failures: none
- Merge/release recommendation: ready-for-merge-review

## Risk
Medium.
- New module and CLI surface.
- Read-only behavior only.
- No workflow changes.
- No auto-fix behavior.
- Sentinel evidence is generated under build/.sdetkit paths.

## Rollback
Revert this PR to remove `adaptive sentinel scan/watch`, the CLI routing, and sentinel tests.