### PR TITLE
Run adaptive sentinel in PR quality workflow

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -47,12 +47,46 @@ jobs:
               --format text
           fi
 
+      - name: Run adaptive sentinel scan
+        if: always()
+        run: |
+          mkdir -p build/sdetkit/sentinel
+          PYTHONPATH=src python -m sdetkit adaptive sentinel scan \
+            --root . \
+            --out-dir build/sdetkit/sentinel \
+            --format text \
+            --no-fail
+
       - name: Build PR comment body
         run: |
           mkdir -p build/pr-quality
           coverage_line="$(grep -E 'Total coverage: [0-9]+\.[0-9]+%' quality.log | tail -n1 || true)"
           coverage_pct="$(echo "$coverage_line" | sed -E 's/.*Total coverage: ([0-9]+\.[0-9]+)%.*/\1/' || true)"
           [ -z "$coverage_pct" ] && coverage_pct="unknown"
+
+          sentinel_state="unknown"
+          if [ -s build/sdetkit/sentinel/sentinel.json ]; then
+            sentinel_state="$(python -c "import json; from pathlib import Path; p=Path('build/sdetkit/sentinel/sentinel.json'); print(json.loads(p.read_text(encoding='utf-8')).get('state', 'unknown'))" 2>/dev/null || echo unknown)"
+          fi
+
+          append_sentinel_summary() {
+            if [ "$sentinel_state" = "warning" ] || [ "$sentinel_state" = "critical" ]; then
+              echo ''
+              echo '### Adaptive Sentinel'
+              echo "- state: \`${sentinel_state}\`"
+              echo '- evidence: `build/sdetkit/sentinel/sentinel.json`'
+              echo '- markdown: `build/sdetkit/sentinel/sentinel.md`'
+              if [ -s build/sdetkit/sentinel/sentinel.md ]; then
+                echo ''
+                echo '**Recommended next commands:**'
+                awk '
+                  /^## Recommended next commands/ {flag=1; next}
+                  /^## Boundary/ {flag=0}
+                  flag && /^- `/ {print; count++; if (count >= 3) exit}
+                ' build/sdetkit/sentinel/sentinel.md || true
+              fi
+            fi
+          }
 
           if [ "${{ steps.quality.outcome }}" = "success" ]; then
             {
@@ -63,6 +97,7 @@ jobs:
                 echo ''
                 cat build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md
               fi
+              append_sentinel_summary
             } > build/pr-quality/pr-comment-body.md
           else
             {
@@ -73,6 +108,7 @@ jobs:
                 echo ''
                 cat build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md
               fi
+              append_sentinel_summary
             } > build/pr-quality/pr-comment-body.md
           fi
 
@@ -82,6 +118,16 @@ jobs:
         with:
           name: pr-quality-failure-intelligence
           path: build/pr-quality/failure-intelligence/
+          if-no-files-found: ignore
+
+      - name: Upload adaptive sentinel artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: pr-quality-adaptive-sentinel
+          path: |
+            build/sdetkit/sentinel/
+            .sdetkit/adaptive-sentinel/
           if-no-files-found: ignore
 
       - name: Comment on PR

--- a/tests/test_pr_quality_adaptive_sentinel_workflow.py
+++ b/tests/test_pr_quality_adaptive_sentinel_workflow.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/pr-quality-comment.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_pr_quality_workflow_runs_adaptive_sentinel_after_failure_bundle() -> None:
+    text = _workflow_text()
+
+    assert "Build adaptive failure intelligence bundle" in text
+    assert "Run adaptive sentinel scan" in text
+    assert text.index("Build adaptive failure intelligence bundle") < text.index(
+        "Run adaptive sentinel scan"
+    )
+    assert "python -m sdetkit adaptive sentinel scan" in text
+    assert "--out-dir build/sdetkit/sentinel" in text
+    assert "--no-fail" in text
+
+
+def test_pr_quality_workflow_comments_warning_or_critical_sentinel_summary() -> None:
+    text = _workflow_text()
+
+    assert 'sentinel_state="unknown"' in text
+    assert 'sentinel_state" = "warning"' in text
+    assert 'sentinel_state" = "critical"' in text
+    assert "### Adaptive Sentinel" in text
+    assert "build/sdetkit/sentinel/sentinel.json" in text
+    assert "build/sdetkit/sentinel/sentinel.md" in text
+    assert "Recommended next commands" in text
+    assert text.count("append_sentinel_summary") >= 3
+
+
+def test_pr_quality_workflow_uploads_adaptive_sentinel_artifacts() -> None:
+    text = _workflow_text()
+
+    assert "Upload adaptive sentinel artifacts" in text
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in text
+    assert "name: pr-quality-adaptive-sentinel" in text
+    assert "build/sdetkit/sentinel/" in text
+    assert ".sdetkit/adaptive-sentinel/" in text


### PR DESCRIPTION
## Summary
- Run `python -m sdetkit adaptive sentinel scan --no-fail` in the PR Quality Comment workflow.
- Run Sentinel after the adaptive failure intelligence bundle is built.
- Add a PR comment block when Sentinel reports `warning` or `critical`.
- Upload Sentinel artifacts:
  - `build/sdetkit/sentinel/`
  - `.sdetkit/adaptive-sentinel/`
- Add workflow contract coverage for Sentinel execution, PR comment visibility, and artifact upload.

## Why
The adaptive sentinel now exists as a local scan/watch control loop. This PR connects it to the PR quality workflow so every PR lane gets an advisory repo-health scan and durable Sentinel evidence.

## Verification
- `python -m pytest -q tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_pr_quality_comment.py tests/test_adaptive_sentinel.py tests/test_github_actions_annotation_hygiene.py tests/test_workflow_template_hygiene.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `bash quality.sh cov`

## Proof result
- Full quality run: 3208 passed, 1 skipped, 3 deselected
- Coverage: 96.69%
- Blocking failures: none
- Merge/release recommendation: ready-for-merge-review

## Risk
Medium-low.
- Workflow-only integration.
- Sentinel is advisory and non-blocking via `--no-fail`.
- No branch mutation.
- No auto-fix.
- No scheduled daemon.

## Rollback
Revert this PR to remove the PR quality Sentinel step, Sentinel artifact upload, and workflow contract tests.