### PR TITLE
Add scheduled adaptive sentinel monitor workflow

### DIFF
--- a/.github/workflows/adaptive-sentinel-monitor.yml
+++ b/.github/workflows/adaptive-sentinel-monitor.yml
@@ -1,0 +1,74 @@
+name: Adaptive Sentinel Monitor
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  sentinel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-test.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .
+
+      - name: Run adaptive sentinel monitor
+        run: |
+          mkdir -p build/sdetkit/sentinel
+          PYTHONPATH=src python -m sdetkit adaptive sentinel scan \
+            --root . \
+            --out-dir build/sdetkit/sentinel \
+            --format json \
+            --no-fail \
+            > build/sdetkit/sentinel/sentinel.stdout.json
+
+      - name: Write adaptive sentinel summary
+        if: always()
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          path = Path("build/sdetkit/sentinel/sentinel.json")
+          payload = {}
+          if path.exists():
+              payload = json.loads(path.read_text(encoding="utf-8"))
+
+          print("## Adaptive Sentinel Monitor")
+          print()
+          print(f"- state: `{payload.get('state', 'unknown')}`")
+          print(f"- ok: `{str(payload.get('ok', False)).lower()}`")
+          print(f"- finding count: `{payload.get('finding_count', 0)}`")
+          print(f"- sentinel json: `build/sdetkit/sentinel/sentinel.json`")
+          print(f"- sentinel markdown: `build/sdetkit/sentinel/sentinel.md`")
+          print()
+          print("### Top recommendations")
+          for command in payload.get("recommendations", [])[:5]:
+              print(f"- `{command}`")
+          if not payload.get("recommendations"):
+              print("- No sentinel recommendations were emitted.")
+          PY
+
+      - name: Upload adaptive sentinel monitor artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: adaptive-sentinel-monitor
+          path: |
+            build/sdetkit/sentinel/
+            .sdetkit/adaptive-sentinel/
+          if-no-files-found: ignore

--- a/tests/test_scheduled_adaptive_sentinel_monitor_workflow.py
+++ b/tests/test_scheduled_adaptive_sentinel_monitor_workflow.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/adaptive-sentinel-monitor.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_scheduled_adaptive_sentinel_monitor_triggers_are_safe() -> None:
+    text = _workflow_text()
+
+    assert "name: Adaptive Sentinel Monitor" in text
+    assert "workflow_dispatch:" in text
+    assert "schedule:" in text
+    assert "cron:" in text
+    assert "permissions:" in text
+    assert "contents: read" in text
+
+
+def test_scheduled_adaptive_sentinel_monitor_runs_read_only_scan() -> None:
+    text = _workflow_text()
+
+    assert "python -m sdetkit adaptive sentinel scan" in text
+    assert "--root ." in text
+    assert "--out-dir build/sdetkit/sentinel" in text
+    assert "--format json" in text
+    assert "--no-fail" in text
+    assert "--no-write" not in text
+    assert "git push" not in text
+    assert "commit-safe-fixes" not in text
+    assert "auto-remediate" not in text
+
+
+def test_scheduled_adaptive_sentinel_monitor_uploads_artifacts_and_summary() -> None:
+    text = _workflow_text()
+
+    assert "GITHUB_STEP_SUMMARY" in text
+    assert "Adaptive Sentinel Monitor" in text
+    assert "build/sdetkit/sentinel/sentinel.json" in text
+    assert "build/sdetkit/sentinel/sentinel.md" in text
+    assert "Upload adaptive sentinel monitor artifacts" in text
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in text
+    assert "name: adaptive-sentinel-monitor" in text
+    assert "build/sdetkit/sentinel/" in text
+    assert ".sdetkit/adaptive-sentinel/" in text
+
+
+def test_scheduled_adaptive_sentinel_monitor_uses_existing_ci_install_pattern() -> None:
+    text = _workflow_text()
+
+    assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" in text
+    assert "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405" in text
+    assert 'python-version: "3.12"' in text
+    assert "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ." in text


### PR DESCRIPTION
## Summary
- Add `.github/workflows/adaptive-sentinel-monitor.yml`.
- Run Adaptive Sentinel on:
  - `workflow_dispatch`
  - scheduled cron every 6 hours
- Execute `python -m sdetkit adaptive sentinel scan --format json --no-fail`.
- Write a GitHub step summary with Sentinel state, finding count, artifact paths, and top recommendations.
- Upload Sentinel monitor artifacts:
  - `build/sdetkit/sentinel/`
  - `.sdetkit/adaptive-sentinel/`
- Add workflow contract tests for triggers, read-only behavior, summary output, artifact upload, and CI install pattern.

## Why
Sentinel now runs inside the PR quality lane. This PR adds a scheduled/manual main-branch monitor so SDETKit has an always-on advisory health scan, closer to the antivirus-style behavior we want.

## Verification
- `python -m pytest -q tests/test_scheduled_adaptive_sentinel_monitor_workflow.py tests/test_github_setup_python_pinning.py tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_adaptive_sentinel.py tests/test_workflow_template_hygiene.py tests/test_github_actions_annotation_hygiene.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `bash quality.sh cov`

## Proof result
- Full quality run: 3213 passed, 3 deselected
- Coverage: 96.69%
- Blocking failures: none
- Merge/release recommendation: ready-for-merge-review

## Risk
Medium-low.
- Workflow-only addition.
- Sentinel remains advisory and non-blocking via `--no-fail`.
- No branch mutation.
- No issue creation.
- No commits.
- No auto-fix.

## Rollback
Revert this PR to remove the scheduled Sentinel monitor workflow and its workflow contract tests.