### PR TITLE
Summarize evidence graph in PR quality comments

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -40,10 +40,14 @@ jobs:
         run: |
           mkdir -p build/pr-quality/failure-intelligence
           if [ -f quality.log ]; then
+            proof_flag="--proof-failed"
+            if [ "${{ steps.quality.outcome }}" = "success" ]; then
+              proof_flag="--proof-passed"
+            fi
             PYTHONPATH=src python -m sdetkit adaptive failure-bundle \
               --log quality.log \
               --out-dir build/pr-quality/failure-intelligence \
-              --proof-failed \
+              "${proof_flag}" \
               --format text
           fi
 
@@ -57,6 +61,14 @@ jobs:
             --format text \
             --no-fail
 
+      - name: Build PR evidence graph
+        if: always()
+        run: |
+          mkdir -p build/sdetkit/evidence-graph
+          PYTHONPATH=src python -m sdetkit.evidence_graph \
+            --sentinel-control-room build/sdetkit/sentinel/control-room.json \
+            --out-dir build/sdetkit/evidence-graph
+
       - name: Build PR comment body
         run: |
           mkdir -p build/pr-quality
@@ -68,6 +80,58 @@ jobs:
           if [ -s build/sdetkit/sentinel/sentinel.json ]; then
             sentinel_state="$(python -c "import json; from pathlib import Path; p=Path('build/sdetkit/sentinel/sentinel.json'); print(json.loads(p.read_text(encoding='utf-8')).get('state', 'unknown'))" 2>/dev/null || echo unknown)"
           fi
+
+          write_evidence_graph_summary() {
+            python - <<'PY' > build/pr-quality/evidence-graph-summary.md
+          import json
+          from pathlib import Path
+
+          path = Path("build/sdetkit/evidence-graph/evidence-graph.json")
+          if not path.exists():
+              raise SystemExit(0)
+
+          payload = json.loads(path.read_text(encoding="utf-8"))
+          nodes = payload.get("nodes", [])
+          if not isinstance(nodes, list) or not nodes:
+              raise SystemExit(0)
+
+          sources = payload.get("source_summary", [])
+          if not isinstance(sources, list):
+              sources = []
+
+          review_first = sum(
+              1 for node in nodes
+              if isinstance(node, dict) and bool(node.get("review_first", False))
+          )
+          critical = sum(
+              1 for node in nodes
+              if isinstance(node, dict) and str(node.get("severity", "")) == "critical"
+          )
+          surfaces = sorted(
+              {
+                  str(node.get("risk_surface", "unknown") or "unknown")
+                  for node in nodes
+                  if isinstance(node, dict)
+              }
+          )
+
+          print("### Evidence Graph")
+          print(f"- active findings: `{len(nodes)}`")
+          print(f"- review-first findings: `{review_first}`")
+          print(f"- critical findings: `{critical}`")
+          print(f"- source count: `{len(sources)}`")
+          print(f"- risk surfaces: `{', '.join(surfaces) or 'none'}`")
+          print("- graph: `build/sdetkit/evidence-graph/evidence-graph.json`")
+          print("- markdown: `build/sdetkit/evidence-graph/evidence-graph.md`")
+          PY
+          }
+
+          append_adaptive_diagnosis_comment() {
+            if [ -s build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md ]; then
+              echo ''
+              cat build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md
+            fi
+          }
 
           append_sentinel_summary() {
             if [ "$sentinel_state" = "warning" ] || [ "$sentinel_state" = "critical" ]; then
@@ -88,27 +152,31 @@ jobs:
             fi
           }
 
+          append_evidence_graph_summary() {
+            if [ -s build/pr-quality/evidence-graph-summary.md ]; then
+              echo ''
+              cat build/pr-quality/evidence-graph-summary.md
+            fi
+          }
+
+          write_evidence_graph_summary
+
           if [ "${{ steps.quality.outcome }}" = "success" ]; then
             {
               echo '✅ quality.sh cov passed'
               echo "- coverage: ${coverage_pct}%"
               echo '- checks: lint + tests + coverage gate are green for this PR run'
-              if [ -s build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md ]; then
-                echo ''
-                cat build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md
-              fi
               append_sentinel_summary
+              append_evidence_graph_summary
             } > build/pr-quality/pr-comment-body.md
           else
             {
               echo '❌ quality.sh cov failed (see workflow logs for details)'
               echo "- coverage (last reported): ${coverage_pct}%"
               echo '- suggested fix: run `python -m pip install -c constraints-ci.txt -r requirements-test.txt -e . && bash quality.sh cov` locally'
-              if [ -s build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md ]; then
-                echo ''
-                cat build/pr-quality/failure-intelligence/adaptive-diagnosis-comment.md
-              fi
+              append_adaptive_diagnosis_comment
               append_sentinel_summary
+              append_evidence_graph_summary
             } > build/pr-quality/pr-comment-body.md
           fi
 

--- a/tests/test_pr_quality_adaptive_sentinel_workflow.py
+++ b/tests/test_pr_quality_adaptive_sentinel_workflow.py
@@ -43,3 +43,21 @@ def test_pr_quality_workflow_uploads_adaptive_sentinel_artifacts() -> None:
     assert "name: pr-quality-adaptive-sentinel" in text
     assert "build/sdetkit/sentinel/" in text
     assert ".sdetkit/adaptive-sentinel/" in text
+
+
+def test_pr_quality_workflow_builds_evidence_graph_from_sentinel_control_room() -> None:
+    text = _workflow_text()
+
+    assert "Build PR evidence graph" in text
+    assert "python -m sdetkit.evidence_graph" in text
+    assert "--sentinel-control-room build/sdetkit/sentinel/control-room.json" in text
+    assert "--out-dir build/sdetkit/evidence-graph" in text
+    assert "### Evidence Graph" in text
+    assert "build/sdetkit/evidence-graph/evidence-graph.json" in text
+    assert "build/sdetkit/evidence-graph/evidence-graph.md" in text
+
+
+def test_pr_quality_workflow_uploads_evidence_graph_artifacts() -> None:
+    text = _workflow_text()
+
+    assert "build/sdetkit/evidence-graph/" in text

--- a/tests/test_pr_quality_failure_bundle_workflow.py
+++ b/tests/test_pr_quality_failure_bundle_workflow.py
@@ -37,3 +37,23 @@ def test_pr_quality_workflow_uploads_failure_intelligence_bundle() -> None:
     assert "name: pr-quality-failure-intelligence" in text
     assert "path: build/pr-quality/failure-intelligence/" in text
     assert "if-no-files-found: ignore" in text
+
+
+def test_pr_quality_workflow_sets_failure_bundle_proof_from_quality_outcome() -> None:
+    text = _workflow_text()
+
+    assert 'proof_flag="--proof-failed"' in text
+    assert 'proof_flag="--proof-passed"' in text
+    assert "steps.quality.outcome" in text
+
+
+def test_pr_quality_success_comment_does_not_reprint_adaptive_diagnosis() -> None:
+    text = _workflow_text()
+    comment_body = text.split("write_evidence_graph_summary", 1)[1]
+    success_block = comment_body.split(
+        'if [ "${{ steps.quality.outcome }}" = "success" ]; then',
+        1,
+    )[1].split("else", 1)[0]
+
+    assert "adaptive-diagnosis-comment.md" not in success_block
+    assert "append_adaptive_diagnosis_comment" not in success_block


### PR DESCRIPTION
## Summary
- Make the PR Quality failure bundle proof-aware:
  - uses `--proof-passed` when `quality.sh cov` succeeds
  - uses `--proof-failed` when `quality.sh cov` fails
- Stop printing adaptive diagnosis comments in the green success path.
- Build a PR evidence graph from Sentinel control-room output.
- Append an Evidence Graph summary when active graph findings exist.
- Upload evidence graph artifacts with the PR Quality artifacts.
- Add focused workflow contract tests.

## Why
The previous PR Quality comment could say coverage passed while also printing a stale adaptive diagnosis such as `COVERAGE_GATE_REGRESSION`. This PR prevents that contradiction and routes real review-required signals through Sentinel/evidence graph evidence instead.

## Verification
- `python -m pytest -q tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_adaptive_quality_gate_advisory_alignment.py tests/test_adaptive_failure_bundle.py tests/test_evidence_graph.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Workflow-only behavior change.
- Rollback: revert the workflow and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Green coverage comments no longer reprint adaptive diagnosis blocks.