### PR TITLE
Improve evidence graph risk-surface classification

### DIFF
--- a/src/sdetkit/evidence_graph.py
+++ b/src/sdetkit/evidence_graph.py
@@ -78,6 +78,8 @@ _REVIEW_FIRST_SURFACES = {
     "cli",
     "package",
     "diagnostic_engine",
+    "pr_quality",
+    "quality",
     "unknown",
 }
 
@@ -92,6 +94,8 @@ _VALID_SURFACES = {
     "package",
     "diagnostic_engine",
     "maintenance",
+    "pr_quality",
+    "quality",
     "unknown",
 }
 
@@ -360,7 +364,16 @@ def _normalize_finding(
     proof_commands = _string_list(
         finding.get("proof_commands") or finding.get("verification_commands")
     )
-    risk_surface = _risk_surface(finding, owner_files, title, summary)
+    risk_surface = _risk_surface(
+        source,
+        finding,
+        owner_files,
+        source_artifacts,
+        recommended_commands,
+        proof_commands,
+        title,
+        summary,
+    )
     review_first = _bool(
         finding.get("review_first"),
         default=risk_surface in _REVIEW_FIRST_SURFACES or severity == "critical",
@@ -435,17 +448,45 @@ def _severity(finding: JsonObject) -> str:
 
 
 def _risk_surface(
+    source: SourceName,
     finding: JsonObject,
     owner_files: list[str],
+    source_artifacts: list[str],
+    recommended_commands: list[str],
+    proof_commands: list[str],
     title: str,
     summary: str,
 ) -> str:
-    explicit = _text(finding, "risk_surface", "surface", "category", default="")
+    explicit = _text(finding, "risk_surface", "surface", "category", default="").lower()
     if explicit in _VALID_SURFACES:
         return explicit
 
-    haystack = " ".join([title, summary, *owner_files]).lower()
+    haystack = " ".join(
+        [
+            source,
+            title,
+            summary,
+            *owner_files,
+            *source_artifacts,
+            *recommended_commands,
+            *proof_commands,
+        ]
+    ).lower()
 
+    if "pr-quality-comment.yml" in haystack or "pr quality" in haystack or "pr-quality" in haystack:
+        return "pr_quality"
+    if (
+        "quality.sh" in haystack
+        or "coverage" in haystack
+        or "quality verdict" in haystack
+        or "cov passed" in haystack
+        or "cov failed" in haystack
+        or "pre_commit" in haystack
+        or "pre-commit" in haystack
+        or "ruff" in haystack
+        or "mypy" in haystack
+    ):
+        return "quality"
     if ".github/workflows" in haystack or "workflow" in haystack:
         return "workflow"
     if "requirements" in haystack or "constraints" in haystack:
@@ -462,7 +503,15 @@ def _risk_surface(
         return "docs"
     if "pyproject.toml" in haystack or "package" in haystack:
         return "package"
-    if "doctor" in haystack or "diagnos" in haystack:
+    if (
+        "doctor" in haystack
+        or "diagnos" in haystack
+        or "sentinel" in haystack
+        or "control-room" in haystack
+        or "evidence graph" in haystack
+        or "evidence-graph" in haystack
+        or "evidence_graph" in haystack
+    ):
         return "diagnostic_engine"
     if "maintenance" in haystack:
         return "maintenance"

--- a/tests/test_evidence_graph.py
+++ b/tests/test_evidence_graph.py
@@ -201,3 +201,90 @@ def test_evidence_graph_docs_describe_advisory_artifacts() -> None:
     assert "automation_allowed_now=false" in docs
     assert "does not auto-fix" in docs
     assert "review_first=true" in docs
+
+
+def test_evidence_graph_classifies_quality_verdict_without_owner_files(
+    tmp_path: Path,
+) -> None:
+    control_room = tmp_path / "control-room.json"
+    control_room.write_text(
+        json.dumps(
+            {
+                "status": "attention_required",
+                "active_threats": [
+                    {
+                        "title": "Quality verdict signal",
+                        "summary": "blocking_failures=coverage",
+                        "severity": "warning",
+                        "recommended_commands": ["bash quality.sh cov"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    graph = build_evidence_graph(sentinel_control_room=control_room)
+
+    assert graph["nodes"][0]["risk_surface"] == "quality"
+    assert graph["nodes"][0]["review_first"] is True
+
+
+def test_evidence_graph_classifies_pr_quality_workflow_signal(
+    tmp_path: Path,
+) -> None:
+    control_room = tmp_path / "control-room.json"
+    control_room.write_text(
+        json.dumps(
+            {
+                "status": "attention_required",
+                "active_threats": [
+                    {
+                        "title": "PR Quality comment workflow changed",
+                        "summary": "The PR Quality evidence comment path changed.",
+                        "severity": "warning",
+                        "owner_files": [".github/workflows/pr-quality-comment.yml"],
+                        "recommended_commands": [
+                            "python -m pytest -q tests/test_pr_quality_adaptive_sentinel_workflow.py -o addopts="
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    graph = build_evidence_graph(sentinel_control_room=control_room)
+
+    assert graph["nodes"][0]["risk_surface"] == "pr_quality"
+    assert graph["nodes"][0]["review_first"] is True
+
+
+def test_evidence_graph_classifies_diagnostic_artifacts_from_source_paths(
+    tmp_path: Path,
+) -> None:
+    control_room = tmp_path / "control-room.json"
+    control_room.write_text(
+        json.dumps(
+            {
+                "status": "attention_required",
+                "active_threats": [
+                    {
+                        "title": "Control-room evidence needs review",
+                        "summary": "Sentinel emitted a control-room finding.",
+                        "severity": "warning",
+                        "source_artifacts": [
+                            "build/sdetkit/sentinel/control-room.json",
+                            "build/sdetkit/evidence-graph/evidence-graph.json",
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    graph = build_evidence_graph(sentinel_control_room=control_room)
+
+    assert graph["nodes"][0]["risk_surface"] == "diagnostic_engine"
+    assert graph["nodes"][0]["review_first"] is True


### PR DESCRIPTION
## Summary
- Add evidence graph risk surfaces for PR Quality and quality-gate findings.
- Classify PR Quality workflow/comment signals as `pr_quality`.
- Classify coverage, quality.sh, Ruff, mypy, and pre-commit signals as `quality`.
- Classify Sentinel/control-room/evidence-graph artifact signals as `diagnostic_engine`.
- Add focused regression tests for previously unknown-style cases.

## Why
PR Quality now summarizes the evidence graph, but PR-only findings could surface as `risk surfaces: unknown`. This improves operator value without changing automation policy.

## Verification
- `python -m pytest -q tests/test_evidence_graph.py -o addopts=`
- `python -m pytest -q tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py -o addopts=`
- `python -m pytest -q tests/test_mission_control_evidence_graph.py -o addopts=`
- `python -m pytest -q tests/test_adaptive_sentinel.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low to medium.
- Classification-only diagnostic behavior.
- Rollback: revert classifier rules and focused tests.

## Notes
- Advisory/read-only only.
- Keeps automation disabled.
- Does not auto-fix, auto-commit, auto-push, auto-merge, or weaken checks.