### PR TITLE
Polish adaptive PR quality narrative

### DIFF
--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -52,6 +52,37 @@ _SURFACE_REASON = {
 }
 
 
+_GREEN_PROOF_BY_SURFACE = {
+    "pr_quality": [
+        "python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py -o addopts=",
+    ],
+    "diagnostic_engine": [
+        "python -m pytest -q tests/test_evidence_graph.py tests/test_adaptive_sentinel.py -o addopts=",
+    ],
+    "quality": [
+        "python -m pytest -q tests/test_adaptive_quality_gate_advisory_alignment.py tests/test_adaptive_failure_bundle.py -o addopts=",
+    ],
+    "workflow": [
+        "python -m pytest -q tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py -o addopts=",
+    ],
+    "dependency": [
+        "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+    ],
+    "security": [
+        "python -m sdetkit security check --root . --format json",
+    ],
+    "release": [
+        "python -m build && python -m twine check dist/*",
+    ],
+    "package": [
+        "python -m build && python -m twine check dist/*",
+    ],
+    "docs": [
+        "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict",
+    ],
+}
+
+
 def _read_text(path: Path | None) -> str:
     if path is None or not path.exists():
         return ""
@@ -217,6 +248,69 @@ def _surface_for_failure(failure: JsonObject) -> str:
     return "unknown"
 
 
+def _operator_relevant_nodes(nodes: list[JsonObject]) -> list[JsonObject]:
+    filtered: list[JsonObject] = []
+    for node in nodes:
+        title = str(node.get("title", "")).lower()
+        summary = str(node.get("summary", "")).lower()
+        if "working tree has local changes" in title:
+            continue
+        if "keep proof tied to the current diff" in summary:
+            continue
+        filtered.append(node)
+    return filtered
+
+
+def _surface_label(surface: str) -> str:
+    return {
+        "pr_quality": "PR Quality",
+        "diagnostic_engine": "Diagnostic intelligence",
+        "quality": "Quality gate",
+        "workflow": "Workflow",
+        "dependency": "Dependency",
+        "security": "Security",
+        "release": "Release",
+        "package": "Package",
+        "tests": "Test",
+        "docs": "Documentation",
+        "cli": "CLI",
+        "maintenance": "Maintenance",
+    }.get(surface, surface.replace("_", " ").title())
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item and item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def _green_proof_commands(
+    *,
+    changed_surfaces: list[str],
+    changed_files: list[str],
+    nodes: list[JsonObject],
+) -> list[str]:
+    surfaces = list(changed_surfaces)
+    for node in nodes:
+        surface = str(node.get("risk_surface", "unknown") or "unknown")
+        if surface not in surfaces:
+            surfaces.append(surface)
+
+    commands: list[str] = []
+    for surface in surfaces:
+        commands.extend(_GREEN_PROOF_BY_SURFACE.get(surface, []))
+
+    if not commands and changed_files:
+        commands.append("python -m pytest -q tests/test_evidence_graph.py -o addopts=")
+
+    commands.append("python -m pre_commit run -a")
+    return _dedupe(commands)[:5]
+
+
 def _commands_from_failure(failure: JsonObject) -> list[str]:
     commands = _string_list(failure.get("proof_commands"))
     if commands:
@@ -272,7 +366,8 @@ def build_narrative(
     coverage = _coverage_percent(log_text)
     quality_ok = _quality_passed(quality_outcome, log_text)
     nodes = _graph_nodes(_read_json(evidence_graph))
-    primary_node = _primary_node(nodes)
+    relevant_nodes = _operator_relevant_nodes(nodes)
+    primary_node = _primary_node(relevant_nodes or nodes)
     changed = _load_changed_files(changed_files)
     changed_surfaces = _changed_file_surfaces(changed)
     failure_payload = _fallback_failure_bundle(failure_bundle)
@@ -290,6 +385,14 @@ def build_narrative(
         primary_kind = "actual_failure"
         primary_surface = _surface_for_failure(failure)
         primary_title = str(failure.get("title") or failure.get("code") or "Quality failure")
+    elif quality_ok and (changed_surfaces or primary_node):
+        primary_kind = "review_signal"
+        primary_surface = (
+            changed_surfaces[0]
+            if changed_surfaces
+            else str(primary_node.get("risk_surface", "unknown") or "unknown")
+        )
+        primary_title = f"{_surface_label(primary_surface)} evidence changed"
     elif primary_node:
         primary_kind = "review_signal"
         primary_surface = str(primary_node.get("risk_surface", "unknown") or "unknown")
@@ -299,14 +402,24 @@ def build_narrative(
         primary_surface = changed_surfaces[0] if changed_surfaces else "quality"
         primary_title = "Quality gate passed"
 
-    commands = _commands_from_failure(failure) if failure else _commands_from_nodes(nodes)
+    if failure:
+        commands = _commands_from_failure(failure)
+    elif quality_ok:
+        commands = _green_proof_commands(
+            changed_surfaces=changed_surfaces,
+            changed_files=changed,
+            nodes=relevant_nodes or nodes,
+        )
+    else:
+        commands = _commands_from_nodes(nodes)
+
     if not commands:
-        commands = ["python -m pre_commit run -a", "bash quality.sh cov"]
+        commands = ["python -m pre_commit run -a"]
 
     what_happened = _what_happened(
         quality_ok=quality_ok,
         coverage=coverage,
-        nodes=nodes,
+        nodes=relevant_nodes if quality_ok else nodes,
         changed_files=changed,
         changed_surfaces=changed_surfaces,
         failure=failure,
@@ -315,13 +428,13 @@ def build_narrative(
         quality_ok=quality_ok,
         primary_surface=primary_surface,
         failure=failure,
-        nodes=nodes,
+        nodes=relevant_nodes if quality_ok else nodes,
     )
     operator_action = _operator_action(
         quality_ok=quality_ok,
         primary_surface=primary_surface,
         failure=failure,
-        nodes=nodes,
+        nodes=relevant_nodes if quality_ok else nodes,
     )
     artifact_paths = _artifact_paths(
         quality_log=quality_log,
@@ -467,8 +580,6 @@ def render_markdown(
 ) -> str:
     status = "✅ quality.sh cov passed" if quality_ok else "❌ quality.sh cov failed"
     lines = [
-        "## SDET Quality Gate",
-        "",
         status,
         "",
         f"coverage: {coverage}%",

--- a/tests/test_pr_quality_evidence_narrative.py
+++ b/tests/test_pr_quality_evidence_narrative.py
@@ -213,3 +213,98 @@ def test_renderer_includes_graph_markdown_evidence_when_present(tmp_path: Path) 
     markdown = str(payload["markdown"])
     assert "evidence-graph.json" in markdown
     assert "evidence-graph.md" in markdown
+
+
+def test_green_narrative_prefers_review_surface_proof_over_failure_commands(
+    tmp_path: Path,
+) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "Working tree has local changes",
+                    "summary": "Sentinel detected uncommitted work; keep proof tied to the current diff.",
+                    "risk_surface": "diagnostic_engine",
+                    "severity": "warning",
+                    "recommended_commands": ["git status -sb", "git diff --stat"],
+                },
+                {
+                    "title": "Adaptive failure bundle signal",
+                    "summary": "The PR Quality evidence comment path changed.",
+                    "risk_surface": "pr_quality",
+                    "severity": "warning",
+                    "recommended_commands": [
+                        "python -m sdetkit investigate failure --log build/quality.log --format markdown",
+                        "python -m sdetkit doctor --diagnose --failure-bundle build/pr-quality/failure-intelligence/failure-intelligence-bundle.json --format json",
+                    ],
+                },
+            ],
+            "source_summary": [],
+        },
+    )
+    changed = _write(
+        tmp_path / "changed-files.txt",
+        ".github/workflows/pr-quality-comment.yml\nsrc/sdetkit/pr_quality_evidence_narrative.py\n",
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=None,
+        evidence_graph=graph,
+        failure_bundle=None,
+        changed_files=changed,
+    )
+
+    markdown = str(payload["markdown"])
+    assert markdown.startswith("✅ quality.sh cov passed")
+    assert "## SDET Quality Gate" not in markdown
+    assert payload["primary_signal"]["title"] == "PR Quality evidence changed"
+    assert payload["primary_signal"]["surface"] == "pr_quality"
+    assert "Quality is green, so the review focus is not coverage." in markdown
+    assert "python -m sdetkit investigate failure" not in markdown
+    assert "python -m sdetkit doctor --diagnose" not in markdown
+    assert "git status -sb" not in markdown
+    assert "git diff --stat" not in markdown
+    assert "tests/test_pr_quality_evidence_narrative.py" in markdown
+    assert "python -m pre_commit run -a" in markdown
+
+
+def test_failed_narrative_keeps_failure_bundle_commands(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "coverage gate failed\nProcess completed with exit code 1\n",
+    )
+    bundle = _write_json(
+        tmp_path / "failure-bundle.json",
+        {
+            "diagnoses": [
+                {
+                    "code": "COVERAGE_GATE_REGRESSION",
+                    "title": "Coverage gate regression",
+                    "diagnosis": "Coverage dropped below the configured threshold.",
+                    "proof_commands": ["bash quality.sh cov"],
+                }
+            ]
+        },
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="failure",
+        sentinel_control_room=None,
+        evidence_graph=None,
+        failure_bundle=bundle,
+        changed_files=None,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["kind"] == "actual_failure"
+    assert "Coverage gate regression" in markdown
+    assert "bash quality.sh cov" in markdown


### PR DESCRIPTION
## Summary
- Remove the duplicate `SDET Quality Gate` heading from renderer output.
- Make green PR narratives select review-surface proof instead of failure-investigation commands.
- De-prioritize noisy working-tree Sentinel findings in green mode.
- Keep failure-bundle proof commands only when quality actually fails.
- Add focused regression tests for green-vs-failed narrative behavior.

## Why
The adaptive PR Quality comment now reads real artifacts, but green PRs should not behave like failure triage. When `quality.sh cov` passes, the comment should focus on the changed risk surface and relevant proof, not failure-bundle investigation commands.

## Verification
- `python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_adaptive_quality_gate_advisory_alignment.py tests/test_adaptive_failure_bundle.py tests/test_evidence_graph.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low to medium.
- Renderer-only behavior change.
- Rollback: revert renderer polish helpers and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Coverage remains a proof signal, not the main diagnosis.