### PR TITLE
Humanize adaptive PR quality findings

### DIFF
--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -482,6 +482,72 @@ def build_narrative(
     return payload
 
 
+_GENERIC_FINDING_TITLES = {
+    "adaptive failure bundle signal",
+    "failure bundle signal",
+    "evidence graph finding",
+    "working tree has local changes",
+}
+
+
+def _generic_finding_title(title: str) -> bool:
+    normalized = title.strip().lower()
+    return normalized in _GENERIC_FINDING_TITLES or normalized.endswith(" signal")
+
+
+def _changed_files_include(changed_files: list[str], *needles: str) -> bool:
+    lowered_files = [path.lower() for path in changed_files]
+    return any(needle.lower() in path for needle in needles for path in lowered_files)
+
+
+def _human_finding_title(
+    node: JsonObject,
+    *,
+    changed_files: list[str],
+    changed_surfaces: list[str],
+) -> str:
+    raw_title = str(node.get("title", "") or "").strip()
+    surface = str(node.get("risk_surface", "unknown") or "unknown")
+
+    if raw_title and not _generic_finding_title(raw_title):
+        return raw_title
+
+    if surface == "pr_quality" or _changed_files_include(
+        changed_files,
+        "pr-quality",
+        "pr_quality_evidence_narrative",
+    ):
+        return "PR Quality evidence changed"
+
+    if surface == "diagnostic_engine" or _changed_files_include(
+        changed_files,
+        "evidence_graph",
+        "evidence-graph",
+        "adaptive_sentinel",
+        "sentinel",
+        "mission_control",
+    ):
+        return "Diagnostic intelligence evidence changed"
+
+    if surface == "quality" or _changed_files_include(
+        changed_files,
+        "quality.sh",
+        "pre_commit",
+        "pre-commit",
+        "ruff",
+        "mypy",
+    ):
+        return "Quality gate evidence changed"
+
+    if surface in changed_surfaces:
+        return f"{_surface_label(surface)} evidence changed"
+
+    if surface != "unknown":
+        return f"{_surface_label(surface)} evidence changed"
+
+    return raw_title or "Evidence graph finding"
+
+
 def _what_happened(
     *,
     quality_ok: bool,
@@ -496,20 +562,27 @@ def _what_happened(
         lines.append(f"quality.sh cov passed with coverage {coverage}%.")
     else:
         lines.append(f"quality.sh cov did not pass; last reported coverage is {coverage}%.")
+
     if failure:
         lines.append(
             "The adaptive failure bundle selected "
             f"{failure.get('code', 'an actual failure')} as the primary blocker."
         )
+
     if changed_files:
         preview = ", ".join(changed_files[:5])
         suffix = "" if len(changed_files) <= 5 else f", plus {len(changed_files) - 5} more"
         lines.append(f"The PR diff includes {preview}{suffix}.")
+
     if changed_surfaces:
         lines.append(f"Diff-owned risk surfaces: {', '.join(changed_surfaces)}.")
+
     if nodes:
         titles = [
-            f"{node.get('title', 'finding')} [{node.get('risk_surface', 'unknown')}]"
+            (
+                f"{_human_finding_title(node, changed_files=changed_files, changed_surfaces=changed_surfaces)} "
+                f"[{node.get('risk_surface', 'unknown')}]"
+            )
             for node in nodes[:3]
         ]
         lines.append(
@@ -517,6 +590,7 @@ def _what_happened(
         )
     else:
         lines.append("Evidence graph emitted no active findings.")
+
     return lines
 
 

--- a/tests/test_pr_quality_evidence_narrative.py
+++ b/tests/test_pr_quality_evidence_narrative.py
@@ -308,3 +308,119 @@ def test_failed_narrative_keeps_failure_bundle_commands(tmp_path: Path) -> None:
     assert payload["primary_signal"]["kind"] == "actual_failure"
     assert "Coverage gate regression" in markdown
     assert "bash quality.sh cov" in markdown
+
+
+def test_green_narrative_humanizes_generic_pr_quality_graph_title(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "Adaptive failure bundle signal",
+                    "summary": "The PR Quality evidence comment path changed.",
+                    "risk_surface": "pr_quality",
+                    "severity": "warning",
+                    "recommended_commands": [
+                        "python -m pytest -q tests/test_pr_quality_evidence_narrative.py -o addopts="
+                    ],
+                }
+            ],
+            "source_summary": [],
+        },
+    )
+    changed = _write(
+        tmp_path / "changed-files.txt",
+        ".github/workflows/pr-quality-comment.yml\nsrc/sdetkit/pr_quality_evidence_narrative.py\n",
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=None,
+        evidence_graph=graph,
+        failure_bundle=None,
+        changed_files=changed,
+    )
+
+    markdown = str(payload["markdown"])
+    assert "PR Quality evidence changed [pr_quality]" in markdown
+    assert "Adaptive failure bundle signal [pr_quality]" not in markdown
+
+
+def test_green_narrative_keeps_specific_non_generic_finding_title(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "Security-owned surface changed",
+                    "summary": "A protected security surface needs review.",
+                    "risk_surface": "security",
+                    "severity": "critical",
+                }
+            ],
+            "source_summary": [],
+        },
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=None,
+        evidence_graph=graph,
+        failure_bundle=None,
+        changed_files=None,
+    )
+
+    markdown = str(payload["markdown"])
+    assert "Security-owned surface changed [security]" in markdown
+    assert "Security evidence changed [security]" not in markdown
+
+
+def test_green_narrative_humanizes_diagnostic_graph_title_from_diff(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "Evidence graph finding",
+                    "summary": "The graph renderer changed.",
+                    "risk_surface": "diagnostic_engine",
+                    "severity": "warning",
+                }
+            ],
+            "source_summary": [],
+        },
+    )
+    changed = _write(
+        tmp_path / "changed-files.txt",
+        "src/sdetkit/evidence_graph.py\n",
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=None,
+        evidence_graph=graph,
+        failure_bundle=None,
+        changed_files=changed,
+    )
+
+    markdown = str(payload["markdown"])
+    assert "Diagnostic intelligence evidence changed [diagnostic_engine]" in markdown
+    assert "Evidence graph finding [diagnostic_engine]" not in markdown


### PR DESCRIPTION
## Summary
- Humanize generic evidence graph finding titles in the adaptive PR Quality narrative.
- Convert generic PR Quality graph titles such as `Adaptive failure bundle signal` into `PR Quality evidence changed`.
- Convert generic diagnostic graph titles into `Diagnostic intelligence evidence changed` when the diff points to diagnostic surfaces.
- Preserve specific meaningful titles such as security-owned surface findings.
- Add focused regression tests for generic, specific, and diff-aware finding titles.

## Why
The adaptive PR Quality comment now reads real evidence, but generic graph titles still make the output feel scripted. This PR makes the narrative more operator-readable while preserving the underlying evidence graph data.

## Verification
- `python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_adaptive_quality_gate_advisory_alignment.py tests/test_adaptive_failure_bundle.py tests/test_evidence_graph.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low.
- Renderer-only wording improvement.
- Rollback: revert the human-title helpers and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Keeps specific high-value graph titles intact.