### PR TITLE
Rank real failure domains in PR quality narrative

### DIFF
--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -35,6 +35,23 @@ _SEVERITY_PRIORITY = {
     "unknown": 0,
 }
 
+_FAILURE_SURFACE_PRIORITY = {
+    "security": 100,
+    "dependency": 95,
+    "release": 90,
+    "package": 88,
+    "workflow": 82,
+    "cli": 78,
+    "tests": 75,
+    "pr_quality": 70,
+    "diagnostic_engine": 68,
+    "docs": 60,
+    "quality": 45,
+    "coverage": 30,
+    "unknown": 0,
+}
+
+
 _SURFACE_REASON = {
     "security": "Security evidence affects trust boundaries, credentials, permissions, or supply-chain exposure.",
     "dependency": "Dependency evidence affects whether the repo can install, resolve, and test reproducibly.",
@@ -200,26 +217,89 @@ def _fallback_failure_bundle(path: Path | None) -> JsonObject:
     return {}
 
 
+def _failure_text(failure: JsonObject) -> str:
+    return " ".join(
+        [
+            str(failure.get("code", "")),
+            str(failure.get("title", "")),
+            str(failure.get("diagnosis", "")),
+            str(failure.get("summary", "")),
+            str(failure.get("message", "")),
+            " ".join(_string_list(failure.get("evidence"))),
+            " ".join(_string_list(failure.get("proof_commands"))),
+            " ".join(_string_list(failure.get("recommended_fix"))),
+        ]
+    ).lower()
+
+
+def _failure_priority_surface(failure: JsonObject) -> str:
+    text = _failure_text(failure)
+
+    if any(token in text for token in ("security", "secret", "vulnerability", "cve")):
+        return "security"
+    if any(
+        token in text for token in ("dependency", "resolver", "pip", "constraints", "requirements")
+    ):
+        return "dependency"
+    if any(token in text for token in ("release", "publish", "twine", "dist/", "build backend")):
+        return "release"
+    if any(token in text for token in ("package", "wheel", "sdist", "metadata", "pyproject")):
+        return "package"
+    if any(token in text for token in ("workflow", "github actions", ".github/workflows", "yaml")):
+        return "workflow"
+    if any(token in text for token in ("cli", "argparse", "command", "entry point")):
+        return "cli"
+    if any(token in text for token in ("pytest", "assertion", "test failed", "regression test")):
+        return "tests"
+    if any(token in text for token in ("docs", "mkdocs", "documentation", "nav")):
+        return "docs"
+    if any(token in text for token in ("coverage", "coverage_gate", "coverage gate")):
+        return "coverage"
+    if any(token in text for token in ("ruff", "mypy", "pre-commit", "pre_commit", "quality")):
+        return "quality"
+    return _surface_for_failure(failure)
+
+
+def _failure_score(failure: JsonObject) -> tuple[int, int]:
+    surface = _failure_priority_surface(failure)
+    severity = str(failure.get("severity", failure.get("level", "unknown"))).lower()
+    severity_score = _SEVERITY_PRIORITY.get(severity, 0)
+    return (_FAILURE_SURFACE_PRIORITY.get(surface, 0), severity_score)
+
+
 def _primary_failure(payload: JsonObject) -> JsonObject:
     if not payload:
         return {}
-    diagnoses = _as_list(payload.get("diagnoses"))
-    if diagnoses and isinstance(diagnoses[0], dict):
-        return _as_dict(diagnoses[0])
+
+    candidates: list[JsonObject] = []
+
+    for item in _as_list(payload.get("diagnoses")):
+        if isinstance(item, dict):
+            candidates.append(_as_dict(item))
+
     diagnosis = _as_dict(payload.get("diagnosis"))
-    nested = _as_list(diagnosis.get("diagnoses"))
-    if nested and isinstance(nested[0], dict):
-        return _as_dict(nested[0])
+    for item in _as_list(diagnosis.get("diagnoses")):
+        if isinstance(item, dict):
+            candidates.append(_as_dict(item))
+
     code = str(payload.get("primary_diagnosis_code", "")).strip()
     if code:
-        return {
-            "code": code,
-            "title": str(payload.get("primary_diagnosis_title", code.replace("_", " ").title())),
-            "diagnosis": str(payload.get("summary", "")),
-            "recommended_fix": _string_list(payload.get("recommended_fix")),
-            "proof_commands": _string_list(payload.get("proof_commands")),
-        }
-    return {}
+        candidates.append(
+            {
+                "code": code,
+                "title": str(
+                    payload.get("primary_diagnosis_title", code.replace("_", " ").title())
+                ),
+                "diagnosis": str(payload.get("summary", "")),
+                "recommended_fix": _string_list(payload.get("recommended_fix")),
+                "proof_commands": _string_list(payload.get("proof_commands")),
+            }
+        )
+
+    if not candidates:
+        return {}
+
+    return max(candidates, key=_failure_score)
 
 
 def _surface_for_failure(failure: JsonObject) -> str:

--- a/tests/test_pr_quality_evidence_narrative.py
+++ b/tests/test_pr_quality_evidence_narrative.py
@@ -424,3 +424,183 @@ def test_green_narrative_humanizes_diagnostic_graph_title_from_diff(tmp_path: Pa
     markdown = str(payload["markdown"])
     assert "Diagnostic intelligence evidence changed [diagnostic_engine]" in markdown
     assert "Evidence graph finding [diagnostic_engine]" not in markdown
+
+
+def test_failed_narrative_ranks_dependency_above_coverage_when_both_exist(
+    tmp_path: Path,
+) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov failed\nTotal coverage: 96.69%\nProcess completed with exit code 1\n",
+    )
+    bundle = _write_json(
+        tmp_path / "failure-bundle.json",
+        {
+            "diagnoses": [
+                {
+                    "code": "COVERAGE_GATE_REGRESSION",
+                    "title": "Coverage gate regression",
+                    "diagnosis": "Coverage dropped below threshold.",
+                    "proof_commands": ["bash quality.sh cov"],
+                },
+                {
+                    "code": "PACKAGE_INSTALL_FAILURE",
+                    "title": "Dependency resolver failed",
+                    "diagnosis": "pip could not resolve constraints-ci.txt.",
+                    "proof_commands": [
+                        "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+                    ],
+                },
+            ]
+        },
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="failure",
+        sentinel_control_room=None,
+        evidence_graph=None,
+        failure_bundle=bundle,
+        changed_files=None,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["title"] == "Dependency resolver failed"
+    assert payload["primary_signal"]["surface"] == "dependency"
+    assert "python -m pip install -c constraints-ci.txt" in markdown
+    assert "bash quality.sh cov" not in markdown
+
+
+def test_failed_narrative_ranks_security_above_dependency_and_coverage(
+    tmp_path: Path,
+) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov failed\nProcess completed with exit code 1\n",
+    )
+    bundle = _write_json(
+        tmp_path / "failure-bundle.json",
+        {
+            "diagnoses": [
+                {
+                    "code": "PACKAGE_INSTALL_FAILURE",
+                    "title": "Dependency resolver failed",
+                    "diagnosis": "pip could not resolve requirements.",
+                    "proof_commands": ["python -m pip install -e ."],
+                },
+                {
+                    "code": "SECRET_EXPOSURE",
+                    "title": "Secret exposure detected",
+                    "diagnosis": "A secret-like token was detected in a protected surface.",
+                    "severity": "critical",
+                    "proof_commands": ["python -m sdetkit security check --root . --format json"],
+                },
+                {
+                    "code": "COVERAGE_GATE_REGRESSION",
+                    "title": "Coverage gate regression",
+                    "diagnosis": "Coverage dropped below threshold.",
+                    "proof_commands": ["bash quality.sh cov"],
+                },
+            ]
+        },
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="failure",
+        sentinel_control_room=None,
+        evidence_graph=None,
+        failure_bundle=bundle,
+        changed_files=None,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["title"] == "Secret exposure detected"
+    assert payload["primary_signal"]["surface"] == "security"
+    assert "python -m sdetkit security check --root . --format json" in markdown
+    assert "bash quality.sh cov" not in markdown
+
+
+def test_failed_narrative_ranks_release_above_quality_tooling(
+    tmp_path: Path,
+) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov failed\nProcess completed with exit code 1\n",
+    )
+    bundle = _write_json(
+        tmp_path / "failure-bundle.json",
+        {
+            "diagnoses": [
+                {
+                    "code": "RUFF_FORMAT_DRIFT",
+                    "title": "Ruff format drift",
+                    "diagnosis": "ruff format modified files.",
+                    "proof_commands": ["python -m pre_commit run -a"],
+                },
+                {
+                    "code": "RELEASE_ARTIFACT_INVALID",
+                    "title": "Release artifact failed twine check",
+                    "diagnosis": "twine check failed for dist/*.whl.",
+                    "proof_commands": ["python -m build && python -m twine check dist/*"],
+                },
+            ]
+        },
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="failure",
+        sentinel_control_room=None,
+        evidence_graph=None,
+        failure_bundle=bundle,
+        changed_files=None,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["title"] == "Release artifact failed twine check"
+    assert payload["primary_signal"]["surface"] == "release"
+    assert "python -m build && python -m twine check dist/*" in markdown
+
+
+def test_failed_narrative_ranks_tests_above_coverage_noise(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "FAILED tests/test_real_bug.py::test_behavior\nTotal coverage: 96.69%\n",
+    )
+    bundle = _write_json(
+        tmp_path / "failure-bundle.json",
+        {
+            "diagnoses": [
+                {
+                    "code": "COVERAGE_GATE_REGRESSION",
+                    "title": "Coverage gate regression",
+                    "diagnosis": "Coverage dropped below threshold.",
+                    "proof_commands": ["bash quality.sh cov"],
+                },
+                {
+                    "code": "TEST_ASSERTION_FAILURE",
+                    "title": "Behavior regression test failed",
+                    "diagnosis": "pytest assertion failed in tests/test_real_bug.py.",
+                    "proof_commands": [
+                        "python -m pytest -q tests/test_real_bug.py::test_behavior -o addopts="
+                    ],
+                },
+            ]
+        },
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="failure",
+        sentinel_control_room=None,
+        evidence_graph=None,
+        failure_bundle=bundle,
+        changed_files=None,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["title"] == "Behavior regression test failed"
+    assert payload["primary_signal"]["surface"] == "tests"
+    assert "python -m pytest -q tests/test_real_bug.py::test_behavior -o addopts=" in markdown
+    assert "bash quality.sh cov" not in markdown


### PR DESCRIPTION
## Summary
- Rank actual failure domains before selecting the primary PR Quality narrative blocker.
- Prioritize security, dependency, release/package, workflow, CLI, tests, docs, and real quality-tooling failures above coverage noise.
- Stop first-diagnosis ordering from letting coverage/tooling hide a more serious blocker.
- Add focused regression tests for dependency-over-coverage, security-over-dependency, release-over-format, and tests-over-coverage cases.

## Why
The adaptive PR Quality narrative should diagnose the real blocker, not whichever diagnosis appears first in the bundle. Coverage is proof metadata unless it is truly the primary failure. This moves SDETKit closer to company-grade failure triage across real domains.

## Verification
- `python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_adaptive_quality_gate_advisory_alignment.py tests/test_adaptive_failure_bundle.py tests/test_evidence_graph.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Renderer failure-selection behavior changes.
- Rollback: revert failure-domain priority helpers and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Coverage remains a proof signal unless it is the actual highest-priority blocker.