### PR TITLE
Teach adaptive diagnosis multi-domain log routing

### DIFF
--- a/src/sdetkit/adaptive_diagnosis.py
+++ b/src/sdetkit/adaptive_diagnosis.py
@@ -1288,12 +1288,250 @@ def _append_coverage_gate_regression(
     )
 
 
+def _contains_any(text: str, tokens: Sequence[str]) -> bool:
+    return any(token in text for token in tokens)
+
+
+def _append_multidomain_log_diagnoses(
+    text: str,
+    files: Sequence[str],
+    diagnoses: list[dict[str, Any]],
+) -> None:
+    lower = text.lower()
+
+    if _contains_any(
+        lower,
+        (
+            "resolutionimpossible",
+            "could not find a version that satisfies the requirement",
+            "no matching distribution found",
+            "dependency resolver",
+            "pip's dependency resolver",
+            "conflicting dependencies",
+        ),
+    ):
+        diagnoses.append(
+            _diag(
+                "PACKAGE_INSTALL_FAILURE",
+                "high",
+                "high",
+                "Dependency resolver failed",
+                "The install log shows a dependency resolver or package availability failure before tests could prove behavior.",
+                "Developers often chase coverage or test summaries even though the environment never installed correctly.",
+                [
+                    "matched failure signal: dependency resolver",
+                    *_failure_snippets(text, limit=3),
+                ],
+                [
+                    "Reproduce the exact install lane.",
+                    "Compare pyproject, requirements, constraints, and workflow install commands.",
+                    "Align the smallest dependency surface instead of changing product code.",
+                ],
+                [
+                    "PYTHONPATH=src python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+                    "PYTHONPATH=src python -m pip install -c constraints-ci.txt -e '.[dev,test]'",
+                ],
+                "CI cannot prove product behavior until dependencies resolve.",
+                "dependency-resolver-contract",
+                files=files,
+            )
+        )
+
+    if _contains_any(
+        lower,
+        (
+            "sdetkit-security-gate",
+            "high entropy string",
+            "secret exposure",
+            "secret-like token",
+            "vulnerability detected",
+            "critical vulnerability",
+            "security gate",
+        ),
+    ):
+        diagnoses.append(
+            _diag(
+                "SECURITY_FINDING_REVIEW_REQUIRED",
+                "high",
+                "high",
+                "Security finding requires review",
+                "The log reports a security-sensitive finding that must be reviewed before treating quality or coverage as the blocker.",
+                "Security findings can look like ordinary CI noise, but they protect trust boundaries and release eligibility.",
+                [
+                    "matched failure signal: security finding",
+                    *_failure_snippets(text, limit=3),
+                ],
+                [
+                    "Inspect the security finding and affected surface.",
+                    "Confirm whether the token or vulnerable dependency is real, generated, or test-only.",
+                    "Do not dismiss security evidence from the quality wrapper alone.",
+                ],
+                [
+                    "PYTHONPATH=src python -m pre_commit run -a",
+                ],
+                "Security-sensitive findings can block release even when tests and coverage pass.",
+                "security-review-required",
+                files=files,
+            )
+        )
+
+    if _contains_any(
+        lower,
+        (
+            "twine check",
+            "invaliddistribution",
+            "failed to build",
+            "build backend",
+            "python -m build",
+            "dist/*.whl",
+            "wheel contents",
+        ),
+    ):
+        diagnoses.append(
+            _diag(
+                "RELEASE_ARTIFACT_INVALID",
+                "high",
+                "high",
+                "Release artifact validation failed",
+                "The release/package validation log shows an artifact or build contract failure.",
+                "Release failures are often hidden behind generic quality wrappers, but the owner surface is packaging and distribution.",
+                [
+                    "matched failure signal: release artifact",
+                    *_failure_snippets(text, limit=3),
+                ],
+                [
+                    "Rebuild the package artifacts from a clean workspace.",
+                    "Run package metadata validation before changing tests or coverage.",
+                ],
+                [
+                    "rm -rf dist build/lib build/bdist.*",
+                    "PYTHONPATH=src python -m build && PYTHONPATH=src python -m twine check dist/*",
+                ],
+                "Invalid release artifacts can ship broken metadata or unusable packages.",
+                "release-artifact-contract",
+                files=files,
+            )
+        )
+
+    if _contains_any(
+        lower,
+        (
+            "invalid workflow file",
+            "workflow is not valid",
+            ".github/workflows",
+            "yaml syntax",
+            "mapping values are not allowed",
+            "the workflow is not valid",
+        ),
+    ):
+        diagnoses.append(
+            _diag(
+                "WORKFLOW_CONTRACT_FAILURE",
+                "high",
+                "high",
+                "GitHub Actions workflow contract failed",
+                "The log points to a workflow or YAML contract failure before product behavior could be trusted.",
+                "Workflow syntax and permission errors can masquerade as normal CI failures while preventing the right proof from running.",
+                [
+                    "matched failure signal: workflow contract",
+                    *_failure_snippets(text, limit=3),
+                ],
+                [
+                    "Inspect the changed workflow stanza.",
+                    "Validate YAML and rerun the targeted workflow contract tests.",
+                ],
+                [
+                    "PYTHONPATH=src python -m pytest -q tests/test_pr_quality_adaptive_sentinel_workflow.py -o addopts=",
+                    "PYTHONPATH=src python -m pre_commit run -a",
+                ],
+                "Broken workflow contracts can make CI evidence incomplete or misleading.",
+                "workflow-contract",
+                files=files,
+            )
+        )
+
+    if _contains_any(
+        lower,
+        (
+            "mkdocs build",
+            "mkdocs.exceptions",
+            "documentation file",
+            "not found in docs_dir",
+            "nav item",
+            "strict mode",
+        ),
+    ):
+        diagnoses.append(
+            _diag(
+                "DOCS_BUILD_CONTRACT",
+                "medium",
+                "high",
+                "Documentation build contract failed",
+                "The log shows a docs build, navigation, or strict-mode failure.",
+                "Docs failures often look harmless, but they break operator discoverability and release evidence.",
+                [
+                    "matched failure signal: docs build",
+                    *_failure_snippets(text, limit=3),
+                ],
+                [
+                    "Validate MkDocs navigation and referenced files.",
+                    "Fix the smallest docs/nav contract mismatch.",
+                ],
+                [
+                    "NO_MKDOCS_2_WARNING=1 PYTHONPATH=src python -m mkdocs build --strict",
+                    "PYTHONPATH=src python -m pytest -q tests/test_docs_qa.py tests/test_docs_nav_current_discoverability.py -o addopts=",
+                ],
+                "Broken docs navigation weakens operator handoff and release evidence.",
+                "docs-build-contract",
+                files=files,
+            )
+        )
+
+    if _contains_any(
+        lower,
+        (
+            "unrecognized arguments:",
+            "invalid choice:",
+            "no module named sdetkit.__main__",
+            "entry point",
+            "console_scripts",
+            "usage: sdetkit",
+        ),
+    ):
+        diagnoses.append(
+            _diag(
+                "CLI_CONTRACT_FAILURE",
+                "high",
+                "medium",
+                "CLI contract failed",
+                "The log shows a command-line contract or entry-point failure.",
+                "CLI failures break the operator path even when library tests or coverage appear healthy.",
+                [
+                    "matched failure signal: CLI contract",
+                    *_failure_snippets(text, limit=3),
+                ],
+                [
+                    "Reproduce the exact CLI command.",
+                    "Check command dispatch, parser wiring, and package entry points.",
+                ],
+                [
+                    "PYTHONPATH=src python -m sdetkit --help",
+                    "PYTHONPATH=src python -m pytest -q tests/test_cli_help_discoverability_contract.py tests/test_investigate_cli.py -o addopts=",
+                ],
+                "Broken CLI contracts block normal operator workflows.",
+                "cli-contract",
+                files=files,
+            )
+        )
+
+
 def _append_log(
     text: str, diagnoses: list[dict[str, Any]], adaptive_history: dict[str, Any] | None = None
 ) -> None:
     start_index = len(diagnoses)
     lower = text.lower()
     files = _file_mentions(text)
+    _append_multidomain_log_diagnoses(text, files, diagnoses)
     if _is_coverage_gate_regression(text):
         _append_coverage_gate_regression(text, files, diagnoses, adaptive_history)
     handled_local = _append_local_investigation(text, files, diagnoses)

--- a/tests/fixtures/adaptive_logs/metadata.json
+++ b/tests/fixtures/adaptive_logs/metadata.json
@@ -85,10 +85,9 @@
   },
   {
     "file": "package_install_unknown.log",
-    "primary": "UNKNOWN_REVIEW_REQUIRED",
-    "proof_contains": "pip install -r requirements-test.txt -e .",
-    "safe": false,
-    "candidate": "PACKAGE_INSTALL_FAILURE"
+    "primary": "PACKAGE_INSTALL_FAILURE",
+    "proof_contains": "pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+    "safe": false
   },
   {
     "file": "cache_artifact_unknown.log",
@@ -99,10 +98,9 @@
   },
   {
     "file": "docs_build_unknown.log",
-    "primary": "UNKNOWN_REVIEW_REQUIRED",
-    "proof_contains": "tests/test_docs*.py",
-    "safe": false,
-    "candidate": "DOCS_BUILD_CONTRACT"
+    "primary": "DOCS_BUILD_CONTRACT",
+    "proof_contains": "mkdocs build --strict",
+    "safe": false
   },
   {
     "file": "release_version_unknown.log",

--- a/tests/test_adaptive_diagnosis.py
+++ b/tests/test_adaptive_diagnosis.py
@@ -670,3 +670,115 @@ def test_generated_matrix_candidates_are_not_fixed_three_scenarios() -> None:
     assert len(adaptive_diagnosis.SEEDED_SCENARIO_DB) >= 5000
     assert any(candidate.code.startswith("MATRIX_") for candidate in candidates)
     assert len({candidate.code for candidate in candidates}) > 3
+
+
+def test_dependency_resolver_failure_is_specific_not_unknown():
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="\n".join(
+            [
+                "ERROR: Cannot install -r requirements-test.txt because these package versions have conflicting dependencies.",
+                "ResolutionImpossible: for help visit https://pip.pypa.io/",
+                "Process completed with exit code 1",
+            ]
+        )
+    )
+
+    assert "PACKAGE_INSTALL_FAILURE" in _codes(payload)
+    assert "UNKNOWN_REVIEW_REQUIRED" not in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis["code"] == "PACKAGE_INSTALL_FAILURE"
+    assert "pip install -c constraints-ci.txt -r requirements-test.txt -e ." in " ".join(
+        diagnosis["proof_commands"]
+    )
+    assert payload["fix_plan"][0]["safe_to_auto_fix"] is False
+
+
+def test_security_gate_failure_is_specific_not_quality_noise():
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="\n".join(
+            [
+                "sdetkit-security-gate / High entropy string",
+                "High-entropy string literal detected.",
+                "Process completed with exit code 1",
+            ]
+        )
+    )
+
+    assert "SECURITY_FINDING_REVIEW_REQUIRED" in _codes(payload)
+    assert "UNKNOWN_REVIEW_REQUIRED" not in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis["code"] == "SECURITY_FINDING_REVIEW_REQUIRED"
+    assert "pre_commit run -a" in " ".join(diagnosis["proof_commands"])
+
+
+def test_release_artifact_failure_is_specific_not_coverage_noise():
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="\n".join(
+            [
+                "Run python -m build && python -m twine check dist/*",
+                "ERROR InvalidDistribution: Metadata is missing required fields",
+                "Process completed with exit code 1",
+                "Total coverage: 96.69%",
+            ]
+        )
+    )
+
+    assert "RELEASE_ARTIFACT_INVALID" in _codes(payload)
+    assert "UNKNOWN_REVIEW_REQUIRED" not in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis["code"] == "RELEASE_ARTIFACT_INVALID"
+    assert "twine check dist/*" in " ".join(diagnosis["proof_commands"])
+
+
+def test_workflow_contract_failure_is_specific():
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="\n".join(
+            [
+                "Invalid workflow file: .github/workflows/pr-quality-comment.yml#L42",
+                "The workflow is not valid. .github/workflows/pr-quality-comment.yml (Line: 42, Col: 9): Unexpected value",
+                "Process completed with exit code 1",
+            ]
+        )
+    )
+
+    assert "WORKFLOW_CONTRACT_FAILURE" in _codes(payload)
+    assert "UNKNOWN_REVIEW_REQUIRED" not in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis["code"] == "WORKFLOW_CONTRACT_FAILURE"
+    assert "test_pr_quality_adaptive_sentinel_workflow.py" in " ".join(diagnosis["proof_commands"])
+
+
+def test_docs_build_failure_is_specific():
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="\n".join(
+            [
+                "NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict",
+                "mkdocs.exceptions.ConfigurationError: Documentation file 'missing.md' not found in docs_dir",
+                "Process completed with exit code 1",
+            ]
+        )
+    )
+
+    assert "DOCS_BUILD_CONTRACT" in _codes(payload)
+    assert "UNKNOWN_REVIEW_REQUIRED" not in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis["code"] == "DOCS_BUILD_CONTRACT"
+    assert "mkdocs build --strict" in " ".join(diagnosis["proof_commands"])
+
+
+def test_cli_contract_failure_is_specific():
+    payload = adaptive_diagnosis.analyze_evidence(
+        log_text="\n".join(
+            [
+                "usage: sdetkit [-h] {investigate,adaptive,doctor} ...",
+                "sdetkit: error: unrecognized arguments: --broken-flag",
+                "Process completed with exit code 2",
+            ]
+        )
+    )
+
+    assert "CLI_CONTRACT_FAILURE" in _codes(payload)
+    assert "UNKNOWN_REVIEW_REQUIRED" not in _codes(payload)
+    diagnosis = payload["diagnoses"][0]
+    assert diagnosis["code"] == "CLI_CONTRACT_FAILURE"
+    assert "python -m sdetkit --help" in " ".join(diagnosis["proof_commands"])


### PR DESCRIPTION
## Summary
- Teach adaptive diagnosis to recognize multi-domain failure logs directly.
- Add specific review-first diagnoses for:
  - dependency resolver/package install failures
  - security findings
  - release/package artifact validation failures
  - GitHub Actions workflow contract failures
  - MkDocs/docs build failures
  - CLI contract failures
- Promote fixture corpus expectations for package install and docs build logs from generic unknown to specific diagnoses.
- Add focused regression tests proving these logs no longer fall through to `UNKNOWN_REVIEW_REQUIRED`.

## Why
SDETKit should diagnose real company-grade blockers from raw logs instead of treating them as generic unknowns or coverage noise. This makes failure bundles more useful before the PR narrative ranks and explains them.

## Verification
- `python -m pytest -q tests/test_adaptive_diagnosis.py tests/test_adaptive_fixture_corpus.py tests/test_investigate_failure.py tests/test_pr_quality_evidence_narrative.py tests/test_adaptive_quality_gate_advisory_alignment.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Diagnosis behavior intentionally changes for package-install and docs-build fixture logs.
- Rollback: revert the multi-domain routing helper, fixture metadata updates, and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- This improves diagnosis generation; the PR Quality narrative ranking from prior PRs can now consume better failure-bundle data.