### PR TITLE
Ingest security review evidence into PR quality graph

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -61,12 +61,55 @@ jobs:
             --format text \
             --no-fail
 
+      - name: Collect security review evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+        run: |
+          mkdir -p build/pr-quality/security-review
+          gh api graphql \
+            -F owner="$REPOSITORY_OWNER" \
+            -F repo="$REPOSITORY_NAME" \
+            -F number="$PR_NUMBER" \
+            -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 100) {
+                      nodes {
+                        isResolved
+                        isOutdated
+                        path
+                        line
+                        comments(first: 20) {
+                          nodes {
+                            author { login }
+                            body
+                            url
+                            createdAt
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ' > build/pr-quality/security-review/review-threads.json || echo '{"data":{}}' > build/pr-quality/security-review/review-threads.json
+
+          PYTHONPATH=src python -m sdetkit.security_review_evidence \
+            --review-threads-json build/pr-quality/security-review/review-threads.json \
+            --sentinel-control-room build/sdetkit/sentinel/control-room.json \
+            --merged-control-room build/sdetkit/sentinel/control-room-with-security-review.json \
+            --out-dir build/pr-quality/security-review
+
       - name: Build PR evidence graph
         if: always()
         run: |
           mkdir -p build/sdetkit/evidence-graph
           PYTHONPATH=src python -m sdetkit.evidence_graph \
-            --sentinel-control-room build/sdetkit/sentinel/control-room.json \
+            --sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json \
             --out-dir build/sdetkit/evidence-graph
 
       - name: Build PR comment body

--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -381,6 +381,12 @@ def _green_proof_commands(
             surfaces.append(surface)
 
     commands: list[str] = []
+    for node in nodes:
+        surface = str(node.get("risk_surface", "unknown") or "unknown")
+        if surface == "security":
+            commands.extend(_string_list(node.get("recommended_commands")))
+            commands.extend(_string_list(node.get("proof_commands")))
+
     for surface in surfaces:
         commands.extend(_GREEN_PROOF_BY_SURFACE.get(surface, []))
 
@@ -467,12 +473,30 @@ def build_narrative(
         primary_title = str(failure.get("title") or failure.get("code") or "Quality failure")
     elif quality_ok and (changed_surfaces or primary_node):
         primary_kind = "review_signal"
-        primary_surface = (
-            changed_surfaces[0]
-            if changed_surfaces
-            else str(primary_node.get("risk_surface", "unknown") or "unknown")
+        primary_node_surface = (
+            str(primary_node.get("risk_surface", "unknown") or "unknown")
+            if primary_node
+            else "unknown"
         )
-        primary_title = f"{_surface_label(primary_surface)} evidence changed"
+        changed_surface = changed_surfaces[0] if changed_surfaces else ""
+        if (
+            primary_node
+            and primary_node_surface != "unknown"
+            and (
+                not changed_surface
+                or _SURFACE_PRIORITY.get(primary_node_surface, 0)
+                >= _SURFACE_PRIORITY.get(changed_surface, 0)
+            )
+        ):
+            primary_surface = primary_node_surface
+            primary_title = _human_finding_title(
+                primary_node,
+                changed_files=changed,
+                changed_surfaces=changed_surfaces,
+            )
+        else:
+            primary_surface = changed_surface or primary_node_surface
+            primary_title = f"{_surface_label(primary_surface)} evidence changed"
     elif primary_node:
         primary_kind = "review_signal"
         primary_surface = str(primary_node.get("risk_surface", "unknown") or "unknown")

--- a/src/sdetkit/security_review_evidence.py
+++ b/src/sdetkit/security_review_evidence.py
@@ -1,0 +1,289 @@
+"""Collect GitHub security review evidence for PR quality narratives.
+
+This module is advisory/read-only. It turns unresolved security review
+threads into Sentinel-compatible findings so the Evidence Graph and PR Quality
+narrative can treat security review as a first-class release-confidence signal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.security-review-evidence.v1"
+
+SECURITY_AUTHOR_TOKENS = (
+    "github-advanced-security",
+    "sdetkit-security-gate",
+)
+
+SECURITY_BODY_TOKENS = (
+    "github-advanced-security",
+    "sdetkit-security-gate",
+    "high entropy string",
+    "secret",
+    "secret-like",
+    "vulnerability",
+    "security gate",
+    "fix or dismiss",
+    "dismissing the alert",
+)
+
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _read_json(path: Path | None) -> JsonObject:
+    if not path or not path.exists():
+        return {}
+    return _as_dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def _write_json(path: Path, payload: JsonObject) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _thread_nodes(payload: JsonObject) -> list[JsonObject]:
+    pull_request = _as_dict(
+        _as_dict(_as_dict(payload.get("data")).get("repository")).get("pullRequest")
+    )
+    threads = _as_dict(pull_request.get("reviewThreads"))
+    return [_as_dict(item) for item in _as_list(threads.get("nodes")) if isinstance(item, dict)]
+
+
+def _comment_nodes(thread: JsonObject) -> list[JsonObject]:
+    comments = _as_dict(thread.get("comments"))
+    return [_as_dict(item) for item in _as_list(comments.get("nodes")) if isinstance(item, dict)]
+
+
+def _author_login(comment: JsonObject) -> str:
+    return str(_as_dict(comment.get("author")).get("login", "")).lower()
+
+
+def _is_security_comment(comment: JsonObject) -> bool:
+    author = _author_login(comment)
+    body = str(comment.get("body", "")).lower()
+    return any(token in author for token in SECURITY_AUTHOR_TOKENS) or any(
+        token in body for token in SECURITY_BODY_TOKENS
+    )
+
+
+def _summary(comment: JsonObject, path: str) -> str:
+    body = " ".join(str(comment.get("body", "")).split())
+    if len(body) > 180:
+        body = body[:177].rstrip() + "..."
+    if path:
+        return f"Unresolved security review comment on {path}: {body}"
+    return f"Unresolved security review comment: {body}"
+
+
+def _finding_id(thread: JsonObject, comment: JsonObject) -> str:
+    raw = "|".join(
+        [
+            str(thread.get("path", "")),
+            str(thread.get("line", "")),
+            str(comment.get("url", "")),
+            str(comment.get("body", ""))[:120],
+        ]
+    )
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+    return f"security-review-{digest}"
+
+
+def findings_from_review_threads(payload: JsonObject) -> list[JsonObject]:
+    findings: list[JsonObject] = []
+    for thread in _thread_nodes(payload):
+        if bool(thread.get("isResolved", False)):
+            continue
+
+        security_comments = [
+            comment for comment in _comment_nodes(thread) if _is_security_comment(comment)
+        ]
+        if not security_comments:
+            continue
+
+        path = str(thread.get("path", "") or "")
+        line = thread.get("line")
+        comment = security_comments[-1]
+        title = "Security review comment requires fix or dismissal"
+        if path:
+            title = f"Security review requires action in {path}"
+
+        commands = [
+            "Review unresolved GitHub Advanced Security comments on the PR.",
+            "Fix the flagged surface or dismiss the false positive with a review reason.",
+            "PYTHONPATH=src python -m pre_commit run -a",
+        ]
+
+        findings.append(
+            {
+                "finding_id": _finding_id(thread, comment),
+                "title": title,
+                "summary": _summary(comment, path),
+                "risk_surface": "security",
+                "severity": "warning",
+                "review_first": True,
+                "safe_to_auto_fix": False,
+                "owner_files": [path] if path else [],
+                "source_artifacts": ["build/pr-quality/security-review/review-threads.json"],
+                "recommended_commands": commands,
+                "proof_commands": commands[:2],
+                "recurrence_state": "unknown",
+                "operator_action": "review",
+                "automation_allowed_now": False,
+                "line": line,
+                "comment_url": comment.get("url", ""),
+                "author": _author_login(comment),
+            }
+        )
+
+    return findings
+
+
+def build_security_review_evidence(review_threads: Path | None) -> JsonObject:
+    findings = findings_from_review_threads(_read_json(review_threads))
+    state = "warning" if findings else "healthy"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "state": state,
+        "automation_allowed_now": False,
+        "automation_reason": "Security review evidence is advisory/read-only and requires human fix or dismissal.",
+        "active_threat_count": len(findings),
+        "active_threats": findings,
+        "review_first_count": len(findings),
+        "source_artifacts": {
+            "review_threads": str(review_threads) if review_threads else "",
+        },
+    }
+
+
+def merge_with_sentinel_control_room(
+    sentinel_control_room: Path | None,
+    security_evidence: JsonObject,
+) -> JsonObject:
+    base = dict(_read_json(sentinel_control_room))
+    if not base:
+        base = {
+            "schema_version": "sdetkit.adaptive.sentinel.control_room.v1",
+            "state": "healthy",
+            "automation_allowed_now": False,
+            "active_threats": [],
+            "active_threat_count": 0,
+            "review_first_count": 0,
+            "source_artifacts": {},
+        }
+
+    existing = [_as_dict(item) for item in _as_list(base.get("active_threats"))]
+    security_findings = [
+        _as_dict(item) for item in _as_list(security_evidence.get("active_threats"))
+    ]
+    active = [*existing, *security_findings]
+
+    base["active_threats"] = active
+    base["active_threat_count"] = len(active)
+    base["review_first_count"] = sum(1 for item in active if bool(item.get("review_first", False)))
+    base["automation_allowed_now"] = False
+
+    if security_findings:
+        base["state"] = (
+            "warning" if str(base.get("state", "healthy")) == "healthy" else base.get("state")
+        )
+        base["security_review_state"] = "review_required"
+    else:
+        base.setdefault("security_review_state", "healthy")
+
+    source_artifacts = _as_dict(base.get("source_artifacts"))
+    source_artifacts["security_review_json"] = (
+        "build/pr-quality/security-review/security-review.json"
+    )
+    source_artifacts["security_review_markdown"] = (
+        "build/pr-quality/security-review/security-review.md"
+    )
+    base["source_artifacts"] = source_artifacts
+    return base
+
+
+def render_markdown(payload: JsonObject) -> str:
+    findings = [_as_dict(item) for item in _as_list(payload.get("active_threats"))]
+    lines = [
+        "# Security Review Evidence",
+        "",
+        f"state: {payload.get('state', 'unknown')}",
+        f"active_security_review_findings: {len(findings)}",
+        "",
+    ]
+    if not findings:
+        lines.append("No unresolved security review findings were collected.")
+        return "\n".join(lines).rstrip() + "\n"
+
+    for finding in findings:
+        lines.extend(
+            [
+                f"## {finding.get('title', 'Security review finding')}",
+                "",
+                str(finding.get("summary", "")),
+                "",
+                f"- Risk surface: `{finding.get('risk_surface', 'security')}`",
+                f"- Review first: `{str(finding.get('review_first', True)).lower()}`",
+                f"- Automation allowed now: `{str(finding.get('automation_allowed_now', False)).lower()}`",
+                "",
+                "Recommended commands:",
+            ]
+        )
+        for command in _as_list(finding.get("recommended_commands")):
+            lines.append(f"- `{command}`")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.security_review_evidence")
+    parser.add_argument("--review-threads-json", type=Path)
+    parser.add_argument("--sentinel-control-room", type=Path)
+    parser.add_argument("--out-dir", type=Path, default=Path("build/pr-quality/security-review"))
+    parser.add_argument("--merged-control-room", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    security = build_security_review_evidence(args.review_threads_json)
+    _write_json(args.out_dir / "security-review.json", security)
+    (args.out_dir / "security-review.md").write_text(render_markdown(security), encoding="utf-8")
+
+    if args.merged_control_room:
+        merged = merge_with_sentinel_control_room(args.sentinel_control_room, security)
+        _write_json(args.merged_control_room, merged)
+
+    print(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "state": security.get("state", "unknown"),
+                "active_security_review_findings": security.get("active_threat_count", 0),
+                "security_review_json": str(args.out_dir / "security-review.json"),
+                "merged_control_room": str(args.merged_control_room or ""),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_quality_evidence_narrative.py
+++ b/tests/test_pr_quality_evidence_narrative.py
@@ -604,3 +604,60 @@ def test_failed_narrative_ranks_tests_above_coverage_noise(tmp_path: Path) -> No
     assert payload["primary_signal"]["surface"] == "tests"
     assert "python -m pytest -q tests/test_real_bug.py::test_behavior -o addopts=" in markdown
     assert "bash quality.sh cov" not in markdown
+
+
+def test_green_narrative_prioritizes_security_review_graph_signal(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "Security review requires action in src/sdetkit/adaptive_diagnosis.py",
+                    "summary": "GitHub Advanced Security reported an unresolved review finding.",
+                    "risk_surface": "security",
+                    "severity": "warning",
+                    "review_first": True,
+                    "safe_to_auto_fix": False,
+                    "recommended_commands": [
+                        "Review unresolved GitHub Advanced Security comments on the PR.",
+                        "Fix the flagged surface or dismiss the false positive with a review reason.",
+                    ],
+                },
+                {
+                    "title": "PR Quality evidence changed",
+                    "summary": "The PR Quality evidence comment path changed.",
+                    "risk_surface": "pr_quality",
+                    "severity": "warning",
+                },
+            ],
+            "source_summary": [],
+        },
+    )
+    changed = _write(
+        tmp_path / "changed-files.txt",
+        "src/sdetkit/adaptive_diagnosis.py\n",
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=None,
+        evidence_graph=graph,
+        failure_bundle=None,
+        changed_files=changed,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["surface"] == "security"
+    assert (
+        payload["primary_signal"]["title"]
+        == "Security review requires action in src/sdetkit/adaptive_diagnosis.py"
+    )
+    assert "Quality is green, so the review focus is not coverage." in markdown
+    assert "Review unresolved GitHub Advanced Security comments on the PR." in markdown
+    assert "Fix the flagged surface or dismiss the false positive with a review reason." in markdown

--- a/tests/test_pr_quality_security_review_workflow.py
+++ b/tests/test_pr_quality_security_review_workflow.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/pr-quality-comment.yml")
+
+
+def test_pr_quality_workflow_collects_security_review_threads_before_graph() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Collect security review evidence" in text
+    assert "gh api graphql" in text
+    assert "reviewThreads(first: 100)" in text
+    assert "python -m sdetkit.security_review_evidence" in text
+    assert "build/pr-quality/security-review/review-threads.json" in text
+    assert "build/sdetkit/sentinel/control-room-with-security-review.json" in text
+
+    collect_index = text.index("Collect security review evidence")
+    graph_index = text.index("Build PR evidence graph")
+    assert collect_index < graph_index
+
+
+def test_pr_quality_workflow_builds_graph_from_security_merged_control_room() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert (
+        "--sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json"
+        in text
+    )

--- a/tests/test_security_review_evidence.py
+++ b/tests/test_security_review_evidence.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import security_review_evidence as security_review
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _review_threads(*threads: dict) -> dict:
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": list(threads),
+                    }
+                }
+            }
+        }
+    }
+
+
+def _thread(*, resolved: bool, body: str, author: str = "github-advanced-security") -> dict:
+    return {
+        "isResolved": resolved,
+        "isOutdated": False,
+        "path": "src/sdetkit/adaptive_diagnosis.py",
+        "line": 1320,
+        "comments": {
+            "nodes": [
+                {
+                    "author": {"login": author},
+                    "body": body,
+                    "url": "https://github.example/review-comment",
+                }
+            ]
+        },
+    }
+
+
+def test_security_review_evidence_emits_unresolved_security_finding(tmp_path: Path) -> None:
+    path = _write_json(
+        tmp_path / "review-threads.json",
+        _review_threads(
+            _thread(
+                resolved=False,
+                body="sdetkit-security-gate / High entropy string. Dismissing the alert will mark this conversation as resolved.",
+            )
+        ),
+    )
+
+    payload = security_review.build_security_review_evidence(path)
+
+    assert payload["state"] == "warning"
+    assert payload["active_threat_count"] == 1
+    finding = payload["active_threats"][0]
+    assert finding["risk_surface"] == "security"
+    assert finding["review_first"] is True
+    assert finding["safe_to_auto_fix"] is False
+    assert finding["automation_allowed_now"] is False
+    assert finding["owner_files"] == ["src/sdetkit/adaptive_diagnosis.py"]
+    assert "requires action" in finding["title"].lower()
+    assert "Fix the flagged surface or dismiss the false positive" in " ".join(
+        finding["recommended_commands"]
+    )
+
+
+def test_security_review_evidence_ignores_resolved_threads(tmp_path: Path) -> None:
+    path = _write_json(
+        tmp_path / "review-threads.json",
+        _review_threads(_thread(resolved=True, body="sdetkit-security-gate / High entropy string")),
+    )
+
+    payload = security_review.build_security_review_evidence(path)
+
+    assert payload["state"] == "healthy"
+    assert payload["active_threat_count"] == 0
+    assert payload["active_threats"] == []
+
+
+def test_security_review_evidence_ignores_non_security_review_threads(tmp_path: Path) -> None:
+    path = _write_json(
+        tmp_path / "review-threads.json",
+        _review_threads(
+            _thread(resolved=False, body="Please rename this helper.", author="reviewer")
+        ),
+    )
+
+    payload = security_review.build_security_review_evidence(path)
+
+    assert payload["state"] == "healthy"
+    assert payload["active_threat_count"] == 0
+
+
+def test_security_review_evidence_merges_with_sentinel_control_room(tmp_path: Path) -> None:
+    review_threads = _write_json(
+        tmp_path / "review-threads.json",
+        _review_threads(
+            _thread(resolved=False, body="github-advanced-security warning: security gate")
+        ),
+    )
+    sentinel = _write_json(
+        tmp_path / "control-room.json",
+        {
+            "schema_version": "sdetkit.adaptive.sentinel.control_room.v1",
+            "state": "healthy",
+            "active_threat_count": 0,
+            "active_threats": [],
+            "review_first_count": 0,
+            "automation_allowed_now": False,
+        },
+    )
+
+    security = security_review.build_security_review_evidence(review_threads)
+    merged = security_review.merge_with_sentinel_control_room(sentinel, security)
+
+    assert merged["state"] == "warning"
+    assert merged["security_review_state"] == "review_required"
+    assert merged["active_threat_count"] == 1
+    assert merged["review_first_count"] == 1
+    assert merged["active_threats"][0]["risk_surface"] == "security"


### PR DESCRIPTION
## Summary
- Add a read-only security review evidence collector for unresolved GitHub security review threads.
- Convert unresolved security review comments into Sentinel-compatible security findings.
- Merge security review evidence into the Sentinel control-room artifact before building the Evidence Graph.
- Make green PR narratives prioritize security graph signals above lower-priority changed-file surfaces.
- Include security node recommended actions in green-mode next proof.
- Add workflow, collector, and narrative regression tests.

## Why
Advanced Security comments are release-confidence signals. A PR can have `quality.sh cov` green while still requiring security fix/dismissal review. SDETKit must see those review signals and surface them as `security` findings instead of reporting only `pr_quality`.

## Verification
- `python -m pytest -q tests/test_security_review_evidence.py tests/test_pr_quality_security_review_workflow.py tests/test_pr_quality_evidence_narrative.py tests/test_evidence_graph.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Workflow behavior changes by adding a read-only GitHub review-thread collection step.
- Rollback: revert the collector, workflow step, and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Security review comments require human fix or dismissal.