### PR TITLE
Expose security review status in PR quality narrative

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -123,7 +123,7 @@ jobs:
           PYTHONPATH=src python -m sdetkit.pr_quality_evidence_narrative \
             --quality-log quality.log \
             --quality-outcome "${{ steps.quality.outcome }}" \
-            --sentinel-control-room build/sdetkit/sentinel/control-room.json \
+            --sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json \
             --evidence-graph build/sdetkit/evidence-graph/evidence-graph.json \
             --failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json \
             --changed-files build/pr-quality/changed-files.txt \

--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -546,6 +546,7 @@ def build_narrative(
         evidence_graph=evidence_graph,
         failure_bundle=failure_bundle,
     )
+    what_happened.extend(_security_review_status_lines_from_control_room(sentinel_control_room))
 
     payload: JsonObject = {
         "schema_version": SCHEMA_VERSION,
@@ -650,6 +651,27 @@ def _human_finding_title(
         return f"{_surface_label(surface)} evidence changed"
 
     return raw_title or "Evidence graph finding"
+
+
+def _security_review_status_lines_from_control_room(control_room: Path | None) -> list[str]:
+    if not control_room:
+        return []
+    payload = _read_json(control_room)
+    if not payload:
+        return [
+            "Security review evidence was unavailable; manually inspect Advanced Security review comments."
+        ]
+
+    if "security_review_collection_status" not in payload:
+        return []
+
+    status = str(payload.get("security_review_collection_status", "unknown"))
+    try:
+        count = int(payload.get("security_review_finding_count", 0) or 0)
+    except (TypeError, ValueError):
+        count = 0
+
+    return [f"Security review evidence: {status}; unresolved findings: {count}."]
 
 
 def _what_happened(

--- a/src/sdetkit/security_review_evidence.py
+++ b/src/sdetkit/security_review_evidence.py
@@ -153,11 +153,16 @@ def findings_from_review_threads(payload: JsonObject) -> list[JsonObject]:
 
 
 def build_security_review_evidence(review_threads: Path | None) -> JsonObject:
-    findings = findings_from_review_threads(_read_json(review_threads))
+    raw_payload = _read_json(review_threads)
+    found = bool(raw_payload)
+    findings = findings_from_review_threads(raw_payload)
     state = "warning" if findings else "healthy"
+    collection_status = "collected" if found else "unavailable"
     return {
         "schema_version": SCHEMA_VERSION,
         "state": state,
+        "collection_status": collection_status,
+        "found": found,
         "automation_allowed_now": False,
         "automation_reason": "Security review evidence is advisory/read-only and requires human fix or dismissal.",
         "active_threat_count": len(findings),
@@ -195,6 +200,11 @@ def merge_with_sentinel_control_room(
     base["active_threat_count"] = len(active)
     base["review_first_count"] = sum(1 for item in active if bool(item.get("review_first", False)))
     base["automation_allowed_now"] = False
+    base["security_review_collection_status"] = security_evidence.get(
+        "collection_status",
+        "unknown",
+    )
+    base["security_review_finding_count"] = len(security_findings)
 
     if security_findings:
         base["state"] = (
@@ -221,6 +231,7 @@ def render_markdown(payload: JsonObject) -> str:
         "# Security Review Evidence",
         "",
         f"state: {payload.get('state', 'unknown')}",
+        f"collection_status: {payload.get('collection_status', 'unknown')}",
         f"active_security_review_findings: {len(findings)}",
         "",
     ]

--- a/tests/test_pr_quality_evidence_narrative.py
+++ b/tests/test_pr_quality_evidence_narrative.py
@@ -661,3 +661,36 @@ def test_green_narrative_prioritizes_security_review_graph_signal(tmp_path: Path
     assert "Quality is green, so the review focus is not coverage." in markdown
     assert "Review unresolved GitHub Advanced Security comments on the PR." in markdown
     assert "Fix the flagged surface or dismiss the false positive with a review reason." in markdown
+
+
+def test_green_narrative_reports_security_review_collection_status(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    control_room = _write_json(
+        tmp_path / "control-room-with-security-review.json",
+        {
+            "schema_version": "sdetkit.adaptive.sentinel.control_room.v1",
+            "state": "healthy",
+            "active_threat_count": 0,
+            "active_threats": [],
+            "review_first_count": 0,
+            "automation_allowed_now": False,
+            "security_review_collection_status": "collected",
+            "security_review_finding_count": 0,
+            "security_review_state": "healthy",
+        },
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=control_room,
+        evidence_graph=None,
+        failure_bundle=None,
+        changed_files=None,
+    )
+
+    markdown = str(payload["markdown"])
+    assert "Security review evidence: collected; unresolved findings: 0." in markdown

--- a/tests/test_pr_quality_security_review_workflow.py
+++ b/tests/test_pr_quality_security_review_workflow.py
@@ -27,3 +27,14 @@ def test_pr_quality_workflow_builds_graph_from_security_merged_control_room() ->
         "--sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json"
         in text
     )
+
+
+def test_pr_quality_workflow_narrative_uses_security_merged_control_room() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    command_index = text.index("python -m sdetkit.pr_quality_evidence_narrative")
+    narrative_command = text[command_index : command_index + 1400]
+
+    assert (
+        "--sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json"
+        in narrative_command
+    )

--- a/tests/test_security_review_evidence.py
+++ b/tests/test_security_review_evidence.py
@@ -125,3 +125,46 @@ def test_security_review_evidence_merges_with_sentinel_control_room(tmp_path: Pa
     assert merged["active_threat_count"] == 1
     assert merged["review_first_count"] == 1
     assert merged["active_threats"][0]["risk_surface"] == "security"
+
+
+def test_security_review_evidence_reports_collection_status(tmp_path: Path) -> None:
+    path = _write_json(tmp_path / "review-threads.json", _review_threads())
+
+    payload = security_review.build_security_review_evidence(path)
+
+    assert payload["collection_status"] == "collected"
+    assert payload["found"] is True
+    assert payload["active_threat_count"] == 0
+    assert "collection_status: collected" in security_review.render_markdown(payload)
+
+
+def test_security_review_evidence_reports_unavailable_when_payload_missing(tmp_path: Path) -> None:
+    payload = security_review.build_security_review_evidence(
+        tmp_path / "missing-review-threads.json"
+    )
+
+    assert payload["collection_status"] == "unavailable"
+    assert payload["found"] is False
+    assert payload["active_threat_count"] == 0
+
+
+def test_security_review_merge_exposes_collection_status(tmp_path: Path) -> None:
+    review_threads = _write_json(tmp_path / "review-threads.json", _review_threads())
+    sentinel = _write_json(
+        tmp_path / "control-room.json",
+        {
+            "schema_version": "sdetkit.adaptive.sentinel.control_room.v1",
+            "state": "healthy",
+            "active_threat_count": 0,
+            "active_threats": [],
+            "review_first_count": 0,
+            "automation_allowed_now": False,
+        },
+    )
+
+    security = security_review.build_security_review_evidence(review_threads)
+    merged = security_review.merge_with_sentinel_control_room(sentinel, security)
+
+    assert merged["security_review_collection_status"] == "collected"
+    assert merged["security_review_finding_count"] == 0
+    assert merged["security_review_state"] == "healthy"


### PR DESCRIPTION
## Summary
- Expose security review collection status in security review evidence.
- Preserve whether review-thread evidence was collected or unavailable.
- Store unresolved security review finding count in the merged Sentinel control-room artifact.
- Make the PR Quality narrative read the merged security control room.
- Add focused tests for collection status, merged control-room status, narrative visibility, and workflow wiring.

## Why
A green quality gate is not enough if security review evidence is invisible. The PR narrative should show whether Advanced Security review evidence was collected and how many unresolved findings exist, so maintainers can distinguish “no findings” from “not collected.”

## Verification
- `python -m pytest -q tests/test_security_review_evidence.py tests/test_pr_quality_security_review_workflow.py tests/test_pr_quality_evidence_narrative.py tests/test_evidence_graph.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low to medium.
- Workflow/narrative evidence visibility change only.
- Rollback: revert the status fields, workflow narrative input, and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Security review findings remain review-first and require human fix or dismissal.