### PR TITLE
Feed failure bundle diagnoses into evidence graph

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -110,6 +110,7 @@ jobs:
           mkdir -p build/sdetkit/evidence-graph
           PYTHONPATH=src python -m sdetkit.evidence_graph \
             --sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json \
+            --failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json \
             --out-dir build/sdetkit/evidence-graph
 
       - name: Build PR comment body

--- a/src/sdetkit/evidence_graph.py
+++ b/src/sdetkit/evidence_graph.py
@@ -21,6 +21,7 @@ SourceName = Literal[
     "dependency",
     "maintenance",
     "pr_quality",
+    "failure_bundle",
 ]
 
 JsonScalar = str | int | float | bool | None
@@ -114,6 +115,7 @@ def build_evidence_graph(
     *,
     sentinel_control_room: Path | None = None,
     mission_control: Path | None = None,
+    failure_bundle: Path | None = None,
 ) -> EvidenceGraph:
     nodes: list[EvidenceNode] = []
     source_summary: list[SourceSummary] = []
@@ -133,6 +135,14 @@ def build_evidence_graph(
     )
     nodes.extend(mission_nodes)
     source_summary.append(mission_summary)
+
+    failure_bundle_nodes, failure_bundle_summary = _normalize_source(
+        source="failure_bundle",
+        path=failure_bundle,
+        finding_keys=("diagnoses", "findings", "active_findings"),
+    )
+    nodes.extend(failure_bundle_nodes)
+    source_summary.append(failure_bundle_summary)
 
     nodes.sort(key=lambda node: (node["source"], node["finding_id"]))
 
@@ -268,6 +278,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to a Mission Control JSON artifact.",
     )
     parser.add_argument(
+        "--failure-bundle",
+        type=Path,
+        default=None,
+        help="Adaptive failure bundle or adaptive diagnosis JSON artifact to normalize.",
+    )
+    parser.add_argument(
         "--out-dir",
         type=Path,
         default=DEFAULT_OUTPUT_DIR,
@@ -278,6 +294,7 @@ def main(argv: list[str] | None = None) -> int:
     graph = build_evidence_graph(
         sentinel_control_room=args.sentinel_control_room,
         mission_control=args.mission_control,
+        failure_bundle=args.failure_bundle,
     )
     manifest = write_evidence_graph(graph, output_dir=args.out_dir)
     print(json.dumps(manifest, indent=2, sort_keys=True))
@@ -354,12 +371,13 @@ def _normalize_finding(
         "message",
         default=title,
     )
-    owner_files = _string_list(finding.get("owner_files"))
+    owner_files = _string_list(finding.get("owner_files") or finding.get("affected_files"))
     source_artifacts = _string_list(finding.get("source_artifacts"))
     recommended_commands = _string_list(
         finding.get("recommended_commands")
         or finding.get("next_commands")
         or finding.get("commands")
+        or finding.get("recommended_fix")
     )
     proof_commands = _string_list(
         finding.get("proof_commands") or finding.get("verification_commands")
@@ -460,6 +478,18 @@ def _risk_surface(
     explicit = _text(finding, "risk_surface", "surface", "category", default="").lower()
     if explicit in _VALID_SURFACES:
         return explicit
+
+    code = _text(finding, "code", "diagnosis_code", "primary_diagnosis_code", default="").upper()
+    code_surfaces = {
+        "PACKAGE_INSTALL_FAILURE": "dependency",
+        "MISSING_TEST_DEPENDENCY": "dependency",
+        "SECURITY_FINDING_REVIEW_REQUIRED": "security",
+        "SECRET_EXPOSURE": "security",
+        "RELEASE_ARTIFACT_INVALID": "release",
+        "WORKFLOW_CONTRACT_FAILURE": "workflow",
+    }
+    if code in code_surfaces:
+        return code_surfaces[code]
 
     haystack = " ".join(
         [

--- a/tests/test_evidence_graph.py
+++ b/tests/test_evidence_graph.py
@@ -288,3 +288,126 @@ def test_evidence_graph_classifies_diagnostic_artifacts_from_source_paths(
 
     assert graph["nodes"][0]["risk_surface"] == "diagnostic_engine"
     assert graph["nodes"][0]["review_first"] is True
+
+
+def test_evidence_graph_normalizes_failure_bundle_diagnoses(tmp_path: Path) -> None:
+    failure_bundle = tmp_path / "failure-bundle.json"
+    failure_bundle.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.adaptive.diagnosis.v1",
+                "diagnoses": [
+                    {
+                        "code": "PACKAGE_INSTALL_FAILURE",
+                        "title": "Dependency resolver failed",
+                        "diagnosis": "pip could not resolve constraints before tests could prove behavior.",
+                        "severity": "high",
+                        "confidence": "high",
+                        "affected_files": ["constraints-ci.txt", "requirements-test.txt"],
+                        "recommended_fix": [
+                            "Reproduce the exact install lane.",
+                            "Align the smallest dependency surface instead of changing product code.",
+                        ],
+                        "proof_commands": [
+                            "PYTHONPATH=src python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+                        ],
+                    },
+                    {
+                        "code": "SECURITY_FINDING_REVIEW_REQUIRED",
+                        "title": "Security finding requires review",
+                        "diagnosis": "A security-sensitive finding must be reviewed before treating coverage as the blocker.",
+                        "severity": "high",
+                        "confidence": "high",
+                        "recommended_fix": [
+                            "Inspect the security finding and affected surface.",
+                        ],
+                        "proof_commands": [
+                            "PYTHONPATH=src python -m pre_commit run -a",
+                        ],
+                    },
+                    {
+                        "code": "RELEASE_ARTIFACT_INVALID",
+                        "title": "Release artifact validation failed",
+                        "diagnosis": "The release/package validation log shows an artifact contract failure.",
+                        "severity": "high",
+                        "confidence": "high",
+                        "proof_commands": [
+                            "PYTHONPATH=src python -m build && PYTHONPATH=src python -m twine check dist/*",
+                        ],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    graph = build_evidence_graph(failure_bundle=failure_bundle)
+
+    assert graph["source_summary"][-1]["source"] == "failure_bundle"
+    assert graph["source_summary"][-1]["found"] is True
+    assert graph["source_summary"][-1]["findings_seen"] == 3
+    assert graph["source_summary"][-1]["findings_emitted"] == 3
+
+    nodes = {node["title"]: node for node in graph["nodes"]}
+
+    dependency = nodes["Dependency resolver failed"]
+    assert dependency["source"] == "failure_bundle"
+    assert dependency["risk_surface"] == "dependency"
+    assert dependency["review_first"] is True
+    assert dependency["safe_to_auto_fix"] is False
+    assert dependency["owner_files"] == ["constraints-ci.txt", "requirements-test.txt"]
+    assert "PYTHONPATH=src python -m pip install -c constraints-ci.txt" in " ".join(
+        dependency["proof_commands"]
+    )
+    assert "Reproduce the exact install lane." in dependency["recommended_commands"]
+
+    security = nodes["Security finding requires review"]
+    assert security["risk_surface"] == "security"
+    assert security["review_first"] is True
+    assert security["safe_to_auto_fix"] is False
+
+    release = nodes["Release artifact validation failed"]
+    assert release["risk_surface"] == "release"
+    assert release["review_first"] is True
+    assert release["safe_to_auto_fix"] is False
+
+
+def test_evidence_graph_module_cli_accepts_failure_bundle(tmp_path: Path, capsys) -> None:
+    failure_bundle = tmp_path / "failure-bundle.json"
+    failure_bundle.write_text(
+        json.dumps(
+            {
+                "diagnoses": [
+                    {
+                        "code": "PACKAGE_INSTALL_FAILURE",
+                        "title": "Dependency resolver failed",
+                        "diagnosis": "pip dependency resolver failed.",
+                        "severity": "high",
+                        "proof_commands": [
+                            "PYTHONPATH=src python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--failure-bundle",
+            str(failure_bundle),
+            "--out-dir",
+            str(tmp_path / "evidence-graph"),
+        ]
+    )
+
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert "evidence-graph.json" in captured
+
+    graph = json.loads(
+        (tmp_path / "evidence-graph" / "evidence-graph.json").read_text(encoding="utf-8")
+    )
+    assert graph["nodes"][0]["source"] == "failure_bundle"
+    assert graph["nodes"][0]["risk_surface"] == "dependency"

--- a/tests/test_pr_quality_failure_bundle_evidence_graph_workflow.py
+++ b/tests/test_pr_quality_failure_bundle_evidence_graph_workflow.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/pr-quality-comment.yml")
+
+
+def test_pr_quality_workflow_feeds_failure_bundle_into_evidence_graph() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    command_index = text.index("sdetkit.evidence_graph")
+    next_step_index = text.find("      - name:", command_index + 1)
+    if next_step_index == -1:
+        next_step_index = len(text)
+    graph_command = text[command_index:next_step_index]
+
+    assert (
+        "--failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json"
+        in graph_command
+    )
+    assert "--out-dir build/sdetkit/evidence-graph" in graph_command
+    assert "sdetkit.pr_quality_evidence_narrative" not in graph_command


### PR DESCRIPTION
## Summary
- Teach Evidence Graph to ingest adaptive failure bundles / adaptive diagnosis artifacts.
- Normalize failure-bundle diagnoses as first-class graph nodes.
- Preserve diagnosis title, summary, owner files, recommended fixes, and proof commands.
- Map diagnosis codes to correct risk surfaces such as dependency, security, release, and workflow.
- Keep review-first and safe-to-auto-fix boundaries intact.
- Add CLI and unit coverage for failure-bundle graph ingestion.
- Add PR Quality workflow contract coverage for feeding the failure bundle into graph generation.

## Why
Adaptive diagnosis already identifies real multi-domain failures, but those diagnoses need to flow into the shared evidence spine. This makes dependency, security, release, workflow, docs, and CLI failures visible to Evidence Graph, Mission Control, and PR Quality through one normalized contract.

## Verification
- `python -m pytest -q tests/test_evidence_graph.py tests/test_pr_quality_failure_bundle_evidence_graph_workflow.py tests/test_adaptive_diagnosis.py tests/test_pr_quality_evidence_narrative.py tests/test_security_review_evidence.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Evidence Graph ingestion expands to a new source.
- Rollback: revert failure-bundle source support, CLI arg, and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Failure-bundle findings remain review-first unless a separate safe-remediation policy explicitly allows otherwise.