### PR TITLE
Summarize evidence graph top blockers in Mission Control

### DIFF
--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -368,6 +368,60 @@ def _doctor_cortex_artifacts(summary: dict[str, Any] | None) -> list[dict[str, s
     return [artifact for artifact in artifacts if isinstance(artifact, dict)]
 
 
+_EVIDENCE_GRAPH_SURFACE_PRIORITY = {
+    "security": 100,
+    "dependency": 90,
+    "release": 85,
+    "workflow": 80,
+    "cli": 75,
+    "tests": 70,
+    "docs": 60,
+    "diagnostic_engine": 50,
+    "pr_quality": 40,
+    "quality": 30,
+    "maintenance": 20,
+    "unknown": 0,
+}
+
+_EVIDENCE_GRAPH_SEVERITY_PRIORITY = {
+    "critical": 30,
+    "warning": 20,
+    "healthy": 0,
+}
+
+
+def _evidence_graph_node_score(node: dict[str, Any]) -> tuple[int, int, int, str]:
+    surface = str(node.get("risk_surface", "unknown") or "unknown")
+    severity = str(node.get("severity", "unknown") or "unknown")
+    review_first = 1 if bool(node.get("review_first", False)) else 0
+    return (
+        review_first,
+        _EVIDENCE_GRAPH_SEVERITY_PRIORITY.get(severity, 0),
+        _EVIDENCE_GRAPH_SURFACE_PRIORITY.get(surface, 0),
+        str(node.get("title", "")),
+    )
+
+
+def _evidence_graph_top_blocker(nodes: list[dict[str, Any]]) -> dict[str, Any]:
+    if not nodes:
+        return {}
+    return max(nodes, key=_evidence_graph_node_score)
+
+
+def _evidence_graph_next_commands(node: dict[str, Any]) -> list[str]:
+    commands: list[str] = []
+    for key in ("proof_commands", "recommended_commands"):
+        values = node.get(key)
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if isinstance(value, str) and value and value not in commands:
+                commands.append(value)
+            if len(commands) >= 5:
+                return commands
+    return commands
+
+
 def _collect_evidence_graph(graph_path: Path | None) -> dict[str, Any] | None:
     if graph_path is None:
         return None
@@ -441,6 +495,8 @@ def _collect_evidence_graph(graph_path: Path | None) -> dict[str, Any] | None:
     risk_surfaces = sorted(
         {str(node.get("risk_surface", "unknown") or "unknown") for node in nodes}
     )
+    top_blocker = _evidence_graph_top_blocker(nodes)
+    top_blocker_next_commands = _evidence_graph_next_commands(top_blocker)
 
     graph_dir = resolved.parent
     artifact_specs = [
@@ -468,6 +524,12 @@ def _collect_evidence_graph(graph_path: Path | None) -> dict[str, Any] | None:
         "critical_count": critical_count,
         "automation_allowed_now": automation_allowed_now,
         "risk_surfaces": risk_surfaces,
+        "top_blocker_title": str(top_blocker.get("title", "") or "none"),
+        "top_blocker_surface": str(top_blocker.get("risk_surface", "") or "none"),
+        "top_blocker_severity": str(top_blocker.get("severity", "") or "none"),
+        "top_blocker_action": str(top_blocker.get("operator_action", "") or "none"),
+        "top_blocker_review_first": bool(top_blocker.get("review_first", False)),
+        "next_commands": top_blocker_next_commands,
         "source_count": len(source_summary),
         "source_summary": source_summary,
         "artifacts": artifacts,
@@ -506,6 +568,10 @@ def _format_evidence_graph(summary: dict[str, Any] | None) -> list[str]:
         f"- Source count: {summary.get('source_count', 0)}",
         f"- Automation allowed now: {str(summary.get('automation_allowed_now', False)).lower()}",
         f"- Risk surfaces: {', '.join(str(surface) for surface in risk_surfaces) or 'none'}",
+        f"- Top blocker: {summary.get('top_blocker_title', 'none')}",
+        f"- Top blocker surface: {summary.get('top_blocker_surface', 'none')}",
+        f"- Top blocker action: {summary.get('top_blocker_action', 'none')}",
+        f"- Next commands: {'; '.join(str(command) for command in summary.get('next_commands', [])) or 'none'}",
         f"- Graph: `{summary.get('path', '')}`",
     ]
 
@@ -522,6 +588,10 @@ def _evidence_graph_ledger_summary(bundle: dict[str, Any]) -> dict[str, Any] | N
         "critical_count": int(summary.get("critical_count", 0) or 0),
         "automation_allowed_now": bool(summary.get("automation_allowed_now", False)),
         "risk_surfaces": summary.get("risk_surfaces", []),
+        "top_blocker_title": str(summary.get("top_blocker_title", "")),
+        "top_blocker_surface": str(summary.get("top_blocker_surface", "")),
+        "top_blocker_action": str(summary.get("top_blocker_action", "")),
+        "next_commands": summary.get("next_commands", []),
     }
 
 
@@ -1300,6 +1370,17 @@ def _summarize(args: argparse.Namespace) -> int:
         print(
             f"{summary_prefix}_automation_allowed_now="
             f"{str(evidence_graph.get('automation_allowed_now', False)).lower()}"
+        )
+        print(
+            f"{summary_prefix}_top_blocker_surface="
+            f"{evidence_graph.get('top_blocker_surface', 'none')}"
+        )
+        print(
+            f"{summary_prefix}_top_blocker_title={evidence_graph.get('top_blocker_title', 'none')}"
+        )
+        print(
+            f"{summary_prefix}_top_blocker_action="
+            f"{evidence_graph.get('top_blocker_action', 'none')}"
         )
     adaptive_failure_bundle = bundle.get("adaptive_failure_bundle")
     if isinstance(adaptive_failure_bundle, dict):

--- a/tests/test_mission_control_evidence_graph.py
+++ b/tests/test_mission_control_evidence_graph.py
@@ -115,6 +115,13 @@ def test_mission_control_run_summarizes_evidence_graph(tmp_path: Path) -> None:
     assert summary["critical_count"] == 1
     assert summary["automation_allowed_now"] is False
     assert summary["risk_surfaces"] == ["security"]
+    assert summary["top_blocker_surface"] == "security"
+    assert summary["top_blocker_title"] == "Security surface changed"
+    assert summary["top_blocker_action"] == "review"
+    assert summary["next_commands"] == [
+        "python -m pre_commit run -a",
+        "python -m pytest -q tests/test_owned_surface_hygiene_contract.py -o addopts=",
+    ]
     assert summary["source_count"] == 1
 
     labels = {artifact["label"] for artifact in bundle["artifacts"]}
@@ -127,6 +134,8 @@ def test_mission_control_run_summarizes_evidence_graph(tmp_path: Path) -> None:
     assert "Node count: 1" in markdown
     assert "Review-first nodes: 1" in markdown
     assert "Automation allowed now: false" in markdown
+    assert "Top blocker: Security surface changed" in markdown
+    assert "Top blocker surface: security" in markdown
 
 
 def test_mission_control_summarize_prints_evidence_graph(tmp_path: Path, capsys) -> None:
@@ -162,6 +171,9 @@ def test_mission_control_summarize_prints_evidence_graph(tmp_path: Path, capsys)
     assert _eg_line("review_first_count", 1) in output
     assert _eg_line("critical_count", 1) in output
     assert _eg_line("automation_allowed_now", "false") in output
+    assert _eg_line("top_blocker_surface", "security") in output
+    assert _eg_line("top_blocker_title", "Security surface changed") in output
+    assert _eg_line("top_blocker_action", "review") in output
 
 
 def test_mission_control_ledger_records_evidence_graph_summary(tmp_path: Path) -> None:
@@ -207,3 +219,99 @@ def test_mission_control_schema_mentions_evidence_graph(capsys) -> None:
     assert "evidence_graph" in payload["required_top_level_keys"]
     assert "evidence_graph" in payload["ledger_record_keys"]
     assert "Evidence Graph" in payload["report_sections"]
+
+
+def test_mission_control_evidence_graph_ranks_top_blocker(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+
+    graph_dir = tmp_path / "evidence-graph"
+    graph_dir.mkdir()
+    graph_path = graph_dir / "evidence-graph.json"
+    (graph_dir / "evidence-graph.md").write_text("# Evidence Graph\n", encoding="utf-8")
+    graph_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.evidence-graph.v1",
+                "nodes": [
+                    {
+                        "finding_id": "quality-coverage",
+                        "title": "Coverage gate regression",
+                        "summary": "Coverage dropped below threshold.",
+                        "risk_surface": "quality",
+                        "severity": "warning",
+                        "review_first": True,
+                        "safe_to_auto_fix": False,
+                        "recommended_commands": ["bash quality.sh cov"],
+                        "proof_commands": ["bash quality.sh cov"],
+                        "operator_action": "review",
+                        "automation_allowed_now": False,
+                    },
+                    {
+                        "finding_id": "dependency-resolver",
+                        "title": "Dependency resolver failed",
+                        "summary": "pip could not resolve constraints before tests ran.",
+                        "risk_surface": "dependency",
+                        "severity": "warning",
+                        "review_first": True,
+                        "safe_to_auto_fix": False,
+                        "recommended_commands": [
+                            "Reproduce the exact install lane.",
+                        ],
+                        "proof_commands": [
+                            "PYTHONPATH=src python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+                        ],
+                        "operator_action": "review",
+                        "automation_allowed_now": False,
+                    },
+                ],
+                "source_summary": [
+                    {
+                        "source": "failure_bundle",
+                        "path": "build/pr-quality/failure-intelligence/failure-bundle.json",
+                        "found": True,
+                        "status": "needs_fix",
+                        "findings_seen": 2,
+                        "findings_emitted": 2,
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rc = mission_control.main(
+        [
+            "run",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--evidence-graph",
+            str(graph_path),
+            "--no-ledger",
+        ]
+    )
+
+    assert rc == 0
+    bundle = json.loads((out_dir / "mission-control.json").read_text(encoding="utf-8"))
+    summary = bundle["evidence_graph"]
+
+    assert summary["top_blocker_surface"] == "dependency"
+    assert summary["top_blocker_title"] == "Dependency resolver failed"
+    assert summary["top_blocker_action"] == "review"
+    assert summary["top_blocker_review_first"] is True
+    assert summary["next_commands"] == [
+        "PYTHONPATH=src python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+        "Reproduce the exact install lane.",
+    ]
+
+    markdown = (out_dir / "mission-control.md").read_text(encoding="utf-8")
+    assert "Top blocker: Dependency resolver failed" in markdown
+    assert "Top blocker surface: dependency" in markdown
+    assert "Top blocker action: review" in markdown
+    assert "PYTHONPATH=src python -m pip install -c constraints-ci.txt" in markdown


### PR DESCRIPTION
## Summary
- Teach Mission Control to rank Evidence Graph nodes by review-first status, severity, and risk surface.
- Add top-blocker fields to the Mission Control evidence graph summary:
  - `top_blocker_title`
  - `top_blocker_surface`
  - `top_blocker_severity`
  - `top_blocker_action`
  - `top_blocker_review_first`
  - `next_commands`
- Surface the top blocker and next commands in Mission Control Markdown.
- Include top-blocker fields in ledger summaries.
- Print top-blocker surface/title/action from `mission-control summarize`.
- Add regression tests proving dependency/security blockers outrank coverage/quality noise.

## Why
Evidence Graph now receives Sentinel, security-review, Mission Control, and failure-bundle signals. Mission Control should not only report counts; it should identify the real top blocker and preserve the exact next commands operators need.

## Verification
- `python -m pytest -q tests/test_mission_control_evidence_graph.py tests/test_evidence_graph.py tests/test_pr_quality_evidence_narrative.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Mission Control bundle schema gains additional evidence graph summary fields.
- Rollback: revert the top-blocker ranking helpers, summary fields, and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Top blocker commands are evidence-derived proof/review commands, not automatic remediation.