### PR TITLE
Expose evidence graph top blocker in PR quality narrative

### DIFF
--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -69,6 +69,17 @@ _SURFACE_REASON = {
 }
 
 
+_REAL_BLOCKER_SURFACES = {
+    "security",
+    "dependency",
+    "release",
+    "workflow",
+    "cli",
+    "tests",
+    "docs",
+}
+
+
 _GREEN_PROOF_BY_SURFACE = {
     "pr_quality": [
         "python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py -o addopts=",
@@ -368,6 +379,17 @@ def _dedupe(items: list[str]) -> list[str]:
     return out
 
 
+def _commands_from_node(node: JsonObject) -> list[str]:
+    commands: list[str] = []
+    for key in ("proof_commands", "recommended_commands"):
+        for command in _string_list(node.get(key)):
+            if command not in commands:
+                commands.append(command)
+            if len(commands) >= 5:
+                return commands
+    return commands
+
+
 def _green_proof_commands(
     *,
     changed_surfaces: list[str],
@@ -381,11 +403,10 @@ def _green_proof_commands(
             surfaces.append(surface)
 
     commands: list[str] = []
-    for node in nodes:
+    for node in sorted(nodes, key=_node_score, reverse=True):
         surface = str(node.get("risk_surface", "unknown") or "unknown")
-        if surface == "security":
-            commands.extend(_string_list(node.get("recommended_commands")))
-            commands.extend(_string_list(node.get("proof_commands")))
+        if surface in _REAL_BLOCKER_SURFACES:
+            commands.extend(_commands_from_node(node))
 
     for surface in surfaces:
         commands.extend(_GREEN_PROOF_BY_SURFACE.get(surface, []))
@@ -560,6 +581,24 @@ def build_narrative(
             "critical_count": sum(
                 1 for node in nodes if str(node.get("severity", "")) == "critical"
             ),
+            "top_blocker": {
+                "title": _human_finding_title(
+                    primary_node,
+                    changed_files=changed,
+                    changed_surfaces=changed_surfaces,
+                )
+                if primary_node
+                else "none",
+                "surface": str(primary_node.get("risk_surface", "none") or "none")
+                if primary_node
+                else "none",
+                "action": str(primary_node.get("operator_action", "none") or "none")
+                if primary_node
+                else "none",
+                "review_first": bool(primary_node.get("review_first", False))
+                if primary_node
+                else False,
+            },
         },
         "primary_signal": {
             "kind": primary_kind,
@@ -704,6 +743,16 @@ def _what_happened(
         lines.append(f"Diff-owned risk surfaces: {', '.join(changed_surfaces)}.")
 
     if nodes:
+        top_node = _primary_node(nodes)
+        top_surface = str(top_node.get("risk_surface", "unknown") or "unknown")
+        top_title = _human_finding_title(
+            top_node,
+            changed_files=changed_files,
+            changed_surfaces=changed_surfaces,
+        )
+        if top_surface in _REAL_BLOCKER_SURFACES:
+            lines.append(f"Evidence graph top blocker: {top_title} [{top_surface}].")
+
         titles = [
             (
                 f"{_human_finding_title(node, changed_files=changed_files, changed_surfaces=changed_surfaces)} "

--- a/tests/test_pr_quality_evidence_narrative.py
+++ b/tests/test_pr_quality_evidence_narrative.py
@@ -694,3 +694,133 @@ def test_green_narrative_reports_security_review_collection_status(tmp_path: Pat
 
     markdown = str(payload["markdown"])
     assert "Security review evidence: collected; unresolved findings: 0." in markdown
+
+
+def test_green_narrative_uses_evidence_graph_dependency_top_blocker(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "PR Quality evidence changed",
+                    "summary": "The PR Quality evidence comment path changed.",
+                    "risk_surface": "pr_quality",
+                    "severity": "warning",
+                    "review_first": True,
+                    "recommended_commands": [
+                        "python -m pytest -q tests/test_pr_quality_evidence_narrative.py -o addopts="
+                    ],
+                    "operator_action": "review",
+                },
+                {
+                    "title": "Dependency resolver failed",
+                    "summary": "pip could not resolve constraints before tests proved behavior.",
+                    "risk_surface": "dependency",
+                    "severity": "warning",
+                    "review_first": True,
+                    "safe_to_auto_fix": False,
+                    "proof_commands": [
+                        "PYTHONPATH=src python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+                    ],
+                    "recommended_commands": [
+                        "Reproduce the exact install lane.",
+                    ],
+                    "operator_action": "review",
+                },
+            ],
+            "source_summary": [],
+        },
+    )
+    control_room = _write_json(
+        tmp_path / "control-room-with-security-review.json",
+        {
+            "schema_version": "sdetkit.adaptive.sentinel.control_room.v1",
+            "state": "healthy",
+            "active_threat_count": 0,
+            "active_threats": [],
+            "review_first_count": 0,
+            "automation_allowed_now": False,
+            "security_review_collection_status": "collected",
+            "security_review_finding_count": 0,
+            "security_review_state": "healthy",
+        },
+    )
+    changed = _write(
+        tmp_path / "changed-files.txt",
+        "src/sdetkit/pr_quality_evidence_narrative.py\n",
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=control_room,
+        evidence_graph=graph,
+        failure_bundle=None,
+        changed_files=changed,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["kind"] == "review_signal"
+    assert payload["primary_signal"]["surface"] == "dependency"
+    assert payload["primary_signal"]["title"] == "Dependency resolver failed"
+    assert payload["graph"]["top_blocker"]["surface"] == "dependency"
+    assert payload["graph"]["top_blocker"]["title"] == "Dependency resolver failed"
+    assert payload["graph"]["top_blocker"]["action"] == "review"
+    assert "Evidence graph top blocker: Dependency resolver failed [dependency]." in markdown
+    assert "Security review evidence: collected; unresolved findings: 0." in markdown
+    assert "PYTHONPATH=src python -m pip install -c constraints-ci.txt" in markdown
+    assert "Reproduce the exact install lane." in markdown
+
+
+def test_green_narrative_keeps_pr_quality_primary_when_graph_only_has_pr_quality(
+    tmp_path: Path,
+) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "Adaptive failure bundle signal",
+                    "summary": "The PR Quality evidence comment path changed.",
+                    "risk_surface": "pr_quality",
+                    "severity": "warning",
+                    "review_first": True,
+                    "recommended_commands": [
+                        "python -m pytest -q tests/test_pr_quality_evidence_narrative.py -o addopts="
+                    ],
+                    "operator_action": "review",
+                }
+            ],
+            "source_summary": [],
+        },
+    )
+    changed = _write(
+        tmp_path / "changed-files.txt",
+        "src/sdetkit/pr_quality_evidence_narrative.py\n",
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=None,
+        evidence_graph=graph,
+        failure_bundle=None,
+        changed_files=changed,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["surface"] == "pr_quality"
+    assert payload["primary_signal"]["title"] == "PR Quality evidence changed"
+    assert "Evidence graph top blocker:" not in markdown
+    assert "tests/test_pr_quality_evidence_narrative.py" in markdown
+    assert "python -m pre_commit run -a" in markdown


### PR DESCRIPTION
## Summary
- Add real-blocker surface handling to the PR Quality evidence narrative.
- Surface the Evidence Graph top blocker in the JSON payload.
- Add an explicit `Evidence graph top blocker: ...` line in the PR comment when the graph contains a real dependency/security/release/workflow/CLI/tests/docs blocker.
- Use real blocker node proof/recommended commands in green review mode.
- Preserve existing PR Quality-only behavior when the graph only contains PR Quality review evidence.
- Add regression tests for dependency top-blocker and PR Quality-only graph behavior.

## Why
Mission Control now summarizes Evidence Graph top blockers. PR Quality should use the same evidence spine so maintainers see the real blocker, not only generic PR Quality wiring changes.

## Verification
- `python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_mission_control_evidence_graph.py tests/test_evidence_graph.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- PR comment prioritization changes when Evidence Graph contains a real blocker.
- Rollback: revert real-blocker command extraction, graph top-blocker payload fields, and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Real blocker commands are proof/review commands, not automatic remediation.