### PR TITLE
Extend full-spine proof to security and release blockers

### DIFF
--- a/tests/test_full_spine_real_blocker_integration.py
+++ b/tests/test_full_spine_real_blocker_integration.py
@@ -20,6 +20,137 @@ def _write_json(path: Path, payload: dict) -> Path:
     return path
 
 
+def _assert_full_spine_blocker(
+    *,
+    tmp_path: Path,
+    code: str,
+    title: str,
+    diagnosis: str,
+    severity: str,
+    expected_surface: str,
+    proof_commands: list[str],
+    recommended_fix: list[str],
+    affected_files: list[str] | None = None,
+) -> None:
+    repo = tmp_path / f"repo-{expected_surface}"
+    repo.mkdir()
+
+    failure_bundle = _write_json(
+        tmp_path / f"build/{expected_surface}/failure-bundle.json",
+        {
+            "schema_version": "sdetkit.adaptive.diagnosis.v1",
+            "status": "review_required",
+            "review_first": True,
+            "safe_to_auto_fix": False,
+            "primary_diagnosis_code": code,
+            "diagnosis_count": 1,
+            "diagnoses": [
+                {
+                    "code": code,
+                    "title": title,
+                    "diagnosis": diagnosis,
+                    "severity": severity,
+                    "confidence": "high",
+                    "affected_files": affected_files or [],
+                    "recommended_fix": recommended_fix,
+                    "proof_commands": proof_commands,
+                }
+            ],
+        },
+    )
+
+    graph = build_evidence_graph(failure_bundle=failure_bundle)
+    graph_manifest = write_evidence_graph(
+        graph,
+        output_dir=tmp_path / f"build/{expected_surface}/evidence-graph",
+    )
+    graph_path = Path(graph_manifest["graph_path"])
+    graph_payload = json.loads(graph_path.read_text(encoding="utf-8"))
+    graph_node = graph_payload["nodes"][0]
+
+    assert graph_node["source"] == "failure_bundle"
+    assert graph_node["risk_surface"] == expected_surface
+    assert graph_node["title"] == title
+    assert graph_node["review_first"] is True
+    assert graph_node["safe_to_auto_fix"] is False
+
+    mission_out = tmp_path / f"build/{expected_surface}/mission-control"
+    rc = mission_control.main(
+        [
+            "run",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(mission_out),
+            "--evidence-graph",
+            str(graph_path),
+            "--failure-bundle",
+            str(failure_bundle),
+            "--no-ledger",
+        ]
+    )
+
+    assert rc == 0
+    mission_bundle = json.loads((mission_out / "mission-control.json").read_text(encoding="utf-8"))
+    mission_graph = mission_bundle["evidence_graph"]
+
+    assert mission_bundle["decision"] == "SHIP_WITH_FINDINGS"
+    assert mission_graph["top_blocker_surface"] == expected_surface
+    assert mission_graph["top_blocker_title"] == title
+    assert mission_graph["top_blocker_action"] == "review"
+
+    for command in proof_commands:
+        assert command in mission_graph["next_commands"]
+    for command in recommended_fix:
+        assert command in mission_graph["next_commands"]
+
+    mission_markdown = (mission_out / "mission-control.md").read_text(encoding="utf-8")
+    assert f"Top blocker: {title}" in mission_markdown
+    assert f"Top blocker surface: {expected_surface}" in mission_markdown
+
+    quality_log = _write(
+        tmp_path / f"build/{expected_surface}/quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    security_control_room = _write_json(
+        tmp_path / f"build/{expected_surface}/control-room-with-security-review.json",
+        {
+            "schema_version": "sdetkit.adaptive.sentinel.control_room.v1",
+            "state": "healthy",
+            "active_threat_count": 0,
+            "active_threats": [],
+            "review_first_count": 0,
+            "automation_allowed_now": False,
+            "security_review_collection_status": "collected",
+            "security_review_finding_count": 0,
+            "security_review_state": "healthy",
+        },
+    )
+
+    pr_payload = narrative.build_narrative(
+        quality_log=quality_log,
+        quality_outcome="success",
+        sentinel_control_room=security_control_room,
+        evidence_graph=graph_path,
+        failure_bundle=failure_bundle,
+        changed_files=None,
+    )
+    pr_markdown = str(pr_payload["markdown"])
+
+    assert pr_payload["primary_signal"]["kind"] == "review_signal"
+    assert pr_payload["primary_signal"]["surface"] == expected_surface
+    assert pr_payload["primary_signal"]["title"] == title
+    assert pr_payload["graph"]["top_blocker"]["surface"] == expected_surface
+    assert pr_payload["graph"]["top_blocker"]["title"] == title
+    assert f"Evidence graph top blocker: {title} [{expected_surface}]." in pr_markdown
+    assert "Security review evidence: collected; unresolved findings: 0." in pr_markdown
+
+    for command in proof_commands:
+        assert command in pr_markdown
+    for command in recommended_fix:
+        assert command in pr_markdown
+
+
 def test_dependency_failure_flows_from_failure_bundle_to_graph_mission_control_and_pr_quality(
     tmp_path: Path,
 ) -> None:
@@ -155,3 +286,39 @@ def test_dependency_failure_flows_from_failure_bundle_to_graph_mission_control_a
     assert "Security review evidence: collected; unresolved findings: 0." in pr_markdown
     assert "PYTHONPATH=src python -m pip install -c constraints-ci.txt" in pr_markdown
     assert "Reproduce the exact install lane." in pr_markdown
+
+
+def test_security_failure_flows_through_full_spine(tmp_path: Path) -> None:
+    _assert_full_spine_blocker(
+        tmp_path=tmp_path,
+        code="SECURITY_FINDING_REVIEW_REQUIRED",
+        title="Security finding requires review",
+        diagnosis="A security-sensitive finding must be reviewed before treating quality as the blocker.",
+        severity="high",
+        expected_surface="security",
+        affected_files=["src/sdetkit/adaptive_diagnosis.py"],
+        proof_commands=["PYTHONPATH=src python -m pre_commit run -a"],
+        recommended_fix=[
+            "Inspect the security finding and affected surface.",
+            "Fix the finding or dismiss the false positive with a review reason.",
+        ],
+    )
+
+
+def test_release_failure_flows_through_full_spine(tmp_path: Path) -> None:
+    _assert_full_spine_blocker(
+        tmp_path=tmp_path,
+        code="RELEASE_ARTIFACT_INVALID",
+        title="Release artifact validation failed",
+        diagnosis="The release/package validation log shows an artifact contract failure.",
+        severity="high",
+        expected_surface="release",
+        affected_files=["pyproject.toml"],
+        proof_commands=[
+            "PYTHONPATH=src python -m build && PYTHONPATH=src python -m twine check dist/*"
+        ],
+        recommended_fix=[
+            "Rebuild the distribution artifacts from a clean tree.",
+            "Run twine check before release publication.",
+        ],
+    )


### PR DESCRIPTION
## Summary
- Extend the full-spine integration proof beyond dependency failures.
- Add full-spine coverage for `SECURITY_FINDING_REVIEW_REQUIRED`.
- Add full-spine coverage for `RELEASE_ARTIFACT_INVALID`.
- Prove each blocker flows through:
  - failure bundle diagnosis
  - Evidence Graph node
  - Mission Control top blocker
  - PR Quality primary signal
  - preserved proof/review commands
  - visible security review status

## Why
The dependency full-spine path was locked first. Security and release blockers are higher-stakes release-confidence surfaces, so they must be protected by the same end-to-end regression proof.

## Verified chain
`failure bundle diagnosis`
→ `Evidence Graph risk surface`
→ `Mission Control top blocker`
→ `PR Quality primary signal`
→ `operator proof commands`

## Verification
- `python -m pytest -q tests/test_full_spine_real_blocker_integration.py tests/test_pr_quality_evidence_narrative.py tests/test_mission_control_evidence_graph.py tests/test_evidence_graph.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low.
- Test-only integration proof.
- No runtime behavior changes.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Security findings remain review-first and require human fix or dismissal.
- Release findings remain review-first and require artifact validation proof.