### PR TITLE
Make PR quality narrative proof aware

### DIFF
--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -190,6 +190,60 @@ def _load_changed_files(path: Path | None) -> list[str]:
     return [line.strip() for line in _read_text(path).splitlines() if line.strip()]
 
 
+def _proof_signal_from_changed_files(changed_files: list[str]) -> JsonObject:
+    lowered = [path.lower() for path in changed_files]
+
+    if any("test_full_spine_raw_log_diagnosis_integration.py" in path for path in lowered):
+        return {
+            "kind": "integration_proof",
+            "surface": "tests",
+            "title": "Raw-log full-spine proof changed",
+            "what_happened": [
+                "This PR changes the raw-log full-spine regression proof.",
+                "The proof verifies that raw dependency, security, and release logs route through adaptive diagnosis, Evidence Graph, Mission Control, and PR Quality.",
+            ],
+            "why_it_matters": [
+                "This is not a product failure and not a coverage issue.",
+                "The review focus is whether the integration fixture starts from raw log text and proves the real evidence chain without weakening safety boundaries.",
+            ],
+            "operator_action": [
+                "Review the raw-log full-spine proof fixture.",
+                "Confirm it starts from raw log text, not hand-written graph nodes.",
+                "Confirm automation remains advisory/read-only.",
+            ],
+            "next_proof": [
+                "python -m pytest -q tests/test_full_spine_raw_log_diagnosis_integration.py tests/test_full_spine_real_blocker_integration.py -o addopts=",
+                "python -m pre_commit run -a",
+            ],
+        }
+
+    if any("test_full_spine_real_blocker_integration.py" in path for path in lowered):
+        return {
+            "kind": "integration_proof",
+            "surface": "tests",
+            "title": "Full-spine real-blocker proof changed",
+            "what_happened": [
+                "This PR changes the full-spine real-blocker regression proof.",
+                "The proof verifies that blocker diagnoses flow through failure bundle, Evidence Graph, Mission Control, and PR Quality.",
+            ],
+            "why_it_matters": [
+                "This is proof coverage for the evidence spine, not a product failure.",
+                "The review focus is whether real blocker classes remain protected end-to-end.",
+            ],
+            "operator_action": [
+                "Review the full-spine integration fixture.",
+                "Confirm blocker classes keep review-first safety boundaries.",
+                "Confirm proof commands remain evidence-derived and not auto-remediation.",
+            ],
+            "next_proof": [
+                "python -m pytest -q tests/test_full_spine_real_blocker_integration.py tests/test_pr_quality_evidence_narrative.py -o addopts=",
+                "python -m pre_commit run -a",
+            ],
+        }
+
+    return {}
+
+
 def _changed_file_surfaces(files: list[str]) -> list[str]:
     surfaces = {_surface_for_path(path) for path in files}
     surfaces.discard("unknown")
@@ -479,6 +533,7 @@ def build_narrative(
     changed_surfaces = _changed_file_surfaces(changed)
     failure_payload = _fallback_failure_bundle(failure_bundle)
     failure = _primary_failure(failure_payload) if not quality_ok else {}
+    proof_signal = _proof_signal_from_changed_files(changed) if quality_ok else {}
 
     surfaces = {
         str(node.get("risk_surface", "unknown") or "unknown")
@@ -492,6 +547,10 @@ def build_narrative(
         primary_kind = "actual_failure"
         primary_surface = _surface_for_failure(failure)
         primary_title = str(failure.get("title") or failure.get("code") or "Quality failure")
+    elif proof_signal:
+        primary_kind = str(proof_signal.get("kind", "integration_proof"))
+        primary_surface = str(proof_signal.get("surface", "tests"))
+        primary_title = str(proof_signal.get("title", "Integration proof changed"))
     elif quality_ok and (changed_surfaces or primary_node):
         primary_kind = "review_signal"
         primary_node_surface = (
@@ -529,6 +588,8 @@ def build_narrative(
 
     if failure:
         commands = _commands_from_failure(failure)
+    elif proof_signal:
+        commands = _string_list(proof_signal.get("next_proof"))
     elif quality_ok:
         commands = _green_proof_commands(
             changed_surfaces=changed_surfaces,
@@ -549,18 +610,26 @@ def build_narrative(
         changed_surfaces=changed_surfaces,
         failure=failure,
     )
+    if proof_signal:
+        what_happened.extend(_string_list(proof_signal.get("what_happened")))
+
     why_it_matters = _why_it_matters(
         quality_ok=quality_ok,
         primary_surface=primary_surface,
         failure=failure,
         nodes=relevant_nodes if quality_ok else nodes,
     )
+    if proof_signal:
+        why_it_matters = _string_list(proof_signal.get("why_it_matters"))
+
     operator_action = _operator_action(
         quality_ok=quality_ok,
         primary_surface=primary_surface,
         failure=failure,
         nodes=relevant_nodes if quality_ok else nodes,
     )
+    if proof_signal:
+        operator_action = _string_list(proof_signal.get("operator_action"))
     artifact_paths = _artifact_paths(
         quality_log=quality_log,
         sentinel_control_room=sentinel_control_room,

--- a/tests/test_pr_quality_evidence_narrative.py
+++ b/tests/test_pr_quality_evidence_narrative.py
@@ -824,3 +824,96 @@ def test_green_narrative_keeps_pr_quality_primary_when_graph_only_has_pr_quality
     assert "Evidence graph top blocker:" not in markdown
     assert "tests/test_pr_quality_evidence_narrative.py" in markdown
     assert "python -m pre_commit run -a" in markdown
+
+
+def test_green_narrative_explains_raw_log_full_spine_proof_changes(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "PR Quality evidence changed",
+                    "summary": "The PR Quality evidence comment path changed.",
+                    "risk_surface": "pr_quality",
+                    "severity": "warning",
+                    "review_first": True,
+                    "operator_action": "review",
+                }
+            ],
+            "source_summary": [],
+        },
+    )
+    control_room = _write_json(
+        tmp_path / "control-room-with-security-review.json",
+        {
+            "schema_version": "sdetkit.adaptive.sentinel.control_room.v1",
+            "state": "healthy",
+            "active_threat_count": 0,
+            "active_threats": [],
+            "review_first_count": 0,
+            "automation_allowed_now": False,
+            "security_review_collection_status": "collected",
+            "security_review_finding_count": 0,
+            "security_review_state": "healthy",
+        },
+    )
+    changed = _write(
+        tmp_path / "changed-files.txt",
+        "tests/test_full_spine_raw_log_diagnosis_integration.py\n",
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=control_room,
+        evidence_graph=graph,
+        failure_bundle=None,
+        changed_files=changed,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["kind"] == "integration_proof"
+    assert payload["primary_signal"]["surface"] == "tests"
+    assert payload["primary_signal"]["title"] == "Raw-log full-spine proof changed"
+    assert "This PR changes the raw-log full-spine regression proof." in markdown
+    assert "raw dependency, security, and release logs route through adaptive diagnosis" in markdown
+    assert "This is not a product failure and not a coverage issue." in markdown
+    assert "Confirm it starts from raw log text, not hand-written graph nodes." in markdown
+    assert "tests/test_full_spine_raw_log_diagnosis_integration.py" in markdown
+    assert "Security review evidence: collected; unresolved findings: 0." in markdown
+
+
+def test_green_narrative_explains_full_spine_real_blocker_proof_changes(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    changed = _write(
+        tmp_path / "changed-files.txt",
+        "tests/test_full_spine_real_blocker_integration.py\n",
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=None,
+        evidence_graph=None,
+        failure_bundle=None,
+        changed_files=changed,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["primary_signal"]["kind"] == "integration_proof"
+    assert payload["primary_signal"]["surface"] == "tests"
+    assert payload["primary_signal"]["title"] == "Full-spine real-blocker proof changed"
+    assert "real-blocker regression proof" in markdown
+    assert (
+        "blocker diagnoses flow through failure bundle, Evidence Graph, Mission Control, and PR Quality"
+        in markdown
+    )
+    assert "python -m pytest -q tests/test_full_spine_real_blocker_integration.py" in markdown


### PR DESCRIPTION
## Summary
- Add proof-aware changed-file signals to the PR Quality narrative.
- Detect raw-log full-spine proof changes and classify them as `integration_proof`.
- Detect full-spine real-blocker proof changes and classify them as `integration_proof`.
- Replace generic PR Quality plumbing wording with proof-focused reviewer guidance.
- Add regression tests for raw-log and full-spine proof-only PR comments.

## Why
Proof-only PRs should not read like generic PR Quality wiring changes. When the changed file is a full-spine integration proof, the PR comment should explain what proof changed, what chain it verifies, and what reviewers should inspect.

## Expected comment behavior
For raw-log full-spine proof changes:

`Primary signal: Raw-log full-spine proof changed`  
`Signal type: integration_proof`  
`Risk surface: tests`

The comment should tell reviewers to confirm the fixture starts from raw log text, proves the evidence chain, and keeps automation advisory/read-only.

## Verification
- `python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_full_spine_raw_log_diagnosis_integration.py tests/test_full_spine_real_blocker_integration.py tests/test_mission_control_evidence_graph.py tests/test_evidence_graph.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- PR comment wording and prioritization changes for proof-only full-spine test PRs.
- Rollback: revert proof-signal detection and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Real runtime graph blockers still outrank generic proof wording when present.