### PR TITLE
Extend raw-log full-spine proof to workflow CLI docs and tests

### DIFF
--- a/src/sdetkit/evidence_graph.py
+++ b/src/sdetkit/evidence_graph.py
@@ -82,6 +82,7 @@ _REVIEW_FIRST_SURFACES = {
     "pr_quality",
     "quality",
     "unknown",
+    "docs",
 }
 
 _VALID_SURFACES = {
@@ -487,6 +488,9 @@ def _risk_surface(
         "SECRET_EXPOSURE": "security",
         "RELEASE_ARTIFACT_INVALID": "release",
         "WORKFLOW_CONTRACT_FAILURE": "workflow",
+        "CLI_CONTRACT_FAILURE": "cli",
+        "DOCS_BUILD_CONTRACT": "docs",
+        "PYTEST_ASSERTION_FAILURE": "tests",
     }
     if code in code_surfaces:
         return code_surfaces[code]

--- a/tests/test_evidence_graph.py
+++ b/tests/test_evidence_graph.py
@@ -411,3 +411,32 @@ def test_evidence_graph_module_cli_accepts_failure_bundle(tmp_path: Path, capsys
     )
     assert graph["nodes"][0]["source"] == "failure_bundle"
     assert graph["nodes"][0]["risk_surface"] == "dependency"
+
+
+def test_evidence_graph_marks_docs_contract_failures_review_first(tmp_path: Path) -> None:
+    failure_bundle = tmp_path / "failure-bundle.json"
+    failure_bundle.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.adaptive.diagnosis.v1",
+                "diagnoses": [
+                    {
+                        "code": "DOCS_BUILD_CONTRACT",
+                        "title": "Documentation build contract failed",
+                        "diagnosis": "The documentation build or navigation contract failed.",
+                        "severity": "high",
+                        "proof_commands": [
+                            "NO_MKDOCS_2_WARNING=1 PYTHONPATH=src python -m mkdocs build --strict"
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    graph = build_evidence_graph(failure_bundle=failure_bundle)
+
+    assert graph["nodes"][0]["risk_surface"] == "docs"
+    assert graph["nodes"][0]["review_first"] is True
+    assert graph["nodes"][0]["safe_to_auto_fix"] is False

--- a/tests/test_full_spine_raw_log_diagnosis_integration.py
+++ b/tests/test_full_spine_raw_log_diagnosis_integration.py
@@ -201,3 +201,72 @@ def test_raw_release_log_flows_through_full_spine(tmp_path: Path) -> None:
         expected_title="Release artifact validation failed",
         expected_command_fragment="twine check",
     )
+
+
+def test_raw_workflow_log_flows_through_full_spine(tmp_path: Path) -> None:
+    _assert_raw_log_full_spine(
+        tmp_path=tmp_path,
+        surface="workflow",
+        raw_log="\n".join(
+            [
+                "Invalid workflow file: .github/workflows/pr-quality-comment.yml",
+                "You have an error in your yaml syntax on line 42",
+                "Process completed with exit code 1",
+            ]
+        ),
+        expected_code="WORKFLOW_CONTRACT_FAILURE",
+        expected_title="GitHub Actions workflow contract failed",
+        expected_command_fragment="pre_commit",
+    )
+
+
+def test_raw_cli_log_flows_through_full_spine(tmp_path: Path) -> None:
+    _assert_raw_log_full_spine(
+        tmp_path=tmp_path,
+        surface="cli",
+        raw_log="\n".join(
+            [
+                "python -m sdetkit mission-control summarize --bundle build/mission-control/mission-control.json",
+                "error: unrecognized arguments: --bundle",
+                "Process completed with exit code 2",
+            ]
+        ),
+        expected_code="CLI_CONTRACT_FAILURE",
+        expected_title="CLI contract failed",
+        expected_command_fragment="sdetkit",
+    )
+
+
+def test_raw_docs_log_flows_through_full_spine(tmp_path: Path) -> None:
+    _assert_raw_log_full_spine(
+        tmp_path=tmp_path,
+        surface="docs",
+        raw_log="\n".join(
+            [
+                "mkdocs build --strict",
+                "ERROR - Config value 'nav': The file docs/missing.md does not exist",
+                "Aborted with 1 Configuration Errors!",
+                "Process completed with exit code 1",
+            ]
+        ),
+        expected_code="DOCS_BUILD_CONTRACT",
+        expected_title="Documentation build contract failed",
+        expected_command_fragment="mkdocs build",
+    )
+
+
+def test_raw_pytest_log_flows_through_full_spine(tmp_path: Path) -> None:
+    _assert_raw_log_full_spine(
+        tmp_path=tmp_path,
+        surface="tests",
+        raw_log="\n".join(
+            [
+                "FAILED tests/test_real_behavior.py::test_behavior - AssertionError",
+                "E AssertionError: expected healthy state",
+                "Process completed with exit code 1",
+            ]
+        ),
+        expected_code="PYTEST_ASSERTION_FAILURE",
+        expected_title="Targeted test behavior failed",
+        expected_command_fragment="pytest",
+    )


### PR DESCRIPTION
## Summary
- Extend raw-log full-spine proof to workflow, CLI, docs, and pytest failures.
- Add explicit Evidence Graph diagnosis-code mappings for:
  - `CLI_CONTRACT_FAILURE -> cli`
  - `DOCS_BUILD_CONTRACT -> docs`
  - `PYTEST_ASSERTION_FAILURE -> tests`
- Mark docs contract failures review-first.
- Add focused Evidence Graph regression for docs review-first behavior.
- Prove raw workflow/CLI/docs/tests logs flow through:
  - adaptive diagnosis
  - failure bundle
  - Evidence Graph
  - Mission Control top blocker
  - PR Quality primary signal
  - preserved proof commands

## Why
The raw-log full-spine proof already covered dependency, security, and release. This PR completes raw-log coverage for workflow, CLI, docs, and tests blockers. It also fixes a real Evidence Graph policy gap where docs contract failures were not review-first and CLI diagnosis evidence could be pulled toward the tests surface by proof-command text.

## Verified chain
`raw log text`
→ `adaptive_diagnosis.analyze_evidence`
→ `failure bundle`
→ `Evidence Graph risk surface`
→ `Mission Control top blocker`
→ `PR Quality primary signal`
→ `operator proof commands`

## Verification
- `python -m pytest -q tests/test_full_spine_raw_log_diagnosis_integration.py tests/test_full_spine_real_blocker_integration.py tests/test_pr_quality_evidence_narrative.py tests/test_mission_control_evidence_graph.py tests/test_evidence_graph.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Evidence Graph risk-surface and review-first policy expanded for CLI/docs/tests diagnosis codes.
- Rollback: revert diagnosis-code mappings, docs review-first policy, and focused tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Docs, CLI, workflow, and tests blockers remain review-first unless a separate safe-remediation policy explicitly allows otherwise.