### PR TITLE
Make PR quality comment workflow fail loud

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -9,9 +9,14 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: pr-quality-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -113,6 +118,32 @@ jobs:
             --failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json \
             --out-dir build/sdetkit/evidence-graph
 
+      - name: Initialize PR comment status
+        if: always()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p build/pr-quality
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          Path("build/pr-quality/comment-status.json").write_text(
+              json.dumps(
+                  {
+                      "status": "failed",
+                      "pr_number": int(os.environ["PR_NUMBER"]),
+                      "reason": "comment step did not complete",
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
       - name: Build PR comment body
         run: |
           mkdir -p build/pr-quality
@@ -149,16 +180,109 @@ jobs:
             .sdetkit/adaptive-sentinel/
           if-no-files-found: ignore
 
+      - name: Upload PR quality comment artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: pr-quality-comment
+          path: |
+            build/pr-quality/pr-comment-body.md
+            build/pr-quality/pr-evidence-narrative.json
+            build/pr-quality/changed-files.txt
+            build/pr-quality/comment-status.json
+            build/sdetkit/evidence-graph/
+          if-no-files-found: ignore
+
       - name: Comment on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const fs = require('fs');
-            const text = fs.readFileSync('build/pr-quality/pr-comment-body.md', 'utf8');
-            const body = `### SDET Quality Gate\n${text}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
+            const path = require('path');
+
+            const statusPath = 'build/pr-quality/comment-status.json';
+            const writeStatus = (payload) => {
+              fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+              fs.writeFileSync(
+                statusPath,
+                `${JSON.stringify(payload, null, 2)}\n`,
+                'utf8'
+              );
+            };
+
+            try {
+              const text = fs.readFileSync('build/pr-quality/pr-comment-body.md', 'utf8');
+              const body = `### SDET Quality Gate\n${text}`;
+              const marker = '### SDET Quality Gate';
+
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+
+              const existing = comments.find((comment) =>
+                comment.user?.type === 'Bot' && comment.body?.startsWith(marker)
+              );
+
+              if (existing) {
+                const { data: updated } = await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                writeStatus({
+                  status: 'updated',
+                  pr_number: context.issue.number,
+                  comment_id: updated.id,
+                  comment_url: updated.html_url,
+                  reason: 'updated existing SDET Quality Gate comment',
+                });
+                core.info(`comment_status=updated comment_url=${updated.html_url}`);
+              } else {
+                const { data: created } = await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+                writeStatus({
+                  status: 'posted',
+                  pr_number: context.issue.number,
+                  comment_id: created.id,
+                  comment_url: created.html_url,
+                  reason: 'posted SDET Quality Gate comment',
+                });
+                core.info(`comment_status=posted comment_url=${created.html_url}`);
+              }
+            } catch (error) {
+              writeStatus({
+                status: 'failed',
+                pr_number: context.issue.number,
+                reason: String(error && error.message ? error.message : error),
+              });
+              core.setFailed(`failed to post PR Quality comment: ${error && error.message ? error.message : error}`);
+            }
+
+      - name: Verify PR Quality comment visibility
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("build/pr-quality/comment-status.json")
+          if not path.exists():
+              raise SystemExit("comment_status=missing: build/pr-quality/comment-status.json was not written")
+
+          payload = json.loads(path.read_text(encoding="utf-8"))
+          status = str(payload.get("status", "missing"))
+          reason = str(payload.get("reason", ""))
+          print(f"comment_status={status}")
+          print(f"comment_reason={reason}")
+
+          if status not in {"posted", "updated"}:
+              raise SystemExit(f"PR Quality comment was not posted or updated: status={status} reason={reason}")
+          PY

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(".github/workflows/pr-quality-comment.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_pr_quality_comment_workflow_has_queue_safe_concurrency_and_timeout() -> None:
+    text = _workflow_text()
+
+    assert "name: PR Quality Comment" in text
+    assert "pull_request:" in text
+    assert "concurrency:" in text
+    assert "group: pr-quality-comment-${{ github.event.pull_request.number }}" in text
+    assert "cancel-in-progress: true" in text
+    assert "timeout-minutes: 20" in text
+
+
+def test_pr_quality_comment_workflow_has_comment_permissions() -> None:
+    text = _workflow_text()
+
+    assert "contents: read" in text
+    assert "pull-requests: write" in text
+    assert "issues: write" in text
+
+
+def test_pr_quality_comment_workflow_writes_comment_status_before_posting() -> None:
+    text = _workflow_text()
+
+    assert "Initialize PR comment status" in text
+    assert "build/pr-quality/comment-status.json" in text
+    assert '"status": "failed"' in text
+    assert '"reason": "comment step did not complete"' in text
+
+
+def test_pr_quality_comment_workflow_uploads_comment_artifacts() -> None:
+    text = _workflow_text()
+
+    assert "Upload PR quality comment artifacts" in text
+    assert "build/pr-quality/pr-comment-body.md" in text
+    assert "build/pr-quality/pr-evidence-narrative.json" in text
+    assert "build/pr-quality/changed-files.txt" in text
+    assert "build/pr-quality/comment-status.json" in text
+    assert "build/sdetkit/evidence-graph/" in text
+
+
+def test_pr_quality_comment_workflow_updates_or_posts_comment_and_records_status() -> None:
+    text = _workflow_text()
+
+    assert "listComments" in text
+    assert "updateComment" in text
+    assert "createComment" in text
+    assert "comment_status=updated" in text
+    assert "comment_status=posted" in text
+    assert "posted SDET Quality Gate comment" in text
+    assert "updated existing SDET Quality Gate comment" in text
+
+
+def test_pr_quality_comment_workflow_fails_loud_when_comment_not_visible() -> None:
+    text = _workflow_text()
+
+    assert "Verify PR Quality comment visibility" in text
+    assert "if: always()" in text
+    assert "comment_status=missing" in text
+    assert 'status not in {"posted", "updated"}' in text
+    assert "PR Quality comment was not posted or updated" in text


### PR DESCRIPTION
## Summary
- Add queue-safe concurrency and job timeout to the PR Quality Comment workflow.
- Initialize `build/pr-quality/comment-status.json` before posting.
- Upload PR Quality comment artifacts:
  - rendered comment body
  - narrative JSON
  - changed-files list
  - comment status
  - evidence graph artifacts
- Change the comment step to update an existing SDET Quality Gate comment or create one if missing.
- Record `comment_status=posted|updated|failed`.
- Add a final `if: always()` verification step that fails if the comment was not posted or updated.
- Add workflow contract tests for permissions, concurrency, artifacts, status recording, update/create behavior, and fail-loud verification.

## Why
PR #1304 merged green while the PR Quality Comment workflow stayed queued and no SDET Quality Gate comment was visible. A missing review comment is worse than a weak comment because the operator loses the control-room signal. This PR makes started PR Quality runs observable and fail-loud instead of silently passing without a visible comment.

## Verification
- `python -m pytest -q tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_pr_quality_security_review_workflow.py tests/test_pr_quality_evidence_narrative.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Workflow behavior changes from “best effort comment” to “comment visibility is required once the job starts.”
- Rollback: revert workflow status/artifact/fail-loud steps and observability tests.

## Notes
- Advisory/read-only only.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened quality checks.
- This cannot force GitHub to start a queued run, but every started run must now produce a visible status and fail if the SDET Quality Gate comment is missing.