### PR TITLE
Add repo-agnostic check intelligence engine

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -1,0 +1,611 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from . import adaptive_diagnosis
+
+CHECK_INTELLIGENCE_SCHEMA_VERSION = "sdetkit.pr_quality.check_intelligence.v1"
+ACTION_REPORT_SCHEMA_VERSION = "sdetkit.pr_quality.action_report.v1"
+
+JsonObject = dict[str, Any]
+
+
+_FAILURE_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "startup_failure",
+    "timed_out",
+}
+
+_SUCCESS_CONCLUSIONS = {
+    "neutral",
+    "skipped",
+    "success",
+}
+
+_PENDING_STATUSES = {
+    "expected",
+    "in_progress",
+    "pending",
+    "queued",
+    "requested",
+    "waiting",
+}
+
+_SAFE_AUTO_FIX_CODES = {
+    "PRE_COMMIT_FORMAT_DRIFT",
+    "RUFF_FIXABLE_LINT",
+}
+
+_DIAGNOSIS_SURFACES = {
+    "PACKAGE_INSTALL_FAILURE": "dependency",
+    "MISSING_TEST_DEPENDENCY": "dependency",
+    "SECURITY_FINDING_REVIEW_REQUIRED": "security",
+    "SECRET_EXPOSURE": "security",
+    "RELEASE_ARTIFACT_INVALID": "release",
+    "WORKFLOW_CONTRACT_FAILURE": "workflow",
+    "CLI_CONTRACT_FAILURE": "cli",
+    "DOCS_BUILD_CONTRACT": "docs",
+    "PYTEST_ASSERTION_FAILURE": "tests",
+    "PYTEST_IMPORT_FAILURE": "tests",
+    "PRE_COMMIT_FORMAT_DRIFT": "quality",
+    "RUFF_FIXABLE_LINT": "quality",
+    "RUFF_LINT_FAILURE": "quality",
+    "MYPY_TYPE_CONTRACT_DRIFT": "quality",
+    "COVERAGE_GATE_REGRESSION": "quality",
+}
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _read_json(path: Path | None) -> JsonObject:
+    if path is None or not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return _as_dict(payload)
+
+
+def _write_json(path: Path, payload: JsonObject) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip().lower()).strip("-")
+    return slug or "check"
+
+
+def _iter_check_records(payload: JsonObject) -> list[JsonObject]:
+    if isinstance(payload.get("checks"), list):
+        return [_as_dict(item) for item in _as_list(payload.get("checks"))]
+
+    records: list[JsonObject] = []
+    for key in (
+        "check_runs",
+        "jobs",
+        "workflow_runs",
+        "statuses",
+        "check_suites",
+    ):
+        records.extend(_as_dict(item) for item in _as_list(payload.get(key)))
+
+    if not records and payload:
+        records.append(payload)
+
+    return records
+
+
+def _check_name(record: JsonObject, index: int) -> str:
+    for key in ("name", "displayName", "workflowName", "context", "check_name"):
+        value = _string(record.get(key))
+        if value:
+            return value
+    return f"check-{index + 1}"
+
+
+def _check_status(record: JsonObject) -> str:
+    return _string(record.get("status")).lower()
+
+
+def _check_conclusion(record: JsonObject) -> str:
+    return _string(record.get("conclusion") or record.get("state")).lower()
+
+
+def _is_failed(record: JsonObject) -> bool:
+    conclusion = _check_conclusion(record)
+    status = _check_status(record)
+    if conclusion in _FAILURE_CONCLUSIONS:
+        return True
+    return status == "completed" and conclusion not in _SUCCESS_CONCLUSIONS
+
+
+def _is_queued_or_pending(record: JsonObject) -> bool:
+    status = _check_status(record)
+    conclusion = _check_conclusion(record)
+    return status in _PENDING_STATUSES and conclusion not in _FAILURE_CONCLUSIONS
+
+
+def _is_cancelled(record: JsonObject) -> bool:
+    return _check_conclusion(record) == "cancelled"
+
+
+def _is_startup_failure(record: JsonObject) -> bool:
+    return _check_conclusion(record) == "startup_failure"
+
+
+def _record_url(record: JsonObject) -> str:
+    for key in ("url", "html_url", "details_url"):
+        value = _string(record.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _record_log_text(record: JsonObject, logs_dir: Path | None, name: str) -> str:
+    for key in ("log", "logs", "stdout", "stderr", "output", "text"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+
+    log_path_value = _string(record.get("log_path") or record.get("logPath"))
+    if log_path_value:
+        log_path = Path(log_path_value)
+        if log_path.exists():
+            return log_path.read_text(encoding="utf-8", errors="ignore")
+
+    if logs_dir is None or not logs_dir.exists():
+        return ""
+
+    candidates = [
+        logs_dir / f"{_slug(name)}.log",
+        logs_dir / f"{_slug(name)}.txt",
+        logs_dir / f"{name}.log",
+        logs_dir / f"{name}.txt",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.read_text(encoding="utf-8", errors="ignore")
+
+    slug = _slug(name)
+    for candidate in sorted(logs_dir.glob("*")):
+        if candidate.is_file() and slug in _slug(candidate.stem):
+            return candidate.read_text(encoding="utf-8", errors="ignore")
+
+    return ""
+
+
+_FAILURE_LINE_PATTERNS = (
+    "error:",
+    "failed",
+    "failure",
+    "traceback",
+    "assertionerror",
+    "modulenotfounderror",
+    "importerror",
+    "process completed with exit code",
+    "ruff",
+    "mypy",
+    "pytest",
+    "resolutionimpossible",
+    "cannot install",
+)
+
+
+def _failure_focused_log_text(text: str, *, context: int = 10, limit: int = 240) -> str:
+    lines = text.splitlines()
+    if not lines:
+        return text
+
+    selected: set[int] = set()
+    for index, line in enumerate(lines):
+        lowered = line.lower()
+        if any(pattern in lowered for pattern in _FAILURE_LINE_PATTERNS):
+            start = max(0, index - context)
+            end = min(len(lines), index + context + 1)
+            selected.update(range(start, end))
+
+    if not selected:
+        return "\n".join(lines[-limit:])
+
+    ordered = sorted(selected)
+    if len(ordered) > limit:
+        ordered = ordered[: limit // 2] + ordered[-(limit // 2) :]
+
+    return "\n".join(lines[index] for index in ordered)
+
+
+def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) -> JsonObject:
+    name = _check_name(record, index)
+    log_text = _record_log_text(record, logs_dir, name)
+    focused_log_text = _failure_focused_log_text(log_text)
+    diagnostic_text = "\n".join(
+        part
+        for part in [
+            f"check_name={name}",
+            f"status={_check_status(record)}",
+            f"conclusion={_check_conclusion(record)}",
+            focused_log_text,
+        ]
+        if part
+    )
+
+    diagnosis = adaptive_diagnosis.analyze_evidence(log_text=diagnostic_text)
+    diagnoses = [
+        _as_dict(item) for item in _as_list(diagnosis.get("diagnoses")) if isinstance(item, dict)
+    ]
+
+    primary = diagnoses[0] if diagnoses else {}
+    return {
+        "name": name,
+        "status": _check_status(record),
+        "conclusion": _check_conclusion(record),
+        "url": _record_url(record),
+        "log_collected": bool(log_text.strip()),
+        "diagnosis": primary,
+        "diagnoses": diagnoses,
+        "diagnosis_status": diagnosis.get("status", "unknown"),
+        "safe_to_auto_fix": bool(
+            _as_dict((_as_list(diagnosis.get("fix_plan")) or [{}])[0]).get(
+                "safe_to_auto_fix",
+                False,
+            )
+        ),
+    }
+
+
+def _security_review_summary(review_threads_json: Path | None) -> JsonObject:
+    if review_threads_json is None:
+        return {
+            "collected": False,
+            "unresolved_findings": 0,
+            "source": "",
+        }
+
+    if not review_threads_json.exists():
+        return {
+            "collected": False,
+            "unresolved_findings": 0,
+            "source": review_threads_json.as_posix(),
+        }
+
+    try:
+        from .security_review_evidence import findings_from_review_threads
+
+        findings = findings_from_review_threads(review_threads_json)
+    except Exception:
+        findings = []
+
+    return {
+        "collected": True,
+        "unresolved_findings": len(findings),
+        "source": review_threads_json.as_posix(),
+    }
+
+
+def build_check_intelligence(
+    *,
+    checks_json: Path,
+    logs_dir: Path | None = None,
+    review_threads_json: Path | None = None,
+) -> JsonObject:
+    payload = _read_json(checks_json)
+    records = _iter_check_records(payload)
+
+    failed_checks: list[JsonObject] = []
+    queued_checks: list[JsonObject] = []
+    cancelled_checks: list[JsonObject] = []
+    startup_failures: list[JsonObject] = []
+
+    for index, record in enumerate(records):
+        check = {
+            "name": _check_name(record, index),
+            "status": _check_status(record),
+            "conclusion": _check_conclusion(record),
+            "url": _record_url(record),
+        }
+
+        if _is_failed(record):
+            diagnosed = _diagnose_check(record, index=index, logs_dir=logs_dir)
+            failed_checks.append(diagnosed)
+
+        if _is_queued_or_pending(record):
+            queued_checks.append(check)
+
+        if _is_cancelled(record):
+            cancelled_checks.append(check)
+
+        if _is_startup_failure(record):
+            startup_failures.append(check)
+
+    return {
+        "schema_version": CHECK_INTELLIGENCE_SCHEMA_VERSION,
+        "checks_seen": len(records),
+        "failed_checks": failed_checks,
+        "queued_checks": queued_checks,
+        "cancelled_checks": cancelled_checks,
+        "startup_failures": startup_failures,
+        "security_review": _security_review_summary(review_threads_json),
+    }
+
+
+def _primary_failed_check(intelligence: JsonObject) -> JsonObject:
+    failed = [_as_dict(item) for item in _as_list(intelligence.get("failed_checks"))]
+    if not failed:
+        return {}
+
+    def score(check: JsonObject) -> tuple[int, int]:
+        diagnosis = _as_dict(check.get("diagnosis"))
+        safe = 1 if bool(check.get("safe_to_auto_fix", False)) else 0
+        unsafe_priority = 0 if safe else 1
+        surface_priority = {
+            "security": 100,
+            "dependency": 95,
+            "release": 90,
+            "workflow": 85,
+            "cli": 80,
+            "tests": 75,
+            "docs": 70,
+            "quality": 40,
+            "unknown": 0,
+        }
+        surface = _surface_for_diagnosis(diagnosis)
+        return (unsafe_priority, surface_priority.get(surface, 0))
+
+    return max(failed, key=score)
+
+
+def _surface_for_diagnosis(diagnosis: JsonObject) -> str:
+    explicit = _string(diagnosis.get("risk_surface") or diagnosis.get("surface")).lower()
+    if explicit:
+        return explicit
+
+    code = _string(diagnosis.get("code")).upper()
+    if code in _DIAGNOSIS_SURFACES:
+        return _DIAGNOSIS_SURFACES[code]
+
+    text = " ".join(
+        [
+            _string(diagnosis.get("title")),
+            _string(diagnosis.get("diagnosis")),
+            " ".join(str(item) for item in _as_list(diagnosis.get("proof_commands"))),
+            " ".join(str(item) for item in _as_list(diagnosis.get("recommended_fix"))),
+        ]
+    ).lower()
+
+    if any(token in text for token in ("security", "secret", "vulnerability")):
+        return "security"
+    if any(token in text for token in ("dependency", "resolver", "pip", "requirements")):
+        return "dependency"
+    if any(token in text for token in ("release", "twine", "publish", "dist/")):
+        return "release"
+    if any(token in text for token in ("workflow", "github actions", "yaml")):
+        return "workflow"
+    if any(token in text for token in ("cli", "entry point", "argparse")):
+        return "cli"
+    if any(token in text for token in ("pytest", "assertion", "test")):
+        return "tests"
+    if any(token in text for token in ("docs", "mkdocs", "documentation")):
+        return "docs"
+    if any(token in text for token in ("ruff", "format", "mypy", "coverage", "pre-commit")):
+        return "quality"
+    return "unknown"
+
+
+def _safe_fix_reason(code: str, safe: bool) -> str:
+    if safe and code in _SAFE_AUTO_FIX_CODES:
+        return "diagnosis is approved for narrow mechanical safe-fix planning"
+    if safe:
+        return "diagnosis reported safe_to_auto_fix=true"
+    return "diagnosis is review-first or not approved for automatic mutation"
+
+
+def _diagnosis_commands(diagnosis: JsonObject, key: str) -> list[str]:
+    return [str(item) for item in _as_list(diagnosis.get(key)) if isinstance(item, str)]
+
+
+def build_action_report(intelligence: JsonObject) -> JsonObject:
+    failed = _as_list(intelligence.get("failed_checks"))
+    queued = _as_list(intelligence.get("queued_checks"))
+    startup = _as_list(intelligence.get("startup_failures"))
+
+    if failed:
+        check = _primary_failed_check(intelligence)
+        diagnosis = _as_dict(check.get("diagnosis"))
+        code = _string(diagnosis.get("code")).upper()
+        title = _string(diagnosis.get("title") or code or check.get("name"))
+        surface = _surface_for_diagnosis(diagnosis)
+        safe = bool(check.get("safe_to_auto_fix", False)) and code in _SAFE_AUTO_FIX_CODES
+        status = "safe_fix_available" if safe else "review_required"
+
+        return {
+            "schema_version": ACTION_REPORT_SCHEMA_VERSION,
+            "status": status,
+            "primary_blocker": {
+                "check": check.get("name", ""),
+                "title": title,
+                "surface": surface,
+                "impact": _string(
+                    diagnosis.get("diagnosis")
+                    or "The check failed before the PR could be treated as fully proven."
+                ),
+                "code": code,
+                "url": check.get("url", ""),
+            },
+            "automation": {
+                "attempted": False,
+                "allowed": safe,
+                "reason": _safe_fix_reason(code, safe),
+            },
+            "recommended_actions": _diagnosis_commands(diagnosis, "recommended_fix"),
+            "proof_commands": _diagnosis_commands(diagnosis, "proof_commands"),
+            "evidence": {
+                "failed_check_count": len(failed),
+                "queued_check_count": len(queued),
+                "startup_failure_count": len(startup),
+                "security_review": intelligence.get("security_review", {}),
+            },
+        }
+
+    if queued or startup:
+        return {
+            "schema_version": ACTION_REPORT_SCHEMA_VERSION,
+            "status": "incomplete",
+            "primary_blocker": {
+                "check": _string(_as_dict((queued or startup)[0]).get("name")),
+                "title": "Checks are not complete",
+                "surface": "workflow",
+                "impact": "The PR cannot be treated as fully proven while required checks are queued, pending, or failed to start.",
+                "code": "CHECKS_INCOMPLETE",
+                "url": _string(_as_dict((queued or startup)[0]).get("url")),
+            },
+            "automation": {
+                "attempted": False,
+                "allowed": False,
+                "reason": "check completion is required before remediation or green signoff",
+            },
+            "recommended_actions": [
+                "Wait for queued checks to complete or inspect the workflow-start issue.",
+                "Do not treat the PR as green until check intelligence is complete.",
+            ],
+            "proof_commands": [],
+            "evidence": {
+                "failed_check_count": 0,
+                "queued_check_count": len(queued),
+                "startup_failure_count": len(startup),
+                "security_review": intelligence.get("security_review", {}),
+            },
+        }
+
+    return {
+        "schema_version": ACTION_REPORT_SCHEMA_VERSION,
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {
+            "attempted": False,
+            "allowed": False,
+            "reason": "no remediation needed",
+        },
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {
+            "failed_check_count": 0,
+            "queued_check_count": 0,
+            "startup_failure_count": 0,
+            "security_review": intelligence.get("security_review", {}),
+        },
+    }
+
+
+def render_action_report(report: JsonObject) -> str:
+    status = _string(report.get("status"))
+    lines = [
+        "# SDETKit Check Intelligence Action Report",
+        "",
+        f"Status: `{status}`",
+        "",
+    ]
+
+    primary = _as_dict(report.get("primary_blocker"))
+    if primary:
+        lines.extend(
+            [
+                "## Primary blocker",
+                "",
+                f"- Check: `{primary.get('check', '')}`",
+                f"- Title: {primary.get('title', '')}",
+                f"- Surface: `{primary.get('surface', '')}`",
+                f"- Code: `{primary.get('code', '')}`",
+                f"- Impact: {primary.get('impact', '')}",
+                "",
+            ]
+        )
+    else:
+        lines.extend(["## Primary blocker", "", "- none", ""])
+
+    automation = _as_dict(report.get("automation"))
+    lines.extend(
+        [
+            "## Automation decision",
+            "",
+            f"- Attempted: `{str(automation.get('attempted', False)).lower()}`",
+            f"- Allowed: `{str(automation.get('allowed', False)).lower()}`",
+            f"- Reason: {automation.get('reason', '')}",
+            "",
+            "## Recommended actions",
+            "",
+        ]
+    )
+    actions = [str(item) for item in _as_list(report.get("recommended_actions"))]
+    lines.extend([f"- {item}" for item in actions] or ["- none"])
+    lines.extend(["", "## Proof commands", ""])
+    commands = [str(item) for item in _as_list(report.get("proof_commands"))]
+    lines.extend([f"- `{item}`" for item in commands] or ["- none"])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_artifacts(
+    *,
+    intelligence: JsonObject,
+    action_report: JsonObject,
+    out_dir: Path,
+) -> JsonObject:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    check_path = out_dir / "check-intelligence.json"
+    action_path = out_dir / "action-report.json"
+    markdown_path = out_dir / "action-report.md"
+
+    _write_json(check_path, intelligence)
+    _write_json(action_path, action_report)
+    markdown_path.write_text(render_action_report(action_report), encoding="utf-8")
+
+    return {
+        "check_intelligence": check_path.as_posix(),
+        "action_report": action_path.as_posix(),
+        "action_report_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.check_intelligence")
+    parser.add_argument("--checks-json", type=Path, required=True)
+    parser.add_argument("--logs-dir", type=Path)
+    parser.add_argument("--review-threads-json", type=Path)
+    parser.add_argument("--out-dir", type=Path, default=Path("build/pr-quality"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    intelligence = build_check_intelligence(
+        checks_json=args.checks_json,
+        logs_dir=args.logs_dir,
+        review_threads_json=args.review_threads_json,
+    )
+    action_report = build_action_report(intelligence)
+    artifacts = write_artifacts(
+        intelligence=intelligence,
+        action_report=action_report,
+        out_dir=args.out_dir,
+    )
+    print(json.dumps(artifacts, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import check_intelligence
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_check_intelligence_reports_green_when_all_checks_pass(tmp_path: Path) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "CI",
+                    "status": "completed",
+                    "conclusion": "success",
+                },
+                {
+                    "name": "Security",
+                    "status": "completed",
+                    "conclusion": "success",
+                },
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    assert intelligence["schema_version"] == check_intelligence.CHECK_INTELLIGENCE_SCHEMA_VERSION
+    assert intelligence["checks_seen"] == 2
+    assert intelligence["failed_checks"] == []
+    assert intelligence["queued_checks"] == []
+    assert report["schema_version"] == check_intelligence.ACTION_REPORT_SCHEMA_VERSION
+    assert report["status"] == "green"
+    assert report["primary_blocker"] == {}
+    assert report["automation"]["allowed"] is False
+
+
+def test_check_intelligence_turns_dependency_check_failure_into_review_required_action(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Install dependencies",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "url": "https://example.test/checks/install",
+                }
+            ]
+        },
+    )
+    logs_dir = tmp_path / "logs"
+    _write(
+        logs_dir / "install-dependencies.log",
+        "\n".join(
+            [
+                "ERROR: Cannot install -r requirements-test.txt because these package versions have conflicting dependencies.",
+                "ResolutionImpossible: for help visit https://pip.pypa.io/",
+                "Process completed with exit code 1",
+            ]
+        ),
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        logs_dir=logs_dir,
+    )
+    report = check_intelligence.build_action_report(intelligence)
+
+    assert intelligence["checks_seen"] == 1
+    assert len(intelligence["failed_checks"]) == 1
+    failed = intelligence["failed_checks"][0]
+    assert failed["diagnosis"]["code"] == "PACKAGE_INSTALL_FAILURE"
+    assert failed["safe_to_auto_fix"] is False
+
+    assert report["status"] == "review_required"
+    assert report["primary_blocker"]["surface"] == "dependency"
+    assert report["primary_blocker"]["title"] == "Dependency resolver failed"
+    assert report["automation"]["allowed"] is False
+    assert "requirements-test.txt" in " ".join(report["proof_commands"])
+
+
+def test_check_intelligence_marks_ruff_import_sorting_as_safe_fix_available(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "jobs": [
+                {
+                    "name": "ruff",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "python -m ruff check src tests",
+                            "I001 [*] Import block is un-sorted or un-formatted",
+                            "--> tests/test_widget.py:1:1",
+                            "Found 1 error.",
+                            "[*] 1 fixable with the `--fix` option.",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    assert intelligence["failed_checks"][0]["diagnosis"]["code"] == "RUFF_FIXABLE_LINT"
+    assert intelligence["failed_checks"][0]["safe_to_auto_fix"] is True
+    assert report["status"] == "safe_fix_available"
+    assert report["primary_blocker"]["surface"] == "quality"
+    assert report["automation"]["allowed"] is True
+    assert report["automation"]["attempted"] is False
+    assert "ruff check --fix" in " ".join(report["recommended_actions"])
+
+
+def test_check_intelligence_treats_queued_checks_as_incomplete_not_green(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "workflow_runs": [
+                {
+                    "name": "PR Quality Comment",
+                    "status": "queued",
+                    "conclusion": "",
+                    "url": "https://example.test/runs/queued",
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    assert intelligence["checks_seen"] == 1
+    assert intelligence["failed_checks"] == []
+    assert intelligence["queued_checks"][0]["name"] == "PR Quality Comment"
+    assert report["status"] == "incomplete"
+    assert report["primary_blocker"]["surface"] == "workflow"
+    assert report["automation"]["allowed"] is False
+    assert "queued" in report["primary_blocker"]["impact"]
+
+
+def test_check_intelligence_cli_writes_json_and_markdown_artifacts(tmp_path: Path, capsys) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {"check_runs": [{"name": "CI", "status": "completed", "conclusion": "success"}]},
+    )
+    out_dir = tmp_path / "out"
+
+    rc = check_intelligence.main(
+        [
+            "--checks-json",
+            str(checks),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["check_intelligence"] == (out_dir / "check-intelligence.json").as_posix()
+    assert printed["action_report"] == (out_dir / "action-report.json").as_posix()
+    assert printed["action_report_markdown"] == (out_dir / "action-report.md").as_posix()
+
+    intelligence = json.loads((out_dir / "check-intelligence.json").read_text(encoding="utf-8"))
+    report = json.loads((out_dir / "action-report.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "action-report.md").read_text(encoding="utf-8")
+
+    assert intelligence["checks_seen"] == 1
+    assert report["status"] == "green"
+    assert "SDETKit Check Intelligence Action Report" in markdown
+
+
+def test_check_intelligence_prioritizes_actionable_ruff_failure_over_ci_noise(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane py3.12",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "Install project + dev/test extras",
+                            "Collecting build",
+                            "Collecting twine",
+                            "Successfully installed build twine sdetkit",
+                            "Generate kit sample artifacts",
+                            "release metadata check not requested",
+                            "Ruff lint baseline",
+                            "Run python -m ruff check src tests",
+                            "F841 Local variable `code` is assigned to but never used",
+                            "--> src/sdetkit/check_intelligence.py:314:9",
+                            "help: Remove assignment to unused variable `code`",
+                            "Found 1 error.",
+                            "No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).",
+                            "Process completed with exit code 1",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    diagnosis = intelligence["failed_checks"][0]["diagnosis"]
+    assert diagnosis["code"] == "RUFF_LINT_FAILURE"
+    assert report["status"] == "review_required"
+    assert report["primary_blocker"]["surface"] == "quality"
+    assert report["primary_blocker"]["title"] == "Ruff lint contract failed"
+    assert report["automation"]["allowed"] is False
+    assert report["primary_blocker"]["code"] != "RELEASE_ARTIFACT_INVALID"


### PR DESCRIPTION
## Summary
- Add repo-agnostic SDETKit check intelligence engine.
- Accept generic checks JSON plus optional logs directory and security review threads.
- Classify failed, queued, cancelled, and startup-failure checks.
- Run `adaptive_diagnosis` against failed-check evidence.
- Emit:
  - `check-intelligence.json`
  - `action-report.json`
  - `action-report.md`
- Distinguish:
  - green
  - incomplete
  - review_required
  - safe_fix_available
- Keep automatic mutation disabled; only report safe-fix availability for narrow mechanical classes.

## Why
The PR comment should not be the product. The product needs a repo/company-ready engine that collects check evidence, diagnoses failed checks, classifies impact, decides whether safe fix is even eligible, and then produces an action report.

This PR proves the engine offline first, without hardcoding DevS69-specific owner, repo, PR number, branch, or workflow run IDs.

## Verified behavior
- Green checks produce a green action report.
- Dependency resolver failure becomes review-required.
- Ruff import sorting becomes safe-fix-available, not auto-applied.
- Queued PR Quality checks produce incomplete status instead of green.
- CLI writes JSON and Markdown artifacts.

## Verification
- `python -m pytest -q tests/test_check_intelligence.py tests/test_adaptive_diagnosis.py tests/test_evidence_graph.py tests/test_pr_quality_comment_observability_workflow.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low.
- New offline engine only.
- No workflow integration yet.
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened gates.

## Notes
- This is the foundation for company-ready SDETKit check intelligence.
- Next PR should wire this engine into the PR Quality workflow after the offline contract is merged.