### PR TITLE
Render PR quality comments from action reports

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -118,6 +118,58 @@ jobs:
             --failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json \
             --out-dir build/sdetkit/evidence-graph
 
+      - name: Build PR check intelligence action report
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          QUALITY_OUTCOME: ${{ steps.quality.outcome }}
+        run: |
+          mkdir -p build/pr-quality/checks build/pr-quality/check-intelligence
+
+          gh api \
+            "repos/$REPOSITORY_OWNER/$REPOSITORY_NAME/commits/$HEAD_SHA/check-runs?per_page=100" \
+            > build/pr-quality/checks/check-runs-raw.json \
+            || echo '{"check_runs":[]}' > build/pr-quality/checks/check-runs-raw.json
+
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          raw_path = Path("build/pr-quality/checks/check-runs-raw.json")
+          payload = json.loads(raw_path.read_text(encoding="utf-8"))
+          runs = payload.get("check_runs")
+          if not isinstance(runs, list):
+              runs = []
+
+          outcome = os.environ.get("QUALITY_OUTCOME", "failure")
+          local_conclusion = "success" if outcome == "success" else "failure"
+          runs.append(
+              {
+                  "name": "PR Quality local quality gate",
+                  "status": "completed",
+                  "conclusion": local_conclusion,
+                  "log_path": "quality.log",
+              }
+          )
+
+          Path("build/pr-quality/checks/check-runs.json").write_text(
+              json.dumps({"check_runs": runs}, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+          PYTHONPATH=src python -m sdetkit.check_intelligence \
+            --checks-json build/pr-quality/checks/check-runs.json \
+            --logs-dir . \
+            --review-threads-json build/pr-quality/security-review/review-threads.json \
+            --out-dir build/pr-quality/check-intelligence
+
+
       - name: Initialize PR comment status
         if: always()
         env:
@@ -159,8 +211,14 @@ jobs:
             --evidence-graph build/sdetkit/evidence-graph/evidence-graph.json \
             --failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json \
             --changed-files build/pr-quality/changed-files.txt \
-            --out build/pr-quality/pr-comment-body.md \
+            --out build/pr-quality/pr-evidence-narrative.md \
             --json-out build/pr-quality/pr-evidence-narrative.json
+
+          PYTHONPATH=src python -m sdetkit.pr_quality_action_report \
+            --action-report build/pr-quality/check-intelligence/action-report.json \
+            --check-intelligence build/pr-quality/check-intelligence/check-intelligence.json \
+            --evidence-narrative build/pr-quality/pr-evidence-narrative.json \
+            --out build/pr-quality/pr-comment-body.md
 
       - name: Upload failure intelligence bundle
         if: always()
@@ -190,6 +248,9 @@ jobs:
             build/pr-quality/pr-evidence-narrative.json
             build/pr-quality/changed-files.txt
             build/pr-quality/comment-status.json
+            build/pr-quality/checks/
+            build/pr-quality/check-intelligence/
+            build/pr-quality/pr-evidence-narrative.md
             build/sdetkit/evidence-graph/
           if-no-files-found: ignore
 

--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -290,9 +290,26 @@ def _security_review_summary(review_threads_json: Path | None) -> JsonObject:
     except Exception:
         findings = []
 
+    compact_findings = [
+        {
+            "title": _string(item.get("title")),
+            "summary": _string(item.get("summary") or item.get("message")),
+            "path": _string(item.get("path")),
+            "line": item.get("line", ""),
+            "comment_url": _string(item.get("comment_url") or item.get("url")),
+            "recommended_commands": [
+                str(command)
+                for command in _as_list(item.get("recommended_commands"))
+                if isinstance(command, str)
+            ],
+        }
+        for item in findings
+    ]
+
     return {
         "collected": True,
         "unresolved_findings": len(findings),
+        "findings": compact_findings,
         "source": review_threads_json.as_posix(),
     }
 
@@ -422,6 +439,58 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
     failed = _as_list(intelligence.get("failed_checks"))
     queued = _as_list(intelligence.get("queued_checks"))
     startup = _as_list(intelligence.get("startup_failures"))
+
+    security_review = _as_dict(intelligence.get("security_review"))
+    security_findings = [
+        _as_dict(item)
+        for item in _as_list(security_review.get("findings"))
+        if isinstance(item, dict)
+    ]
+    unresolved_security = int(security_review.get("unresolved_findings", 0) or 0)
+    if unresolved_security and not failed:
+        finding = security_findings[0] if security_findings else {}
+        commands = [
+            str(command)
+            for command in _as_list(finding.get("recommended_commands"))
+            if isinstance(command, str)
+        ]
+        return {
+            "schema_version": ACTION_REPORT_SCHEMA_VERSION,
+            "status": "review_required",
+            "primary_blocker": {
+                "check": "GitHub security review",
+                "title": _string(finding.get("title") or "Security review requires action"),
+                "surface": "security",
+                "impact": _string(
+                    finding.get("summary")
+                    or "An unresolved security review finding must be fixed or dismissed with a review reason."
+                ),
+                "code": "SECURITY_REVIEW_FINDING",
+                "url": _string(finding.get("comment_url")),
+                "path": _string(finding.get("path")),
+                "line": finding.get("line", ""),
+            },
+            "automation": {
+                "attempted": False,
+                "allowed": False,
+                "reason": "security review findings are review-first and cannot be auto-dismissed",
+            },
+            "recommended_actions": commands
+            or [
+                "Review unresolved GitHub Advanced Security comments on the PR.",
+                "Fix the flagged surface or dismiss the false positive with a review reason.",
+            ],
+            "proof_commands": [
+                "python -m sdetkit security check --root . --format json",
+                "python -m pre_commit run -a",
+            ],
+            "evidence": {
+                "failed_check_count": 0,
+                "queued_check_count": len(queued),
+                "startup_failure_count": len(startup),
+                "security_review": security_review,
+            },
+        }
 
     if failed:
         check = _primary_failed_check(intelligence)

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+BANNED_EDUCATIONAL_PHRASES = (
+    "Quality is green, so the review focus is not coverage.",
+    "The comment must guide maintainers toward the changed risk surface.",
+    "Review the security evidence against the PR diff.",
+    "Confirm the graph findings match the changed files and artifacts.",
+    "PR Quality evidence affects the comment maintainers use",
+)
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _read_json(path: Path | None) -> JsonObject:
+    if path is None or not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return _as_dict(payload)
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _status_title(status: str) -> str:
+    return {
+        "green": "Green",
+        "incomplete": "Checks incomplete",
+        "review_required": "Action required",
+        "safe_fix_available": "Safe fix available",
+    }.get(status, status.replace("_", " ").title() or "Unknown")
+
+
+def _quality_lines(evidence_narrative: JsonObject) -> list[str]:
+    quality = _as_dict(evidence_narrative.get("quality"))
+    if not quality:
+        return []
+
+    ok = quality.get("ok")
+    coverage = (
+        quality.get("coverage")
+        or quality.get("coverage_percent")
+        or quality.get("coverage_pct")
+        or ""
+    )
+
+    lines: list[str] = []
+    if ok is True:
+        lines.append("- Quality gate: `passed`")
+    elif ok is False:
+        lines.append("- Quality gate: `failed`")
+
+    if coverage not in {"", None}:
+        lines.append(f"- Coverage: `{coverage}`")
+
+    return lines
+
+
+def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -> list[str]:
+    security = _as_dict(
+        check_intelligence.get("security_review")
+        or _as_dict(action_report.get("evidence")).get("security_review")
+    )
+    failed_count = len(_as_list(check_intelligence.get("failed_checks")))
+    queued_count = len(_as_list(check_intelligence.get("queued_checks")))
+    startup_count = len(_as_list(check_intelligence.get("startup_failures")))
+    checks_seen = _int(check_intelligence.get("checks_seen"))
+    unresolved_security = _int(security.get("unresolved_findings"))
+
+    lines = [
+        f"- Checks seen: `{checks_seen}`",
+        f"- Failed checks: `{failed_count}`",
+        f"- Queued checks: `{queued_count}`",
+        f"- Startup failures: `{startup_count}`",
+    ]
+
+    if security:
+        collected = "true" if bool(security.get("collected", False)) else "false"
+        lines.append(f"- Security review collected: `{collected}`")
+        lines.append(f"- Unresolved security findings: `{unresolved_security}`")
+
+    return lines
+
+
+def _failed_check_lines(check_intelligence: JsonObject) -> list[str]:
+    failed = [_as_dict(item) for item in _as_list(check_intelligence.get("failed_checks"))]
+    if not failed:
+        return ["- none"]
+
+    lines: list[str] = []
+    for item in failed[:5]:
+        diagnosis = _as_dict(item.get("diagnosis"))
+        name = _string(item.get("name"))
+        code = _string(diagnosis.get("code") or "unknown")
+        title = _string(diagnosis.get("title") or "Unknown failure")
+        safe = str(bool(item.get("safe_to_auto_fix", False))).lower()
+        lines.append(f"- `{name}` -> {title} (`{code}`), safe_to_auto_fix=`{safe}`")
+    return lines
+
+
+def _primary_blocker_lines(primary: JsonObject) -> list[str]:
+    if not primary:
+        return ["- none"]
+
+    lines = [
+        f"- Check/source: `{primary.get('check', '')}`",
+        f"- Title: {primary.get('title', '')}",
+        f"- Surface: `{primary.get('surface', '')}`",
+        f"- Code: `{primary.get('code', '')}`",
+    ]
+
+    path = _string(primary.get("path"))
+    line = _string(primary.get("line"))
+    if path:
+        location = f"{path}:{line}" if line else path
+        lines.append(f"- File: `{location}`")
+
+    url = _string(primary.get("url"))
+    if url:
+        lines.append(f"- URL: {url}")
+
+    impact = _string(primary.get("impact"))
+    if impact:
+        lines.append(f"- Impact: {impact}")
+
+    return lines
+
+
+def _automation_lines(action_report: JsonObject) -> list[str]:
+    automation = _as_dict(action_report.get("automation"))
+    return [
+        f"- Attempted: `{str(bool(automation.get('attempted', False))).lower()}`",
+        f"- Allowed: `{str(bool(automation.get('allowed', False))).lower()}`",
+        f"- Reason: {automation.get('reason', '')}",
+    ]
+
+
+def _bullet_lines(values: list[Any], *, none_text: str = "none") -> list[str]:
+    items = [str(item) for item in values if isinstance(item, str) and item.strip()]
+    return [f"- {item}" for item in items] or [f"- {none_text}"]
+
+
+def _command_lines(values: list[Any]) -> list[str]:
+    items = [str(item) for item in values if isinstance(item, str) and item.strip()]
+    return [f"- `{item}`" for item in items] or ["- none"]
+
+
+def render_comment_body(
+    *,
+    action_report: JsonObject,
+    check_intelligence: JsonObject,
+    evidence_narrative: JsonObject | None = None,
+) -> str:
+    evidence_narrative = evidence_narrative or {}
+    status = _string(action_report.get("status") or "unknown")
+
+    lines = [
+        f"## SDETKit Review Result: {_status_title(status)}",
+        "",
+        f"Status: `{status}`",
+        "",
+    ]
+
+    quality = _quality_lines(evidence_narrative)
+    if quality:
+        lines.extend(["## Quality summary", "", *quality, ""])
+
+    lines.extend(
+        [
+            "## Primary blocker",
+            "",
+            *_primary_blocker_lines(_as_dict(action_report.get("primary_blocker"))),
+            "",
+            "## Automation decision",
+            "",
+            *_automation_lines(action_report),
+            "",
+            "## Evidence collected",
+            "",
+            *_evidence_lines(check_intelligence, action_report),
+            "",
+            "## Failed check diagnoses",
+            "",
+            *_failed_check_lines(check_intelligence),
+            "",
+            "## Recommended actions",
+            "",
+            *_bullet_lines(_as_list(action_report.get("recommended_actions"))),
+            "",
+            "## Required proof",
+            "",
+            *_command_lines(_as_list(action_report.get("proof_commands"))),
+            "",
+        ]
+    )
+
+    if status == "green":
+        lines.extend(["## Merge assessment", "", "- No action required from SDETKit.", ""])
+
+    rendered = "\n".join(lines)
+    for phrase in BANNED_EDUCATIONAL_PHRASES:
+        if phrase in rendered:
+            raise ValueError(f"educational PR Quality phrase leaked into action report: {phrase}")
+    return rendered
+
+
+def write_comment_body(
+    *,
+    action_report_path: Path,
+    check_intelligence_path: Path,
+    out: Path,
+    evidence_narrative_path: Path | None = None,
+) -> JsonObject:
+    action_report = _read_json(action_report_path)
+    check_intelligence = _read_json(check_intelligence_path)
+    evidence_narrative = _read_json(evidence_narrative_path)
+
+    body = render_comment_body(
+        action_report=action_report,
+        check_intelligence=check_intelligence,
+        evidence_narrative=evidence_narrative,
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(body, encoding="utf-8")
+
+    return {
+        "out": out.as_posix(),
+        "status": _string(action_report.get("status") or "unknown"),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.pr_quality_action_report")
+    parser.add_argument("--action-report", type=Path, required=True)
+    parser.add_argument("--check-intelligence", type=Path, required=True)
+    parser.add_argument("--evidence-narrative", type=Path)
+    parser.add_argument("--out", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = write_comment_body(
+        action_report_path=args.action_report,
+        check_intelligence_path=args.check_intelligence,
+        evidence_narrative_path=args.evidence_narrative,
+        out=args.out,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import check_intelligence
+from sdetkit import pr_quality_action_report as report
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_action_report_green_comment_is_short_and_not_educational() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 12,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        evidence_narrative={"quality": {"ok": True, "coverage_percent": "96.69%"}},
+    )
+
+    assert "SDETKit Review Result: Green" in body
+    assert "No action required from SDETKit." in body
+    assert "Failed checks: `0`" in body
+    assert "Unresolved security findings: `0`" in body
+    assert "Why it matters" not in body
+    assert "Quality is green, so the review focus is not coverage." not in body
+    assert "The comment must guide maintainers" not in body
+
+
+def test_action_report_review_required_comment_shows_real_blocker_and_fix_path() -> None:
+    action = {
+        "status": "review_required",
+        "primary_blocker": {
+            "check": "Fast CI lane py3.12",
+            "title": "Ruff lint contract failed",
+            "surface": "quality",
+            "code": "RUFF_LINT_FAILURE",
+            "impact": "CI is blocked by an unused local variable.",
+            "path": "src/sdetkit/check_intelligence.py",
+        },
+        "automation": {
+            "attempted": False,
+            "allowed": False,
+            "reason": "diagnosis is review-first or not approved for automatic mutation",
+        },
+        "recommended_actions": ["Remove the unused assignment and rerun Ruff."],
+        "proof_commands": ["python -m ruff check src tests", "python -m pre_commit run -a"],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 4,
+        "failed_checks": [
+            {
+                "name": "Fast CI lane py3.12",
+                "safe_to_auto_fix": False,
+                "diagnosis": {
+                    "code": "RUFF_LINT_FAILURE",
+                    "title": "Ruff lint contract failed",
+                },
+            }
+        ],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert "SDETKit Review Result: Action required" in body
+    assert "Fast CI lane py3.12" in body
+    assert "Ruff lint contract failed" in body
+    assert "src/sdetkit/check_intelligence.py" in body
+    assert "Remove the unused assignment" in body
+    assert "python -m ruff check src tests" in body
+    assert "Review the security evidence against the PR diff." not in body
+    assert "Confirm the graph findings match the changed files and artifacts." not in body
+
+
+def test_action_report_safe_fix_available_comment_preserves_no_auto_apply_boundary() -> None:
+    action = {
+        "status": "safe_fix_available",
+        "primary_blocker": {
+            "check": "ruff",
+            "title": "Ruff fixable lint can be mechanically remediated",
+            "surface": "quality",
+            "code": "RUFF_FIXABLE_LINT",
+            "impact": "A narrow import sorting issue is fixable by Ruff.",
+        },
+        "automation": {
+            "attempted": False,
+            "allowed": True,
+            "reason": "diagnosis is approved for narrow mechanical safe-fix planning",
+        },
+        "recommended_actions": ["Run ruff check --fix on affected files."],
+        "proof_commands": ["python -m ruff check src tests", "python -m pre_commit run -a"],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 1,
+        "failed_checks": [
+            {
+                "name": "ruff",
+                "safe_to_auto_fix": True,
+                "diagnosis": {
+                    "code": "RUFF_FIXABLE_LINT",
+                    "title": "Ruff fixable lint can be mechanically remediated",
+                },
+            }
+        ],
+        "queued_checks": [],
+        "startup_failures": [],
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert "SDETKit Review Result: Safe fix available" in body
+    assert "Allowed: `true`" in body
+    assert "Attempted: `false`" in body
+    assert "Run ruff check --fix on affected files." in body
+
+
+def test_action_report_cli_writes_comment_body(tmp_path: Path, capsys) -> None:
+    action_path = _write_json(
+        tmp_path / "action-report.json",
+        {
+            "status": "green",
+            "primary_blocker": {},
+            "automation": {
+                "attempted": False,
+                "allowed": False,
+                "reason": "no remediation needed",
+            },
+            "recommended_actions": [],
+            "proof_commands": [],
+        },
+    )
+    intelligence_path = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "checks_seen": 1,
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "security_review": {"collected": True, "unresolved_findings": 0},
+        },
+    )
+    out = tmp_path / "comment.md"
+
+    rc = report.main(
+        [
+            "--action-report",
+            str(action_path),
+            "--check-intelligence",
+            str(intelligence_path),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["out"] == out.as_posix()
+    assert printed["status"] == "green"
+    assert "SDETKit Review Result: Green" in out.read_text(encoding="utf-8")
+
+
+def test_check_intelligence_promotes_unresolved_security_review_to_action_report() -> None:
+    intelligence = {
+        "checks_seen": 2,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {
+            "collected": True,
+            "unresolved_findings": 1,
+            "findings": [
+                {
+                    "title": "Security review requires action in src/sdetkit/check_intelligence.py",
+                    "summary": "CodeQL reported an unused local variable.",
+                    "path": "src/sdetkit/check_intelligence.py",
+                    "line": 314,
+                    "comment_url": "https://example.test/security-comment",
+                    "recommended_commands": ["python -m ruff check src tests"],
+                }
+            ],
+        },
+    }
+
+    action = check_intelligence.build_action_report(intelligence)
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert action["status"] == "review_required"
+    assert action["primary_blocker"]["surface"] == "security"
+    assert action["primary_blocker"]["path"] == "src/sdetkit/check_intelligence.py"
+    assert "Security review requires action" in body
+    assert "src/sdetkit/check_intelligence.py:314" in body
+    assert "CodeQL reported an unused local variable." in body
+    assert "python -m ruff check src tests" in body

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -68,3 +68,36 @@ def test_pr_quality_comment_workflow_fails_loud_when_comment_not_visible() -> No
     assert "comment_status=missing" in text
     assert 'status not in {"posted", "updated"}' in text
     assert "PR Quality comment was not posted or updated" in text
+
+
+def test_pr_quality_comment_workflow_builds_check_intelligence_action_report() -> None:
+    text = _workflow_text()
+
+    assert "Build PR check intelligence action report" in text
+    assert "check-runs?per_page=100" in text
+    assert "build/pr-quality/checks/check-runs.json" in text
+    assert "PR Quality local quality gate" in text
+    assert "python -m sdetkit.check_intelligence" in text
+    assert "--review-threads-json build/pr-quality/security-review/review-threads.json" in text
+    assert "--out-dir build/pr-quality/check-intelligence" in text
+
+
+def test_pr_quality_comment_workflow_renders_comment_from_action_report() -> None:
+    text = _workflow_text()
+
+    assert "python -m sdetkit.pr_quality_evidence_narrative" in text
+    assert "--out build/pr-quality/pr-evidence-narrative.md" in text
+    assert "python -m sdetkit.pr_quality_action_report" in text
+    assert "--action-report build/pr-quality/check-intelligence/action-report.json" in text
+    assert (
+        "--check-intelligence build/pr-quality/check-intelligence/check-intelligence.json" in text
+    )
+    assert "--out build/pr-quality/pr-comment-body.md" in text
+
+
+def test_pr_quality_comment_workflow_uploads_check_intelligence_artifacts() -> None:
+    text = _workflow_text()
+
+    assert "build/pr-quality/checks/" in text
+    assert "build/pr-quality/check-intelligence/" in text
+    assert "build/pr-quality/pr-evidence-narrative.md" in text


### PR DESCRIPTION
## Summary
- Add `sdetkit.pr_quality_action_report` to render PR comments from `action-report.json` and `check-intelligence.json`.
- Wire the PR Quality Comment workflow to:
  - collect GitHub check runs for the PR head SHA
  - add the local PR Quality quality gate as a check input
  - run `sdetkit.check_intelligence`
  - keep the legacy evidence narrative as a JSON/Markdown artifact
  - render the visible PR comment from the action report
- Promote unresolved security review findings into `review_required` action reports.
- Upload check-intelligence and action-report artifacts with the PR Quality comment artifacts.
- Add workflow contract tests proving the action-report comment path.

## Why
The old PR comment was surface-level and educational. It could detect security or PR Quality surfaces, but it did not produce a practical operator report with the exact blocker, impact, automation decision, recommended action, and proof.

This PR makes the visible SDET Quality Gate comment the output of the check-intelligence/action-report engine.

## Expected comment behavior
- Green PR:
  - `SDETKit Review Result: Green`
  - evidence counts
  - no action required
- Failed/incomplete PR:
  - exact primary blocker
  - failed check/source
  - risk surface and diagnosis code
  - impacted file/location when available
  - automation allowed/blocked decision
  - recommended actions
  - required proof commands
- Security review finding:
  - exact security review finding title
  - file/line
  - URL when available
  - proof commands
  - review-first automation boundary

## Verification
- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_check_intelligence.py tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_evidence_narrative.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Changes the PR Quality Comment workflow output path.
- Keeps the old evidence narrative as an artifact, but the visible PR comment now comes from the action report.
- Rollback: revert the workflow wiring and remove `pr_quality_action_report.py`.

## Notes
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Safe-fix availability is reported only; mutation remains disabled unless a separate safe-remediation policy explicitly allows it.