### PR TITLE
Render PR quality comments from action reports

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -135,30 +135,83 @@ jobs:
             > build/pr-quality/checks/check-runs-raw.json \
             || echo '{"check_runs":[]}' > build/pr-quality/checks/check-runs-raw.json
 
+          gh api \
+            "repos/$REPOSITORY_OWNER/$REPOSITORY_NAME/commits/$HEAD_SHA/status" \
+            > build/pr-quality/checks/combined-status-raw.json \
+            || echo '{"statuses":[]}' > build/pr-quality/checks/combined-status-raw.json
+
+          gh api \
+            "repos/$REPOSITORY_OWNER/$REPOSITORY_NAME/branches/${{ github.event.pull_request.base.ref }}/protection/required_status_checks/contexts" \
+            > build/pr-quality/checks/required-contexts.json \
+            || echo '[]' > build/pr-quality/checks/required-contexts.json
+
           python - <<'PY'
           import json
           import os
           from pathlib import Path
 
           raw_path = Path("build/pr-quality/checks/check-runs-raw.json")
+          status_path = Path("build/pr-quality/checks/combined-status-raw.json")
+          required_path = Path("build/pr-quality/checks/required-contexts.json")
+
           payload = json.loads(raw_path.read_text(encoding="utf-8"))
           runs = payload.get("check_runs")
           if not isinstance(runs, list):
               runs = []
 
+          statuses_payload = json.loads(status_path.read_text(encoding="utf-8"))
+          statuses = statuses_payload.get("statuses")
+          if not isinstance(statuses, list):
+              statuses = []
+
+          required_payload = json.loads(required_path.read_text(encoding="utf-8"))
+          required_contexts = set(required_payload if isinstance(required_payload, list) else [])
+
+          normalized = []
+          for run in runs:
+              if not isinstance(run, dict):
+                  continue
+              name = str(run.get("name") or "")
+              item = dict(run)
+              item["required"] = name in required_contexts
+              normalized.append(item)
+
+          state_to_conclusion = {
+              "success": "success",
+              "failure": "failure",
+              "error": "failure",
+              "pending": "",
+          }
+          for status in statuses:
+              if not isinstance(status, dict):
+                  continue
+              context = str(status.get("context") or "")
+              state = str(status.get("state") or "").lower()
+              normalized.append(
+                  {
+                      "name": context,
+                      "context": context,
+                      "status": "completed" if state in {"success", "failure", "error"} else "queued",
+                      "conclusion": state_to_conclusion.get(state, state),
+                      "url": status.get("target_url") or "",
+                      "required": context in required_contexts,
+                  }
+              )
+
           outcome = os.environ.get("QUALITY_OUTCOME", "failure")
           local_conclusion = "success" if outcome == "success" else "failure"
-          runs.append(
+          normalized.append(
               {
                   "name": "PR Quality local quality gate",
                   "status": "completed",
                   "conclusion": local_conclusion,
                   "log_path": "quality.log",
+                  "required": "PR Quality local quality gate" in required_contexts,
               }
           )
 
           Path("build/pr-quality/checks/check-runs.json").write_text(
-              json.dumps({"check_runs": runs}, indent=2, sort_keys=True) + "\n",
+              json.dumps({"check_runs": normalized}, indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
           )
           PY

--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -148,6 +148,22 @@ def _is_startup_failure(record: JsonObject) -> bool:
     return _check_conclusion(record) == "startup_failure"
 
 
+def _check_required(record: JsonObject) -> bool:
+    value = record.get("required")
+    if isinstance(value, bool):
+        return value
+
+    value = record.get("is_required")
+    if isinstance(value, bool):
+        return value
+
+    value = record.get("required_status")
+    if isinstance(value, bool):
+        return value
+
+    return False
+
+
 def _record_url(record: JsonObject) -> str:
     for key in ("url", "html_url", "details_url"):
         value = _string(record.get(key))
@@ -333,6 +349,7 @@ def build_check_intelligence(
             "name": _check_name(record, index),
             "status": _check_status(record),
             "conclusion": _check_conclusion(record),
+            "required": _check_required(record),
             "url": _record_url(record),
         }
 
@@ -487,7 +504,21 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
             "evidence": {
                 "failed_check_count": 0,
                 "queued_check_count": len(queued),
+                "required_queued_check_count": len(
+                    [
+                        _as_dict(item)
+                        for item in queued
+                        if bool(_as_dict(item).get("required", False))
+                    ]
+                ),
                 "startup_failure_count": len(startup),
+                "required_startup_failure_count": len(
+                    [
+                        _as_dict(item)
+                        for item in startup
+                        if bool(_as_dict(item).get("required", False))
+                    ]
+                ),
                 "security_review": security_review,
             },
         }
@@ -525,37 +556,61 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
             "evidence": {
                 "failed_check_count": len(failed),
                 "queued_check_count": len(queued),
+                "required_queued_check_count": len(
+                    [
+                        _as_dict(item)
+                        for item in queued
+                        if bool(_as_dict(item).get("required", False))
+                    ]
+                ),
                 "startup_failure_count": len(startup),
+                "required_startup_failure_count": len(
+                    [
+                        _as_dict(item)
+                        for item in startup
+                        if bool(_as_dict(item).get("required", False))
+                    ]
+                ),
                 "security_review": intelligence.get("security_review", {}),
             },
         }
 
-    if queued or startup:
+    required_queued = [
+        _as_dict(item) for item in queued if bool(_as_dict(item).get("required", False))
+    ]
+    required_startup = [
+        _as_dict(item) for item in startup if bool(_as_dict(item).get("required", False))
+    ]
+
+    if required_queued or required_startup:
+        blocker = _as_dict((required_queued or required_startup)[0])
         return {
             "schema_version": ACTION_REPORT_SCHEMA_VERSION,
             "status": "incomplete",
             "primary_blocker": {
-                "check": _string(_as_dict((queued or startup)[0]).get("name")),
-                "title": "Checks are not complete",
+                "check": _string(blocker.get("name")),
+                "title": "Required checks are not complete",
                 "surface": "workflow",
                 "impact": "The PR cannot be treated as fully proven while required checks are queued, pending, or failed to start.",
                 "code": "CHECKS_INCOMPLETE",
-                "url": _string(_as_dict((queued or startup)[0]).get("url")),
+                "url": _string(blocker.get("url")),
             },
             "automation": {
                 "attempted": False,
                 "allowed": False,
-                "reason": "check completion is required before remediation or green signoff",
+                "reason": "required check completion is needed before remediation or green signoff",
             },
             "recommended_actions": [
-                "Wait for queued checks to complete or inspect the workflow-start issue.",
-                "Do not treat the PR as green until check intelligence is complete.",
+                "Wait for required queued checks to complete or inspect the workflow-start issue.",
+                "Do not treat the PR as green until required check intelligence is complete.",
             ],
             "proof_commands": [],
             "evidence": {
                 "failed_check_count": 0,
                 "queued_check_count": len(queued),
+                "required_queued_check_count": len(required_queued),
                 "startup_failure_count": len(startup),
+                "required_startup_failure_count": len(required_startup),
                 "security_review": intelligence.get("security_review", {}),
             },
         }
@@ -573,8 +628,10 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
         "proof_commands": [],
         "evidence": {
             "failed_check_count": 0,
-            "queued_check_count": 0,
-            "startup_failure_count": 0,
+            "queued_check_count": len(queued),
+            "required_queued_check_count": 0,
+            "startup_failure_count": len(startup),
+            "required_startup_failure_count": 0,
             "security_review": intelligence.get("security_review", {}),
         },
     }

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -82,8 +82,12 @@ def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -
         or _as_dict(action_report.get("evidence")).get("security_review")
     )
     failed_count = len(_as_list(check_intelligence.get("failed_checks")))
-    queued_count = len(_as_list(check_intelligence.get("queued_checks")))
-    startup_count = len(_as_list(check_intelligence.get("startup_failures")))
+    queued = [_as_dict(item) for item in _as_list(check_intelligence.get("queued_checks"))]
+    startup = [_as_dict(item) for item in _as_list(check_intelligence.get("startup_failures"))]
+    queued_count = len(queued)
+    startup_count = len(startup)
+    required_queued_count = len([item for item in queued if bool(item.get("required", False))])
+    required_startup_count = len([item for item in startup if bool(item.get("required", False))])
     checks_seen = _int(check_intelligence.get("checks_seen"))
     unresolved_security = _int(security.get("unresolved_findings"))
 
@@ -91,7 +95,9 @@ def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -
         f"- Checks seen: `{checks_seen}`",
         f"- Failed checks: `{failed_count}`",
         f"- Queued checks: `{queued_count}`",
+        f"- Required queued checks: `{required_queued_count}`",
         f"- Startup failures: `{startup_count}`",
+        f"- Required startup failures: `{required_startup_count}`",
     ]
 
     if security:

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -145,6 +145,7 @@ def test_check_intelligence_treats_queued_checks_as_incomplete_not_green(
                     "name": "PR Quality Comment",
                     "status": "queued",
                     "conclusion": "",
+                    "required": True,
                     "url": "https://example.test/runs/queued",
                 }
             ]
@@ -157,6 +158,7 @@ def test_check_intelligence_treats_queued_checks_as_incomplete_not_green(
     assert intelligence["checks_seen"] == 1
     assert intelligence["failed_checks"] == []
     assert intelligence["queued_checks"][0]["name"] == "PR Quality Comment"
+    assert intelligence["queued_checks"][0]["required"] is True
     assert report["status"] == "incomplete"
     assert report["primary_blocker"]["surface"] == "workflow"
     assert report["automation"]["allowed"] is False
@@ -238,3 +240,63 @@ def test_check_intelligence_prioritizes_actionable_ruff_failure_over_ci_noise(
     assert report["primary_blocker"]["title"] == "Ruff lint contract failed"
     assert report["automation"]["allowed"] is False
     assert report["primary_blocker"]["code"] != "RELEASE_ARTIFACT_INVALID"
+
+
+def test_check_intelligence_does_not_block_green_on_optional_queued_checks(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "ci",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "required": True,
+                },
+                {
+                    "name": "Full CI lane",
+                    "status": "queued",
+                    "conclusion": "",
+                    "required": False,
+                    "url": "https://example.test/full-ci",
+                },
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    assert intelligence["queued_checks"][0]["name"] == "Full CI lane"
+    assert intelligence["queued_checks"][0]["required"] is False
+    assert report["status"] == "green"
+    assert report["primary_blocker"] == {}
+    assert report["evidence"]["queued_check_count"] == 1
+    assert report["evidence"]["required_queued_check_count"] == 0
+
+
+def test_check_intelligence_blocks_green_on_required_queued_checks(tmp_path: Path) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "ci",
+                    "status": "queued",
+                    "conclusion": "",
+                    "required": True,
+                    "url": "https://example.test/ci",
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    assert report["status"] == "incomplete"
+    assert report["primary_blocker"]["check"] == "ci"
+    assert report["primary_blocker"]["title"] == "Required checks are not complete"
+    assert report["evidence"]["required_queued_check_count"] == 1

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -213,3 +213,35 @@ def test_check_intelligence_promotes_unresolved_security_review_to_action_report
     assert "src/sdetkit/check_intelligence.py:314" in body
     assert "CodeQL reported an unused local variable." in body
     assert "python -m ruff check src tests" in body
+
+
+def test_action_report_green_comment_reports_optional_queued_without_blocking() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {
+            "queued_check_count": 1,
+            "required_queued_check_count": 0,
+            "startup_failure_count": 0,
+            "required_startup_failure_count": 0,
+        },
+    }
+    intelligence = {
+        "checks_seen": 42,
+        "failed_checks": [],
+        "queued_checks": [{"name": "Full CI lane", "status": "queued", "required": False}],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert "SDETKit Review Result: Green" in body
+    assert "Queued checks: `1`" in body
+    assert "Required queued checks: `0`" in body
+    assert "Primary blocker" in body
+    assert "- none" in body
+    assert "Checks are not complete" not in body

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -101,3 +101,13 @@ def test_pr_quality_comment_workflow_uploads_check_intelligence_artifacts() -> N
     assert "build/pr-quality/checks/" in text
     assert "build/pr-quality/check-intelligence/" in text
     assert "build/pr-quality/pr-evidence-narrative.md" in text
+
+
+def test_pr_quality_comment_workflow_marks_required_contexts_for_check_intelligence() -> None:
+    text = _workflow_text()
+
+    assert "required_status_checks/contexts" in text
+    assert "combined-status-raw.json" in text
+    assert "required-contexts.json" in text
+    assert '"required": context in required_contexts' in text
+    assert 'item["required"] = name in required_contexts' in text


### PR DESCRIPTION
## Summary
- Render PR Quality comments from check-intelligence/action-report output.
- Promote unresolved security review findings into review-required action reports.
- Keep the legacy PR Quality evidence narrative as an artifact, while the visible comment becomes the action report.
- Collect PR check runs, combined statuses, and required status-check contexts.
- Mark checks as required/non-required before running check intelligence.
- Fix queued-check handling:
  - required queued/startup checks block green signoff
  - optional queued checks remain visible but do not create a false blocker
- Add renderer and workflow contract tests.

## Why
The previous PR Quality comment was too generic. It described evidence surfaces but did not behave like an operator action report.

This PR makes the comment report:
- result status
- exact primary blocker
- failed check/source
- impacted surface/code/file/location
- automation decision
- evidence counts
- recommended actions
- required proof

It also fixes the false “Checks incomplete” result seen when optional queued checks remained pending while the required `ci` bridge had already passed.

## Verification
- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_check_intelligence.py tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_evidence_narrative.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Changes visible PR Quality comment behavior and workflow check collection.
- Required-context lookup depends on GitHub branch protection API availability.
- Fallback behavior remains safe: if required contexts cannot be fetched, checks default to non-required and are shown as evidence rather than false blockers.

## Notes
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- Safe-fix availability is reported only; mutation remains disabled unless a separate safe-remediation policy explicitly allows it.