### PR TITLE
Detect missing required contexts in action reports

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -211,7 +211,15 @@ jobs:
           )
 
           Path("build/pr-quality/checks/check-runs.json").write_text(
-              json.dumps({"check_runs": normalized}, indent=2, sort_keys=True) + "\n",
+              json.dumps(
+                  {
+                      "check_runs": normalized,
+                      "required_contexts": sorted(required_contexts),
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
               encoding="utf-8",
           )
           PY

--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -330,6 +330,29 @@ def _security_review_summary(review_threads_json: Path | None) -> JsonObject:
     }
 
 
+def _required_contexts(payload: JsonObject) -> list[str]:
+    direct = payload.get("required_contexts")
+    if isinstance(direct, list):
+        return sorted({str(item).strip() for item in direct if str(item).strip()})
+
+    required_status_checks = _as_dict(payload.get("required_status_checks"))
+    contexts = required_status_checks.get("contexts")
+    if isinstance(contexts, list):
+        return sorted({str(item).strip() for item in contexts if str(item).strip()})
+
+    return []
+
+
+def _record_identities(record: JsonObject, *, index: int) -> set[str]:
+    identities = {
+        _check_name(record, index),
+        _string(record.get("context")),
+        _string(record.get("check_name")),
+        _string(record.get("name")),
+    }
+    return {item for item in identities if item}
+
+
 def build_check_intelligence(
     *,
     checks_json: Path,
@@ -338,13 +361,16 @@ def build_check_intelligence(
 ) -> JsonObject:
     payload = _read_json(checks_json)
     records = _iter_check_records(payload)
+    required_contexts = set(_required_contexts(payload))
 
     failed_checks: list[JsonObject] = []
     queued_checks: list[JsonObject] = []
     cancelled_checks: list[JsonObject] = []
     startup_failures: list[JsonObject] = []
+    seen_identities: set[str] = set()
 
     for index, record in enumerate(records):
+        seen_identities.update(_record_identities(record, index=index))
         check = {
             "name": _check_name(record, index),
             "status": _check_status(record),
@@ -366,9 +392,24 @@ def build_check_intelligence(
         if _is_startup_failure(record):
             startup_failures.append(check)
 
+    missing_required_contexts = sorted(required_contexts - seen_identities)
+    for context in missing_required_contexts:
+        queued_checks.append(
+            {
+                "name": context,
+                "status": "queued",
+                "conclusion": "",
+                "required": True,
+                "missing_required_context": True,
+                "url": "",
+            }
+        )
+
     return {
         "schema_version": CHECK_INTELLIGENCE_SCHEMA_VERSION,
-        "checks_seen": len(records),
+        "checks_seen": len(records) + len(missing_required_contexts),
+        "required_contexts": sorted(required_contexts),
+        "missing_required_contexts": missing_required_contexts,
         "failed_checks": failed_checks,
         "queued_checks": queued_checks,
         "cancelled_checks": cancelled_checks,

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -88,6 +88,7 @@ def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -
     startup_count = len(startup)
     required_queued_count = len([item for item in queued if bool(item.get("required", False))])
     required_startup_count = len([item for item in startup if bool(item.get("required", False))])
+    missing_required_count = len(_as_list(check_intelligence.get("missing_required_contexts")))
     checks_seen = _int(check_intelligence.get("checks_seen"))
     unresolved_security = _int(security.get("unresolved_findings"))
 
@@ -96,6 +97,7 @@ def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -
         f"- Failed checks: `{failed_count}`",
         f"- Queued checks: `{queued_count}`",
         f"- Required queued checks: `{required_queued_count}`",
+        f"- Missing required contexts: `{missing_required_count}`",
         f"- Startup failures: `{startup_count}`",
         f"- Required startup failures: `{required_startup_count}`",
     ]

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -300,3 +300,68 @@ def test_check_intelligence_blocks_green_on_required_queued_checks(tmp_path: Pat
     assert report["primary_blocker"]["check"] == "ci"
     assert report["primary_blocker"]["title"] == "Required checks are not complete"
     assert report["evidence"]["required_queued_check_count"] == 1
+
+
+def test_check_intelligence_synthesizes_missing_required_context_as_blocker(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "required_contexts": ["ci"],
+            "check_runs": [
+                {
+                    "name": "quality",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "required": False,
+                }
+            ],
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    assert intelligence["checks_seen"] == 2
+    assert intelligence["required_contexts"] == ["ci"]
+    assert intelligence["missing_required_contexts"] == ["ci"]
+    assert intelligence["queued_checks"][0]["name"] == "ci"
+    assert intelligence["queued_checks"][0]["required"] is True
+    assert intelligence["queued_checks"][0]["missing_required_context"] is True
+
+    assert report["status"] == "incomplete"
+    assert report["primary_blocker"]["check"] == "ci"
+    assert report["primary_blocker"]["title"] == "Required checks are not complete"
+    assert report["evidence"]["queued_check_count"] == 1
+    assert report["evidence"]["required_queued_check_count"] == 1
+
+
+def test_check_intelligence_does_not_synthesize_required_context_when_reported(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "required_contexts": ["ci"],
+            "check_runs": [
+                {
+                    "name": "ci",
+                    "context": "ci",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "required": True,
+                }
+            ],
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    assert intelligence["checks_seen"] == 1
+    assert intelligence["required_contexts"] == ["ci"]
+    assert intelligence["missing_required_contexts"] == []
+    assert intelligence["queued_checks"] == []
+    assert report["status"] == "green"
+    assert report["primary_blocker"] == {}

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -245,3 +245,47 @@ def test_action_report_green_comment_reports_optional_queued_without_blocking() 
     assert "Primary blocker" in body
     assert "- none" in body
     assert "Checks are not complete" not in body
+
+
+def test_action_report_incomplete_comment_shows_missing_required_context() -> None:
+    action = {
+        "status": "incomplete",
+        "primary_blocker": {
+            "check": "ci",
+            "title": "Required checks are not complete",
+            "surface": "workflow",
+            "code": "CHECKS_INCOMPLETE",
+            "impact": "Required context has not reported yet.",
+        },
+        "automation": {
+            "attempted": False,
+            "allowed": False,
+            "reason": "required check completion is needed before remediation or green signoff",
+        },
+        "recommended_actions": ["Wait for required queued checks to complete."],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 2,
+        "missing_required_contexts": ["ci"],
+        "failed_checks": [],
+        "queued_checks": [
+            {
+                "name": "ci",
+                "status": "queued",
+                "required": True,
+                "missing_required_context": True,
+            }
+        ],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert "SDETKit Review Result: Checks incomplete" in body
+    assert "Check/source: `ci`" in body
+    assert "Required queued checks: `1`" in body
+    assert "Missing required contexts: `1`" in body
+    assert "Required context has not reported yet." in body

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -111,3 +111,13 @@ def test_pr_quality_comment_workflow_marks_required_contexts_for_check_intellige
     assert "required-contexts.json" in text
     assert '"required": context in required_contexts' in text
     assert 'item["required"] = name in required_contexts' in text
+
+
+def test_pr_quality_comment_workflow_persists_required_contexts_for_missing_status_detection() -> (
+    None
+):
+    text = _workflow_text()
+
+    assert '"required_contexts": sorted(required_contexts)' in text
+    assert "required-contexts.json" in text
+    assert "combined-status-raw.json" in text


### PR DESCRIPTION
## Summary
- Persist branch-protection required status contexts into PR Quality check-intelligence input.
- Synthesize missing required contexts as required queued checks when no check run/status has reported yet.
- Keep optional queued checks non-blocking.
- Show missing required context counts in the action-report comment.
- Add regressions for:
  - missing required context blocks green signoff
  - reported required context does not duplicate
  - renderer shows missing required context evidence
  - workflow persists required contexts for missing-status detection

## Why
#1310 fixed false blockers from optional queued checks. This PR covers the final edge case: a required context may exist in branch protection but not have any check/status record yet. SDETKit must not report green while GitHub is still waiting for that required context.

## Expected behavior
- Required context missing from all check/status records:
  - `SDETKit Review Result: Checks incomplete`
  - primary blocker is the missing required context
- Required context reported and green:
  - no synthetic blocker
- Optional queued checks:
  - visible in evidence only
  - no false incomplete result

## Verification
- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_check_intelligence.py tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_evidence_narrative.py tests/test_adaptive_diagnosis.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium.
- Changes PR Quality check aggregation and comment evidence.
- Safe fallback: if required contexts cannot be fetched, no synthetic required blockers are created.

## Notes
- No auto-fix, auto-commit, auto-push, auto-merge, or weakened checks.
- This PR completes the required/optional/pending check intelligence loop.