### PR TITLE
Normalize PR Quality action reports into evidence graph

### DIFF
--- a/src/sdetkit/evidence_graph.py
+++ b/src/sdetkit/evidence_graph.py
@@ -117,6 +117,7 @@ def build_evidence_graph(
     sentinel_control_room: Path | None = None,
     mission_control: Path | None = None,
     failure_bundle: Path | None = None,
+    pr_quality_action_report: Path | None = None,
 ) -> EvidenceGraph:
     nodes: list[EvidenceNode] = []
     source_summary: list[SourceSummary] = []
@@ -144,6 +145,13 @@ def build_evidence_graph(
     )
     nodes.extend(failure_bundle_nodes)
     source_summary.append(failure_bundle_summary)
+
+    if pr_quality_action_report is not None:
+        pr_quality_nodes, pr_quality_summary = _normalize_pr_quality_action_report(
+            pr_quality_action_report
+        )
+        nodes.extend(pr_quality_nodes)
+        source_summary.append(pr_quality_summary)
 
     nodes.sort(key=lambda node: (node["source"], node["finding_id"]))
 
@@ -285,6 +293,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Adaptive failure bundle or adaptive diagnosis JSON artifact to normalize.",
     )
     parser.add_argument(
+        "--pr-quality-action-report",
+        type=Path,
+        default=None,
+        help="Path to a PR Quality action-report JSON artifact.",
+    )
+    parser.add_argument(
         "--out-dir",
         type=Path,
         default=DEFAULT_OUTPUT_DIR,
@@ -296,10 +310,101 @@ def main(argv: list[str] | None = None) -> int:
         sentinel_control_room=args.sentinel_control_room,
         mission_control=args.mission_control,
         failure_bundle=args.failure_bundle,
+        pr_quality_action_report=args.pr_quality_action_report,
     )
     manifest = write_evidence_graph(graph, output_dir=args.out_dir)
     print(json.dumps(manifest, indent=2, sort_keys=True))
     return 0
+
+
+def _normalize_pr_quality_action_report(
+    path: Path | None,
+) -> tuple[list[EvidenceNode], SourceSummary]:
+    source: SourceName = "pr_quality"
+
+    if path is None or not path.exists():
+        return [], {
+            "source": source,
+            "path": "" if path is None else path.as_posix(),
+            "found": False,
+            "status": "missing",
+            "findings_seen": 0,
+            "findings_emitted": 0,
+        }
+
+    payload = load_json_object(path)
+    status = str(payload.get("status", "unknown") or "unknown")
+    normalized_status = status.lower().strip()
+    primary_raw = payload.get("primary_blocker")
+
+    if (
+        normalized_status in {"green", "ok", "pass", "passed", "healthy", "clear"}
+        or not isinstance(primary_raw, dict)
+        or not primary_raw
+    ):
+        return [], {
+            "source": source,
+            "path": path.as_posix(),
+            "found": True,
+            "status": status,
+            "findings_seen": 0,
+            "findings_emitted": 0,
+        }
+
+    primary = cast(JsonObject, primary_raw)
+    finding: JsonObject = dict(primary)
+
+    title = str(
+        finding.get("title") or finding.get("check") or "PR Quality action report requires review"
+    )
+    summary = str(
+        finding.get("summary")
+        or finding.get("impact")
+        or "PR Quality action report emitted a review-required blocker."
+    )
+    finding["title"] = title
+    finding["summary"] = summary
+
+    if "risk_surface" not in finding and "surface" in finding:
+        finding["risk_surface"] = finding["surface"]
+
+    if not str(finding.get("severity") or "").strip():
+        finding["severity"] = (
+            "critical" if normalized_status in {"review_required", "incomplete"} else "warning"
+        )
+
+    path_value = finding.get("path")
+    if isinstance(path_value, str) and path_value.strip() and "owner_files" not in finding:
+        finding["owner_files"] = [path_value]
+
+    recommended_raw = payload.get("recommended_actions")
+    if isinstance(recommended_raw, list) and "recommended_commands" not in finding:
+        finding["recommended_commands"] = [
+            item for item in recommended_raw if isinstance(item, str) and item.strip()
+        ]
+
+    proof_raw = payload.get("proof_commands")
+    if isinstance(proof_raw, list) and "proof_commands" not in finding:
+        finding["proof_commands"] = [
+            item for item in proof_raw if isinstance(item, str) and item.strip()
+        ]
+
+    finding["source_artifacts"] = [path.as_posix()]
+    finding["review_first"] = True
+    finding["safe_to_auto_fix"] = False
+    finding["operator_action"] = "review"
+
+    node = _normalize_finding(source, finding, path)
+    nodes = [node] if node is not None else []
+
+    return nodes, {
+        "source": source,
+        "path": path.as_posix(),
+        "found": True,
+        "status": status,
+        "findings_seen": 1,
+        "findings_emitted": len(nodes),
+    }
 
 
 def _normalize_source(

--- a/tests/test_evidence_graph.py
+++ b/tests/test_evidence_graph.py
@@ -440,3 +440,102 @@ def test_evidence_graph_marks_docs_contract_failures_review_first(tmp_path: Path
     assert graph["nodes"][0]["risk_surface"] == "docs"
     assert graph["nodes"][0]["review_first"] is True
     assert graph["nodes"][0]["safe_to_auto_fix"] is False
+
+
+def test_evidence_graph_normalizes_pr_quality_action_report_primary_blocker(
+    tmp_path: Path,
+) -> None:
+    action_report = tmp_path / "action-report.json"
+    action_report.write_text(
+        json.dumps(
+            {
+                "status": "incomplete",
+                "primary_blocker": {
+                    "check": "ci",
+                    "title": "Required checks are not complete",
+                    "surface": "workflow",
+                    "code": "CHECKS_INCOMPLETE",
+                    "impact": "Required context has not reported yet.",
+                    "path": ".github/workflows/ci.yml",
+                },
+                "automation": {
+                    "attempted": False,
+                    "allowed": False,
+                    "reason": "required check completion is needed before remediation or green signoff",
+                },
+                "recommended_actions": ["Wait for required queued checks to complete."],
+                "proof_commands": ["gh pr checks --required"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    graph = build_evidence_graph(pr_quality_action_report=action_report)
+
+    summary = graph["source_summary"][-1]
+    assert summary["source"] == "pr_quality"
+    assert summary["found"] is True
+    assert summary["status"] == "incomplete"
+    assert summary["findings_seen"] == 1
+    assert summary["findings_emitted"] == 1
+
+    node = graph["nodes"][0]
+    assert node["source"] == "pr_quality"
+    assert node["title"] == "Required checks are not complete"
+    assert node["summary"] == "Required context has not reported yet."
+    assert node["risk_surface"] == "workflow"
+    assert node["severity"] == "critical"
+    assert node["review_first"] is True
+    assert node["safe_to_auto_fix"] is False
+    assert node["automation_allowed_now"] is False
+    assert node["operator_action"] == "review"
+    assert node["owner_files"] == [".github/workflows/ci.yml"]
+    assert "Wait for required queued checks to complete." in node["recommended_commands"]
+    assert node["proof_commands"] == ["gh pr checks --required"]
+    assert node["source_artifacts"] == [action_report.as_posix()]
+
+
+def test_evidence_graph_module_cli_accepts_pr_quality_action_report(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    action_report = tmp_path / "action-report.json"
+    action_report.write_text(
+        json.dumps(
+            {
+                "status": "review_required",
+                "primary_blocker": {
+                    "check": "Fast CI lane py3.12",
+                    "title": "Ruff lint contract failed",
+                    "surface": "quality",
+                    "code": "RUFF_LINT_FAILURE",
+                    "impact": "CI is blocked by an unused local variable.",
+                    "path": "src/sdetkit/check_intelligence.py",
+                },
+                "recommended_actions": ["Remove the unused assignment and rerun Ruff."],
+                "proof_commands": ["python -m ruff check src tests"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--pr-quality-action-report",
+            action_report.as_posix(),
+            "--out-dir",
+            str(tmp_path / "evidence-graph"),
+        ]
+    )
+
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert "evidence-graph.json" in captured
+
+    graph = json.loads(
+        (tmp_path / "evidence-graph" / "evidence-graph.json").read_text(encoding="utf-8")
+    )
+    assert graph["nodes"][0]["source"] == "pr_quality"
+    assert graph["nodes"][0]["risk_surface"] == "quality"
+    assert graph["nodes"][0]["review_first"] is True
+    assert graph["nodes"][0]["automation_allowed_now"] is False


### PR DESCRIPTION
## Summary
- Added advisory-only Evidence Graph ingestion for PR Quality action-report artifacts.
- Normalized action-report primary blockers into review-first graph nodes.
- Preserved the existing source-summary contract for callers that do not provide an action report.

## Why
- Action reports already identify missing required contexts and review-required blockers.
- This change makes that signal available to the release-confidence spine through Evidence Graph and Mission Control instead of leaving it only in the PR comment layer.

## Verification
- `python -m pytest -q tests/test_evidence_graph.py tests/test_pr_quality_action_report.py tests/test_pr_quality_evidence_narrative.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Rollback: easy, revert the Evidence Graph ingestion and focused tests.

## Notes
- Advisory only.
- Automation remains disabled through `automation_allowed_now=false`.
- PR Quality action-report blockers are normalized as `source=pr_quality`.