### PR TITLE
Feed PR Quality action reports into evidence graph workflow

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -109,15 +109,6 @@ jobs:
             --merged-control-room build/sdetkit/sentinel/control-room-with-security-review.json \
             --out-dir build/pr-quality/security-review
 
-      - name: Build PR evidence graph
-        if: always()
-        run: |
-          mkdir -p build/sdetkit/evidence-graph
-          PYTHONPATH=src python -m sdetkit.evidence_graph \
-            --sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json \
-            --failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json \
-            --out-dir build/sdetkit/evidence-graph
-
       - name: Build PR check intelligence action report
         if: always()
         env:
@@ -230,6 +221,16 @@ jobs:
             --review-threads-json build/pr-quality/security-review/review-threads.json \
             --out-dir build/pr-quality/check-intelligence
 
+
+      - name: Build PR evidence graph
+        if: always()
+        run: |
+          mkdir -p build/sdetkit/evidence-graph
+          PYTHONPATH=src python -m sdetkit.evidence_graph \
+            --sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json \
+            --failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json \
+            --pr-quality-action-report build/pr-quality/check-intelligence/action-report.json \
+            --out-dir build/sdetkit/evidence-graph
 
       - name: Initialize PR comment status
         if: always()

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -121,3 +121,22 @@ def test_pr_quality_comment_workflow_persists_required_contexts_for_missing_stat
     assert '"required_contexts": sorted(required_contexts)' in text
     assert "required-contexts.json" in text
     assert "combined-status-raw.json" in text
+
+
+def test_pr_quality_comment_workflow_feeds_action_report_into_evidence_graph() -> None:
+    text = _workflow_text()
+
+    check_intelligence_step = text.index("Build PR check intelligence action report")
+    graph_step = text.index("Build PR evidence graph")
+    narrative_step = text.index("python -m sdetkit.pr_quality_evidence_narrative")
+
+    assert check_intelligence_step < graph_step < narrative_step
+    assert "python -m sdetkit.evidence_graph" in text
+    assert (
+        "--pr-quality-action-report build/pr-quality/check-intelligence/action-report.json" in text
+    )
+    assert (
+        "--sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json"
+        in text
+    )
+    assert "--failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json" in text


### PR DESCRIPTION
## Summary
- Moved the PR Evidence Graph build after check intelligence action-report generation.
- Passed the PR Quality action-report artifact into `python -m sdetkit.evidence_graph`.
- Added a workflow contract test proving action-report evidence reaches the graph before PR narrative rendering.

## Why
- #1313 taught Evidence Graph to normalize PR Quality action reports.
- This PR wires that capability into the live PR Quality workflow so missing required contexts and review-required action-report blockers become normalized release-confidence evidence automatically.

## Verification
- `python -m pytest -q tests/test_pr_quality_comment_observability_workflow.py tests/test_evidence_graph.py tests/test_pr_quality_action_report.py tests/test_pr_quality_evidence_narrative.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Rollback: easy, revert the workflow ordering and workflow contract test.

## Notes
- Advisory only.
- Automation remains disabled.
- Mission Control and PR narratives already consume Evidence Graph once the graph contains the normalized node.