### PR TITLE
Surface Evidence Graph review signals in PR Quality action reports

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -173,6 +173,51 @@ def _command_lines(values: list[Any]) -> list[str]:
     return [f"- `{item}`" for item in items] or ["- none"]
 
 
+def _evidence_review_signal_lines(evidence_narrative: JsonObject) -> list[str]:
+    primary = _as_dict(evidence_narrative.get("primary_signal"))
+    graph = _as_dict(evidence_narrative.get("graph"))
+    top_blocker = _as_dict(graph.get("top_blocker"))
+
+    kind = _string(primary.get("kind") or "")
+    title = _string(primary.get("title") or top_blocker.get("title") or "")
+    surface = _string(primary.get("surface") or top_blocker.get("surface") or "unknown")
+    action = _string(top_blocker.get("action") or "")
+    top_title = _string(top_blocker.get("title") or "")
+    top_surface = _string(top_blocker.get("surface") or "")
+
+    has_review_signal = kind == "review_signal"
+    has_review_top_blocker = (
+        bool(top_title) and top_title != "none" and top_surface != "none" and action == "review"
+    )
+    if not has_review_signal and not has_review_top_blocker:
+        return []
+
+    lines = [
+        "- Review signal: `present`",
+        f"- Surface: `{surface or 'unknown'}`",
+        f"- Title: {title or top_title or 'Evidence graph finding'}",
+        f"- Graph nodes: `{_int(graph.get('node_count'))}`",
+        f"- Review-first nodes: `{_int(graph.get('review_first_count'))}`",
+        f"- Critical nodes: `{_int(graph.get('critical_count'))}`",
+    ]
+
+    if action:
+        lines.append(f"- Operator action: `{action}`")
+    if isinstance(top_blocker.get("review_first"), bool):
+        lines.append(f"- Review first: `{str(top_blocker.get('review_first')).lower()}`")
+
+    proof_commands = [
+        str(item)
+        for item in _as_list(evidence_narrative.get("next_proof"))
+        if isinstance(item, str) and item.strip()
+    ]
+    if proof_commands:
+        lines.extend(["- Next proof:"])
+        lines.extend(f"  - `{command}`" for command in proof_commands[:5])
+
+    return lines
+
+
 def render_comment_body(
     *,
     action_report: JsonObject,
@@ -192,6 +237,10 @@ def render_comment_body(
     quality = _quality_lines(evidence_narrative)
     if quality:
         lines.extend(["## Quality summary", "", *quality, ""])
+
+    evidence_review_signal = _evidence_review_signal_lines(evidence_narrative)
+    if evidence_review_signal:
+        lines.extend(["## Evidence review signal", "", *evidence_review_signal, ""])
 
     lines.extend(
         [
@@ -223,7 +272,17 @@ def render_comment_body(
     )
 
     if status == "green":
-        lines.extend(["## Merge assessment", "", "- No action required from SDETKit.", ""])
+        if evidence_review_signal:
+            lines.extend(
+                [
+                    "## Merge assessment",
+                    "",
+                    "- Evidence review signal present; review the listed surface before merge.",
+                    "",
+                ]
+            )
+        else:
+            lines.extend(["## Merge assessment", "", "- No action required from SDETKit.", ""])
 
     rendered = "\n".join(lines)
     for phrase in BANNED_EDUCATIONAL_PHRASES:

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -289,3 +289,63 @@ def test_action_report_incomplete_comment_shows_missing_required_context() -> No
     assert "Required queued checks: `1`" in body
     assert "Missing required contexts: `1`" in body
     assert "Required context has not reported yet." in body
+
+
+def test_action_report_green_comment_surfaces_evidence_review_signal() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+    evidence_narrative = {
+        "quality": {"ok": True, "coverage_percent": "96.69%"},
+        "primary_signal": {
+            "kind": "review_signal",
+            "surface": "workflow",
+            "title": "Required checks are not complete",
+        },
+        "graph": {
+            "node_count": 1,
+            "review_first_count": 1,
+            "critical_count": 1,
+            "top_blocker": {
+                "title": "Required checks are not complete",
+                "surface": "workflow",
+                "action": "review",
+                "review_first": True,
+            },
+        },
+        "next_proof": [
+            "gh pr checks --required",
+            "python -m pre_commit run -a",
+        ],
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        evidence_narrative=evidence_narrative,
+    )
+
+    assert "SDETKit Review Result: Green" in body
+    assert "## Evidence review signal" in body
+    assert "Review signal: `present`" in body
+    assert "Surface: `workflow`" in body
+    assert "Required checks are not complete" in body
+    assert "Operator action: `review`" in body
+    assert "`gh pr checks --required`" in body
+    assert "Evidence review signal present; review the listed surface before merge." in body
+    assert "No action required from SDETKit." not in body
+    assert "Quality is green, so the review focus is not coverage." not in body
+    assert "The comment must guide maintainers" not in body
+    assert "Confirm the graph findings match the changed files and artifacts." not in body


### PR DESCRIPTION
## Summary
- Added an Evidence review signal section to PR Quality action-report comments.
- Surfaced narrative primary review signals and Evidence Graph top-blocker data in the final PR comment.
- Prevented green local-quality comments from saying “No action required” when a graph review signal is present.

## Why
The local quality gate can be green while Evidence Graph still has review-required findings from workflow, security, dependency, release, or other diagnostic surfaces. The final PR comment should preserve that distinction instead of hiding it behind a green status.

## Verification
- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_evidence_narrative.py tests/test_full_spine_action_report_integration.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Public surface: PR Quality comment content
- Rollback: easy, revert the rendering helper and focused test

## Notes
- Advisory only.
- Does not enable automation.
- Keeps banned educational narrative phrases out of the final action-report comment.