### PR TITLE
Differentiate Evidence Graph review and proof signals

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -173,7 +173,7 @@ def _command_lines(values: list[Any]) -> list[str]:
     return [f"- `{item}`" for item in items] or ["- none"]
 
 
-def _evidence_review_signal_lines(evidence_narrative: JsonObject) -> list[str]:
+def _evidence_signal(evidence_narrative: JsonObject) -> tuple[str, list[str], bool]:
     primary = _as_dict(evidence_narrative.get("primary_signal"))
     graph = _as_dict(evidence_narrative.get("graph"))
     top_blocker = _as_dict(graph.get("top_blocker"))
@@ -184,21 +184,27 @@ def _evidence_review_signal_lines(evidence_narrative: JsonObject) -> list[str]:
     action = _string(top_blocker.get("action") or "")
     top_title = _string(top_blocker.get("title") or "")
     top_surface = _string(top_blocker.get("surface") or "")
+    review_first_count = _int(graph.get("review_first_count"))
+    critical_count = _int(graph.get("critical_count"))
+    top_review_first = bool(top_blocker.get("review_first", False))
 
-    has_review_signal = kind == "review_signal"
-    has_review_top_blocker = (
-        bool(top_title) and top_title != "none" and top_surface != "none" and action == "review"
+    has_narrative_signal = kind in {"review_signal", "integration_proof"}
+    has_top_blocker = bool(top_title) and top_title != "none" and top_surface != "none"
+    if not has_narrative_signal and not has_top_blocker:
+        return "", [], False
+
+    review_required = (
+        review_first_count > 0 or critical_count > 0 or action == "review" or top_review_first
     )
-    if not has_review_signal and not has_review_top_blocker:
-        return []
+    signal_label = "Review signal" if review_required else "Proof signal"
 
     lines = [
-        "- Review signal: `present`",
+        f"- {signal_label}: `present`",
         f"- Surface: `{surface or 'unknown'}`",
         f"- Title: {title or top_title or 'Evidence graph finding'}",
         f"- Graph nodes: `{_int(graph.get('node_count'))}`",
-        f"- Review-first nodes: `{_int(graph.get('review_first_count'))}`",
-        f"- Critical nodes: `{_int(graph.get('critical_count'))}`",
+        f"- Review-first nodes: `{review_first_count}`",
+        f"- Critical nodes: `{critical_count}`",
     ]
 
     if action:
@@ -215,7 +221,8 @@ def _evidence_review_signal_lines(evidence_narrative: JsonObject) -> list[str]:
         lines.extend(["- Next proof:"])
         lines.extend(f"  - `{command}`" for command in proof_commands[:5])
 
-    return lines
+    heading = "Evidence review signal" if review_required else "Evidence proof signal"
+    return heading, lines, review_required
 
 
 def render_comment_body(
@@ -238,9 +245,11 @@ def render_comment_body(
     if quality:
         lines.extend(["## Quality summary", "", *quality, ""])
 
-    evidence_review_signal = _evidence_review_signal_lines(evidence_narrative)
-    if evidence_review_signal:
-        lines.extend(["## Evidence review signal", "", *evidence_review_signal, ""])
+    evidence_signal_heading, evidence_signal_lines, evidence_review_required = _evidence_signal(
+        evidence_narrative
+    )
+    if evidence_signal_lines:
+        lines.extend(["## " + evidence_signal_heading, "", *evidence_signal_lines, ""])
 
     lines.extend(
         [
@@ -272,12 +281,21 @@ def render_comment_body(
     )
 
     if status == "green":
-        if evidence_review_signal:
+        if evidence_review_required:
             lines.extend(
                 [
                     "## Merge assessment",
                     "",
                     "- Evidence review signal present; review the listed surface before merge.",
+                    "",
+                ]
+            )
+        elif evidence_signal_lines:
+            lines.extend(
+                [
+                    "## Merge assessment",
+                    "",
+                    "- Evidence proof signal present; verify the listed proof before routine merge.",
                     "",
                 ]
             )

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -349,3 +349,64 @@ def test_action_report_green_comment_surfaces_evidence_review_signal() -> None:
     assert "Quality is green, so the review focus is not coverage." not in body
     assert "The comment must guide maintainers" not in body
     assert "Confirm the graph findings match the changed files and artifacts." not in body
+
+
+def test_action_report_green_comment_distinguishes_proof_signal_from_review_signal() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+    evidence_narrative = {
+        "quality": {"ok": True, "coverage_percent": "96.69%"},
+        "primary_signal": {
+            "kind": "review_signal",
+            "surface": "pr_quality",
+            "title": "PR Quality evidence changed",
+        },
+        "graph": {
+            "node_count": 2,
+            "review_first_count": 0,
+            "critical_count": 0,
+            "top_blocker": {
+                "title": "PR Quality evidence changed",
+                "surface": "pr_quality",
+                "action": "rerun_proof",
+                "review_first": False,
+            },
+        },
+        "next_proof": [
+            "python -m pytest -q tests/test_pr_quality_evidence_narrative.py -o addopts=",
+            "python -m pre_commit run -a",
+        ],
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        evidence_narrative=evidence_narrative,
+    )
+
+    assert "SDETKit Review Result: Green" in body
+    assert "## Evidence proof signal" in body
+    assert "Proof signal: `present`" in body
+    assert "Surface: `pr_quality`" in body
+    assert "PR Quality evidence changed" in body
+    assert "Operator action: `rerun_proof`" in body
+    assert "Review-first nodes: `0`" in body
+    assert "Critical nodes: `0`" in body
+    assert "Evidence proof signal present; verify the listed proof before routine merge." in body
+    assert "## Evidence review signal" not in body
+    assert "Review signal: `present`" not in body
+    assert "Evidence review signal present; review the listed surface before merge." not in body
+    assert "No action required from SDETKit." not in body


### PR DESCRIPTION
## Summary
- Split Evidence Graph signal wording in PR Quality action-report comments.
- Kept “Evidence review signal” only for review-required evidence: review-first nodes, critical nodes, or top-blocker action `review`.
- Added “Evidence proof signal” for proof-rerun evidence where no review-first or critical graph finding exists.
- Updated merge assessment wording so proof-only signals ask maintainers to verify proof, not review before merge.

## Why
#1316 correctly surfaced Evidence Graph signals in the final PR comment, but it labeled proof-rerun evidence as a review signal. That made green PR Quality comments sound stricter than the underlying graph evidence required.

This change preserves visibility while making the language precise.

## Verification
- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_evidence_narrative.py tests/test_full_spine_action_report_integration.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-medium
- Public surface: PR Quality comment wording
- Rollback: easy, revert the helper rename/wording logic and focused test

## Notes
- Advisory only.
- Does not enable automation.
- Keeps review-before-merge wording only for true review-required evidence.