### PR TITLE
Reflect Evidence Graph signal state in PR Quality result title

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -51,6 +51,22 @@ def _status_title(status: str) -> str:
     }.get(status, status.replace("_", " ").title() or "Unknown")
 
 
+def _result_title(
+    status: str,
+    *,
+    evidence_signal_present: bool,
+    evidence_review_required: bool,
+) -> str:
+    base = _status_title(status)
+    if status != "green":
+        return base
+    if evidence_review_required:
+        return f"{base} with evidence review"
+    if evidence_signal_present:
+        return f"{base} with proof signal"
+    return base
+
+
 def _quality_lines(evidence_narrative: JsonObject) -> list[str]:
     quality = _as_dict(evidence_narrative.get("quality"))
     if not quality:
@@ -233,9 +249,17 @@ def render_comment_body(
 ) -> str:
     evidence_narrative = evidence_narrative or {}
     status = _string(action_report.get("status") or "unknown")
+    evidence_signal_heading, evidence_signal_lines, evidence_review_required = _evidence_signal(
+        evidence_narrative
+    )
 
     lines = [
-        f"## SDETKit Review Result: {_status_title(status)}",
+        "## SDETKit Review Result: "
+        + _result_title(
+            status,
+            evidence_signal_present=bool(evidence_signal_lines),
+            evidence_review_required=evidence_review_required,
+        ),
         "",
         f"Status: `{status}`",
         "",
@@ -245,9 +269,6 @@ def render_comment_body(
     if quality:
         lines.extend(["## Quality summary", "", *quality, ""])
 
-    evidence_signal_heading, evidence_signal_lines, evidence_review_required = _evidence_signal(
-        evidence_narrative
-    )
     if evidence_signal_lines:
         lines.extend(["## " + evidence_signal_heading, "", *evidence_signal_lines, ""])
 

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -337,7 +337,8 @@ def test_action_report_green_comment_surfaces_evidence_review_signal() -> None:
         evidence_narrative=evidence_narrative,
     )
 
-    assert "SDETKit Review Result: Green" in body
+    assert "SDETKit Review Result: Green with evidence review" in body
+    assert "Status: `green`" in body
     assert "## Evidence review signal" in body
     assert "Review signal: `present`" in body
     assert "Surface: `workflow`" in body
@@ -397,7 +398,8 @@ def test_action_report_green_comment_distinguishes_proof_signal_from_review_sign
         evidence_narrative=evidence_narrative,
     )
 
-    assert "SDETKit Review Result: Green" in body
+    assert "SDETKit Review Result: Green with proof signal" in body
+    assert "Status: `green`" in body
     assert "## Evidence proof signal" in body
     assert "Proof signal: `present`" in body
     assert "Surface: `pr_quality`" in body
@@ -475,6 +477,8 @@ def test_write_comment_body_preserves_evidence_review_signal_artifact(
     body = out.read_text(encoding="utf-8")
     assert result["out"] == out.as_posix()
     assert result["status"] == "green"
+    assert "SDETKit Review Result: Green with evidence review" in body
+    assert "Status: `green`" in body
     assert "## Evidence review signal" in body
     assert "Review signal: `present`" in body
     assert "Surface: `workflow`" in body
@@ -552,6 +556,8 @@ def test_write_comment_body_preserves_evidence_proof_signal_artifact(
     body = out.read_text(encoding="utf-8")
     assert result["out"] == out.as_posix()
     assert result["status"] == "green"
+    assert "SDETKit Review Result: Green with proof signal" in body
+    assert "Status: `green`" in body
     assert "## Evidence proof signal" in body
     assert "Proof signal: `present`" in body
     assert "Surface: `pr_quality`" in body


### PR DESCRIPTION
## Summary
- Made the PR Quality result title aware of Evidence Graph signal state.
- Kept machine-readable `Status: green` unchanged.
- Rendered `Green with proof signal` for proof-only evidence.
- Rendered `Green with evidence review` for review-required graph evidence.
- Added focused assertions for direct rendering and final comment artifact output.

## Why
The body already distinguishes Evidence review signals from Evidence proof signals, but the top title still said plain `Green`. This made the first line less precise than the rest of the comment.

## Verification
- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_evidence_narrative.py tests/test_full_spine_action_report_integration.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-medium
- Public surface: PR Quality comment title wording
- Rollback: easy, revert the title helper and focused assertions

## Notes
- Advisory only.
- Does not change the underlying action-report status.
- Does not enable automation.