### PR TITLE
Prove PR Quality final comment uses evidence narrative

### DIFF
--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -87,11 +87,13 @@ def test_pr_quality_comment_workflow_renders_comment_from_action_report() -> Non
 
     assert "python -m sdetkit.pr_quality_evidence_narrative" in text
     assert "--out build/pr-quality/pr-evidence-narrative.md" in text
+    assert "--json-out build/pr-quality/pr-evidence-narrative.json" in text
     assert "python -m sdetkit.pr_quality_action_report" in text
     assert "--action-report build/pr-quality/check-intelligence/action-report.json" in text
     assert (
         "--check-intelligence build/pr-quality/check-intelligence/check-intelligence.json" in text
     )
+    assert "--evidence-narrative build/pr-quality/pr-evidence-narrative.json" in text
     assert "--out build/pr-quality/pr-comment-body.md" in text
 
 
@@ -140,3 +142,16 @@ def test_pr_quality_comment_workflow_feeds_action_report_into_evidence_graph() -
         in text
     )
     assert "--failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json" in text
+
+
+def test_pr_quality_comment_workflow_passes_evidence_narrative_into_final_comment() -> None:
+    text = _workflow_text()
+
+    narrative_step = text.index("python -m sdetkit.pr_quality_evidence_narrative")
+    narrative_json = text.index("--json-out build/pr-quality/pr-evidence-narrative.json")
+    action_report_step = text.index("python -m sdetkit.pr_quality_action_report")
+    evidence_arg = text.index("--evidence-narrative build/pr-quality/pr-evidence-narrative.json")
+    comment_out = text.index("--out build/pr-quality/pr-comment-body.md")
+
+    assert narrative_step < narrative_json < action_report_step
+    assert action_report_step < evidence_arg < comment_out


### PR DESCRIPTION
## Summary
- Added workflow contract proof that PR Quality writes `pr-evidence-narrative.json`.
- Proved the final comment writer receives that JSON via `--evidence-narrative`.
- Added ordering proof so narrative JSON is produced before `pr_quality_action_report` renders `pr-comment-body.md`.

## Why
The final PR comment now depends on Evidence Graph signal state for the title and review/proof wording. This PR protects the live workflow wiring so the final comment cannot silently drop the evidence narrative JSON.

## Verification
- `python -m pytest -q tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_action_report.py tests/test_pr_quality_evidence_narrative.py tests/test_full_spine_action_report_integration.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low
- Test-only
- Rollback: easy, remove the workflow contract assertions

## Notes
- No production behavior changed.
- Advisory only.
- Protects final PR comment wiring for Evidence Graph signal-aware wording.