### PR TITLE
Record PR Quality final comment signal state

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -280,7 +280,8 @@ jobs:
             --action-report build/pr-quality/check-intelligence/action-report.json \
             --check-intelligence build/pr-quality/check-intelligence/check-intelligence.json \
             --evidence-narrative build/pr-quality/pr-evidence-narrative.json \
-            --out build/pr-quality/pr-comment-body.md
+            --out build/pr-quality/pr-comment-body.md \
+            > build/pr-quality/pr-comment-metadata.json
 
       - name: Upload failure intelligence bundle
         if: always()
@@ -307,6 +308,7 @@ jobs:
           name: pr-quality-comment
           path: |
             build/pr-quality/pr-comment-body.md
+            build/pr-quality/pr-comment-metadata.json
             build/pr-quality/pr-evidence-narrative.json
             build/pr-quality/changed-files.txt
             build/pr-quality/comment-status.json
@@ -324,11 +326,32 @@ jobs:
             const path = require('path');
 
             const statusPath = 'build/pr-quality/comment-status.json';
+            const readCommentMetadata = () => {
+              const metadataPath = 'build/pr-quality/pr-comment-metadata.json';
+              try {
+                if (!fs.existsSync(metadataPath)) {
+                  return {};
+                }
+                return JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+              } catch (error) {
+                core.warning(`failed to read PR Quality comment metadata: ${error && error.message ? error.message : error}`);
+                return {};
+              }
+            };
             const writeStatus = (payload) => {
+              const metadata = readCommentMetadata();
+              const enrichedPayload = {
+                ...payload,
+                action_report_status: metadata.status || 'unknown',
+                comment_result_title: metadata.result_title || 'unknown',
+                evidence_signal_kind: metadata.evidence_signal_kind || 'unknown',
+                evidence_signal_present: Boolean(metadata.evidence_signal_present),
+                evidence_review_required: Boolean(metadata.evidence_review_required),
+              };
               fs.mkdirSync(path.dirname(statusPath), { recursive: true });
               fs.writeFileSync(
                 statusPath,
-                `${JSON.stringify(payload, null, 2)}\n`,
+                `${JSON.stringify(enrichedPayload, null, 2)}\n`,
                 'utf8'
               );
             };

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -349,9 +349,26 @@ def write_comment_body(
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(body, encoding="utf-8")
 
+    status = _string(action_report.get("status") or "unknown")
+    _heading, evidence_signal_lines, evidence_review_required = _evidence_signal(evidence_narrative)
+    if evidence_review_required:
+        evidence_signal_kind = "review"
+    elif evidence_signal_lines:
+        evidence_signal_kind = "proof"
+    else:
+        evidence_signal_kind = "none"
+
     return {
         "out": out.as_posix(),
-        "status": _string(action_report.get("status") or "unknown"),
+        "status": status,
+        "result_title": _result_title(
+            status,
+            evidence_signal_present=bool(evidence_signal_lines),
+            evidence_review_required=evidence_review_required,
+        ),
+        "evidence_signal_kind": evidence_signal_kind,
+        "evidence_signal_present": bool(evidence_signal_lines),
+        "evidence_review_required": evidence_review_required,
     }
 
 

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -178,6 +178,10 @@ def test_action_report_cli_writes_comment_body(tmp_path: Path, capsys) -> None:
     printed = json.loads(capsys.readouterr().out)
     assert printed["out"] == out.as_posix()
     assert printed["status"] == "green"
+    assert printed["result_title"] == "Green"
+    assert printed["evidence_signal_kind"] == "none"
+    assert printed["evidence_signal_present"] is False
+    assert printed["evidence_review_required"] is False
     assert "SDETKit Review Result: Green" in out.read_text(encoding="utf-8")
 
 
@@ -477,6 +481,10 @@ def test_write_comment_body_preserves_evidence_review_signal_artifact(
     body = out.read_text(encoding="utf-8")
     assert result["out"] == out.as_posix()
     assert result["status"] == "green"
+    assert result["result_title"] == "Green with evidence review"
+    assert result["evidence_signal_kind"] == "review"
+    assert result["evidence_signal_present"] is True
+    assert result["evidence_review_required"] is True
     assert "SDETKit Review Result: Green with evidence review" in body
     assert "Status: `green`" in body
     assert "## Evidence review signal" in body
@@ -556,6 +564,10 @@ def test_write_comment_body_preserves_evidence_proof_signal_artifact(
     body = out.read_text(encoding="utf-8")
     assert result["out"] == out.as_posix()
     assert result["status"] == "green"
+    assert result["result_title"] == "Green with proof signal"
+    assert result["evidence_signal_kind"] == "proof"
+    assert result["evidence_signal_present"] is True
+    assert result["evidence_review_required"] is False
     assert "SDETKit Review Result: Green with proof signal" in body
     assert "Status: `green`" in body
     assert "## Evidence proof signal" in body

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -42,6 +42,7 @@ def test_pr_quality_comment_workflow_uploads_comment_artifacts() -> None:
 
     assert "Upload PR quality comment artifacts" in text
     assert "build/pr-quality/pr-comment-body.md" in text
+    assert "build/pr-quality/pr-comment-metadata.json" in text
     assert "build/pr-quality/pr-evidence-narrative.json" in text
     assert "build/pr-quality/changed-files.txt" in text
     assert "build/pr-quality/comment-status.json" in text
@@ -58,6 +59,12 @@ def test_pr_quality_comment_workflow_updates_or_posts_comment_and_records_status
     assert "comment_status=posted" in text
     assert "posted SDET Quality Gate comment" in text
     assert "updated existing SDET Quality Gate comment" in text
+    assert "readCommentMetadata" in text
+    assert "action_report_status: metadata.status || 'unknown'" in text
+    assert "comment_result_title: metadata.result_title || 'unknown'" in text
+    assert "evidence_signal_kind: metadata.evidence_signal_kind || 'unknown'" in text
+    assert "evidence_signal_present: Boolean(metadata.evidence_signal_present)" in text
+    assert "evidence_review_required: Boolean(metadata.evidence_review_required)" in text
 
 
 def test_pr_quality_comment_workflow_fails_loud_when_comment_not_visible() -> None:
@@ -95,6 +102,7 @@ def test_pr_quality_comment_workflow_renders_comment_from_action_report() -> Non
     )
     assert "--evidence-narrative build/pr-quality/pr-evidence-narrative.json" in text
     assert "--out build/pr-quality/pr-comment-body.md" in text
+    assert "> build/pr-quality/pr-comment-metadata.json" in text
 
 
 def test_pr_quality_comment_workflow_uploads_check_intelligence_artifacts() -> None:


### PR DESCRIPTION
## Summary
- Extended PR Quality action-report metadata with final rendered signal state.
- Captured `pr-comment-metadata.json` from the final comment writer.
- Enriched `comment-status.json` with action-report status, rendered title, evidence signal kind, and review-required state.
- Uploaded the new metadata artifact with PR Quality comment artifacts.
- Added focused action-report and workflow observability assertions.

## Why
The PR Quality comment is now signal-aware, but the posting/status artifact only recorded whether the comment was posted or updated. This PR makes the final comment state auditable without manually reading Markdown.

## Verification
- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_evidence_narrative.py tests/test_full_spine_action_report_integration.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-medium
- Public behavior: comment artifact metadata only
- Rollback: easy, revert metadata capture/enrichment and focused assertions

## Notes
- Advisory only.
- Does not change merge logic.
- Does not enable automation.
- Preserves the final rendered comment body while making its signal state auditable.