### PR TITLE
Print PR Quality comment signal state in visibility verification

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -426,8 +426,19 @@ jobs:
           payload = json.loads(path.read_text(encoding="utf-8"))
           status = str(payload.get("status", "missing"))
           reason = str(payload.get("reason", ""))
+          action_report_status = str(payload.get("action_report_status", "unknown"))
+          comment_result_title = str(payload.get("comment_result_title", "unknown"))
+          evidence_signal_kind = str(payload.get("evidence_signal_kind", "unknown"))
+          evidence_signal_present = bool(payload.get("evidence_signal_present", False))
+          evidence_review_required = bool(payload.get("evidence_review_required", False))
+
           print(f"comment_status={status}")
           print(f"comment_reason={reason}")
+          print(f"action_report_status={action_report_status}")
+          print(f"comment_result_title={comment_result_title}")
+          print(f"evidence_signal_kind={evidence_signal_kind}")
+          print(f"evidence_signal_present={str(evidence_signal_present).lower()}")
+          print(f"evidence_review_required={str(evidence_review_required).lower()}")
 
           if status not in {"posted", "updated"}:
               raise SystemExit(f"PR Quality comment was not posted or updated: status={status} reason={reason}")

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -77,6 +77,21 @@ def test_pr_quality_comment_workflow_fails_loud_when_comment_not_visible() -> No
     assert "PR Quality comment was not posted or updated" in text
 
 
+def test_pr_quality_comment_workflow_logs_final_comment_signal_state() -> None:
+    text = _workflow_text()
+
+    assert "action_report_status = str(payload.get(" in text
+    assert "comment_result_title = str(payload.get(" in text
+    assert "evidence_signal_kind = str(payload.get(" in text
+    assert "evidence_signal_present = bool(payload.get(" in text
+    assert "evidence_review_required = bool(payload.get(" in text
+    assert 'print(f"action_report_status={action_report_status}")' in text
+    assert 'print(f"comment_result_title={comment_result_title}")' in text
+    assert 'print(f"evidence_signal_kind={evidence_signal_kind}")' in text
+    assert 'print(f"evidence_signal_present={str(evidence_signal_present).lower()}")' in text
+    assert 'print(f"evidence_review_required={str(evidence_review_required).lower()}")' in text
+
+
 def test_pr_quality_comment_workflow_builds_check_intelligence_action_report() -> None:
     text = _workflow_text()
 


### PR DESCRIPTION
## Summary
- Printed final PR Quality comment signal metadata during visibility verification.
- Added CI log output for action-report status, rendered comment title, evidence signal kind, signal presence, and review-required state.
- Added workflow contract assertions proving the visibility step logs those fields.

## Why
#1321 records final comment signal metadata in `comment-status.json`, but operators still had to download artifacts to inspect it. This PR surfaces that metadata directly in the workflow log.

## Verification
- `python -m pytest -q tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_action_report.py tests/test_pr_quality_evidence_narrative.py tests/test_full_spine_action_report_integration.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low
- Public surface: CI logs only
- Rollback: easy, revert the workflow print lines and workflow contract test

## Notes
- Observability only.
- Does not change merge logic.
- Does not change the PR comment body.
- Does not enable automation.