### PR TITLE
Require PR Quality final comment signal metadata

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -442,4 +442,14 @@ jobs:
 
           if status not in {"posted", "updated"}:
               raise SystemExit(f"PR Quality comment was not posted or updated: status={status} reason={reason}")
+
+          if action_report_status == "unknown":
+              raise SystemExit("PR Quality comment signal metadata missing: action_report_status=unknown")
+          if comment_result_title == "unknown":
+              raise SystemExit("PR Quality comment signal metadata missing: comment_result_title=unknown")
+          if evidence_signal_kind not in {"none", "proof", "review"}:
+              raise SystemExit(
+                  "PR Quality comment signal metadata invalid: "
+                  f"evidence_signal_kind={evidence_signal_kind}"
+              )
           PY

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -92,6 +92,15 @@ def test_pr_quality_comment_workflow_logs_final_comment_signal_state() -> None:
     assert 'print(f"evidence_review_required={str(evidence_review_required).lower()}")' in text
 
 
+def test_pr_quality_comment_workflow_requires_final_comment_signal_metadata() -> None:
+    text = _workflow_text()
+
+    assert "PR Quality comment signal metadata missing: action_report_status=unknown" in text
+    assert "PR Quality comment signal metadata missing: comment_result_title=unknown" in text
+    assert 'evidence_signal_kind not in {"none", "proof", "review"}' in text
+    assert "PR Quality comment signal metadata invalid: " in text
+
+
 def test_pr_quality_comment_workflow_builds_check_intelligence_action_report() -> None:
     text = _workflow_text()
 


### PR DESCRIPTION
## Summary
- Added visibility verification guards for PR Quality final comment signal metadata.
- Fail loud when a posted/updated PR Quality comment has missing `action_report_status`.
- Fail loud when a posted/updated PR Quality comment has missing `comment_result_title`.
- Fail loud when `evidence_signal_kind` is not one of `none`, `proof`, or `review`.
- Added workflow contract assertions for the required metadata guard.

## Why
#1321 records final comment signal metadata and #1322 prints it in the visibility step. This PR closes the loop by requiring the metadata to be present and valid whenever the PR Quality comment is successfully posted or updated.

## Verification
- `python -m pytest -q tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_action_report.py tests/test_pr_quality_evidence_narrative.py tests/test_full_spine_action_report_integration.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-medium
- Public surface: CI verification behavior
- Rollback: easy, revert the visibility guard and workflow contract test

## Notes
- Observability guardrail only.
- Does not change merge logic.
- Does not change the PR comment body.
- Does not enable automation.
- Plain green comments remain valid with `evidence_signal_kind=none`.