### PR TITLE
Refresh roadmap manifest test-reference counts

### DIFF
--- a/docs/roadmap/manifest.json
+++ b/docs/roadmap/manifest.json
@@ -276,7 +276,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.distribution",
         "module_path": "src/sdetkit/distribution.py",
-        "tests_referencing_module": 10
+        "tests_referencing_module": 11
       },
       {
         "contract_script_paths": [
@@ -360,7 +360,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.evidence_narrative",
         "module_path": "src/sdetkit/evidence_narrative.py",
-        "tests_referencing_module": 2
+        "tests_referencing_module": 12
       },
       {
         "contract_script_paths": [
@@ -720,7 +720,7 @@
         "legacy_anchor_refs_in_module": 0,
         "module": "sdetkit.proof",
         "module_path": "src/sdetkit/proof.py",
-        "tests_referencing_module": 81
+        "tests_referencing_module": 91
       },
       {
         "contract_script_paths": [


### PR DESCRIPTION
## Summary
- Refreshed `docs/roadmap/manifest.json`.
- Updated generated `tests_referencing_module` counts for distribution, evidence narrative, and proof modules.
- No production code changed.

## Why
The full dependency-aware proof passed, but the roadmap manifest freshness check showed the committed manifest was stale. Regenerating the manifest produced only deterministic test-reference count updates.

## Verification
- `python -m pytest -q tests/test_roadmap_manifest_tooling.py tests/test_roadmap_manifest_edges_wave12.py tests/test_roadmap_cli.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low
- Generated docs manifest only
- Rollback: easy, revert the manifest refresh

## Notes
- No runtime behavior changed.
- No workflow behavior changed.
- Keeps `test_roadmap_manifest_is_fresh` green.