### PR TITLE
Expose complete failure bundle diagnoses

### DIFF
--- a/src/sdetkit/adaptive_failure_bundle.py
+++ b/src/sdetkit/adaptive_failure_bundle.py
@@ -80,7 +80,8 @@ def build_failure_bundle(
     out_dir.mkdir(parents=True, exist_ok=True)
 
     diagnosis = adaptive_diagnosis.analyze_evidence(log_text=log_text)
-    primary = _primary_diagnosis(diagnosis)
+    diagnoses = [_as_dict(item) for item in _as_list(diagnosis.get("diagnoses"))]
+    primary = diagnoses[0] if diagnoses else {}
     primary_code = str(primary.get("code", "") or "")
     review_first = primary_code in {"UNKNOWN", "UNKNOWN_REVIEW_REQUIRED"}
 
@@ -155,6 +156,9 @@ def build_failure_bundle(
         "artifacts": artifacts,
         "source_log": log_path.as_posix(),
         "primary_diagnosis_code": primary_code,
+        "diagnosis_codes": [
+            str(item.get("code", "") or "") for item in diagnoses if str(item.get("code", "") or "")
+        ],
         "review_first": review_first,
         "safe_to_auto_fix": bool(safe_fix_plan.get("safe_to_auto_fix", False)),
     }
@@ -167,7 +171,12 @@ def build_failure_bundle(
         "source_log": log_path.as_posix(),
         "status": str(diagnosis.get("status", "unknown")),
         "primary_diagnosis_code": primary_code,
-        "diagnosis_count": int(diagnosis.get("diagnosis_count", 0) or 0),
+        "primary_diagnosis_title": str(primary.get("title", "") or ""),
+        "diagnosis_count": len(diagnoses),
+        "diagnosis_codes": [
+            str(item.get("code", "") or "") for item in diagnoses if str(item.get("code", "") or "")
+        ],
+        "diagnoses": diagnoses,
         "review_first": review_first,
         "safe_to_auto_fix": bool(safe_fix_plan.get("safe_to_auto_fix", False)),
         "artifacts": artifacts,

--- a/tests/test_adaptive_failure_bundle.py
+++ b/tests/test_adaptive_failure_bundle.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from pytest import MonkeyPatch
+
 from sdetkit import adaptive_failure_bundle
 
 
@@ -162,3 +164,92 @@ def test_sdetkit_adaptive_failure_bundle_subprocess(tmp_path: Path) -> None:
     assert payload["primary_diagnosis_code"] == "PYTEST_ASSERTION_FAILURE"
     assert Path(payload["bundle_path"]).exists()
     assert Path(payload["artifacts"]["operator_brief_markdown"]).exists()
+
+
+def test_failure_bundle_exposes_complete_diagnosis_set_for_graph_consumers(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    diagnoses = [
+        {
+            "code": "PACKAGE_INSTALL_FAILURE",
+            "title": "Dependency resolver failed",
+            "diagnosis": "pip could not resolve constraints before tests could prove behavior.",
+            "severity": "high",
+            "confidence": "high",
+            "affected_files": ["constraints-ci.txt", "requirements-test.txt"],
+            "recommended_fix": ["Align the smallest dependency surface."],
+            "proof_commands": [
+                "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+            ],
+        },
+        {
+            "code": "SECURITY_FINDING_REVIEW_REQUIRED",
+            "title": "Security finding requires review",
+            "diagnosis": "A protected security surface emitted a review-first finding.",
+            "severity": "high",
+            "confidence": "high",
+            "affected_files": ["docs/security-posture.md"],
+            "recommended_fix": ["Inspect the security finding and affected surface."],
+            "proof_commands": ["python -m pre_commit run -a"],
+        },
+    ]
+
+    diagnosis = {
+        "schema_version": "sdetkit.adaptive.diagnosis.v1",
+        "ok": False,
+        "status": "needs_fix",
+        "risk_score": 100,
+        "confidence": "high",
+        "summary": "Primary issue: Dependency resolver failed. Fix this before release signoff.",
+        "diagnosis_count": len(diagnoses),
+        "diagnoses": diagnoses,
+        "fix_plan": [],
+        "scenario_database": {},
+        "scenario_codes": [],
+    }
+
+    def fake_analyze_evidence(*, log_text: str) -> dict[str, object]:
+        assert "synthetic multi-domain failure" in log_text
+        return diagnosis
+
+    monkeypatch.setattr(
+        adaptive_failure_bundle.adaptive_diagnosis,
+        "analyze_evidence",
+        fake_analyze_evidence,
+    )
+
+    log = _write(tmp_path / "failure.log", "synthetic multi-domain failure\n")
+    bundle = adaptive_failure_bundle.build_failure_bundle(
+        log_path=log,
+        out_dir=tmp_path / "bundle",
+        proof_failed=True,
+    )
+
+    assert bundle["primary_diagnosis_code"] == "PACKAGE_INSTALL_FAILURE"
+    assert bundle["primary_diagnosis_title"] == "Dependency resolver failed"
+    assert bundle["diagnosis_count"] == 2
+    assert bundle["diagnosis_codes"] == [
+        "PACKAGE_INSTALL_FAILURE",
+        "SECURITY_FINDING_REVIEW_REQUIRED",
+    ]
+    assert bundle["diagnoses"] == diagnoses
+    assert bundle["diagnosis"]["diagnoses"] == diagnoses
+
+    manifest = json.loads(
+        Path(bundle["artifacts"]["artifact_manifest_json"]).read_text(encoding="utf-8")
+    )
+    assert manifest["diagnosis_codes"] == bundle["diagnosis_codes"]
+
+    from sdetkit.evidence_graph import build_evidence_graph
+
+    graph = build_evidence_graph(failure_bundle=Path(str(bundle["bundle_path"])))
+    assert graph["source_summary"][-1]["source"] == "failure_bundle"
+    assert graph["source_summary"][-1]["findings_seen"] == 2
+    assert graph["source_summary"][-1]["findings_emitted"] == 2
+
+    nodes = {node["title"]: node for node in graph["nodes"]}
+    assert nodes["Dependency resolver failed"]["risk_surface"] == "dependency"
+    assert nodes["Dependency resolver failed"]["review_first"] is True
+    assert nodes["Security finding requires review"]["risk_surface"] == "security"
+    assert nodes["Security finding requires review"]["review_first"] is True


### PR DESCRIPTION
## Summary
- Expose the complete adaptive diagnosis set at the top level of generated failure bundles.
- Add diagnosis codes and primary diagnosis title while preserving the existing nested diagnosis payload.
- Add regression coverage proving Evidence Graph consumes all generated bundle diagnoses.

## Why
- Failure bundles previously exposed primary diagnosis metadata but did not provide top-level graph-ready diagnoses.
- Evidence Graph already normalizes failure bundles from top-level `diagnoses`, so generated bundles should preserve all ranked diagnosis signals for downstream Mission Control and PR Quality ranking.

## Verification
- `python -m pytest -q tests/test_adaptive_failure_bundle.py tests/test_evidence_graph.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Public artifact schema is expanded but existing keys are preserved.
- Rollback: easy; revert this commit.
