### PR TITLE
Surface secondary Evidence Graph blockers in Mission Control

### DIFF
--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -422,6 +422,33 @@ def _evidence_graph_next_commands(node: dict[str, Any]) -> list[str]:
     return commands
 
 
+def _evidence_graph_node_handoff(node: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "title": str(node.get("title", "") or "Untitled evidence graph finding"),
+        "risk_surface": str(node.get("risk_surface", "") or "unknown"),
+        "severity": str(node.get("severity", "") or "unknown"),
+        "operator_action": str(node.get("operator_action", "") or "rerun_proof"),
+        "review_first": bool(node.get("review_first", False)),
+        "next_commands": _evidence_graph_next_commands(node),
+    }
+
+
+def _evidence_graph_secondary_blockers(
+    nodes: list[dict[str, Any]],
+    top_blocker: dict[str, Any],
+    *,
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    secondary: list[dict[str, Any]] = []
+    for node in sorted(nodes, key=_evidence_graph_node_score, reverse=True):
+        if node is top_blocker:
+            continue
+        secondary.append(_evidence_graph_node_handoff(node))
+        if len(secondary) >= limit:
+            break
+    return secondary
+
+
 def _collect_evidence_graph(graph_path: Path | None) -> dict[str, Any] | None:
     if graph_path is None:
         return None
@@ -497,6 +524,7 @@ def _collect_evidence_graph(graph_path: Path | None) -> dict[str, Any] | None:
     )
     top_blocker = _evidence_graph_top_blocker(nodes)
     top_blocker_next_commands = _evidence_graph_next_commands(top_blocker)
+    secondary_blockers = _evidence_graph_secondary_blockers(nodes, top_blocker)
 
     graph_dir = resolved.parent
     artifact_specs = [
@@ -529,6 +557,8 @@ def _collect_evidence_graph(graph_path: Path | None) -> dict[str, Any] | None:
         "top_blocker_severity": str(top_blocker.get("severity", "") or "none"),
         "top_blocker_action": str(top_blocker.get("operator_action", "") or "none"),
         "top_blocker_review_first": bool(top_blocker.get("review_first", False)),
+        "secondary_blocker_count": len(secondary_blockers),
+        "secondary_blockers": secondary_blockers,
         "next_commands": top_blocker_next_commands,
         "source_count": len(source_summary),
         "source_summary": source_summary,
@@ -552,7 +582,7 @@ def _format_evidence_graph(summary: dict[str, Any] | None) -> list[str]:
     if summary.get("error"):
         return [
             "- Status: error",
-            f"- Error: {summary.get('error')}",
+            f"- Error: {summary.get('error', 'unknown')}",
             f"- Graph: `{summary.get('path', '')}`",
         ]
 
@@ -560,7 +590,7 @@ def _format_evidence_graph(summary: dict[str, Any] | None) -> list[str]:
     if not isinstance(risk_surfaces, list):
         risk_surfaces = []
 
-    return [
+    lines = [
         f"- Status: {summary.get('status', 'unknown')}",
         f"- Node count: {summary.get('node_count', 0)}",
         f"- Review-first nodes: {summary.get('review_first_count', 0)}",
@@ -571,9 +601,30 @@ def _format_evidence_graph(summary: dict[str, Any] | None) -> list[str]:
         f"- Top blocker: {summary.get('top_blocker_title', 'none')}",
         f"- Top blocker surface: {summary.get('top_blocker_surface', 'none')}",
         f"- Top blocker action: {summary.get('top_blocker_action', 'none')}",
-        f"- Next commands: {'; '.join(str(command) for command in summary.get('next_commands', [])) or 'none'}",
-        f"- Graph: `{summary.get('path', '')}`",
     ]
+
+    secondary_blockers = summary.get("secondary_blockers", [])
+    if isinstance(secondary_blockers, list) and secondary_blockers:
+        lines.append(f"- Secondary blockers: {len(secondary_blockers)}")
+        for blocker in secondary_blockers:
+            if not isinstance(blocker, dict):
+                continue
+            lines.append(
+                "- Secondary blocker: "
+                f"{blocker.get('title', 'Untitled evidence graph finding')} "
+                f"[{blocker.get('risk_surface', 'unknown')}; "
+                f"{blocker.get('operator_action', 'rerun_proof')}]"
+            )
+    else:
+        lines.append("- Secondary blockers: none")
+
+    lines.extend(
+        [
+            f"- Next commands: {'; '.join(str(command) for command in summary.get('next_commands', [])) or 'none'}",
+            f"- Graph: `{summary.get('path', '')}`",
+        ]
+    )
+    return lines
 
 
 def _evidence_graph_ledger_summary(bundle: dict[str, Any]) -> dict[str, Any] | None:
@@ -591,6 +642,8 @@ def _evidence_graph_ledger_summary(bundle: dict[str, Any]) -> dict[str, Any] | N
         "top_blocker_title": str(summary.get("top_blocker_title", "")),
         "top_blocker_surface": str(summary.get("top_blocker_surface", "")),
         "top_blocker_action": str(summary.get("top_blocker_action", "")),
+        "secondary_blocker_count": int(summary.get("secondary_blocker_count", 0) or 0),
+        "secondary_blockers": summary.get("secondary_blockers", []),
         "next_commands": summary.get("next_commands", []),
     }
 
@@ -1381,6 +1434,10 @@ def _summarize(args: argparse.Namespace) -> int:
         print(
             f"{summary_prefix}_top_blocker_action="
             f"{evidence_graph.get('top_blocker_action', 'none')}"
+        )
+        print(
+            f"{summary_prefix}_secondary_blocker_count="
+            f"{evidence_graph.get('secondary_blocker_count', 0)}"
         )
     adaptive_failure_bundle = bundle.get("adaptive_failure_bundle")
     if isinstance(adaptive_failure_bundle, dict):

--- a/tests/test_mission_control_evidence_graph.py
+++ b/tests/test_mission_control_evidence_graph.py
@@ -315,3 +315,118 @@ def test_mission_control_evidence_graph_ranks_top_blocker(tmp_path: Path) -> Non
     assert "Top blocker surface: dependency" in markdown
     assert "Top blocker action: review" in markdown
     assert "PYTHONPATH=src python -m pip install -c constraints-ci.txt" in markdown
+
+
+def test_mission_control_preserves_secondary_evidence_graph_blockers(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+
+    graph_dir = tmp_path / "evidence-graph"
+    graph_dir.mkdir()
+    graph_path = graph_dir / "evidence-graph.json"
+    graph_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.evidence-graph.v1",
+                "nodes": [
+                    {
+                        "finding_id": "security-review",
+                        "title": "Security finding requires review",
+                        "summary": "A protected security surface changed.",
+                        "risk_surface": "security",
+                        "severity": "critical",
+                        "review_first": True,
+                        "safe_to_auto_fix": False,
+                        "owner_files": ["docs/security-posture.md"],
+                        "source_artifacts": ["security-review.json"],
+                        "recommended_commands": [
+                            "python -m pre_commit run -a",
+                        ],
+                        "proof_commands": [
+                            "python -m pytest -q tests/test_owned_surface_hygiene_contract.py -o addopts=",
+                        ],
+                        "recurrence_state": "first_seen",
+                        "operator_action": "review",
+                        "automation_allowed_now": False,
+                    },
+                    {
+                        "finding_id": "dependency-resolver",
+                        "title": "Dependency resolver failed",
+                        "summary": "pip could not resolve constraints before tests could run.",
+                        "risk_surface": "dependency",
+                        "severity": "high",
+                        "review_first": True,
+                        "safe_to_auto_fix": False,
+                        "owner_files": ["constraints-ci.txt", "requirements-test.txt"],
+                        "source_artifacts": ["failure-bundle.json"],
+                        "recommended_commands": [
+                            "Reproduce the exact install lane.",
+                        ],
+                        "proof_commands": [
+                            "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+                        ],
+                        "recurrence_state": "first_seen",
+                        "operator_action": "review",
+                        "automation_allowed_now": False,
+                    },
+                    {
+                        "finding_id": "coverage-gate",
+                        "title": "Coverage gate regression",
+                        "summary": "Coverage dropped below threshold.",
+                        "risk_surface": "quality",
+                        "severity": "warning",
+                        "review_first": False,
+                        "safe_to_auto_fix": False,
+                        "owner_files": ["src/sdetkit/example.py"],
+                        "source_artifacts": ["quality.log"],
+                        "recommended_commands": ["python -m pytest -q --cov=sdetkit"],
+                        "proof_commands": [],
+                        "recurrence_state": "first_seen",
+                        "operator_action": "rerun_proof",
+                        "automation_allowed_now": False,
+                    },
+                ],
+                "source_summary": [{"source": "failure_bundle", "found": True}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = mission_control.main(
+        [
+            "run",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--evidence-graph",
+            str(graph_path),
+            "--no-ledger",
+        ]
+    )
+
+    assert rc == 0
+    bundle = json.loads((out_dir / "mission-control.json").read_text(encoding="utf-8"))
+    summary = bundle["evidence_graph"]
+
+    assert summary["top_blocker_title"] == "Security finding requires review"
+    assert summary["top_blocker_surface"] == "security"
+    assert summary["secondary_blocker_count"] == 2
+    assert [item["title"] for item in summary["secondary_blockers"]] == [
+        "Dependency resolver failed",
+        "Coverage gate regression",
+    ]
+    assert summary["secondary_blockers"][0]["risk_surface"] == "dependency"
+    assert summary["secondary_blockers"][0]["review_first"] is True
+    assert summary["secondary_blockers"][0]["next_commands"] == [
+        "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+        "Reproduce the exact install lane.",
+    ]
+
+    markdown = (out_dir / "mission-control.md").read_text(encoding="utf-8")
+    assert "Secondary blockers: 2" in markdown
+    assert "Secondary blocker: Dependency resolver failed [dependency; review]" in markdown
+    assert "Secondary blocker: Coverage gate regression [quality; rerun_proof]" in markdown


### PR DESCRIPTION
## Summary
- Add bounded secondary Evidence Graph blockers to Mission Control summaries.
- Preserve top-blocker fields while adding secondary blocker count and handoff details.
- Render secondary blockers in Mission Control Markdown and carry them into ledger summaries.
- Add regression coverage for security primary, dependency secondary, and quality secondary graph signals.

## Why
- Mission Control already ranks the top Evidence Graph blocker, but secondary blockers were only counted indirectly.
- Operators need primary and secondary release-confidence risks in one handoff so dependency, security, release, workflow, test, and quality signals do not disappear behind a single ranked node.

## Verification
- `python -m pytest -q tests/test_mission_control_evidence_graph.py tests/test_mission_control_adaptive_failure_bundle.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Public Mission Control artifacts are expanded, but existing keys are preserved.
- Rollback: easy; revert this commit.
