### PR TITLE
Surface secondary graph blockers in PR Quality narrative

### DIFF
--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -269,6 +269,50 @@ def _primary_node(nodes: list[JsonObject]) -> JsonObject:
     return max(nodes, key=_node_score) if nodes else {}
 
 
+def _graph_node_handoff(
+    node: JsonObject,
+    *,
+    changed_files: list[str],
+    changed_surfaces: list[str],
+) -> JsonObject:
+    return {
+        "title": _human_finding_title(
+            node,
+            changed_files=changed_files,
+            changed_surfaces=changed_surfaces,
+        ),
+        "surface": str(node.get("risk_surface", "unknown") or "unknown"),
+        "severity": str(node.get("severity", "unknown") or "unknown"),
+        "action": str(node.get("operator_action", "rerun_proof") or "rerun_proof"),
+        "review_first": bool(node.get("review_first", False)),
+        "next_proof": _commands_from_node(node),
+    }
+
+
+def _secondary_graph_blockers(
+    nodes: list[JsonObject],
+    primary_node: JsonObject,
+    *,
+    changed_files: list[str],
+    changed_surfaces: list[str],
+    limit: int = 3,
+) -> list[JsonObject]:
+    secondary: list[JsonObject] = []
+    for node in sorted(nodes, key=_node_score, reverse=True):
+        if node is primary_node:
+            continue
+        secondary.append(
+            _graph_node_handoff(
+                node,
+                changed_files=changed_files,
+                changed_surfaces=changed_surfaces,
+            )
+        )
+        if len(secondary) >= limit:
+            break
+    return secondary
+
+
 def _fallback_failure_bundle(path: Path | None) -> JsonObject:
     if path is None:
         return {}
@@ -534,6 +578,13 @@ def build_narrative(
     failure_payload = _fallback_failure_bundle(failure_bundle)
     failure = _primary_failure(failure_payload) if not quality_ok else {}
     proof_signal = _proof_signal_from_changed_files(changed) if quality_ok else {}
+    narrative_nodes = relevant_nodes if quality_ok else nodes
+    secondary_graph_blockers = _secondary_graph_blockers(
+        narrative_nodes,
+        primary_node,
+        changed_files=changed,
+        changed_surfaces=changed_surfaces,
+    )
 
     surfaces = {
         str(node.get("risk_surface", "unknown") or "unknown")
@@ -668,6 +719,8 @@ def build_narrative(
                 if primary_node
                 else False,
             },
+            "secondary_blocker_count": len(secondary_graph_blockers),
+            "secondary_blockers": secondary_graph_blockers,
         },
         "primary_signal": {
             "kind": primary_kind,
@@ -691,6 +744,7 @@ def build_narrative(
         operator_action=operator_action,
         next_proof=commands,
         evidence=artifact_paths,
+        secondary_graph_blockers=secondary_graph_blockers,
     )
     return payload
 
@@ -895,12 +949,14 @@ def render_markdown(
     operator_action: list[str],
     next_proof: list[str],
     evidence: list[str],
+    secondary_graph_blockers: list[JsonObject] | None = None,
 ) -> str:
     status = "✅ quality.sh cov passed" if quality_ok else "❌ quality.sh cov failed"
+    if coverage:
+        status = f"{status} — coverage {coverage}%"
+
     lines = [
         status,
-        "",
-        f"coverage: {coverage}%",
         "",
         "## Adaptive release confidence",
         "",
@@ -920,16 +976,36 @@ def render_markdown(
         "",
         *_bullets(operator_action),
         "",
-        "### Next proof",
-        "",
-        *_code_bullets(next_proof),
-        "",
-        "### Evidence",
-        "",
-        *_code_bullets(evidence or ["No evidence artifacts were available."]),
-        "",
     ]
-    return "\n".join(lines).rstrip() + "\n"
+
+    if secondary_graph_blockers:
+        lines.extend(
+            [
+                "### Secondary graph blockers",
+                "",
+            ]
+        )
+        for blocker in secondary_graph_blockers:
+            lines.append(
+                "- "
+                f"{blocker.get('title', 'Untitled evidence graph finding')} "
+                f"[{blocker.get('surface', 'unknown')}; "
+                f"{blocker.get('action', 'rerun_proof')}]"
+            )
+        lines.append("")
+
+    lines.extend(
+        [
+            "### Next proof",
+            "",
+            *_code_bullets(next_proof),
+            "",
+            "### Evidence",
+            "",
+            *_code_bullets(evidence),
+        ]
+    )
+    return "\n".join(lines) + "\n"
 
 
 def _bullets(items: list[str]) -> list[str]:

--- a/tests/test_pr_quality_evidence_narrative.py
+++ b/tests/test_pr_quality_evidence_narrative.py
@@ -917,3 +917,80 @@ def test_green_narrative_explains_full_spine_real_blocker_proof_changes(tmp_path
         in markdown
     )
     assert "python -m pytest -q tests/test_full_spine_real_blocker_integration.py" in markdown
+
+
+def test_green_narrative_preserves_secondary_graph_blockers(tmp_path: Path) -> None:
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "Security finding requires review",
+                    "summary": "A protected security surface changed.",
+                    "risk_surface": "security",
+                    "severity": "critical",
+                    "review_first": True,
+                    "operator_action": "review",
+                    "proof_commands": [
+                        "python -m pytest -q tests/test_owned_surface_hygiene_contract.py -o addopts="
+                    ],
+                    "recommended_commands": ["python -m pre_commit run -a"],
+                },
+                {
+                    "title": "Dependency resolver failed",
+                    "summary": "pip could not resolve constraints before tests could run.",
+                    "risk_surface": "dependency",
+                    "severity": "high",
+                    "review_first": True,
+                    "operator_action": "review",
+                    "proof_commands": [
+                        "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+                    ],
+                    "recommended_commands": ["Reproduce the exact install lane."],
+                },
+                {
+                    "title": "Coverage gate regression",
+                    "summary": "Coverage dropped below threshold.",
+                    "risk_surface": "quality",
+                    "severity": "warning",
+                    "review_first": False,
+                    "operator_action": "rerun_proof",
+                    "recommended_commands": ["python -m pytest -q --cov=sdetkit"],
+                },
+            ],
+            "source_summary": [{"source": "failure_bundle", "found": True}],
+        },
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=None,
+        evidence_graph=graph,
+        failure_bundle=None,
+        changed_files=None,
+    )
+
+    markdown = str(payload["markdown"])
+    assert payload["graph"]["top_blocker"]["title"] == "Security finding requires review"
+    assert payload["graph"]["top_blocker"]["surface"] == "security"
+    assert payload["graph"]["secondary_blocker_count"] == 2
+    assert [item["title"] for item in payload["graph"]["secondary_blockers"]] == [
+        "Dependency resolver failed",
+        "Coverage gate regression",
+    ]
+    assert payload["graph"]["secondary_blockers"][0]["surface"] == "dependency"
+    assert payload["graph"]["secondary_blockers"][0]["review_first"] is True
+    assert payload["graph"]["secondary_blockers"][0]["next_proof"] == [
+        "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+        "Reproduce the exact install lane.",
+    ]
+
+    assert "### Secondary graph blockers" in markdown
+    assert "Dependency resolver failed [dependency; review]" in markdown
+    assert "Coverage gate regression [quality; rerun_proof]" in markdown


### PR DESCRIPTION
## Summary
- Add bounded secondary Evidence Graph blockers to PR Quality narrative output.
- Preserve existing top-blocker and primary-signal fields while adding secondary blocker count/details.
- Render secondary graph blockers in the Markdown PR narrative.
- Add regression coverage for security primary, dependency secondary, and quality secondary graph signals.

## Why
- PR Quality already ranked an Evidence Graph top blocker, but secondary signals were not exposed as a structured reviewer handoff.
- Reviewers need to see primary and secondary release-confidence risks directly in the PR comment, not only in downstream Mission Control artifacts.

## Verification
- `python -m py_compile src/sdetkit/pr_quality_evidence_narrative.py`
- `python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_failure_bundle_evidence_graph_workflow.py tests/test_pr_quality_failure_bundle_workflow.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Public PR Quality narrative JSON/Markdown is expanded, but existing fields are preserved.
- Rollback: easy; revert this commit.
