### PR TITLE
Build review-first patch plans from graph evidence

### DIFF
--- a/src/sdetkit/adaptive_patch_plan.py
+++ b/src/sdetkit/adaptive_patch_plan.py
@@ -8,8 +8,28 @@ from typing import Any
 
 SCHEMA_VERSION = "sdetkit.adaptive.patch_plan.v1"
 SOURCE_SCHEMA_VERSION = "sdetkit.adaptive.diagnosis.v1"
+FAILURE_BUNDLE_SCHEMA_VERSION = "sdetkit.adaptive.failure_bundle.v1"
+EVIDENCE_GRAPH_SCHEMA_VERSION = "sdetkit.evidence-graph.v1"
+SUPPORTED_SOURCE_SCHEMAS = {
+    SOURCE_SCHEMA_VERSION,
+    FAILURE_BUNDLE_SCHEMA_VERSION,
+    EVIDENCE_GRAPH_SCHEMA_VERSION,
+}
 SAFE_MECHANICAL_CODES = {"PRE_COMMIT_FORMAT_DRIFT", "RUFF_FIXABLE_LINT"}
 ACTIONABLE_STATUSES = {"needs_fix", "needs_attention"}
+_SEVERITY_PRIORITY = {"critical": 4, "high": 3, "warning": 2, "low": 1, "unknown": 0}
+_SURFACE_PRIORITY = {
+    "security": 9,
+    "release": 8,
+    "dependency": 7,
+    "workflow": 6,
+    "cli": 5,
+    "docs": 4,
+    "tests": 3,
+    "quality": 2,
+    "diagnostic_engine": 1,
+    "unknown": 0,
+}
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -29,9 +49,96 @@ def _load_diagnosis(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"expected JSON object in {path}")
-    if payload.get("schema_version") != SOURCE_SCHEMA_VERSION:
-        raise ValueError(f"unsupported adaptive diagnosis schema in {path}")
-    return payload
+    schema = str(payload.get("schema_version", ""))
+    if schema not in SUPPORTED_SOURCE_SCHEMAS:
+        raise ValueError(f"unsupported adaptive patch-plan source schema in {path}")
+    return _normalize_patch_plan_source(payload, path)
+
+
+def _normalize_patch_plan_source(payload: dict[str, Any], path: Path) -> dict[str, Any]:
+    schema = str(payload.get("schema_version", ""))
+    if schema == SOURCE_SCHEMA_VERSION:
+        normalized = dict(payload)
+        normalized.setdefault("source_kind", "adaptive_diagnosis")
+        normalized.setdefault("source_schema_version", SOURCE_SCHEMA_VERSION)
+        normalized.setdefault("source_artifacts", [path.as_posix()])
+        return normalized
+
+    if schema == FAILURE_BUNDLE_SCHEMA_VERSION:
+        diagnoses = [_as_dict(item) for item in _as_list(payload.get("diagnoses"))]
+        nested = _as_dict(payload.get("diagnosis"))
+        if not diagnoses:
+            diagnoses = [_as_dict(item) for item in _as_list(nested.get("diagnoses"))]
+        return {
+            "schema_version": SOURCE_SCHEMA_VERSION,
+            "source_schema_version": schema,
+            "source_kind": "failure_bundle",
+            "source_artifacts": [path.as_posix()],
+            "status": "needs_attention" if diagnoses else "monitor",
+            "original_status": str(payload.get("status", "unknown")),
+            "confidence": str(nested.get("confidence", payload.get("confidence", "unknown"))),
+            "diagnoses": diagnoses,
+            "evidence": [
+                f"source_schema={schema}",
+                f"source_path={path.as_posix()}",
+                f"diagnosis_count={len(diagnoses)}",
+            ],
+        }
+
+    nodes = [_as_dict(item) for item in _as_list(payload.get("nodes"))]
+    nodes = [node for node in nodes if node]
+    ranked_nodes = sorted(nodes, key=_graph_node_score, reverse=True)
+    diagnoses = [_diagnosis_from_graph_node(node, path=path) for node in ranked_nodes]
+    return {
+        "schema_version": SOURCE_SCHEMA_VERSION,
+        "source_schema_version": schema,
+        "source_kind": "evidence_graph",
+        "source_artifacts": [path.as_posix()],
+        "status": "needs_attention" if diagnoses else "monitor",
+        "confidence": "high" if diagnoses else "low",
+        "diagnoses": diagnoses,
+        "evidence": [
+            f"source_schema={schema}",
+            f"source_path={path.as_posix()}",
+            f"graph_node_count={len(nodes)}",
+        ],
+    }
+
+
+def _graph_node_score(node: dict[str, Any]) -> tuple[int, int, int]:
+    surface = str(node.get("risk_surface", "unknown") or "unknown")
+    severity = str(node.get("severity", "unknown") or "unknown")
+    return (
+        1 if bool(node.get("review_first", False)) else 0,
+        _SEVERITY_PRIORITY.get(severity, 0),
+        _SURFACE_PRIORITY.get(surface, 0),
+    )
+
+
+def _diagnosis_from_graph_node(node: dict[str, Any], *, path: Path) -> dict[str, Any]:
+    surface = str(node.get("risk_surface", "unknown") or "unknown")
+    finding_id = _safe_text(
+        node.get("code") or node.get("diagnosis_code") or node.get("finding_id") or surface.upper(),
+        80,
+    )
+    return {
+        "code": finding_id,
+        "title": _safe_text(node.get("title") or "Evidence graph finding", 160),
+        "diagnosis": _safe_text(node.get("summary") or "Evidence Graph finding requires review."),
+        "severity": _safe_text(node.get("severity") or "warning", 80),
+        "confidence": "high" if bool(node.get("review_first", False)) else "medium",
+        "affected_files": _as_list(node.get("owner_files")),
+        "recommended_fix": _as_list(
+            node.get("recommended_commands") or node.get("next_commands") or node.get("commands")
+        ),
+        "proof_commands": _as_list(node.get("proof_commands")),
+        "evidence": [
+            f"source_artifact={path.as_posix()}",
+            f"risk_surface={surface}",
+            f"operator_action={node.get('operator_action', 'review')}",
+            f"automation_allowed_now={str(node.get('automation_allowed_now', False)).lower()}",
+        ],
+    }
 
 
 def _first_diagnosis(payload: dict[str, Any]) -> dict[str, Any]:
@@ -58,6 +165,18 @@ def _candidate_scenarios(diagnosis: dict[str, Any]) -> list[str]:
 def _target_files(diagnosis: dict[str, Any]) -> list[str]:
     files = [_safe_text(value, 180) for value in _as_list(diagnosis.get("affected_files"))]
     return [value for value in files if value and "<" not in value and ">" not in value]
+
+
+def _recommended_commands(diagnosis: dict[str, Any]) -> list[str]:
+    commands = [
+        _safe_text(value, 240)
+        for value in _as_list(
+            diagnosis.get("recommended_commands")
+            or diagnosis.get("recommended_fix")
+            or diagnosis.get("next_commands")
+        )
+    ]
+    return [command for command in commands if command][:4]
 
 
 def _proof_commands(diagnosis: dict[str, Any]) -> list[str]:
@@ -136,10 +255,13 @@ def build_patch_plan(payload: dict[str, Any]) -> dict[str, Any]:
         )
     return {
         "schema_version": SCHEMA_VERSION,
-        "source_schema_version": str(payload.get("schema_version", "")),
         "ok": True,
         "status": plan_status,
         "source_status": source_status,
+        "source_schema_version": str(
+            payload.get("source_schema_version", payload.get("schema_version", "unknown"))
+        ),
+        "source_kind": str(payload.get("source_kind", "adaptive_diagnosis")),
         "source_code": code,
         "confidence": confidence,
         "safe_to_auto_fix": False,
@@ -157,7 +279,9 @@ def build_patch_plan(payload: dict[str, Any]) -> dict[str, Any]:
         },
         "candidate_scenarios": _candidate_scenarios(diagnosis),
         "affected_files": _target_files(diagnosis),
+        "recommended_commands": _recommended_commands(diagnosis),
         "proof_commands": proof_commands,
+        "source_artifacts": _as_list(payload.get("source_artifacts")),
         "patch_steps": [] if plan_status == "not_applicable" else _patch_steps(diagnosis),
         "rollback_notes": [
             "Keep changes in a small reviewable commit.",
@@ -170,6 +294,8 @@ def render_text(payload: dict[str, Any]) -> str:
     lines = [
         f"schema_version={payload['schema_version']}",
         f"status={payload['status']}",
+        f"source_kind={payload.get('source_kind', 'adaptive_diagnosis')}",
+        f"source_schema_version={payload.get('source_schema_version', 'unknown')}",
         f"source_code={payload['source_code']}",
         f"safe_to_auto_fix={str(payload['safe_to_auto_fix']).lower()}",
         f"requires_human_review={str(payload['requires_human_review']).lower()}",
@@ -186,6 +312,8 @@ def render_markdown(payload: dict[str, Any]) -> str:
         "# Adaptive assisted patch plan",
         "",
         f"- Status: `{payload['status']}`",
+        f"- Source kind: `{payload.get('source_kind', 'adaptive_diagnosis')}`",
+        f"- Source schema: `{payload.get('source_schema_version', 'unknown')}`",
         f"- Source code: `{payload['source_code']}`",
         f"- Safe to auto-fix: `{str(payload['safe_to_auto_fix']).lower()}`",
         f"- Requires human review: `{str(payload['requires_human_review']).lower()}`",
@@ -210,6 +338,13 @@ def render_markdown(payload: dict[str, Any]) -> str:
         lines.append(f"- `{command}`")
     if not _as_list(payload.get("proof_commands")):
         lines.append("- `<add-focused-proof-command>`")
+
+    recommended = _as_list(payload.get("recommended_commands"))
+    if recommended:
+        lines += ["", "## Recommended review commands", ""]
+        for command in recommended:
+            lines.append(f"- `{command}`")
+
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_adaptive_patch_plan.py
+++ b/tests/test_adaptive_patch_plan.py
@@ -86,3 +86,156 @@ def test_top_level_cli_adaptive_patch_plan_passthrough(tmp_path: Path) -> None:
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["status"] == "review_required"
     assert payload["guardrails"]["post_fix_proof_required"] is True
+
+
+def test_patch_plan_accepts_evidence_graph_input_review_first(tmp_path: Path) -> None:
+    graph = tmp_path / "evidence-graph.json"
+    graph.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.evidence-graph.v1",
+                "nodes": [
+                    {
+                        "finding_id": "security-review",
+                        "title": "Security finding requires review",
+                        "summary": "A protected security surface changed.",
+                        "risk_surface": "security",
+                        "severity": "critical",
+                        "review_first": True,
+                        "safe_to_auto_fix": False,
+                        "owner_files": ["src/sdetkit/adaptive_diagnosis.py"],
+                        "recommended_commands": [
+                            "Review the unresolved security finding.",
+                        ],
+                        "proof_commands": [
+                            "python -m sdetkit security check --root . --format json",
+                        ],
+                        "operator_action": "review",
+                        "automation_allowed_now": False,
+                    },
+                    {
+                        "finding_id": "dependency-resolver",
+                        "title": "Dependency resolver failed",
+                        "summary": "pip could not resolve constraints before tests could run.",
+                        "risk_surface": "dependency",
+                        "severity": "high",
+                        "review_first": True,
+                        "safe_to_auto_fix": False,
+                        "owner_files": ["constraints-ci.txt", "requirements-test.txt"],
+                        "recommended_commands": ["Reproduce the exact install lane."],
+                        "proof_commands": [
+                            "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+                        ],
+                        "operator_action": "review",
+                        "automation_allowed_now": False,
+                    },
+                ],
+                "source_summary": [{"source": "failure_bundle", "found": True}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plan = adaptive_patch_plan.patch_plan_from_file(graph)
+
+    assert plan["schema_version"] == "sdetkit.adaptive.patch_plan.v1"
+    assert plan["source_kind"] == "evidence_graph"
+    assert plan["source_schema_version"] == "sdetkit.evidence-graph.v1"
+    assert plan["status"] == "review_required"
+    assert plan["source_code"] == "security-review"
+    assert plan["safe_to_auto_fix"] is False
+    assert plan["dry_run_only"] is True
+    assert plan["requires_human_review"] is True
+    assert plan["guardrails"]["automation_mutation_allowed"] is False
+    assert plan["affected_files"] == ["src/sdetkit/adaptive_diagnosis.py"]
+    assert plan["recommended_commands"] == ["Review the unresolved security finding."]
+    assert plan["proof_commands"] == [
+        "python -m sdetkit security check --root . --format json",
+    ]
+    assert plan["patch_steps"][0]["action"] == "reproduce"
+    assert plan["patch_steps"][0]["mutation_allowed"] is False
+    assert plan["source_artifacts"] == [graph.as_posix()]
+
+
+def test_patch_plan_accepts_failure_bundle_input_review_first(tmp_path: Path) -> None:
+    bundle = tmp_path / "failure-bundle.json"
+    bundle.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.adaptive.failure_bundle.v1",
+                "status": "review_required",
+                "review_first": True,
+                "safe_to_auto_fix": False,
+                "primary_diagnosis_code": "PACKAGE_INSTALL_FAILURE",
+                "diagnosis_count": 1,
+                "diagnoses": [
+                    {
+                        "code": "PACKAGE_INSTALL_FAILURE",
+                        "title": "Dependency resolver failed",
+                        "diagnosis": "pip could not resolve constraints before tests could run.",
+                        "severity": "high",
+                        "confidence": "high",
+                        "affected_files": ["constraints-ci.txt", "requirements-test.txt"],
+                        "recommended_fix": ["Reproduce the exact install lane."],
+                        "proof_commands": [
+                            "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plan = adaptive_patch_plan.patch_plan_from_file(bundle)
+
+    assert plan["source_kind"] == "failure_bundle"
+    assert plan["source_schema_version"] == "sdetkit.adaptive.failure_bundle.v1"
+    assert plan["source_status"] == "needs_attention"
+    assert plan["source_code"] == "PACKAGE_INSTALL_FAILURE"
+    assert plan["safe_to_auto_fix"] is False
+    assert plan["dry_run_only"] is True
+    assert plan["requires_human_review"] is True
+    assert plan["affected_files"] == ["constraints-ci.txt", "requirements-test.txt"]
+    assert plan["recommended_commands"] == ["Reproduce the exact install lane."]
+    assert plan["proof_commands"] == [
+        "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+    ]
+
+
+def test_patch_plan_cli_accepts_evidence_graph_markdown(tmp_path: Path) -> None:
+    graph = tmp_path / "evidence-graph.json"
+    out = tmp_path / "patch-plan.md"
+    graph.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.evidence-graph.v1",
+                "nodes": [
+                    {
+                        "finding_id": "dependency-resolver",
+                        "title": "Dependency resolver failed",
+                        "summary": "pip could not resolve constraints.",
+                        "risk_surface": "dependency",
+                        "severity": "high",
+                        "review_first": True,
+                        "owner_files": ["constraints-ci.txt"],
+                        "recommended_commands": ["Reproduce the exact install lane."],
+                        "proof_commands": [
+                            "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e .",
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = adaptive_patch_plan.main([str(graph), "--format", "md", "--out", str(out)])
+
+    assert rc == 0
+    rendered = out.read_text(encoding="utf-8")
+    assert "Source kind: `evidence_graph`" in rendered
+    assert "Safe to auto-fix: `false`" in rendered
+    assert "Requires human review: `true`" in rendered
+    assert "Mutation allowed: `false`" in rendered
+    assert "Reproduce the exact install lane." in rendered


### PR DESCRIPTION
## Summary
- Allow adaptive patch plans to consume Evidence Graph and failure-bundle artifacts.
- Normalize graph nodes and bundle diagnoses into the existing review-first assisted patch-plan contract.
- Preserve safety boundaries: no mutation, no auto-fix, dry-run only, human review required.
- Add regression coverage for Evidence Graph input, failure-bundle input, and CLI Markdown output.

## Why
- The evidence spine now preserves ranked blockers across failure bundles, Evidence Graph, Mission Control, and PR Quality.
- Patch planning should consume that evidence directly while remaining advisory-only and review-first.

## Verification
- `python -m pytest -q tests/test_adaptive_patch_plan.py tests/test_adaptive_remediation_policy.py tests/test_evidence_graph.py tests/test_adaptive_failure_bundle.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Public patch-plan input support expands, but existing adaptive diagnosis input remains compatible.
- Auto-fix behavior is not expanded.
- Rollback: easy; revert this commit.
