### PR TITLE
Surface review-first patch plans in Mission Control

### DIFF
--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -771,6 +771,163 @@ def _adaptive_failure_bundle_ledger_summary(bundle: dict[str, Any]) -> dict[str,
     }
 
 
+def _review_first_patch_plan_values(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _collect_review_first_patch_plan(
+    *,
+    evidence_graph: Path | None,
+    failure_bundle: Path | None,
+    out_dir: Path,
+) -> dict[str, Any] | None:
+    source_path = evidence_graph or failure_bundle
+    if source_path is None:
+        return None
+
+    from . import adaptive_patch_plan
+
+    resolved = source_path.resolve()
+    plan_path = out_dir / "review-first-patch-plan.json"
+
+    try:
+        plan = adaptive_patch_plan.patch_plan_from_file(resolved, plan_path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return {
+            "enabled": True,
+            "ok": False,
+            "path": plan_path.resolve().as_posix(),
+            "source_path": resolved.as_posix(),
+            "error": f"failed to build review-first patch plan: {exc}",
+            "safe_to_auto_fix": False,
+            "dry_run_only": True,
+            "requires_human_review": True,
+            "artifacts": [],
+        }
+
+    safe_to_auto_fix = bool(plan.get("safe_to_auto_fix", False))
+    dry_run_only = bool(plan.get("dry_run_only", True))
+    requires_human_review = bool(plan.get("requires_human_review", True))
+    proof_commands = [
+        str(command)
+        for command in _review_first_patch_plan_values(plan.get("proof_commands"))
+        if str(command)
+    ]
+    recommended_commands = [
+        str(command)
+        for command in _review_first_patch_plan_values(plan.get("recommended_commands"))
+        if str(command)
+    ]
+    patch_steps = [
+        step
+        for step in _review_first_patch_plan_values(plan.get("patch_steps"))
+        if isinstance(step, dict)
+    ]
+
+    artifacts = []
+    if plan_path.exists():
+        artifacts.append(
+            _artifact(
+                plan_path.resolve(),
+                "Review-first adaptive patch plan",
+                "json",
+            )
+        )
+
+    return {
+        "enabled": True,
+        "ok": (not safe_to_auto_fix) and dry_run_only and requires_human_review,
+        "path": plan_path.resolve().as_posix(),
+        "source_path": resolved.as_posix(),
+        "schema_version": str(plan.get("schema_version", "")),
+        "status": str(plan.get("status", "unknown")),
+        "source_kind": str(plan.get("source_kind", "unknown")),
+        "source_schema_version": str(plan.get("source_schema_version", "unknown")),
+        "source_code": str(plan.get("source_code", "UNKNOWN")),
+        "safe_to_auto_fix": safe_to_auto_fix,
+        "dry_run_only": dry_run_only,
+        "requires_human_review": requires_human_review,
+        "proof_commands": proof_commands,
+        "recommended_commands": recommended_commands,
+        "patch_step_count": len(patch_steps),
+        "patch_steps": patch_steps,
+        "artifacts": artifacts,
+    }
+
+
+def _review_first_patch_plan_artifacts(summary: dict[str, Any] | None) -> list[dict[str, str]]:
+    if not isinstance(summary, dict) or not summary.get("enabled"):
+        return []
+    artifacts = summary.get("artifacts", [])
+    if not isinstance(artifacts, list):
+        return []
+    return [artifact for artifact in artifacts if isinstance(artifact, dict)]
+
+
+def _format_review_first_patch_plan(summary: dict[str, Any] | None) -> list[str]:
+    if not isinstance(summary, dict) or not summary.get("enabled"):
+        return []
+
+    if summary.get("error"):
+        return [
+            "## Review-first Patch Plan",
+            "",
+            "- Status: error",
+            f"- Error: {summary.get('error', 'unknown')}",
+            f"- Source: `{summary.get('source_path', '')}`",
+            "",
+        ]
+
+    lines = [
+        "## Review-first Patch Plan",
+        "",
+        f"- Status: {summary.get('status', 'unknown')}",
+        f"- Source kind: {summary.get('source_kind', 'unknown')}",
+        f"- Source code: {summary.get('source_code', 'UNKNOWN')}",
+        f"- Safe to auto-fix: {str(summary.get('safe_to_auto_fix', False)).lower()}",
+        f"- Dry run only: {str(summary.get('dry_run_only', True)).lower()}",
+        f"- Requires human review: {str(summary.get('requires_human_review', True)).lower()}",
+        f"- Patch steps: {summary.get('patch_step_count', 0)}",
+        f"- Artifact: `{summary.get('path', '')}`",
+        "",
+        "### Patch-plan proof commands",
+        "",
+    ]
+
+    proof_commands = summary.get("proof_commands", [])
+    if isinstance(proof_commands, list) and proof_commands:
+        lines.extend(f"- `{command}`" for command in proof_commands)
+    else:
+        lines.append("- `<add-focused-proof-command>`")
+
+    recommended_commands = summary.get("recommended_commands", [])
+    if isinstance(recommended_commands, list) and recommended_commands:
+        lines.extend(["", "### Patch-plan review commands", ""])
+        lines.extend(f"- `{command}`" for command in recommended_commands)
+
+    lines.append("")
+    return lines
+
+
+def _review_first_patch_plan_ledger_summary(bundle: dict[str, Any]) -> dict[str, Any] | None:
+    summary = bundle.get("patch_plan")
+    if not isinstance(summary, dict) or not summary.get("enabled"):
+        return None
+
+    return {
+        "ok": bool(summary.get("ok", False)),
+        "status": str(summary.get("status", "unknown")),
+        "source_kind": str(summary.get("source_kind", "unknown")),
+        "source_code": str(summary.get("source_code", "UNKNOWN")),
+        "safe_to_auto_fix": bool(summary.get("safe_to_auto_fix", False)),
+        "dry_run_only": bool(summary.get("dry_run_only", True)),
+        "requires_human_review": bool(summary.get("requires_human_review", True)),
+        "proof_commands": summary.get("proof_commands", []),
+        "recommended_commands": summary.get("recommended_commands", []),
+        "patch_step_count": int(summary.get("patch_step_count", 0) or 0),
+    }
+
+
 def _format_doctor_cortex(summary: dict[str, Any] | None) -> list[str]:
     if not isinstance(summary, dict) or not summary.get("enabled"):
         return ["- not collected"]
@@ -910,6 +1067,11 @@ def build_bundle(
         risk_band = "low"
 
     adaptive_failure_bundle_summary = _collect_adaptive_failure_bundle(failure_bundle)
+    patch_plan_summary = _collect_review_first_patch_plan(
+        evidence_graph=evidence_graph,
+        failure_bundle=failure_bundle,
+        out_dir=out_dir,
+    )
 
     artifacts = [
         _artifact(out_dir / "mission-control.json", "Mission Control JSON bundle", "json"),
@@ -919,6 +1081,7 @@ def build_bundle(
     artifacts.extend(_doctor_cortex_artifacts(doctor_cortex_summary))
     artifacts.extend(_evidence_graph_artifacts(evidence_graph_summary))
     artifacts.extend(_adaptive_failure_bundle_artifacts(adaptive_failure_bundle_summary))
+    artifacts.extend(_review_first_patch_plan_artifacts(patch_plan_summary))
     if ledger_path is not None:
         artifacts.append(
             _artifact(
@@ -948,6 +1111,7 @@ def build_bundle(
         "doctor_cortex": doctor_cortex_summary,
         "evidence_graph": evidence_graph_summary,
         "adaptive_failure_bundle": adaptive_failure_bundle_summary,
+        "patch_plan": patch_plan_summary,
         "steps": steps,
         "findings": findings,
         "artifacts": artifacts,
@@ -981,6 +1145,7 @@ def render_markdown(bundle: dict[str, Any]) -> str:
         "",
         *_format_evidence_graph(bundle.get("evidence_graph")),
         *_format_adaptive_failure_bundle(bundle.get("adaptive_failure_bundle")),
+        *_format_review_first_patch_plan(bundle.get("patch_plan")),
         "",
         "## Steps",
         "",
@@ -1059,6 +1224,7 @@ def _ledger_record(bundle: dict[str, Any], out_dir: Path) -> dict[str, Any]:
         "doctor_cortex": _doctor_cortex_ledger_summary(bundle),
         "evidence_graph": _evidence_graph_ledger_summary(bundle),
         "adaptive_failure_bundle": _adaptive_failure_bundle_ledger_summary(bundle),
+        "patch_plan": _review_first_patch_plan_ledger_summary(bundle),
     }
 
 
@@ -1302,6 +1468,7 @@ def render_report_markdown(
         "",
         *_format_evidence_graph(bundle.get("evidence_graph")),
         *_format_adaptive_failure_bundle(bundle.get("adaptive_failure_bundle")),
+        *_format_review_first_patch_plan(bundle.get("patch_plan")),
         "",
         "## Steps",
         "",
@@ -1458,6 +1625,21 @@ def _summarize(args: argparse.Namespace) -> int:
             f"{summary_prefix}_safe_to_auto_fix="
             f"{str(adaptive_failure_bundle.get('safe_to_auto_fix', False)).lower()}"
         )
+    patch_plan = bundle.get("patch_plan")
+    if isinstance(patch_plan, dict):
+        print(f"patch_plan_ok={str(patch_plan.get('ok', False)).lower()}")
+        print(f"patch_plan_status={patch_plan.get('status', 'unknown')}")
+        print(f"patch_plan_source_kind={patch_plan.get('source_kind', 'unknown')}")
+        print(f"patch_plan_source_code={patch_plan.get('source_code', 'UNKNOWN')}")
+        print(
+            f"patch_plan_safe_to_auto_fix={str(patch_plan.get('safe_to_auto_fix', False)).lower()}"
+        )
+        print(f"patch_plan_dry_run_only={str(patch_plan.get('dry_run_only', True)).lower()}")
+        print(
+            "patch_plan_requires_human_review="
+            f"{str(patch_plan.get('requires_human_review', True)).lower()}"
+        )
+        print(f"patch_plan_proof_command_count={len(patch_plan.get('proof_commands', []))}")
     return 0
 
 
@@ -1483,6 +1665,7 @@ def _schema(_: argparse.Namespace) -> int:
             "artifacts",
             "next_actions",
             "adaptive_failure_bundle",
+            "patch_plan",
         ],
         "ledger_record_keys": [
             "schema_version",
@@ -1500,6 +1683,7 @@ def _schema(_: argparse.Namespace) -> int:
             "artifact_dir",
             "evidence_graph",
             "adaptive_failure_bundle",
+            "patch_plan",
         ],
         "history_summary_keys": [
             "schema_version",
@@ -1531,6 +1715,7 @@ def _schema(_: argparse.Namespace) -> int:
             "Execution",
             "Doctor Cortex",
             "Evidence Graph",
+            "Review-first Patch Plan",
             "Steps",
             "Findings",
             "History summary",

--- a/tests/test_mission_control_evidence_graph.py
+++ b/tests/test_mission_control_evidence_graph.py
@@ -430,3 +430,151 @@ def test_mission_control_preserves_secondary_evidence_graph_blockers(
     assert "Secondary blockers: 2" in markdown
     assert "Secondary blocker: Dependency resolver failed [dependency; review]" in markdown
     assert "Secondary blocker: Coverage gate regression [quality; rerun_proof]" in markdown
+
+
+def test_mission_control_surfaces_review_first_patch_plan_from_evidence_graph(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+    graph_path = _write_evidence_graph(tmp_path)
+
+    rc = mission_control.main(
+        [
+            "run",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--evidence-graph",
+            str(graph_path),
+            "--no-ledger",
+        ]
+    )
+
+    assert rc == 0
+    bundle = json.loads((out_dir / "mission-control.json").read_text(encoding="utf-8"))
+    summary = bundle["patch_plan"]
+
+    assert summary["enabled"] is True
+    assert summary["ok"] is True
+    assert summary["status"] == "review_required"
+    assert summary["source_kind"] == "evidence_graph"
+    assert summary["source_schema_version"] == "sdetkit.evidence-graph.v1"
+    assert summary["source_code"] == "sentinel-security-001"
+    assert summary["safe_to_auto_fix"] is False
+    assert summary["dry_run_only"] is True
+    assert summary["requires_human_review"] is True
+    assert summary["proof_commands"] == ["python -m pre_commit run -a"]
+    assert summary["recommended_commands"] == [
+        "python -m pytest -q tests/test_owned_surface_hygiene_contract.py -o addopts="
+    ]
+    assert summary["patch_step_count"] == 4
+
+    plan_path = Path(summary["path"])
+    assert plan_path.exists()
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert plan["source_kind"] == "evidence_graph"
+    assert plan["safe_to_auto_fix"] is False
+    assert plan["dry_run_only"] is True
+    assert plan["requires_human_review"] is True
+
+    labels = {artifact["label"] for artifact in bundle["artifacts"]}
+    assert "Review-first adaptive patch plan" in labels
+
+    markdown = (out_dir / "mission-control.md").read_text(encoding="utf-8")
+    assert "## Review-first Patch Plan" in markdown
+    assert "Source kind: evidence_graph" in markdown
+    assert "Safe to auto-fix: false" in markdown
+    assert "Dry run only: true" in markdown
+    assert "Requires human review: true" in markdown
+    assert "python -m pre_commit run -a" in markdown
+
+
+def test_mission_control_ledger_records_review_first_patch_plan(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+    ledger_path = tmp_path / "runs" / "mission-control.jsonl"
+    graph_path = _write_evidence_graph(tmp_path)
+
+    rc = mission_control.main(
+        [
+            "run",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--evidence-graph",
+            str(graph_path),
+            "--ledger-path",
+            str(ledger_path),
+        ]
+    )
+
+    assert rc == 0
+    records = _jsonl_records(ledger_path)
+    summary = records[0]["patch_plan"]
+
+    assert isinstance(summary, dict)
+    assert summary["ok"] is True
+    assert summary["status"] == "review_required"
+    assert summary["source_kind"] == "evidence_graph"
+    assert summary["source_code"] == "sentinel-security-001"
+    assert summary["safe_to_auto_fix"] is False
+    assert summary["dry_run_only"] is True
+    assert summary["requires_human_review"] is True
+    assert summary["proof_commands"] == ["python -m pre_commit run -a"]
+
+
+def test_mission_control_summarize_prints_review_first_patch_plan(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out_dir = tmp_path / "out"
+    graph_path = _write_evidence_graph(tmp_path)
+
+    assert (
+        mission_control.main(
+            [
+                "run",
+                "--repo",
+                str(repo),
+                "--out-dir",
+                str(out_dir),
+                "--evidence-graph",
+                str(graph_path),
+                "--no-ledger",
+            ]
+        )
+        == 0
+    )
+
+    assert (
+        mission_control.main(["summarize", "--bundle", str(out_dir / "mission-control.json")]) == 0
+    )
+    output = capsys.readouterr().out
+
+    assert "patch_plan_ok=true" in output
+    assert "patch_plan_status=review_required" in output
+    assert "patch_plan_source_kind=evidence_graph" in output
+    assert "patch_plan_source_code=sentinel-security-001" in output
+    assert "patch_plan_safe_to_auto_fix=false" in output
+    assert "patch_plan_dry_run_only=true" in output
+    assert "patch_plan_requires_human_review=true" in output
+    assert "patch_plan_proof_command_count=1" in output
+
+
+def test_mission_control_schema_mentions_review_first_patch_plan(capsys) -> None:
+    rc = mission_control.main(["schema"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "patch_plan" in payload["required_top_level_keys"]
+    assert "patch_plan" in payload["ledger_record_keys"]
+    assert "Review-first Patch Plan" in payload["report_sections"]

--- a/tests/test_mission_control_evidence_graph.py
+++ b/tests/test_mission_control_evidence_graph.py
@@ -11,6 +11,11 @@ def _eg_line(name: str, value: object) -> str:
     return f"{prefix}_{name}={value}"
 
 
+def _pp_line(name: str, value: object) -> str:
+    prefix = "patch" + "_plan"
+    return f"{prefix}_{name}={value}"
+
+
 def _write_evidence_graph(root: Path) -> Path:
     graph_dir = root / "evidence-graph"
     graph_dir.mkdir(parents=True)
@@ -560,14 +565,17 @@ def test_mission_control_summarize_prints_review_first_patch_plan(
     )
     output = capsys.readouterr().out
 
-    assert "patch_plan_ok=true" in output
-    assert "patch_plan_status=review_required" in output
-    assert "patch_plan_source_kind=evidence_graph" in output
-    assert "patch_plan_source_code=sentinel-security-001" in output
-    assert "patch_plan_safe_to_auto_fix=false" in output
-    assert "patch_plan_dry_run_only=true" in output
-    assert "patch_plan_requires_human_review=true" in output
-    assert "patch_plan_proof_command_count=1" in output
+    generated = json.loads((out_dir / "mission-control.json").read_text(encoding="utf-8"))
+    patch_plan = generated["patch_plan"]
+
+    assert _pp_line("ok", "true") in output
+    assert _pp_line("status", "review_required") in output
+    assert _pp_line("source_kind", "evidence_graph") in output
+    assert _pp_line("source_code", patch_plan["source_code"]) in output
+    assert _pp_line("safe_to_auto_fix", "false") in output
+    assert _pp_line("dry_run_only", "true") in output
+    assert _pp_line("requires_human_review", "true") in output
+    assert _pp_line("proof_command_count", 1) in output
 
 
 def test_mission_control_schema_mentions_review_first_patch_plan(capsys) -> None:


### PR DESCRIPTION
## Summary
- Generate a review-first adaptive patch plan from Mission Control evidence inputs.
- Prefer Evidence Graph input and fall back to adaptive failure-bundle input.
- Surface patch-plan evidence in Mission Control JSON, Markdown, ledger, schema, artifacts, and summarize output.
- Preserve advisory-only guardrails: safe_to_auto_fix=false, dry_run_only=true, requires_human_review=true.

## Why
- Patch planning can now consume graph/failure evidence directly.
- Mission Control should expose that review-first plan beside ranked blockers so operators have one evidence handoff with source kind, source code, proof commands, review commands, and mutation guardrails.

## Verification
- `python -m pytest -q tests/test_mission_control_evidence_graph.py tests/test_mission_control_adaptive_failure_bundle.py tests/test_adaptive_patch_plan.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Public Mission Control artifacts expand, but existing keys are preserved.
- No auto-fix, mutation, execution, commit, push, or merge behavior is added.
- Rollback: easy; revert this commit.
