### PR TITLE
Surface review-first patch plans in PR Quality

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -276,6 +276,42 @@ def _evidence_review_clarity_lines(
     return lines
 
 
+def _patch_plan_lines(evidence_narrative: JsonObject) -> list[str]:
+    patch_plan = _as_dict(evidence_narrative.get("patch_plan"))
+    if not patch_plan or not patch_plan.get("enabled"):
+        return []
+
+    lines = [
+        f"- Status: `{_string(patch_plan.get('status') or 'unknown')}`",
+        f"- Source kind: `{_string(patch_plan.get('source_kind') or 'unknown')}`",
+        f"- Source code: `{_string(patch_plan.get('source_code') or 'UNKNOWN')}`",
+        f"- Safe to auto-fix: `{str(bool(patch_plan.get('safe_to_auto_fix', False))).lower()}`",
+        f"- Dry run only: `{str(bool(patch_plan.get('dry_run_only', True))).lower()}`",
+        f"- Requires human review: `{str(bool(patch_plan.get('requires_human_review', True))).lower()}`",
+        f"- Patch steps: `{int(patch_plan.get('patch_step_count', 0) or 0)}`",
+    ]
+
+    proof_commands = [
+        str(command)
+        for command in _as_list(patch_plan.get("proof_commands"))
+        if isinstance(command, str) and command.strip()
+    ]
+    if proof_commands:
+        lines.extend(["- Proof commands:"])
+        lines.extend(f"  - `{command}`" for command in proof_commands[:5])
+
+    review_commands = [
+        str(command)
+        for command in _as_list(patch_plan.get("recommended_commands"))
+        if isinstance(command, str) and command.strip()
+    ]
+    if review_commands:
+        lines.extend(["- Review commands:"])
+        lines.extend(f"  - `{command}`" for command in review_commands[:5])
+
+    return lines
+
+
 def render_comment_body(
     *,
     action_report: JsonObject,
@@ -306,6 +342,10 @@ def render_comment_body(
 
     if evidence_signal_lines:
         lines.extend(["## " + evidence_signal_heading, "", *evidence_signal_lines, ""])
+
+    patch_plan = _patch_plan_lines(evidence_narrative)
+    if patch_plan:
+        lines.extend(["## Review-first patch plan", "", *patch_plan, ""])
 
     lines.extend(
         [

--- a/src/sdetkit/pr_quality_evidence_narrative.py
+++ b/src/sdetkit/pr_quality_evidence_narrative.py
@@ -477,6 +477,72 @@ def _dedupe(items: list[str]) -> list[str]:
     return out
 
 
+def _read_mission_control_patch_plan(mission_control: Path | None) -> JsonObject:
+    if mission_control is None:
+        return {}
+
+    try:
+        payload = json.loads(mission_control.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    if not isinstance(payload, dict):
+        return {}
+
+    patch_plan = _as_dict(payload.get("patch_plan"))
+    if not patch_plan or not patch_plan.get("enabled"):
+        return {}
+
+    return {
+        "enabled": True,
+        "ok": bool(patch_plan.get("ok", False)),
+        "status": str(patch_plan.get("status", "unknown")),
+        "source_kind": str(patch_plan.get("source_kind", "unknown")),
+        "source_schema_version": str(patch_plan.get("source_schema_version", "unknown")),
+        "source_code": str(patch_plan.get("source_code", "UNKNOWN")),
+        "safe_to_auto_fix": bool(patch_plan.get("safe_to_auto_fix", False)),
+        "dry_run_only": bool(patch_plan.get("dry_run_only", True)),
+        "requires_human_review": bool(patch_plan.get("requires_human_review", True)),
+        "proof_commands": _string_list(patch_plan.get("proof_commands")),
+        "recommended_commands": _string_list(patch_plan.get("recommended_commands")),
+        "patch_step_count": int(patch_plan.get("patch_step_count", 0) or 0),
+        "path": str(patch_plan.get("path", "")),
+    }
+
+
+def _patch_plan_markdown_lines(patch_plan: JsonObject | None) -> list[str]:
+    plan = _as_dict(patch_plan)
+    if not plan or not plan.get("enabled"):
+        return []
+
+    lines = [
+        "### Review-first patch plan",
+        "",
+        f"- Status: `{plan.get('status', 'unknown')}`",
+        f"- Source kind: `{plan.get('source_kind', 'unknown')}`",
+        f"- Source code: `{plan.get('source_code', 'UNKNOWN')}`",
+        f"- Safe to auto-fix: `{str(plan.get('safe_to_auto_fix', False)).lower()}`",
+        f"- Dry run only: `{str(plan.get('dry_run_only', True)).lower()}`",
+        f"- Requires human review: `{str(plan.get('requires_human_review', True)).lower()}`",
+        f"- Patch steps: `{plan.get('patch_step_count', 0)}`",
+        "",
+    ]
+
+    proof_commands = _string_list(plan.get("proof_commands"))
+    if proof_commands:
+        lines.extend(["#### Patch-plan proof commands", ""])
+        lines.extend(f"- `{command}`" for command in proof_commands[:5])
+        lines.append("")
+
+    review_commands = _string_list(plan.get("recommended_commands"))
+    if review_commands:
+        lines.extend(["#### Patch-plan review commands", ""])
+        lines.extend(f"- `{command}`" for command in review_commands[:5])
+        lines.append("")
+
+    return lines
+
+
 def _commands_from_node(node: JsonObject) -> list[str]:
     commands: list[str] = []
     for key in ("proof_commands", "recommended_commands"):
@@ -565,6 +631,7 @@ def build_narrative(
     sentinel_control_room: Path | None,
     evidence_graph: Path | None,
     failure_bundle: Path | None,
+    mission_control: Path | None = None,
     changed_files: Path | None,
 ) -> JsonObject:
     log_text = _read_text(quality_log)
@@ -687,6 +754,7 @@ def build_narrative(
         evidence_graph=evidence_graph,
         failure_bundle=failure_bundle,
     )
+    patch_plan = _read_mission_control_patch_plan(mission_control)
     what_happened.extend(_security_review_status_lines_from_control_room(sentinel_control_room))
 
     payload: JsonObject = {
@@ -732,6 +800,7 @@ def build_narrative(
         "operator_action": operator_action,
         "next_proof": commands,
         "evidence": artifact_paths,
+        "patch_plan": patch_plan,
     }
     payload["markdown"] = render_markdown(
         quality_ok=quality_ok,
@@ -745,6 +814,7 @@ def build_narrative(
         next_proof=commands,
         evidence=artifact_paths,
         secondary_graph_blockers=secondary_graph_blockers,
+        patch_plan=patch_plan,
     )
     return payload
 
@@ -950,6 +1020,7 @@ def render_markdown(
     next_proof: list[str],
     evidence: list[str],
     secondary_graph_blockers: list[JsonObject] | None = None,
+    patch_plan: JsonObject | None = None,
 ) -> str:
     status = "✅ quality.sh cov passed" if quality_ok else "❌ quality.sh cov failed"
     if coverage:
@@ -994,6 +1065,10 @@ def render_markdown(
             )
         lines.append("")
 
+    patch_plan_lines = _patch_plan_markdown_lines(patch_plan)
+    if patch_plan_lines:
+        lines.extend(patch_plan_lines)
+
     lines.extend(
         [
             "### Next proof",
@@ -1031,6 +1106,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--sentinel-control-room", type=Path, default=None)
     parser.add_argument("--evidence-graph", type=Path, default=None)
     parser.add_argument("--failure-bundle", type=Path, default=None)
+    parser.add_argument("--mission-control", type=Path, default=None)
     parser.add_argument("--changed-files", type=Path, default=None)
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--json-out", type=Path, default=None)
@@ -1045,6 +1121,7 @@ def main(argv: list[str] | None = None) -> int:
         sentinel_control_room=args.sentinel_control_room,
         evidence_graph=args.evidence_graph,
         failure_bundle=args.failure_bundle,
+        mission_control=args.mission_control,
         changed_files=args.changed_files,
     )
     write_narrative(payload, out=args.out, json_out=args.json_out)

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -673,3 +673,77 @@ def test_action_report_security_review_signal_explains_green_gate_review_route()
         in body
     )
     assert "No action required from SDETKit." not in body
+
+
+def test_action_report_surfaces_review_first_patch_plan_handoff() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+    evidence_narrative = {
+        "quality": {"ok": True, "coverage_percent": "96.69%"},
+        "primary_signal": {
+            "kind": "proof_signal",
+            "surface": "pr_quality",
+            "title": "PR Quality evidence changed",
+        },
+        "graph": {
+            "node_count": 2,
+            "review_first_count": 0,
+            "critical_count": 0,
+            "top_blocker": {
+                "title": "PR Quality evidence changed",
+                "surface": "pr_quality",
+                "action": "rerun_proof",
+                "review_first": False,
+            },
+        },
+        "patch_plan": {
+            "enabled": True,
+            "ok": True,
+            "status": "review_required",
+            "source_kind": "evidence_graph",
+            "source_code": "security-review",
+            "safe_to_auto_fix": False,
+            "dry_run_only": True,
+            "requires_human_review": True,
+            "proof_commands": ["python -m sdetkit security check --root . --format json"],
+            "recommended_commands": [
+                "Review unresolved GitHub Advanced Security comments on the PR."
+            ],
+            "patch_step_count": 4,
+        },
+        "next_proof": [
+            "python -m pytest -q tests/test_pr_quality_evidence_narrative.py -o addopts=",
+            "python -m pre_commit run -a",
+        ],
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        evidence_narrative=evidence_narrative,
+    )
+
+    assert "SDETKit Review Result: Green with proof signal" in body
+    assert "## Review-first patch plan" in body
+    assert "Status: `review_required`" in body
+    assert "Source kind: `evidence_graph`" in body
+    assert "Source code: `security-review`" in body
+    assert "Safe to auto-fix: `false`" in body
+    assert "Dry run only: `true`" in body
+    assert "Requires human review: `true`" in body
+    assert "Patch steps: `4`" in body
+    assert "python -m sdetkit security check --root . --format json" in body
+    assert "Review unresolved GitHub Advanced Security comments on the PR." in body

--- a/tests/test_pr_quality_evidence_narrative.py
+++ b/tests/test_pr_quality_evidence_narrative.py
@@ -994,3 +994,145 @@ def test_green_narrative_preserves_secondary_graph_blockers(tmp_path: Path) -> N
     assert "### Secondary graph blockers" in markdown
     assert "Dependency resolver failed [dependency; review]" in markdown
     assert "Coverage gate regression [quality; rerun_proof]" in markdown
+
+
+def test_narrative_surfaces_review_first_patch_plan_from_mission_control(
+    tmp_path: Path,
+) -> None:
+    quality = _write(tmp_path / "quality.log", "quality.sh cov passed\nTotal coverage: 96.69%\n")
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [
+                {
+                    "title": "PR Quality evidence changed",
+                    "summary": "The PR Quality evidence comment path changed.",
+                    "risk_surface": "pr_quality",
+                    "severity": "warning",
+                    "review_first": False,
+                    "recommended_commands": [
+                        "python -m pytest -q tests/test_pr_quality_evidence_narrative.py -o addopts="
+                    ],
+                    "operator_action": "rerun_proof",
+                }
+            ],
+            "source_summary": [],
+        },
+    )
+    mission_control = _write_json(
+        tmp_path / "mission-control.json",
+        {
+            "schema_version": "sdetkit.mission-control.v1",
+            "patch_plan": {
+                "enabled": True,
+                "ok": True,
+                "status": "review_required",
+                "source_kind": "evidence_graph",
+                "source_schema_version": "sdetkit.evidence-graph.v1",
+                "source_code": "security-review",
+                "safe_to_auto_fix": False,
+                "dry_run_only": True,
+                "requires_human_review": True,
+                "proof_commands": ["python -m sdetkit security check --root . --format json"],
+                "recommended_commands": [
+                    "Review unresolved GitHub Advanced Security comments on the PR."
+                ],
+                "patch_step_count": 4,
+                "path": "build/sdetkit/mission-control/review-first-patch-plan.json",
+            },
+        },
+    )
+    changed = _write(
+        tmp_path / "changed-files.txt",
+        "src/sdetkit/pr_quality_evidence_narrative.py\n",
+    )
+
+    payload = narrative.build_narrative(
+        quality_log=quality,
+        quality_outcome="success",
+        sentinel_control_room=None,
+        evidence_graph=graph,
+        failure_bundle=None,
+        mission_control=mission_control,
+        changed_files=changed,
+    )
+
+    patch_plan = payload["patch_plan"]
+    markdown = str(payload["markdown"])
+
+    assert patch_plan["enabled"] is True
+    assert patch_plan["status"] == "review_required"
+    assert patch_plan["source_kind"] == "evidence_graph"
+    assert patch_plan["source_code"] == "security-review"
+    assert patch_plan["safe_to_auto_fix"] is False
+    assert patch_plan["dry_run_only"] is True
+    assert patch_plan["requires_human_review"] is True
+    assert patch_plan["proof_commands"] == [
+        "python -m sdetkit security check --root . --format json"
+    ]
+    assert "### Review-first patch plan" in markdown
+    assert "Source kind: `evidence_graph`" in markdown
+    assert "Safe to auto-fix: `false`" in markdown
+    assert "Dry run only: `true`" in markdown
+    assert "Requires human review: `true`" in markdown
+    assert "python -m sdetkit security check --root . --format json" in markdown
+
+
+def test_narrative_cli_accepts_mission_control_patch_plan(tmp_path: Path) -> None:
+    quality = _write(tmp_path / "quality.log", "quality.sh cov passed\nTotal coverage: 96.69%\n")
+    graph = _write_json(
+        tmp_path / "evidence-graph.json",
+        {
+            "schema_version": "sdetkit.evidence-graph.v1",
+            "nodes": [],
+            "source_summary": [],
+        },
+    )
+    mission_control = _write_json(
+        tmp_path / "mission-control.json",
+        {
+            "patch_plan": {
+                "enabled": True,
+                "ok": True,
+                "status": "review_required",
+                "source_kind": "failure_bundle",
+                "source_code": "PACKAGE_INSTALL_FAILURE",
+                "safe_to_auto_fix": False,
+                "dry_run_only": True,
+                "requires_human_review": True,
+                "proof_commands": [
+                    "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+                ],
+                "recommended_commands": ["Reproduce the exact install lane."],
+                "patch_step_count": 4,
+            },
+        },
+    )
+    out = tmp_path / "narrative.md"
+    json_out = tmp_path / "narrative.json"
+
+    rc = narrative.main(
+        [
+            "--quality-log",
+            str(quality),
+            "--quality-outcome",
+            "success",
+            "--evidence-graph",
+            str(graph),
+            "--mission-control",
+            str(mission_control),
+            "--out",
+            str(out),
+            "--json-out",
+            str(json_out),
+        ]
+    )
+
+    assert rc == 0
+    markdown = out.read_text(encoding="utf-8")
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["patch_plan"]["source_kind"] == "failure_bundle"
+    assert payload["patch_plan"]["source_code"] == "PACKAGE_INSTALL_FAILURE"
+    assert "Review-first patch plan" in payload["markdown"]
+    assert "Review-first patch plan" in markdown


### PR DESCRIPTION
## Summary
- Add read-only Mission Control patch-plan ingestion to PR Quality evidence narrative.
- Surface review-first patch-plan status, source kind, source code, proof commands, review commands, and safety guardrails.
- Render patch-plan evidence in both the narrative Markdown and PR Quality action report comment.
- Preserve advisory-only behavior: no patch-plan regeneration, no command execution, no mutation, no dismissal, and no auto-remediation.

## Why
- Mission Control now exposes review-first patch plans, but PR Quality comments did not carry that operator handoff forward.
- Maintainers should see the same review-first evidence path directly in the PR Quality comment.

## Verification
- `python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_action_report.py tests/test_mission_control_evidence_graph.py tests/test_adaptive_patch_plan.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Public PR Quality comment/narrative output expands.
- Existing inputs and behavior are preserved.
- No runtime remediation, mutation, dismissal, push, or merge behavior is added.
- Rollback: easy; revert this commit.
