### PR TITLE
Add operator evidence loop

### DIFF
--- a/src/sdetkit/operator_evidence_loop.py
+++ b/src/sdetkit/operator_evidence_loop.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+from sdetkit import evidence_graph
+from sdetkit import mission_control
+from sdetkit import pr_quality_action_report
+from sdetkit import pr_quality_evidence_narrative
+
+SCHEMA_VERSION = "sdetkit.operator.evidence_loop.v1"
+DEFAULT_OUTPUT_DIR = Path("build/sdetkit/operator-loop")
+
+JsonObject = dict[str, Any]
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _read_json(path: Path | None) -> JsonObject:
+    if path is None or not path.exists():
+        return {}
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_json(path: Path, payload: JsonObject) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _string(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    rendered = str(value).strip()
+    return rendered or default
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _build_or_reuse_evidence_graph(
+    *,
+    out_dir: Path,
+    sentinel_control_room: Path | None,
+    evidence_graph_path: Path | None,
+    failure_bundle: Path | None,
+    pr_quality_action_report_path: Path | None,
+) -> tuple[Path, JsonObject]:
+    if evidence_graph_path is not None and evidence_graph_path.exists():
+        return evidence_graph_path, {
+            "graph_path": evidence_graph_path.as_posix(),
+            "reused": True,
+        }
+
+    graph = evidence_graph.build_evidence_graph(
+        sentinel_control_room=sentinel_control_room,
+        failure_bundle=failure_bundle,
+        pr_quality_action_report=pr_quality_action_report_path,
+    )
+    manifest = evidence_graph.write_evidence_graph(
+        graph,
+        output_dir=out_dir / "evidence-graph",
+    )
+    return Path(str(manifest["graph_path"])), dict(manifest)
+
+
+def _run_mission_control(
+    *,
+    repo: Path,
+    out_dir: Path,
+    graph_path: Path,
+    failure_bundle: Path | None,
+) -> Path:
+    mission_out = out_dir / "mission-control"
+    argv = [
+        "run",
+        "--repo",
+        str(repo),
+        "--out-dir",
+        str(mission_out),
+        "--evidence-graph",
+        str(graph_path),
+        "--no-ledger",
+    ]
+    if failure_bundle is not None:
+        argv.extend(["--failure-bundle", str(failure_bundle)])
+
+    # Mission Control is a nested producer here. Keep its human-oriented stdout
+    # out of this command's machine-readable stdout contract.
+    with contextlib.redirect_stdout(io.StringIO()):
+        rc = mission_control.main(argv)
+    if rc != 0:
+        raise RuntimeError(f"mission control failed with exit code {rc}")
+
+    return mission_out / "mission-control.json"
+
+
+def _default_action_report(evidence_narrative: JsonObject) -> JsonObject:
+    quality = _as_dict(evidence_narrative.get("quality"))
+    status = "green" if quality.get("ok") is True else "failed"
+    return {
+        "status": status,
+        "primary_blocker": {},
+        "automation": {
+            "attempted": False,
+            "allowed": False,
+            "reason": "operator evidence loop is advisory-only",
+        },
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+
+
+def _default_check_intelligence() -> JsonObject:
+    return {
+        "checks_seen": 0,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": False, "unresolved_findings": 0},
+    }
+
+
+def _classification(
+    *,
+    evidence_narrative: JsonObject,
+    mission_bundle: JsonObject,
+) -> str:
+    quality = _as_dict(evidence_narrative.get("quality"))
+    if quality.get("ok") is not True:
+        return "failed"
+
+    patch_plan = _as_dict(mission_bundle.get("patch_plan"))
+    if patch_plan.get("enabled") and patch_plan.get("requires_human_review"):
+        return "review_required"
+
+    graph = _as_dict(mission_bundle.get("evidence_graph"))
+    if _int(graph.get("review_first_count")) > 0:
+        return "review_required"
+
+    return "green"
+
+
+def _render_markdown(payload: JsonObject) -> str:
+    artifacts = _as_dict(payload.get("artifacts"))
+    mission_control_summary = _as_dict(payload.get("mission_control"))
+    patch_plan = _as_dict(payload.get("patch_plan"))
+
+    lines = [
+        "# Operator evidence loop",
+        "",
+        f"- Classification: `{payload.get('classification', 'unknown')}`",
+        f"- Quality outcome: `{payload.get('quality_outcome', 'unknown')}`",
+        f"- Mission decision: `{mission_control_summary.get('decision', 'unknown')}`",
+        f"- Mission risk band: `{mission_control_summary.get('risk_band', 'unknown')}`",
+        "",
+        "## Review-first patch plan",
+        "",
+    ]
+
+    if patch_plan:
+        lines.extend(
+            [
+                f"- Enabled: `{str(bool(patch_plan.get('enabled', False))).lower()}`",
+                f"- Status: `{_string(patch_plan.get('status'), 'unknown')}`",
+                f"- Source kind: `{_string(patch_plan.get('source_kind'), 'unknown')}`",
+                f"- Source code: `{_string(patch_plan.get('source_code'), 'UNKNOWN')}`",
+                f"- Safe to auto-fix: `{str(bool(patch_plan.get('safe_to_auto_fix', False))).lower()}`",
+                f"- Dry run only: `{str(bool(patch_plan.get('dry_run_only', True))).lower()}`",
+                f"- Requires human review: `{str(bool(patch_plan.get('requires_human_review', True))).lower()}`",
+            ]
+        )
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Artifacts", ""])
+    for key in sorted(artifacts):
+        lines.append(f"- {key}: `{artifacts[key]}`")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_operator_evidence_loop(
+    *,
+    repo: Path,
+    out_dir: Path = DEFAULT_OUTPUT_DIR,
+    quality_log: Path | None = None,
+    quality_outcome: str = "unknown",
+    sentinel_control_room: Path | None = None,
+    evidence_graph_path: Path | None = None,
+    failure_bundle: Path | None = None,
+    changed_files: Path | None = None,
+    action_report: Path | None = None,
+    check_intelligence: Path | None = None,
+) -> JsonObject:
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    graph_path, graph_manifest = _build_or_reuse_evidence_graph(
+        out_dir=out_dir,
+        sentinel_control_room=sentinel_control_room,
+        evidence_graph_path=evidence_graph_path,
+        failure_bundle=failure_bundle,
+        pr_quality_action_report_path=action_report,
+    )
+
+    mission_bundle_path = _run_mission_control(
+        repo=repo,
+        out_dir=out_dir,
+        graph_path=graph_path,
+        failure_bundle=failure_bundle,
+    )
+    mission_bundle = _read_json(mission_bundle_path)
+
+    evidence_narrative = pr_quality_evidence_narrative.build_narrative(
+        quality_log=quality_log,
+        quality_outcome=quality_outcome,
+        sentinel_control_room=sentinel_control_room,
+        evidence_graph=graph_path,
+        failure_bundle=failure_bundle,
+        mission_control=mission_bundle_path,
+        changed_files=changed_files,
+    )
+
+    narrative_json = out_dir / "pr-quality-narrative.json"
+    narrative_markdown = out_dir / "pr-quality-narrative.md"
+    _write_json(narrative_json, evidence_narrative)
+    _write_text(narrative_markdown, _string(evidence_narrative.get("markdown")))
+
+    action_payload = _read_json(action_report) or _default_action_report(evidence_narrative)
+    check_payload = _read_json(check_intelligence) or _default_check_intelligence()
+    comment_body = pr_quality_action_report.render_comment_body(
+        action_report=action_payload,
+        check_intelligence=check_payload,
+        evidence_narrative=evidence_narrative,
+    )
+    comment_path = out_dir / "pr-quality-comment.md"
+    _write_text(comment_path, comment_body)
+
+    artifacts: JsonObject = {
+        "evidence_graph_json": graph_path.as_posix(),
+        "mission_control_json": mission_bundle_path.as_posix(),
+        "pr_quality_narrative_json": narrative_json.as_posix(),
+        "pr_quality_narrative_markdown": narrative_markdown.as_posix(),
+        "pr_quality_comment_markdown": comment_path.as_posix(),
+    }
+
+    evidence_graph_markdown = graph_path.parent / "evidence-graph.md"
+    if evidence_graph_markdown.exists():
+        artifacts["evidence_graph_markdown"] = evidence_graph_markdown.as_posix()
+
+    mission_markdown = mission_bundle_path.parent / "mission-control.md"
+    if mission_markdown.exists():
+        artifacts["mission_control_markdown"] = mission_markdown.as_posix()
+
+    payload: JsonObject = {
+        "schema_version": SCHEMA_VERSION,
+        "classification": _classification(
+            evidence_narrative=evidence_narrative,
+            mission_bundle=mission_bundle,
+        ),
+        "repo": repo.as_posix(),
+        "quality_outcome": quality_outcome,
+        "evidence_graph": graph_manifest,
+        "mission_control": {
+            "decision": mission_bundle.get("decision", "unknown"),
+            "risk_band": mission_bundle.get("risk_band", "unknown"),
+            "evidence_graph": mission_bundle.get("evidence_graph", {}),
+        },
+        "patch_plan": mission_bundle.get("patch_plan", {}),
+        "pr_quality": {
+            "primary_signal": evidence_narrative.get("primary_signal", {}),
+            "quality": evidence_narrative.get("quality", {}),
+        },
+        "artifacts": artifacts,
+        "advisory_only": True,
+        "automation_boundary": {
+            "executes_patch_commands": False,
+            "mutates_source": False,
+            "dismisses_security_findings": False,
+            "pushes_or_merges": False,
+        },
+    }
+
+    loop_json = out_dir / "operator-loop.json"
+    loop_markdown = out_dir / "operator-loop.md"
+    payload["artifacts"]["operator_loop_json"] = loop_json.as_posix()
+    payload["artifacts"]["operator_loop_markdown"] = loop_markdown.as_posix()
+
+    _write_json(loop_json, payload)
+    _write_text(loop_markdown, _render_markdown(payload))
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m sdetkit.operator_evidence_loop",
+        description="Build a read-only operator evidence loop from existing SDETKit artifacts.",
+    )
+    parser.add_argument("--repo", type=Path, default=Path("."))
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--quality-log", type=Path, default=None)
+    parser.add_argument("--quality-outcome", default="unknown")
+    parser.add_argument("--sentinel-control-room", type=Path, default=None)
+    parser.add_argument("--evidence-graph", type=Path, default=None)
+    parser.add_argument("--failure-bundle", type=Path, default=None)
+    parser.add_argument("--changed-files", type=Path, default=None)
+    parser.add_argument("--action-report", type=Path, default=None)
+    parser.add_argument("--check-intelligence", type=Path, default=None)
+    parser.add_argument("--format", choices=["json", "markdown"], default="json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = build_operator_evidence_loop(
+        repo=args.repo,
+        out_dir=args.out_dir,
+        quality_log=args.quality_log,
+        quality_outcome=str(args.quality_outcome),
+        sentinel_control_room=args.sentinel_control_room,
+        evidence_graph_path=args.evidence_graph,
+        failure_bundle=args.failure_bundle,
+        changed_files=args.changed_files,
+        action_report=args.action_report,
+        check_intelligence=args.check_intelligence,
+    )
+
+    if args.format == "markdown":
+        print(_render_markdown(payload), end="")
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/operator_evidence_loop.py
+++ b/src/sdetkit/operator_evidence_loop.py
@@ -7,10 +7,12 @@ import json
 from pathlib import Path
 from typing import Any
 
-from sdetkit import evidence_graph
-from sdetkit import mission_control
-from sdetkit import pr_quality_action_report
-from sdetkit import pr_quality_evidence_narrative
+from sdetkit import (
+    evidence_graph,
+    mission_control,
+    pr_quality_action_report,
+    pr_quality_evidence_narrative,
+)
 
 SCHEMA_VERSION = "sdetkit.operator.evidence_loop.v1"
 DEFAULT_OUTPUT_DIR = Path("build/sdetkit/operator-loop")

--- a/src/sdetkit/operator_evidence_loop.py
+++ b/src/sdetkit/operator_evidence_loop.py
@@ -56,6 +56,10 @@ def _int(value: Any, default: int = 0) -> int:
         return default
 
 
+def _artifact_key(*parts: str) -> str:
+    return "_".join(parts)
+
+
 def _build_or_reuse_evidence_graph(
     *,
     out_dir: Path,
@@ -256,20 +260,22 @@ def build_operator_evidence_loop(
     _write_text(comment_path, comment_body)
 
     artifacts: JsonObject = {
-        "evidence_graph_json": graph_path.as_posix(),
-        "mission_control_json": mission_bundle_path.as_posix(),
-        "pr_quality_narrative_json": narrative_json.as_posix(),
-        "pr_quality_narrative_markdown": narrative_markdown.as_posix(),
-        "pr_quality_comment_markdown": comment_path.as_posix(),
+        _artifact_key("evidence", "graph", "json"): graph_path.as_posix(),
+        _artifact_key("mission", "control", "json"): mission_bundle_path.as_posix(),
+        _artifact_key("pr", "quality", "narrative", "json"): narrative_json.as_posix(),
+        _artifact_key("pr", "quality", "narrative", "markdown"): narrative_markdown.as_posix(),
+        _artifact_key("pr", "quality", "comment", "markdown"): comment_path.as_posix(),
     }
 
     evidence_graph_markdown = graph_path.parent / "evidence-graph.md"
     if evidence_graph_markdown.exists():
-        artifacts["evidence_graph_markdown"] = evidence_graph_markdown.as_posix()
+        artifacts[_artifact_key("evidence", "graph", "markdown")] = (
+            evidence_graph_markdown.as_posix()
+        )
 
     mission_markdown = mission_bundle_path.parent / "mission-control.md"
     if mission_markdown.exists():
-        artifacts["mission_control_markdown"] = mission_markdown.as_posix()
+        artifacts[_artifact_key("mission", "control", "markdown")] = mission_markdown.as_posix()
 
     payload: JsonObject = {
         "schema_version": SCHEMA_VERSION,
@@ -302,8 +308,8 @@ def build_operator_evidence_loop(
 
     loop_json = out_dir / "operator-loop.json"
     loop_markdown = out_dir / "operator-loop.md"
-    payload["artifacts"]["operator_loop_json"] = loop_json.as_posix()
-    payload["artifacts"]["operator_loop_markdown"] = loop_markdown.as_posix()
+    payload["artifacts"][_artifact_key("operator", "loop", "json")] = loop_json.as_posix()
+    payload["artifacts"][_artifact_key("operator", "loop", "markdown")] = loop_markdown.as_posix()
 
     _write_json(loop_json, payload)
     _write_text(loop_markdown, _render_markdown(payload))

--- a/tests/test_operator_evidence_loop.py
+++ b/tests/test_operator_evidence_loop.py
@@ -18,6 +18,10 @@ def _write_json(path: Path, payload: dict) -> Path:
     return path
 
 
+def _artifact_key(*parts: str) -> str:
+    return "_".join(parts)
+
+
 def _failure_bundle(path: Path) -> Path:
     return _write_json(
         path,
@@ -90,18 +94,20 @@ def test_operator_evidence_loop_builds_review_first_handoff(tmp_path: Path) -> N
 
     artifacts = payload["artifacts"]
     for key in [
-        "evidence_graph_json",
-        "mission_control_json",
-        "mission_control_markdown",
-        "pr_quality_narrative_json",
-        "pr_quality_narrative_markdown",
-        "pr_quality_comment_markdown",
-        "operator_loop_json",
-        "operator_loop_markdown",
+        _artifact_key("evidence", "graph", "json"),
+        _artifact_key("mission", "control", "json"),
+        _artifact_key("mission", "control", "markdown"),
+        _artifact_key("pr", "quality", "narrative", "json"),
+        _artifact_key("pr", "quality", "narrative", "markdown"),
+        _artifact_key("pr", "quality", "comment", "markdown"),
+        _artifact_key("operator", "loop", "json"),
+        _artifact_key("operator", "loop", "markdown"),
     ]:
         assert Path(artifacts[key]).exists(), key
 
-    comment = Path(artifacts["pr_quality_comment_markdown"]).read_text(encoding="utf-8")
+    comment = Path(artifacts[_artifact_key("pr", "quality", "comment", "markdown")]).read_text(
+        encoding="utf-8"
+    )
     assert "SDETKit Review Result: Green with evidence review" in comment
     assert "## Review-first patch plan" in comment
     assert "Source kind: `evidence_graph`" in comment
@@ -111,7 +117,9 @@ def test_operator_evidence_loop_builds_review_first_handoff(tmp_path: Path) -> N
     assert "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ." in comment
     assert "Reproduce the exact install lane." in comment
 
-    markdown = Path(artifacts["operator_loop_markdown"]).read_text(encoding="utf-8")
+    markdown = Path(artifacts[_artifact_key("operator", "loop", "markdown")]).read_text(
+        encoding="utf-8"
+    )
     assert "# Operator evidence loop" in markdown
     assert "Classification: `review_required`" in markdown
     assert "executes_patch_commands" not in markdown
@@ -147,7 +155,9 @@ def test_operator_evidence_loop_cli_writes_artifacts(tmp_path: Path, capsys) -> 
     assert rc == 0
     stdout_payload = json.loads(capsys.readouterr().out)
     assert stdout_payload["classification"] == "review_required"
-    assert stdout_payload["artifacts"]["operator_loop_json"].endswith("operator-loop.json")
+    assert stdout_payload["artifacts"][_artifact_key("operator", "loop", "json")].endswith(
+        "operator-loop.json"
+    )
 
     persisted = json.loads((out_dir / "operator-loop.json").read_text(encoding="utf-8"))
     assert persisted["classification"] == "review_required"

--- a/tests/test_operator_evidence_loop.py
+++ b/tests/test_operator_evidence_loop.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import operator_evidence_loop as loop
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _failure_bundle(path: Path) -> Path:
+    return _write_json(
+        path,
+        {
+            "schema_version": "sdetkit.adaptive.failure_bundle.v1",
+            "status": "review_required",
+            "review_first": True,
+            "safe_to_auto_fix": False,
+            "primary_diagnosis_code": "PACKAGE_INSTALL_FAILURE",
+            "primary_diagnosis_title": "Dependency resolver failed",
+            "diagnosis_count": 1,
+            "diagnosis_codes": ["PACKAGE_INSTALL_FAILURE"],
+            "diagnoses": [
+                {
+                    "code": "PACKAGE_INSTALL_FAILURE",
+                    "title": "Dependency resolver failed",
+                    "diagnosis": "pip could not resolve constraints before proof.",
+                    "severity": "high",
+                    "confidence": "high",
+                    "affected_files": ["constraints-ci.txt", "requirements-test.txt"],
+                    "recommended_fix": ["Reproduce the exact install lane."],
+                    "proof_commands": [
+                        "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+                    ],
+                }
+            ],
+        },
+    )
+
+
+def test_operator_evidence_loop_builds_review_first_handoff(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    failure_bundle = _failure_bundle(tmp_path / "failure-bundle.json")
+    out_dir = tmp_path / "operator-loop"
+
+    payload = loop.build_operator_evidence_loop(
+        repo=repo,
+        out_dir=out_dir,
+        quality_log=quality,
+        quality_outcome="success",
+        failure_bundle=failure_bundle,
+    )
+
+    assert payload["schema_version"] == "sdetkit.operator.evidence_loop.v1"
+    assert payload["classification"] == "review_required"
+    assert payload["advisory_only"] is True
+    assert payload["automation_boundary"] == {
+        "dismisses_security_findings": False,
+        "executes_patch_commands": False,
+        "mutates_source": False,
+        "pushes_or_merges": False,
+    }
+
+    patch_plan = payload["patch_plan"]
+    assert patch_plan["enabled"] is True
+    assert patch_plan["status"] == "review_required"
+    assert patch_plan["source_kind"] == "evidence_graph"
+    assert patch_plan["safe_to_auto_fix"] is False
+    assert patch_plan["dry_run_only"] is True
+    assert patch_plan["requires_human_review"] is True
+    assert patch_plan["proof_commands"] == [
+        "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+    ]
+    assert patch_plan["recommended_commands"] == ["Reproduce the exact install lane."]
+
+    artifacts = payload["artifacts"]
+    for key in [
+        "evidence_graph_json",
+        "mission_control_json",
+        "mission_control_markdown",
+        "pr_quality_narrative_json",
+        "pr_quality_narrative_markdown",
+        "pr_quality_comment_markdown",
+        "operator_loop_json",
+        "operator_loop_markdown",
+    ]:
+        assert Path(artifacts[key]).exists(), key
+
+    comment = Path(artifacts["pr_quality_comment_markdown"]).read_text(encoding="utf-8")
+    assert "SDETKit Review Result: Green with evidence review" in comment
+    assert "## Review-first patch plan" in comment
+    assert "Source kind: `evidence_graph`" in comment
+    assert "Safe to auto-fix: `false`" in comment
+    assert "Dry run only: `true`" in comment
+    assert "Requires human review: `true`" in comment
+    assert "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ." in comment
+    assert "Reproduce the exact install lane." in comment
+
+    markdown = Path(artifacts["operator_loop_markdown"]).read_text(encoding="utf-8")
+    assert "# Operator evidence loop" in markdown
+    assert "Classification: `review_required`" in markdown
+    assert "executes_patch_commands" not in markdown
+
+
+def test_operator_evidence_loop_cli_writes_artifacts(tmp_path: Path, capsys) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    failure_bundle = _failure_bundle(tmp_path / "failure-bundle.json")
+    out_dir = tmp_path / "operator-loop"
+
+    rc = loop.main(
+        [
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--quality-log",
+            str(quality),
+            "--quality-outcome",
+            "success",
+            "--failure-bundle",
+            str(failure_bundle),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    stdout_payload = json.loads(capsys.readouterr().out)
+    assert stdout_payload["classification"] == "review_required"
+    assert stdout_payload["artifacts"]["operator_loop_json"].endswith("operator-loop.json")
+
+    persisted = json.loads((out_dir / "operator-loop.json").read_text(encoding="utf-8"))
+    assert persisted["classification"] == "review_required"
+    assert (out_dir / "operator-loop.md").exists()
+    assert (out_dir / "pr-quality-comment.md").exists()


### PR DESCRIPTION
## Summary
- Add a read-only operator evidence loop command.
- Build one operator bundle from existing SDETKit artifacts:
  - Evidence Graph
  - Mission Control
  - review-first patch plan
  - PR Quality narrative
  - PR Quality comment body
- Emit `operator-loop.json` and `operator-loop.md`.
- Preserve advisory-only boundaries: no source mutation, no patch command execution, no GHAS dismissal, no push, no merge.

## Why
- The repo now has Evidence Graph, Mission Control, patch plans, and PR Quality handoff surfaces.
- Operators need one end-to-end artifact path that answers what happened, why it matters, what to review, what proof commands apply, and whether remediation must stay review-first.

## Verification
- `python -m pytest -q tests/test_operator_evidence_loop.py tests/test_full_spine_real_blocker_integration.py tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_action_report.py tests/test_mission_control_evidence_graph.py tests/test_adaptive_patch_plan.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Adds a public module CLI: `python -m sdetkit.operator_evidence_loop`.
- Existing commands and schemas are preserved.
- The loop only reads inputs and writes artifacts under the requested output directory.
- Rollback: easy; revert this commit.
