### PR TITLE
Reconcile cleared PR Quality security review signals

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -189,6 +189,78 @@ def _command_lines(values: list[Any]) -> list[str]:
     return [f"- `{item}`" for item in items] or ["- none"]
 
 
+def _required_count(items: list[Any]) -> int:
+    return sum(1 for item in items if bool(_as_dict(item).get("required", False)))
+
+
+def _cleared_security_review_lines(
+    *,
+    check_intelligence: JsonObject,
+    action_report: JsonObject,
+    evidence_narrative: JsonObject,
+    evidence_review_required: bool,
+) -> list[str]:
+    if not evidence_review_required:
+        return []
+
+    primary = _as_dict(evidence_narrative.get("primary_signal"))
+    graph = _as_dict(evidence_narrative.get("graph"))
+    top_blocker = _as_dict(graph.get("top_blocker"))
+    surface = _string(primary.get("surface") or top_blocker.get("surface") or "")
+
+    if surface != "security":
+        return []
+
+    security = _as_dict(
+        check_intelligence.get("security_review")
+        or _as_dict(action_report.get("evidence")).get("security_review")
+    )
+    if security.get("collected") is not True:
+        return []
+
+    if _int(security.get("unresolved_findings")) != 0:
+        return []
+
+    failed = _as_list(check_intelligence.get("failed_checks"))
+    queued = _as_list(check_intelligence.get("queued_checks"))
+    startup = _as_list(check_intelligence.get("startup_failures"))
+    missing_required = _as_list(check_intelligence.get("missing_required_contexts"))
+
+    if failed or missing_required or _required_count(queued) or _required_count(startup):
+        return []
+
+    return [
+        "- Proof signal: `present`",
+        "- Surface: `security`",
+        "- Title: Security review cleared for changed code",
+        "- Review signal reconciliation: `latest security review has no unresolved PR-owned findings`",
+        "- Failed checks: `0`",
+        "- Unresolved security findings: `0`",
+        "- Security review action: `no fix or dismissal required for PR-owned security findings`",
+    ]
+
+
+def _reconciled_evidence_signal(
+    *,
+    check_intelligence: JsonObject,
+    action_report: JsonObject,
+    evidence_narrative: JsonObject,
+    heading: str,
+    lines: list[str],
+    review_required: bool,
+) -> tuple[str, list[str], bool]:
+    cleared_security = _cleared_security_review_lines(
+        check_intelligence=check_intelligence,
+        action_report=action_report,
+        evidence_narrative=evidence_narrative,
+        evidence_review_required=review_required,
+    )
+    if cleared_security:
+        return "Evidence proof signal", cleared_security, False
+
+    return heading, lines, review_required
+
+
 def _evidence_signal(evidence_narrative: JsonObject) -> tuple[str, list[str], bool]:
     primary = _as_dict(evidence_narrative.get("primary_signal"))
     graph = _as_dict(evidence_narrative.get("graph"))
@@ -323,6 +395,16 @@ def render_comment_body(
     evidence_signal_heading, evidence_signal_lines, evidence_review_required = _evidence_signal(
         evidence_narrative
     )
+    evidence_signal_heading, evidence_signal_lines, evidence_review_required = (
+        _reconciled_evidence_signal(
+            check_intelligence=check_intelligence,
+            action_report=action_report,
+            evidence_narrative=evidence_narrative,
+            heading=evidence_signal_heading,
+            lines=evidence_signal_lines,
+            review_required=evidence_review_required,
+        )
+    )
 
     lines = [
         "## SDETKit Review Result: "
@@ -426,6 +508,14 @@ def write_comment_body(
 
     status = _string(action_report.get("status") or "unknown")
     _heading, evidence_signal_lines, evidence_review_required = _evidence_signal(evidence_narrative)
+    _heading, evidence_signal_lines, evidence_review_required = _reconciled_evidence_signal(
+        check_intelligence=check_intelligence,
+        action_report=action_report,
+        evidence_narrative=evidence_narrative,
+        heading=_heading,
+        lines=evidence_signal_lines,
+        review_required=evidence_review_required,
+    )
     if evidence_review_required:
         evidence_signal_kind = "review"
     elif evidence_signal_lines:

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -747,3 +747,62 @@ def test_action_report_surfaces_review_first_patch_plan_handoff() -> None:
     assert "Patch steps: `4`" in body
     assert "python -m sdetkit security check --root . --format json" in body
     assert "Review unresolved GitHub Advanced Security comments on the PR." in body
+
+
+def test_action_report_reconciles_cleared_security_review_signal() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 43,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "missing_required_contexts": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+    evidence_narrative = {
+        "quality": {"ok": True, "coverage_percent": "96.69%"},
+        "primary_signal": {
+            "kind": "review_signal",
+            "surface": "security",
+            "title": "Security review requires action in tests/test_example.py",
+        },
+        "graph": {
+            "node_count": 3,
+            "review_first_count": 1,
+            "critical_count": 0,
+            "top_blocker": {
+                "title": "Security review requires action in tests/test_example.py",
+                "surface": "security",
+                "action": "review",
+                "review_first": True,
+            },
+        },
+        "next_proof": [
+            "Review unresolved GitHub Advanced Security comments on the PR.",
+            "Fix the flagged surface or dismiss the false positive with a review reason.",
+        ],
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        evidence_narrative=evidence_narrative,
+    )
+
+    assert "SDETKit Review Result: Green with proof signal" in body
+    assert "## Evidence proof signal" in body
+    assert "Security review cleared for changed code" in body
+    assert "latest security review has no unresolved PR-owned findings" in body
+    assert "Unresolved security findings: `0`" in body
+    assert "no fix or dismissal required for PR-owned security findings" in body
+    assert "SDETKit Review Result: Green with evidence review" not in body
+    assert "Evidence review signal present; quality gate passed" not in body
+    assert "human review required before merge" not in body
+    assert "Fix the flagged surface or dismiss the false positive" not in body


### PR DESCRIPTION
## Summary
- Reconcile stale PR Quality security review signals when latest check intelligence reports zero unresolved PR-owned security findings.
- Downgrade cleared security review signals from `Green with evidence review` to `Green with proof signal`.
- Add explicit wording that no fix or dismissal is required when the latest security review is clean.
- Preserve active security review behavior when unresolved findings remain.

## Why
- Operators were seeing `Green with evidence review` after code scanning/security-gate refreshed to no new alerts.
- That created stale merge anxiety even though the PR was clean and mergeable.

## Verification
- `python -m pytest -q tests/test_pr_quality_action_report.py tests/test_security_review_evidence.py tests/test_pr_quality_evidence_narrative.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Medium
- Public PR Quality comment wording changes for cleared security-review cases.
- Active unresolved security review findings still require human review.
- No security dismissal, source mutation, auto-remediation, push, or merge behavior is added.
