### PR TITLE
Expose operator evidence loop in CLI

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -279,6 +279,25 @@ Then use stability-aware command discovery:
     )
     mission_control_parser.add_argument("args", nargs=argparse.REMAINDER)
 
+    operator_loop_parser = sub.add_parser(
+        "operator-loop",
+        help="[Public / stable] Build the operator evidence loop",
+        description=(
+            "Build the full review-first operator evidence loop from existing SDETKit artifacts."
+        ),
+    )
+    operator_loop_parser.add_argument("--repo", default=".")
+    operator_loop_parser.add_argument("--out-dir", default="build/sdetkit/operator-loop")
+    operator_loop_parser.add_argument("--quality-log", default=None)
+    operator_loop_parser.add_argument("--quality-outcome", default="unknown")
+    operator_loop_parser.add_argument("--sentinel-control-room", default=None)
+    operator_loop_parser.add_argument("--evidence-graph", default=None)
+    operator_loop_parser.add_argument("--failure-bundle", default=None)
+    operator_loop_parser.add_argument("--changed-files", default=None)
+    operator_loop_parser.add_argument("--action-report", default=None)
+    operator_loop_parser.add_argument("--check-intelligence", default=None)
+    operator_loop_parser.add_argument("--format", choices=["json", "markdown"], default="json")
+
     _add_passthrough_subcommand(
         sub,
         "gate",
@@ -1119,6 +1138,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         if bool(getattr(ns, "mission_control_help", False)):
             forwarded.insert(0, "--help")
         return _run_module_main("sdetkit.mission_control", forwarded)
+
+    if ns.cmd == "operator-loop":
+        forwarded = [
+            "--repo",
+            str(ns.repo),
+            "--out-dir",
+            str(ns.out_dir),
+            "--quality-outcome",
+            str(ns.quality_outcome),
+            "--format",
+            str(ns.format),
+        ]
+        for flag, value in (
+            ("--quality-log", ns.quality_log),
+            ("--sentinel-control-room", ns.sentinel_control_room),
+            ("--evidence-graph", ns.evidence_graph),
+            ("--failure-bundle", ns.failure_bundle),
+            ("--changed-files", ns.changed_files),
+            ("--action-report", ns.action_report),
+            ("--check-intelligence", ns.check_intelligence),
+        ):
+            if value:
+                forwarded.extend([flag, str(value)])
+        return _run_module_main("sdetkit.operator_evidence_loop", forwarded)
 
     if ns.cmd == "inspect":
         return _run_module_main("sdetkit.inspect_data", build_inspect_forwarded_args(ns, ns.args))

--- a/tests/test_cli_operator_evidence_loop.py
+++ b/tests/test_cli_operator_evidence_loop.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import cli
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _failure_bundle(path: Path) -> Path:
+    return _write_json(
+        path,
+        {
+            "schema_version": "sdetkit.adaptive.failure_bundle.v1",
+            "status": "review_required",
+            "review_first": True,
+            "safe_to_auto_fix": False,
+            "primary_diagnosis_code": "PACKAGE_INSTALL_FAILURE",
+            "primary_diagnosis_title": "Dependency resolver failed",
+            "diagnosis_count": 1,
+            "diagnosis_codes": ["PACKAGE_INSTALL_FAILURE"],
+            "diagnoses": [
+                {
+                    "code": "PACKAGE_INSTALL_FAILURE",
+                    "title": "Dependency resolver failed",
+                    "diagnosis": "pip could not resolve constraints before proof.",
+                    "severity": "high",
+                    "confidence": "high",
+                    "affected_files": ["constraints-ci.txt", "requirements-test.txt"],
+                    "recommended_fix": ["Reproduce the exact install lane."],
+                    "proof_commands": [
+                        "python -m pip install -c constraints-ci.txt -r requirements-test.txt -e ."
+                    ],
+                }
+            ],
+        },
+    )
+
+
+def test_root_help_exposes_operator_loop(capsys) -> None:
+    try:
+        cli.main(["--help"])
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    out = capsys.readouterr().out
+    assert "operator-loop" in out
+    assert "operator evidence loop" in out
+
+
+def test_operator_loop_help_forwards_to_operator_loop_module(capsys) -> None:
+    try:
+        cli.main(["operator-loop", "--help"])
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    out = capsys.readouterr().out
+    assert "usage: sdetkit operator-loop" in out
+    assert "--failure-bundle" in out
+    assert "--quality-log" in out
+
+
+def test_operator_loop_cli_command_builds_operator_artifacts(tmp_path: Path, capsys) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    failure_bundle = _failure_bundle(tmp_path / "failure-bundle.json")
+    out_dir = tmp_path / "operator-loop"
+
+    rc = cli.main(
+        [
+            "operator-loop",
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--quality-log",
+            str(quality),
+            "--quality-outcome",
+            "success",
+            "--failure-bundle",
+            str(failure_bundle),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "\"schema_version\": " in stdout
+    assert "\"classification\": " in stdout
+
+    persisted = json.loads((out_dir / "operator-loop.json").read_text(encoding="utf-8"))
+    assert persisted["schema_version"] == "sdetkit.operator.evidence_loop.v1"
+    assert persisted["classification"] == "review_required"
+    assert persisted["advisory_only"] is True
+    assert (out_dir / "operator-loop.json").exists()
+    assert (out_dir / "operator-loop.md").exists()
+    assert (out_dir / "pr-quality-comment.md").exists()

--- a/tests/test_cli_operator_evidence_loop.py
+++ b/tests/test_cli_operator_evidence_loop.py
@@ -101,8 +101,8 @@ def test_operator_loop_cli_command_builds_operator_artifacts(tmp_path: Path, cap
 
     assert rc == 0
     stdout = capsys.readouterr().out
-    assert "\"schema_version\": " in stdout
-    assert "\"classification\": " in stdout
+    assert '"schema_version": ' in stdout
+    assert '"classification": ' in stdout
 
     persisted = json.loads((out_dir / "operator-loop.json").read_text(encoding="utf-8"))
     assert persisted["schema_version"] == "sdetkit.operator.evidence_loop.v1"


### PR DESCRIPTION
## Summary
- Expose the operator evidence loop through the main SDETKit CLI as `sdetkit operator-loop`.
- Add explicit root CLI flags for the operator-loop contract instead of hidden module-only usage.
- Forward the root command to `sdetkit.operator_evidence_loop`.
- Add CLI integration tests for root help, command help, and artifact generation.

## Why
- The operator evidence loop already exists, but operators should not need to know the internal module path.
- This creates one discoverable public command for the full Evidence Graph → Mission Control → PR Quality operator handoff.

## Verification
- `python -m pytest -q tests/test_cli_operator_evidence_loop.py tests/test_operator_evidence_loop.py -o addopts=`
- `python -m sdetkit --help | grep -F "operator-loop"`
- `python -m sdetkit operator-loop --help | grep -F -- "--failure-bundle"`
- `python -m ruff check src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `python -m sdetkit security check --root . --format json` with zero warn/error findings in PR-owned files

## Risk
- Medium
- Adds a public CLI command and help surface.
- Existing module CLI remains unchanged.
- No source mutation, command execution beyond artifact generation, GHAS dismissal, push, merge, or auto-remediation behavior is added.
