### PR TITLE
Verify operator evidence loop artifacts

### DIFF
--- a/src/sdetkit/cli.py
+++ b/src/sdetkit/cli.py
@@ -297,6 +297,11 @@ Then use stability-aware command discovery:
     operator_loop_parser.add_argument("--action-report", default=None)
     operator_loop_parser.add_argument("--check-intelligence", default=None)
     operator_loop_parser.add_argument("--format", choices=["json", "markdown"], default="json")
+    operator_loop_parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Return non-zero when the generated operator loop is incomplete.",
+    )
 
     _add_passthrough_subcommand(
         sub,
@@ -1161,6 +1166,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         ):
             if value:
                 forwarded.extend([flag, str(value)])
+        if bool(ns.verify):
+            forwarded.append("--verify")
         return _run_module_main("sdetkit.operator_evidence_loop", forwarded)
 
     if ns.cmd == "inspect":

--- a/src/sdetkit/operator_evidence_loop.py
+++ b/src/sdetkit/operator_evidence_loop.py
@@ -164,6 +164,72 @@ def _classification(
     return "green"
 
 
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _artifact_exists(artifacts: JsonObject, *parts: str) -> bool:
+    value = artifacts.get(_artifact_key(*parts))
+    return bool(value) and Path(str(value)).exists()
+
+
+def _verify_operator_loop_payload(payload: JsonObject) -> JsonObject:
+    artifacts = _as_dict(payload.get("artifacts"))
+    required_artifacts = [
+        ("evidence", "graph", "json"),
+        ("mission", "control", "json"),
+        ("pr", "quality", "narrative", "json"),
+        ("pr", "quality", "narrative", "markdown"),
+        ("pr", "quality", "comment", "markdown"),
+        ("operator", "loop", "json"),
+        ("operator", "loop", "markdown"),
+    ]
+
+    missing = [
+        _artifact_key(*parts)
+        for parts in required_artifacts
+        if not _artifact_exists(artifacts, *parts)
+    ]
+
+    boundary = _as_dict(payload.get("automation_boundary"))
+    advisory_ok = payload.get("advisory_only") is True and all(
+        boundary.get(key) is False
+        for key in [
+            "executes_patch_commands",
+            "mutates_source",
+            "dismisses_security_findings",
+            "pushes_or_merges",
+        ]
+    )
+
+    comment_key = _artifact_key("pr", "quality", "comment", "markdown")
+    comment_path = Path(str(artifacts.get(comment_key, "")))
+    comment_ok = comment_path.exists() and "SDETKit Review Result" in comment_path.read_text(
+        encoding="utf-8"
+    )
+
+    mission_key = _artifact_key("mission", "control", "json")
+    mission_ok = bool(_read_json(Path(str(artifacts.get(mission_key, "")))))
+
+    patch_plan = _as_dict(payload.get("patch_plan"))
+    patch_plan_expected = payload.get("classification") == "review_required"
+    patch_plan_ok = bool(patch_plan) if patch_plan_expected else True
+
+    checks = {
+        "required_artifacts": not missing,
+        "advisory_boundary": advisory_ok,
+        "comment": comment_ok,
+        "mission": mission_ok,
+        "patch_plan": patch_plan_ok,
+    }
+
+    return {
+        "ok": all(checks.values()),
+        "missing_artifacts": missing,
+        "checks": checks,
+    }
+
+
 def _render_markdown(payload: JsonObject) -> str:
     artifacts = _as_dict(payload.get("artifacts"))
     mission_control_summary = _as_dict(payload.get("mission_control"))
@@ -195,6 +261,21 @@ def _render_markdown(payload: JsonObject) -> str:
         )
     else:
         lines.append("- none")
+
+    verification = _as_dict(payload.get("verification"))
+    if verification:
+        checks = _as_dict(verification.get("checks"))
+        lines.extend(
+            [
+                "",
+                "## Verification",
+                "",
+                f"- OK: `{str(bool(verification.get('ok', False))).lower()}`",
+                f"- Missing artifacts: `{len(_as_list(verification.get('missing_artifacts')))}`",
+            ]
+        )
+        for key in sorted(checks):
+            lines.append(f"- {key}: `{str(bool(checks[key])).lower()}`")
 
     lines.extend(["", "## Artifacts", ""])
     for key in sorted(artifacts):
@@ -313,6 +394,10 @@ def build_operator_evidence_loop(
 
     _write_json(loop_json, payload)
     _write_text(loop_markdown, _render_markdown(payload))
+
+    payload["verification"] = _verify_operator_loop_payload(payload)
+    _write_json(loop_json, payload)
+    _write_text(loop_markdown, _render_markdown(payload))
     return payload
 
 
@@ -332,6 +417,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--action-report", type=Path, default=None)
     parser.add_argument("--check-intelligence", type=Path, default=None)
     parser.add_argument("--format", choices=["json", "markdown"], default="json")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Return a non-zero exit code when the generated operator loop is incomplete.",
+    )
     return parser
 
 
@@ -355,6 +445,8 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(json.dumps(payload, indent=2, sort_keys=True))
 
+    if args.verify and not bool(_as_dict(payload.get("verification")).get("ok", False)):
+        return 1
     return 0
 
 

--- a/tests/test_cli_operator_evidence_loop.py
+++ b/tests/test_cli_operator_evidence_loop.py
@@ -68,6 +68,7 @@ def test_operator_loop_help_forwards_to_operator_loop_module(capsys) -> None:
     out = capsys.readouterr().out
     assert "usage: sdetkit operator-loop" in out
     assert "--failure-bundle" in out
+    assert "--verify" in out
     assert "--quality-log" in out
 
 
@@ -96,6 +97,7 @@ def test_operator_loop_cli_command_builds_operator_artifacts(tmp_path: Path, cap
             str(failure_bundle),
             "--format",
             "json",
+            "--verify",
         ]
     )
 
@@ -108,6 +110,7 @@ def test_operator_loop_cli_command_builds_operator_artifacts(tmp_path: Path, cap
     assert persisted["schema_version"] == "sdetkit.operator.evidence_loop.v1"
     assert persisted["classification"] == "review_required"
     assert persisted["advisory_only"] is True
+    assert persisted["verification"]["ok"] is True
     assert (out_dir / "operator-loop.json").exists()
     assert (out_dir / "operator-loop.md").exists()
     assert (out_dir / "pr-quality-comment.md").exists()

--- a/tests/test_operator_evidence_loop.py
+++ b/tests/test_operator_evidence_loop.py
@@ -163,3 +163,76 @@ def test_operator_evidence_loop_cli_writes_artifacts(tmp_path: Path, capsys) -> 
     assert persisted["classification"] == "review_required"
     assert (out_dir / "operator-loop.md").exists()
     assert (out_dir / "pr-quality-comment.md").exists()
+
+
+def test_operator_evidence_loop_verification_marks_complete_bundle(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    failure_bundle = _failure_bundle(tmp_path / "failure-bundle.json")
+    out_dir = tmp_path / "operator-loop"
+
+    payload = loop.build_operator_evidence_loop(
+        repo=repo,
+        out_dir=out_dir,
+        quality_log=quality,
+        quality_outcome="success",
+        failure_bundle=failure_bundle,
+    )
+
+    verification = payload["verification"]
+    assert verification["ok"] is True
+    assert verification["missing_artifacts"] == []
+    assert verification["checks"] == {
+        "advisory_boundary": True,
+        "comment": True,
+        "mission": True,
+        "patch_plan": True,
+        "required_artifacts": True,
+    }
+
+    markdown = (out_dir / "operator-loop.md").read_text(encoding="utf-8")
+    assert "## Verification" in markdown
+    assert "OK: `true`" in markdown
+    assert "Missing artifacts: `0`" in markdown
+
+
+def test_operator_evidence_loop_cli_verify_returns_success_for_complete_bundle(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    quality = _write(
+        tmp_path / "quality.log",
+        "quality.sh cov passed\nTotal coverage: 96.69%\n",
+    )
+    failure_bundle = _failure_bundle(tmp_path / "failure-bundle.json")
+    out_dir = tmp_path / "operator-loop"
+
+    rc = loop.main(
+        [
+            "--repo",
+            str(repo),
+            "--out-dir",
+            str(out_dir),
+            "--quality-log",
+            str(quality),
+            "--quality-outcome",
+            "success",
+            "--failure-bundle",
+            str(failure_bundle),
+            "--format",
+            "json",
+            "--verify",
+        ]
+    )
+
+    assert rc == 0
+    stdout_payload = json.loads(capsys.readouterr().out)
+    assert stdout_payload["verification"]["ok"] is True
+    persisted = json.loads((out_dir / "operator-loop.json").read_text(encoding="utf-8"))
+    assert persisted["verification"]["ok"] is True


### PR DESCRIPTION
## Summary
- Add verification metadata to the operator evidence loop payload.
- Verify required generated artifacts, PR Quality comment presence, Mission Control presence, patch-plan expectations, and advisory-only automation boundaries.
- Add `--verify` to `python -m sdetkit.operator_evidence_loop`.
- Forward `--verify` through `sdetkit operator-loop`.
- Render verification status in `operator-loop.md`.

## Why
- The operator loop can generate artifacts, but operators need a deterministic completeness verdict before relying on the bundle in PRs or CI.
- This makes the loop gateable without adding auto-fix, mutation, GHAS dismissal, push, or merge automation.

## Verification
- `python -m pytest -q tests/test_operator_evidence_loop.py tests/test_cli_operator_evidence_loop.py -o addopts=`
- `python -m sdetkit operator-loop --help | grep -F -- "--verify"`
- `python -m ruff check src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `python -m sdetkit security check --root . --format json` with zero warn/error findings in PR-owned files

## Risk
- Medium
- Public CLI/schema addition: `verification` payload section and `--verify`.
- Existing operator-loop generation behavior remains advisory-only.
- Rollback: easy; revert this commit.
