### PR TITLE
Publish operator evidence loop from PR Quality

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -283,6 +283,25 @@ jobs:
             --out build/pr-quality/pr-comment-body.md \
             > build/pr-quality/pr-comment-metadata.json
 
+      - name: Build verified operator evidence loop
+        if: always()
+        run: |
+          mkdir -p build/sdetkit/operator-loop
+          PYTHONPATH=src python -m sdetkit operator-loop \
+            --repo . \
+            --quality-log quality.log \
+            --quality-outcome "${{ steps.quality.outcome }}" \
+            --sentinel-control-room build/sdetkit/sentinel/control-room-with-security-review.json \
+            --evidence-graph build/sdetkit/evidence-graph/evidence-graph.json \
+            --failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json \
+            --changed-files build/pr-quality/changed-files.txt \
+            --action-report build/pr-quality/check-intelligence/action-report.json \
+            --check-intelligence build/pr-quality/check-intelligence/check-intelligence.json \
+            --out-dir build/sdetkit/operator-loop \
+            --format json \
+            --verify \
+            > build/sdetkit/operator-loop/operator-loop-stdout.json
+
       - name: Upload failure intelligence bundle
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -316,6 +335,7 @@ jobs:
             build/pr-quality/check-intelligence/
             build/pr-quality/pr-evidence-narrative.md
             build/sdetkit/evidence-graph/
+            build/sdetkit/operator-loop/
           if-no-files-found: ignore
 
       - name: Comment on PR

--- a/tests/test_pr_quality_operator_loop_workflow.py
+++ b/tests/test_pr_quality_operator_loop_workflow.py
@@ -14,7 +14,10 @@ def test_pr_quality_workflow_publishes_verified_operator_loop() -> None:
     assert "--evidence-graph build/sdetkit/evidence-graph/evidence-graph.json" in workflow
     assert "--failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json" in workflow
     assert "--action-report build/pr-quality/check-intelligence/action-report.json" in workflow
-    assert "--check-intelligence build/pr-quality/check-intelligence/check-intelligence.json" in workflow
+    assert (
+        "--check-intelligence build/pr-quality/check-intelligence/check-intelligence.json"
+        in workflow
+    )
     assert "--out-dir build/sdetkit/operator-loop" in workflow
     assert "> build/sdetkit/operator-loop/operator-loop-stdout.json" in workflow
     assert "build/sdetkit/operator-loop/" in workflow

--- a/tests/test_pr_quality_operator_loop_workflow.py
+++ b/tests/test_pr_quality_operator_loop_workflow.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_pr_quality_workflow_publishes_verified_operator_loop() -> None:
+    workflow = Path(".github/workflows/pr-quality-comment.yml").read_text(encoding="utf-8")
+
+    assert "Build verified operator evidence loop" in workflow
+    assert "python -m sdetkit operator-loop" in workflow
+    assert "--verify" in workflow
+    assert "--quality-log quality.log" in workflow
+    assert '--quality-outcome "${{ steps.quality.outcome }}"' in workflow
+    assert "--evidence-graph build/sdetkit/evidence-graph/evidence-graph.json" in workflow
+    assert "--failure-bundle build/pr-quality/failure-intelligence/failure-bundle.json" in workflow
+    assert "--action-report build/pr-quality/check-intelligence/action-report.json" in workflow
+    assert "--check-intelligence build/pr-quality/check-intelligence/check-intelligence.json" in workflow
+    assert "--out-dir build/sdetkit/operator-loop" in workflow
+    assert "> build/sdetkit/operator-loop/operator-loop-stdout.json" in workflow
+    assert "build/sdetkit/operator-loop/" in workflow
+
+
+def test_pr_quality_workflow_builds_operator_loop_after_pr_comment_body() -> None:
+    workflow = Path(".github/workflows/pr-quality-comment.yml").read_text(encoding="utf-8")
+
+    comment_body_index = workflow.index("Build PR comment body")
+    operator_loop_index = workflow.index("Build verified operator evidence loop")
+    upload_index = workflow.index("Upload PR quality comment artifacts")
+
+    assert comment_body_index < operator_loop_index < upload_index


### PR DESCRIPTION
## Summary
- Run `sdetkit operator-loop --verify` inside the existing PR Quality workflow.
- Reuse existing PR Quality artifacts: quality log, failure bundle, sentinel/security control room, evidence graph, action report, check intelligence, and changed files.
- Upload `build/sdetkit/operator-loop/` with the existing PR Quality comment artifact pack.
- Add workflow guardrail tests proving the operator loop runs after PR comment body generation and before artifact upload.

## Why
- The operator loop is built, exposed in CLI, and self-verifying.
- This PR closes the loop by publishing the verified operator-loop artifact pack on every PR Quality run.
- Operators no longer need to run the loop locally to see the full evidence bundle.

## Verification
- `python -m pytest -q tests/test_pr_quality_operator_loop_workflow.py tests/test_operator_evidence_loop.py tests/test_cli_operator_evidence_loop.py -o addopts=`
- `python -m sdetkit operator-loop --help | grep -F -- "--verify"`
- `python -m ruff check src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `python -m sdetkit security check --root . --format json` with zero warn/error findings in PR-owned files

## Risk
- Medium
- CI workflow integration only.
- No new engine behavior.
- No auto-fix, no source mutation, no GHAS dismissal, no push, no merge automation.
- Rollback: easy; revert this workflow/test PR.
