### PR TITLE
Collect failed check logs for PR Quality diagnosis

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -215,9 +215,20 @@ jobs:
           )
           PY
 
+          mkdir -p build/pr-quality/check-logs
+          PYTHONPATH=src python -m sdetkit.failed_check_log_collection \
+            --checks-json build/pr-quality/checks/check-runs.json \
+            --out-dir build/pr-quality/check-logs
+
+          bash build/pr-quality/check-logs/download-failed-check-logs.sh || true
+
+          PYTHONPATH=src python -m sdetkit.failed_check_log_collection \
+            --checks-json build/pr-quality/checks/check-runs.json \
+            --out-dir build/pr-quality/check-logs
+
           PYTHONPATH=src python -m sdetkit.check_intelligence \
             --checks-json build/pr-quality/checks/check-runs.json \
-            --logs-dir . \
+            --logs-dir build/pr-quality/check-logs/failed-check-logs \
             --review-threads-json build/pr-quality/security-review/review-threads.json \
             --out-dir build/pr-quality/check-intelligence
 
@@ -332,6 +343,7 @@ jobs:
             build/pr-quality/changed-files.txt
             build/pr-quality/comment-status.json
             build/pr-quality/checks/
+            build/pr-quality/check-logs/
             build/pr-quality/check-intelligence/
             build/pr-quality/pr-evidence-narrative.md
             build/sdetkit/evidence-graph/

--- a/src/sdetkit/failed_check_log_collection.py
+++ b/src/sdetkit/failed_check_log_collection.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.pr_quality.failed_check_logs.v1"
+
+JsonObject = dict[str, Any]
+
+_FAILURE_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "startup_failure",
+    "timed_out",
+}
+
+_SUCCESS_CONCLUSIONS = {
+    "neutral",
+    "skipped",
+    "success",
+}
+
+_ACTIONS_URL_PATTERN = re.compile(
+    r"/actions/runs/(?P<run_id>[0-9]+)(?:/job/(?P<job_id>[0-9]+))?"
+)
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _read_json(path: Path) -> JsonObject:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return _as_dict(payload)
+
+
+def _write_json(path: Path, payload: JsonObject) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    return slug or "check"
+
+
+def _iter_check_records(payload: JsonObject) -> list[JsonObject]:
+    if isinstance(payload.get("checks"), list):
+        return [_as_dict(item) for item in _as_list(payload.get("checks"))]
+
+    records: list[JsonObject] = []
+    for key in (
+        "check_runs",
+        "jobs",
+        "workflow_runs",
+        "statuses",
+        "check_suites",
+    ):
+        records.extend(_as_dict(item) for item in _as_list(payload.get(key)))
+
+    if not records and payload:
+        records.append(payload)
+
+    return records
+
+
+def _check_name(record: JsonObject, index: int) -> str:
+    for key in ("name", "displayName", "workflowName", "context", "check_name"):
+        value = _string(record.get(key))
+        if value:
+            return value
+    return f"check-{index + 1}"
+
+
+def _check_status(record: JsonObject) -> str:
+    return _string(record.get("status")).lower()
+
+
+def _check_conclusion(record: JsonObject) -> str:
+    return _string(record.get("conclusion") or record.get("state")).lower()
+
+
+def _is_failed(record: JsonObject) -> bool:
+    conclusion = _check_conclusion(record)
+    status = _check_status(record)
+    if conclusion in _FAILURE_CONCLUSIONS:
+        return True
+    return status == "completed" and conclusion not in _SUCCESS_CONCLUSIONS
+
+
+def _record_url(record: JsonObject) -> str:
+    for key in ("url", "html_url", "details_url", "target_url"):
+        value = _string(record.get(key))
+        if value:
+            return value
+    return ""
+
+
+def _inline_log_text(record: JsonObject) -> str:
+    for key in ("log", "logs", "stdout", "stderr", "output", "text"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+def _source_log_path(record: JsonObject) -> Path | None:
+    value = _string(record.get("log_path") or record.get("logPath"))
+    if not value:
+        return None
+    path = Path(value)
+    return path if path.exists() else None
+
+
+def _actions_run_job(url: str) -> tuple[str, str]:
+    match = _ACTIONS_URL_PATTERN.search(url)
+    if not match:
+        return "", ""
+    return match.group("run_id") or "", match.group("job_id") or ""
+
+
+def _collect_existing_log(record: JsonObject, target: Path) -> bool:
+    if target.exists() and target.stat().st_size > 0:
+        return True
+
+    inline = _inline_log_text(record)
+    if inline.strip():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(inline.rstrip() + "\n", encoding="utf-8")
+        return True
+
+    source = _source_log_path(record)
+    if source is not None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source.read_text(encoding="utf-8", errors="ignore"), encoding="utf-8")
+        return target.exists() and target.stat().st_size > 0
+
+    return False
+
+
+def build_failed_check_log_manifest(
+    *,
+    checks_json: Path,
+    out_dir: Path,
+) -> JsonObject:
+    payload = _read_json(checks_json)
+    records = _iter_check_records(payload)
+    log_dir = out_dir / "failed-check-logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    logs: list[JsonObject] = []
+    for index, record in enumerate(records):
+        if not _is_failed(record):
+            continue
+
+        name = _check_name(record, index)
+        url = _record_url(record)
+        run_id, job_id = _actions_run_job(url)
+        log_path = log_dir / f"{index + 1:02d}-{_slug(name)}.log"
+        collected = _collect_existing_log(record, log_path)
+
+        logs.append(
+            {
+                "check_name": name,
+                "status": _check_status(record),
+                "conclusion": _check_conclusion(record),
+                "url": url,
+                "run_id": run_id,
+                "job_id": job_id,
+                "download_supported": bool(run_id),
+                "log_path": log_path.as_posix(),
+                "collected": collected,
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "checks_source": checks_json.as_posix(),
+        "logs_dir": log_dir.as_posix(),
+        "failed_check_count": len(logs),
+        "collected_log_count": len([item for item in logs if bool(item.get("collected", False))]),
+        "logs": logs,
+    }
+
+
+def render_download_script(manifest: JsonObject) -> str:
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -u",
+        f"mkdir -p {shlex.quote(_string(manifest.get('logs_dir')))}",
+        "",
+    ]
+
+    for item in [_as_dict(value) for value in _as_list(manifest.get("logs"))]:
+        run_id = _string(item.get("run_id"))
+        job_id = _string(item.get("job_id"))
+        log_path = _string(item.get("log_path"))
+        if not run_id or not log_path:
+            continue
+
+        quoted_run = shlex.quote(run_id)
+        quoted_log = shlex.quote(log_path)
+        quoted_err = shlex.quote(f"{log_path}.stderr")
+        job_args = f" --job {shlex.quote(job_id)}" if job_id else ""
+
+        lines.extend(
+            [
+                f"echo collecting_failed_check_log={shlex.quote(_string(item.get('check_name')))}",
+                (
+                    f"gh run view {quoted_run}{job_args} --log-failed > {quoted_log} "
+                    f"2> {quoted_err} || "
+                    f"gh run view {quoted_run}{job_args} --log > {quoted_log} "
+                    f"2>> {quoted_err} || true"
+                ),
+                f'if [ ! -s {quoted_log} ]; then rm -f {quoted_log}; fi',
+                "",
+            ]
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_failed_check_log_artifacts(
+    *,
+    checks_json: Path,
+    out_dir: Path,
+    write_script: bool = True,
+) -> JsonObject:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest = build_failed_check_log_manifest(checks_json=checks_json, out_dir=out_dir)
+
+    script_path = out_dir / "download-failed-check-logs.sh"
+    if write_script:
+        script_path.write_text(render_download_script(manifest), encoding="utf-8")
+        script_path.chmod(0o755)
+        manifest["download_script"] = script_path.as_posix()
+
+    manifest_path = out_dir / "check-log-manifest.json"
+    manifest["manifest_path"] = manifest_path.as_posix()
+    _write_json(manifest_path, manifest)
+    return manifest
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.failed_check_log_collection")
+    parser.add_argument("--checks-json", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=Path("build/pr-quality/check-logs"))
+    parser.add_argument(
+        "--no-script",
+        action="store_true",
+        help="Do not write the GitHub Actions log download script.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    manifest = write_failed_check_log_artifacts(
+        checks_json=args.checks_json,
+        out_dir=args.out_dir,
+        write_script=not bool(args.no_script),
+    )
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/failed_check_log_collection.py
+++ b/src/sdetkit/failed_check_log_collection.py
@@ -25,9 +25,7 @@ _SUCCESS_CONCLUSIONS = {
     "success",
 }
 
-_ACTIONS_URL_PATTERN = re.compile(
-    r"/actions/runs/(?P<run_id>[0-9]+)(?:/job/(?P<job_id>[0-9]+))?"
-)
+_ACTIONS_URL_PATTERN = re.compile(r"/actions/runs/(?P<run_id>[0-9]+)(?:/job/(?P<job_id>[0-9]+))?")
 
 
 def _as_dict(value: Any) -> JsonObject:
@@ -104,7 +102,9 @@ def _is_failed(record: JsonObject) -> bool:
 
 
 def _record_url(record: JsonObject) -> str:
-    for key in ("url", "html_url", "details_url", "target_url"):
+    # GitHub check-runs include both an API URL and one or more human/action URLs.
+    # The API URL cannot be parsed by `gh run view`; prefer Actions/job URLs.
+    for key in ("details_url", "html_url", "target_url", "url"):
         value = _string(record.get(key))
         if value:
             return value
@@ -227,7 +227,7 @@ def render_download_script(manifest: JsonObject) -> str:
                     f"gh run view {quoted_run}{job_args} --log > {quoted_log} "
                     f"2>> {quoted_err} || true"
                 ),
-                f'if [ ! -s {quoted_log} ]; then rm -f {quoted_log}; fi',
+                f"if [ ! -s {quoted_log} ]; then rm -f {quoted_log}; fi",
                 "",
             ]
         )

--- a/tests/test_failed_check_log_collection.py
+++ b/tests/test_failed_check_log_collection.py
@@ -119,3 +119,37 @@ def test_failed_check_log_collection_cli_writes_manifest_and_script(
     assert stdout["failed_check_count"] == 1
     assert Path(stdout["manifest_path"]).exists()
     assert Path(stdout["download_script"]).exists()
+
+
+def test_failed_check_log_collection_prefers_actions_url_over_check_run_api_url(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane (py3.11)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "url": "https://api.github.com/repos/acme/project/check-runs/76639814418",
+                    "details_url": "https://github.com/acme/project/actions/runs/26063321385/job/76628412038",
+                }
+            ]
+        },
+    )
+
+    manifest = logs.write_failed_check_log_artifacts(
+        checks_json=checks,
+        out_dir=tmp_path / "check-logs",
+    )
+
+    item = manifest["logs"][0]
+    assert item["url"] == "https://github.com/acme/project/actions/runs/26063321385/job/76628412038"
+    assert item["run_id"] == "26063321385"
+    assert item["job_id"] == "76628412038"
+    assert item["download_supported"] is True
+
+    script = Path(manifest["download_script"]).read_text(encoding="utf-8")
+    assert "gh run view 26063321385 --job 76628412038 --log-failed" in script
+    assert "api.github.com" not in script

--- a/tests/test_failed_check_log_collection.py
+++ b/tests/test_failed_check_log_collection.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import failed_check_log_collection as logs
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_failed_check_log_collection_plans_github_actions_job_download(tmp_path: Path) -> None:
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane (py3.12)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "html_url": "https://github.com/acme/project/actions/runs/123456/job/789",
+                }
+            ]
+        },
+    )
+
+    manifest = logs.write_failed_check_log_artifacts(
+        checks_json=checks,
+        out_dir=tmp_path / "check-logs",
+    )
+
+    assert manifest["schema_version"] == "sdetkit.pr_quality.failed_check_logs.v1"
+    assert manifest["failed_check_count"] == 1
+    assert manifest["collected_log_count"] == 0
+
+    item = manifest["logs"][0]
+    assert item["check_name"] == "Fast CI lane (py3.12)"
+    assert item["run_id"] == "123456"
+    assert item["job_id"] == "789"
+    assert item["download_supported"] is True
+    assert item["collected"] is False
+    assert item["log_path"].endswith("01-fast-ci-lane-py3-12.log")
+
+    script = Path(manifest["download_script"]).read_text(encoding="utf-8")
+    assert "gh run view 123456 --job 789 --log-failed" in script
+    assert "01-fast-ci-lane-py3-12.log" in script
+
+
+def test_failed_check_log_collection_collects_inline_and_log_path_sources(
+    tmp_path: Path,
+) -> None:
+    existing = tmp_path / "quality.log"
+    existing.write_text("quality.sh cov failed\nerror: coverage dropped\n", encoding="utf-8")
+
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "PR Quality local quality gate",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log_path": existing.as_posix(),
+                },
+                {
+                    "name": "pre-commit",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "output": "ruff format failed\n1 file reformatted\n",
+                },
+            ]
+        },
+    )
+
+    manifest = logs.write_failed_check_log_artifacts(
+        checks_json=checks,
+        out_dir=tmp_path / "check-logs",
+    )
+
+    assert manifest["failed_check_count"] == 2
+    assert manifest["collected_log_count"] == 2
+    for item in manifest["logs"]:
+        assert item["collected"] is True
+        assert Path(item["log_path"]).read_text(encoding="utf-8").strip()
+
+
+def test_failed_check_log_collection_cli_writes_manifest_and_script(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "ci",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "details_url": "https://github.com/acme/project/actions/runs/42",
+                }
+            ]
+        },
+    )
+
+    rc = logs.main(
+        [
+            "--checks-json",
+            str(checks),
+            "--out-dir",
+            str(tmp_path / "check-logs"),
+        ]
+    )
+
+    assert rc == 0
+    stdout = json.loads(capsys.readouterr().out)
+    assert stdout["failed_check_count"] == 1
+    assert Path(stdout["manifest_path"]).exists()
+    assert Path(stdout["download_script"]).exists()

--- a/tests/test_pr_quality_failed_check_log_workflow.py
+++ b/tests/test_pr_quality_failed_check_log_workflow.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_pr_quality_workflow_collects_failed_check_logs_before_check_intelligence() -> None:
+    workflow = Path(".github/workflows/pr-quality-comment.yml").read_text(encoding="utf-8")
+
+    assert "python -m sdetkit.failed_check_log_collection" in workflow
+    assert "--checks-json build/pr-quality/checks/check-runs.json" in workflow
+    assert "--out-dir build/pr-quality/check-logs" in workflow
+    assert "bash build/pr-quality/check-logs/download-failed-check-logs.sh || true" in workflow
+    assert "--logs-dir build/pr-quality/check-logs/failed-check-logs" in workflow
+
+    first_collection = workflow.index("python -m sdetkit.failed_check_log_collection")
+    intelligence = workflow.index("python -m sdetkit.check_intelligence")
+    assert first_collection < intelligence
+
+
+def test_pr_quality_workflow_uploads_failed_check_log_artifacts() -> None:
+    workflow = Path(".github/workflows/pr-quality-comment.yml").read_text(encoding="utf-8")
+
+    assert "build/pr-quality/check-logs/" in workflow
+    assert "build/pr-quality/check-intelligence/" in workflow


### PR DESCRIPTION
## Summary
- Add a failed-check log collection module for PR Quality.
- Build `build/pr-quality/check-logs/check-log-manifest.json`.
- Generate a GitHub Actions log download script for failed check-run URLs.
- Re-run the collector after download so the manifest records collected logs.
- Point check intelligence at `build/pr-quality/check-logs/failed-check-logs`.
- Upload failed-check logs with the PR Quality artifact pack.

## Why
- PR Quality currently sees failed check metadata, but not the raw failed job logs.
- Without raw logs, it can only produce generic diagnoses like `Type contract drift` or `Unknown failure`.
- This is the first infrastructure step toward exact first-failing-line extraction and safe remediation.

## Verification
- `python -m pytest -q tests/test_failed_check_log_collection.py tests/test_pr_quality_failed_check_log_workflow.py tests/test_pr_quality_action_report.py tests/test_pr_quality_operator_loop_workflow.py tests/test_operator_evidence_loop.py -o addopts=`
- `python -m ruff check src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `python -m sdetkit security check --root . --format json` with zero warn/error findings in PR-owned files

## Risk
- Medium
- CI evidence collection path changes.
- Read-only: no source mutation, no auto-fix, no GHAS dismissal, no push, no merge automation.
- If logs cannot be downloaded, the manifest records missing logs and PR Quality continues using existing check metadata.
