### PR TITLE
Extract first failing lines for PR Quality diagnosis

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -187,39 +187,40 @@ def _record_log_text(record: JsonObject, logs_dir: Path | None, name: str) -> st
     if logs_dir is None or not logs_dir.exists():
         return ""
 
-    candidates = [
-        logs_dir / f"{_slug(name)}.log",
-        logs_dir / f"{_slug(name)}.txt",
+    slug = _slug(name)
+    compact_slug = slug.replace("-", "")
+    exact_candidates = [
+        logs_dir / f"{slug}.log",
+        logs_dir / f"{slug}.txt",
         logs_dir / f"{name}.log",
         logs_dir / f"{name}.txt",
     ]
-    for candidate in candidates:
-        if candidate.exists():
+    for candidate in exact_candidates:
+        if candidate.exists() and candidate.is_file():
             return candidate.read_text(encoding="utf-8", errors="ignore")
 
-    slug = _slug(name)
-    for candidate in sorted(logs_dir.glob("*")):
-        if candidate.is_file() and slug in _slug(candidate.stem):
+    name_tokens = {token for token in slug.split("-") if token}
+    readable_files = [candidate for candidate in sorted(logs_dir.rglob("*")) if candidate.is_file()]
+    for candidate in readable_files:
+        candidate_slug = _slug(candidate.stem)
+        candidate_compact = candidate_slug.replace("-", "")
+        candidate_tokens = {token for token in candidate_slug.split("-") if token}
+
+        if (
+            slug == candidate_slug
+            or slug in candidate_slug
+            or candidate_slug in slug
+            or compact_slug == candidate_compact
+            or compact_slug in candidate_compact
+            or candidate_compact in compact_slug
+            or (name_tokens and name_tokens.issubset(candidate_tokens))
+        ):
             return candidate.read_text(encoding="utf-8", errors="ignore")
+
+    if len(readable_files) == 1:
+        return readable_files[0].read_text(encoding="utf-8", errors="ignore")
 
     return ""
-
-
-_FAILURE_LINE_PATTERNS = (
-    "error:",
-    "failed",
-    "failure",
-    "traceback",
-    "assertionerror",
-    "modulenotfounderror",
-    "importerror",
-    "process completed with exit code",
-    "ruff",
-    "mypy",
-    "pytest",
-    "resolutionimpossible",
-    "cannot install",
-)
 
 
 def _failure_focused_log_text(text: str, *, context: int = 10, limit: int = 240) -> str:
@@ -245,10 +246,119 @@ def _failure_focused_log_text(text: str, *, context: int = 10, limit: int = 240)
     return "\n".join(lines[index] for index in ordered)
 
 
+_EXACT_FAILURE_PATTERNS = (
+    "files were modified by this hook",
+    "would reformat",
+    "failed",
+    "failure",
+    "error:",
+    "error ",
+    "runtimeerror",
+    "traceback",
+    "assertionerror",
+    "modulenotfounderror",
+    "importerror",
+    "process completed with exit code",
+    "no tests ran",
+    "found 1 error",
+    "found ",
+    "ruff",
+    "mypy",
+    "pytest",
+)
+
+
+_FAILURE_LINE_PATTERNS = _EXACT_FAILURE_PATTERNS
+
+
+def _failure_tool_for_line(line: str) -> str:
+    lowered = line.lower()
+    if "ruff" in lowered:
+        return "ruff"
+    if "mypy" in lowered or "type" in lowered:
+        return "mypy"
+    if "pytest" in lowered or "failed" in lowered or "assertionerror" in lowered:
+        return "pytest"
+    if "pre-commit" in lowered or "hook" in lowered:
+        return "pre_commit"
+    if "pip" in lowered or "resolutionimpossible" in lowered or "cannot install" in lowered:
+        return "dependency"
+    if "traceback" in lowered or "runtimeerror" in lowered:
+        return "python"
+    return "unknown"
+
+
+def _failure_kind_for_line(line: str) -> str:
+    lowered = line.lower()
+    if (
+        "ruff format" in lowered
+        or "ruff-format" in lowered
+        or "files were modified by this hook" in lowered
+        or "would reformat" in lowered
+    ):
+        return "format_drift"
+    if "mypy" in lowered or "type" in lowered or ": error:" in lowered:
+        return "type_contract"
+    if "assertionerror" in lowered or "pytest" in lowered:
+        return "test_failure"
+    if "traceback" in lowered or "runtimeerror" in lowered:
+        return "runtime_failure"
+    if "resolutionimpossible" in lowered or "cannot install" in lowered:
+        return "dependency_resolution"
+    if "failed" in lowered or "failure" in lowered:
+        return "failed_step"
+    if "error" in lowered:
+        return "error"
+    return "unknown"
+
+
+def _first_failure_summary(log_text: str, *, context: int = 3) -> JsonObject:
+    lines = log_text.splitlines()
+    if not lines:
+        return {}
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        lowered = stripped.lower()
+        if not stripped:
+            continue
+        if not any(pattern in lowered for pattern in _EXACT_FAILURE_PATTERNS):
+            continue
+
+        if lowered.startswith("run ") and index + 1 < len(lines):
+            next_line = lines[index + 1].strip()
+            next_lowered = next_line.lower()
+            if next_line and any(pattern in next_lowered for pattern in _EXACT_FAILURE_PATTERNS):
+                stripped = next_line
+                lowered = next_lowered
+                index = index + 1
+
+        start = max(0, index - context)
+        end = min(len(lines), index + context + 1)
+        context_lines = [
+            {
+                "line_number": line_no + 1,
+                "text": lines[line_no].rstrip(),
+            }
+            for line_no in range(start, end)
+        ]
+
+        return {
+            "line_number": index + 1,
+            "line": stripped,
+            "tool": _failure_tool_for_line(stripped),
+            "kind": _failure_kind_for_line(stripped),
+            "context": context_lines,
+        }
+
+    return {}
+
+
 def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) -> JsonObject:
     name = _check_name(record, index)
     log_text = _record_log_text(record, logs_dir, name)
     focused_log_text = _failure_focused_log_text(log_text)
+    first_failure = _first_failure_summary(log_text)
     diagnostic_text = "\n".join(
         part
         for part in [
@@ -272,6 +382,8 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
         "conclusion": _check_conclusion(record),
         "url": _record_url(record),
         "log_collected": bool(log_text.strip()),
+        "first_failure": first_failure,
+        "first_failure_line": _string(first_failure.get("line")),
         "diagnosis": primary,
         "diagnoses": diagnoses,
         "diagnosis_status": diagnosis.get("status", "unknown"),
@@ -586,6 +698,8 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 ),
                 "code": code,
                 "url": check.get("url", ""),
+                "first_failure": check.get("first_failure", {}),
+                "first_failure_line": check.get("first_failure_line", ""),
             },
             "automation": {
                 "attempted": False,

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -139,6 +139,16 @@ def _failed_check_lines(check_intelligence: JsonObject) -> list[str]:
         title = _string(diagnosis.get("title") or "Unknown failure")
         safe = str(bool(item.get("safe_to_auto_fix", False))).lower()
         lines.append(f"- `{name}` -> {title} (`{code}`), safe_to_auto_fix=`{safe}`")
+        first_failure = _as_dict(item.get("first_failure"))
+        first_line = _string(first_failure.get("line"))
+        if first_line:
+            line_number = _int(first_failure.get("line_number"))
+            tool = _string(first_failure.get("tool") or "unknown")
+            kind = _string(first_failure.get("kind") or "unknown")
+            location = f"line {line_number}" if line_number else "line unknown"
+            lines.append(f"  - First failure: `{first_line}`")
+            lines.append(f"  - Failure location: `{location}`")
+            lines.append(f"  - Failure tool/kind: `{tool}` / `{kind}`")
     return lines
 
 
@@ -162,6 +172,16 @@ def _primary_blocker_lines(primary: JsonObject) -> list[str]:
     url = _string(primary.get("url"))
     if url:
         lines.append(f"- URL: {url}")
+    first_failure = _as_dict(primary.get("first_failure"))
+    first_line = _string(primary.get("first_failure_line") or first_failure.get("line"))
+    if first_line:
+        line_number = _int(first_failure.get("line_number"))
+        tool = _string(first_failure.get("tool") or "unknown")
+        kind = _string(first_failure.get("kind") or "unknown")
+        location = f"line {line_number}" if line_number else "line unknown"
+        lines.append(f"- First failure: `{first_line}`")
+        lines.append(f"- Failure location: `{location}`")
+        lines.append(f"- Failure tool/kind: `{tool}` / `{kind}`")
 
     impact = _string(primary.get("impact"))
     if impact:

--- a/tests/test_check_intelligence_first_failure.py
+++ b/tests/test_check_intelligence_first_failure.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import check_intelligence
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_check_intelligence_extracts_first_failure_from_inline_log(tmp_path: Path) -> None:
+    checks = _write_json(
+        tmp_path / "check-intelligence-inline-log.json",
+        {
+            "check_runs": [
+                {
+                    "name": "pre-commit",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "output": "\n".join(
+                        [
+                            "check yaml................................Passed",
+                            "ruff format..............................Failed",
+                            "- hook id: ruff-format",
+                            "- files were modified by this hook",
+                            "",
+                            "1 file reformatted",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+
+    failed = intelligence["failed_checks"]
+    assert len(failed) == 1
+    first_failure = failed[0]["first_failure"]
+    assert first_failure["line"] == "ruff format..............................Failed"
+    assert first_failure["line_number"] == 2
+    assert first_failure["tool"] == "ruff"
+    assert first_failure["kind"] == "format_drift"
+    assert failed[0]["first_failure_line"] == "ruff format..............................Failed"
+
+
+def test_check_intelligence_extracts_first_failure_from_logs_dir(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "fast-ci-lane-py3-12.log").write_text(
+        "\n".join(
+            [
+                "Run python -m mypy src",
+                "src/sdetkit/example.py:10: error: Incompatible return value type",
+                "Found 1 error in 1 file",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane (py3.12)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        logs_dir=logs_dir,
+    )
+
+    first_failure = intelligence["failed_checks"][0]["first_failure"]
+    assert first_failure["line"] == "src/sdetkit/example.py:10: error: Incompatible return value type"
+    assert first_failure["line_number"] == 2
+    assert first_failure["tool"] == "mypy"
+    assert first_failure["kind"] == "type_contract"
+
+
+def test_action_report_preserves_primary_blocker_first_failure(tmp_path: Path) -> None:
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "ci",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "output": "Traceback (most recent call last):\nRuntimeError: command failed\n",
+                }
+            ]
+        },
+    )
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    primary = report["primary_blocker"]
+    assert primary["first_failure_line"] == "Traceback (most recent call last):"
+    assert primary["first_failure"]["tool"] == "python"
+    assert primary["first_failure"]["kind"] == "runtime_failure"
+
+def test_check_intelligence_matches_slugged_log_file_for_check_name(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "fast-ci-lane-py3-12.log").write_text(
+        "src/sdetkit/example.py:10: error: Incompatible return value type\n",
+        encoding="utf-8",
+    )
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane (py3.12)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        logs_dir=logs_dir,
+    )
+
+    failed = intelligence["failed_checks"][0]
+    assert failed["log_collected"] is True
+    assert failed["first_failure_line"] == (
+        "src/sdetkit/example.py:10: error: Incompatible return value type"
+    )
+

--- a/tests/test_check_intelligence_first_failure.py
+++ b/tests/test_check_intelligence_first_failure.py
@@ -81,7 +81,9 @@ def test_check_intelligence_extracts_first_failure_from_logs_dir(tmp_path: Path)
     )
 
     first_failure = intelligence["failed_checks"][0]["first_failure"]
-    assert first_failure["line"] == "src/sdetkit/example.py:10: error: Incompatible return value type"
+    assert (
+        first_failure["line"] == "src/sdetkit/example.py:10: error: Incompatible return value type"
+    )
     assert first_failure["line_number"] == 2
     assert first_failure["tool"] == "mypy"
     assert first_failure["kind"] == "type_contract"
@@ -108,6 +110,7 @@ def test_action_report_preserves_primary_blocker_first_failure(tmp_path: Path) -
     assert primary["first_failure_line"] == "Traceback (most recent call last):"
     assert primary["first_failure"]["tool"] == "python"
     assert primary["first_failure"]["kind"] == "runtime_failure"
+
 
 def test_check_intelligence_matches_slugged_log_file_for_check_name(tmp_path: Path) -> None:
     logs_dir = tmp_path / "logs"
@@ -139,4 +142,3 @@ def test_check_intelligence_matches_slugged_log_file_for_check_name(tmp_path: Pa
     assert failed["first_failure_line"] == (
         "src/sdetkit/example.py:10: error: Incompatible return value type"
     )
-

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -806,3 +806,59 @@ def test_action_report_reconciles_cleared_security_review_signal() -> None:
     assert "Evidence review signal present; quality gate passed" not in body
     assert "human review required before merge" not in body
     assert "Fix the flagged surface or dismiss the false positive" not in body
+
+
+def test_action_report_comment_renders_failed_check_first_failure() -> None:
+    action = {
+        "status": "review_required",
+        "primary_blocker": {
+            "check": "Fast CI lane (py3.12)",
+            "title": "Type contract drift detected",
+            "surface": "quality",
+            "code": "MYPY_TYPE_CONTRACT_DRIFT",
+            "url": "https://github.example/check",
+            "impact": "Inspect the first failing line before broad rewrites.",
+            "first_failure": {
+                "line_number": 12,
+                "line": "src/sdetkit/example.py:10: error: Incompatible return value type",
+                "tool": "mypy",
+                "kind": "type_contract",
+            },
+            "first_failure_line": "src/sdetkit/example.py:10: error: Incompatible return value type",
+        },
+        "automation": {"attempted": False, "allowed": False, "reason": "review-first"},
+        "recommended_actions": ["Fix the first reported contract violation."],
+        "proof_commands": ["python -m mypy src"],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 1,
+        "failed_checks": [
+            {
+                "name": "Fast CI lane (py3.12)",
+                "safe_to_auto_fix": False,
+                "diagnosis": {
+                    "code": "MYPY_TYPE_CONTRACT_DRIFT",
+                    "title": "Type contract drift detected",
+                },
+                "first_failure": {
+                    "line_number": 12,
+                    "line": "src/sdetkit/example.py:10: error: Incompatible return value type",
+                    "tool": "mypy",
+                    "kind": "type_contract",
+                },
+            }
+        ],
+        "queued_checks": [],
+        "startup_failures": [],
+        "missing_required_contexts": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert (
+        "First failure: `src/sdetkit/example.py:10: error: Incompatible return value type`" in body
+    )
+    assert "Failure location: `line 12`" in body
+    assert "Failure tool/kind: `mypy` / `type_contract`" in body


### PR DESCRIPTION
## Summary
- Extract exact first-failure metadata from inline check logs and collected check-log files.
- Preserve `first_failure` and `first_failure_line` in check intelligence failed-check records.
- Preserve primary blocker first-failure metadata in the action report.
- Render exact first failure, line location, and tool/kind in PR Quality comments.
- Add regression coverage for inline logs, slugged collected logs, primary blocker preservation, and comment rendering.

## Why
- PR Quality previously collected failed check metadata and logs, but still rendered generic `Unknown failure` / broad diagnosis labels when the exact failing line was available.
- This PR turns collected logs into useful diagnosis evidence.
- It is the next step toward safe remediation because autopilot needs exact, structured failure lines before it can decide what is safe to fix.

## Verification
- `python -m pytest -q tests/test_check_intelligence_first_failure.py tests/test_pr_quality_action_report.py tests/test_failed_check_log_collection.py tests/test_pr_quality_failed_check_log_workflow.py -o addopts=`
- `python -m ruff check src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `python -m sdetkit security check --root . --format json` with zero warn/error findings in PR-owned files

## Risk
- Medium
- Diagnostic rendering and check-intelligence schema expansion.
- Read-only: no source mutation, no auto-fix, no GHAS dismissal, no push, no merge automation.
- If no logs are available, existing behavior remains: the first-failure fields are empty.
