### PR TITLE
Classify safe remediation eligibility from exact failures

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from sdetkit import safe_remediation_eligibility
+
 from . import adaptive_diagnosis
 
 CHECK_INTELLIGENCE_SCHEMA_VERSION = "sdetkit.pr_quality.check_intelligence.v1"
@@ -376,6 +378,12 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
     ]
 
     primary = diagnoses[0] if diagnoses else {}
+    safe_remediation = safe_remediation_eligibility.classify_check_failure(
+        name=name,
+        diagnosis=primary,
+        first_failure=first_failure,
+        log_text=log_text,
+    )
     return {
         "name": name,
         "status": _check_status(record),
@@ -384,15 +392,11 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
         "log_collected": bool(log_text.strip()),
         "first_failure": first_failure,
         "first_failure_line": _string(first_failure.get("line")),
+        "safe_remediation": safe_remediation,
         "diagnosis": primary,
         "diagnoses": diagnoses,
         "diagnosis_status": diagnosis.get("status", "unknown"),
-        "safe_to_auto_fix": bool(
-            _as_dict((_as_list(diagnosis.get("fix_plan")) or [{}])[0]).get(
-                "safe_to_auto_fix",
-                False,
-            )
-        ),
+        "safe_to_auto_fix": bool(safe_remediation.get("safe_to_auto_fix", False)),
     }
 
 
@@ -700,6 +704,8 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 "url": check.get("url", ""),
                 "first_failure": check.get("first_failure", {}),
                 "first_failure_line": check.get("first_failure_line", ""),
+                "safe_remediation": check.get("safe_remediation", {}),
+                "safe_to_auto_fix": check.get("safe_to_auto_fix", False),
             },
             "automation": {
                 "attempted": False,

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -149,6 +149,12 @@ def _failed_check_lines(check_intelligence: JsonObject) -> list[str]:
             lines.append(f"  - First failure: `{first_line}`")
             lines.append(f"  - Failure location: `{location}`")
             lines.append(f"  - Failure tool/kind: `{tool}` / `{kind}`")
+        safe_remediation = _as_dict(item.get("safe_remediation"))
+        if bool(safe_remediation.get("safe_to_auto_fix", False)):
+            strategy = _string(safe_remediation.get("strategy") or "unknown")
+            reason = _string(safe_remediation.get("reason") or "approved safe remediation")
+            lines.append(f"  - Safe remediation: `{strategy}`")
+            lines.append(f"  - Safe reason: `{reason}`")
     return lines
 
 
@@ -182,6 +188,12 @@ def _primary_blocker_lines(primary: JsonObject) -> list[str]:
         lines.append(f"- First failure: `{first_line}`")
         lines.append(f"- Failure location: `{location}`")
         lines.append(f"- Failure tool/kind: `{tool}` / `{kind}`")
+    safe_remediation = _as_dict(primary.get("safe_remediation"))
+    if bool(safe_remediation.get("safe_to_auto_fix", False)):
+        strategy = _string(safe_remediation.get("strategy") or "unknown")
+        reason = _string(safe_remediation.get("reason") or "approved safe remediation")
+        lines.append(f"- Safe remediation: `{strategy}`")
+        lines.append(f"- Safe reason: `{reason}`")
 
     impact = _string(primary.get("impact"))
     if impact:

--- a/src/sdetkit/safe_remediation_eligibility.py
+++ b/src/sdetkit/safe_remediation_eligibility.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Any
+
+SCHEMA_VERSION = "sdetkit.safe_remediation_eligibility.v1"
+
+JsonObject = dict[str, Any]
+
+FORMAT_SAFE_STRATEGY = "run_pre_commit"
+REVIEW_FIRST_STRATEGY = "review_first"
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _string(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _lower(value: Any) -> str:
+    return _string(value).lower()
+
+
+def _contains_any(text: str, needles: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(needle in lowered for needle in needles)
+
+
+SAFE_FORMAT_MARKERS = (
+    "end-of-file-fixer",
+    "fix end of files",
+    "trim trailing whitespace",
+    "trailing whitespace",
+    "ruff format",
+    "ruff-format",
+    "files were modified by this hook",
+    "would reformat",
+    "import block is un-sorted or un-formatted",
+    "organize imports",
+    "found 1 error (1 fixed, 0 remaining)",
+    "1 file reformatted",
+    "files reformatted",
+)
+
+UNSAFE_REVIEW_MARKERS = (
+    "assertionerror",
+    "traceback",
+    "runtimeerror",
+    "modulenotfounderror",
+    "importerror",
+    "invaliddistribution",
+    "twine",
+    "metadata is invalid",
+    "resolutionimpossible",
+    "cannot install",
+    "mypy",
+    "incompatible return value",
+    "high entropy",
+    "secret",
+    "token",
+    "github advanced security",
+    "ghas",
+    "permission",
+    "oidc",
+    "publish",
+    "release artifact",
+)
+
+
+def classify_check_failure(
+    *,
+    name: str = "",
+    diagnosis: JsonObject | None = None,
+    first_failure: JsonObject | None = None,
+    log_text: str = "",
+) -> JsonObject:
+    diagnosis = _as_dict(diagnosis)
+    first_failure = _as_dict(first_failure)
+
+    first_line = _string(first_failure.get("line"))
+    tool = _lower(first_failure.get("tool"))
+    kind = _lower(first_failure.get("kind"))
+    code = _lower(diagnosis.get("code"))
+    title = _lower(diagnosis.get("title"))
+    combined = "\n".join(
+        value
+        for value in (
+            name,
+            first_line,
+            tool,
+            kind,
+            code,
+            title,
+            log_text,
+        )
+        if value
+    )
+
+    if _contains_any(combined, UNSAFE_REVIEW_MARKERS) and not _contains_any(
+        combined,
+        SAFE_FORMAT_MARKERS,
+    ):
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "safe_to_auto_fix": False,
+            "strategy": REVIEW_FIRST_STRATEGY,
+            "category": "review_first",
+            "reason": "Failure matches review-first markers and is not formatting-only.",
+            "proof_commands": [],
+        }
+
+    if kind == "format_drift" or _contains_any(combined, SAFE_FORMAT_MARKERS):
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "safe_to_auto_fix": True,
+            "strategy": FORMAT_SAFE_STRATEGY,
+            "category": "formatting_only",
+            "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
+            "proof_commands": [
+                "python -m pre_commit run -a",
+                "python -m ruff check src tests",
+                "python -m mypy src",
+            ],
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "safe_to_auto_fix": False,
+        "strategy": REVIEW_FIRST_STRATEGY,
+        "category": "unknown",
+        "reason": "Failure is not in the approved safe-remediation allowlist.",
+        "proof_commands": [],
+    }

--- a/tests/test_check_intelligence_safe_remediation.py
+++ b/tests/test_check_intelligence_safe_remediation.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import check_intelligence
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_check_intelligence_marks_formatting_failure_safe_to_auto_fix(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "autopilot",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "output": "\n".join(
+                        [
+                            "ruff format..............................Failed",
+                            "- hook id: ruff-format",
+                            "- files were modified by this hook",
+                            "1 file reformatted",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    failed = intelligence["failed_checks"][0]
+
+    assert failed["safe_to_auto_fix"] is True
+    assert failed["safe_remediation"]["strategy"] == "run_pre_commit"
+    assert failed["safe_remediation"]["category"] == "formatting_only"
+
+
+def test_check_intelligence_keeps_type_failure_review_first(tmp_path: Path) -> None:
+    checks = _write_json(
+        tmp_path / "check-runs.json",
+        {
+            "check_runs": [
+                {
+                    "name": "ci",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "output": "src/sdetkit/example.py:10: error: Incompatible return value type\n",
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    failed = intelligence["failed_checks"][0]
+
+    assert failed["safe_to_auto_fix"] is False
+    assert failed["safe_remediation"]["strategy"] == "review_first"

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -862,3 +862,67 @@ def test_action_report_comment_renders_failed_check_first_failure() -> None:
     )
     assert "Failure location: `line 12`" in body
     assert "Failure tool/kind: `mypy` / `type_contract`" in body
+
+
+def test_action_report_comment_renders_safe_remediation_eligibility() -> None:
+    action = {
+        "status": "review_required",
+        "primary_blocker": {
+            "check": "autopilot",
+            "title": "Formatter drift blocked pre-commit",
+            "surface": "quality",
+            "code": "PRE_COMMIT_FORMAT_DRIFT",
+            "first_failure": {
+                "line_number": 3,
+                "line": "- files were modified by this hook",
+                "tool": "pre_commit",
+                "kind": "format_drift",
+            },
+            "first_failure_line": "- files were modified by this hook",
+            "safe_to_auto_fix": True,
+            "safe_remediation": {
+                "safe_to_auto_fix": True,
+                "strategy": "run_pre_commit",
+                "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
+            },
+        },
+        "automation": {"attempted": False, "allowed": True, "reason": "safe formatting only"},
+        "recommended_actions": ["Run pre-commit and commit formatting changes."],
+        "proof_commands": ["python -m pre_commit run -a"],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 1,
+        "failed_checks": [
+            {
+                "name": "autopilot",
+                "safe_to_auto_fix": True,
+                "diagnosis": {
+                    "code": "PRE_COMMIT_FORMAT_DRIFT",
+                    "title": "Formatter drift blocked pre-commit",
+                },
+                "first_failure": {
+                    "line_number": 3,
+                    "line": "- files were modified by this hook",
+                    "tool": "pre_commit",
+                    "kind": "format_drift",
+                },
+                "safe_remediation": {
+                    "safe_to_auto_fix": True,
+                    "strategy": "run_pre_commit",
+                    "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
+                },
+            }
+        ],
+        "queued_checks": [],
+        "startup_failures": [],
+        "missing_required_contexts": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert "Safe remediation: `run_pre_commit`" in body
+    assert (
+        "Safe reason: `Failure is limited to deterministic formatting or whitespace hooks.`" in body
+    )

--- a/tests/test_safe_remediation_eligibility.py
+++ b/tests/test_safe_remediation_eligibility.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from sdetkit import safe_remediation_eligibility as eligibility
+
+
+def test_safe_remediation_allows_format_hook_modified_files() -> None:
+    result = eligibility.classify_check_failure(
+        name="autopilot",
+        diagnosis={"code": "PRE_COMMIT_FORMAT_DRIFT"},
+        first_failure={
+            "line": "- files were modified by this hook",
+            "tool": "pre_commit",
+            "kind": "format_drift",
+        },
+    )
+
+    assert result["schema_version"] == "sdetkit.safe_remediation_eligibility.v1"
+    assert result["safe_to_auto_fix"] is True
+    assert result["strategy"] == "run_pre_commit"
+    assert result["category"] == "formatting_only"
+    assert "python -m pre_commit run -a" in result["proof_commands"]
+
+
+def test_safe_remediation_allows_ruff_import_sorting_only() -> None:
+    result = eligibility.classify_check_failure(
+        name="Fast CI lane (py3.12)",
+        diagnosis={"code": "RUFF_IMPORT_SORT"},
+        first_failure={
+            "line": "I001 [*] Import block is un-sorted or un-formatted",
+            "tool": "ruff",
+            "kind": "format_drift",
+        },
+    )
+
+    assert result["safe_to_auto_fix"] is True
+    assert result["strategy"] == "run_pre_commit"
+
+
+def test_safe_remediation_blocks_type_runtime_release_and_security_failures() -> None:
+    unsafe_lines = [
+        "src/sdetkit/example.py:10: error: Incompatible return value type",
+        "Traceback (most recent call last):",
+        "ERROR: InvalidDistribution: Metadata is invalid",
+        "High-entropy string literal detected.",
+    ]
+
+    for line in unsafe_lines:
+        result = eligibility.classify_check_failure(
+            name="ci",
+            diagnosis={"code": "UNKNOWN"},
+            first_failure={"line": line, "tool": "unknown", "kind": "error"},
+        )
+
+        assert result["safe_to_auto_fix"] is False
+        assert result["strategy"] == "review_first"


### PR DESCRIPTION
## Summary
- Add deterministic safe-remediation eligibility classification from exact first-failure evidence.
- Mark narrow formatting-only failures as `safe_to_auto_fix=true`.
- Keep type, runtime, release/package, dependency, security, and unknown failures review-first.
- Preserve safe-remediation metadata in check intelligence and action reports.
- Render safe-remediation strategy/reason in PR Quality comments.

## Why
- PR Quality now extracts exact first-failure lines.
- The next step is deciding whether a failure is safe to fix automatically.
- This PR adds the policy layer only; it does not mutate files, commit fixes, push branches, dismiss security findings, or merge.

## Verification
- `python -m pytest -q tests/test_safe_remediation_eligibility.py tests/test_check_intelligence_safe_remediation.py tests/test_check_intelligence_first_failure.py tests/test_pr_quality_action_report.py tests/test_failed_check_log_collection.py tests/test_pr_quality_failed_check_log_workflow.py -o addopts=`
- `python -m ruff check src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `PYTHONPATH=src python -m build`
- `PYTHONPATH=src python -m twine check dist/*`
- `python -m sdetkit security check --root . --format json` with zero warn/error findings in PR-owned files

## Safety
- Read-only classification and rendering only.
- No source mutation.
- No auto-commit.
- No push automation.
- No GHAS/security dismissal.
- No merge automation.

## Safe allowlist
- end-of-file fixer
- trailing whitespace
- ruff format
- import sorting

## Review-first surfaces
- mypy/type errors
- pytest/assertion failures
- runtime tracebacks
- release/package failures
- dependency resolver failures
- GHAS/security findings
- workflow permissions, secrets, OIDC, or publish surfaces
