### PR TITLE
Commit approved safe formatting fixes from PR Quality

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -5,10 +5,11 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: write
   issues: write
-
+  pull-requests: write
+  checks: read
+  actions: read
 concurrency:
   group: pr-quality-comment-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -269,6 +270,18 @@ jobs:
           )
           PY
 
+      - name: Commit approved safe formatting fixes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PYTHONPATH=src python tools/maintenance_autopilot.py \
+            --owner "${{ github.repository_owner }}" \
+            --repo "${{ github.event.repository.name }}" \
+            --commit-safe-fixes \
+            --check-intelligence-json build/pr-quality/check-intelligence/check-intelligence.json \
+            --pr-quality-safe-bridge-only \
+            --out-dir build/pr-quality/safe-formatting-autopilot
+
       - name: Build PR comment body
         run: |
           mkdir -p build/pr-quality
@@ -345,6 +358,7 @@ jobs:
             build/pr-quality/checks/
             build/pr-quality/check-logs/
             build/pr-quality/check-intelligence/
+            build/pr-quality/safe-formatting-autopilot/
             build/pr-quality/pr-evidence-narrative.md
             build/sdetkit/evidence-graph/
             build/sdetkit/operator-loop/

--- a/src/sdetkit/safe_remediation_eligibility.py
+++ b/src/sdetkit/safe_remediation_eligibility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 SCHEMA_VERSION = "sdetkit.safe_remediation_eligibility.v1"
@@ -20,6 +21,26 @@ def _string(value: Any) -> str:
 
 def _lower(value: Any) -> str:
     return _string(value).lower()
+
+
+FILE_PATH_RE = re.compile(
+    r"(?P<path>(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\."
+    r"(?:py|pyi|toml|yaml|yml|md|rst|txt|json|cfg|ini))"
+)
+
+
+def _extract_affected_files(text: str) -> list[str]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for match in FILE_PATH_RE.finditer(text):
+        value = match.group("path").strip().strip(":")
+        if not value or value in seen:
+            continue
+        if value.startswith(("http://", "https://")):
+            continue
+        seen.add(value)
+        values.append(value)
+    return values
 
 
 def _contains_any(text: str, needles: tuple[str, ...]) -> bool:
@@ -97,6 +118,16 @@ def classify_check_failure(
         if value
     )
 
+    raw_context = first_failure.get("context", [])
+    if not isinstance(raw_context, list):
+        raw_context = []
+    context_text = "\n".join(
+        _string(_as_dict(item).get("text")) for item in raw_context if isinstance(item, dict)
+    )
+    affected_files = _extract_affected_files(
+        "\n".join(value for value in (first_line, context_text, log_text) if value)
+    )
+
     if _contains_any(combined, UNSAFE_REVIEW_MARKERS) and not _contains_any(
         combined,
         SAFE_FORMAT_MARKERS,
@@ -116,6 +147,7 @@ def classify_check_failure(
             "safe_to_auto_fix": True,
             "strategy": FORMAT_SAFE_STRATEGY,
             "category": "formatting_only",
+            "affected_files": affected_files,
             "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
             "proof_commands": [
                 "python -m pre_commit run -a",

--- a/tests/test_maintenance_autopilot_pr_quality_bridge.py
+++ b/tests/test_maintenance_autopilot_pr_quality_bridge.py
@@ -146,6 +146,7 @@ def test_autopilot_bridge_refuses_mixed_review_first_failures(
     assert result["failed_check_count"] == 2
     assert result["eligible_plan_count"] == 1
 
+
 def test_autopilot_bridge_only_mode_skips_full_baseline(
     tmp_path: Path,
     monkeypatch,
@@ -180,3 +181,16 @@ def test_autopilot_bridge_only_mode_skips_full_baseline(
     )
     assert "baseline_pre_commit" not in report["steps"]
 
+
+def test_autopilot_bridge_creates_missing_output_directory(tmp_path: Path) -> None:
+    autopilot = _load_autopilot()
+    check_intelligence = _write_json(tmp_path / "check-intelligence.json", {"failed_checks": []})
+    missing_out = tmp_path / "missing" / "safe-formatting-autopilot"
+
+    result = autopilot._write_safe_fix_artifacts_from_check_intelligence(
+        missing_out,
+        check_intelligence,
+    )
+
+    assert result["ok"] is True
+    assert (missing_out / "pr-quality-safe-remediation-bridge.json").exists()

--- a/tests/test_maintenance_autopilot_pr_quality_bridge.py
+++ b/tests/test_maintenance_autopilot_pr_quality_bridge.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from sdetkit import adaptive_safe_remediation
+
+
+def _load_autopilot():
+    path = Path("tools/maintenance_autopilot.py")
+    spec = importlib.util.spec_from_file_location("maintenance_autopilot", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+BRIDGE_ONLY_MODE = "_".join(("pr", "quality", "safe", "bridge", "only"))
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_autopilot_bridges_pr_quality_safe_remediation_to_existing_commit_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    autopilot = _load_autopilot()
+    check_intelligence = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "failed_checks": [
+                {
+                    "name": "autopilot",
+                    "safe_to_auto_fix": True,
+                    "diagnosis": {"code": "PRE_COMMIT_FORMAT_DRIFT"},
+                    "first_failure": {
+                        "line": "- files were modified by this hook",
+                        "tool": "pre_commit",
+                        "kind": "format_drift",
+                    },
+                    "safe_remediation": {
+                        "schema_version": "sdetkit.safe_remediation_eligibility.v1",
+                        "safe_to_auto_fix": True,
+                        "strategy": "run_pre_commit",
+                        "category": "formatting_only",
+                        "affected_files": ["tests/test_example.py"],
+                        "proof_commands": ["python -m pre_commit run -a"],
+                    },
+                }
+            ]
+        },
+    )
+
+    captured: dict[str, dict] = {}
+
+    def fake_run_plan(plan, cwd):
+        captured["plan"] = plan
+        return {
+            "schema_version": "sdetkit.adaptive_safe_remediation.v1",
+            "ok": True,
+            "safe_to_auto_fix": True,
+            "fix_type": "format_only",
+            "commands": [{"command": "python -m pre_commit run -a", "ok": True}],
+        }
+
+    def fake_commit(out_dir, plan, result):
+        captured["commit_plan"] = plan
+        captured["commit_result"] = result
+        return {"ok": True, "attempted": True, "pushed": True, "reason": "pushed"}
+
+    monkeypatch.setattr(adaptive_safe_remediation, "run_plan", fake_run_plan)
+    monkeypatch.setattr(autopilot, "_commit_safe_fix_changes", fake_commit)
+
+    result = autopilot._write_safe_fix_artifacts_from_check_intelligence(
+        tmp_path,
+        check_intelligence,
+    )
+
+    assert result["attempted"] is True
+    assert result["remediation_ok"] is True
+    assert result["commit_pushed"] is True
+    assert captured["plan"]["safe_to_auto_fix"] is True
+    assert captured["plan"]["fix_type"] == "format_only"
+    assert captured["plan"]["requires_human_review"] is False
+    assert captured["plan"]["commands"] == ["python -m pre_commit run -a"]
+    assert captured["plan"]["affected_files"] == ["tests/test_example.py"]
+    assert (tmp_path / "safe-fix-plan.json").exists()
+    assert (tmp_path / "pr-quality-safe-remediation-bridge.json").exists()
+
+
+def test_autopilot_bridge_refuses_mixed_review_first_failures(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    autopilot = _load_autopilot()
+    check_intelligence = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "failed_checks": [
+                {
+                    "name": "autopilot",
+                    "safe_to_auto_fix": True,
+                    "diagnosis": {"code": "PRE_COMMIT_FORMAT_DRIFT"},
+                    "safe_remediation": {
+                        "schema_version": "sdetkit.safe_remediation_eligibility.v1",
+                        "safe_to_auto_fix": True,
+                        "strategy": "run_pre_commit",
+                        "category": "formatting_only",
+                        "affected_files": ["tests/test_example.py"],
+                    },
+                },
+                {
+                    "name": "ci",
+                    "safe_to_auto_fix": False,
+                    "diagnosis": {"code": "MYPY_TYPE_CONTRACT_DRIFT"},
+                    "safe_remediation": {
+                        "schema_version": "sdetkit.safe_remediation_eligibility.v1",
+                        "safe_to_auto_fix": False,
+                        "strategy": "review_first",
+                        "category": "review_first",
+                    },
+                },
+            ]
+        },
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("mixed review-first failures must not remediate")
+
+    monkeypatch.setattr(adaptive_safe_remediation, "run_plan", fail_if_called)
+    monkeypatch.setattr(autopilot, "_commit_safe_fix_changes", fail_if_called)
+
+    result = autopilot._write_safe_fix_artifacts_from_check_intelligence(
+        tmp_path,
+        check_intelligence,
+    )
+
+    assert result["attempted"] is False
+    assert result["ok"] is False
+    assert "review-first" in result["reason"]
+    assert result["failed_check_count"] == 2
+    assert result["eligible_plan_count"] == 1
+
+def test_autopilot_bridge_only_mode_skips_full_baseline(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    autopilot = _load_autopilot()
+    check_intelligence = _write_json(tmp_path / "check-intelligence.json", {"failed_checks": []})
+
+    def fail_if_baseline_runs(*args, **kwargs):
+        raise AssertionError("bridge-only mode must not run the full maintenance baseline")
+
+    monkeypatch.setattr(autopilot, "_run", fail_if_baseline_runs)
+
+    rc = autopilot.main(
+        [
+            "--owner",
+            "sherif69-sa",
+            "--repo",
+            "DevS69-sdetkit",
+            "--check-intelligence-json",
+            str(check_intelligence),
+            "--pr-quality-safe-bridge-only",
+            "--out-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+
+    assert rc == 0
+    report = json.loads((tmp_path / "out" / "autopilot-report.json").read_text())
+    assert report["mode"] == BRIDGE_ONLY_MODE
+    assert report["steps"]["pr_quality_safe_remediation_bridge"]["reason"] == (
+        "no failed checks to remediate"
+    )
+    assert "baseline_pre_commit" not in report["steps"]
+

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -22,10 +22,13 @@ def test_pr_quality_comment_workflow_has_queue_safe_concurrency_and_timeout() ->
 
 def test_pr_quality_comment_workflow_has_comment_permissions() -> None:
     text = _workflow_text()
+    permissions = text.split("jobs:", 1)[0]
 
-    assert "contents: read" in text
-    assert "pull-requests: write" in text
-    assert "issues: write" in text
+    assert "contents: write" in permissions
+    assert "issues: write" in permissions
+    assert "pull-requests: write" in permissions
+    assert "checks: read" in permissions
+    assert "actions: read" in permissions
 
 
 def test_pr_quality_comment_workflow_writes_comment_status_before_posting() -> None:
@@ -187,3 +190,30 @@ def test_pr_quality_comment_workflow_passes_evidence_narrative_into_final_commen
 
     assert narrative_step < narrative_json < action_report_step
     assert action_report_step < evidence_arg < comment_out
+
+
+def test_pr_quality_workflow_runs_safe_formatting_autopilot_bridge() -> None:
+    text = Path(".github/workflows/pr-quality-comment.yml").read_text(encoding="utf-8")
+
+    check_intelligence = text.index("python -m sdetkit.check_intelligence")
+    bridge = text.index("Commit approved safe formatting fixes")
+    narrative = text.index("--out build/pr-quality/pr-evidence-narrative.md")
+
+    assert check_intelligence < bridge < narrative
+    assert "tools/maintenance_autopilot.py" in text
+    assert "--commit-safe-fixes" in text
+    assert (
+        "--check-intelligence-json build/pr-quality/check-intelligence/check-intelligence.json"
+        in text
+    )
+    assert "--pr-quality-safe-bridge-only" in text
+    assert "--out-dir build/pr-quality/safe-formatting-autopilot" in text
+    assert "build/pr-quality/safe-formatting-autopilot/" in text
+
+
+def test_pr_quality_workflow_grants_contents_write_for_safe_branch_commit() -> None:
+    text = Path(".github/workflows/pr-quality-comment.yml").read_text(encoding="utf-8")
+    permissions = text.split("jobs:", 1)[0]
+
+    assert "permissions:" in permissions
+    assert "contents: write" in permissions

--- a/tests/test_safe_remediation_eligibility.py
+++ b/tests/test_safe_remediation_eligibility.py
@@ -53,3 +53,24 @@ def test_safe_remediation_blocks_type_runtime_release_and_security_failures() ->
 
         assert result["safe_to_auto_fix"] is False
         assert result["strategy"] == "review_first"
+
+
+def test_safe_remediation_extracts_affected_files_from_log_context() -> None:
+    result = eligibility.classify_check_failure(
+        name="autopilot",
+        diagnosis={"code": "PRE_COMMIT_FORMAT_DRIFT"},
+        first_failure={
+            "line": "- files were modified by this hook",
+            "tool": "pre_commit",
+            "kind": "format_drift",
+            "context": [
+                {"line_number": 1, "text": "fix end of files................Failed"},
+                {"line_number": 2, "text": "Fixing tests/test_example.py"},
+            ],
+        },
+        log_text="ruff format\n1 file reformatted\n",
+    )
+
+    assert result["safe_to_auto_fix"] is True
+    assert result["strategy"] == "run_pre_commit"
+    assert result["affected_files"] == ["tests/test_example.py"]

--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -499,6 +499,7 @@ def _write_safe_fix_artifacts_from_check_intelligence(
     out_dir: Path,
     check_intelligence_path: Path,
 ) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
     payload: dict[str, Any] = {
         "schema_version": "sdetkit.maintenance.autopilot.pr_quality_safe_remediation_bridge.v1",
         "ok": False,

--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -430,6 +430,147 @@ def _commit_safe_fix_changes(
     return result
 
 
+BRIDGE_ONLY_MODE = "_".join(("pr", "quality", "safe", "bridge", "only"))
+
+
+def _bridge_as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _bridge_as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_plan_from_pr_quality_check(check: dict[str, Any]) -> dict[str, Any]:
+    from sdetkit import adaptive_safe_fix
+
+    safe_remediation = _bridge_as_dict(check.get("safe_remediation"))
+    diagnosis = _bridge_as_dict(check.get("diagnosis"))
+    if check.get("safe_to_auto_fix") is not True:
+        return {}
+    if safe_remediation.get("safe_to_auto_fix") is not True:
+        return {}
+    if str(safe_remediation.get("strategy", "")) != "run_pre_commit":
+        return {}
+    if str(safe_remediation.get("category", "")) != "formatting_only":
+        return {}
+
+    affected_files = [
+        str(value).strip()
+        for value in _bridge_as_list(safe_remediation.get("affected_files"))
+        if str(value).strip() and "<" not in str(value) and ">" not in str(value)
+    ]
+    if not affected_files:
+        return {}
+
+    proof_commands = [
+        str(value).strip()
+        for value in _bridge_as_list(safe_remediation.get("proof_commands"))
+        if str(value).strip()
+    ] or [
+        "python -m pre_commit run -a",
+        "python -m ruff check src tests",
+        "python -m mypy src",
+    ]
+
+    return {
+        "schema_version": adaptive_safe_fix.SCHEMA_VERSION,
+        "source_schema_version": str(safe_remediation.get("schema_version", "")),
+        "source_code": str(
+            diagnosis.get("code")
+            or _bridge_as_dict(check.get("first_failure")).get("kind")
+            or "PRE_COMMIT_FORMAT_DRIFT"
+        ).upper(),
+        "title": "PR Quality approved formatting-only remediation",
+        "safe_to_auto_fix": True,
+        "fix_type": "format_only",
+        "requires_human_review": False,
+        "affected_files": sorted(set(affected_files)),
+        "reason": str(
+            safe_remediation.get("reason")
+            or "PR Quality classified this failure as formatting-only safe remediation."
+        ),
+        "commands": ["python -m pre_commit run -a"],
+        "proof_commands": proof_commands[:3],
+    }
+
+
+def _write_safe_fix_artifacts_from_check_intelligence(
+    out_dir: Path,
+    check_intelligence_path: Path,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": "sdetkit.maintenance.autopilot.pr_quality_safe_remediation_bridge.v1",
+        "ok": False,
+        "attempted": False,
+        "reason": "",
+        "check_intelligence_path": check_intelligence_path.as_posix(),
+    }
+
+    if not check_intelligence_path.exists():
+        payload["reason"] = "check intelligence file not found"
+        _write_json(out_dir / "pr-quality-safe-remediation-bridge.json", payload)
+        return payload
+
+    intelligence = _load_json(check_intelligence_path)
+    failed_checks = [
+        _bridge_as_dict(item)
+        for item in _bridge_as_list(intelligence.get("failed_checks"))
+        if isinstance(item, dict)
+    ]
+
+    if not failed_checks:
+        payload["ok"] = True
+        payload["reason"] = "no failed checks to remediate"
+        _write_json(out_dir / "pr-quality-safe-remediation-bridge.json", payload)
+        return payload
+
+    plans = [_safe_plan_from_pr_quality_check(check) for check in failed_checks]
+    eligible_plans = [plan for plan in plans if plan]
+
+    if len(eligible_plans) != len(failed_checks):
+        payload["reason"] = "one or more failed checks are review-first or lack affected files"
+        payload["failed_check_count"] = len(failed_checks)
+        payload["eligible_plan_count"] = len(eligible_plans)
+        _write_json(out_dir / "pr-quality-safe-remediation-bridge.json", payload)
+        return payload
+
+    affected_files: set[str] = set()
+    for plan in eligible_plans:
+        affected_files.update(str(value) for value in _bridge_as_list(plan.get("affected_files")))
+
+    merged_plan = dict(eligible_plans[0])
+    merged_plan["affected_files"] = sorted(affected_files)
+    merged_plan["reason"] = "All failed checks are PR Quality approved formatting-only remediation."
+    _write_json(out_dir / "safe-fix-plan.json", merged_plan)
+
+    from sdetkit import adaptive_safe_remediation
+
+    remediation_result = adaptive_safe_remediation.run_plan(merged_plan, cwd=Path.cwd())
+    remediation_result["plan_path"] = (out_dir / "safe-fix-plan.json").as_posix()
+    _write_json(out_dir / "adaptive-safe-remediation-result.json", remediation_result)
+    (out_dir / "adaptive-safe-remediation-result.md").write_text(
+        adaptive_safe_remediation.render_markdown(remediation_result),
+        encoding="utf-8",
+    )
+
+    commit_result = _commit_safe_fix_changes(out_dir, merged_plan, remediation_result)
+    payload.update(
+        {
+            "ok": bool(remediation_result.get("ok", False)),
+            "attempted": True,
+            "reason": "PR Quality safe-remediation bridge executed",
+            "remediation_ok": bool(remediation_result.get("ok", False)),
+            "commit_ok": bool(commit_result.get("ok", False)),
+            "commit_pushed": bool(commit_result.get("pushed", False)),
+            "affected_files": sorted(affected_files),
+        }
+    )
+    _write_json(out_dir / "pr-quality-safe-remediation-bridge.json", payload)
+    _write_safe_fix_learning_outcome(out_dir, merged_plan, remediation_result, commit_result)
+    return payload
+
+
 POLICY_RULES: dict[str, dict[str, Any]] = {
     "baseline_pre_commit": {
         "actions": ["python -m pre_commit run -a"],
@@ -555,6 +696,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--memory-db", default=".sdetkit/maintenance/failure-memory.jsonl")
     parser.add_argument("--auto-remediate-safe", action="store_true")
     parser.add_argument("--commit-safe-fixes", action="store_true")
+    parser.add_argument("--check-intelligence-json", default="")
+    parser.add_argument("--pr-quality-safe-bridge-only", action="store_true")
     parser.add_argument("--max-remediation-attempts", type=int, default=3)
     parser.add_argument("--remediation-cooldown-runs", type=int, default=2)
     args = parser.parse_args(argv)
@@ -576,6 +719,39 @@ def main(argv: list[str] | None = None) -> int:
     _ACTIVE_FAILURE_CONTEXT["owner"] = args.owner
     _ACTIVE_FAILURE_CONTEXT["repo"] = args.repo
 
+    if str(args.check_intelligence_json).strip():
+        report["steps"]["pr_quality_safe_remediation_bridge"] = (
+            _write_safe_fix_artifacts_from_check_intelligence(
+                out_dir,
+                Path(str(args.check_intelligence_json)),
+            )
+        )
+
+    if bool(args.pr_quality_safe_bridge_only):
+        report["mode"] = BRIDGE_ONLY_MODE
+        bridge = report["steps"].get("pr_quality_safe_remediation_bridge", {})
+        report["live_run"] = {
+            "attempted": False,
+            "executed": False,
+            "reason": "safe bridge only; skip the full maintenance baseline",
+        }
+        _write_json(out_dir / "autopilot-report.json", report)
+        (out_dir / "autopilot-report.md").write_text(
+            "\n".join(
+                [
+                    "# Maintenance autopilot report",
+                    "",
+                    f"- mode: `{BRIDGE_ONLY_MODE}`",
+                    f"- bridge attempted: `{bool(bridge.get('attempted', False))}`",
+                    f"- bridge reason: `{bridge.get('reason', 'n/a')}`",
+                ]
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"json: {out_dir / 'autopilot-report.json'}")
+        print(f"markdown: {out_dir / 'autopilot-report.md'}")
+        return 0
     # 1) Baseline checks
     report["steps"]["baseline_pre_commit"] = _run([sys.executable, "-m", "pre_commit", "run", "-a"])
     report["steps"]["baseline_kpi_test"] = _run(


### PR DESCRIPTION
## Summary
- Bridge PR Quality safe-remediation evidence into the existing maintenance autopilot safe-fix path.
- Extract affected files for formatting-only safe remediation.
- Add bridge-only autopilot mode for PR Quality so it can run without the full maintenance baseline.
- Wire PR Quality to run the safe-formatting bridge after check intelligence is built.
- Upload safe-formatting autopilot artifacts with PR Quality artifacts.

## Why
This completes the guarded mutation loop:

failed check logs
→ exact first failure extraction
→ safe remediation eligibility
→ PR Quality safe-formatting bridge
→ existing autopilot safe-remediation plan
→ existing same-repo PR commit/push guard

## Safety
- Only runs when PR Quality marks every failed check as safe formatting-only remediation.
- Requires affected files from safe-remediation metadata.
- Uses existing `_commit_safe_fix_changes` guardrails:
  - `--commit-safe-fixes` must be enabled.
  - event must be `pull_request`.
  - branch must be same-repository, not base/protected.
  - token must exist.
  - changed files must be inside the safe plan.
- Review-first remains required for type, runtime, release, dependency, security, and unknown failures.
- No GHAS/security dismissal.
- No broad auto-fix for tests, mypy, release, or dependency failures.

## Verification
- `python -m pytest -q tests/test_maintenance_autopilot_pr_quality_bridge.py tests/test_pr_quality_comment_observability_workflow.py tests/test_safe_remediation_eligibility.py -o addopts=`
- `python -m ruff check tools src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `PYTHONPATH=src python -m twine check dist/*`
- `python -m sdetkit security check --root . --format json` with zero PR-owned warn/error findings
