### PR TITLE
Surface safe fix outcomes in PR Quality

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -92,6 +92,35 @@ def _quality_lines(evidence_narrative: JsonObject) -> list[str]:
     return lines
 
 
+def _safe_fix_outcome_lines(outcome: JsonObject) -> list[str]:
+    if not outcome:
+        return ["- none"]
+
+    files = [_string(item) for item in _as_list(outcome.get("affected_files")) if _string(item)]
+    proof_commands = [
+        _string(item) for item in _as_list(outcome.get("proof_commands")) if _string(item)
+    ]
+
+    lines = [
+        f"- Status: `{_string(outcome.get('status') or 'unknown')}`",
+        f"- Attempted: `{str(bool(outcome.get('attempted', False))).lower()}`",
+        f"- Remediation OK: `{str(bool(outcome.get('remediation_ok', False))).lower()}`",
+        f"- Committed: `{str(bool(outcome.get('committed', False))).lower()}`",
+        f"- Pushed: `{str(bool(outcome.get('pushed', False))).lower()}`",
+        f"- Commit SHA: `{_string(outcome.get('commit_sha') or 'none')}`",
+        "- Files: " + (", ".join(f"`{item}`" for item in files) if files else "`none`"),
+        f"- Reason: {_string(outcome.get('reason') or 'none')}",
+    ]
+
+    if proof_commands:
+        lines.append("- Proof after fix:")
+        lines.extend(f"  - `{item}`" for item in proof_commands)
+    else:
+        lines.append("- Proof after fix: none")
+
+    return lines
+
+
 def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -> list[str]:
     security = _as_dict(
         check_intelligence.get("security_review")
@@ -421,8 +450,10 @@ def render_comment_body(
     action_report: JsonObject,
     check_intelligence: JsonObject,
     evidence_narrative: JsonObject | None = None,
+    safe_fix_outcome: JsonObject | None = None,
 ) -> str:
     evidence_narrative = evidence_narrative or {}
+    safe_fix_outcome = safe_fix_outcome or _as_dict(check_intelligence.get("safe_fix_outcome"))
     status = _string(action_report.get("status") or "unknown")
     evidence_signal_heading, evidence_signal_lines, evidence_review_required = _evidence_signal(
         evidence_narrative
@@ -470,6 +501,10 @@ def render_comment_body(
             "## Automation decision",
             "",
             *_automation_lines(action_report),
+            "",
+            "## Safe fix outcome",
+            "",
+            *_safe_fix_outcome_lines(_as_dict(safe_fix_outcome)),
             "",
             "## Evidence collected",
             "",

--- a/src/sdetkit/safe_fix_outcome.py
+++ b/src/sdetkit/safe_fix_outcome.py
@@ -115,9 +115,7 @@ def build_outcome(artifacts_dir: Path) -> JsonObject:
         commit.get("commit"),
     )
     committed = (
-        _truthy(bridge.get("commit_ok"))
-        or _truthy(commit.get("committed"))
-        or bool(commit_sha)
+        _truthy(bridge.get("commit_ok")) or _truthy(commit.get("committed")) or bool(commit_sha)
     )
     pushed = _truthy(bridge.get("commit_pushed")) or _truthy(commit.get("pushed"))
 

--- a/src/sdetkit/safe_fix_outcome.py
+++ b/src/sdetkit/safe_fix_outcome.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+SCHEMA_VERSION = ".".join(("sdetkit", "safe", "fix", "outcome", "v1"))
+
+
+def _load_json(path: Path) -> JsonObject:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _string_list(value: Any) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in _as_list(value):
+        text = _string(item)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def _first_nonempty(*values: Any) -> str:
+    for value in values:
+        text = _string(value)
+        if text and text.lower() not in {"none", "null", "unknown"}:
+            return text
+    return ""
+
+
+def _existing_artifact(artifacts_dir: Path, name: str) -> str:
+    path = artifacts_dir / name
+    return path.as_posix() if path.exists() else ""
+
+
+def _files_from_sources(*sources: Any) -> list[str]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for source in sources:
+        for item in _as_list(source):
+            text = _string(item)
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            values.append(text)
+    return values
+
+
+def _command_results(remediation_result: JsonObject) -> list[JsonObject]:
+    values: list[JsonObject] = []
+    for item in _as_list(remediation_result.get("commands")):
+        if not isinstance(item, dict):
+            continue
+        command = _string(item.get("command"))
+        if not command:
+            continue
+        values.append(
+            {
+                "command": command,
+                "ok": _truthy(item.get("ok")),
+                "returncode": item.get("returncode", item.get("exit_code", "")),
+            }
+        )
+    return values
+
+
+def build_outcome(artifacts_dir: Path) -> JsonObject:
+    artifacts_dir = Path(artifacts_dir)
+    bridge = _load_json(artifacts_dir / "pr-quality-safe-remediation-bridge.json")
+    plan = _load_json(artifacts_dir / "safe-fix-plan.json")
+    remediation = _load_json(artifacts_dir / "adaptive-safe-remediation-result.json")
+    commit = _load_json(artifacts_dir / "adaptive-safe-commit-result.json")
+
+    attempted = (
+        _truthy(bridge.get("attempted"))
+        or _truthy(remediation.get("attempted"))
+        or bool(remediation)
+        or _truthy(commit.get("attempted"))
+    )
+    remediation_ok = _truthy(bridge.get("remediation_ok")) or _truthy(remediation.get("ok"))
+
+    commit_sha = _first_nonempty(
+        bridge.get("commit_sha"),
+        commit.get("commit_sha"),
+        commit.get("sha"),
+        commit.get("commit"),
+    )
+    committed = (
+        _truthy(bridge.get("commit_ok"))
+        or _truthy(commit.get("committed"))
+        or bool(commit_sha)
+    )
+    pushed = _truthy(bridge.get("commit_pushed")) or _truthy(commit.get("pushed"))
+
+    if not attempted:
+        status = "not_attempted"
+    elif pushed:
+        status = "pushed"
+    elif committed:
+        status = "committed_not_pushed"
+    elif remediation_ok:
+        status = "remediated_not_committed"
+    else:
+        status = "attempted_without_success"
+
+    affected_files = _files_from_sources(
+        bridge.get("affected_files"),
+        plan.get("affected_files"),
+        commit.get("affected_files"),
+        commit.get("files"),
+        remediation.get("affected_files"),
+        remediation.get("changed_files"),
+    )
+
+    proof_commands = _string_list(plan.get("proof_commands"))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "attempted": attempted,
+        "remediation_ok": remediation_ok,
+        "committed": committed,
+        "pushed": pushed,
+        "commit_sha": commit_sha or "none",
+        "affected_files": affected_files,
+        "reason": _first_nonempty(
+            bridge.get("reason"),
+            commit.get("reason"),
+            remediation.get("reason"),
+            plan.get("reason"),
+            "no safe-fix outcome recorded",
+        ),
+        "safe_to_auto_fix": _truthy(plan.get("safe_to_auto_fix")),
+        "fix_type": _string(plan.get("fix_type"), "unknown"),
+        "proof_commands": proof_commands,
+        "command_results": _command_results(remediation),
+        "artifacts": {
+            "bridge": _existing_artifact(
+                artifacts_dir,
+                "pr-quality-safe-remediation-bridge.json",
+            ),
+            "plan": _existing_artifact(artifacts_dir, "safe-fix-plan.json"),
+            "remediation": _existing_artifact(
+                artifacts_dir,
+                "adaptive-safe-remediation-result.json",
+            ),
+            "commit": _existing_artifact(
+                artifacts_dir,
+                "adaptive-safe-commit-result.json",
+            ),
+        },
+    }
+
+
+def render_markdown(outcome: JsonObject) -> str:
+    files = _string_list(outcome.get("affected_files"))
+    proof_commands = _string_list(outcome.get("proof_commands"))
+    command_results = [
+        item for item in _as_list(outcome.get("command_results")) if isinstance(item, dict)
+    ]
+
+    lines = [
+        "# Safe fix outcome",
+        "",
+        f"- Status: `{_string(outcome.get('status'), 'unknown')}`",
+        f"- Attempted: `{str(_truthy(outcome.get('attempted'))).lower()}`",
+        f"- Remediation OK: `{str(_truthy(outcome.get('remediation_ok'))).lower()}`",
+        f"- Committed: `{str(_truthy(outcome.get('committed'))).lower()}`",
+        f"- Pushed: `{str(_truthy(outcome.get('pushed'))).lower()}`",
+        f"- Commit SHA: `{_string(outcome.get('commit_sha'), 'none')}`",
+        f"- Fix type: `{_string(outcome.get('fix_type'), 'unknown')}`",
+        f"- Reason: {_string(outcome.get('reason'), 'none')}",
+        "- Files: " + (", ".join(f"`{item}`" for item in files) if files else "`none`"),
+        "",
+        "## Proof after fix",
+        "",
+    ]
+
+    if proof_commands:
+        lines.extend(f"- `{item}`" for item in proof_commands)
+    elif command_results:
+        for item in command_results:
+            command = _string(item.get("command"))
+            ok = str(_truthy(item.get("ok"))).lower()
+            lines.append(f"- `{command}` -> ok=`{ok}`")
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_outcome(artifacts_dir: Path) -> JsonObject:
+    artifacts_dir = Path(artifacts_dir)
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    outcome = build_outcome(artifacts_dir)
+    (artifacts_dir / "safe-fix-outcome.json").write_text(
+        json.dumps(outcome, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (artifacts_dir / "safe-fix-outcome.md").write_text(
+        render_markdown(outcome),
+        encoding="utf-8",
+    )
+    return outcome

--- a/tests/test_maintenance_autopilot_pr_quality_bridge.py
+++ b/tests/test_maintenance_autopilot_pr_quality_bridge.py
@@ -194,3 +194,71 @@ def test_autopilot_bridge_creates_missing_output_directory(tmp_path: Path) -> No
 
     assert result["ok"] is True
     assert (missing_out / "pr-quality-safe-remediation-bridge.json").exists()
+
+
+def test_autopilot_bridge_writes_safe_fix_outcome_and_attaches_check_intelligence(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    autopilot = _load_autopilot()
+    check_intelligence = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "failed_checks": [
+                {
+                    "name": "autopilot",
+                    "safe_to_auto_fix": True,
+                    "diagnosis": {"code": "PRE_COMMIT_FORMAT_DRIFT"},
+                    "safe_remediation": {
+                        "schema_version": "sdetkit.safe_remediation_eligibility.v1",
+                        "safe_to_auto_fix": True,
+                        "strategy": "run_pre_commit",
+                        "category": "formatting_only",
+                        "affected_files": ["tests/test_example.py"],
+                        "proof_commands": ["python -m pre_commit run -a"],
+                    },
+                }
+            ]
+        },
+    )
+
+    def fake_run_plan(plan, cwd):
+        return {
+            "schema_version": "sdetkit.adaptive_safe_remediation.v1",
+            "ok": True,
+            "safe_to_auto_fix": True,
+            "fix_type": "format_only",
+            "commands": [{"command": "python -m pre_commit run -a", "ok": True}],
+        }
+
+    def fake_commit(out_dir, plan, result):
+        return {
+            "ok": True,
+            "attempted": True,
+            "committed": True,
+            "pushed": True,
+            "commit_sha": "abc123",
+            "reason": "pushed",
+        }
+
+    monkeypatch.setattr(adaptive_safe_remediation, "run_plan", fake_run_plan)
+    monkeypatch.setattr(autopilot, "_commit_safe_fix_changes", fake_commit)
+
+    out_dir = tmp_path / "safe-formatting-autopilot"
+    result = autopilot._write_safe_fix_artifacts_from_check_intelligence(
+        out_dir,
+        check_intelligence,
+    )
+
+    assert result["attempted"] is True
+    assert result["commit_pushed"] is True
+
+    outcome = json.loads((out_dir / "safe-fix-outcome.json").read_text(encoding="utf-8"))
+    assert outcome["status"] == "pushed"
+    assert outcome["commit_sha"] == "abc123"
+    assert outcome["affected_files"] == ["tests/test_example.py"]
+
+    attached = json.loads(check_intelligence.read_text(encoding="utf-8"))
+    assert attached["safe_fix_outcome"]["status"] == "pushed"
+    assert attached["safe_fix_outcome"]["commit_sha"] == "abc123"
+    assert (out_dir / "safe-fix-outcome.md").exists()

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -926,3 +926,49 @@ def test_action_report_comment_renders_safe_remediation_eligibility() -> None:
     assert (
         "Safe reason: `Failure is limited to deterministic formatting or whitespace hooks.`" in body
     )
+
+
+def test_action_report_comment_renders_safe_fix_outcome() -> None:
+    action = {
+        "status": "green",
+        "quality_gate": {"passed": True, "coverage": 96.69},
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+    }
+    intelligence = {
+        "summary": {
+            "failed_check_count": 0,
+            "queued_check_count": 0,
+            "required_queued_check_count": 0,
+            "missing_required_context_count": 0,
+            "startup_failure_count": 0,
+            "required_startup_failure_count": 0,
+            "security_review": {"collected": True, "unresolved_findings": 0},
+        },
+        "failed_checks": [],
+        "safe_fix_outcome": {
+            "status": "pushed",
+            "attempted": True,
+            "remediation_ok": True,
+            "committed": True,
+            "pushed": True,
+            "commit_sha": "abc123",
+            "affected_files": ["tests/test_example.py"],
+            "reason": "PR Quality safe-remediation bridge executed",
+            "proof_commands": ["python -m pre_commit run -a"],
+        },
+    }
+
+    body = report.render_comment_body(action_report=action, check_intelligence=intelligence)
+
+    assert "## Safe fix outcome" in body
+    assert "- Status: `pushed`" in body
+    assert "- Attempted: `true`" in body
+    assert "- Committed: `true`" in body
+    assert "- Pushed: `true`" in body
+    assert "- Commit SHA: `abc123`" in body
+    assert "`tests/test_example.py`" in body
+    assert "- Proof after fix:" in body
+    assert "`python -m pre_commit run -a`" in body

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -217,3 +217,12 @@ def test_pr_quality_workflow_grants_contents_write_for_safe_branch_commit() -> N
 
     assert "permissions:" in permissions
     assert "contents: write" in permissions
+
+
+def test_pr_quality_workflow_uploads_safe_fix_outcome_artifacts() -> None:
+    text = _workflow_text()
+
+    assert "build/pr-quality/safe-formatting-autopilot/" in text
+    assert "Commit approved safe formatting fixes" in text
+    assert "Build PR comment body" in text
+    assert text.index("Commit approved safe formatting fixes") < text.index("Build PR comment body")

--- a/tests/test_safe_fix_outcome.py
+++ b/tests/test_safe_fix_outcome.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import safe_fix_outcome
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_safe_fix_outcome_builds_visible_push_summary(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "pr-quality-safe-remediation-bridge.json",
+        {
+            "attempted": True,
+            "remediation_ok": True,
+            "commit_ok": True,
+            "commit_pushed": True,
+            "commit_sha": "abc123",
+            "affected_files": ["tests/test_example.py"],
+            "reason": "PR Quality safe-remediation bridge executed",
+        },
+    )
+    _write_json(
+        tmp_path / "safe-fix-plan.json",
+        {
+            "safe_to_auto_fix": True,
+            "fix_type": "format_only",
+            "affected_files": ["tests/test_example.py"],
+            "proof_commands": ["python -m pre_commit run -a"],
+        },
+    )
+    _write_json(
+        tmp_path / "adaptive-safe-remediation-result.json",
+        {
+            "ok": True,
+            "commands": [
+                {
+                    "command": "python -m pre_commit run -a",
+                    "ok": True,
+                    "returncode": 0,
+                }
+            ],
+        },
+    )
+
+    outcome = safe_fix_outcome.write_outcome(tmp_path)
+
+    assert outcome["status"] == "pushed"
+    assert outcome["attempted"] is True
+    assert outcome["remediation_ok"] is True
+    assert outcome["committed"] is True
+    assert outcome["pushed"] is True
+    assert outcome["commit_sha"] == "abc123"
+    assert outcome["affected_files"] == ["tests/test_example.py"]
+    assert outcome["proof_commands"] == ["python -m pre_commit run -a"]
+
+    markdown = (tmp_path / "safe-fix-outcome.md").read_text(encoding="utf-8")
+    assert "Safe fix outcome" in markdown
+    assert "Commit SHA: `abc123`" in markdown
+    assert "`tests/test_example.py`" in markdown
+
+
+def test_safe_fix_outcome_records_not_attempted_state(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "pr-quality-safe-remediation-bridge.json",
+        {
+            "attempted": False,
+            "reason": "no failed checks to remediate",
+        },
+    )
+
+    outcome = safe_fix_outcome.write_outcome(tmp_path)
+
+    assert outcome["status"] == "not_attempted"
+    assert outcome["attempted"] is False
+    assert outcome["committed"] is False
+    assert outcome["pushed"] is False
+    assert outcome["commit_sha"] == "none"
+    assert outcome["reason"] == "no failed checks to remediate"

--- a/tools/maintenance_autopilot.py
+++ b/tools/maintenance_autopilot.py
@@ -290,6 +290,20 @@ def _write_safe_fix_commit_result(out_dir: Path, payload: dict[str, Any]) -> Non
     _write_json(out_dir / "adaptive-safe-commit-result.json", payload)
 
 
+def _write_safe_fix_outcome_artifacts(
+    out_dir: Path,
+    check_intelligence_path: Path | None = None,
+) -> dict[str, Any]:
+    from sdetkit import safe_fix_outcome
+
+    outcome = safe_fix_outcome.write_outcome(out_dir)
+    if check_intelligence_path is not None and check_intelligence_path.exists():
+        check_intelligence = _load_json(check_intelligence_path)
+        check_intelligence["safe_fix_outcome"] = outcome
+        _write_json(check_intelligence_path, check_intelligence)
+    return outcome
+
+
 def _write_safe_fix_learning_outcome(
     out_dir: Path,
     plan: dict[str, Any],
@@ -511,6 +525,7 @@ def _write_safe_fix_artifacts_from_check_intelligence(
     if not check_intelligence_path.exists():
         payload["reason"] = "check intelligence file not found"
         _write_json(out_dir / "pr-quality-safe-remediation-bridge.json", payload)
+        _write_safe_fix_outcome_artifacts(out_dir, check_intelligence_path)
         return payload
 
     intelligence = _load_json(check_intelligence_path)
@@ -524,6 +539,7 @@ def _write_safe_fix_artifacts_from_check_intelligence(
         payload["ok"] = True
         payload["reason"] = "no failed checks to remediate"
         _write_json(out_dir / "pr-quality-safe-remediation-bridge.json", payload)
+        _write_safe_fix_outcome_artifacts(out_dir, check_intelligence_path)
         return payload
 
     plans = [_safe_plan_from_pr_quality_check(check) for check in failed_checks]
@@ -534,6 +550,7 @@ def _write_safe_fix_artifacts_from_check_intelligence(
         payload["failed_check_count"] = len(failed_checks)
         payload["eligible_plan_count"] = len(eligible_plans)
         _write_json(out_dir / "pr-quality-safe-remediation-bridge.json", payload)
+        _write_safe_fix_outcome_artifacts(out_dir, check_intelligence_path)
         return payload
 
     affected_files: set[str] = set()
@@ -564,11 +581,13 @@ def _write_safe_fix_artifacts_from_check_intelligence(
             "remediation_ok": bool(remediation_result.get("ok", False)),
             "commit_ok": bool(commit_result.get("ok", False)),
             "commit_pushed": bool(commit_result.get("pushed", False)),
+            "commit_sha": str(commit_result.get("commit_sha") or commit_result.get("sha") or ""),
             "affected_files": sorted(affected_files),
         }
     )
     _write_json(out_dir / "pr-quality-safe-remediation-bridge.json", payload)
     _write_safe_fix_learning_outcome(out_dir, merged_plan, remediation_result, commit_result)
+    _write_safe_fix_outcome_artifacts(out_dir, check_intelligence_path)
     return payload
 
 


### PR DESCRIPTION
## Summary
- Add `safe_fix_outcome` artifacts for the PR Quality safe-formatting bridge.
- Write `safe-fix-outcome.json` and `safe-fix-outcome.md` from existing bridge, plan, remediation, and commit artifacts.
- Attach the outcome back into `check-intelligence.json` so PR Quality and the operator loop can render it naturally.
- Render safe-fix status, attempted/remediation/commit/push flags, commit SHA, files, reason, and proof commands in the PR Quality comment.

## Why
The safe-formatting mutation loop now exists, but reviewers need a clear audit trail. This PR makes the loop visible without expanding what automation is allowed to mutate.

## Safety
- No new mutation behavior.
- No broader auto-fix scope.
- No security dismissal.
- No release/type/test/dependency remediation.
- Observability only: reads existing safe bridge artifacts and summarizes outcome.

## Verification
- `python -m pytest -q tests/test_safe_fix_outcome.py tests/test_maintenance_autopilot_pr_quality_bridge.py tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py tests/test_operator_evidence_loop.py -o addopts=`
- `python -m ruff check tools src tests`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `PYTHONPATH=src python -m build`
- `PYTHONPATH=src python -m twine check dist/*`
- `python -m sdetkit security check --root . --format json` with zero PR-owned warn/error findings
