### PR TITLE
Roll up safe fix outcomes in operator loop

### DIFF
--- a/src/sdetkit/operator_evidence_loop.py
+++ b/src/sdetkit/operator_evidence_loop.py
@@ -12,6 +12,7 @@ from sdetkit import (
     mission_control,
     pr_quality_action_report,
     pr_quality_evidence_narrative,
+    safe_fix_operator_rollup,
 )
 
 SCHEMA_VERSION = "sdetkit.operator.evidence_loop.v1"
@@ -144,6 +145,34 @@ def _default_check_intelligence() -> JsonObject:
     }
 
 
+def _read_optional_json(path: Path | None) -> JsonObject:
+    if path is None or not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return _as_dict(payload)
+
+
+def _write_safe_fix_outcome_rollup(
+    *,
+    out_dir: Path,
+    check_intelligence: Path | None,
+) -> tuple[JsonObject, JsonObject]:
+    rollup_dir = out_dir / "safe-fix-outcome-rollup"
+    payload = _read_optional_json(check_intelligence)
+    rollup = safe_fix_operator_rollup.write_rollup(payload, rollup_dir)
+    return rollup, {
+        _artifact_key("safe", "fix", "outcome", "rollup", "json"): (
+            rollup_dir / "safe-fix-outcome-rollup.json"
+        ).as_posix(),
+        _artifact_key("safe", "fix", "outcome", "rollup", "markdown"): (
+            rollup_dir / "safe-fix-outcome-rollup.md"
+        ).as_posix(),
+    }
+
+
 def _classification(
     *,
     evidence_narrative: JsonObject,
@@ -230,10 +259,44 @@ def _verify_operator_loop_payload(payload: JsonObject) -> JsonObject:
     }
 
 
+def _safe_fix_rollup_lines(rollup: JsonObject) -> list[str]:
+    if not rollup:
+        return ["- not collected"]
+
+    recommendation = _as_dict(rollup.get("recommendation"))
+    lines = [
+        f"- Status: `{rollup.get('status', 'unknown')}`",
+        f"- Outcomes: `{_int(rollup.get('outcome_count'))}`",
+        f"- Attempted: `{_int(rollup.get('attempted_count'))}`",
+        f"- Committed: `{_int(rollup.get('committed_count'))}`",
+        f"- Pushed: `{_int(rollup.get('pushed_count'))}`",
+        f"- Safe candidates: `{_int(rollup.get('safe_candidate_count'))}`",
+        f"- Review-first blockers: `{_int(rollup.get('review_first_blocker_count'))}`",
+        f"- Recommendation: `{recommendation.get('action', 'unknown')}`",
+    ]
+
+    files = [_as_dict(item) for item in _as_list(rollup.get("recurring_files"))]
+    if files:
+        lines.append("- Recurring files:")
+        for item in files[:5]:
+            lines.append(f"  - `{item.get('path', '')}` seen `{_int(item.get('count'))}` time(s)")
+
+    reasons = [_as_dict(item) for item in _as_list(rollup.get("refusal_reasons"))]
+    if reasons:
+        lines.append("- Refusal reasons:")
+        for item in reasons[:5]:
+            lines.append(
+                f"  - `{item.get('reason', 'unknown')}` seen `{_int(item.get('count'))}` time(s)"
+            )
+
+    return lines
+
+
 def _render_markdown(payload: JsonObject) -> str:
     artifacts = _as_dict(payload.get("artifacts"))
     mission_control_summary = _as_dict(payload.get("mission_control"))
     patch_plan = _as_dict(payload.get("patch_plan"))
+    safe_fix_rollup = _as_dict(payload.get("safe_fix_outcome_rollup"))
 
     lines = [
         "# Operator evidence loop",
@@ -276,6 +339,15 @@ def _render_markdown(payload: JsonObject) -> str:
         )
         for key in sorted(checks):
             lines.append(f"- {key}: `{str(bool(checks[key])).lower()}`")
+
+    lines.extend(
+        [
+            "",
+            "## Safe-fix outcome rollup",
+            "",
+            *_safe_fix_rollup_lines(safe_fix_rollup),
+        ]
+    )
 
     lines.extend(["", "## Artifacts", ""])
     for key in sorted(artifacts):
@@ -358,6 +430,11 @@ def build_operator_evidence_loop(
     if mission_markdown.exists():
         artifacts[_artifact_key("mission", "control", "markdown")] = mission_markdown.as_posix()
 
+    safe_fix_rollup, safe_fix_rollup_artifacts = _write_safe_fix_outcome_rollup(
+        out_dir=out_dir,
+        check_intelligence=check_intelligence,
+    )
+
     payload: JsonObject = {
         "schema_version": SCHEMA_VERSION,
         "classification": _classification(
@@ -386,6 +463,8 @@ def build_operator_evidence_loop(
             "pushes_or_merges": False,
         },
     }
+    payload["safe_fix_outcome_rollup"] = safe_fix_rollup
+    _as_dict(payload.setdefault("artifacts", {})).update(safe_fix_rollup_artifacts)
 
     loop_json = out_dir / "operator-loop.json"
     loop_markdown = out_dir / "operator-loop.md"

--- a/src/sdetkit/safe_fix_operator_rollup.py
+++ b/src/sdetkit/safe_fix_operator_rollup.py
@@ -211,7 +211,9 @@ def render_markdown(rollup: JsonObject) -> str:
     files = [_as_dict(item) for item in _as_list(rollup.get("recurring_files"))]
     if files:
         for item in files[:10]:
-            lines.append(f"- `{_string(item.get('path'))}` seen `{int(item.get('count', 0) or 0)}` time(s)")
+            lines.append(
+                f"- `{_string(item.get('path'))}` seen `{int(item.get('count', 0) or 0)}` time(s)"
+            )
     else:
         lines.append("- none")
 

--- a/src/sdetkit/safe_fix_operator_rollup.py
+++ b/src/sdetkit/safe_fix_operator_rollup.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+SCHEMA_VERSION = "sdetkit.operator.safe_fix_outcome_rollup.v1"
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def _safe_outcomes(check_intelligence: JsonObject) -> list[JsonObject]:
+    outcome = _as_dict(check_intelligence.get("safe_fix_outcome"))
+    if outcome:
+        return [outcome]
+
+    outcomes = [
+        _as_dict(item)
+        for item in _as_list(check_intelligence.get("safe_fix_outcomes"))
+        if isinstance(item, dict)
+    ]
+    return [item for item in outcomes if item]
+
+
+def _failed_checks(check_intelligence: JsonObject) -> list[JsonObject]:
+    return [
+        _as_dict(item)
+        for item in _as_list(check_intelligence.get("failed_checks"))
+        if isinstance(item, dict)
+    ]
+
+
+def _files_from_outcomes(outcomes: list[JsonObject]) -> list[JsonObject]:
+    counts: dict[str, int] = {}
+    for outcome in outcomes:
+        for item in _as_list(outcome.get("affected_files")):
+            path = _string(item)
+            if not path:
+                continue
+            counts[path] = counts.get(path, 0) + 1
+
+    return [
+        {"path": path, "count": count}
+        for path, count in sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))
+    ]
+
+
+def _refusal_reasons(outcomes: list[JsonObject]) -> list[JsonObject]:
+    counts: dict[str, int] = {}
+    for outcome in outcomes:
+        status = _string(outcome.get("status"), "unknown")
+        if status in {"pushed", "committed_not_pushed", "remediated_not_committed"}:
+            continue
+        reason = _string(outcome.get("reason"), "unknown")
+        counts[reason] = counts.get(reason, 0) + 1
+
+    return [
+        {"reason": reason, "count": count}
+        for reason, count in sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))
+    ]
+
+
+def _recommendation(
+    *,
+    pushed_count: int,
+    committed_count: int,
+    remediation_ok_count: int,
+    attempted_count: int,
+    review_first_blocker_count: int,
+    refusal_count: int,
+) -> JsonObject:
+    if pushed_count:
+        return {
+            "action": "rerun_proof",
+            "reason": "At least one safe fix was pushed; rerun required proof on the refreshed branch.",
+        }
+    if committed_count:
+        return {
+            "action": "inspect_commit_push",
+            "reason": "A safe fix was committed but not pushed; inspect branch/token guardrails.",
+        }
+    if remediation_ok_count:
+        return {
+            "action": "inspect_commit_guard",
+            "reason": "Safe remediation succeeded but did not produce a commit.",
+        }
+    if review_first_blocker_count or refusal_count:
+        return {
+            "action": "review_blockers",
+            "reason": "Safe mutation was blocked by review-first failures or missing affected files.",
+        }
+    if attempted_count:
+        return {
+            "action": "inspect_failed_safe_fix",
+            "reason": "Safe fix was attempted but did not complete successfully.",
+        }
+    return {
+        "action": "no_action",
+        "reason": "No safe fix was attempted or needed.",
+    }
+
+
+def build_rollup(check_intelligence: JsonObject) -> JsonObject:
+    check_intelligence = _as_dict(check_intelligence)
+    outcomes = _safe_outcomes(check_intelligence)
+    failed = _failed_checks(check_intelligence)
+
+    attempted_count = sum(1 for item in outcomes if _truthy(item.get("attempted")))
+    remediation_ok_count = sum(1 for item in outcomes if _truthy(item.get("remediation_ok")))
+    committed_count = sum(1 for item in outcomes if _truthy(item.get("committed")))
+    pushed_count = sum(1 for item in outcomes if _truthy(item.get("pushed")))
+    not_attempted_count = sum(
+        1 for item in outcomes if _string(item.get("status")) == "not_attempted"
+    )
+    refusal_count = sum(
+        1
+        for item in outcomes
+        if _string(item.get("status")) in {"not_attempted", "attempted_without_success"}
+    )
+
+    safe_candidate_count = sum(1 for item in failed if _truthy(item.get("safe_to_auto_fix")))
+    review_first_blocker_count = sum(
+        1 for item in failed if not _truthy(item.get("safe_to_auto_fix"))
+    )
+
+    if pushed_count:
+        status = "pushed"
+    elif committed_count:
+        status = "committed_not_pushed"
+    elif remediation_ok_count:
+        status = "remediated_not_committed"
+    elif review_first_blocker_count or refusal_count:
+        status = "blocked_by_review_first"
+    elif attempted_count:
+        status = "attempted_without_success"
+    else:
+        status = "not_attempted"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "outcome_count": len(outcomes),
+        "attempted_count": attempted_count,
+        "remediation_ok_count": remediation_ok_count,
+        "committed_count": committed_count,
+        "pushed_count": pushed_count,
+        "not_attempted_count": not_attempted_count,
+        "refusal_count": refusal_count,
+        "safe_candidate_count": safe_candidate_count,
+        "review_first_blocker_count": review_first_blocker_count,
+        "recurring_files": _files_from_outcomes(outcomes),
+        "refusal_reasons": _refusal_reasons(outcomes),
+        "recommendation": _recommendation(
+            pushed_count=pushed_count,
+            committed_count=committed_count,
+            remediation_ok_count=remediation_ok_count,
+            attempted_count=attempted_count,
+            review_first_blocker_count=review_first_blocker_count,
+            refusal_count=refusal_count,
+        ),
+    }
+
+
+def render_markdown(rollup: JsonObject) -> str:
+    rollup = _as_dict(rollup)
+    recommendation = _as_dict(rollup.get("recommendation"))
+
+    lines = [
+        "# Operator safe-fix outcome rollup",
+        "",
+        f"- Status: `{_string(rollup.get('status'), 'unknown')}`",
+        f"- Outcomes: `{int(rollup.get('outcome_count', 0) or 0)}`",
+        f"- Attempted: `{int(rollup.get('attempted_count', 0) or 0)}`",
+        f"- Remediation OK: `{int(rollup.get('remediation_ok_count', 0) or 0)}`",
+        f"- Committed: `{int(rollup.get('committed_count', 0) or 0)}`",
+        f"- Pushed: `{int(rollup.get('pushed_count', 0) or 0)}`",
+        f"- Safe candidates: `{int(rollup.get('safe_candidate_count', 0) or 0)}`",
+        f"- Review-first blockers: `{int(rollup.get('review_first_blocker_count', 0) or 0)}`",
+        "",
+        "## Recommendation",
+        "",
+        f"- Action: `{_string(recommendation.get('action'), 'unknown')}`",
+        f"- Reason: {_string(recommendation.get('reason'), 'none')}",
+        "",
+        "## Recurring safe-fix files",
+        "",
+    ]
+
+    files = [_as_dict(item) for item in _as_list(rollup.get("recurring_files"))]
+    if files:
+        for item in files[:10]:
+            lines.append(f"- `{_string(item.get('path'))}` seen `{int(item.get('count', 0) or 0)}` time(s)")
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Refusal reasons", ""])
+    reasons = [_as_dict(item) for item in _as_list(rollup.get("refusal_reasons"))]
+    if reasons:
+        for item in reasons[:10]:
+            lines.append(
+                f"- `{_string(item.get('reason'), 'unknown')}` seen `{int(item.get('count', 0) or 0)}` time(s)"
+            )
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_rollup(check_intelligence: JsonObject, out_dir: Path) -> JsonObject:
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rollup = build_rollup(check_intelligence)
+    (out_dir / "safe-fix-outcome-rollup.json").write_text(
+        json.dumps(rollup, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "safe-fix-outcome-rollup.md").write_text(
+        render_markdown(rollup),
+        encoding="utf-8",
+    )
+    return rollup

--- a/tests/test_operator_evidence_loop.py
+++ b/tests/test_operator_evidence_loop.py
@@ -236,3 +236,69 @@ def test_operator_evidence_loop_cli_verify_returns_success_for_complete_bundle(
     assert stdout_payload["verification"]["ok"] is True
     persisted = json.loads((out_dir / "operator-loop.json").read_text(encoding="utf-8"))
     assert persisted["verification"]["ok"] is True
+
+
+def test_operator_evidence_loop_surfaces_safe_fix_outcome_rollup(tmp_path: Path) -> None:
+    graph_path = tmp_path / "evidence-graph.json"
+    graph_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "sdetkit.evidence-graph.v1",
+                "nodes": [],
+                "source_summary": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    check_intelligence = tmp_path / "check-intelligence.json"
+    check_intelligence.write_text(
+        json.dumps(
+            {
+                "checks_seen": 1,
+                "failed_checks": [
+                    {
+                        "name": "autopilot",
+                        "safe_to_auto_fix": True,
+                    }
+                ],
+                "queued_checks": [],
+                "startup_failures": [],
+                "security_review": {"collected": True, "unresolved_findings": 0},
+                "safe_fix_outcome": {
+                    "status": "pushed",
+                    "attempted": True,
+                    "remediation_ok": True,
+                    "committed": True,
+                    "pushed": True,
+                    "affected_files": ["tests/test_example.py"],
+                    "reason": "PR Quality safe-remediation bridge executed",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out_dir = tmp_path / "operator-loop"
+    payload = loop.build_operator_evidence_loop(
+        repo=tmp_path,
+        out_dir=out_dir,
+        evidence_graph_path=graph_path,
+        check_intelligence=check_intelligence,
+        quality_outcome="success",
+    )
+
+    rollup = payload["safe_fix_outcome_rollup"]
+    assert rollup["status"] == "pushed"
+    assert rollup["pushed_count"] == 1
+    assert rollup["recommendation"]["action"] == "rerun_proof"
+
+    artifacts = payload["artifacts"]
+    assert Path(artifacts[_artifact_key("safe", "fix", "outcome", "rollup", "json")]).exists()
+    assert Path(artifacts[_artifact_key("safe", "fix", "outcome", "rollup", "markdown")]).exists()
+
+    markdown = (out_dir / "operator-loop.md").read_text(encoding="utf-8")
+    assert "## Safe-fix outcome rollup" in markdown
+    assert "Recommendation: `rerun_proof`" in markdown
+    assert "`tests/test_example.py`" in markdown

--- a/tests/test_safe_fix_operator_rollup.py
+++ b/tests/test_safe_fix_operator_rollup.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit import safe_fix_operator_rollup
+
+
+def test_operator_rollup_summarizes_pushed_safe_fix() -> None:
+    payload = {
+        "failed_checks": [
+            {
+                "name": "autopilot",
+                "safe_to_auto_fix": True,
+            }
+        ],
+        "safe_fix_outcome": {
+            "status": "pushed",
+            "attempted": True,
+            "remediation_ok": True,
+            "committed": True,
+            "pushed": True,
+            "affected_files": ["tests/test_example.py"],
+            "reason": "PR Quality safe-remediation bridge executed",
+        },
+    }
+
+    rollup = safe_fix_operator_rollup.build_rollup(payload)
+
+    assert rollup["status"] == "pushed"
+    assert rollup["attempted_count"] == 1
+    assert rollup["committed_count"] == 1
+    assert rollup["pushed_count"] == 1
+    assert rollup["safe_candidate_count"] == 1
+    assert rollup["review_first_blocker_count"] == 0
+    assert rollup["recurring_files"] == [{"path": "tests/test_example.py", "count": 1}]
+    assert rollup["recommendation"]["action"] == "rerun_proof"
+
+
+def test_operator_rollup_reports_review_first_refusal_reason() -> None:
+    payload = {
+        "failed_checks": [
+            {
+                "name": "ci",
+                "safe_to_auto_fix": False,
+            },
+            {
+                "name": "autopilot",
+                "safe_to_auto_fix": True,
+            },
+        ],
+        "safe_fix_outcome": {
+            "status": "not_attempted",
+            "attempted": False,
+            "committed": False,
+            "pushed": False,
+            "reason": "one or more failed checks are review-first or lack affected files",
+        },
+    }
+
+    rollup = safe_fix_operator_rollup.build_rollup(payload)
+
+    assert rollup["status"] == "blocked_by_review_first"
+    assert rollup["safe_candidate_count"] == 1
+    assert rollup["review_first_blocker_count"] == 1
+    assert rollup["refusal_count"] == 1
+    assert rollup["refusal_reasons"] == [
+        {
+            "reason": "one or more failed checks are review-first or lack affected files",
+            "count": 1,
+        }
+    ]
+    assert rollup["recommendation"]["action"] == "review_blockers"
+
+
+def test_operator_rollup_writes_json_and_markdown(tmp_path: Path) -> None:
+    payload = {
+        "safe_fix_outcome": {
+            "status": "not_attempted",
+            "attempted": False,
+            "reason": "no failed checks to remediate",
+        }
+    }
+
+    rollup = safe_fix_operator_rollup.write_rollup(payload, tmp_path)
+
+    assert rollup["status"] == "blocked_by_review_first"
+    json_payload = json.loads((tmp_path / "safe-fix-outcome-rollup.json").read_text())
+    assert json_payload["schema_version"] == safe_fix_operator_rollup.SCHEMA_VERSION
+
+    markdown = (tmp_path / "safe-fix-outcome-rollup.md").read_text(encoding="utf-8")
+    assert "# Operator safe-fix outcome rollup" in markdown
+    assert "no failed checks to remediate" in markdown


### PR DESCRIPTION
## Summary
- Add operator-level safe-fix outcome rollup artifacts.
- Read `safe_fix_outcome` from PR Quality check intelligence.
- Write `safe-fix-outcome-rollup.json` and `safe-fix-outcome-rollup.md` inside the operator loop output.
- Surface attempted/remediated/committed/pushed counts, safe candidates, review-first blockers, recurring files, refusal reasons, and next operator recommendation.
- Include the rollup in operator-loop verification and markdown output.

## Why
PR Quality now shows safe-fix outcome details per PR. This PR moves that signal into the operator evidence loop so the repo can reason about safe-fix attempts at the operator layer, not only inside a single PR comment.

## Safety
- Observability only.
- No new mutation behavior.
- No broader auto-fix scope.
- No security dismissal.
- No release/type/test/dependency remediation.
- The operator loop remains advisory-only.

## Verification
- `python -m pytest -q tests/test_safe_fix_operator_rollup.py tests/test_operator_evidence_loop.py tests/test_mission_control.py tests/test_operator_brief.py tests/test_safe_fix_outcome.py tests/test_pr_quality_action_report.py tests/test_maintenance_autopilot_pr_quality_bridge.py -o addopts=`
- `python -m ruff check src tests tools`
- `python -m mypy src`
- `python -m pre_commit run -a`
- `PYTHONPATH=src python -m build`
- `PYTHONPATH=src python -m twine check dist/*`
- `python -m sdetkit security check --root . --format json` with zero PR-owned warn/error findings
