### PR TITLE
Require current-head exact failure evidence in PR Quality

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -273,6 +273,154 @@ _EXACT_FAILURE_PATTERNS = (
 _FAILURE_LINE_PATTERNS = _EXACT_FAILURE_PATTERNS
 
 
+_SETUP_NOISE_PREFIXES = (
+    "shell:",
+    "env:",
+    "pythonlocation",
+    "python_root_dir",
+    "python2_root_dir",
+    "python3_root_dir",
+    "pkg_config_path",
+    "ld_library_path",
+    "github_token",
+)
+
+_SETUP_NOISE_CONTAINS = (
+    "pytest_addopts:",
+    "##[group]",
+    "##[endgroup]",
+    "collecting ",
+    "installing ",
+    "successfully installed",
+    "requirement already satisfied",
+)
+
+
+def _is_setup_noise_line(line: str) -> bool:
+    lowered = line.strip().lower()
+    if not lowered:
+        return True
+    return lowered.startswith(_SETUP_NOISE_PREFIXES) or any(
+        token in lowered for token in _SETUP_NOISE_CONTAINS
+    )
+
+
+def _record_head_sha(record: JsonObject) -> str:
+    for key in ("headSha", "head_sha", "headRefOid", "head_ref_oid", "head_oid"):
+        value = _string(record.get(key))
+        if value:
+            return value
+
+    check_suite = _as_dict(record.get("check_suite") or record.get("checkSuite"))
+    for key in ("head_sha", "headSha"):
+        value = _string(check_suite.get(key))
+        if value:
+            return value
+
+    return ""
+
+
+def _record_current_pr_head_sha(record: JsonObject) -> str:
+    for key in ("current_pr_head_sha", "pr_head_sha", "currentHeadSha", "current_head_sha"):
+        value = _string(record.get(key))
+        if value:
+            return value
+
+    pull_request = _as_dict(record.get("pull_request") or record.get("pullRequest"))
+    head = _as_dict(pull_request.get("head"))
+    return _string(head.get("sha"))
+
+
+def _check_head_sha(check: JsonObject) -> str:
+    return _string(check.get("head_sha") or check.get("headSha"))
+
+
+def _check_current_pr_head_sha(check: JsonObject, fallback: str = "") -> str:
+    return _string(
+        check.get("current_pr_head_sha")
+        or check.get("pr_head_sha")
+        or check.get("currentHeadSha")
+        or fallback
+    )
+
+
+def _is_stale_check_evidence(check: JsonObject, *, current_pr_head_sha: str = "") -> bool:
+    if bool(check.get("stale_evidence") or check.get("stale")):
+        return True
+
+    head_sha = _check_head_sha(check)
+    expected_sha = _check_current_pr_head_sha(check, current_pr_head_sha)
+    return bool(head_sha and expected_sha and head_sha != expected_sha)
+
+
+def _path_like_tokens(text: str) -> list[str]:
+    import re as _re
+
+    paths = []
+    for raw in _re.findall(r"(?:src|tests|tools|docs|templates|\.github)/[A-Za-z0-9_./-]+", text):
+        token = raw.strip("`'\"()[]{}:,;")
+        if token:
+            paths.append(token)
+    return sorted(set(paths))
+
+
+def _formatter_changed_files(log_text: str) -> list[str]:
+    files: list[str] = []
+    for line in log_text.splitlines():
+        lowered = line.lower()
+        if (
+            "would reformat" in lowered
+            or "reformatted" in lowered
+            or "files were modified by this hook" in lowered
+        ):
+            files.extend(_path_like_tokens(line))
+
+    if files:
+        return sorted(set(files))
+
+    if "ruff format" not in log_text.lower() and "pre-commit" not in log_text.lower():
+        return []
+
+    return _path_like_tokens(log_text)
+
+
+def _referenced_failure_files(log_text: str) -> list[str]:
+    return _path_like_tokens(log_text)
+
+
+def _changed_files_from_record(record: JsonObject) -> list[str]:
+    files: list[str] = []
+    for key in (
+        "changed_files",
+        "pr_changed_files",
+        "affected_files",
+        "owner_files",
+        "files",
+    ):
+        for item in _as_list(record.get(key)):
+            value = _string(item)
+            if value:
+                files.append(value)
+    return sorted(set(files))
+
+
+def _outside_changed_files(record: JsonObject, log_text: str) -> list[str]:
+    changed = set(_changed_files_from_record(record))
+    if not changed:
+        return []
+
+    referenced = set(_referenced_failure_files(log_text))
+    return sorted(path for path in referenced if path not in changed)
+
+
+def _possible_changed_files_gate_fallout(record: JsonObject, log_text: str) -> bool:
+    lowered = log_text.lower()
+    outside = _outside_changed_files(record, log_text)
+    if outside:
+        return True
+    return "fatal: bad object" in lowered and "templates/platform_problem" in lowered
+
+
 def _failure_tool_for_line(line: str) -> str:
     lowered = line.lower()
     if "ruff" in lowered:
@@ -322,7 +470,7 @@ def _first_failure_summary(log_text: str, *, context: int = 3) -> JsonObject:
     for index, line in enumerate(lines):
         stripped = line.strip()
         lowered = stripped.lower()
-        if not stripped:
+        if not stripped or _is_setup_noise_line(stripped):
             continue
         if not any(pattern in lowered for pattern in _EXACT_FAILURE_PATTERNS):
             continue
@@ -330,7 +478,11 @@ def _first_failure_summary(log_text: str, *, context: int = 3) -> JsonObject:
         if lowered.startswith("run ") and index + 1 < len(lines):
             next_line = lines[index + 1].strip()
             next_lowered = next_line.lower()
-            if next_line and any(pattern in next_lowered for pattern in _EXACT_FAILURE_PATTERNS):
+            if (
+                next_line
+                and not _is_setup_noise_line(next_line)
+                and any(pattern in next_lowered for pattern in _EXACT_FAILURE_PATTERNS)
+            ):
                 stripped = next_line
                 lowered = next_lowered
                 index = index + 1
@@ -384,14 +536,27 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
         first_failure=first_failure,
         log_text=log_text,
     )
+    head_sha = _record_head_sha(record)
+    current_pr_head_sha = _record_current_pr_head_sha(record)
+    stale_evidence = bool(head_sha and current_pr_head_sha and head_sha != current_pr_head_sha)
     return {
         "name": name,
         "status": _check_status(record),
         "conclusion": _check_conclusion(record),
         "url": _record_url(record),
+        "head_sha": head_sha,
+        "current_pr_head_sha": current_pr_head_sha,
+        "stale_evidence": stale_evidence,
         "log_collected": bool(log_text.strip()),
         "first_failure": first_failure,
         "first_failure_line": _string(first_failure.get("line")),
+        "formatter_changed_files": _formatter_changed_files(log_text),
+        "referenced_files": _referenced_failure_files(log_text),
+        "outside_changed_files": _outside_changed_files(record, log_text),
+        "possible_changed_files_gate_fallout": _possible_changed_files_gate_fallout(
+            record,
+            log_text,
+        ),
         "safe_remediation": safe_remediation,
         "diagnosis": primary,
         "diagnoses": diagnoses,
@@ -539,10 +704,25 @@ def _primary_failed_check(intelligence: JsonObject) -> JsonObject:
     if not failed:
         return {}
 
-    def score(check: JsonObject) -> tuple[int, int]:
+    current_pr_head_sha = _string(
+        intelligence.get("current_pr_head_sha") or intelligence.get("pr_head_sha")
+    )
+
+    def score(check: JsonObject) -> tuple[int, int, int, int]:
         diagnosis = _as_dict(check.get("diagnosis"))
         safe = 1 if bool(check.get("safe_to_auto_fix", False)) else 0
         unsafe_priority = 0 if safe else 1
+        stale_priority = (
+            0
+            if _is_stale_check_evidence(
+                check,
+                current_pr_head_sha=current_pr_head_sha,
+            )
+            else 1
+        )
+        actionable_priority = (
+            0 if bool(check.get("possible_changed_files_gate_fallout", False)) else 1
+        )
         surface_priority = {
             "security": 100,
             "dependency": 95,
@@ -555,7 +735,12 @@ def _primary_failed_check(intelligence: JsonObject) -> JsonObject:
             "unknown": 0,
         }
         surface = _surface_for_diagnosis(diagnosis)
-        return (unsafe_priority, surface_priority.get(surface, 0))
+        return (
+            stale_priority,
+            actionable_priority,
+            unsafe_priority,
+            surface_priority.get(surface, 0),
+        )
 
     return max(failed, key=score)
 
@@ -704,6 +889,16 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 "url": check.get("url", ""),
                 "first_failure": check.get("first_failure", {}),
                 "first_failure_line": check.get("first_failure_line", ""),
+                "head_sha": check.get("head_sha", ""),
+                "current_pr_head_sha": check.get("current_pr_head_sha", ""),
+                "stale_evidence": check.get("stale_evidence", False),
+                "formatter_changed_files": check.get("formatter_changed_files", []),
+                "referenced_files": check.get("referenced_files", []),
+                "outside_changed_files": check.get("outside_changed_files", []),
+                "possible_changed_files_gate_fallout": check.get(
+                    "possible_changed_files_gate_fallout",
+                    False,
+                ),
                 "safe_remediation": check.get("safe_remediation", {}),
                 "safe_to_auto_fix": check.get("safe_to_auto_fix", False),
             },

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -184,6 +184,28 @@ def _failed_check_lines(check_intelligence: JsonObject) -> list[str]:
             reason = _string(safe_remediation.get("reason") or "approved safe remediation")
             lines.append(f"  - Safe remediation: `{strategy}`")
             lines.append(f"  - Safe reason: `{reason}`")
+        formatter_files = [
+            _string(path) for path in _as_list(item.get("formatter_changed_files")) if _string(path)
+        ]
+        if formatter_files:
+            lines.append(
+                "  - Formatter changed files: "
+                + ", ".join(f"`{path}`" for path in formatter_files[:8])
+            )
+        if bool(item.get("stale_evidence", False)):
+            head_sha = _string(item.get("head_sha") or "unknown")
+            current_sha = _string(item.get("current_pr_head_sha") or "unknown")
+            lines.append(f"  - Evidence freshness: `stale` (`{head_sha}` != `{current_sha}`)")
+        outside_files = [
+            _string(path) for path in _as_list(item.get("outside_changed_files")) if _string(path)
+        ]
+        if outside_files:
+            lines.append(
+                "  - Outside PR changed set: "
+                + ", ".join(f"`{path}`" for path in outside_files[:8])
+            )
+        if bool(item.get("possible_changed_files_gate_fallout", False)):
+            lines.append("  - Gate fallout: possible changed-files base-resolution issue")
     return lines
 
 
@@ -223,6 +245,30 @@ def _primary_blocker_lines(primary: JsonObject) -> list[str]:
         reason = _string(safe_remediation.get("reason") or "approved safe remediation")
         lines.append(f"- Safe remediation: `{strategy}`")
         lines.append(f"- Safe reason: `{reason}`")
+
+    formatter_files = [
+        _string(path) for path in _as_list(primary.get("formatter_changed_files")) if _string(path)
+    ]
+    if formatter_files:
+        lines.append(
+            "- Formatter changed files: " + ", ".join(f"`{path}`" for path in formatter_files[:8])
+        )
+
+    if bool(primary.get("stale_evidence", False)):
+        head_sha = _string(primary.get("head_sha") or "unknown")
+        current_sha = _string(primary.get("current_pr_head_sha") or "unknown")
+        lines.append(f"- Evidence freshness: `stale` (`{head_sha}` != `{current_sha}`)")
+
+    outside_files = [
+        _string(path) for path in _as_list(primary.get("outside_changed_files")) if _string(path)
+    ]
+    if outside_files:
+        lines.append(
+            "- Outside PR changed set: " + ", ".join(f"`{path}`" for path in outside_files[:8])
+        )
+
+    if bool(primary.get("possible_changed_files_gate_fallout", False)):
+        lines.append("- Gate fallout: possible changed-files base-resolution issue")
 
     impact = _string(primary.get("impact"))
     if impact:

--- a/tests/test_check_intelligence_first_failure.py
+++ b/tests/test_check_intelligence_first_failure.py
@@ -142,3 +142,114 @@ def test_check_intelligence_matches_slugged_log_file_for_check_name(tmp_path: Pa
     assert failed["first_failure_line"] == (
         "src/sdetkit/example.py:10: error: Incompatible return value type"
     )
+
+
+def test_check_intelligence_skips_setup_noise_first_failure(tmp_path: Path) -> None:
+    from sdetkit.check_intelligence import build_check_intelligence
+
+    checks = tmp_path / "checks.json"
+    _write_json(
+        checks,
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane (py3.12)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "PYTEST_ADDOPTS: -n auto",
+                            "shell: /usr/bin/bash -e {0}",
+                            "src/sdetkit/example.py:10: error: Incompatible return value type",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = build_check_intelligence(checks_json=checks)
+    first_failure = intelligence["failed_checks"][0]["first_failure"]
+
+    assert (
+        first_failure["line"] == "src/sdetkit/example.py:10: error: Incompatible return value type"
+    )
+    assert first_failure["tool"] == "mypy"
+    assert first_failure["kind"] == "type_contract"
+
+
+def test_action_report_prefers_current_actionable_failure_over_stale_release() -> None:
+    from sdetkit.check_intelligence import build_action_report
+
+    report = build_action_report(
+        {
+            "current_pr_head_sha": "current-sha",
+            "failed_checks": [
+                {
+                    "name": "ci",
+                    "head_sha": "old-sha",
+                    "current_pr_head_sha": "current-sha",
+                    "stale_evidence": True,
+                    "safe_to_auto_fix": False,
+                    "diagnosis": {
+                        "code": "RELEASE_ARTIFACT_INVALID",
+                        "title": "Release artifact validation failed",
+                    },
+                },
+                {
+                    "name": "autopilot",
+                    "head_sha": "current-sha",
+                    "current_pr_head_sha": "current-sha",
+                    "safe_to_auto_fix": True,
+                    "formatter_changed_files": ["src/sdetkit/example.py"],
+                    "diagnosis": {
+                        "code": "PRE_COMMIT_FORMAT_DRIFT",
+                        "title": "Formatter drift blocked pre-commit",
+                    },
+                    "safe_remediation": {
+                        "safe_to_auto_fix": True,
+                        "strategy": "run_pre_commit",
+                    },
+                },
+            ],
+            "queued_checks": [],
+            "startup_failures": [],
+        }
+    )
+
+    primary = report["primary_blocker"]
+    assert primary["check"] == "autopilot"
+    assert primary["code"] == "PRE_COMMIT_FORMAT_DRIFT"
+    assert primary["formatter_changed_files"] == ["src/sdetkit/example.py"]
+    assert primary["stale_evidence"] is False
+
+
+def test_check_intelligence_marks_changed_files_gate_fallout(tmp_path: Path) -> None:
+    from sdetkit.check_intelligence import build_check_intelligence
+
+    checks = tmp_path / "checks.json"
+    _write_json(
+        checks,
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane (py3.12)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "changed_files": ["src/sdetkit/current_pr_file.py"],
+                    "log": "\n".join(
+                        [
+                            "fatal: bad object old-sha",
+                            "templates/platform_problem/rich/problem.py:1:1: F401 unused import",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = build_check_intelligence(checks_json=checks)
+    failed = intelligence["failed_checks"][0]
+
+    assert failed["possible_changed_files_gate_fallout"] is True
+    assert failed["outside_changed_files"] == ["templates/platform_problem/rich/problem.py"]

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -972,3 +972,66 @@ def test_action_report_comment_renders_safe_fix_outcome() -> None:
     assert "`tests/test_example.py`" in body
     assert "- Proof after fix:" in body
     assert "`python -m pre_commit run -a`" in body
+
+
+def test_action_report_comment_renders_freshness_formatter_and_gate_fallout_details() -> None:
+    from sdetkit.pr_quality_action_report import render_comment_body
+
+    action_report = {
+        "status": "review_required",
+        "primary_blocker": {
+            "check": "autopilot",
+            "title": "Formatter drift blocked pre-commit",
+            "surface": "quality",
+            "code": "PRE_COMMIT_FORMAT_DRIFT",
+            "first_failure": {"line": "- files were modified by this hook", "line_number": 30},
+            "first_failure_line": "- files were modified by this hook",
+            "formatter_changed_files": ["src/sdetkit/example.py"],
+            "stale_evidence": False,
+            "outside_changed_files": ["templates/platform_problem/rich/problem.py"],
+            "possible_changed_files_gate_fallout": True,
+            "safe_to_auto_fix": True,
+            "safe_remediation": {
+                "safe_to_auto_fix": True,
+                "strategy": "run_pre_commit",
+                "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
+            },
+        },
+        "automation": {"attempted": False, "allowed": True, "reason": "safe formatting"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    check_intelligence = {
+        "failed_checks": [
+            {
+                "name": "autopilot",
+                "diagnosis": {
+                    "code": "PRE_COMMIT_FORMAT_DRIFT",
+                    "title": "Formatter drift blocked pre-commit",
+                },
+                "first_failure": {"line": "- files were modified by this hook", "line_number": 30},
+                "safe_to_auto_fix": True,
+                "formatter_changed_files": ["src/sdetkit/example.py"],
+                "outside_changed_files": ["templates/platform_problem/rich/problem.py"],
+                "possible_changed_files_gate_fallout": True,
+                "safe_remediation": {
+                    "safe_to_auto_fix": True,
+                    "strategy": "run_pre_commit",
+                    "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
+                },
+            }
+        ],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {},
+    }
+
+    body = render_comment_body(
+        action_report=action_report,
+        check_intelligence=check_intelligence,
+    )
+
+    assert "Formatter changed files: `src/sdetkit/example.py`" in body
+    assert "Outside PR changed set: `templates/platform_problem/rich/problem.py`" in body
+    assert "Gate fallout: possible changed-files base-resolution issue" in body


### PR DESCRIPTION
## Summary
- Make first-failure extraction skip setup noise such as `PYTEST_ADDOPTS`.
- Preserve check/run head SHA freshness metadata and prefer current-head actionable evidence over stale blockers.
- Surface exact formatter-changed files in PR Quality comments.
- Classify files outside the PR changed set as possible changed-files gate/base-resolution fallout.

## Why
- PR Quality must be trustworthy before guarded autopilot execution consumes remediation plans.
- This prevents stale release evidence, setup metadata, and unrelated template fallout from driving the operator decision.

## Safety
- No security dismissal.
- No auto-merge.
- No broad auto-remediation.
- Review-first classes remain review-first.
- Compatibility preserved.

## Verification
- `python -m pytest -q tests/test_check_intelligence_first_failure.py tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_failed_check_log_collection.py -o addopts=`
- `python -m ruff check src tests tools`
- `python -m mypy src`
- `PRE_COMMIT_HOME=/tmp/sdetkit-pr1355-precommit-home python -m pre_commit run -a`
- `PYTHONPATH=src python -m build`
- `PYTHONPATH=src python -m twine check dist/*`
- `python -m sdetkit security check --root . --format json` with zero PR-owned warn/error findings
