### PR TITLE
Close remediation proof refresh loop

### DIFF
--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -121,6 +121,57 @@ def _safe_fix_outcome_lines(outcome: JsonObject) -> list[str]:
     return lines
 
 
+def _remediation_refresh_lines(refresh: JsonObject) -> list[str]:
+    if not refresh:
+        return ["none"]
+
+    lines = [
+        f"- Safe fix pushed: `{str(bool(refresh.get('safe_fix_pushed', False))).lower()}`",
+        f"- Safe fix committed: `{str(bool(refresh.get('safe_fix_committed', False))).lower()}`",
+        f"- Safe fix commit SHA: `{_string(refresh.get('safe_fix_commit_sha') or 'none')}`",
+        f"- Previous head SHA: `{_string(refresh.get('previous_head_sha') or 'unknown')}`",
+        f"- Refreshed head SHA: `{_string(refresh.get('refreshed_head_sha') or 'unknown')}`",
+    ]
+
+    if bool(refresh.get("safe_fix_pushed", False)):
+        lines.append("- Safe fix pushed to branch.")
+
+    proof_after_fix_passed = bool(refresh.get("proof_after_fix_passed", False))
+    proof_after_fix_failed = bool(refresh.get("proof_after_fix_failed", False))
+    proof_after_fix_started = bool(refresh.get("proof_after_fix_started", False))
+    if proof_after_fix_passed:
+        proof_result = "passed"
+    elif proof_after_fix_failed:
+        proof_result = "failed"
+    elif proof_after_fix_started:
+        proof_result = "started"
+    else:
+        proof_result = "not_started"
+
+    lines.append(f"- Proof after fix result: `{proof_result}`")
+
+    failed = [
+        _string(item) for item in _as_list(refresh.get("remaining_failed_checks")) if _string(item)
+    ]
+    blockers = [
+        _string(item)
+        for item in _as_list(refresh.get("remaining_review_first_blockers"))
+        if _string(item)
+    ]
+    if failed:
+        lines.append("- Remaining failed checks: " + ", ".join(f"`{item}`" for item in failed[:8]))
+    else:
+        lines.append("- Remaining failed checks: none")
+
+    if blockers:
+        lines.append("- Remaining blockers: " + ", ".join(f"`{item}`" for item in blockers[:8]))
+    else:
+        lines.append("- Remaining blockers: none")
+
+    lines.append(f"- Merge assessment: `{_string(refresh.get('merge_assessment') or 'unknown')}`")
+    return lines
+
+
 def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -> list[str]:
     security = _as_dict(
         check_intelligence.get("security_review")
@@ -500,6 +551,7 @@ def render_comment_body(
 ) -> str:
     evidence_narrative = evidence_narrative or {}
     safe_fix_outcome = safe_fix_outcome or _as_dict(check_intelligence.get("safe_fix_outcome"))
+    remediation_refresh = _as_dict(check_intelligence.get("remediation_refresh"))
     status = _string(action_report.get("status") or "unknown")
     evidence_signal_heading, evidence_signal_lines, evidence_review_required = _evidence_signal(
         evidence_narrative
@@ -551,6 +603,8 @@ def render_comment_body(
             "## Safe fix outcome",
             "",
             *_safe_fix_outcome_lines(_as_dict(safe_fix_outcome)),
+            "Remediation refresh",
+            *_remediation_refresh_lines(_as_dict(remediation_refresh)),
             "",
             "## Evidence collected",
             "",

--- a/src/sdetkit/pr_quality_remediation_refresh.py
+++ b/src/sdetkit/pr_quality_remediation_refresh.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+SCHEMA_VERSION = "sdetkit.pr_quality.remediation_refresh.v1"
+DEFAULT_OUT_DIR = Path("build/pr-quality/remediation-refresh")
+
+ASSESS_GREEN_AFTER_SAFE_FIX = "green_after_safe_fix"
+ASSESS_GREEN_WITH_PROOF_SIGNAL = "green_with_proof_signal"
+ASSESS_STILL_REVIEW_REQUIRED = "still_review_required"
+ASSESS_STALE_WAIT_FOR_REFRESHED_CHECKS = "stale_wait_for_refreshed_checks"
+ASSESS_BLOCKED_BY_REVIEW_FIRST = "blocked_by_review_first"
+ASSESS_BLOCKED_BY_UNKNOWN_FAILURE = "blocked_by_unknown_failure"
+
+REVIEW_FIRST_SURFACES = {
+    "security",
+    "release",
+    "dependency",
+    "runtime",
+    "type_contract",
+    "unknown",
+}
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any, default: str = "") -> str:
+    text = str(value or "").strip()
+    return text or default
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes"}
+
+
+def _read_json(path: Path | None) -> JsonObject:
+    if path is None or not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"expected JSON object in {path}"
+        raise ValueError(msg)
+    return payload
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _check_name(check: Mapping[str, Any]) -> str:
+    diagnosis = _as_dict(check.get("diagnosis"))
+    return (
+        _string(check.get("name"))
+        or _string(check.get("check"))
+        or _string(diagnosis.get("title"))
+        or "unknown"
+    )
+
+
+def _failed_check_names(check_intelligence: Mapping[str, Any]) -> list[str]:
+    names = [
+        _check_name(_as_dict(item))
+        for item in _as_list(check_intelligence.get("failed_checks"))
+    ]
+    return sorted({name for name in names if name})
+
+
+def _queued_check_names(check_intelligence: Mapping[str, Any]) -> list[str]:
+    names = [
+        _check_name(_as_dict(item))
+        for item in _as_list(check_intelligence.get("queued_checks"))
+    ]
+    return sorted({name for name in names if name})
+
+
+def _surface(check: Mapping[str, Any]) -> str:
+    diagnosis = _as_dict(check.get("diagnosis"))
+    return (
+        _string(check.get("surface"))
+        or _string(check.get("failure_surface"))
+        or _string(diagnosis.get("surface"))
+        or _string(diagnosis.get("kind"))
+        or "unknown"
+    )
+
+
+def _has_unknown_failure(check_intelligence: Mapping[str, Any]) -> bool:
+    for item in _as_list(check_intelligence.get("failed_checks")):
+        check = _as_dict(item)
+        diagnosis = _as_dict(check.get("diagnosis"))
+        surface = _surface(check)
+        code = _string(diagnosis.get("code")).lower()
+        title = _string(diagnosis.get("title")).lower()
+        if surface == "unknown" or code == "unknown" or "unknown failure" in title:
+            return True
+    return False
+
+
+def _review_first_blockers(
+    *,
+    action_report: Mapping[str, Any],
+    check_intelligence: Mapping[str, Any],
+) -> list[str]:
+    blockers: set[str] = set()
+
+    for item in _as_list(check_intelligence.get("failed_checks")):
+        check = _as_dict(item)
+        diagnosis = _as_dict(check.get("diagnosis"))
+        safe = _bool(check.get("safe_to_auto_fix"))
+        review_first = _bool(check.get("review_first")) or _bool(diagnosis.get("review_first"))
+        surface = _surface(check)
+        if review_first or (not safe and surface in REVIEW_FIRST_SURFACES):
+            blockers.add(_check_name(check))
+
+    primary = _as_dict(action_report.get("primary_blocker"))
+    if primary and _string(action_report.get("status")) == "review_required":
+        primary_safe = _bool(primary.get("safe_to_auto_fix"))
+        primary_surface = _string(primary.get("surface")) or _surface(primary)
+        if not primary_safe or primary_surface in REVIEW_FIRST_SURFACES:
+            blockers.add(_check_name(primary))
+
+    return sorted(blockers)
+
+
+def _safe_fix_outcome_from_sources(
+    *,
+    action_report: Mapping[str, Any],
+    check_intelligence: Mapping[str, Any],
+    safe_fix_outcome: Mapping[str, Any] | None,
+) -> JsonObject:
+    if safe_fix_outcome:
+        return dict(safe_fix_outcome)
+
+    from_check = _as_dict(check_intelligence.get("safe_fix_outcome"))
+    if from_check:
+        return from_check
+
+    return _as_dict(action_report.get("safe_fix_outcome"))
+
+
+def _first_head_sha(*values: Any) -> str:
+    for value in values:
+        text = _string(value)
+        if text and text != "none":
+            return text
+    return ""
+
+
+def build_remediation_refresh(
+    *,
+    action_report: Mapping[str, Any] | None = None,
+    check_intelligence: Mapping[str, Any] | None = None,
+    safe_fix_outcome: Mapping[str, Any] | None = None,
+    previous_head_sha: str = "",
+    refreshed_head_sha: str = "",
+) -> JsonObject:
+    action_report = _as_dict(action_report)
+    check_intelligence = _as_dict(check_intelligence)
+    outcome = _safe_fix_outcome_from_sources(
+        action_report=action_report,
+        check_intelligence=check_intelligence,
+        safe_fix_outcome=safe_fix_outcome,
+    )
+
+    safe_fix_attempted = _bool(outcome.get("attempted")) or _bool(outcome.get("safe_fix_attempted"))
+    safe_fix_committed = _bool(outcome.get("committed")) or _bool(outcome.get("safe_fix_committed"))
+    safe_fix_pushed = _bool(outcome.get("pushed")) or _bool(outcome.get("safe_fix_pushed"))
+    safe_fix_commit_sha = _first_head_sha(
+        outcome.get("commit_sha"),
+        outcome.get("safe_fix_commit_sha"),
+    ) or "none"
+
+    previous_head = _first_head_sha(
+        previous_head_sha,
+        outcome.get("previous_head_sha"),
+        outcome.get("head_sha"),
+        action_report.get("previous_head_sha"),
+        check_intelligence.get("previous_head_sha"),
+    ) or "unknown"
+
+    refreshed_head = _first_head_sha(
+        refreshed_head_sha,
+        check_intelligence.get("current_pr_head_sha"),
+        check_intelligence.get("pr_head_sha"),
+        action_report.get("current_pr_head_sha"),
+        action_report.get("refreshed_head_sha"),
+        outcome.get("refreshed_head_sha"),
+        safe_fix_commit_sha if safe_fix_commit_sha != "none" else "",
+    ) or "unknown"
+
+    remaining_failed_checks = _failed_check_names(check_intelligence)
+    queued_checks = _queued_check_names(check_intelligence)
+    remaining_review_first_blockers = _review_first_blockers(
+        action_report=action_report,
+        check_intelligence=check_intelligence,
+    )
+
+    proof_after_fix_started = safe_fix_pushed and refreshed_head != "unknown"
+    proof_after_fix_failed = proof_after_fix_started and bool(remaining_failed_checks)
+    proof_after_fix_passed = (
+        proof_after_fix_started
+        and not remaining_failed_checks
+        and not queued_checks
+        and not remaining_review_first_blockers
+    )
+
+    if _has_unknown_failure(check_intelligence):
+        merge_assessment = ASSESS_BLOCKED_BY_UNKNOWN_FAILURE
+    elif remaining_review_first_blockers:
+        merge_assessment = ASSESS_BLOCKED_BY_REVIEW_FIRST
+    elif proof_after_fix_started and queued_checks:
+        merge_assessment = ASSESS_STALE_WAIT_FOR_REFRESHED_CHECKS
+    elif remaining_failed_checks:
+        merge_assessment = ASSESS_STILL_REVIEW_REQUIRED
+    elif safe_fix_pushed and proof_after_fix_passed:
+        merge_assessment = ASSESS_GREEN_AFTER_SAFE_FIX
+    else:
+        merge_assessment = ASSESS_GREEN_WITH_PROOF_SIGNAL
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "safe_fix_attempted": safe_fix_attempted,
+        "safe_fix_committed": safe_fix_committed,
+        "safe_fix_pushed": safe_fix_pushed,
+        "safe_fix_commit_sha": safe_fix_commit_sha,
+        "previous_head_sha": previous_head,
+        "refreshed_head_sha": refreshed_head,
+        "proof_after_fix_started": proof_after_fix_started,
+        "proof_after_fix_passed": proof_after_fix_passed,
+        "proof_after_fix_failed": proof_after_fix_failed,
+        "remaining_failed_checks": remaining_failed_checks,
+        "remaining_review_first_blockers": remaining_review_first_blockers,
+        "queued_checks": queued_checks,
+        "merge_assessment": merge_assessment,
+    }
+
+
+def render_markdown(payload: Mapping[str, Any]) -> str:
+    failed = [_string(item) for item in _as_list(payload.get("remaining_failed_checks")) if _string(item)]
+    blockers = [
+        _string(item)
+        for item in _as_list(payload.get("remaining_review_first_blockers"))
+        if _string(item)
+    ]
+    queued = [_string(item) for item in _as_list(payload.get("queued_checks")) if _string(item)]
+
+    lines = [
+        "# Remediation refresh",
+        "",
+        f"- Safe fix attempted: `{str(_bool(payload.get('safe_fix_attempted'))).lower()}`",
+        f"- Safe fix committed: `{str(_bool(payload.get('safe_fix_committed'))).lower()}`",
+        f"- Safe fix pushed: `{str(_bool(payload.get('safe_fix_pushed'))).lower()}`",
+        f"- Safe fix commit SHA: `{_string(payload.get('safe_fix_commit_sha'), 'none')}`",
+        f"- Previous head SHA: `{_string(payload.get('previous_head_sha'), 'unknown')}`",
+        f"- Refreshed head SHA: `{_string(payload.get('refreshed_head_sha'), 'unknown')}`",
+        f"- Proof after fix started: `{str(_bool(payload.get('proof_after_fix_started'))).lower()}`",
+        f"- Proof after fix passed: `{str(_bool(payload.get('proof_after_fix_passed'))).lower()}`",
+        f"- Proof after fix failed: `{str(_bool(payload.get('proof_after_fix_failed'))).lower()}`",
+        f"- Merge assessment: `{_string(payload.get('merge_assessment'), 'unknown')}`",
+        "",
+        "## Remaining failed checks",
+    ]
+
+    lines.extend([f"- `{item}`" for item in failed] or ["- None"])
+    lines.append("")
+    lines.append("## Remaining review-first blockers")
+    lines.extend([f"- `{item}`" for item in blockers] or ["- None"])
+    lines.append("")
+    lines.append("## Queued checks")
+    lines.extend([f"- `{item}`" for item in queued] or ["- None"])
+    return "\n".join(lines).strip() + "\n"
+
+
+def write_remediation_refresh(payload: Mapping[str, Any], out_dir: Path) -> dict[str, str]:
+    json_path = out_dir / "remediation-refresh.json"
+    markdown_path = out_dir / "remediation-refresh.md"
+    _write_json(json_path, payload)
+    _write_text(markdown_path, render_markdown(payload))
+    return {
+        "remediation_refresh_json": json_path.as_posix(),
+        "remediation_refresh_markdown": markdown_path.as_posix(),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m sdetkit.pr_quality_remediation_refresh")
+    parser.add_argument("--action-report-json", default="")
+    parser.add_argument("--check-intelligence-json", default="")
+    parser.add_argument("--safe-fix-outcome-json", default="")
+    parser.add_argument("--previous-head-sha", default="")
+    parser.add_argument("--refreshed-head-sha", default="")
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = build_remediation_refresh(
+            action_report=_read_json(Path(args.action_report_json)) if args.action_report_json else {},
+            check_intelligence=(
+                _read_json(Path(args.check_intelligence_json))
+                if args.check_intelligence_json
+                else {}
+            ),
+            safe_fix_outcome=(
+                _read_json(Path(args.safe_fix_outcome_json))
+                if args.safe_fix_outcome_json
+                else {}
+            ),
+            previous_head_sha=args.previous_head_sha,
+            refreshed_head_sha=args.refreshed_head_sha,
+        )
+        artifacts = write_remediation_refresh(payload, Path(args.out_dir))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error={exc}")
+        return 2
+
+    if args.format == "json":
+        print(json.dumps({"artifacts": artifacts, "payload": payload}, indent=2, sort_keys=True))
+    else:
+        for key, value in artifacts.items():
+            print(f"{key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sdetkit/pr_quality_remediation_refresh.py
+++ b/src/sdetkit/pr_quality_remediation_refresh.py
@@ -79,16 +79,14 @@ def _check_name(check: Mapping[str, Any]) -> str:
 
 def _failed_check_names(check_intelligence: Mapping[str, Any]) -> list[str]:
     names = [
-        _check_name(_as_dict(item))
-        for item in _as_list(check_intelligence.get("failed_checks"))
+        _check_name(_as_dict(item)) for item in _as_list(check_intelligence.get("failed_checks"))
     ]
     return sorted({name for name in names if name})
 
 
 def _queued_check_names(check_intelligence: Mapping[str, Any]) -> list[str]:
     names = [
-        _check_name(_as_dict(item))
-        for item in _as_list(check_intelligence.get("queued_checks"))
+        _check_name(_as_dict(item)) for item in _as_list(check_intelligence.get("queued_checks"))
     ]
     return sorted({name for name in names if name})
 
@@ -185,28 +183,37 @@ def build_remediation_refresh(
     safe_fix_attempted = _bool(outcome.get("attempted")) or _bool(outcome.get("safe_fix_attempted"))
     safe_fix_committed = _bool(outcome.get("committed")) or _bool(outcome.get("safe_fix_committed"))
     safe_fix_pushed = _bool(outcome.get("pushed")) or _bool(outcome.get("safe_fix_pushed"))
-    safe_fix_commit_sha = _first_head_sha(
-        outcome.get("commit_sha"),
-        outcome.get("safe_fix_commit_sha"),
-    ) or "none"
+    safe_fix_commit_sha = (
+        _first_head_sha(
+            outcome.get("commit_sha"),
+            outcome.get("safe_fix_commit_sha"),
+        )
+        or "none"
+    )
 
-    previous_head = _first_head_sha(
-        previous_head_sha,
-        outcome.get("previous_head_sha"),
-        outcome.get("head_sha"),
-        action_report.get("previous_head_sha"),
-        check_intelligence.get("previous_head_sha"),
-    ) or "unknown"
+    previous_head = (
+        _first_head_sha(
+            previous_head_sha,
+            outcome.get("previous_head_sha"),
+            outcome.get("head_sha"),
+            action_report.get("previous_head_sha"),
+            check_intelligence.get("previous_head_sha"),
+        )
+        or "unknown"
+    )
 
-    refreshed_head = _first_head_sha(
-        refreshed_head_sha,
-        check_intelligence.get("current_pr_head_sha"),
-        check_intelligence.get("pr_head_sha"),
-        action_report.get("current_pr_head_sha"),
-        action_report.get("refreshed_head_sha"),
-        outcome.get("refreshed_head_sha"),
-        safe_fix_commit_sha if safe_fix_commit_sha != "none" else "",
-    ) or "unknown"
+    refreshed_head = (
+        _first_head_sha(
+            refreshed_head_sha,
+            check_intelligence.get("current_pr_head_sha"),
+            check_intelligence.get("pr_head_sha"),
+            action_report.get("current_pr_head_sha"),
+            action_report.get("refreshed_head_sha"),
+            outcome.get("refreshed_head_sha"),
+            safe_fix_commit_sha if safe_fix_commit_sha != "none" else "",
+        )
+        or "unknown"
+    )
 
     remaining_failed_checks = _failed_check_names(check_intelligence)
     queued_checks = _queued_check_names(check_intelligence)
@@ -256,7 +263,9 @@ def build_remediation_refresh(
 
 
 def render_markdown(payload: Mapping[str, Any]) -> str:
-    failed = [_string(item) for item in _as_list(payload.get("remaining_failed_checks")) if _string(item)]
+    failed = [
+        _string(item) for item in _as_list(payload.get("remaining_failed_checks")) if _string(item)
+    ]
     blockers = [
         _string(item)
         for item in _as_list(payload.get("remaining_review_first_blockers"))
@@ -318,16 +327,16 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         payload = build_remediation_refresh(
-            action_report=_read_json(Path(args.action_report_json)) if args.action_report_json else {},
+            action_report=_read_json(Path(args.action_report_json))
+            if args.action_report_json
+            else {},
             check_intelligence=(
                 _read_json(Path(args.check_intelligence_json))
                 if args.check_intelligence_json
                 else {}
             ),
             safe_fix_outcome=(
-                _read_json(Path(args.safe_fix_outcome_json))
-                if args.safe_fix_outcome_json
-                else {}
+                _read_json(Path(args.safe_fix_outcome_json)) if args.safe_fix_outcome_json else {}
             ),
             previous_head_sha=args.previous_head_sha,
             refreshed_head_sha=args.refreshed_head_sha,

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1035,3 +1035,48 @@ def test_action_report_comment_renders_freshness_formatter_and_gate_fallout_deta
     assert "Formatter changed files: `src/sdetkit/example.py`" in body
     assert "Outside PR changed set: `templates/platform_problem/rich/problem.py`" in body
     assert "Gate fallout: possible changed-files base-resolution issue" in body
+
+
+def test_action_report_comment_renders_remediation_refresh_loop_summary() -> None:
+    from sdetkit.pr_quality_action_report import render_comment_body
+
+    action_report = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    check_intelligence = {
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {},
+        "remediation_refresh": {
+            "safe_fix_attempted": True,
+            "safe_fix_committed": True,
+            "safe_fix_pushed": True,
+            "safe_fix_commit_sha": "new123",
+            "previous_head_sha": "old111",
+            "refreshed_head_sha": "new123",
+            "proof_after_fix_started": True,
+            "proof_after_fix_passed": True,
+            "proof_after_fix_failed": False,
+            "remaining_failed_checks": [],
+            "remaining_review_first_blockers": [],
+            "merge_assessment": "green_after_safe_fix",
+        },
+    }
+
+    body = render_comment_body(
+        action_report=action_report,
+        check_intelligence=check_intelligence,
+    )
+
+    assert "Remediation refresh" in body
+    assert "Safe fix pushed to branch." in body
+    assert "Refreshed head SHA: `new123`" in body
+    assert "Proof after fix result: `passed`" in body
+    assert "Remaining blockers: none" in body
+    assert "Merge assessment: `green_after_safe_fix`" in body

--- a/tests/test_pr_quality_remediation_refresh_loop.py
+++ b/tests/test_pr_quality_remediation_refresh_loop.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.pr_quality_remediation_refresh import (
+    ASSESS_BLOCKED_BY_REVIEW_FIRST,
+    ASSESS_BLOCKED_BY_UNKNOWN_FAILURE,
+    ASSESS_GREEN_AFTER_SAFE_FIX,
+    ASSESS_STALE_WAIT_FOR_REFRESHED_CHECKS,
+    build_remediation_refresh,
+    main,
+)
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_remediation_refresh_marks_green_after_safe_fix_when_refreshed_checks_pass() -> None:
+    payload = build_remediation_refresh(
+        safe_fix_outcome={
+            "attempted": True,
+            "committed": True,
+            "pushed": True,
+            "commit_sha": "new123",
+            "previous_head_sha": "old111",
+        },
+        check_intelligence={
+            "current_pr_head_sha": "new123",
+            "failed_checks": [],
+            "queued_checks": [],
+        },
+    )
+
+    assert payload["safe_fix_attempted"] is True
+    assert payload["safe_fix_committed"] is True
+    assert payload["safe_fix_pushed"] is True
+    assert payload["safe_fix_commit_sha"] == "new123"
+    assert payload["previous_head_sha"] == "old111"
+    assert payload["refreshed_head_sha"] == "new123"
+    assert payload["proof_after_fix_started"] is True
+    assert payload["proof_after_fix_passed"] is True
+    assert payload["proof_after_fix_failed"] is False
+    assert payload["merge_assessment"] == ASSESS_GREEN_AFTER_SAFE_FIX
+
+
+def test_remediation_refresh_waits_for_refreshed_queued_checks() -> None:
+    payload = build_remediation_refresh(
+        safe_fix_outcome={
+            "attempted": True,
+            "committed": True,
+            "pushed": True,
+            "commit_sha": "new123",
+        },
+        check_intelligence={
+            "current_pr_head_sha": "new123",
+            "failed_checks": [],
+            "queued_checks": [{"name": "Fast CI lane (py3.12)", "status": "queued"}],
+        },
+    )
+
+    assert payload["proof_after_fix_started"] is True
+    assert payload["proof_after_fix_passed"] is False
+    assert payload["merge_assessment"] == ASSESS_STALE_WAIT_FOR_REFRESHED_CHECKS
+
+
+def test_remediation_refresh_blocks_review_first_failures() -> None:
+    payload = build_remediation_refresh(
+        safe_fix_outcome={
+            "attempted": True,
+            "committed": True,
+            "pushed": True,
+            "commit_sha": "new123",
+        },
+        check_intelligence={
+            "current_pr_head_sha": "new123",
+            "failed_checks": [
+                {
+                    "name": "ci",
+                    "safe_to_auto_fix": False,
+                    "diagnosis": {
+                        "surface": "release",
+                        "title": "Release artifact validation failed",
+                    },
+                }
+            ],
+            "queued_checks": [],
+        },
+    )
+
+    assert payload["remaining_review_first_blockers"] == ["ci"]
+    assert payload["proof_after_fix_passed"] is False
+    assert payload["merge_assessment"] == ASSESS_BLOCKED_BY_REVIEW_FIRST
+
+
+def test_remediation_refresh_blocks_unknown_failures_before_review_first_bucket() -> None:
+    payload = build_remediation_refresh(
+        safe_fix_outcome={
+            "attempted": True,
+            "committed": True,
+            "pushed": True,
+            "commit_sha": "new123",
+        },
+        check_intelligence={
+            "current_pr_head_sha": "new123",
+            "failed_checks": [
+                {
+                    "name": "Fast CI lane (py3.11)",
+                    "safe_to_auto_fix": False,
+                    "diagnosis": {
+                        "surface": "unknown",
+                        "title": "Unknown failure",
+                    },
+                }
+            ],
+            "queued_checks": [],
+        },
+    )
+
+    assert payload["merge_assessment"] == ASSESS_BLOCKED_BY_UNKNOWN_FAILURE
+
+
+def test_remediation_refresh_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
+    safe_fix_outcome = _write_json(
+        tmp_path / "safe-fix-outcome.json",
+        {
+            "attempted": True,
+            "committed": True,
+            "pushed": True,
+            "commit_sha": "new123",
+            "previous_head_sha": "old111",
+        },
+    )
+    check_intelligence = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "current_pr_head_sha": "new123",
+            "failed_checks": [],
+            "queued_checks": [],
+        },
+    )
+
+    rc = main(
+        [
+            "--safe-fix-outcome-json",
+            str(safe_fix_outcome),
+            "--check-intelligence-json",
+            str(check_intelligence),
+            "--out-dir",
+            str(tmp_path / "refresh"),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads((tmp_path / "refresh" / "remediation-refresh.json").read_text())
+    markdown = (tmp_path / "refresh" / "remediation-refresh.md").read_text()
+    assert payload["merge_assessment"] == ASSESS_GREEN_AFTER_SAFE_FIX
+    assert "Remediation refresh" in markdown
+    assert "remediation_refresh_json" in stdout


### PR DESCRIPTION
## Summary
- Add reporting-only remediation refresh artifacts for PR Quality.
- Record safe-fix attempt, commit, push, previous head, refreshed head, proof-after-fix state, remaining failed checks, remaining review-first blockers, and merge assessment.
- Render remediation refresh status in the PR Quality comment.
- Keep queued refreshed checks as stale/wait state rather than green.

## Why
- PR Quality can now close the loop after guarded autopilot pushes a safe fix.
- This completes the diagnosis → plan → guarded execution → refreshed proof reporting chain without adding auto-merge or bypass behavior.

## Safety
- No security dismissal.
- No auto-merge.
- No broad auto-remediation.
- Review-first classes remain review-first.
- Compatibility preserved.
- Queued checks are not treated as green.
- Required checks are not bypassed.

## Verification
- `python -m pytest -q tests/test_pr_quality_remediation_refresh_loop.py tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py tests/test_operator_evidence_loop.py tests/test_safe_fix_history_memory.py tests/test_maintenance_autopilot_remediation_plan_bridge.py -o addopts=`
- `python -m ruff check src tests tools`
- `python -m mypy src`
- `PRE_COMMIT_HOME=/tmp/sdetkit-pr1357-precommit-home python -m pre_commit run -a`
- `PYTHONPATH=src python -m build`
- `PYTHONPATH=src python -m twine check dist/*`
- `python -m sdetkit security check --root . --format json` with zero PR-owned warn/error findings
