### PR TITLE
Harden PR Quality setup noise filtering

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -289,10 +289,18 @@ _SETUP_NOISE_CONTAINS = (
     "pytest_addopts:",
     "##[group]",
     "##[endgroup]",
+    "using cached ",
     "collecting ",
+    "downloading ",
     "installing ",
+    "installing collected packages",
     "successfully installed",
     "requirement already satisfied",
+    "preparing metadata",
+    "building wheel",
+    "stored in directory",
+    "resolved ",
+    "looking in indexes",
 )
 
 

--- a/tests/test_check_intelligence_first_failure.py
+++ b/tests/test_check_intelligence_first_failure.py
@@ -253,3 +253,79 @@ def test_check_intelligence_marks_changed_files_gate_fallout(tmp_path: Path) -> 
 
     assert failed["possible_changed_files_gate_fallout"] is True
     assert failed["outside_changed_files"] == ["templates/platform_problem/rich/problem.py"]
+
+
+def test_check_intelligence_skips_pip_cache_install_noise_before_real_failure(
+    tmp_path: Path,
+) -> None:
+    from sdetkit.check_intelligence import build_check_intelligence
+
+    checks = tmp_path / "checks.json"
+    _write_json(
+        checks,
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane (py3.11)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "Using cached pytest-9.0.3-py3-none-any.whl.metadata (7.6 kB)",
+                            "Collecting pluggy<2,>=1.5",
+                            "Downloading pluggy-1.6.0-py3-none-any.whl",
+                            "Installing collected packages: pluggy, pytest",
+                            "Successfully installed pluggy-1.6.0 pytest-9.0.3",
+                            "FAILED tests/test_real_contract.py::test_real_contract - AssertionError: expected ready",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = build_check_intelligence(checks_json=checks)
+    first_failure = intelligence["failed_checks"][0]["first_failure"]
+
+    assert first_failure["line"] == (
+        "FAILED tests/test_real_contract.py::test_real_contract - AssertionError: expected ready"
+    )
+    assert "Using cached pytest" not in first_failure["line"]
+
+
+def test_check_intelligence_skips_build_metadata_noise_before_real_mypy_failure(
+    tmp_path: Path,
+) -> None:
+    from sdetkit.check_intelligence import build_check_intelligence
+
+    checks = tmp_path / "checks.json"
+    _write_json(
+        checks,
+        {
+            "check_runs": [
+                {
+                    "name": "Fast CI lane (py3.12)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "Preparing metadata (pyproject.toml): started",
+                            "Preparing metadata (pyproject.toml): finished with status 'done'",
+                            "Building wheel for package (pyproject.toml): started",
+                            "Stored in directory: /tmp/pip-ephem-wheel-cache",
+                            "src/sdetkit/example.py:12: error: Incompatible return value type",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = build_check_intelligence(checks_json=checks)
+    first_failure = intelligence["failed_checks"][0]["first_failure"]
+
+    assert (
+        first_failure["line"] == "src/sdetkit/example.py:12: error: Incompatible return value type"
+    )
+    assert first_failure["tool"] == "mypy"
+    assert first_failure["kind"] == "type_contract"


### PR DESCRIPTION
## Summary
- Expand PR Quality/check-intelligence setup-noise filtering for pip/cache/install/build metadata lines.
- Prevent lines like `Using cached pytest...`, `Collecting...`, `Downloading...`, `Installing collected packages...`, `Successfully installed...`, `Preparing metadata...`, and `Building wheel...` from being selected as first real failures.
- Add regression coverage proving the real pytest and mypy failures are selected after setup noise is skipped.

## Why
- Recent PR Quality comments correctly found actionable formatter drift, but still surfaced pip setup/cache lines as Fast CI first failures.
- This sharpens diagnosis quality without changing remediation, release, or security policy.

## Safety
- No security dismissal.
- No auto-merge.
- No broad auto-remediation.
- Review-first classes remain review-first.
- Compatibility preserved.
- Release gates are not weakened.
- Only first-failure noise filtering is changed.

## Verification
- `python -m pytest -q tests/test_check_intelligence_first_failure.py tests/test_pr_quality_action_report.py tests/test_pr_quality_failure_bundle_workflow.py -o addopts=`
- `python -m ruff check src tests tools`
- `python -m mypy src`
- `PRE_COMMIT_HOME=/tmp/sdetkit-pr1358-precommit-home python -m pre_commit run -a`
- `PYTHONPATH=src python -m build`
- `PYTHONPATH=src python -m twine check dist/*`
- `python -m sdetkit security check --root . --format json` with zero PR-owned warn/error findings
