### PR TITLE
Extract dependency audit evidence in PR Quality

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -28,7 +28,6 @@ DEPENDENCY_AUDIT_OWNER_FILES = [
 
 
 def _extract_dependency_audit_evidence(log_text: str) -> JsonObject:
-    import re
 
     command = ""
     report_path = ""
@@ -580,7 +579,6 @@ def _first_failure_summary(log_text: str, *, context: int = 3) -> JsonObject:
 
 
 def _dependency_audit_first_failure(log_text: str) -> JsonObject:
-    import re
 
     for index, raw_line in enumerate(log_text.splitlines(), 1):
         line = raw_line.strip()

--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -15,6 +15,64 @@ ACTION_REPORT_SCHEMA_VERSION = "sdetkit.pr_quality.action_report.v1"
 
 JsonObject = dict[str, Any]
 
+DEPENDENCY_AUDIT_VULNERABILITY = "DEPENDENCY_AUDIT_VULNERABILITY"
+DEPENDENCY_AUDIT_OWNER_FILES = [
+    "requirements-test.txt",
+    "requirements-docs.txt",
+    "requirements.txt",
+    "constraints-ci.txt",
+    "pyproject.toml",
+    ".github/workflows/",
+    ".github/scripts/check_pip_audit_baseline.py",
+]
+
+
+def _extract_dependency_audit_evidence(log_text: str) -> JsonObject:
+    import re
+
+    command = ""
+    report_path = ""
+    artifact_url = ""
+    ignored: list[str] = []
+    vulnerability_count = 0
+    package_count = 0
+
+    for raw_line in log_text.splitlines():
+        line = raw_line.strip()
+        if "pip-audit " in line and not command:
+            command = line
+            ignored = re.findall(r"--ignore-vuln\s+([A-Za-z0-9_.:-]+)", line)
+            report_match = re.search(r"(?:-o|--output)\s+(\S+)", line)
+            if report_match:
+                report_path = report_match.group(1)
+
+        if "path:" in line and "pip-audit-report" in line and not report_path:
+            report_path = line.split("path:", 1)[1].strip()
+
+        if "Artifact download URL:" in line and "artifact" in line.lower():
+            artifact_url = line.split("Artifact download URL:", 1)[1].strip()
+
+        summary_match = re.search(
+            r"Found\s+(\d+)\s+known\s+vulnerabilit(?:y|ies)\s+in\s+(\d+)\s+package",
+            line,
+            flags=re.IGNORECASE,
+        )
+        if summary_match:
+            vulnerability_count = int(summary_match.group(1))
+            package_count = int(summary_match.group(2))
+
+    if not vulnerability_count:
+        return {}
+
+    return {
+        "vulnerability_count": vulnerability_count,
+        "package_count": package_count,
+        "command": command,
+        "report_path": report_path,
+        "artifact_url": artifact_url,
+        "ignored_vulnerabilities": ignored,
+    }
+
 
 _FAILURE_CONCLUSIONS = {
     "action_required",
@@ -261,6 +319,7 @@ _EXACT_FAILURE_PATTERNS = (
     "modulenotfounderror",
     "importerror",
     "process completed with exit code",
+    "known vulnerability",
     "no tests ran",
     "found 1 error",
     "found ",
@@ -431,6 +490,8 @@ def _possible_changed_files_gate_fallout(record: JsonObject, log_text: str) -> b
 
 def _failure_tool_for_line(line: str) -> str:
     lowered = line.lower()
+    if "known vulnerabilit" in lowered and "package" in lowered:
+        return "pip-audit"
     if "ruff" in lowered:
         return "ruff"
     if "mypy" in lowered or "type" in lowered:
@@ -448,6 +509,8 @@ def _failure_tool_for_line(line: str) -> str:
 
 def _failure_kind_for_line(line: str) -> str:
     lowered = line.lower()
+    if "known vulnerabilit" in lowered and "package" in lowered:
+        return "dependency_vulnerability"
     if (
         "ruff format" in lowered
         or "ruff-format" in lowered
@@ -516,11 +579,34 @@ def _first_failure_summary(log_text: str, *, context: int = 3) -> JsonObject:
     return {}
 
 
+def _dependency_audit_first_failure(log_text: str) -> JsonObject:
+    import re
+
+    for index, raw_line in enumerate(log_text.splitlines(), 1):
+        line = raw_line.strip()
+        if re.search(
+            r"Found\s+\d+\s+known\s+vulnerabilit(?:y|ies)\s+in\s+\d+\s+package",
+            line,
+            flags=re.IGNORECASE,
+        ):
+            return {
+                "line_number": index,
+                "line": line,
+                "tool": "pip-audit",
+                "kind": "dependency_vulnerability",
+                "context": [{"line_number": index, "text": raw_line.rstrip()}],
+            }
+    return {}
+
+
 def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) -> JsonObject:
     name = _check_name(record, index)
     log_text = _record_log_text(record, logs_dir, name)
     focused_log_text = _failure_focused_log_text(log_text)
     first_failure = _first_failure_summary(log_text)
+    dependency_audit = _extract_dependency_audit_evidence(log_text)
+    if dependency_audit:
+        first_failure = _dependency_audit_first_failure(log_text) or first_failure
     diagnostic_text = "\n".join(
         part
         for part in [
@@ -538,6 +624,25 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
     ]
 
     primary = diagnoses[0] if diagnoses else {}
+    if dependency_audit:
+        primary = {
+            "code": DEPENDENCY_AUDIT_VULNERABILITY,
+            "title": "Dependency audit reported vulnerable packages",
+            "diagnosis": (
+                f"pip-audit reported {dependency_audit.get('vulnerability_count')} "
+                f"known vulnerabilit"
+                f"{'y' if dependency_audit.get('vulnerability_count') == 1 else 'ies'} "
+                f"in {dependency_audit.get('package_count')} package"
+                f"{'' if dependency_audit.get('package_count') == 1 else 's'}."
+            ),
+            "recommended_fix": [
+                "Review pip-audit-report.json for package/advisory/fixed-version details.",
+                "Create a dependency-only PR if the finding is not baseline-approved.",
+            ],
+            "proof_commands": [
+                "python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .",
+            ],
+        }
     safe_remediation = safe_remediation_eligibility.classify_check_failure(
         name=name,
         diagnosis=primary,
@@ -570,6 +675,12 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
         "diagnoses": diagnoses,
         "diagnosis_status": diagnosis.get("status", "unknown"),
         "safe_to_auto_fix": bool(safe_remediation.get("safe_to_auto_fix", False)),
+        "review_first": bool(dependency_audit),
+        "surface": "dependency" if dependency_audit else _surface_for_diagnosis(primary),
+        "code": _string(primary.get("code")).upper(),
+        "title": _string(primary.get("title")),
+        "dependency_audit": dependency_audit,
+        "owner_files": DEPENDENCY_AUDIT_OWNER_FILES if dependency_audit else [],
     }
 
 
@@ -909,6 +1020,9 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 ),
                 "safe_remediation": check.get("safe_remediation", {}),
                 "safe_to_auto_fix": check.get("safe_to_auto_fix", False),
+                "review_first": bool(check.get("review_first", False)),
+                "dependency_audit": check.get("dependency_audit", {}),
+                "owner_files": check.get("owner_files", []),
             },
             "automation": {
                 "attempted": False,

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -305,6 +305,9 @@ def _primary_blocker_lines(primary: JsonObject) -> list[str]:
             "- Formatter changed files: " + ", ".join(f"`{path}`" for path in formatter_files[:8])
         )
 
+    if bool(primary.get("review_first", False)):
+        lines.append("- Review first: `true`")
+
     if bool(primary.get("stale_evidence", False)):
         head_sha = _string(primary.get("head_sha") or "unknown")
         current_sha = _string(primary.get("current_pr_head_sha") or "unknown")
@@ -321,9 +324,47 @@ def _primary_blocker_lines(primary: JsonObject) -> list[str]:
     if bool(primary.get("possible_changed_files_gate_fallout", False)):
         lines.append("- Gate fallout: possible changed-files base-resolution issue")
 
+    lines.extend(_dependency_audit_lines(primary))
+
     impact = _string(primary.get("impact"))
     if impact:
         lines.append(f"- Impact: {impact}")
+
+    return lines
+
+
+def _dependency_audit_lines(primary: JsonObject) -> list[str]:
+    audit = _as_dict(primary.get("dependency_audit"))
+    if not audit:
+        return []
+
+    lines = ["", "Dependency audit evidence"]
+    vulnerability_count = _int(audit.get("vulnerability_count"))
+    package_count = _int(audit.get("package_count"))
+    if vulnerability_count or package_count:
+        lines.append(f"- Vulnerabilities: {vulnerability_count}")
+        lines.append(f"- Packages: {package_count}")
+
+    command = _string(audit.get("command"))
+    if command:
+        lines.append(f"- Command: `{command}`")
+
+    report_path = _string(audit.get("report_path"))
+    if report_path:
+        lines.append(f"- Report: `{report_path}`")
+
+    artifact_url = _string(audit.get("artifact_url"))
+    if artifact_url:
+        lines.append(f"- Artifact: {artifact_url}")
+
+    ignored = [str(item) for item in _as_list(audit.get("ignored_vulnerabilities"))]
+    if ignored:
+        lines.append(f"- Ignored vulnerabilities: {', '.join(ignored)}")
+
+    owner_files = [str(item) for item in _as_list(primary.get("owner_files"))]
+    if owner_files:
+        lines.append("- Owner files:")
+        lines.extend(f"  - `{item}`" for item in owner_files)
 
     return lines
 

--- a/tests/test_check_intelligence_first_failure.py
+++ b/tests/test_check_intelligence_first_failure.py
@@ -329,3 +329,93 @@ def test_check_intelligence_skips_build_metadata_noise_before_real_mypy_failure(
     )
     assert first_failure["tool"] == "mypy"
     assert first_failure["kind"] == "type_contract"
+
+
+def test_check_intelligence_extracts_pip_audit_dependency_vulnerability_evidence(
+    tmp_path: Path,
+) -> None:
+    from sdetkit.check_intelligence import build_check_intelligence
+
+    checks = tmp_path / "checks.json"
+    _write_json(
+        checks,
+        {
+            "check_runs": [
+                {
+                    "name": "audit",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "##[group]Run python -m pip install -c constraints-ci.txt -e .",
+                            "python -m pip install -c constraints-ci.txt -e .",
+                            "pip-audit --format json -o pip-audit-report.json -r requirements-test.txt -r requirements-docs.txt --ignore-vuln CVE-2026-4539",
+                            "python .github/scripts/check_pip_audit_baseline.py",
+                            "Collecting pip-audit==2.10.0",
+                            "Using cached pip_audit-2.10.0-py3-none-any.whl.metadata (28 kB)",
+                            "Successfully installed pip-audit-2.10.0",
+                            "Found 1 known vulnerability in 1 package",
+                            "##[error]Process completed with exit code 1.",
+                            "name: pip-audit-report",
+                            "path: pip-audit-report.json",
+                            "Artifact download URL: https://github.com/example/actions/runs/1/artifacts/2",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = build_check_intelligence(checks_json=checks)
+    failed = intelligence["failed_checks"][0]
+
+    assert failed["surface"] == "dependency"
+    assert failed["code"] == "DEPENDENCY_AUDIT_VULNERABILITY"
+    assert failed["title"] == "Dependency audit reported vulnerable packages"
+    assert failed["safe_to_auto_fix"] is False
+    assert failed["review_first"] is True
+    assert failed["first_failure"]["line"] == "Found 1 known vulnerability in 1 package"
+    assert failed["first_failure"]["tool"] == "pip-audit"
+    assert failed["first_failure"]["kind"] == "dependency_vulnerability"
+    assert failed["dependency_audit"]["vulnerability_count"] == 1
+    assert failed["dependency_audit"]["package_count"] == 1
+    assert failed["dependency_audit"]["report_path"] == "pip-audit-report.json"
+    assert failed["dependency_audit"]["artifact_url"].endswith("/artifacts/2")
+    assert failed["dependency_audit"]["ignored_vulnerabilities"] == ["CVE-2026-4539"]
+    assert failed["dependency_audit"]["command"].startswith("pip-audit --format json")
+    assert "constraints-ci.txt" in failed["owner_files"]
+    assert "requirements-test.txt" in failed["owner_files"]
+    assert "requirements-docs.txt" in failed["owner_files"]
+
+
+def test_check_intelligence_skips_pip_audit_install_noise_before_summary(tmp_path: Path) -> None:
+    from sdetkit.check_intelligence import build_check_intelligence
+
+    checks = tmp_path / "checks.json"
+    _write_json(
+        checks,
+        {
+            "check_runs": [
+                {
+                    "name": "audit",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "log": "\n".join(
+                        [
+                            "Collecting pip-audit==2.10.0",
+                            "Using cached pip_audit-2.10.0-py3-none-any.whl.metadata (28 kB)",
+                            "Installing collected packages: pip-audit",
+                            "Successfully installed pip-audit-2.10.0",
+                            "Found 2 known vulnerabilities in 1 package",
+                        ]
+                    ),
+                }
+            ]
+        },
+    )
+
+    intelligence = build_check_intelligence(checks_json=checks)
+    first_failure = intelligence["failed_checks"][0]["first_failure"]
+
+    assert first_failure["line"] == "Found 2 known vulnerabilities in 1 package"
+    assert "Using cached" not in first_failure["line"]

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1080,3 +1080,89 @@ def test_action_report_comment_renders_remediation_refresh_loop_summary() -> Non
     assert "Proof after fix result: `passed`" in body
     assert "Remaining blockers: none" in body
     assert "Merge assessment: `green_after_safe_fix`" in body
+
+
+def test_pr_quality_action_report_renders_dependency_audit_evidence() -> None:
+    from sdetkit import pr_quality_action_report as report
+
+    body = report.render_comment_body(
+        action_report={
+            "status": "review_required",
+            "quality_gate": "passed",
+            "coverage": 96.69,
+            "operator_action": "review",
+            "review_first": True,
+            "primary_blocker": {
+                "check_name": "audit",
+                "title": "Dependency audit reported vulnerable packages",
+                "surface": "dependency",
+                "code": "DEPENDENCY_AUDIT_VULNERABILITY",
+                "safe_to_auto_fix": False,
+                "review_first": True,
+                "first_failure": {
+                    "line": "Found 1 known vulnerability in 1 package",
+                    "line_number": 300,
+                    "tool": "pip-audit",
+                    "kind": "dependency_vulnerability",
+                },
+                "dependency_audit": {
+                    "vulnerability_count": 1,
+                    "package_count": 1,
+                    "command": "pip-audit --format json -o pip-audit-report.json -r requirements-test.txt -r requirements-docs.txt --ignore-vuln CVE-2026-4539",
+                    "report_path": "pip-audit-report.json",
+                    "artifact_url": "https://github.com/example/actions/runs/1/artifacts/2",
+                    "ignored_vulnerabilities": ["CVE-2026-4539"],
+                },
+                "owner_files": [
+                    "requirements-test.txt",
+                    "requirements-docs.txt",
+                    "constraints-ci.txt",
+                    "pyproject.toml",
+                    ".github/workflows/",
+                ],
+            },
+            "recommended_actions": [
+                "Review pip-audit-report.json for package/advisory/fixed-version details.",
+                "Create a dependency-only PR if the finding is not baseline-approved.",
+            ],
+            "required_proof": [
+                "python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .",
+            ],
+        },
+        check_intelligence={
+            "failed_checks": [
+                {
+                    "name": "audit",
+                    "surface": "dependency",
+                    "code": "DEPENDENCY_AUDIT_VULNERABILITY",
+                    "title": "Dependency audit reported vulnerable packages",
+                    "safe_to_auto_fix": False,
+                    "dependency_audit": {
+                        "vulnerability_count": 1,
+                        "package_count": 1,
+                        "report_path": "pip-audit-report.json",
+                        "artifact_url": "https://github.com/example/actions/runs/1/artifacts/2",
+                    },
+                }
+            ],
+            "checks_seen": 44,
+            "failed_checks_count": 1,
+            "queued_checks_count": 0,
+            "required_queued_checks_count": 0,
+            "missing_required_contexts_count": 0,
+            "startup_failures_count": 0,
+            "required_startup_failures_count": 0,
+            "security_review_collected": True,
+            "unresolved_security_findings": 0,
+        },
+        safe_fix_outcome={},
+    )
+
+    assert "Dependency audit reported vulnerable packages" in body
+    assert "DEPENDENCY_AUDIT_VULNERABILITY" in body
+    assert "Found 1 known vulnerability in 1 package" in body
+    assert "pip-audit-report.json" in body
+    assert "https://github.com/example/actions/runs/1/artifacts/2" in body
+    assert "requirements-test.txt" in body
+    assert "constraints-ci.txt" in body
+    assert "review_first" in body or "Review first" in body


### PR DESCRIPTION
## Summary
- Add a first-class dependency-audit diagnosis family for pip-audit vulnerability summaries.
- Extract vulnerability/package counts, audit command, report path, artifact URL, ignored vulnerability IDs, and dependency owner files.
- Render dependency-audit evidence in PR Quality comments.
- Keep behavior advisory-only and review-first.

## Why
- PR Quality previously reported pip-audit failures as generic review-required failures.
- Maintainers needed to manually inspect full logs/artifacts to find the audit report and owning dependency files.
- This makes dependency audit blockers actionable without broadening auto-remediation.

## Safety
- No dependency upgrade.
- No audit bypass.
- No security dismissal.
- No auto-remediation.
- Review-first remains true.
- Compatibility preserved.
- Comment/diagnosis evidence only.

## Verification
- `python -m pytest -q tests/test_check_intelligence_first_failure.py tests/test_pr_quality_action_report.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_diagnostic_vector_engine.py -o addopts=`
- `python -m ruff check src tests tools`
- `python -m mypy src`
- `PRE_COMMIT_HOME=/tmp/sdetkit-pr1364-precommit-home python -m pre_commit run -a`
- `PYTHONPATH=src python -m build`
- `PYTHONPATH=src python -m twine check dist/*`
- `python -m sdetkit security check --root . --format json` with zero PR-owned warn/error findings
