### PR TITLE
Persist current-head failure evidence bundles

### DIFF
--- a/src/sdetkit/current_head_failure_bundle.py
+++ b/src/sdetkit/current_head_failure_bundle.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+
+SCHEMA_VERSION = "sdetkit.current_head_failure_bundle.v1"
+
+
+def _as_dict(value: Any) -> JsonObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _bool(value: Any) -> bool:
+    return bool(value)
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _stable_json(payload: JsonObject) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def build_current_head_failure_bundle(
+    *,
+    pr_number: int,
+    head_sha: str,
+    base_sha: str,
+    check_intelligence: JsonObject | None = None,
+    action_report: JsonObject | None = None,
+    diagnostic_vectors: JsonObject | None = None,
+    remediation_plans: JsonObject | None = None,
+    safe_fix_outcome: JsonObject | None = None,
+    refresh_summary: JsonObject | None = None,
+    created_at: str = "",
+) -> JsonObject:
+    check_payload = _as_dict(check_intelligence)
+    action_payload = _as_dict(action_report)
+    vectors_payload = _as_dict(diagnostic_vectors)
+    plans_payload = _as_dict(remediation_plans)
+    safe_fix_payload = _as_dict(safe_fix_outcome)
+    refresh_payload = _as_dict(refresh_summary)
+
+    failed_checks = [_as_dict(item) for item in _as_list(check_payload.get("failed_checks"))]
+    queued_checks = [_as_dict(item) for item in _as_list(check_payload.get("queued_checks"))]
+    startup_failures = [_as_dict(item) for item in _as_list(check_payload.get("startup_failures"))]
+    missing_required = _as_list(check_payload.get("missing_required_contexts"))
+
+    review_first = _bool(action_payload.get("review_first")) or any(
+        _bool(item.get("review_first")) for item in failed_checks
+    )
+    safe_fix_allowed = _bool(action_payload.get("safe_fix_available")) or any(
+        _bool(item.get("safe_to_auto_fix")) for item in failed_checks
+    )
+
+    first_failures: list[JsonObject] = []
+    for item in failed_checks:
+        first_failure = _as_dict(item.get("first_failure"))
+        if first_failure:
+            first_failures.append(
+                {
+                    "check_name": _string(item.get("name")),
+                    "line": _string(first_failure.get("line")),
+                    "line_number": _int(first_failure.get("line_number")),
+                    "tool": _string(first_failure.get("tool") or "unknown"),
+                    "kind": _string(first_failure.get("kind") or "unknown"),
+                }
+            )
+
+    owner_files: list[str] = []
+    for item in failed_checks:
+        diagnosis = _as_dict(item.get("diagnosis"))
+        for path in _as_list(diagnosis.get("owner_files")):
+            value = _string(path)
+            if value and value not in owner_files:
+                owner_files.append(value)
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "pr_number": pr_number,
+        "head_sha": _string(head_sha),
+        "base_sha": _string(base_sha),
+        "created_at": _string(created_at),
+        "source": "pr_quality",
+        "current_head": True,
+        "checks_seen": _int(check_payload.get("checks_seen")),
+        "failed_checks": len(failed_checks),
+        "queued_checks": len(queued_checks),
+        "required_queued_checks": len(
+            [item for item in queued_checks if _bool(item.get("required"))]
+        ),
+        "startup_failures": len(startup_failures),
+        "missing_required_contexts": len(missing_required),
+        "review_first": review_first,
+        "safe_fix_allowed": safe_fix_allowed,
+        "bundle_files": [
+            "manifest.json",
+            "failure-bundle.json",
+            "failure-bundle.md",
+        ],
+    }
+
+    return {
+        "manifest": manifest,
+        "check_intelligence": check_payload,
+        "action_report": action_payload,
+        "first_failures": first_failures,
+        "diagnostic_vectors": vectors_payload,
+        "remediation_plans": plans_payload,
+        "safe_fix_outcome": safe_fix_payload,
+        "refresh_summary": refresh_payload,
+        "owner_files": owner_files,
+    }
+
+
+def render_current_head_failure_bundle_markdown(bundle: JsonObject) -> str:
+    manifest = _as_dict(bundle.get("manifest"))
+    first_failures = [_as_dict(item) for item in _as_list(bundle.get("first_failures"))]
+    owner_files = [_string(item) for item in _as_list(bundle.get("owner_files")) if _string(item)]
+
+    lines = [
+        "# Current-head failure evidence bundle",
+        "",
+        f"- Schema: `{_string(manifest.get('schema_version'))}`",
+        f"- PR: `#{_int(manifest.get('pr_number'))}`",
+        f"- Head SHA: `{_string(manifest.get('head_sha') or 'unknown')}`",
+        f"- Base SHA: `{_string(manifest.get('base_sha') or 'unknown')}`",
+        f"- Checks seen: `{_int(manifest.get('checks_seen'))}`",
+        f"- Failed checks: `{_int(manifest.get('failed_checks'))}`",
+        f"- Required queued checks: `{_int(manifest.get('required_queued_checks'))}`",
+        f"- Review first: `{str(_bool(manifest.get('review_first'))).lower()}`",
+        f"- Safe fix allowed: `{str(_bool(manifest.get('safe_fix_allowed'))).lower()}`",
+        "",
+        "## First failures",
+    ]
+
+    if first_failures:
+        for item in first_failures:
+            location = (
+                f"line {_int(item.get('line_number'))}"
+                if _int(item.get("line_number"))
+                else "line unknown"
+            )
+            lines.append(
+                f"- `{_string(item.get('check_name') or 'unknown')}`: "
+                f"`{_string(item.get('line'))}` ({location}, "
+                f"{_string(item.get('tool') or 'unknown')}/{_string(item.get('kind') or 'unknown')})"
+            )
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Owner files"])
+    if owner_files:
+        lines.extend(f"- `{path}`" for path in owner_files)
+    else:
+        lines.append("- none")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_current_head_failure_bundle(bundle: JsonObject, out_dir: Path) -> list[Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = _as_dict(bundle.get("manifest"))
+    paths = [
+        out_dir / "manifest.json",
+        out_dir / "failure-bundle.json",
+        out_dir / "failure-bundle.md",
+    ]
+
+    paths[0].write_text(_stable_json(manifest), encoding="utf-8")
+    paths[1].write_text(_stable_json(bundle), encoding="utf-8")
+    paths[2].write_text(render_current_head_failure_bundle_markdown(bundle), encoding="utf-8")
+
+    return paths

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -5,6 +5,11 @@ import json
 from pathlib import Path
 from typing import Any
 
+from sdetkit.current_head_failure_bundle import (
+    build_current_head_failure_bundle,
+    write_current_head_failure_bundle,
+)
+
 JsonObject = dict[str, Any]
 
 BANNED_EDUCATIONAL_PHRASES = (
@@ -701,6 +706,10 @@ def write_comment_body(
     check_intelligence_path: Path,
     out: Path,
     evidence_narrative_path: Path | None = None,
+    failure_bundle_out_dir: Path | None = None,
+    pr_number: int = 0,
+    head_sha: str = "",
+    base_sha: str = "",
 ) -> JsonObject:
     action_report = _read_json(action_report_path)
     check_intelligence = _read_json(check_intelligence_path)
@@ -713,6 +722,41 @@ def write_comment_body(
     )
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(body, encoding="utf-8")
+
+    failure_bundle_result: JsonObject = {}
+    if failure_bundle_out_dir is not None:
+        bundle = build_current_head_failure_bundle(
+            pr_number=pr_number,
+            head_sha=head_sha
+            or _string(check_intelligence.get("head_sha") or action_report.get("head_sha")),
+            base_sha=base_sha
+            or _string(check_intelligence.get("base_sha") or action_report.get("base_sha")),
+            check_intelligence=check_intelligence,
+            action_report=action_report,
+            diagnostic_vectors=_as_dict(
+                check_intelligence.get("diagnostic_vectors")
+                or action_report.get("diagnostic_vectors")
+            ),
+            remediation_plans=_as_dict(
+                check_intelligence.get("remediation_plans")
+                or action_report.get("remediation_plans")
+            ),
+            safe_fix_outcome=_as_dict(
+                check_intelligence.get("safe_fix_outcome") or action_report.get("safe_fix_outcome")
+            ),
+            refresh_summary=_as_dict(
+                check_intelligence.get("remediation_refresh")
+                or action_report.get("remediation_refresh")
+            ),
+        )
+        written_bundle_paths = write_current_head_failure_bundle(
+            bundle,
+            failure_bundle_out_dir,
+        )
+        failure_bundle_result = {
+            "out_dir": failure_bundle_out_dir.as_posix(),
+            "files": [item.as_posix() for item in written_bundle_paths],
+        }
 
     status = _string(action_report.get("status") or "unknown")
     _heading, evidence_signal_lines, evidence_review_required = _evidence_signal(evidence_narrative)
@@ -731,7 +775,7 @@ def write_comment_body(
     else:
         evidence_signal_kind = "none"
 
-    return {
+    result: JsonObject = {
         "out": out.as_posix(),
         "status": status,
         "result_title": _result_title(
@@ -743,6 +787,9 @@ def write_comment_body(
         "evidence_signal_present": bool(evidence_signal_lines),
         "evidence_review_required": evidence_review_required,
     }
+    if failure_bundle_result:
+        result["failure_bundle"] = failure_bundle_result
+    return result
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -751,6 +798,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--check-intelligence", type=Path, required=True)
     parser.add_argument("--evidence-narrative", type=Path)
     parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--failure-bundle-out-dir", type=Path)
+    parser.add_argument("--pr-number", type=int, default=0)
+    parser.add_argument("--head-sha", default="")
+    parser.add_argument("--base-sha", default="")
     return parser
 
 
@@ -761,6 +812,10 @@ def main(argv: list[str] | None = None) -> int:
         check_intelligence_path=args.check_intelligence,
         evidence_narrative_path=args.evidence_narrative,
         out=args.out,
+        failure_bundle_out_dir=args.failure_bundle_out_dir,
+        pr_number=args.pr_number,
+        head_sha=args.head_sha,
+        base_sha=args.base_sha,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/tests/test_current_head_failure_bundle.py
+++ b/tests/test_current_head_failure_bundle.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+
+from sdetkit.current_head_failure_bundle import (
+    SCHEMA_VERSION,
+    build_current_head_failure_bundle,
+    render_current_head_failure_bundle_markdown,
+    write_current_head_failure_bundle,
+)
+
+
+def test_current_head_failure_bundle_persists_replayable_manifest(tmp_path):
+    bundle = build_current_head_failure_bundle(
+        pr_number=1366,
+        head_sha="abc123",
+        base_sha="def456",
+        created_at="2026-05-21T03:00:00Z",
+        check_intelligence={
+            "checks_seen": 4,
+            "failed_checks": [
+                {
+                    "name": "Validate (ubuntu-latest / py3.12)",
+                    "safe_to_auto_fix": False,
+                    "review_first": True,
+                    "first_failure": {
+                        "line": "FAILED tests/test_contract.py::test_contract",
+                        "line_number": 42,
+                        "tool": "pytest",
+                        "kind": "test_failure",
+                    },
+                    "diagnosis": {
+                        "owner_files": [
+                            "src/sdetkit/check_intelligence.py",
+                            "tests/test_check_intelligence_first_failure.py",
+                        ]
+                    },
+                }
+            ],
+            "queued_checks": [{"name": "CI", "required": True}],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+        },
+        action_report={"review_first": True, "safe_fix_available": False},
+        diagnostic_vectors={"vectors": [{"classification": "test_failure"}]},
+        remediation_plans={"plans": [{"classification": "review_first"}]},
+        safe_fix_outcome={"attempted": False},
+        refresh_summary={"merge_assessment": "blocked"},
+    )
+
+    written = write_current_head_failure_bundle(bundle, tmp_path)
+
+    assert [path.name for path in written] == [
+        "manifest.json",
+        "failure-bundle.json",
+        "failure-bundle.md",
+    ]
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+    payload = json.loads((tmp_path / "failure-bundle.json").read_text(encoding="utf-8"))
+    markdown = (tmp_path / "failure-bundle.md").read_text(encoding="utf-8")
+
+    assert manifest["schema_version"] == SCHEMA_VERSION
+    assert manifest["pr_number"] == 1366
+    assert manifest["head_sha"] == "abc123"
+    assert manifest["base_sha"] == "def456"
+    assert manifest["checks_seen"] == 4
+    assert manifest["failed_checks"] == 1
+    assert manifest["required_queued_checks"] == 1
+    assert manifest["review_first"] is True
+    assert manifest["safe_fix_allowed"] is False
+    assert payload["first_failures"][0]["line"] == "FAILED tests/test_contract.py::test_contract"
+    assert payload["owner_files"] == [
+        "src/sdetkit/check_intelligence.py",
+        "tests/test_check_intelligence_first_failure.py",
+    ]
+    assert "# Current-head failure evidence bundle" in markdown
+    assert "Validate (ubuntu-latest / py3.12)" in markdown
+    assert "src/sdetkit/check_intelligence.py" in markdown
+
+
+def test_current_head_failure_bundle_rendering_is_deterministic():
+    bundle = build_current_head_failure_bundle(
+        pr_number=1,
+        head_sha="head",
+        base_sha="base",
+        check_intelligence={"checks_seen": 0, "failed_checks": []},
+        action_report={},
+    )
+
+    first = render_current_head_failure_bundle_markdown(bundle)
+    second = render_current_head_failure_bundle_markdown(bundle)
+
+    assert first == second
+    assert "- Failed checks: `0`" in first
+    assert "- none" in first

--- a/tests/test_pr_quality_current_head_failure_bundle.py
+++ b/tests/test_pr_quality_current_head_failure_bundle.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sdetkit.pr_quality_action_report import main, write_comment_body
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def test_pr_quality_action_report_writes_optional_current_head_failure_bundle(tmp_path):
+    action_report_path = _write_json(
+        tmp_path / "action-report.json",
+        {
+            "status": "review_required",
+            "review_first": True,
+            "safe_fix_available": False,
+            "automation": {
+                "attempted": False,
+                "allowed": False,
+                "reason": "review-first failure",
+            },
+            "primary_blocker": {
+                "code": "TEST_FAILURE",
+                "title": "Test failure",
+                "review_first": True,
+                "impact": "human review required before merge",
+            },
+            "recommended_actions": ["Review the failing test before merge."],
+            "proof_commands": ["python -m pytest -q tests/test_contract.py -o addopts="],
+        },
+    )
+    check_intelligence_path = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "checks_seen": 3,
+            "head_sha": "head-from-intelligence",
+            "base_sha": "base-from-intelligence",
+            "failed_checks": [
+                {
+                    "name": "Full CI lane",
+                    "review_first": True,
+                    "safe_to_auto_fix": False,
+                    "first_failure": {
+                        "line": "FAILED tests/test_contract.py::test_contract",
+                        "line_number": 17,
+                        "tool": "pytest",
+                        "kind": "test_failure",
+                    },
+                    "diagnosis": {
+                        "code": "TEST_FAILURE",
+                        "title": "Test failure",
+                        "owner_files": [
+                            "src/sdetkit/check_intelligence.py",
+                            "tests/test_check_intelligence_first_failure.py",
+                        ],
+                    },
+                }
+            ],
+            "queued_checks": [{"name": "security", "required": True}],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+            "diagnostic_vectors": {"vectors": [{"classification": "test_failure"}]},
+            "remediation_plans": {"plans": [{"classification": "review_first"}]},
+            "safe_fix_outcome": {"attempted": False},
+            "remediation_refresh": {"merge_assessment": "blocked"},
+        },
+    )
+
+    out = tmp_path / "comment.md"
+    bundle_dir = tmp_path / "failure-bundle"
+
+    result = write_comment_body(
+        action_report_path=action_report_path,
+        check_intelligence_path=check_intelligence_path,
+        out=out,
+        failure_bundle_out_dir=bundle_dir,
+        pr_number=1366,
+        head_sha="explicit-head",
+        base_sha="explicit-base",
+    )
+
+    assert result["out"] == out.as_posix()
+    assert result["failure_bundle"]["out_dir"] == bundle_dir.as_posix()
+    assert sorted(path.name for path in bundle_dir.iterdir()) == [
+        "failure-bundle.json",
+        "failure-bundle.md",
+        "manifest.json",
+    ]
+
+    manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+    bundle = json.loads((bundle_dir / "failure-bundle.json").read_text(encoding="utf-8"))
+    markdown = (bundle_dir / "failure-bundle.md").read_text(encoding="utf-8")
+
+    assert manifest["schema_version"] == "sdetkit.current_head_failure_bundle.v1"
+    assert manifest["pr_number"] == 1366
+    assert manifest["head_sha"] == "explicit-head"
+    assert manifest["base_sha"] == "explicit-base"
+    assert manifest["checks_seen"] == 3
+    assert manifest["failed_checks"] == 1
+    assert manifest["required_queued_checks"] == 1
+    assert manifest["review_first"] is True
+    assert manifest["safe_fix_allowed"] is False
+    assert bundle["first_failures"][0]["line"] == "FAILED tests/test_contract.py::test_contract"
+    assert "src/sdetkit/check_intelligence.py" in bundle["owner_files"]
+    assert "# Current-head failure evidence bundle" in markdown
+    assert "Full CI lane" in markdown
+
+
+def test_pr_quality_action_report_cli_keeps_bundle_writing_optional(tmp_path):
+    action_report_path = _write_json(
+        tmp_path / "action-report.json",
+        {
+            "status": "green",
+            "automation": {
+                "attempted": False,
+                "allowed": False,
+                "reason": "no action required",
+            },
+            "recommended_actions": [],
+            "proof_commands": [],
+        },
+    )
+    check_intelligence_path = _write_json(
+        tmp_path / "check-intelligence.json",
+        {
+            "checks_seen": 1,
+            "failed_checks": [],
+            "queued_checks": [],
+            "startup_failures": [],
+            "missing_required_contexts": [],
+        },
+    )
+
+    out = tmp_path / "comment.md"
+    assert (
+        main(
+            [
+                "--action-report",
+                str(action_report_path),
+                "--check-intelligence",
+                str(check_intelligence_path),
+                "--out",
+                str(out),
+            ]
+        )
+        == 0
+    )
+
+    assert out.exists()
+    assert not (tmp_path / "failure-bundle").exists()


### PR DESCRIPTION
## Summary
- Add a deterministic current-head failure evidence bundle contract.
- Persist replayable `manifest.json`, `failure-bundle.json`, and `failure-bundle.md` artifacts when PR Quality receives an optional bundle output directory.
- Preserve existing PR Quality comment and JSON return contracts.

## Why
PR Quality now diagnoses current-head failures, safe-fix eligibility, review-first blockers, remediation plans, and refresh outcomes, but the evidence is spread across separate outputs. This adds one replayable current-head bundle so a maintainer can inspect why SDETKit chose review-first, safe-fix, or no action for a PR head.

## Safety
- Evidence-only change.
- No dependency upgrade.
- No vulnerability dismissal.
- No broad auto-remediation.
- No change to safe-fix eligibility.
- No change to review-first policy.
- Bundle writing is optional and additive.

## Verification
- `python -m pytest -q tests/test_current_head_failure_bundle.py tests/test_pr_quality_current_head_failure_bundle.py tests/test_pr_quality_action_report.py tests/test_pr_quality_failure_bundle_workflow.py tests/test_check_intelligence_first_failure.py tests/test_diagnostic_vector_engine.py tests/test_remediation_plan_engine.py tests/test_maintenance_autopilot_remediation_plan_bridge.py tests/test_pr_quality_remediation_refresh_loop.py tests/test_safe_fix_history_memory.py -o addopts=`
- `python -m ruff check src tests tools`
- `python -m mypy src`
- `PRE_COMMIT_HOME=/tmp/sdetkit-current-head-failure-bundle-precommit-home python -m pre_commit run -a`
- `PYTHONPATH=src python -m build`
- `PYTHONPATH=src python -m twine check dist/*`
- `python -m sdetkit security check --root . --format json`
- PR-owned security filter: no warn/error findings in touched files.

## Rollback
Remove `src/sdetkit/current_head_failure_bundle.py`, its tests, and the optional PR Quality bundle wiring. Existing PR Quality behavior remains unchanged.