### PR TITLE
Lower setuptools minimum in pyproject.toml for bootstrap compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=82.0.1", "wheel"]
+requires = ["setuptools>=65.5.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
### Motivation
- The bootstrap/install step failed in environments where the configured package index/proxy could not provide `setuptools>=82.0.1`, so the build isolation needs a lower setuptools floor to avoid install failures.

### Description
- Change `build-system.requires` in `pyproject.toml` from `setuptools>=82.0.1` to `setuptools>=65.5.1` to restore bootstrap compatibility in constrained package-index environments.

### Testing
- Ran `pytest -q tests/test_bootstrap_idempotency.py`, which completed (test skipped in this environment).
- Ran `pytest -x -q` and observed the test suite progress substantially with no immediate regressions within the verification window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e8a47ff008330aa73d6f61f4eac7a)