### PR TITLE
Harden Mission Control sensitive output contract

### DIFF
--- a/src/sdetkit/mission_control.py
+++ b/src/sdetkit/mission_control.py
@@ -368,6 +368,53 @@ def _doctor_cortex_artifacts(summary: dict[str, Any] | None) -> list[dict[str, s
     return [artifact for artifact in artifacts if isinstance(artifact, dict)]
 
 
+def _doctor_cortex_public_status(value: Any) -> str:
+    if value == "pass":
+        return "pass"
+    if value == "fail":
+        return "fail"
+    if value == "error":
+        return "error"
+    if value == "warning":
+        return "warning"
+    return "unknown"
+
+
+def _doctor_cortex_public_severity(value: Any) -> str:
+    if value == "low":
+        return "low"
+    if value == "medium":
+        return "medium"
+    if value == "high":
+        return "high"
+    if value == "critical":
+        return "critical"
+    return "unknown"
+
+
+def _doctor_cortex_public_summary(summary: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(summary, dict) or not summary.get("enabled"):
+        return None
+
+    diagnosis = summary.get("diagnosis", {})
+    prescriptions = summary.get("prescriptions", {})
+    if not isinstance(diagnosis, dict):
+        diagnosis = {}
+    if not isinstance(prescriptions, dict):
+        prescriptions = {}
+
+    return {
+        "enabled": True,
+        "ok": bool(summary.get("ok", False)),
+        "diagnosis_status": _doctor_cortex_public_status(diagnosis.get("status")),
+        "diagnosis_severity": _doctor_cortex_public_severity(diagnosis.get("severity")),
+        "diagnosis_count": int(diagnosis.get("diagnosis_count", 0) or 0),
+        "prescription_status": _doctor_cortex_public_status(prescriptions.get("status")),
+        "prescription_severity": _doctor_cortex_public_severity(prescriptions.get("severity")),
+        "prescription_count": int(prescriptions.get("prescription_count", 0) or 0),
+    }
+
+
 _EVIDENCE_GRAPH_SURFACE_PRIORITY = {
     "security": 100,
     "dependency": 90,
@@ -939,14 +986,30 @@ def _format_doctor_cortex(summary: dict[str, Any] | None) -> list[str]:
     if not isinstance(prescriptions, dict):
         prescriptions = {}
 
+    diagnosis_status = summary.get("diagnosis_status", diagnosis.get("status", "unknown"))
+    diagnosis_severity = summary.get("diagnosis_severity", diagnosis.get("severity", "unknown"))
+    diagnosis_count = summary.get("diagnosis_count", diagnosis.get("diagnosis_count", 0))
+    prescription_status = summary.get(
+        "prescription_status",
+        prescriptions.get("status", "unknown"),
+    )
+    prescription_severity = summary.get(
+        "prescription_severity",
+        prescriptions.get("severity", "unknown"),
+    )
+    prescription_count = summary.get(
+        "prescription_count",
+        prescriptions.get("prescription_count", 0),
+    )
+
     return [
         f"- OK: {str(summary.get('ok', False)).lower()}",
-        f"- Diagnosis status: {diagnosis.get('status', 'unknown')}",
-        f"- Diagnosis severity: {diagnosis.get('severity', 'unknown')}",
-        f"- Diagnosis count: {diagnosis.get('diagnosis_count', 0)}",
-        f"- Prescription status: {prescriptions.get('status', 'unknown')}",
-        f"- Prescription severity: {prescriptions.get('severity', 'unknown')}",
-        f"- Prescription count: {prescriptions.get('prescription_count', 0)}",
+        f"- Diagnosis status: {diagnosis_status}",
+        f"- Diagnosis severity: {diagnosis_severity}",
+        f"- Diagnosis count: {diagnosis_count}",
+        f"- Prescription status: {prescription_status}",
+        f"- Prescription severity: {prescription_severity}",
+        f"- Prescription count: {prescription_count}",
     ]
 
 
@@ -1108,7 +1171,7 @@ def build_bundle(
         "executed_step_count": executed_count,
         "passed_step_count": passed_count,
         "failed_step_count": failed_count,
-        "doctor_cortex": doctor_cortex_summary,
+        "doctor_cortex": _doctor_cortex_public_summary(doctor_cortex_summary),
         "evidence_graph": evidence_graph_summary,
         "adaptive_failure_bundle": adaptive_failure_bundle_summary,
         "patch_plan": patch_plan_summary,
@@ -1198,9 +1261,9 @@ def _doctor_cortex_ledger_summary(bundle: dict[str, Any]) -> dict[str, Any] | No
     return {
         "enabled": True,
         "ok": bool(doctor_cortex.get("ok", False)),
-        "diagnosis_status": str(diagnosis.get("status", "unknown")),
+        "diagnosis_status": _doctor_cortex_public_status(diagnosis.get("status")),
         "diagnosis_count": int(diagnosis.get("diagnosis_count", 0) or 0),
-        "prescription_status": str(prescriptions.get("status", "unknown")),
+        "prescription_status": _doctor_cortex_public_status(prescriptions.get("status")),
         "prescription_count": int(prescriptions.get("prescription_count", 0) or 0),
     }
 
@@ -1570,15 +1633,12 @@ def _summarize(args: argparse.Namespace) -> int:
     print(f"findings={len(bundle['findings'])}")
     doctor_cortex = bundle.get("doctor_cortex")
     if isinstance(doctor_cortex, dict):
-        diagnosis = doctor_cortex.get("diagnosis", {})
-        prescriptions = doctor_cortex.get("prescriptions", {})
-        if not isinstance(diagnosis, dict):
-            diagnosis = {}
-        if not isinstance(prescriptions, dict):
-            prescriptions = {}
         print(f"doctor_cortex_ok={str(doctor_cortex.get('ok', False)).lower()}")
-        print(f"doctor_cortex_diagnosis_count={diagnosis.get('diagnosis_count', 0)}")
-        print(f"doctor_cortex_prescription_count={prescriptions.get('prescription_count', 0)}")
+        print(f"doctor_cortex_diagnosis_count={int(doctor_cortex.get('diagnosis_count', 0) or 0)}")
+        print(
+            "doctor_cortex_prescription_count="
+            f"{int(doctor_cortex.get('prescription_count', 0) or 0)}"
+        )
     evidence_graph = bundle.get("evidence_graph")
     if isinstance(evidence_graph, dict):
         summary_prefix = "evidence" + "_graph"

--- a/tests/test_mission_control_doctor_cortex.py
+++ b/tests/test_mission_control_doctor_cortex.py
@@ -2,6 +2,8 @@ import json
 
 from sdetkit import mission_control
 
+HIDDEN_DOCTOR_DETAIL = "diagnostic" + "-detail-alpha"
+
 
 def _fake_doctor_cortex(repo, out_dir):
     diagnosis_path = out_dir / "doctor-cortex-diagnosis.json"
@@ -20,6 +22,7 @@ def _fake_doctor_cortex(repo, out_dir):
             "status": "pass",
             "severity": "low",
             "diagnosis_count": 0,
+            "detail": HIDDEN_DOCTOR_DETAIL,
         },
         "prescriptions": {
             "status": "pass",
@@ -67,38 +70,25 @@ def test_mission_control_run_includes_doctor_cortex(tmp_path, monkeypatch):
     assert bundle["doctor_cortex"] == {
         "enabled": True,
         "ok": True,
-        "diagnosis": {
-            "status": "pass",
-            "severity": "low",
-            "diagnosis_count": 0,
-        },
-        "prescriptions": {
-            "status": "pass",
-            "severity": "low",
-            "prescription_count": 0,
-        },
-        "artifacts": [
-            {
-                "label": "Doctor Cortex diagnosis contract",
-                "kind": "json",
-                "path": (out_dir / "doctor-cortex-diagnosis.json").as_posix(),
-            },
-            {
-                "label": "Doctor Cortex prescription contract",
-                "kind": "json",
-                "path": (out_dir / "doctor-cortex-prescriptions.json").as_posix(),
-            },
-        ],
+        "diagnosis_status": "pass",
+        "diagnosis_severity": "low",
+        "diagnosis_count": 0,
+        "prescription_status": "pass",
+        "prescription_severity": "low",
+        "prescription_count": 0,
     }
 
     labels = {artifact["label"] for artifact in bundle["artifacts"]}
     assert "Doctor Cortex diagnosis contract" in labels
     assert "Doctor Cortex prescription contract" in labels
 
+    json_text = (out_dir / "mission-control.json").read_text(encoding="utf-8")
     markdown = (out_dir / "mission-control.md").read_text(encoding="utf-8")
     assert "## Doctor Cortex" in markdown
     assert "Diagnosis count: 0" in markdown
     assert "Prescription count: 0" in markdown
+    assert HIDDEN_DOCTOR_DETAIL not in json_text
+    assert HIDDEN_DOCTOR_DETAIL not in markdown
 
 
 def test_mission_control_summarize_prints_doctor_cortex(tmp_path, monkeypatch, capsys):
@@ -129,6 +119,7 @@ def test_mission_control_summarize_prints_doctor_cortex(tmp_path, monkeypatch, c
     assert "doctor_cortex_ok=true" in output
     assert "doctor_cortex_diagnosis_count=0" in output
     assert "doctor_cortex_prescription_count=0" in output
+    assert HIDDEN_DOCTOR_DETAIL not in output
 
 
 def test_mission_control_report_includes_doctor_cortex_section(tmp_path, monkeypatch):
@@ -167,3 +158,4 @@ def test_mission_control_report_includes_doctor_cortex_section(tmp_path, monkeyp
     assert "## Doctor Cortex" in report
     assert "Diagnosis status: pass" in report
     assert "Prescription status: pass" in report
+    assert HIDDEN_DOCTOR_DETAIL not in report


### PR DESCRIPTION
## Summary
- Store only a public Doctor Cortex summary in Mission Control artifacts.
- Preserve Doctor Cortex artifact links through the top-level artifact list.
- Keep summarize stdout on scalar public fields instead of nested diagnostic/prescription payloads.
- Add regression coverage proving nested Doctor Cortex detail text is absent from JSON, Markdown, report, and summarize output.

## Security alerts targeted
- `py/clear-text-storage-sensitive-data` in `src/sdetkit/mission_control.py`
- `py/clear-text-logging-sensitive-data` in `src/sdetkit/mission_control.py`

## Verification
- `python -m pytest -q tests/test_mission_control.py tests/test_mission_control_doctor_cortex.py tests/test_mission_control_evidence_graph.py tests/test_mission_control_adaptive_failure_bundle.py -o addopts=`
- `python -m pytest -q tests/test_security_scan_json_reuse.py tests/test_security_review_evidence.py tests/test_security_quality_review_guard.py tests/test_repo_security_suite.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
Medium. This changes the public Mission Control `doctor_cortex` artifact shape from nested diagnostic/prescription payloads to a public scalar summary, while preserving artifact references in the top-level artifact list.