### PR TITLE
Pin fixed dependency versions for security alerts

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,3 +2,6 @@ mkdocs==1.6.1
 mkdocs-material==9.7.6
 pymdown-extensions==10.21.3
 pygments==2.20.0
+
+# Security scanner transitive dependency floors
+idna==3.15

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,6 @@ httpx==0.28.1
 ruff==0.15.13
 mypy==2.1.0
 mutmut==3.5.0
+
+# Security scanner transitive dependency floors
+idna==3.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,7 @@ pymdown-extensions==10.21.3
 # Backport for environments below Python 3.11
 # (kept for compatibility in ad-hoc environments)
 tomli==2.4.1; python_version < "3.11"
+
+# Security scanner transitive dependency floors
+idna==3.15
+lxml==6.1.1


### PR DESCRIPTION
## Summary
- Add explicit exact pins for fixed-version vulnerability alerts.
- Pin `idna` to `3.15` across affected requirement manifests.
- Pin `lxml` to `6.1.1` in the consolidated requirements manifest.
- Keep `markdown` / CVE-2025-69534 policy-baselined because `pip-audit` reports no fixed version and the latest available release is already installed locally.

## Security alerts targeted
Fixed by exact dependency pin:
- CVE-2026-45409: `idna@3.9.0`
- CVE-2026-41066: `lxml@5.4.0`

Policy-baselined / not fixed by version:
- CVE-2025-69534 / PYSEC-2026-89: `markdown@3.10.2`, no fixed version reported by `pip-audit`.

## Verification
- `python -m pip check`
- `pip-audit --format json -o build/security-alert-inventory/pip-audit-after-dependency-fix.json -r requirements.txt -r requirements-test.txt -r requirements-docs.txt --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2025-69534`
- `python -m sdetkit repo check . --profile enterprise --format json --out sdet_check.json --force`
- `python -m pytest -q tests/test_workflow_dependency_install_contract.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
Low. This PR only adds exact security pins for transitive dependencies with fixed safe versions.