### PR TITLE
Recover code scanning alert regression

### DIFF
--- a/constraints-ci.txt
+++ b/constraints-ci.txt
@@ -15,4 +15,3 @@ ruff==0.15.13
 twine==6.2.0
 pytest-xdist==3.8.0
 psutil==7.2.2
-Markdown==3.10

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,5 +4,4 @@ pymdown-extensions==10.21.3
 pygments==2.20.0
 
 # Security scanner transitive dependency floors
-Markdown==3.10
 idna==3.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,5 @@ pymdown-extensions==10.21.3
 tomli==2.4.1; python_version < "3.11"
 
 # Security scanner transitive dependency floors
-Markdown==3.10
 idna==3.15
 lxml==6.1.1


### PR DESCRIPTION
## Summary
- Reverts the Markdown direct dependency floor that increased CVE-2025-69534 code scanning alerts.
- Reverts ineffective CodeQL sink suppression comments from the clear-text output files.
- Keeps the separate maintenance-autopilot empty dry-run fix already merged in PR #1372.

## Why
After PR #1372 merged, open code scanning alerts on main increased from 81 to 83. The CVE-2025-69534 group increased from 2 to 4. This recovery PR restores the pre-regression security posture before continuing deeper alert remediation.

## Verification
- `python -m pip install -c constraints-ci.txt -r requirements.txt`
- `python -m pip install -c constraints-ci.txt -r requirements-docs.txt`
- `python -m pip check`
- `python -m pre_commit run -a`
- `python -m mypy src`
- `python -m pytest -q tests/test_adaptive_diagnosis.py tests/test_adaptive_memory.py tests/test_adaptive_remediation_policy.py tests/test_adaptive_sentinel.py -o addopts=`

## Risk
- Low recovery PR.
- Does not weaken workflows, tests, or security gates.
- Rollback: revert this PR.