### PR TITLE
Clear simple Python code scanning notes

### DIFF
--- a/src/sdetkit/apiget.py
+++ b/src/sdetkit/apiget.py
@@ -69,7 +69,6 @@ def _merged_headers(client, extra, debug: bool) -> dict[str, str]:
             except Exception:
                 if debug:
                     traceback.print_exc()
-                pass
     return out
 
 

--- a/src/sdetkit/kvcli.py
+++ b/src/sdetkit/kvcli.py
@@ -38,7 +38,8 @@ def _build_comment_aware_parser(
             supports_allow_comments = True
             supports_duplicate_policy = True
     except (TypeError, ValueError):
-        pass
+        supports_allow_comments = False
+        supports_duplicate_policy = False
 
     def _wrapped(line: str) -> dict[str, str]:
         kwargs: dict[str, object] = {}

--- a/src/sdetkit/netclient.py
+++ b/src/sdetkit/netclient.py
@@ -201,7 +201,7 @@ async def _emit_async(hook: Hook | AsyncHook | None, ev: ClientEvent) -> None:
         return
     r = hook(ev)
     if asyncio.iscoroutine(r):
-        await r
+        _ = await r
 
 
 class SdetHttpClient:


### PR DESCRIPTION
## Summary
- Removes an unnecessary `pass` in `apiget.py`.
- Replaces an empty exception handler in `kvcli.py` with explicit fallback assignments.
- Makes the intentionally ignored async hook result explicit in `netclient.py`.

## Alert scope
Targets simple CodeQL Python note/warning findings:
- `py/empty-except`
- `py/ineffectual-statement`
- `py/unnecessary-pass`

## Verification
- `python -m pytest -q tests/test_coverage_boost_targets.py tests/test_pr_quality_evidence_narrative.py tests/test_check_intelligence_first_failure.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
Low. Behavior-preserving cleanup only.