### PR TITLE
Improve CodeQL and Validate failure diagnostics

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -118,6 +118,8 @@ _DIAGNOSIS_SURFACES = {
     "RUFF_LINT_FAILURE": "quality",
     "MYPY_TYPE_CONTRACT_DRIFT": "quality",
     "COVERAGE_GATE_REGRESSION": "quality",
+    "CODEQL_SECURITY_REVIEW_REQUIRED": "security",
+    "VALIDATE_JOB_LOG_REVIEW": "workflow",
 }
 
 
@@ -679,6 +681,65 @@ def _dependency_audit_first_failure(log_text: str) -> JsonObject:
     return {}
 
 
+def _is_unknown_diagnosis(diagnosis: JsonObject) -> bool:
+    code = _string(diagnosis.get("code")).upper()
+    title = _string(diagnosis.get("title")).lower()
+    return (
+        not diagnosis
+        or code in {"", "UNKNOWN", "UNKNOWN_REVIEW_REQUIRED"}
+        or title in {"", "unknown failure", "failure needs human review"}
+    )
+
+
+def _fallback_check_diagnosis(name: str, first_failure: JsonObject) -> JsonObject:
+    lowered = name.lower()
+    first_line = _string(first_failure.get("line"))
+
+    if "codeql" in lowered:
+        return {
+            "code": "CODEQL_SECURITY_REVIEW_REQUIRED",
+            "title": "CodeQL security analysis requires review",
+            "risk_surface": "security",
+            "diagnosis": (
+                "CodeQL failed or reported security evidence. Inspect current GitHub "
+                "Advanced Security comments and confirm whether each alert is current, "
+                "fixed, or a reviewed false positive."
+            ),
+            "recommended_fix": [
+                "Review unresolved GitHub Advanced Security comments on the PR.",
+                "For each alert, compare the alert commit SHA with the current PR head.",
+                "Fix current true positives or dismiss reviewed false positives with a short reason.",
+            ],
+            "proof_commands": [
+                "python -m sdetkit security check --root . --format json",
+                "python -m pre_commit run -a",
+            ],
+        }
+
+    if "validate" in lowered or "github actions advanced reference" in lowered:
+        line = first_line or "No exact failing line was collected from the Validate job log."
+        return {
+            "code": "VALIDATE_JOB_LOG_REVIEW",
+            "title": "Validate job needs exact log review",
+            "risk_surface": "workflow",
+            "diagnosis": (
+                "A Validate job failed before PR Quality could classify the exact product "
+                f"failure. First collected signal: {line}"
+            ),
+            "recommended_fix": [
+                "Open the failed Validate job log and extract the first non-setup failure line.",
+                "Patch the smallest affected product or test boundary.",
+                "Rerun the focused failed test or command before broad pre-commit proof.",
+            ],
+            "proof_commands": [
+                "python -m pre_commit run -a",
+                "python -m pytest -q tests/test_pr_quality_evidence_narrative.py tests/test_pr_quality_adaptive_sentinel_workflow.py tests/test_pr_quality_failure_bundle_workflow.py -o addopts=",
+            ],
+        }
+
+    return {}
+
+
 def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) -> JsonObject:
     name = _check_name(record, index)
     log_text = _record_log_text(record, logs_dir, name)
@@ -752,6 +813,10 @@ def _diagnose_check(record: JsonObject, *, index: int, logs_dir: Path | None) ->
                 "python -m pip install -c constraints-ci.txt -r requirements-test.txt -r requirements-docs.txt -e .",
             ],
         }
+    fallback = _fallback_check_diagnosis(name, first_failure)
+    if fallback and _is_unknown_diagnosis(primary):
+        primary = fallback
+
     safe_remediation = safe_remediation_eligibility.classify_check_failure(
         name=name,
         diagnosis=primary,

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -365,3 +365,65 @@ def test_check_intelligence_does_not_synthesize_required_context_when_reported(
     assert intelligence["queued_checks"] == []
     assert report["status"] == "green"
     assert report["primary_blocker"] == {}
+
+
+def test_check_intelligence_codeql_failure_gets_security_review_actions(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "CodeQL",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "url": "https://example.test/check-runs/codeql",
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    failed = intelligence["failed_checks"][0]
+    assert failed["diagnosis"]["code"] == "CODEQL_SECURITY_REVIEW_REQUIRED"
+    assert failed["surface"] == "security"
+
+    assert report["status"] == "review_required"
+    assert report["primary_blocker"]["surface"] == "security"
+    assert report["primary_blocker"]["code"] == "CODEQL_SECURITY_REVIEW_REQUIRED"
+    assert "GitHub Advanced Security" in " ".join(report["recommended_actions"])
+    assert "sdetkit security check" in " ".join(report["proof_commands"])
+
+
+def test_check_intelligence_validate_failure_gets_log_review_actions(
+    tmp_path: Path,
+) -> None:
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {
+            "check_runs": [
+                {
+                    "name": "Validate (ubuntu-latest / py3.12)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "url": "https://example.test/check-runs/validate",
+                }
+            ]
+        },
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(checks_json=checks)
+    report = check_intelligence.build_action_report(intelligence)
+
+    failed = intelligence["failed_checks"][0]
+    assert failed["diagnosis"]["code"] == "VALIDATE_JOB_LOG_REVIEW"
+    assert failed["surface"] == "workflow"
+
+    assert report["status"] == "review_required"
+    assert report["primary_blocker"]["surface"] == "workflow"
+    assert report["primary_blocker"]["code"] == "VALIDATE_JOB_LOG_REVIEW"
+    assert "first non-setup failure line" in " ".join(report["recommended_actions"])
+    assert "python -m pre_commit run -a" in report["proof_commands"]


### PR DESCRIPTION
## Summary
- Adds deterministic fallback diagnoses for failed CodeQL and Validate checks when adaptive diagnosis would otherwise report an unknown failure.
- Gives PR Quality concrete review actions and proof commands for CodeQL/security review and Validate log-review failures.
- Adds regression tests for the diagnostic gap seen during the code scanning cleanup.

## Verification
- `python -m pytest -q tests/test_check_intelligence.py tests/test_check_intelligence_first_failure.py tests/test_pr_quality_action_report.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
Low. Diagnostic/reporting-only change; no remediation or security dismissal behavior is changed.