### PR TITLE
Report code scanning alert freshness in PR quality

### DIFF
--- a/src/sdetkit/check_intelligence.py
+++ b/src/sdetkit/check_intelligence.py
@@ -912,6 +912,93 @@ def _security_review_summary(review_threads_json: Path | None) -> JsonObject:
     }
 
 
+def _open_code_scanning_alerts(payload: Any) -> list[JsonObject]:
+    raw_alerts = payload if isinstance(payload, list) else _as_list(_as_dict(payload).get("alerts"))
+    return [
+        _as_dict(item)
+        for item in raw_alerts
+        if _as_dict(item) and _string(_as_dict(item).get("state") or "open").lower() == "open"
+    ]
+
+
+def _code_scanning_review_summary(
+    alerts_json: Path | None,
+    *,
+    current_head_sha: str = "",
+) -> JsonObject:
+    if alerts_json is None or not alerts_json.exists():
+        return {
+            "collected": False,
+            "source": alerts_json.as_posix() if alerts_json else "",
+            "open_alerts": 0,
+            "current_alerts": 0,
+            "stale_alerts": 0,
+            "unknown_freshness_alerts": 0,
+            "current_head_sha": current_head_sha,
+            "rule_counts": {},
+            "findings": [],
+        }
+
+    payload = json.loads(alerts_json.read_text(encoding="utf-8"))
+    findings: list[JsonObject] = []
+    rule_counts: dict[str, int] = {}
+
+    for alert in _open_code_scanning_alerts(payload):
+        rule = _as_dict(alert.get("rule"))
+        instance = _as_dict(alert.get("most_recent_instance"))
+        location = _as_dict(instance.get("location"))
+        message = _as_dict(instance.get("message"))
+        commit_sha = _string(instance.get("commit_sha"))
+
+        if not commit_sha or not current_head_sha:
+            freshness = "unknown"
+        elif commit_sha == current_head_sha:
+            freshness = "current"
+        else:
+            freshness = "stale"
+
+        if freshness == "current":
+            action = "fix_current_alert_or_dismiss_reviewed_false_positive"
+        elif freshness == "stale":
+            action = "wait_for_code_scanning_refresh"
+        else:
+            action = "review_alert_freshness"
+
+        rule_id = _string(rule.get("id") or "unknown")
+        rule_counts[rule_id] = rule_counts.get(rule_id, 0) + 1
+
+        findings.append(
+            {
+                "number": alert.get("number", ""),
+                "rule_id": rule_id,
+                "severity": _string(
+                    rule.get("security_severity_level") or rule.get("severity") or "unknown"
+                ),
+                "path": _string(location.get("path")),
+                "line": _string(location.get("start_line")),
+                "commit_sha": commit_sha,
+                "current_head_sha": current_head_sha,
+                "freshness": freshness,
+                "recommended_action": action,
+                "message": _string(message.get("text")),
+            }
+        )
+
+    return {
+        "collected": True,
+        "source": alerts_json.as_posix(),
+        "open_alerts": len(findings),
+        "current_alerts": len([item for item in findings if item["freshness"] == "current"]),
+        "stale_alerts": len([item for item in findings if item["freshness"] == "stale"]),
+        "unknown_freshness_alerts": len(
+            [item for item in findings if item["freshness"] == "unknown"]
+        ),
+        "current_head_sha": current_head_sha,
+        "rule_counts": dict(sorted(rule_counts.items())),
+        "findings": findings,
+    }
+
+
 def _required_contexts(payload: JsonObject) -> list[str]:
     direct = payload.get("required_contexts")
     if isinstance(direct, list):
@@ -940,6 +1027,8 @@ def build_check_intelligence(
     checks_json: Path,
     logs_dir: Path | None = None,
     review_threads_json: Path | None = None,
+    code_scanning_alerts_json: Path | None = None,
+    current_head_sha: str = "",
 ) -> JsonObject:
     payload = _read_json(checks_json)
     records = _iter_check_records(payload)
@@ -997,6 +1086,11 @@ def build_check_intelligence(
         "cancelled_checks": cancelled_checks,
         "startup_failures": startup_failures,
         "security_review": _security_review_summary(review_threads_json),
+        "code_scanning_review": _code_scanning_review_summary(
+            code_scanning_alerts_json,
+            current_head_sha=current_head_sha,
+        ),
+        "current_head_sha": current_head_sha,
     }
 
 
@@ -1163,6 +1257,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                     ]
                 ),
                 "security_review": security_review,
+                "code_scanning_review": intelligence.get("code_scanning_review", {}),
             },
         }
 
@@ -1232,6 +1327,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                     ]
                 ),
                 "security_review": intelligence.get("security_review", {}),
+                "code_scanning_review": intelligence.get("code_scanning_review", {}),
             },
         }
 
@@ -1272,6 +1368,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
                 "startup_failure_count": len(startup),
                 "required_startup_failure_count": len(required_startup),
                 "security_review": intelligence.get("security_review", {}),
+                "code_scanning_review": intelligence.get("code_scanning_review", {}),
             },
         }
 
@@ -1293,6 +1390,7 @@ def build_action_report(intelligence: JsonObject) -> JsonObject:
             "startup_failure_count": len(startup),
             "required_startup_failure_count": 0,
             "security_review": intelligence.get("security_review", {}),
+            "code_scanning_review": intelligence.get("code_scanning_review", {}),
         },
     }
 
@@ -1372,6 +1470,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--checks-json", type=Path, required=True)
     parser.add_argument("--logs-dir", type=Path)
     parser.add_argument("--review-threads-json", type=Path)
+    parser.add_argument("--code-scanning-alerts-json", type=Path)
+    parser.add_argument("--current-head-sha", default="")
     parser.add_argument("--out-dir", type=Path, default=Path("build/pr-quality"))
     return parser
 
@@ -1382,6 +1482,8 @@ def main(argv: list[str] | None = None) -> int:
         checks_json=args.checks_json,
         logs_dir=args.logs_dir,
         review_threads_json=args.review_threads_json,
+        code_scanning_alerts_json=args.code_scanning_alerts_json,
+        current_head_sha=args.current_head_sha,
     )
     action_report = build_action_report(intelligence)
     artifacts = write_artifacts(

--- a/src/sdetkit/pr_quality_action_report.py
+++ b/src/sdetkit/pr_quality_action_report.py
@@ -192,6 +192,10 @@ def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -
     missing_required_count = len(_as_list(check_intelligence.get("missing_required_contexts")))
     checks_seen = _int(check_intelligence.get("checks_seen"))
     unresolved_security = _int(security.get("unresolved_findings"))
+    code_scanning = _as_dict(
+        check_intelligence.get("code_scanning_review")
+        or _as_dict(action_report.get("evidence")).get("code_scanning_review")
+    )
 
     lines = [
         f"- Checks seen: `{checks_seen}`",
@@ -207,6 +211,18 @@ def _evidence_lines(check_intelligence: JsonObject, action_report: JsonObject) -
         collected = "true" if bool(security.get("collected", False)) else "false"
         lines.append(f"- Security review collected: `{collected}`")
         lines.append(f"- Unresolved security findings: `{unresolved_security}`")
+
+    if code_scanning:
+        collected = "true" if bool(code_scanning.get("collected", False)) else "false"
+        lines.append(f"- Code scanning review collected: `{collected}`")
+        lines.append(f"- Open code scanning alerts: `{_int(code_scanning.get('open_alerts'))}`")
+        lines.append(
+            f"- Current code scanning alerts: `{_int(code_scanning.get('current_alerts'))}`"
+        )
+        lines.append(f"- Stale code scanning alerts: `{_int(code_scanning.get('stale_alerts'))}`")
+        unknown_count = _int(code_scanning.get("unknown_freshness_alerts"))
+        if unknown_count:
+            lines.append(f"- Unknown-freshness code scanning alerts: `{unknown_count}`")
 
     return lines
 

--- a/tests/test_check_intelligence.py
+++ b/tests/test_check_intelligence.py
@@ -427,3 +427,71 @@ def test_check_intelligence_validate_failure_gets_log_review_actions(
     assert report["primary_blocker"]["code"] == "VALIDATE_JOB_LOG_REVIEW"
     assert "first non-setup failure line" in " ".join(report["recommended_actions"])
     assert "python -m pre_commit run -a" in report["proof_commands"]
+
+
+def test_check_intelligence_reports_code_scanning_freshness_counts(
+    tmp_path: Path,
+) -> None:
+    current_sha = "abc123"
+    checks = _write_json(
+        tmp_path / "checks.json",
+        {"check_runs": [{"name": "CI", "status": "completed", "conclusion": "success"}]},
+    )
+    alerts = _write_json(
+        tmp_path / "alerts.json",
+        [
+            {
+                "number": 10,
+                "state": "open",
+                "rule": {"id": "py/example", "severity": "warning"},
+                "most_recent_instance": {
+                    "commit_sha": current_sha,
+                    "message": {"text": "Current alert"},
+                    "location": {"path": "src/sdetkit/example.py", "start_line": 12},
+                },
+            },
+            {
+                "number": 11,
+                "state": "open",
+                "rule": {"id": "py/example", "severity": "warning"},
+                "most_recent_instance": {
+                    "commit_sha": "old456",
+                    "message": {"text": "Stale alert"},
+                    "location": {"path": "src/sdetkit/old.py", "start_line": 20},
+                },
+            },
+            {
+                "number": 12,
+                "state": "dismissed",
+                "rule": {"id": "py/ignored", "severity": "note"},
+                "most_recent_instance": {
+                    "commit_sha": current_sha,
+                    "location": {"path": "src/sdetkit/ignored.py", "start_line": 1},
+                },
+            },
+        ],
+    )
+
+    intelligence = check_intelligence.build_check_intelligence(
+        checks_json=checks,
+        code_scanning_alerts_json=alerts,
+        current_head_sha=current_sha,
+    )
+
+    review = intelligence["code_scanning_review"]
+    assert review["collected"] is True
+    assert review["open_alerts"] == 2
+    assert review["current_alerts"] == 1
+    assert review["stale_alerts"] == 1
+    assert review["unknown_freshness_alerts"] == 0
+    assert review["rule_counts"] == {"py/example": 2}
+    assert review["findings"][0]["freshness"] == "current"
+    assert review["findings"][0]["recommended_action"] == (
+        "fix_current_alert_or_dismiss_reviewed_false_positive"
+    )
+    assert review["findings"][1]["freshness"] == "stale"
+    assert review["findings"][1]["recommended_action"] == "wait_for_code_scanning_refresh"
+
+    action = check_intelligence.build_action_report(intelligence)
+    assert action["status"] == "green"
+    assert action["evidence"]["code_scanning_review"]["current_alerts"] == 1

--- a/tests/test_pr_quality_action_report.py
+++ b/tests/test_pr_quality_action_report.py
@@ -1166,3 +1166,39 @@ def test_pr_quality_action_report_renders_dependency_audit_evidence() -> None:
     assert "requirements-test.txt" in body
     assert "constraints-ci.txt" in body
     assert "review_first" in body or "Review first" in body
+
+
+def test_action_report_comment_shows_code_scanning_freshness_counts() -> None:
+    action = {
+        "status": "green",
+        "primary_blocker": {},
+        "automation": {"attempted": False, "allowed": False, "reason": "no remediation needed"},
+        "recommended_actions": [],
+        "proof_commands": [],
+        "evidence": {},
+    }
+    intelligence = {
+        "checks_seen": 44,
+        "failed_checks": [],
+        "queued_checks": [],
+        "startup_failures": [],
+        "security_review": {"collected": True, "unresolved_findings": 0},
+        "code_scanning_review": {
+            "collected": True,
+            "open_alerts": 3,
+            "current_alerts": 1,
+            "stale_alerts": 2,
+            "unknown_freshness_alerts": 0,
+        },
+    }
+
+    body = report.render_comment_body(
+        action_report=action,
+        check_intelligence=intelligence,
+        evidence_narrative={"quality": {"ok": True, "coverage_percent": "96.69%"}},
+    )
+
+    assert "Code scanning review collected: `true`" in body
+    assert "Open code scanning alerts: `3`" in body
+    assert "Current code scanning alerts: `1`" in body
+    assert "Stale code scanning alerts: `2`" in body


### PR DESCRIPTION
## Summary
- Adds optional code scanning alert freshness evidence to check intelligence.
- Reports open/current/stale/unknown-freshness alert counts by comparing alert commit SHA to current head SHA.
- Surfaces code scanning freshness counts in PR Quality comments so operators can distinguish patch-now from wait-for-refresh cases.

## Verification
- `python -m pytest -q tests/test_check_intelligence.py tests/test_pr_quality_action_report.py tests/test_check_intelligence_first_failure.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
Low. Reporting-only change; no alert dismissal, remediation, or security state mutation is introduced.