### PR TITLE
Build PR Quality trajectory artifacts

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -282,6 +282,26 @@ jobs:
             --pr-quality-safe-bridge-only \
             --out-dir build/pr-quality/safe-formatting-autopilot
 
+      - name: Build PR trajectory artifact
+        if: always()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p build/pr-quality/trajectory
+          PYTHONPATH=src python -m sdetkit.trajectory_store \
+            --pr-quality-action-report build/pr-quality/check-intelligence/action-report.json \
+            --check-intelligence build/pr-quality/check-intelligence/check-intelligence.json \
+            --out build/pr-quality/trajectory/trajectory.jsonl \
+            --repo "$REPOSITORY" \
+            --branch "$HEAD_REF" \
+            --commit-sha "$HEAD_SHA" \
+            --pr-number "$PR_NUMBER" \
+            --format json \
+            > build/pr-quality/trajectory/trajectory-metadata.json
+
       - name: Build PR comment body
         run: |
           mkdir -p build/pr-quality
@@ -304,6 +324,7 @@ jobs:
             --action-report build/pr-quality/check-intelligence/action-report.json \
             --check-intelligence build/pr-quality/check-intelligence/check-intelligence.json \
             --evidence-narrative build/pr-quality/pr-evidence-narrative.json \
+            --trajectory-jsonl build/pr-quality/trajectory/trajectory.jsonl \
             --out build/pr-quality/pr-comment-body.md \
             > build/pr-quality/pr-comment-metadata.json
 
@@ -359,6 +380,7 @@ jobs:
             build/pr-quality/check-logs/
             build/pr-quality/check-intelligence/
             build/pr-quality/safe-formatting-autopilot/
+            build/pr-quality/trajectory/
             build/pr-quality/pr-evidence-narrative.md
             build/sdetkit/evidence-graph/
             build/sdetkit/operator-loop/
@@ -393,6 +415,10 @@ jobs:
                 evidence_signal_kind: metadata.evidence_signal_kind || 'unknown',
                 evidence_signal_present: Boolean(metadata.evidence_signal_present),
                 evidence_review_required: Boolean(metadata.evidence_review_required),
+                trajectory_signal_present: Boolean(metadata.trajectory_signal_present),
+                trajectory_record_count: Number(metadata.trajectory_record_count || 0),
+                trajectory_review_first_count: Number(metadata.trajectory_review_first_count || 0),
+                trajectory_auto_fix_allowed_count: Number(metadata.trajectory_auto_fix_allowed_count || 0),
               };
               fs.mkdirSync(path.dirname(statusPath), { recursive: true });
               fs.writeFileSync(
@@ -477,6 +503,11 @@ jobs:
           evidence_signal_kind = str(payload.get("evidence_signal_kind", "unknown"))
           evidence_signal_present = bool(payload.get("evidence_signal_present", False))
           evidence_review_required = bool(payload.get("evidence_review_required", False))
+          trajectory_record_count = int(payload.get("trajectory_record_count", 0) or 0)
+          trajectory_review_first_count = int(payload.get("trajectory_review_first_count", 0) or 0)
+          trajectory_auto_fix_allowed_count = int(
+              payload.get("trajectory_auto_fix_allowed_count", 0) or 0
+          )
 
           print(f"comment_status={status}")
           print(f"comment_reason={reason}")
@@ -485,6 +516,9 @@ jobs:
           print(f"evidence_signal_kind={evidence_signal_kind}")
           print(f"evidence_signal_present={str(evidence_signal_present).lower()}")
           print(f"evidence_review_required={str(evidence_review_required).lower()}")
+          print(f"trajectory_record_count={trajectory_record_count}")
+          print(f"trajectory_review_first_count={trajectory_review_first_count}")
+          print(f"trajectory_auto_fix_allowed_count={trajectory_auto_fix_allowed_count}")
 
           if status not in {"posted", "updated"}:
               raise SystemExit(f"PR Quality comment was not posted or updated: status={status} reason={reason}")

--- a/src/sdetkit/trajectory_store.py
+++ b/src/sdetkit/trajectory_store.py
@@ -135,6 +135,197 @@ def _trajectory_id(*, repo: str, commit_sha: str, diagnosis_id: str, action: str
     return _slug(basis)
 
 
+def _failure_class(value: str) -> str:
+    return _slug(value).replace("-", "_")
+
+
+def _first_failure_line(check: Mapping[str, Any]) -> str:
+    first_failure = _as_dict(check.get("first_failure"))
+    return _string(check.get("first_failure_line") or first_failure.get("line"))
+
+
+def _pr_quality_primary_as_check(action_report: Mapping[str, Any]) -> JsonObject:
+    primary = _as_dict(action_report.get("primary_blocker"))
+    if not primary:
+        return {}
+
+    automation = _as_dict(action_report.get("automation"))
+    diagnosis = {
+        "code": _string(primary.get("code") or "UNKNOWN"),
+        "title": _string(primary.get("title") or "PR Quality review required"),
+        "risk_surface": _string(primary.get("surface") or "unknown"),
+        "diagnosis": _string(primary.get("impact")),
+        "proof_commands": _string_list(action_report.get("proof_commands")),
+        "recommended_fix": _string_list(action_report.get("recommended_actions")),
+    }
+
+    return {
+        "name": _string(primary.get("check") or "pr_quality"),
+        "url": _string(primary.get("url")),
+        "diagnosis": diagnosis,
+        "surface": _string(primary.get("surface") or "unknown"),
+        "code": _string(primary.get("code") or "UNKNOWN"),
+        "title": _string(primary.get("title") or "PR Quality review required"),
+        "safe_to_auto_fix": _bool(primary.get("safe_to_auto_fix"))
+        or _bool(automation.get("allowed")),
+        "review_first": _bool(primary.get("review_first")) or not _bool(automation.get("allowed")),
+        "safe_remediation": _as_dict(primary.get("safe_remediation")),
+        "first_failure": _as_dict(primary.get("first_failure")),
+        "first_failure_line": _string(primary.get("first_failure_line")),
+        "formatter_changed_files": _string_list(primary.get("formatter_changed_files")),
+        "referenced_files": _string_list(primary.get("referenced_files")),
+        "owner_files": _string_list(primary.get("owner_files")),
+    }
+
+
+def _pr_quality_checks(
+    *,
+    action_report: Mapping[str, Any],
+    check_intelligence: Mapping[str, Any],
+) -> list[JsonObject]:
+    failed_checks = [_as_dict(item) for item in _as_list(check_intelligence.get("failed_checks"))]
+    if failed_checks:
+        return failed_checks
+
+    primary = _pr_quality_primary_as_check(action_report)
+    return [primary] if primary else []
+
+
+def _pr_quality_action(
+    *,
+    surface: str,
+    safe_remediation: Mapping[str, Any],
+    auto_fix_allowed: bool,
+) -> str:
+    if auto_fix_allowed:
+        return _string(safe_remediation.get("strategy")) or "run_safe_remediation"
+    return f"review_{_failure_class(surface or 'unknown')}_failure"
+
+
+def build_pr_quality_trajectory_records(
+    *,
+    action_report: Mapping[str, Any],
+    check_intelligence: Mapping[str, Any],
+    safe_fix_outcome: Mapping[str, Any] | None = None,
+    repo: str = "",
+    branch: str = "",
+    commit_sha: str = "",
+    pr_number: int = 0,
+    generated_at: str = DEFAULT_GENERATED_AT,
+) -> list[JsonObject]:
+    outcome = _as_dict(safe_fix_outcome)
+    automation = _as_dict(action_report.get("automation"))
+    default_proof_commands = _string_list(action_report.get("proof_commands"))
+    records: list[JsonObject] = []
+
+    for index, check in enumerate(
+        _pr_quality_checks(
+            action_report=action_report,
+            check_intelligence=check_intelligence,
+        ),
+        start=1,
+    ):
+        diagnosis = _as_dict(check.get("diagnosis"))
+        safe_remediation = _as_dict(check.get("safe_remediation"))
+        code = _string(diagnosis.get("code") or check.get("code") or "UNKNOWN")
+        surface = _string(
+            check.get("surface")
+            or diagnosis.get("risk_surface")
+            or diagnosis.get("surface")
+            or "unknown"
+        )
+        auto_fix_allowed = _bool(check.get("safe_to_auto_fix")) and _bool(
+            safe_remediation.get("safe_to_auto_fix")
+            or automation.get("allowed")
+            or check.get("safe_to_auto_fix")
+        )
+        review_first = _bool(check.get("review_first")) or not auto_fix_allowed
+        proof_commands = _string_list(diagnosis.get("proof_commands")) or default_proof_commands
+        owner_files = (
+            _string_list(check.get("owner_files"))
+            or _string_list(diagnosis.get("owner_files"))
+            or _string_list(check.get("referenced_files"))
+            or _string_list(check.get("formatter_changed_files"))
+        )
+        patch_files = _string_list(check.get("formatter_changed_files")) if auto_fix_allowed else []
+        action = _pr_quality_action(
+            surface=surface,
+            safe_remediation=safe_remediation,
+            auto_fix_allowed=auto_fix_allowed,
+        )
+        diagnostic_id = _slug(_string(check.get("name") or f"pr-quality-{index}") + "-" + code)
+
+        records.append(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "trajectory_id": _trajectory_id(
+                    repo=repo,
+                    commit_sha=commit_sha,
+                    diagnosis_id=diagnostic_id,
+                    action=action,
+                ),
+                "repo": repo,
+                "branch": branch,
+                "commit_sha": commit_sha,
+                "pr_number": pr_number,
+                "attempt_number": 1,
+                "generated_at": generated_at,
+                "diagnostic_id": diagnostic_id,
+                "action": action,
+                "command": proof_commands[0] if proof_commands else "none",
+                "environment": {
+                    "runner": "github_actions",
+                    "source": "pr_quality",
+                },
+                "response": {
+                    "response_type": "safe_fix_candidate"
+                    if auto_fix_allowed
+                    else f"{surface or 'unknown'}_review_required",
+                    "exit_code": "unknown",
+                    "first_failing_line": _first_failure_line(check),
+                },
+                "diagnosis": {
+                    "failure_class": _failure_class(code),
+                    "risk_surface": surface or "unknown",
+                    "root_cause": _string(
+                        diagnosis.get("diagnosis") or diagnosis.get("title") or check.get("title")
+                    ),
+                    "owner_files": owner_files,
+                    "confidence": _string(diagnosis.get("confidence")) or "medium",
+                },
+                "decision": {
+                    "review_first": review_first,
+                    "auto_fix_allowed": auto_fix_allowed,
+                    "reason": _string(
+                        safe_remediation.get("reason")
+                        or automation.get("reason")
+                        or check.get("title")
+                    ),
+                },
+                "fix": {
+                    "allowed_strategy": action,
+                    "patch_files": patch_files,
+                    "blocked_reason": ""
+                    if auto_fix_allowed
+                    else _string(automation.get("reason") or "review-first diagnosis"),
+                },
+                "proof": {
+                    "commands": proof_commands,
+                    "focused_proof": "not_run",
+                    "quality_proof": "not_run",
+                    "verifier_result": "not_run",
+                },
+                "final_result": _final_result(
+                    {"safe_to_auto_fix": auto_fix_allowed},
+                    outcome,
+                ),
+                "learned_pattern": "pr_quality_check_intelligence",
+            }
+        )
+
+    return records
+
+
 def build_trajectory_records(
     *,
     diagnostic_vector: Mapping[str, Any],
@@ -258,8 +449,10 @@ def write_trajectory_records(records: list[Mapping[str, Any]], out: Path) -> Jso
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m sdetkit.trajectory_store")
-    parser.add_argument("--diagnostic-vector", required=True)
+    parser.add_argument("--diagnostic-vector", default="")
     parser.add_argument("--remediation-plan", default="")
+    parser.add_argument("--pr-quality-action-report", default="")
+    parser.add_argument("--check-intelligence", default="")
     parser.add_argument("--safe-fix-outcome", default="")
     parser.add_argument("--out", default=DEFAULT_OUT)
     parser.add_argument("--repo", default="")
@@ -279,16 +472,34 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        records = build_trajectory_records(
-            diagnostic_vector=_read_json(Path(args.diagnostic_vector)),
-            remediation_plan=_read_json(_optional_path(args.remediation_plan)),
-            safe_fix_outcome=_read_json(_optional_path(args.safe_fix_outcome)),
-            repo=args.repo,
-            branch=args.branch,
-            commit_sha=args.commit_sha,
-            pr_number=args.pr_number,
-            generated_at=args.generated_at,
-        )
+        if args.pr_quality_action_report or args.check_intelligence:
+            records = build_pr_quality_trajectory_records(
+                action_report=_read_json(_optional_path(args.pr_quality_action_report)),
+                check_intelligence=_read_json(_optional_path(args.check_intelligence)),
+                safe_fix_outcome=_read_json(_optional_path(args.safe_fix_outcome)),
+                repo=args.repo,
+                branch=args.branch,
+                commit_sha=args.commit_sha,
+                pr_number=args.pr_number,
+                generated_at=args.generated_at,
+            )
+        else:
+            if not args.diagnostic_vector:
+                msg = (
+                    "either --diagnostic-vector or "
+                    "--pr-quality-action-report/--check-intelligence is required"
+                )
+                raise ValueError(msg)
+            records = build_trajectory_records(
+                diagnostic_vector=_read_json(Path(args.diagnostic_vector)),
+                remediation_plan=_read_json(_optional_path(args.remediation_plan)),
+                safe_fix_outcome=_read_json(_optional_path(args.safe_fix_outcome)),
+                repo=args.repo,
+                branch=args.branch,
+                commit_sha=args.commit_sha,
+                pr_number=args.pr_number,
+                generated_at=args.generated_at,
+            )
         summary = write_trajectory_records(records, Path(args.out))
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"error={exc}")

--- a/tests/test_pr_quality_comment_observability_workflow.py
+++ b/tests/test_pr_quality_comment_observability_workflow.py
@@ -226,3 +226,41 @@ def test_pr_quality_workflow_uploads_safe_fix_outcome_artifacts() -> None:
     assert "Commit approved safe formatting fixes" in text
     assert "Build PR comment body" in text
     assert text.index("Commit approved safe formatting fixes") < text.index("Build PR comment body")
+
+
+def test_pr_quality_comment_workflow_builds_and_passes_trajectory_artifact() -> None:
+    text = _workflow_text()
+
+    check_intelligence = text.index("python -m sdetkit.check_intelligence")
+    trajectory = text.index("Build PR trajectory artifact")
+    comment_body = text.index("python -m sdetkit.pr_quality_action_report")
+
+    assert check_intelligence < trajectory < comment_body
+    assert "python -m sdetkit.trajectory_store" in text
+    assert (
+        "--pr-quality-action-report build/pr-quality/check-intelligence/action-report.json" in text
+    )
+    assert (
+        "--check-intelligence build/pr-quality/check-intelligence/check-intelligence.json" in text
+    )
+    assert "--out build/pr-quality/trajectory/trajectory.jsonl" in text
+    assert "> build/pr-quality/trajectory/trajectory-metadata.json" in text
+    assert "--trajectory-jsonl build/pr-quality/trajectory/trajectory.jsonl" in text
+    assert "build/pr-quality/trajectory/" in text
+
+
+def test_pr_quality_comment_workflow_exposes_trajectory_comment_metadata() -> None:
+    text = _workflow_text()
+
+    assert "trajectory_signal_present: Boolean(metadata.trajectory_signal_present)" in text
+    assert "trajectory_record_count: Number(metadata.trajectory_record_count || 0)" in text
+    assert (
+        "trajectory_review_first_count: Number(metadata.trajectory_review_first_count || 0)" in text
+    )
+    assert (
+        "trajectory_auto_fix_allowed_count: Number(metadata.trajectory_auto_fix_allowed_count || 0)"
+        in text
+    )
+    assert 'print(f"trajectory_record_count={trajectory_record_count}")' in text
+    assert 'print(f"trajectory_review_first_count={trajectory_review_first_count}")' in text
+    assert 'print(f"trajectory_auto_fix_allowed_count={trajectory_auto_fix_allowed_count}")' in text

--- a/tests/test_trajectory_store.py
+++ b/tests/test_trajectory_store.py
@@ -160,3 +160,125 @@ def test_trajectory_store_cli_writes_jsonl(tmp_path: Path, capsys) -> None:
     assert stdout["summary"]["record_count"] == 2
     assert stdout["summary"]["trajectory_jsonl"] == out.as_posix()
     assert len(out.read_text(encoding="utf-8").splitlines()) == 2
+
+
+def _pr_quality_action_report() -> dict:
+    return {
+        "status": "safe_fix_available",
+        "primary_blocker": {
+            "check": "autopilot",
+            "title": "Formatter drift blocked pre-commit",
+            "surface": "quality",
+            "code": "PRE_COMMIT_FORMAT_DRIFT",
+            "impact": "pre-commit changed a deterministic formatting file.",
+            "formatter_changed_files": ["tools/maintenance_autopilot.py"],
+            "safe_to_auto_fix": True,
+            "safe_remediation": {
+                "safe_to_auto_fix": True,
+                "strategy": "run_pre_commit",
+                "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
+            },
+        },
+        "automation": {
+            "attempted": False,
+            "allowed": True,
+            "reason": "diagnosis is approved for narrow mechanical safe-fix planning",
+        },
+        "recommended_actions": ["Run pre-commit on the affected files."],
+        "proof_commands": ["python -m pre_commit run -a"],
+    }
+
+
+def _pr_quality_check_intelligence() -> dict:
+    return {
+        "checks_seen": 3,
+        "failed_checks": [
+            {
+                "name": "autopilot",
+                "safe_to_auto_fix": True,
+                "surface": "quality",
+                "code": "PRE_COMMIT_FORMAT_DRIFT",
+                "title": "Formatter drift blocked pre-commit",
+                "first_failure_line": "RuntimeError: command failed (1): python -m pre_commit run -a",
+                "formatter_changed_files": ["tools/maintenance_autopilot.py"],
+                "safe_remediation": {
+                    "safe_to_auto_fix": True,
+                    "strategy": "run_pre_commit",
+                    "reason": "Failure is limited to deterministic formatting or whitespace hooks.",
+                },
+                "diagnosis": {
+                    "code": "PRE_COMMIT_FORMAT_DRIFT",
+                    "title": "Formatter drift blocked pre-commit",
+                    "risk_surface": "quality",
+                    "diagnosis": "pre-commit formatting drift was detected.",
+                    "proof_commands": ["python -m pre_commit run -a"],
+                },
+            }
+        ],
+        "queued_checks": [],
+        "startup_failures": [],
+    }
+
+
+def test_pr_quality_trajectory_records_capture_safe_formatter_decision() -> None:
+    from sdetkit.trajectory_store import build_pr_quality_trajectory_records
+
+    records = build_pr_quality_trajectory_records(
+        action_report=_pr_quality_action_report(),
+        check_intelligence=_pr_quality_check_intelligence(),
+        repo="sherif69-sa/DevS69-sdetkit",
+        branch="feature/pr-quality-build-trajectory-artifact",
+        commit_sha="abc123",
+        pr_number=1388,
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["environment"]["source"] == "pr_quality"
+    assert record["diagnosis"]["failure_class"] == "pre_commit_format_drift"
+    assert record["diagnosis"]["risk_surface"] == "quality"
+    assert record["decision"]["auto_fix_allowed"] is True
+    assert record["decision"]["review_first"] is False
+    assert record["action"] == "run_pre_commit"
+    assert record["fix"]["patch_files"] == ["tools/maintenance_autopilot.py"]
+    assert record["proof"]["commands"] == ["python -m pre_commit run -a"]
+    assert record["final_result"] == "safe_fix_candidate"
+
+
+def test_pr_quality_trajectory_cli_writes_artifact(tmp_path: Path, capsys) -> None:
+    action_path = tmp_path / "action-report.json"
+    intelligence_path = tmp_path / "check-intelligence.json"
+    out = tmp_path / "trajectory.jsonl"
+    action_path.write_text(json.dumps(_pr_quality_action_report()), encoding="utf-8")
+    intelligence_path.write_text(
+        json.dumps(_pr_quality_check_intelligence()),
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "--pr-quality-action-report",
+            str(action_path),
+            "--check-intelligence",
+            str(intelligence_path),
+            "--out",
+            str(out),
+            "--repo",
+            "sherif69-sa/DevS69-sdetkit",
+            "--branch",
+            "feature/pr-quality-build-trajectory-artifact",
+            "--commit-sha",
+            "abc123",
+            "--pr-number",
+            "1388",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert rc == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["summary"]["record_count"] == 1
+    assert printed["summary"]["auto_fix_allowed_count"] == 1
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["action"] == "run_pre_commit"


### PR DESCRIPTION
## Summary
- Adds a PR Quality input mode to TrajectoryStore.
- Builds `build/pr-quality/trajectory/trajectory.jsonl` from PR Quality check intelligence and action report artifacts.
- Passes the trajectory JSONL into the PR Quality action report renderer.
- Uploads trajectory artifacts with PR Quality artifacts.
- Exposes trajectory counts in comment status metadata.

## Why
- The TrajectoryStore layer exists and PR Quality can render trajectory summaries.
- This PR completes the chain by making the PR Quality workflow generate and pass the trajectory artifact.

## Verification
- `python -m pytest -q tests/test_trajectory_store.py tests/test_pr_quality_action_report.py tests/test_pr_quality_comment_observability_workflow.py -o addopts=`
- `python -m mypy src`
- `python -m pre_commit run -a`

## Risk
- Low-to-medium.
- Workflow wiring plus local artifact generation.
- No auto-remediation expansion.
- No cloud queue.
- No verifier behavior change.
- Rollback: revert this PR.